### PR TITLE
Stablecoin Yield Fixes

### DIFF
--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBanner.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBanner.tsx
@@ -49,7 +49,10 @@ export const EarnYieldClaimRewardsBanner = ({
                     {isValueLoading ? (
                         <SkeletonRectangle width={50} height={16} animate />
                     ) : (
-                        <BaseCurrencyAmountFormatter value={value} currency={currency} />
+                        <>
+                            {!isClaimDisabled && '≈ '}
+                            <BaseCurrencyAmountFormatter value={value} currency={currency} />
+                        </>
                     )}
                 </Row>
             }

--- a/packages/suite/src/components/earn/yield/claim/YieldClaim.tsx
+++ b/packages/suite/src/components/earn/yield/claim/YieldClaim.tsx
@@ -83,6 +83,10 @@ export const YieldClaim = ({ account }: YieldClaimProps) => {
         }
 
         dispatch(stablecoinYieldActions.initSession({ flowType: 'claim', flowKey }));
+
+        return () => {
+            dispatch(stablecoinYieldActions.disposeSession({ flowType: 'claim', flowKey }));
+        };
     }, [dispatch, flowKey]);
 
     useYieldPendingTransactionTracking({

--- a/packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 
+import { commonQueryKeys, useQueryClient } from '@suite-common/react-query';
 import {
     type YieldFlowType,
     fetchAndUpdateAccountThunk,
@@ -38,6 +39,7 @@ export const useYieldPendingTransactionTracking = ({
     flowKey,
 }: UseYieldPendingTransactionTrackingProps) => {
     const dispatch = useDispatch();
+    const queryClient = useQueryClient();
     const pendingTransaction = useSelector(
         state => selectStablecoinYieldSession(state, flowType, flowKey).action.pendingTransaction,
     );
@@ -110,9 +112,13 @@ export const useYieldPendingTransactionTracking = ({
                 }),
             );
 
+            if (flowType === 'claim') {
+                queryClient.refetchQueries({ queryKey: commonQueryKeys.merkleRewards() });
+            }
+
             return;
         }
 
         dispatch(stablecoinYieldActions.resetSession({ flowType, flowKey }));
-    }, [flowKey, flowType, pendingTransaction, dispatch, trackedPendingTransaction]);
+    }, [flowKey, flowType, pendingTransaction, dispatch, trackedPendingTransaction, queryClient]);
 };


### PR DESCRIPTION
## Description

This PR introduces several fixes for Stablecoin yield:

- resets session after claim has completed
- adds the approximator indicator `≈` for rewards
- NEEDS TO BE TESTED: refetch rewards after claim has completed

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to YieldClaim.tsx, a component in the earn/yield/claim path that handles staking reward claim UI. No static test mappings exist for this file, so all recommendations are inferred from LLM analysis of test behaviors. The highest risk is to tests that directly exercise claim flows (ETH unstake-then-claim, ADA claim rewards), followed by tests that validate staking dashboard states where the claim component is rendered. The recommended strategy is to run all staking claim-related tests at high priority and staking dashboard tests at medium priority to ensure the claim UI renders correctly across all supported networks (ETH, ADA, SOL).

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/earn/yield/claim/YieldClaim.tsx`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `../../suite/e2e/tests/staking/eth/unstake.test.ts` — YieldClaim.tsx is a component for claiming staking rewards/yield. The ETH unstake test exercises the full unstake-then-claim flow, including the claim card, claim modal, device confirmation for claiming, and post-claim balance updates. This is the most directly relevant test for a yield/claim component change.
- `../../suite/e2e/tests/staking/ada/claim.test.ts` — This test directly exercises the Cardano staking reward claim flow including claim button state, claim modal header (TR_EARN_CLAIM_REWARDS), device confirmation during claim, and post-claim balance/reward updates. The YieldClaim component likely renders the claim UI that this test validates.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `../../suite/e2e/tests/staking/eth/initial-stake.test.ts` — The initial ETH stake test covers the full staking dashboard lifecycle including progress indicators and staking amount displays. While focused on staking rather than claiming, changes to YieldClaim could affect the staking dashboard layout or shared earn/yield components.
- `../../suite/e2e/tests/staking/eth/stake-more.test.ts` — This test validates the staking dashboard with staked amounts, rewards display, and instant staking banner — components that share the earn/yield UI surface area with the claim component. Changes to YieldClaim could affect sibling component rendering.
- `../../suite/e2e/tests/staking/ada/unstake.test.ts` — The ADA unstake test validates claim-related UI states (claim rewards button disabled/hidden, staking sub-account visibility) which may be rendered by or interact with the YieldClaim component in the Cardano staking flow.
- `../../suite/e2e/tests/staking/ada/stake.test.ts` — This test checks claim rewards button state (disabled after staking) and reward amount display on the staking tab. The YieldClaim component likely controls the claim rewards button and reward display that this test asserts against.
- `../../suite/e2e/tests/staking/sol/unstake.test.ts` — The SOL unstake test includes a claim flow where the user claims unstaked SOL, verifies the claim card, claim modal, and device confirmation — directly exercising claim functionality that YieldClaim likely renders.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `../../suite/e2e/tests/staking/sol/rewards.test.ts` — This test validates staking amounts and rewards display on the Solana staking dashboard. YieldClaim changes could affect how rewards are presented in the claim-adjacent UI areas.
- `../../suite/e2e/tests/staking/staking-form.test.ts` — The staking form test covers the staking dashboard including amount displays that coexist with the claim component. A regression in YieldClaim rendering could plausibly affect the overall staking tab layout this test validates.

</details>

_Updated: 2026-05-04T09:59:05.714Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/earn-yield-fixes&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/earn-yield-fixes&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy Negative scenarios > Buy form handles input limits and empty quotes | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-04T10:12:57.064Z • 12 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-04T10:12:07.882Z • 13 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/earn-yield-fixes/web/](https://dev.suite.sldev.cz/suite-web/fix/earn-yield-fixes/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->