### PR TITLE
feat(device-authenticity): cross-check serial numbers between deviceCerts

### DIFF
--- a/packages/connect/e2e/tests/device/authenticateDevice.test.ts
+++ b/packages/connect/e2e/tests/device/authenticateDevice.test.ts
@@ -52,6 +52,7 @@ describe('TrezorConnect.authenticateDevice', () => {
                 optigaResult: { valid: true },
                 // trezor-user-env T3W1 has no tropic debug keys provisioned, but it is now required.
                 // TODO change to true when it's fixed in trezor-user-env (this E2E will start failing)
+                // once this is reenabled, note that the serialNumbers must match BETWEEN all results, else it will be failure
                 tropicResult: { valid: false },
             },
         });

--- a/packages/connect/src/api/authenticateDevice.ts
+++ b/packages/connect/src/api/authenticateDevice.ts
@@ -5,6 +5,7 @@ import {
     deviceAuthenticityConfig,
     getRandomChallenge,
     prepareDeviceAuthenticityData,
+    validateSerialNumbers,
     verifyAuthenticityProof,
 } from '@trezor/device-authenticity';
 import { Assert } from '@trezor/schema-utils';
@@ -67,11 +68,13 @@ export default class AuthenticateDevice extends AbstractMethod<
             return { valid: false, error: 'RESPONSE_PAYLOAD_MISSING' };
         };
 
+        const hasTropicAbility =
+            !this.getDevice().unavailableCapabilities['tropicDeviceAuthentication'];
+
         const getTropicResult = async (): Promise<VerifyAuthenticityProofResult | null> => {
             const { tropic_signature: signature, tropic_certificates: certificates } = message;
             const isAvailable = signature !== undefined && certificates.length > 0;
-            const isRequired =
-                !this.getDevice().unavailableCapabilities['tropicDeviceAuthentication'];
+            const isRequired = hasTropicAbility;
             if (isAvailable) {
                 return await verifyAuthenticityProof({ ...commonParams, certificates, signature });
             }
@@ -99,7 +102,9 @@ export default class AuthenticateDevice extends AbstractMethod<
             getTropicResult(),
             getMCUResult(),
         ]);
+        const results = { optigaResult, tropicResult, mcuResult };
 
-        return { optigaResult, tropicResult, mcuResult };
+        // Only T3W1 and later have serialNumber (i.e. devices that support Tropic authentication), this validation is skipped for all older models.
+        return hasTropicAbility ? validateSerialNumbers(results) : results;
     }
 }

--- a/packages/device-authenticity/src/__fixtures__/verifyAuthenticityProof.ts
+++ b/packages/device-authenticity/src/__fixtures__/verifyAuthenticityProof.ts
@@ -53,6 +53,7 @@ export const verifyAuthenticityProofFixtures: Fixture[] = [
             valid: true,
             rootPubKey: T3W1_ROOT_PUB_KEY_TROPIC,
             caPubKey: CA_PUB_KEY_TROPIC,
+            serialNumber: '343732303930323235323232323232323232323232323232',
         },
     },
     {
@@ -61,6 +62,7 @@ export const verifyAuthenticityProofFixtures: Fixture[] = [
         result: {
             valid: true,
             rootPubKey: T3W1_ROOT_PUB_KEY_MLDSA,
+            serialNumber: '3437333032313932363030303972',
         },
     },
 
@@ -89,6 +91,7 @@ export const verifyAuthenticityProofFixtures: Fixture[] = [
             valid: true,
             rootPubKey: T3W1_ROOT_PUB_KEY_TROPIC,
             caPubKey: CA_PUB_KEY_TROPIC,
+            serialNumber: '343732303930323235323232323232323232323232323232',
         },
     },
     {
@@ -101,6 +104,7 @@ export const verifyAuthenticityProofFixtures: Fixture[] = [
         result: {
             valid: true,
             rootPubKey: T3W1_ROOT_PUB_KEY_MLDSA,
+            serialNumber: '3437333032313932363030303972',
         },
     },
 

--- a/packages/device-authenticity/src/__tests__/validateSerialNumbers.test.ts
+++ b/packages/device-authenticity/src/__tests__/validateSerialNumbers.test.ts
@@ -1,0 +1,153 @@
+import type { VerifyAuthenticityProofResult } from '../types';
+import { validateSerialNumbers } from '../validateSerialNumbers';
+
+describe(validateSerialNumbers.name, () => {
+    const createValidResult = (
+        serialNumber: string | undefined,
+    ): VerifyAuthenticityProofResult => ({
+        valid: true,
+        rootPubKey: 'test-root-pubkey',
+        serialNumber,
+    });
+
+    const createInvalidResult = (): VerifyAuthenticityProofResult => ({
+        valid: false,
+        error: 'ROOT_PUBKEY_NOT_FOUND' as const,
+    });
+
+    describe('when all results have valid: false', () => {
+        it('returns all results as-is', () => {
+            const optigaResult = createInvalidResult();
+            const tropicResult = createInvalidResult();
+            const mcuResult = createInvalidResult();
+
+            const results = { optigaResult, tropicResult, mcuResult };
+            expect(validateSerialNumbers(results)).toEqual(results);
+        });
+    });
+
+    describe('when some results are null', () => {
+        it('returns all results as-is when only optiga is defined', () => {
+            const optigaResult = createValidResult('1234567890abcdef');
+
+            const results = { optigaResult, tropicResult: null, mcuResult: null };
+            expect(validateSerialNumbers(results)).toEqual(results);
+        });
+
+        it('returns all results as-is when optiga and tropic are defined', () => {
+            const optigaResult = createValidResult('1234567890abcdef');
+            const tropicResult = createValidResult('1234567890abcdef');
+
+            const results = { optigaResult, tropicResult, mcuResult: null };
+            expect(validateSerialNumbers(results)).toEqual(results);
+        });
+    });
+
+    describe('when any result has valid: false', () => {
+        it('returns all results as-is when tropic is invalid', () => {
+            const optigaResult = createValidResult('1234567890abcdef');
+            const tropicResult = createInvalidResult();
+            const mcuResult = createValidResult('1234567890abcdef');
+
+            const results = { optigaResult, tropicResult, mcuResult };
+            expect(validateSerialNumbers(results)).toEqual(results);
+        });
+        it('returns all results as-is when mcu is invalid', () => {
+            const optigaResult = createValidResult('1234567890abcdef');
+            const tropicResult = createValidResult('1234567890abcdef');
+            const mcuResult = createInvalidResult();
+
+            const results = { optigaResult, tropicResult, mcuResult };
+            expect(validateSerialNumbers(results)).toEqual(results);
+        });
+        it('returns all results as-is when both tropic and optiga are invalid', () => {
+            const optigaResult = createInvalidResult();
+            const tropicResult = createInvalidResult();
+            const mcuResult = createValidResult('1234567890abcdef');
+
+            const results = { optigaResult, tropicResult, mcuResult };
+            expect(validateSerialNumbers(results)).toEqual(results);
+        });
+    });
+
+    describe('when a valid result is missing serialNumber', () => {
+        it('returns all results with valid: false and SERIAL_NUMBER_MISMATCH error', () => {
+            const optigaResult = createValidResult(undefined);
+            const tropicResult = createValidResult('1234567890abcdef');
+            const mcuResult = createValidResult('1234567890abcdef');
+
+            const results = { optigaResult, tropicResult, mcuResult };
+            const validated = validateSerialNumbers(results);
+
+            expect(validated).toEqual({
+                optigaResult: { ...optigaResult, valid: false, error: 'SERIAL_NUMBER_MISMATCH' },
+                tropicResult: { ...tropicResult, valid: false, error: 'SERIAL_NUMBER_MISMATCH' },
+                mcuResult: { ...mcuResult, valid: false, error: 'SERIAL_NUMBER_MISMATCH' },
+            });
+        });
+
+        it('handles empty string serial numbers', () => {
+            const optigaResult = createValidResult('1234567890abcdef');
+            const tropicResult = createValidResult('');
+
+            const results = { optigaResult, tropicResult, mcuResult: null };
+            const validated = validateSerialNumbers(results);
+
+            expect(validated).toEqual({
+                optigaResult: { ...optigaResult, valid: false, error: 'SERIAL_NUMBER_MISMATCH' },
+                tropicResult: { ...tropicResult, valid: false, error: 'SERIAL_NUMBER_MISMATCH' },
+                mcuResult: null,
+            });
+        });
+    });
+
+    describe('when serial numbers do not match', () => {
+        it('returns all results with valid: false and SERIAL_NUMBER_MISMATCH error', () => {
+            const optigaResult = createValidResult('1111111111111111');
+            const tropicResult = createValidResult('2222222222222222');
+            const mcuResult = createValidResult('1111111111111111');
+
+            const results = { optigaResult, tropicResult, mcuResult };
+            const validated = validateSerialNumbers(results);
+
+            expect(validated).toEqual({
+                optigaResult: { ...optigaResult, valid: false, error: 'SERIAL_NUMBER_MISMATCH' },
+                tropicResult: { ...tropicResult, valid: false, error: 'SERIAL_NUMBER_MISMATCH' },
+                mcuResult: { ...mcuResult, valid: false, error: 'SERIAL_NUMBER_MISMATCH' },
+            });
+        });
+
+        it('returns all results with valid: false when optiga and tropic differ', () => {
+            const optigaResult = createValidResult('aaaaaaaaaaaaaaaa');
+            const tropicResult = createValidResult('bbbbbbbbbbbbbbbb');
+
+            const results = { optigaResult, tropicResult, mcuResult: null };
+            const validated = validateSerialNumbers(results);
+
+            expect(validated).toEqual({
+                optigaResult: { ...optigaResult, valid: false, error: 'SERIAL_NUMBER_MISMATCH' },
+                tropicResult: { ...tropicResult, valid: false, error: 'SERIAL_NUMBER_MISMATCH' },
+                mcuResult: null,
+            });
+        });
+    });
+
+    describe('when all serial numbers match', () => {
+        it('returns all results unchanged', () => {
+            const optigaResult = createValidResult('1234567890abcdef');
+            const tropicResult = createValidResult('1234567890abcdef');
+            const mcuResult = createValidResult('1234567890abcdef');
+
+            const results = { optigaResult, tropicResult, mcuResult };
+            expect(validateSerialNumbers(results)).toEqual(results);
+        });
+
+        it('returns optiga and tropic results unchanged when mcu is null', () => {
+            const optigaResult = createValidResult('fedcba0987654321');
+            const tropicResult = createValidResult('fedcba0987654321');
+
+            const results = { optigaResult, tropicResult, mcuResult: null };
+            expect(validateSerialNumbers(results)).toEqual(results);
+        });
+    });
+});

--- a/packages/device-authenticity/src/findSubjectContentByOid.ts
+++ b/packages/device-authenticity/src/findSubjectContentByOid.ts
@@ -1,0 +1,12 @@
+import type { Oid, ParsedCertificate } from './x509certificate';
+
+export const findSubjectContentByOid = (
+    deviceCert: ParsedCertificate,
+    oid: Oid,
+): Uint8Array<ArrayBufferLike> | null => {
+    const subjectItems = deviceCert.tbsCertificate.subject;
+    const matchedItem = subjectItems.find(({ algorithmOid }) => algorithmOid === oid);
+    if (!matchedItem || !matchedItem.parameters) return null;
+
+    return matchedItem.parameters.asn1.contents;
+};

--- a/packages/device-authenticity/src/index.ts
+++ b/packages/device-authenticity/src/index.ts
@@ -1,5 +1,6 @@
 export { verifyAuthenticityProof, prepareDeviceAuthenticityData } from './verifyAuthenticityProof';
 export { validateCaCertExtensions } from './validateCaCertExtensions';
+export { validateSerialNumbers } from './validateSerialNumbers';
 export {
     verifySignatureEd25519,
     verifySignatureP256,

--- a/packages/device-authenticity/src/types.ts
+++ b/packages/device-authenticity/src/types.ts
@@ -30,11 +30,13 @@ export type VerifyAuthenticityProofResult =
           caPubKey?: string;
           rootPubKey: string;
           error?: typeof undefined;
+          serialNumber?: string;
       }
     | {
           valid: false;
           caPubKey?: string;
           rootPubKey?: string;
+          serialNumber?: string;
           error:
               | 'ROOT_PUBKEY_NOT_FOUND'
               | 'CA_PUBKEY_BLACKLISTED'
@@ -42,5 +44,12 @@ export type VerifyAuthenticityProofResult =
               | 'INVALID_DEVICE_CERTIFICATE'
               | 'INVALID_DEVICE_SIGNATURE'
               | 'RESPONSE_PAYLOAD_MISSING'
-              | 'RESPONSE_MALFORMED';
+              | 'RESPONSE_MALFORMED'
+              | 'SERIAL_NUMBER_MISMATCH';
       };
+
+export type ResultsToValidate = {
+    optigaResult: VerifyAuthenticityProofResult;
+    tropicResult: VerifyAuthenticityProofResult | null;
+    mcuResult: VerifyAuthenticityProofResult | null;
+};

--- a/packages/device-authenticity/src/validateSerialNumbers.ts
+++ b/packages/device-authenticity/src/validateSerialNumbers.ts
@@ -1,0 +1,53 @@
+import { type ResultsToValidate } from './types';
+
+const failAllResults = ({
+    optigaResult,
+    tropicResult,
+    mcuResult,
+}: ResultsToValidate): ResultsToValidate => ({
+    optigaResult: {
+        ...optigaResult,
+        valid: false,
+        error: 'SERIAL_NUMBER_MISMATCH',
+    },
+
+    tropicResult: tropicResult
+        ? { ...tropicResult, valid: false, error: 'SERIAL_NUMBER_MISMATCH' }
+        : null,
+
+    mcuResult: mcuResult ? { ...mcuResult, valid: false, error: 'SERIAL_NUMBER_MISMATCH' } : null,
+});
+
+/**
+ * Validates that serial numbers are consistent across authentication results.
+ * If any result has valid: false, returns all as-is.
+ * It compares serialNumbers for all non-null results, and returns all as-is if they all match.
+ * If any of them doesn't match, it sets all of them to valid: false with SERIAL_NUMBER_MISMATCH error.
+ * Assumption: if any of the result is null, it's only because the device doesn't support the method
+ * (see connect authenticateDevice: if device is capable but omits result, it returns failure with RESPONSE_PAYLOAD_MISSING ).
+ */
+export const validateSerialNumbers = (resultsToValidate: ResultsToValidate): ResultsToValidate => {
+    const { optigaResult, tropicResult, mcuResult } = resultsToValidate;
+
+    const availableResults = [optigaResult, tropicResult, mcuResult].filter(r => r !== null);
+    // Cannot happen, see authenticateDevice, there'll always be at least failed optigaResult (it's always required).
+    if (availableResults.length === 0) return resultsToValidate;
+
+    // If any result has failed, it already means DAC has failed as a whole, so return all as they are.
+    const anyInvalid = availableResults.some(({ valid }) => !valid);
+    if (anyInvalid) return resultsToValidate;
+
+    // Check that all have defined serialNumber
+    const allHaveSerialNumber = availableResults.every(
+        ({ serialNumber }) => typeof serialNumber === 'string' && serialNumber.length > 0,
+    );
+    if (!allHaveSerialNumber) return failAllResults(resultsToValidate);
+
+    // Check that all serial numbers are equal
+    const first = availableResults[0].serialNumber!;
+    const allEqual = availableResults.every(({ serialNumber }) => serialNumber === first);
+    if (!allEqual) return failAllResults(resultsToValidate);
+
+    // All validations passed
+    return resultsToValidate;
+};

--- a/packages/device-authenticity/src/verifyAuthenticityProof.ts
+++ b/packages/device-authenticity/src/verifyAuthenticityProof.ts
@@ -1,5 +1,6 @@
 import { bufferUtils } from '@trezor/utils';
 
+import { findSubjectContentByOid } from './findSubjectContentByOid';
 import {
     type PrepareDeviceAuthenticityDataParams,
     type VerifyAuthenticityProofParams,
@@ -8,7 +9,7 @@ import {
 import { getCaPubKeyBlacklist, getRootPubKeys } from './utils';
 import { validateCaCertExtensions } from './validateCaCertExtensions';
 import { getVerifyFn } from './verifySignatures';
-import { parseCertificate } from './x509certificate';
+import { type ParsedCertificate, parseCertificate } from './x509certificate';
 
 // Compose the data against which the signatures will be verified.
 export const prepareDeviceAuthenticityData = ({
@@ -23,8 +24,6 @@ export const prepareDeviceAuthenticityData = ({
         chunks.flatMap(chunk => [bufferUtils.getChunkSize(chunk.byteLength), chunk]),
     );
 };
-
-type ParsedCertificate = ReturnType<typeof parseCertificate>;
 
 type MatchRootPubKeyToCertificateParams = {
     cert: ParsedCertificate;
@@ -54,17 +53,26 @@ export const matchRootPubKeyToCertificate = async ({
 };
 
 /**
- * Validates DEVICE certificate subject (Trezor features internal_model) and return the model
+ * Get internal model name from deviceCert Subject by its OID https://www.alvestrand.no/objectid/2.5.4.3.html
+ * This OID must always be present, so if this returns null, it should be treated as an error.
  */
 const parseModelFromDeviceCertSubject = (deviceCert: ParsedCertificate) => {
-    const [subject] = deviceCert.tbsCertificate.subject;
-    // subject algorithm (OID) https://www.alvestrand.no/objectid/2.5.4.3.html
-    if (!subject.parameters || subject.algorithmOid !== '2.5.4.3') {
-        throw new Error('Missing certificate subject');
-    }
+    const modelDescriptionBytes = findSubjectContentByOid(deviceCert, '2.5.4.3');
+    if (modelDescriptionBytes === null) return null;
 
-    // slice 4 bytes from the subject (internal model)
-    return Buffer.from(subject.parameters.asn1.contents.subarray(0, 4)).toString();
+    // the whole string would be something like 'T3W1 Trezor Safe 7', so only the first 4 chars for internal model name
+    return Buffer.from(modelDescriptionBytes.subarray(0, 4)).toString();
+};
+
+/**
+ * Get serial number from deviceCert Subject by its OID https://www.alvestrand.no/objectid/2.5.4.5.html
+ * This OID is only present on T3W1 and above.
+ */
+const parseSerialNumberFromDeviceCert = (deviceCert: ParsedCertificate) => {
+    const serialNumber = findSubjectContentByOid(deviceCert, '2.5.4.5');
+    if (serialNumber === null) return undefined;
+
+    return Buffer.from(serialNumber).toString('hex');
 };
 
 type VerifyDeviceAndCACertificatesParams = {
@@ -118,6 +126,7 @@ const verifyDeviceAndCACertificates = async ({
         throw new Error(`CA validity from ${caCertValidityFrom} can't be in the future!`);
     }
     const modelFromSubject = parseModelFromDeviceCertSubject(deviceCert);
+    // compulsory field, null value will also be considered an invalid model and fail the check
     if (modelFromSubject !== deviceModel) {
         return {
             valid: false,
@@ -150,7 +159,9 @@ const verifyDeviceAndCACertificates = async ({
         Buffer.from(signature, 'hex'),
     );
     if (isSignatureValid) {
-        return { valid: true, caPubKey, rootPubKey: rootPubKeyMatch };
+        const serialNumber = parseSerialNumberFromDeviceCert(deviceCert);
+
+        return { valid: true, caPubKey, rootPubKey: rootPubKeyMatch, serialNumber };
     }
 
     return {
@@ -189,6 +200,7 @@ const verifyOnlyDeviceCertificate = async ({
     if (rootPubKeyMatch === undefined) {
         return { valid: false, error: 'ROOT_PUBKEY_NOT_FOUND' };
     }
+    // compulsory field, null value will also be considered an invalid model and fail the check
     const modelFromSubject = parseModelFromDeviceCertSubject(deviceCert);
     if (modelFromSubject !== deviceModel) {
         // This path is practically unreachable because here it's the deviceCert that is signed with rootPubKey, so
@@ -208,7 +220,9 @@ const verifyOnlyDeviceCertificate = async ({
         Buffer.from(signature, 'hex'),
     );
     if (isSignatureValid) {
-        return { valid: true, rootPubKey: rootPubKeyMatch };
+        const serialNumber = parseSerialNumberFromDeviceCert(deviceCert);
+
+        return { valid: true, rootPubKey: rootPubKeyMatch, serialNumber };
     }
 
     return {

--- a/packages/device-authenticity/src/x509certificate.ts
+++ b/packages/device-authenticity/src/x509certificate.ts
@@ -16,7 +16,7 @@ interface Asn1 {
 
 type OneOrTwoNumbers = `${number}` | `${number}.${number}`;
 // type that allows between 4 to 8 numbers to specify an OID
-type Oid = `${OneOrTwoNumbers}.${OneOrTwoNumbers}.${OneOrTwoNumbers}.${OneOrTwoNumbers}`;
+export type Oid = `${OneOrTwoNumbers}.${OneOrTwoNumbers}.${OneOrTwoNumbers}.${OneOrTwoNumbers}`;
 
 // algorithms supported by Suite to verify certificates and signatures
 export type AlgorithmName = 'P-256' | 'Ed25519' | 'MLDSA44' | 'unknown';
@@ -470,3 +470,5 @@ export const parseCertificate = (byteArray: Uint8Array) => {
         signatureValue: parseSignatureValue(pieces[2]),
     };
 };
+
+export type ParsedCertificate = ReturnType<typeof parseCertificate>;


### PR DESCRIPTION
## Description

- Return `serialNumber` from `verifyAuthenticityProof` result for each check type
  - that fn cannot cross-check it, because it's limited to one check type, but it parses the `deviceCertificate`
- If device has Tropic DAC capability (i.e. T3W1 and later), verify that:
  - all results that are present have `serialNumber`
    - for T3W1 it is required, for previous models it's not there
    - but even though Optiga,Tropic are always there, MCU result may not be there (T3W1 >= 2.11.2)
  - all `serialNumber`s must match 
- This validation is only done _on top_ of the individual checks, i.e. if any of them has not failed
- If this new validation fails, it sets all individual results to fail because there is no "master failure"

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27277

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/cross-check-deviceCert-serialNumbers&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/cross-check-deviceCert-serialNumbers&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/cross-check-deviceCert-serialNumbers&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy Negative scenarios > Buy form handles input limits and empty quotes | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-04T12:43:24.782Z • 12 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-04T13:58:22.486Z • 13 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/cross-check-deviceCert-serialNumbers/web/](https://dev.suite.sldev.cz/suite-web/feat/cross-check-deviceCert-serialNumbers/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->