### PR TITLE
fix(trading): use selected token balance for swap percentages

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
@@ -80,15 +80,16 @@ export const useTradingFormActions = <T extends TradingSellExchangeFormProps>({
     const { outputs, sendCryptoSelect } = getValues();
     const values = useWatch<TradingSellExchangeFormProps>({ control });
     const previousValues = useRef<typeof values | null>(isNotFormPage ? draftUpdated : null);
-    const tokenAddress = outputs?.[0]?.token;
-    const tokenData = account.tokens?.find(t => t.contract === tokenAddress);
-    const isBalanceZero = tokenData
-        ? isZero(tokenData.balance || '0')
-        : isZero(account.formattedBalance);
-
     const sendCryptoAccount = useSelector(state =>
         selectAccountByKey(state, sendCryptoSelect?.accountKey),
     );
+    const tokenAddress = outputs?.[0]?.token;
+    const tokenData = (sendCryptoAccount ?? account).tokens?.find(
+        t => t.contract.toLowerCase() === tokenAddress?.toLowerCase(),
+    );
+    const isBalanceZero = tokenData
+        ? isZero(tokenData.balance || '0')
+        : isZero(account.formattedBalance);
     const tradingFiatValues = useTradingFiatValues({
         cryptoId: sendCryptoSelect?.id,
         amount: sendCryptoAccount?.balance,
@@ -247,7 +248,7 @@ export const useTradingFormActions = <T extends TradingSellExchangeFormProps>({
         const cryptoAmountWithReserve = isNetworkReserveEnabled
             ? getCryptoAmountWithReserve({
                   symbol: account.symbol,
-                  contractAddress: tokenAddress,
+                  contractAddress: tokenAddress ?? tokenData?.contract,
                   balance: account.formattedBalance,
                   amount: cryptoInputValue,
                   fee: feeInUnits?.toString(),


### PR DESCRIPTION
## Description

- compare EVM token contract addresses case-insensitively when resolving the selected swap token balance
- use the matched token balance for percentage-based amount buttons in swap instead of falling back to the native account balance when address casing differs
- keep the native balance fallback only for non-token swaps where no token is selected

## Notes for QA

- Success path: in Swap on an EVM account with an ERC-20 token balance, select the token as the From asset, click 25% / 50% / 100%, and verify the amount is calculated from the token balance
- Regression: switch between the native coin and an ERC-20 token, use the percentage buttons in both cases, and verify each amount is based on the currently selected asset balance
- Edge path: use a token whose contract address casing differs between the selected asset and account token list, and verify the percentage buttons still use that token balance

## Related Issue

Resolve #27288

## Screenshots:

N/A

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to useTradingFormActions.ts, a common hook shared across all trading form types (buy, sell, swap, and staking). This file maps to 121 tests via static analysis, but the vast majority are unrelated (backup, onboarding, browser, metadata, etc.) and only transitively import it. The real risk is concentrated in the trading flows — buy, sell, swap, and staking form tests — which directly exercise the form action logic. The recommended strategy prioritizes full coverage of the three core trading types (buy/sell/swap) with at least one test each at high priority, then adds medium-priority tests for additional networks, tokens, fee handling, and input validation edge cases.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts`

</details>

**Recommended tests (20)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — useTradingFormActions is a hook directly used in trading form flows. This navigation test exercises multiple trading form entry points (Buy, Sell, Swap) from various locations, directly triggering the trading form initialization where this hook would be invoked.
- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — This test exercises the full buy trading flow including filling the buy form, requesting quotes, confirming trades, and watching transaction status. The useTradingFormActions hook likely governs form submission actions and trade confirmation logic used directly in this flow.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — Tests the buy flow for Ethereum including form fill, quote display, trade confirmation, and redirect handling. useTradingFormActions is a common trading form hook that would be exercised during these form actions.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — Covers the complete sell flow for Bitcoin including form fill, best offer selection, trade confirmation, and device prompt for sending. The trading form actions hook is shared across buy/sell/swap forms and directly affects sell form behavior.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Tests the full SOL-to-BTC swap flow including form fill, offer selection, device confirmation, and transaction status progression. useTradingFormActions is the common hook powering form actions across all trading types including swap.

</details>

<details><summary>🟡 <b>Medium priority (12)</b></summary>

- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Tests Ethereum sell flow with custom gas fees and trade confirmation. Exercises the trading form actions for a different network (ETH) than BTC, verifying the hook works correctly with Ethereum-specific fee handling.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Covers sell flow for Solana including offer comparison, payment method changes, and selecting non-best offers. Tests a third network type through the shared trading form actions, increasing coverage of the hook across different coin types.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Tests cross-network swap (SOL to USDC on Ethereum) which exercises the trading form actions hook with token-level asset selection and cross-chain receive address handling.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — Tests buying an SPL token (Jupiter/JUP) with crypto amount input and fiat/crypto switching. Exercises the trading form actions hook with token-level buy flows and input mode switching.
- `suite/e2e/tests/trading/buy-negative.test.ts` — Tests buy form validation edge cases (max/min limits, empty quotes). The trading form actions hook likely handles form validation state and error display that this test exercises.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Tests sell form input validation (decimal limits, insufficient funds, percentage buttons, max calculation). These input behaviors are likely managed by or interact with useTradingFormActions.
- `suite/e2e/tests/trading/staking-form.test.ts` — Tests the ETH staking form validation and input handling (min amount, decimals, percentage buttons, max button, crypto/fiat switching). The staking form shares the common trading form infrastructure including useTradingFormActions.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Tests BTC-to-ETH swap with custom fee settings. The fee handling in swap forms likely depends on useTradingFormActions for composing the transaction with custom fees.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests ETH-to-BTC swap with custom Ethereum gas parameters. Verifies that custom fee settings are correctly passed through the swap flow, which depends on the trading form actions hook.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Tests selling an ERC-20 token (USDC) which exercises the trading form actions hook with token-level sell flows on Ethereum.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Tests swapping a Solana USDT token to BTC, exercising the trading form actions with token-to-coin cross-chain swap logic.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Tests swapping between two SPL tokens (USDT to USDC) on Solana, covering same-network token swap form actions.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/trading/swap-history.test.ts` — Tests swap transaction history display which may be populated via form actions that create trade records. While primarily a read-only view, the trade data originates from the form actions flow.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — Tests swap form behavior when the buy asset's network is disabled. This edge case in the swap form may exercise useTradingFormActions for handling disabled-network scenarios.
- `suite/e2e/tests/dashboard/assets.test.ts` — Tests initiating a buy action from the dashboard assets section which navigates to the trading page. The buy button click triggers trading form initialization that uses useTradingFormActions.

</details>

_Updated: 2026-05-04T09:39:53.363Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/trading-selected-token-percentage-27288/web/](https://dev.suite.sldev.cz/suite-web/fix/trading-selected-token-percentage-27288/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy Negative scenarios > Buy form handles input limits and empty quotes | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-04T09:44:45.364Z • 12 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-04T09:43:28.030Z • 13 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trading-selected-token-percentage-27288&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->