### PR TITLE
fix(suite): remove debug console.log from Address component

### DIFF
--- a/packages/suite/src/components/suite/Address.tsx
+++ b/packages/suite/src/components/suite/Address.tsx
@@ -86,7 +86,6 @@ export const Address = ({
     const deviceModelInternal = selectedDevice?.features?.internal_model || DEFAULT_FLAGSHIP_MODEL;
     const isChunkedSettings = useSelector(selectAddressDisplayType);
     const isAddressChunked = isChunked ?? isChunkedSettings === 'chunked';
-    console.log(isAddressChunked);
 
     const formattedValue = AddressFormatter.format(value, {
         format: isTruncated ? 'long' : 'full',


### PR DESCRIPTION
## Description

Removes a leftover `console.log(isAddressChunked)` debug statement from the `Address` component.

## Notes for QA

No functional changes — this only removes a debug log. No testing needed.

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is to Address.tsx, a shared UI component that renders cryptocurrency addresses across the Suite application. It maps to 121 tests, indicating it is a widely-used component. The highest risk areas are where addresses are directly displayed, revealed, copied, or verified — primarily the receive address flows and address labeling features. The recommended strategy focuses on tests that directly exercise address rendering and interaction (receive, copy, verify on device, label), while omitting the vast majority of tests that merely transitively import this component without meaningfully exercising address display logic.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/suite/Address.tsx`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/metadata/legacy/address-metadata.test.ts` — This test directly exercises address labeling on Bitcoin receive addresses, which uses the Address component to display and label addresses. Changes to Address.tsx could affect how addresses are rendered, truncated, or interacted with in the receive/labeling flow.
- `suite/e2e/tests/wallet/receive.test.ts` — This test reveals receive addresses for multiple cryptocurrencies (BTC, ETH, SOL, TRX), copies them to clipboard, and validates their format. The Address component is likely used to render these receive addresses, making this a direct consumer of the changed file.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/wallet/cardano.test.ts` — This test verifies Cardano receive address display, device confirmation of addresses, and copying addresses. The Address component is likely used to render the formatted Cardano address, and changes could affect address display or copy functionality.
- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts` — This test reveals and verifies Cardano receive addresses behind a passphrase wallet, checking address output values and copy address buttons. The Address component likely renders the revealed address, so changes could affect address display.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — This test exercises the receive address flow including revealing addresses, verifying them on device, and copying them. The Address component is likely used to display the BTC address in the receive modal.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — This test reveals and verifies BTC receive addresses for multiple passphrase wallets and validates address display on both the app and device. The Address component likely renders these addresses.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test exercises the global receive flow including revealing an ETH address, verifying it matches the device display, and copying it. The Address component is likely used to render the receive address in the global receive modal.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/wallet/pagination.test.ts` — This test verifies transaction addresses displayed on paginated pages. The Address component may be used to render transaction addresses in the transaction list, and changes could affect address truncation or formatting.

</details>

_Updated: 2026-05-04T08:30:46.828Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=remove-console-log-address&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=remove-console-log-address&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-04T08:35:40.818Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-04T08:34:14.004Z • 13 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->