### PR TITLE
chore(eslint): enable no-prototype-builtins globally

### DIFF
--- a/packages/components/src/components/animations/recolorLottieAnimation.tsx
+++ b/packages/components/src/components/animations/recolorLottieAnimation.tsx
@@ -50,8 +50,7 @@ export const recolorLottieAnimation = (
             node.forEach(walk);
         } else if (typeof node === 'object' && node !== null) {
             for (const key in node) {
-                // eslint-disable-next-line no-prototype-builtins
-                if (node.hasOwnProperty(key)) {
+                if (Object.prototype.hasOwnProperty.call(node, key)) {
                     const value = node[key];
 
                     // Simple rgba color

--- a/packages/eslint/src/reactConfig.mjs
+++ b/packages/eslint/src/reactConfig.mjs
@@ -20,7 +20,6 @@ export const reactConfig = [
             'react/react-in-jsx-scope': 'off', // We are not importing React in every file
             'react/prop-types': 'off', // This rule is not needed when using TypeScript
             'react/display-name': 'off', // This is annoying for stuff like `forwardRef`. Todo: reconsider
-            'no-prototype-builtins': 'off', // Todo: just temporary, reconsider to remove it
         },
     },
 


### PR DESCRIPTION
Promotes one previously-disabled lint rule to its `@eslint/js` recommended default.

## Summary
- Replaced the only `node.hasOwnProperty(key)` call (in `recolorLottieAnimation`) with `Object.prototype.hasOwnProperty.call(node, key)`.
- Removed the `no-prototype-builtins: off` override (and its inline `eslint-disable-next-line`) so the recommended rule from `@eslint/js` is back in effect repo-wide.

## Test plan
- [ ] `yarn lint:js:all` is clean

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file `recolorLottieAnimation.tsx` is a shared animation utility component that maps to 121 tests, making it a very broad global dependency. This is a UI rendering/animation helper for Lottie animations, and none of the 121 mapped tests directly exercise Lottie animation recoloring behavior — they all transitively import it through shared component trees. Since no test in the LLM analysis mentions Lottie animations, animation recoloring, or any behavior that would be directly affected by changes to this utility, no E2E tests are recommended. The risk is low: a regression in Lottie animation coloring would be cosmetic and would not affect any functional user flows tested by the E2E suite. Manual visual inspection or unit tests would be more appropriate for validating this change.

<details><summary><b>Changed files (1)</b></summary>

- `packages/components/src/components/animations/recolorLottieAnimation.tsx`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/components/src/components/animations/recolorLottieAnimation.tsx`

_Updated: 2026-05-04T06:54:49.401Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/eslint-quickwin&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/eslint-quickwin&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-04T06:59:33.107Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-04T10:39:01.847Z • 13 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/eslint-quickwin/web/](https://dev.suite.sldev.cz/suite-web/mroz22/eslint-quickwin/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->