### PR TITLE
Update Content-Security-Policy headers

### DIFF
--- a/packages/suite-web/constants/webSecurityHeaders.ts
+++ b/packages/suite-web/constants/webSecurityHeaders.ts
@@ -66,7 +66,7 @@ const PRODUCTION_SECURITY_HEADERS = {
         // Note that connect-src is a CSP policy that has nothing to do with the former TrezorConnect parameter of the same name
         'connect-src': ['data:', '*'],
         'upgrade-insecure-requests': true,
-        'script-src': ['self', 'unsafe-eval'],
+        'script-src': ['self'],
         'form-action': ['self'],
         'frame-ancestors': ['self'],
         'base-uri': ['none'],

--- a/packages/suite-web/constants/webSecurityHeaders.ts
+++ b/packages/suite-web/constants/webSecurityHeaders.ts
@@ -70,7 +70,7 @@ const PRODUCTION_SECURITY_HEADERS = {
         'form-action': ['self'],
         'frame-ancestors': ['self'],
         'base-uri': ['none'],
-        'object-src': ['self'],
+        'object-src': ['none'],
         // trezorsuite deeplinks are opened using iframes to avoid issues with navigation
         'frame-src': ['self', 'trezorsuite://*'],
         'report-uri': SENTRY_REPORT_URL,

--- a/packages/suite-web/constants/webSecurityHeaders.ts
+++ b/packages/suite-web/constants/webSecurityHeaders.ts
@@ -71,6 +71,8 @@ const PRODUCTION_SECURITY_HEADERS = {
         'frame-ancestors': ['self'],
         'base-uri': ['none'],
         'object-src': ['self'],
+        // trezorsuite deeplinks are opened using iframes to avoid issues with navigation
+        'frame-src': ['self', 'trezorsuite://*'],
         'report-uri': SENTRY_REPORT_URL,
         'report-to': 'csp-endpoint',
     },

--- a/packages/suite-web/types/securityHeaders.ts
+++ b/packages/suite-web/types/securityHeaders.ts
@@ -13,6 +13,7 @@ export type ContentSecurityPolicyRules = {
     'frame-ancestors': string[];
     'base-uri': string[];
     'object-src': string[];
+    'frame-src': string[];
 };
 
 /**


### PR DESCRIPTION
## Description

1. Remove `unsafe-eval` from Content-Security-Policy after removal of protobufjs library
2. Add `frame-src` directive, allowing `trezorsuite://*` for opening deeplinks (related #26952)
3. Harden `object-src` directive to `none`, it shouldn't be used

Full updated content: 
```
default-src 'self'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-elem 'self' 'unsafe-inline'; img-src 'self' blob: data: https://*.trezor.io; connect-src data: *; upgrade-insecure-requests; script-src 'self'; form-action 'self'; frame-ancestors 'self'; base-uri 'none'; object-src 'none'; frame-src 'self' trezorsuite://*; report-uri https://o117836.ingest.us.sentry.io/api/5193825/security/?sentry_key=6d91ca6e6a5d4de7b47989455858b5f6; report-to csp-endpoint
```

## Deployment progress

- [x] sldev
- [ ] staging Suite
- [ ] prod Suite

## Notes for QA

Make sure basic Suite flows work correctly and no Content-Security-Policy errors show up in console.

## Related Issue

Resolve #27151, resolve #26952

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is limited to web security headers configuration in suite-web, which has no direct static test coverage. Security headers (CSP, CORS, X-Frame-Options, etc.) primarily affect HTTP response behavior and resource loading policies rather than application logic. The risk is low for functional regressions but could impact page loading across different browsers or cause resource blocking if CSP directives are misconfigured. A small set of browser-compatibility and link-checking tests is recommended to catch any loading issues, but most E2E tests are unlikely to be affected since they test application functionality rather than HTTP header behavior.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite-web/constants/webSecurityHeaders.ts`

</details>

**Recommended tests (3)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `../../suite/e2e/tests/general/check-links.test.ts` — This test crawls all application routes and checks HTTP responses for links. Web security headers (CSP, X-Frame-Options, etc.) can affect how pages load and whether resources are blocked, potentially causing page load failures or missing content that this test would detect.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `../../suite/e2e/tests/browser/safari.test.ts` — Security headers changes could affect how the web app loads in different browsers. Safari has stricter security policies, and changes to headers like CSP or X-Frame-Options could cause the app to fail to load or behave differently in WebKit.
- `../../suite/e2e/tests/browser/firefox.test.ts` — Similar to Safari, Firefox may interpret security header changes differently. This test verifies the app loads successfully in Firefox without unsupported-browser warnings, which could be affected by header misconfiguration.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite-web/constants/webSecurityHeaders.ts`

_Updated: 2026-05-04T08:46:31.091Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/remove-unsafe-eval-csp&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/remove-unsafe-eval-csp&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-06T11:46:20.655Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-07T08:46:32.233Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/remove-unsafe-eval-csp/web/](https://dev.suite.sldev.cz/suite-web/chore/remove-unsafe-eval-csp/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->