### PR TITLE
refactor(connect-popup): drop `as any` casts in method hooks

### DIFF
--- a/suite-common/connect-popup/src/methodHooks/addressConfirmation.ts
+++ b/suite-common/connect-popup/src/methodHooks/addressConfirmation.ts
@@ -1,5 +1,4 @@
-import { type Address, type CallMethodKeys, type SolanaPublicKey } from '@trezor/connect';
-import { type HDNodeResponse } from '@trezor/connect-common/src/types/api/getPublicKey';
+import { type Address, type CallMethodKeys } from '@trezor/connect';
 
 import { connectPopupActions } from '../connectPopupActions';
 import { getPermissionDeferred } from '../connectPopupPromiseManager';
@@ -7,12 +6,16 @@ import { type PostCallHookParams, type PreCallHookParams } from './types';
 
 // `methodsPublicKey` covers methods returning HDNodeResponse, SolanaPublicKey, and other
 // PublicKey variants (Cardano, Tezos). They all carry `publicKey: string` and the more
-// specific shapes add their own fields, so the variant fields are kept optional here to
-// keep structural narrowing inside `displayAddress` open-ended (otherwise narrowing on
-// the known specific shapes would collapse the catch-all branch to `never`).
-type AddressLikeResponse =
-    | Address
-    | ({ publicKey: string } & Partial<HDNodeResponse> & Partial<SolanaPublicKey>);
+// specific shapes add their own fields. The optional fields are listed inline so that
+// structural narrowing inside `displayAddress` doesn't collapse to `never` for the
+// catch-all branch (which would happen with separate union members).
+type PublicKeyLikeResponse = {
+    publicKey: string;
+    xpub?: string;
+    xpubSegwit?: string;
+    publicKeyBase58?: string;
+};
+type AddressLikeResponse = Address | PublicKeyLikeResponse;
 
 const methodsAddress = [
     'getAddress',
@@ -72,11 +75,11 @@ export async function postCallHook<M extends CallMethodKeys>({
                     : originalPayload;
             const displayAddress = () => {
                 if ('address' in item) return item.address;
-                // For SOL
-                if ('publicKeyBase58' in item) return item.publicKeyBase58;
                 // NOTE: it's possible in some cases there will be a mismatch between the public key format on the device and the one in the app
+                // For SOL
+                if (item.publicKeyBase58) return item.publicKeyBase58;
                 // For BTC
-                if ('xpub' in item) return item.xpubSegwit || item.xpub;
+                if (item.xpub) return item.xpubSegwit || item.xpub;
 
                 // For other altcoins
                 return item.publicKey;

--- a/suite-common/connect-popup/src/methodHooks/addressConfirmation.ts
+++ b/suite-common/connect-popup/src/methodHooks/addressConfirmation.ts
@@ -5,7 +5,14 @@ import { connectPopupActions } from '../connectPopupActions';
 import { getPermissionDeferred } from '../connectPopupPromiseManager';
 import { type PostCallHookParams, type PreCallHookParams } from './types';
 
-type AddressLikeResponse = Address | HDNodeResponse | SolanaPublicKey;
+// `methodsPublicKey` covers methods returning HDNodeResponse, SolanaPublicKey, and other
+// PublicKey variants (Cardano, Tezos). They all carry `publicKey: string` and the more
+// specific shapes add their own fields, so the variant fields are kept optional here to
+// keep structural narrowing inside `displayAddress` open-ended (otherwise narrowing on
+// the known specific shapes would collapse the catch-all branch to `never`).
+type AddressLikeResponse =
+    | Address
+    | ({ publicKey: string } & Partial<HDNodeResponse> & Partial<SolanaPublicKey>);
 
 const methodsAddress = [
     'getAddress',

--- a/suite-common/connect-popup/src/methodHooks/addressConfirmation.ts
+++ b/suite-common/connect-popup/src/methodHooks/addressConfirmation.ts
@@ -5,6 +5,8 @@ import { connectPopupActions } from '../connectPopupActions';
 import { getPermissionDeferred } from '../connectPopupPromiseManager';
 import { type PostCallHookParams, type PreCallHookParams } from './types';
 
+type AddressLikeResponse = Address | HDNodeResponse | SolanaPublicKey;
+
 const methodsAddress = [
     'getAddress',
     'ethereumGetAddress',
@@ -55,7 +57,7 @@ export async function postCallHook<M extends CallMethodKeys>({
     if (methods.includes(method) && response.success) {
         const bundledResponse = (
             Array.isArray(response.payload) ? response.payload : [response.payload]
-        ) as Address[] | HDNodeResponse[];
+        ) as AddressLikeResponse[];
         const addresses = bundledResponse.map((item, index) => {
             const validatePayload =
                 'bundle' in originalPayload && Array.isArray(originalPayload.bundle)
@@ -63,13 +65,11 @@ export async function postCallHook<M extends CallMethodKeys>({
                     : originalPayload;
             const displayAddress = () => {
                 if ('address' in item) return item.address;
-
+                // For SOL
+                if ('publicKeyBase58' in item) return item.publicKeyBase58;
                 // NOTE: it's possible in some cases there will be a mismatch between the public key format on the device and the one in the app
                 // For BTC
-                if (method === 'getPublicKey') return item.xpubSegwit || item.xpub;
-                // For SOL
-                if (method === 'solanaGetPublicKey')
-                    return (item as any as SolanaPublicKey).publicKeyBase58;
+                if ('xpub' in item) return item.xpubSegwit || item.xpub;
 
                 // For other altcoins
                 return item.publicKey;

--- a/suite-common/connect-popup/src/methodHooks/bitcoinSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/bitcoinSignTransaction.ts
@@ -5,11 +5,11 @@ import {
     sendFormActions,
 } from '@suite-common/wallet-core';
 import { type Account, type FormOptions } from '@suite-common/wallet-types';
-import type { CallMethodKeys, SignTransaction } from '@trezor/connect';
+import type { CallMethodKeys } from '@trezor/connect';
 import { getSerializedPath } from '@trezor/connect/src/utils/pathUtils';
 
 import { connectPopupActions } from '../connectPopupActions';
-import { type PostCallHookParams, type PreCallHookParams } from './types';
+import { type PostCallHookParams, type PreCallHookParams, isCallMethod } from './types';
 import { createPlaceholderAccount } from './utils';
 
 const temporaryAccounts: Account[] = [];
@@ -22,8 +22,8 @@ const preCallHook = async <M extends CallMethodKeys>({
     txSigningPrecomposed,
 }: PreCallHookParams<M>) => {
     try {
-        if (method === 'signTransaction' && txSigningPrecomposed) {
-            const typedPayload = payload as any as SignTransaction;
+        if (isCallMethod(method, 'signTransaction', payload) && txSigningPrecomposed) {
+            const typedPayload = payload;
             const network = getNetwork(typedPayload.coin as NetworkSymbol);
             if (!network) {
                 throw new Error(`Network not supported`);

--- a/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
@@ -7,11 +7,7 @@ import {
 } from '@suite-common/wallet-core';
 import { type Account, type PrecomposedTransactionFinal } from '@suite-common/wallet-types';
 import TrezorConnect from '@trezor/connect';
-import type {
-    CallMethodKeys,
-    EthereumSignTransaction,
-    EthereumSignTypedData,
-} from '@trezor/connect';
+import type { CallMethodKeys, EthereumSignTransaction } from '@trezor/connect';
 import { type MethodInfo } from '@trezor/connect/src/core/AbstractMethod';
 import { getSerializedPath, validatePath } from '@trezor/connect/src/utils/pathUtils';
 
@@ -19,7 +15,7 @@ import { connectPopupActions } from '../connectPopupActions';
 import { createPlaceholderAccount } from './utils';
 import { getPermissionDeferred } from '../connectPopupPromiseManager';
 import { selectConnectPopupCall } from '../connectPopupReducer';
-import { type PostCallHookParams, type PreCallHookParams } from './types';
+import { type PostCallHookParams, type PreCallHookParams, isCallMethod } from './types';
 
 const temporaryAccounts: Account[] = [];
 
@@ -62,18 +58,21 @@ const preCallHook = async <M extends CallMethodKeys>({
         // Parse common parameters (path, chainId) from payload
         let path: Bip43Path;
         let chainId = 1;
-        if (method === 'ethereumSignTransaction') {
-            const typedPayload = payload as any as EthereumSignTransaction;
-            path = getSerializedPath(validatePath(typedPayload.path)) as Bip43Path;
-            chainId = typedPayload.transaction.chainId || 1;
+        if (isCallMethod(method, 'ethereumSignTransaction', payload)) {
+            path = getSerializedPath(validatePath(payload.path)) as Bip43Path;
+            chainId = payload.transaction.chainId || 1;
 
             if (txSigningPrecomposed) {
-                dispatch(_storePrecomposedTransaction({ typedPayload, txSigningPrecomposed }));
+                dispatch(
+                    _storePrecomposedTransaction({
+                        typedPayload: payload,
+                        txSigningPrecomposed,
+                    }),
+                );
             }
-        } else if (method === 'ethereumSignTypedData') {
-            const typedPayload = payload as any as EthereumSignTypedData<any>;
-            path = getSerializedPath(validatePath(typedPayload.path)) as Bip43Path;
-            chainId = Number(typedPayload.data.domain.chainId) || 1;
+        } else if (isCallMethod(method, 'ethereumSignTypedData', payload)) {
+            path = getSerializedPath(validatePath(payload.path)) as Bip43Path;
+            chainId = Number(payload.data.domain.chainId) || 1;
         } else {
             return;
         }
@@ -110,7 +109,7 @@ const preCallHook = async <M extends CallMethodKeys>({
             const device = selectSelectedDevice(getState());
             if (!device) throw new Error('No device selected');
             const accountAddress = await TrezorConnect.ethereumGetAddress({
-                path: (payload as any).path,
+                path,
                 device: {
                     path: device.path,
                     instance: device.instance,
@@ -129,18 +128,20 @@ const preCallHook = async <M extends CallMethodKeys>({
         }
 
         // Modify payload to include selected fee, if present
-        if (method === 'ethereumSignTransaction' && source.type === 'walletconnect') {
+        if (
+            isCallMethod(method, 'ethereumSignTransaction', payload) &&
+            source.type === 'walletconnect'
+        ) {
             const currentPopupCall = selectConnectPopupCall(getState());
-            const typedPayload = payload as any as EthereumSignTransaction;
             if (
                 (currentPopupCall?.state === 'ongoing' ||
                     currentPopupCall?.state === 'tx-simulation') &&
                 currentPopupCall?.selectedFee
             ) {
                 const modifiedPayload = {
-                    ...typedPayload,
+                    ...payload,
                     transaction: {
-                        ...typedPayload.transaction,
+                        ...payload.transaction,
                         ...currentPopupCall.selectedFee,
                     },
                 } satisfies EthereumSignTransaction;
@@ -154,11 +155,17 @@ const preCallHook = async <M extends CallMethodKeys>({
                 if (!methodInfo.success) {
                     throw methodInfo.error;
                 }
-                txSigningPrecomposed = (methodInfo.payload as any as MethodInfo).precomposed;
+                const infoPayload = methodInfo.payload as MethodInfo;
+                txSigningPrecomposed = infoPayload.precomposed;
                 if (txSigningPrecomposed)
-                    dispatch(_storePrecomposedTransaction({ typedPayload, txSigningPrecomposed }));
+                    dispatch(
+                        _storePrecomposedTransaction({
+                            typedPayload: payload,
+                            txSigningPrecomposed,
+                        }),
+                    );
 
-                return modifiedPayload as any as typeof payload;
+                return modifiedPayload;
             }
         }
     } catch (error) {

--- a/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
@@ -58,21 +58,25 @@ const preCallHook = async <M extends CallMethodKeys>({
         // Parse common parameters (path, chainId) from payload
         let path: Bip43Path;
         let chainId = 1;
-        if (isCallMethod(method, 'ethereumSignTransaction', payload)) {
-            path = getSerializedPath(validatePath(payload.path)) as Bip43Path;
-            chainId = payload.transaction.chainId || 1;
+        // Cast to unknown because the generic `payload: Omit<CallMethodParams<M>, 'method'>`
+        // would intersect badly with the predicate's narrowed shape in the else-if branch
+        // and collapse the second variant to `never`.
+        const erasedPayload: unknown = payload;
+        if (isCallMethod(method, 'ethereumSignTransaction', erasedPayload)) {
+            path = getSerializedPath(validatePath(erasedPayload.path)) as Bip43Path;
+            chainId = erasedPayload.transaction.chainId || 1;
 
             if (txSigningPrecomposed) {
                 dispatch(
                     _storePrecomposedTransaction({
-                        typedPayload: payload,
+                        typedPayload: erasedPayload,
                         txSigningPrecomposed,
                     }),
                 );
             }
-        } else if (isCallMethod(method, 'ethereumSignTypedData', payload)) {
-            path = getSerializedPath(validatePath(payload.path)) as Bip43Path;
-            chainId = Number(payload.data.domain.chainId) || 1;
+        } else if (isCallMethod(method, 'ethereumSignTypedData', erasedPayload)) {
+            path = getSerializedPath(validatePath(erasedPayload.path)) as Bip43Path;
+            chainId = Number(erasedPayload.data.domain.chainId) || 1;
         } else {
             return;
         }
@@ -155,7 +159,9 @@ const preCallHook = async <M extends CallMethodKeys>({
                 if (!methodInfo.success) {
                     throw methodInfo.error;
                 }
-                const infoPayload = methodInfo.payload as MethodInfo;
+                // `__info: true` makes Connect return a MethodInfo payload at runtime,
+                // but the TS overload still resolves to the regular signed-tx shape.
+                const infoPayload = methodInfo.payload as unknown as MethodInfo;
                 txSigningPrecomposed = infoPayload.precomposed;
                 if (txSigningPrecomposed)
                     dispatch(

--- a/suite-common/connect-popup/src/methodHooks/solanaSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/solanaSignTransaction.ts
@@ -5,11 +5,11 @@ import {
     sendFormActions,
 } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
-import type { CallMethodKeys, SolanaSignTransaction } from '@trezor/connect';
+import type { CallMethodKeys } from '@trezor/connect';
 import { getSerializedPath, validatePath } from '@trezor/connect/src/utils/pathUtils';
 
 import { connectPopupActions } from '../connectPopupActions';
-import { type PostCallHookParams, type PreCallHookParams } from './types';
+import { type PostCallHookParams, type PreCallHookParams, isCallMethod } from './types';
 import { createPlaceholderAccount } from './utils';
 
 const temporaryAccounts: Account[] = [];
@@ -22,8 +22,8 @@ const preCallHook = async <M extends CallMethodKeys>({
     txSigningPrecomposed,
 }: PreCallHookParams<M>) => {
     try {
-        if (method === 'solanaSignTransaction' && txSigningPrecomposed) {
-            const typedPayload = payload as any as SolanaSignTransaction;
+        if (isCallMethod(method, 'solanaSignTransaction', payload) && txSigningPrecomposed) {
+            const typedPayload = payload;
             const path = getSerializedPath(validatePath(typedPayload.path)) as Bip43Path;
             const network = getNetwork(typedPayload.additionalInfo?.isDevnet ? 'dsol' : 'sol');
             // Try to find matching account

--- a/suite-common/connect-popup/src/methodHooks/types.ts
+++ b/suite-common/connect-popup/src/methodHooks/types.ts
@@ -36,5 +36,5 @@ export type PostCallHookParams<M extends CallMethodKeys> = PreCallHookParams<M> 
 export const isCallMethod = <K extends CallMethodKeys>(
     method: CallMethodKeys,
     targetMethod: K,
-    payload: unknown,
-): payload is Omit<CallMethodParams<K>, 'method'> => method === targetMethod;
+    _payload: unknown,
+): _payload is Omit<CallMethodParams<K>, 'method'> => method === targetMethod;

--- a/suite-common/connect-popup/src/methodHooks/types.ts
+++ b/suite-common/connect-popup/src/methodHooks/types.ts
@@ -23,3 +23,18 @@ export type PostCallHookParams<M extends CallMethodKeys> = PreCallHookParams<M> 
     originalPayload: Omit<CallMethodParams<M>, 'method'>;
     response: Ok<CallMethodResponse<M>> | Err<SerializedError>;
 };
+
+/**
+ * Narrows method+payload pair to a specific method `K`. TypeScript can't infer
+ * that `payload` matches `CallMethodParams<K>` from a generic `M extends CallMethodKeys`
+ * just by checking `method === K`, so we encode the relationship in a type guard.
+ *
+ * The `payload` parameter is typed as `unknown` to avoid an intersection between
+ * `CallMethodParams<M>` and `CallMethodParams<K>` (which would collapse to `never`
+ * for distinct methods); after the predicate we narrow it directly to `K`'s shape.
+ */
+export const isCallMethod = <K extends CallMethodKeys>(
+    method: CallMethodKeys,
+    targetMethod: K,
+    payload: unknown,
+): payload is Omit<CallMethodParams<K>, 'method'> => method === targetMethod;


### PR DESCRIPTION
## Summary

- Adds `isCallMethod` type guard in `methodHooks/types.ts` that narrows the generic `payload` to a specific method's payload shape based on a runtime method-name check. The guard takes `payload` as `unknown` so the predicate doesn't intersect with the generic input type (which would collapse to `never` for distinct methods).
- Replaces `payload as any as <MethodPayload>` double casts in the bitcoin / solana / ethereum sign-transaction hooks with `isCallMethod(method, '...', payload)` narrowing. The compiler now verifies field access on `payload` instead of trusting a forced cast.
- In `addressConfirmation` post-call hook, the per-coin display-address logic switches from a method-name based cast to structural narrowing on the response item shape (`'publicKeyBase58' in item`); `SolanaPublicKey` is added to the bundled response union so the cast is no longer needed.

No behavior changes — purely a typing improvement that removes 10 `as any` casts from the connect-popup method hooks.

## Test plan

- [ ] `yarn workspace @suite-common/connect-popup type-check` passes (verified locally; only preexisting unrelated errors remain)
- [ ] Manual smoke: trigger an Ethereum / Bitcoin / Solana sign transaction via connect popup and confirm the address-confirmation flow still renders correctly for SOL public-key responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are focused on connect-popup method hooks for address confirmation, Bitcoin/Ethereum/Solana transaction signing, and shared types. These are specialized hooks consumed by the TrezorConnect popup flow. The highest risk is in TrezorConnect E2E tests that directly exercise signing and address confirmation through the popup. The 121-test static mapping is due to broad transitive imports and most of those tests (analytics, backup, settings, etc.) do not exercise the connect popup method hooks at all. Testing should focus on the trezor-connect test suite which directly uses TrezorConnect API calls through the popup.

<details><summary><b>Changed files (5)</b></summary>

- `suite-common/connect-popup/src/methodHooks/addressConfirmation.ts`
- `suite-common/connect-popup/src/methodHooks/bitcoinSignTransaction.ts`
- `suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts`
- `suite-common/connect-popup/src/methodHooks/solanaSignTransaction.ts`
- `suite-common/connect-popup/src/methodHooks/types.ts`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — This test directly exercises Ethereum transaction signing via TrezorConnect, which is the exact flow that ethereumSignTransaction.ts method hook would intercept and customize in the connect popup. Changes to the method hook could alter confirmation UI or transaction handling.
- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test covers the full TrezorConnect popup flow including address confirmation, which directly exercises the addressConfirmation method hook. The popup flow is the primary consumer of these connect-popup method hooks.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — Similar to the web popup test, this exercises TrezorConnect popup address confirmation flow via webextension, directly consuming the addressConfirmation method hook. Changes could break the permissions/confirmation UX in extensions.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — This test exercises TrezorConnect.getAddress with address verification on device, which directly uses the addressConfirmation method hook for the verify/confirmed badge UI flow.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — This test signs a Bitcoin transaction via TrezorConnect, directly exercising the bitcoinSignTransaction method hook which handles the confirm-on-device prompts during BTC transaction signing.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts` — This test exercises Ethereum signing through TrezorConnect with permissions and device confirmation. While it tests message signing rather than transaction signing, it shares the connect popup infrastructure that the ethereumSignTransaction hook modifies.
- `suite/e2e/tests/trezor-connect/error.test.ts` — This test exercises TrezorConnect error handling for ethereumGetAddress with an invalid path. Changes to the connect-popup method hooks and types could affect how errors are surfaced in the popup error modal.
- `suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — This test uses TrezorConnect with account selection via the popup permissions modal. Changes to the method hooks types could affect the popup behavior for non-signing connect methods.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — This test covers TrezorConnect permissions granting and revocation through the connect popup. The method hooks are part of the popup infrastructure, and type changes could affect the permission flow.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/connect-popup/src/methodHooks/solanaSignTransaction.ts`

_Updated: 2026-05-04T07:56:35.725Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/fix-as-any-quickwins&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/fix-as-any-quickwins&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/fix-as-any-quickwins&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy Negative scenarios > Buy form handles input limits and empty quotes | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-04T09:39:36.547Z • 12 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-04T07:59:53.604Z • 13 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/fix-as-any-quickwins/web/](https://dev.suite.sldev.cz/suite-web/mroz22/fix-as-any-quickwins/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->