### PR TITLE
fix(suite): surface connect bootstrap errors

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectErrorModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectErrorModal.tsx
@@ -122,6 +122,24 @@ export const ConnectErrorModal = () => {
         if (isCancelled) return <Translation id="TR_CONNECT_ERROR_CANCELED" />;
         if (isNoTransportError) return <Translation id="TR_BRIDGE_NEEDED_DESCRIPTION" />;
 
+        if (popupCall.error?.code === 'Handshake_Error') {
+            if (popupCall.error.message === 'popup-blocked')
+                return <Translation id="TR_CONNECT_ERROR_POPUP_BLOCKED" />;
+            if (
+                popupCall.error.message === 'handshake-timeout' ||
+                popupCall.error.message === 'iframe-timeout'
+            )
+                return <Translation id="TR_CONNECT_ERROR_HANDSHAKE_TIMEOUT" />;
+            if (popupCall.error.message === 'iframe-blocked')
+                return <Translation id="TR_CONNECT_ERROR_IFRAME_BLOCKED" />;
+            if (popupCall.error.message === 'env-not-supported')
+                return <Translation id="TR_CONNECT_ERROR_ENV_NOT_SUPPORTED" />;
+            if (popupCall.error.message === 'storage-access-denied')
+                return <Translation id="TR_CONNECT_ERROR_STORAGE_ACCESS_DENIED" />;
+
+            return <Translation id="TR_CONNECT_ERROR_GENERIC_DESCRIPTION" />;
+        }
+
         if (popupCall.error?.message === UI_REQUEST.BOOTLOADER)
             return <Translation id="TR_DEVICE_IN_BOOTLOADER" />;
         if (popupCall.error?.message === UI_REQUEST.NOT_IN_BOOTLOADER)

--- a/packages/suite/src/support/suite/useConnectPopupWeb.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupWeb.tsx
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import { connectPopupActions } from '@suite-common/connect-popup';
 import { CORE_CALL, POPUP } from '@trezor/connect';
+
+import { useDispatch } from 'src/hooks/suite';
 
 import {
     type ConnectPopupLink,
@@ -15,6 +18,7 @@ const webChannel = {
 };
 
 export const useConnectPopupWeb = () => {
+    const dispatch = useDispatch();
     const [incomingMessages, setIncomingMessages] = useState<ConnectPopupMessage[]>([]);
     // Start with '*' because we don't know the opener's origin yet.
     // Protocol messages sent before the first incoming message (e.g.
@@ -42,12 +46,7 @@ export const useConnectPopupWeb = () => {
         return {
             sendMessage: (message: ConnectPopupOutgoingMessage) => {
                 message.channel = webChannel;
-                if (broadcast) {
-                    broadcast.postMessage(message);
-                } else {
-                    // TODO: show warning to user
-                    console.warn('BroadcastChannel not available', initialUrl.current);
-                }
+                broadcast.postMessage(message);
             },
             get origin() {
                 return originRef.current;
@@ -73,8 +72,12 @@ export const useConnectPopupWeb = () => {
         }
 
         if (requestErr) {
-            // TODO: show warning to user
-            console.warn('Popup opened with error', { requestErr });
+            dispatch(
+                connectPopupActions.setError({
+                    code: 'Handshake_Error',
+                    message: requestErr,
+                }),
+            );
 
             return;
         }
@@ -83,9 +86,13 @@ export const useConnectPopupWeb = () => {
         try {
             broadcastChannel = new BroadcastChannel(`@trezor/connect-popup/${requestId}`);
             setBroadcast(broadcastChannel);
-        } catch (error) {
-            // TODO: show warning to user
-            console.warn('BroadcastChannel is not supported in this browser', error);
+        } catch {
+            dispatch(
+                connectPopupActions.setError({
+                    code: 'Popup_ConnectionMissing',
+                    message: 'BroadcastChannel is not supported in this browser',
+                }),
+            );
 
             return;
         }
@@ -95,8 +102,12 @@ export const useConnectPopupWeb = () => {
             broadcastChannel.removeEventListener('message', onMessage);
             broadcastChannel.close();
             setBroadcast(null);
-            // TODO: show warning to user
-            console.warn('Popup handshake timeout');
+            dispatch(
+                connectPopupActions.setError({
+                    code: 'Handshake_Error',
+                    message: 'handshake-timeout',
+                }),
+            );
         }, 3000);
 
         const onMessage = (event: MessageEvent) => {
@@ -155,5 +166,5 @@ export const useConnectPopupWeb = () => {
             broadcastChannel.close();
             window.removeEventListener('beforeunload', onBeforeUnload);
         };
-    }, []);
+    }, [dispatch]);
 };

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -11112,6 +11112,28 @@ export const messages = defineMessages({
         id: 'TR_CONNECT_ERROR_CANCELED',
         defaultMessage: 'Request was canceled by the user',
     },
+    TR_CONNECT_ERROR_POPUP_BLOCKED: {
+        id: 'TR_CONNECT_ERROR_POPUP_BLOCKED',
+        defaultMessage:
+            'The popup window was blocked by your browser. Please allow popups for this website.',
+    },
+    TR_CONNECT_ERROR_HANDSHAKE_TIMEOUT: {
+        id: 'TR_CONNECT_ERROR_HANDSHAKE_TIMEOUT',
+        defaultMessage: 'The connection timed out. Please try again.',
+    },
+    TR_CONNECT_ERROR_IFRAME_BLOCKED: {
+        id: 'TR_CONNECT_ERROR_IFRAME_BLOCKED',
+        defaultMessage:
+            'The connection was blocked by your browser. Check your content blocking settings.',
+    },
+    TR_CONNECT_ERROR_ENV_NOT_SUPPORTED: {
+        id: 'TR_CONNECT_ERROR_ENV_NOT_SUPPORTED',
+        defaultMessage: 'Your browser or environment does not support Trezor Connect.',
+    },
+    TR_CONNECT_ERROR_STORAGE_ACCESS_DENIED: {
+        id: 'TR_CONNECT_ERROR_STORAGE_ACCESS_DENIED',
+        defaultMessage: 'Storage access was denied. Please check your browser privacy settings.',
+    },
     TR_NO_CONNECTED_APPS_DESCRIPTION: {
         id: 'TR_NO_CONNECTED_APPS_DESCRIPTION',
         defaultMessage: 'Use your Trezor with third-party apps and wallets to manage your assets.',


### PR DESCRIPTION
## Description

Resolves three `TODO: show warning to user` stubs in `useConnectPopupWeb` by dispatching `connectPopupActions.setError` instead of silently logging to console. Bootstrap failures — a `connect-popup-err` URL param from the connect-web side, `BroadcastChannel` not being supported by the browser, and a handshake timeout — now surface as errors in `ConnectErrorModal`. Also removes a dead `if (broadcast)` branch in `sendMessage` that could never be falsy in that closure.

## Notes for QA

To test: open a connect popup from Explorer with a bootstrap error (for example on Firefox) and verify the error modal appears instead of a blank/silent popup. 
Another possible error is the handshake timeout, than can be simulated by quickly closing the Connect Explorer tab while Suite is loading.

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to useConnectPopupWeb.tsx, which manages the TrezorConnect popup lifecycle for web/webextension contexts. This is a focused infrastructure hook with high impact on Connect popup flows but low direct impact on most other Suite features. The highest risk is in the TrezorConnect popup E2E tests that directly exercise popup open/close/cancel behaviors. Most of the 121 statically-mapped tests only transitively import this file through the Suite support layer and are unlikely to be affected.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/support/suite/useConnectPopupWeb.tsx`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test directly exercises the TrezorConnect popup web flow, which is precisely what useConnectPopupWeb.tsx implements. The hook manages the Connect popup lifecycle for web mode, and this test covers the full popup happy path, cancellation, force-close recovery, and popup-blocked scenarios — all behaviors that would break if the hook changes.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — This test exercises TrezorConnect popup behavior in the webextension context, which relies on the same popup web infrastructure managed by useConnectPopupWeb. It covers happy path, cancellation, force-close recovery, and popup focus behavior — all directly dependent on the popup lifecycle hook.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test covers Bridge session management and device status transitions across multiple browser tabs/sessions. The useConnectPopupWeb hook is part of the Suite web initialization, and changes could affect how sessions are acquired or how the app initializes in new tabs, potentially impacting session takeover behavior.
- `suite/e2e/tests/suite/initial-run.test.ts` — This test validates the initial run/onboarding flow persistence across reloads, including THP pairing code entry and device connection prompts. The useConnectPopupWeb hook is part of Suite's web support infrastructure that initializes during app startup, so changes could affect the initial connection flow.

</details>

_Updated: 2026-05-04T08:45:56.711Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=connect-popup-web-warnings&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=connect-popup-web-warnings&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-07T07:51:19.440Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-07T07:49:51.504Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/connect-popup-web-warnings/web/](https://dev.suite.sldev.cz/suite-web/connect-popup-web-warnings/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->