### PR TITLE
test(e2e-suite): fix enable coin after onboarding

### DIFF
--- a/suite/e2e/support/pageObjects/assetsSection.ts
+++ b/suite/e2e/support/pageObjects/assetsSection.ts
@@ -36,8 +36,13 @@ export class AssetsSection {
     }
 
     @step()
-    async enableNetworkViaActivateAssetsModal(symbol: NetworkSymbol) {
-        await this.activateAssetsModalNetworkButton(symbol).click();
+    async enableNetworkViaActivateAssetsModal(symbol: NetworkSymbol | NetworkSymbol[]) {
+        const symbols = Array.isArray(symbol) ? symbol : [symbol];
+
+        for (const s of symbols) {
+            await this.activateAssetsModalNetworkButton(s).click();
+        }
+
         await this.activateAssetsModalSaveButton.click();
     }
 

--- a/suite/e2e/tests/analytics/promo-banner-events.test.ts
+++ b/suite/e2e/tests/analytics/promo-banner-events.test.ts
@@ -8,6 +8,7 @@ import { PromoBannerType } from '../../support/pageObjects/dashboardPage';
 test.describe('Analytics Events - Promo Banner', { tag: ['@T3T1', '@nightlyOnly'] }, () => {
     test.beforeEach(async ({ onboardingPage, settingsPage }) => {
         await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
+        await settingsPage.changeNetworks({ enableNetworks: ['btc'] });
         await settingsPage.navigateTo('debug');
     });
 

--- a/suite/e2e/tests/general/check-links.test.ts
+++ b/suite/e2e/tests/general/check-links.test.ts
@@ -79,8 +79,9 @@ async function fetchWithRetry(page: Page, url: string, maxRetries = 3) {
 }
 
 test.describe('Check Links', { tag: ['@webOnly', '@nightlyOnly', '@T3T1'] }, () => {
-    test.beforeEach(async ({ onboardingPage }) => {
+    test.beforeEach(async ({ onboardingPage, settingsPage }) => {
         await onboardingPage.completeOnboarding();
+        await settingsPage.changeNetworks({ enableNetworks: ['btc'] });
     });
 
     test(

--- a/suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts
+++ b/suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts
@@ -19,7 +19,15 @@ test.describe('Onboarding - create wallet', { tag: ['@T3W1'] }, () => {
                 priority: TestPriority.Critical,
             }),
         },
-        async ({ page, device, onboardingPage, devicePrompt, analyticsSection, dashboardPage }) => {
+        async ({
+            page,
+            device,
+            onboardingPage,
+            devicePrompt,
+            analyticsSection,
+            dashboardPage,
+            assetsSection,
+        }) => {
             await onboardingPage.optionallyDismissFwHashCheckError();
             await analyticsSection.continueButton.click();
 
@@ -54,6 +62,9 @@ test.describe('Onboarding - create wallet', { tag: ['@T3W1'] }, () => {
             await device.pressYes();
 
             await test.step('Finish wallet creation', async () => {
+                await dashboardPage.discoveryEmptyPrimaryButton.click();
+                await assetsSection.enableNetworkViaActivateAssetsModal(['btc', 'eth']);
+
                 await expect(onboardingPage.suiteLoadedIndicator).toBeVisible({ timeout: 30_000 });
                 await expect(dashboardPage.walletReady).toBeVisible({ timeout: 30_000 });
             });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This changeset includes three directly modified test files and one shared page object (assetsSection.ts). The three test files (promo-banner-events, check-links, t3w1-create-wallet) are highest priority since they were directly changed. The assetsSection page object change poses moderate risk as it's used by several dashboard and settings tests for asset display, coin activation modals, and grid/table view interactions. The recommended strategy is to run all three changed tests plus the assets dashboard test at high priority, with a handful of medium-priority tests that depend on assetsSection functionality.

<details><summary><b>Changed files (4)</b></summary>

- `suite/e2e/support/pageObjects/assetsSection.ts`
- `suite/e2e/tests/analytics/promo-banner-events.test.ts`
- `suite/e2e/tests/general/check-links.test.ts`
- `suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/analytics/promo-banner-events.test.ts` — This test file itself was directly changed. It must be run to verify the modifications don't break the promo banner analytics event tests.
- `suite/e2e/tests/general/check-links.test.ts` — This test file itself was directly changed. It must be run to verify the link-checking test modifications work correctly.
- `suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts` — This test file itself was directly changed. It must be run to verify the T3W1 wallet creation onboarding flow still works correctly.
- `suite/e2e/tests/dashboard/assets.test.ts` — The assetsSection page object was changed, and this test directly exercises the assets section functionality including table/grid views, buy buttons, enable more coins modal, and verifyAssetContents — all methods likely defined in the changed page object.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — This test uses the assetsSection component (assetFiatAmount, tableIcon) for verifying discreet mode behavior across asset views. Changes to the assetsSection page object could affect these interactions.
- `suite/e2e/tests/settings/coins.test.ts` — This test uses assetsSection for the ActivateAssetsModal component (network buttons and save button) on the dashboard empty state. Changes to assetsSection page object could break the coin activation flow tested here.
- `suite/e2e/tests/settings/electrum.test.ts` — This test uses assetsSection to verify the fiat amount for RegTest assets on the dashboard after Electrum backend configuration. Changes to the assetsSection page object could affect this assertion.
- `suite/e2e/tests/suite/db-migration.test.ts` — This test uses assetsSection (enableNetworkViaActivateAssetsModal) for coin activation during the database migration flow. Changes to the assetsSection page object could break this specific interaction.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/analytics/staking-events.test.ts` — This test navigates staking from the dashboard assets section (dashboardPage.stakeButton) and uses the dashboard assets view. While the primary interaction is through dashboardPage, the assetsSection page object changes could indirectly affect the dashboard stake button if it's defined there.

</details>

_Updated: 2026-05-04T05:18:01.437Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/fix-enable-coin-after-onboarding&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/fix-enable-coin-after-onboarding&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-04T05:22:36.356Z • 12 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 15 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-04T05:21:13.606Z • 15 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/fix-enable-coin-after-onboarding/web/](https://dev.suite.sldev.cz/suite-web/test/fix-enable-coin-after-onboarding/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->