### PR TITLE
refactor(connect): unify *GetPublicKey response shape

### DIFF
--- a/packages/connect-common/src/types/api/__tests__/cardano.ts
+++ b/packages/connect-common/src/types/api/__tests__/cardano.ts
@@ -200,6 +200,8 @@ export const cardanoGetPublicKey = async (api: TrezorConnect) => {
         payload.path.map(p => p);
         payload.serializedPath.toLowerCase();
         payload.publicKey.toLowerCase();
+        payload.xpub.toLowerCase();
+        payload.displayablePublicKey.toLowerCase();
         payload.node.chain_code.toLowerCase();
         // @ts-expect-error
         payload.map(p => p);
@@ -212,6 +214,8 @@ export const cardanoGetPublicKey = async (api: TrezorConnect) => {
             item.path.map(p => p);
             item.serializedPath.toLowerCase();
             item.publicKey.toLowerCase();
+            item.xpub.toLowerCase();
+            item.displayablePublicKey.toLowerCase();
             item.node.chain_code.toLowerCase();
         });
         // @ts-expect-error

--- a/packages/connect-common/src/types/api/cardano/index.ts
+++ b/packages/connect-common/src/types/api/cardano/index.ts
@@ -85,6 +85,9 @@ export const CardanoGetPublicKey = Type.Intersect([
 ]);
 
 export interface CardanoPublicKey extends PublicKey {
+    /** Cardano extended public key (xpub). Equals `displayablePublicKey`. */
+    xpub: string;
+    /** Raw HDNode proto returned by the firmware. */
     node: PROTO.HDNodeType;
 }
 

--- a/packages/connect-common/src/types/api/solana/index.ts
+++ b/packages/connect-common/src/types/api/solana/index.ts
@@ -14,6 +14,8 @@ export const SolanaPublicKey = Type.Intersect([
         publicKeyBase58: Type.String(),
     }),
 ]);
+// Note: `publicKeyBase58` is required on Solana responses and equals
+// `displayablePublicKey` from the shared `PublicKey` base.
 
 // solanaSignTransaction
 

--- a/packages/connect-common/src/types/params.ts
+++ b/packages/connect-common/src/types/params.ts
@@ -103,7 +103,44 @@ export const GetPublicKey = Type.Object({
 
 export type PublicKey = Static<typeof PublicKey>;
 export const PublicKey = Type.Object({
+    /**
+     * Per-coin raw public key encoding:
+     * - Bitcoin/Ethereum: hex-encoded compressed public key (33 bytes)
+     * - Solana/Cardano: hex-encoded raw public key (32 bytes)
+     * - Tezos: base58check-encoded public key (`edpk…`)
+     */
     publicKey: Type.String(),
     path: Type.Array(Type.Number()),
     serializedPath: Type.String(),
+    /**
+     * Canonical user-facing representation of the public key for the given coin.
+     * - Bitcoin: `xpubSegwit ?? xpub` (SLIP-132 form matching the requested
+     *   scriptType, e.g. ypub/zpub for SegWit, `tr(...)` descriptor for Taproot)
+     * - Ethereum: `xpub`
+     * - Cardano: extended public key (xpub)
+     * - Solana: base58-encoded address (same value as `publicKeyBase58`)
+     * - Tezos: base58check-encoded public key, `edpk…` (same value as `publicKey`)
+     *
+     * Generic consumers (e.g. UI components that need to display *some* canonical
+     * identifier without knowing the coin) should read this field. Coin-specific
+     * consumers should read the per-coin response type instead, which exposes the
+     * fields that genuinely apply to that coin (e.g. `xpub`, `xpubSegwit`,
+     * `publicKeyBase58`, `node`).
+     *
+     * Relation to what firmware shows on the device screen for
+     * `showOnTrezor: true`:
+     * - Bitcoin (legacy/SegWit), Cardano, Solana, Tezos: byte-identical to the
+     *   firmware display.
+     * - Bitcoin Taproot: same logical descriptor, but firmware renders the bare
+     *   account-level form with `h`-notation (e.g. `tr([fp/86h/0h/0h]xpub…)`),
+     *   while this field is the BIP-389 multipath descriptor with `'`-notation
+     *   and trailing `/<0;1>/*` used to derive both external and change
+     *   addresses (e.g. `tr([fp/86'/0'/0']xpub…/<0;1>/*)`).
+     * - Ethereum: firmware shows the raw compressed public key (`publicKey`,
+     *   33 bytes hex); this field is the `xpub` because that's the more useful
+     *   identifier in host-side UIs. Suite displays the xpub, the device shows
+     *   the compressed key — both are correct representations of the same
+     *   underlying secp256k1 point at the requested path.
+     */
+    displayablePublicKey: Type.String(),
 });

--- a/packages/connect-explorer/src/pages/methods/bitcoin/getPublicKey.mdx
+++ b/packages/connect-explorer/src/pages/methods/bitcoin/getPublicKey.mdx
@@ -83,19 +83,29 @@ Result with only one public key
 {
     success: true,
     payload: {
-        path: Array<number>, // hardended path
-        serializedPath: string, // serialized path
-        xpub: string,        // xpub in legacy format
-        xpubSegwit?: string, // optional for segwit accounts: xpub in segwit format
-        chainCode: string,   // BIP-32 serialization format
-        childNum: number,    // BIP-32 serialization format
-        publicKey: string,   // BIP-32 serialization format
-        fingerprint: number, // BIP-32 serialization format
-        depth: number,       // BIP-32 serialization format
-        descriptor?: string, // BIP-380 descriptor. Not available for model One
+        path: Array<number>,          // hardended path
+        serializedPath: string,       // serialized path
+        xpub: string,                 // xpub in legacy format
+        xpubSegwit?: string,          // optional for segwit accounts: xpub in segwit format (SLIP-132)
+        chainCode: string,            // BIP-32 serialization format
+        childNum: number,             // BIP-32 serialization format
+        publicKey: string,            // BIP-32 serialization format
+        fingerprint: number,          // BIP-32 serialization format
+        depth: number,                // BIP-32 serialization format
+        descriptor?: string,          // BIP-380 descriptor. Not available for model One
+        displayablePublicKey: string, // canonical user-facing form: xpubSegwit ?? xpub (SLIP-132 form matching the requested scriptType — e.g. ypub/zpub for SegWit, tr(...) descriptor for Taproot)
     }
 }
 ```
+
+> **`displayablePublicKey` vs. firmware display.** For legacy and SegWit
+> accounts the field is byte-identical to what the device shows when
+> `showOnTrezor: true`. For Taproot the device renders the bare account-level
+> descriptor with `h`-notation (e.g. `tr([fp/86h/0h/0h]xpub…)`), whereas
+> `displayablePublicKey` is the BIP-389 multipath descriptor with
+> `'`-notation and trailing `/<0;1>/*` (e.g. `tr([fp/86'/0'/0']xpub…/<0;1>/*)`).
+> Both describe the same key; the multipath form is what host-side wallets need
+> to derive both external and change addresses.
 
 [Read more about BIP32 serialization format](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#Serialization_format)
 
@@ -105,9 +115,9 @@ Result with bundle of public keys
 {
     success: true,
     payload: [
-        { path, serializedPath, xpub, xpubSegwit?, chainCode, childNum, publicKey, fingerprint, depth, descriptor }, // account 1
-        { path, serializedPath, xpub, xpubSegwit?, chainCode, childNum, publicKey, fingerprint, depth, descriptor }, // account 2
-        { path, serializedPath, xpub, xpubSegwit?, chainCode, childNum, publicKey, fingerprint, depth, descriptor }  // account 3
+        { path, serializedPath, xpub, xpubSegwit?, chainCode, childNum, publicKey, fingerprint, depth, descriptor, displayablePublicKey }, // account 1
+        { path, serializedPath, xpub, xpubSegwit?, chainCode, childNum, publicKey, fingerprint, depth, descriptor, displayablePublicKey }, // account 2
+        { path, serializedPath, xpub, xpubSegwit?, chainCode, childNum, publicKey, fingerprint, depth, descriptor, displayablePublicKey }  // account 3
     ]
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/cardano/cardanoGetPublicKey.mdx
+++ b/packages/connect-explorer/src/pages/methods/cardano/cardanoGetPublicKey.mdx
@@ -86,9 +86,11 @@ Result with only one public key
 {
     success: true,
     payload: {
-        path: Array<number>, // hardended path
+        path: Array<number>, // BIP32 derivation path
         serializedPath: string,
-        publicKey: string,
+        publicKey: string,             // raw 32-byte public key in hex
+        xpub: string,                  // Cardano extended public key
+        displayablePublicKey: string,  // canonical user-facing form (= xpub)
         node: HDPubNode,
     }
 }
@@ -100,12 +102,18 @@ Result with a bundle of public keys
 {
     success: true,
     payload: [
-        { path: Array<number>, serializedPath: string, publicKey: string, node: HDPubNode }, // account 1
-        { path: Array<number>, serializedPath: string, publicKey: string, node: HDPubNode}, // account 2
-        { path: Array<number>, serializedPath: string, publicKey: string, node: HDPubNode }  // account 3
+        { path, serializedPath, publicKey, xpub, displayablePublicKey, node }, // account 1
+        { path, serializedPath, publicKey, xpub, displayablePublicKey, node }, // account 2
+        { path, serializedPath, publicKey, xpub, displayablePublicKey, node }, // account 3
     ]
 }
 ```
+
+> **Breaking change (version 10):** the `publicKey` field is now the raw 32-byte
+> public key in hex (consistent with other coins). The Cardano extended public
+> key previously returned in `publicKey` is exposed via the new explicit `xpub`
+> field. Use `displayablePublicKey` if you want the canonical user-facing form
+> without per-coin branching.
 
 Error
 

--- a/packages/connect-explorer/src/pages/methods/ethereum/ethereumGetPublicKey.mdx
+++ b/packages/connect-explorer/src/pages/methods/ethereum/ethereumGetPublicKey.mdx
@@ -77,18 +77,24 @@ Result with only one public key
 {
     success: true,
     payload: {
-        path: Array<number>, // hardended path
-        serializedPath: string, // serialized path
-        xpub: string,        // xpub in legacy format
-        xpubSegwit?: string, // optional for segwit accounts: xpub in segwit format
-        chainCode: string,   // BIP32 serialization format
-        childNum: number,    // BIP32 serialization format
-        publicKey: string,   // BIP32 serialization format
-        fingerprint: number, // BIP32 serialization format
-        depth: number,       // BIP32 serialization format
+        path: Array<number>,          // hardended path
+        serializedPath: string,       // serialized path
+        publicKey: string,            // hex-encoded compressed public key (33 bytes)
+        xpub: string,                 // xpub in legacy format (BIP32)
+        chainCode: string,            // BIP32 serialization format
+        childNum: number,             // BIP32 serialization format
+        fingerprint: number,          // BIP32 serialization format
+        depth: number,                // BIP32 serialization format
+        displayablePublicKey: string, // canonical user-facing form (= xpub)
     }
 }
 ```
+
+> **`displayablePublicKey` vs. firmware display.** With `showOnTrezor: true` the
+> device shows the raw compressed `publicKey` (33-byte hex). This field is the
+> `xpub` instead, because that's the more useful identifier in host-side UIs
+> (Trezor Suite displays the xpub in its address-confirmation modal). Both are
+> correct representations of the same secp256k1 point at the requested path.
 
 [Read more about BIP32 serialization format](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#Serialization_format)
 
@@ -98,9 +104,9 @@ Result with bundle of public keys
 {
     success: true,
     payload: [
-        { path, serializedPath, xpub, xpubSegwit?, chainCode, childNum, publicKey, fingerprint, depth }, // account 1
-        { path, serializedPath, xpub, xpubSegwit?, chainCode, childNum, publicKey, fingerprint, depth }, // account 2
-        { path, serializedPath, xpub, xpubSegwit?, chainCode, childNum, publicKey, fingerprint, depth }  // account 3
+        { path, serializedPath, publicKey, xpub, chainCode, childNum, fingerprint, depth, displayablePublicKey }, // account 1
+        { path, serializedPath, publicKey, xpub, chainCode, childNum, fingerprint, depth, displayablePublicKey }, // account 2
+        { path, serializedPath, publicKey, xpub, chainCode, childNum, fingerprint, depth, displayablePublicKey }  // account 3
     ]
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/solana/solanaGetPublicKey.mdx
+++ b/packages/connect-explorer/src/pages/methods/solana/solanaGetPublicKey.mdx
@@ -78,10 +78,11 @@ Result with only one public key
 {
     success: true,
     payload: {
-        path: Array<number>, // hardended path
+        path: Array<number>,          // hardended path
         serializedPath: string,
-        publicKey: string,
-        publicKeyBase58: string,
+        publicKey: string,            // hex-encoded raw public key (32 bytes)
+        publicKeyBase58: string,      // base58-encoded address form
+        displayablePublicKey: string, // canonical user-facing form (= publicKeyBase58)
     }
 }
 ```
@@ -92,9 +93,9 @@ Result with a bundle of public keys
 {
     success: true,
     payload: [
-        { path: Array<number>, serializedPath: string, publicKey: string }, // account 1
-        { path: Array<number>, serializedPath: string, publicKey: string }, // account 2
-        { path: Array<number>, serializedPath: string, publicKey: string }  // account 3
+        { path, serializedPath, publicKey, publicKeyBase58, displayablePublicKey }, // account 1
+        { path, serializedPath, publicKey, publicKeyBase58, displayablePublicKey }, // account 2
+        { path, serializedPath, publicKey, publicKeyBase58, displayablePublicKey }  // account 3
     ]
 }
 ```

--- a/packages/connect-explorer/src/pages/methods/tezos/tezosGetPublicKey.mdx
+++ b/packages/connect-explorer/src/pages/methods/tezos/tezosGetPublicKey.mdx
@@ -81,9 +81,10 @@ Result with only one public key
 {
     success: true,
     payload: {
-        publicKey: string,
         path: Array<number>,
         serializedPath: string,
+        publicKey: string,            // base58check-encoded public key (`edpk…`)
+        displayablePublicKey: string, // canonical user-facing form (= publicKey)
     }
 }
 ```
@@ -94,9 +95,9 @@ Result with bundle of public keys
 {
     success: true,
     payload: [
-        { path, serializedPath, publicKey }, // account 1
-        { path, serializedPath, publicKey }, // account 2
-        { path, serializedPath, publicKey }, // account 3
+        { path, serializedPath, publicKey, displayablePublicKey }, // account 1
+        { path, serializedPath, publicKey, displayablePublicKey }, // account 2
+        { path, serializedPath, publicKey, displayablePublicKey }, // account 3
     ]
 }
 ```

--- a/packages/connect/CHANGELOG.md
+++ b/packages/connect/CHANGELOG.md
@@ -23,10 +23,19 @@ Features:
 
 Breaking changes:
 
-- `getAccountDescriptor` has been removed. The per-coin `*GetPublicKey` methods (`getPublicKey`, `ethereumGetPublicKey`, `cardanoGetPublicKey`, `solanaGetPublicKey`, `tezosGetPublicKey`) now return the same fields after the response-shape unification, so the dedicated descriptor entry point is no longer needed. Consumers that previously called `getAccountDescriptor` should call the appropriate `*GetPublicKey` for the target coin. TODO: exact field mapping (e.g. previous `payload.descriptor`) will be documented as part of the `*GetPublicKey` response-shape unification PR.
+- `getAccountDescriptor` has been removed. The per-coin `*GetPublicKey` methods (`getPublicKey`, `ethereumGetPublicKey`, `cardanoGetPublicKey`, `solanaGetPublicKey`, `tezosGetPublicKey`) now return the same fields after the response-shape unification, so the dedicated descriptor entry point is no longer needed. Consumers that previously called `getAccountDescriptor` should call the appropriate `*GetPublicKey` for the target coin. Field mapping from the old `getAccountDescriptor` payload:
+    - `payload.descriptor` → Bitcoin: `result.descriptor` on `getPublicKey`. Non-Bitcoin coins did not return a descriptor; use `result.displayablePublicKey` for the canonical user-facing form.
+    - `payload.path` (serialized string) → `result.serializedPath` on every `*GetPublicKey`.
+    - For a generic, per-coin agnostic consumer that just needs the canonical user-facing public-key string, read the new `result.displayablePublicKey` field.
 - **`@trezor/connect` and every package in its dependency closure now ship ESM only.** Several transitive dependencies (`@noble/curves`, `@noble/hashes`, `@scure/base`, `@scure/bip39`, `@solana/kit`, `@solana-program/*`, `viem`, `node-fetch@3+`) are already ESM-only, so a CJS consumer of `@trezor/connect` cannot statically import them in any case. To keep the build pipeline consistent, the entire connect ecosystem follows suit: `@trezor/connect`, `@trezor/connect-web`, `@trezor/connect-webextension`, `@trezor/connect-mobile`, `@trezor/connect-common`, `@trezor/connect-data`, `@trezor/connect-plugin-ethereum`, `@trezor/connect-plugin-stellar`, `@trezor/blockchain-link`, `@trezor/blockchain-link-utils`, `@trezor/blockchain-link-types`, `@trezor/utxo-lib`, `@trezor/device-authenticity`, `@trezor/address-validator`, `@trezor/utils`, `@trezor/transport`, `@trezor/protobuf`, `@trezor/protocol`, `@trezor/schema-utils`, `@trezor/crypto-utils`, `@trezor/device-utils`, `@trezor/env-utils`, `@trezor/type-utils`, `@trezor/websocket-client`. Migration:
     - ESM consumer: replace `const TrezorConnect = require('@trezor/connect').default` with `import TrezorConnect from '@trezor/connect'`. Set `"type": "module"` in your `package.json` or use the `.mjs` extension.
     - CJS consumer that cannot migrate: use a dynamic import — `const TrezorConnect = (await import('@trezor/connect')).default;` — or stay on v9.
+- All `*GetPublicKey` methods now return a `displayablePublicKey: string` field — the canonical user-facing representation per coin (`xpubSegwit ?? xpub` for Bitcoin, i.e. ypub/zpub for SegWit and `tr(...)` descriptor for Taproot; xpub for Ethereum/Cardano; base58 for Solana; base58check `edpk…` for Tezos). Generic consumers can display any public-key response without per-coin branching. The shared `PublicKey` base stays minimal (only `displayablePublicKey` is added); per-coin extras remain on per-coin response types.
+- `cardanoGetPublicKey` now exposes the Cardano extended public key via the explicit `xpub: string` field.
+
+Breaking changes:
+
+- `cardanoGetPublicKey`: the `publicKey` field is now the raw 32-byte public key in hex (consistent with other coins). The Cardano extended public key previously returned in `publicKey` is now exposed via the new explicit `xpub` field. Update consumers to read `xpub` (or `displayablePublicKey`) for the extended key.
 
 Deprecations:
 

--- a/packages/connect/e2e/__fixtures__/cardanoGetPublicKey.ts
+++ b/packages/connect/e2e/__fixtures__/cardanoGetPublicKey.ts
@@ -6,6 +6,13 @@ const legacyResults = {
     },
 };
 
+// m/1852'/1815'/0' showOnTrezor: FW renders the same 128-hex extended public
+// key returned in `xpub` / `displayablePublicKey`. deviceScreen is a stable
+// prefix that fits inside the smallest-screen capture.
+const showOnTrezorDisplayablePublicKey =
+    'd507c8f866691bd96e131334c355188b1a1d0b2fa0ab11545075aab332d77d9eb19657ad13ee581b56b0f8d744d66ca356b93d42fe176b3de007d53e9c4c4e7a';
+const showOnTrezorDeviceScreen = showOnTrezorDisplayablePublicKey.slice(0, 40);
+
 export default {
     method: 'cardanoGetPublicKey',
     setup: {
@@ -18,7 +25,8 @@ export default {
                 path: "m/44'/1815'/0'/0/0'",
             },
             result: {
-                publicKey:
+                xpub: 'a938c8554ae04616cfaae7cd0eb557475082c4e910242ce774967e0bd7492408cbf6ab47c8eb1a0477fc40b25dbb6c4a99454edb97d6fe5acedd3e238ef46fe0',
+                displayablePublicKey:
                     'a938c8554ae04616cfaae7cd0eb557475082c4e910242ce774967e0bd7492408cbf6ab47c8eb1a0477fc40b25dbb6c4a99454edb97d6fe5acedd3e238ef46fe0',
             },
         },
@@ -35,7 +43,8 @@ export default {
                 path: "m/44'/1815'/0/0/0",
             },
             result: {
-                publicKey:
+                xpub: '17cc0bf978756d0d5c76f931629036a810c61801b78beecb44555773d13e3791646ac4a6295326bae6831be05921edfbcb362de48dfd37b12e74c227dfad768d',
+                displayablePublicKey:
                     '17cc0bf978756d0d5c76f931629036a810c61801b78beecb44555773d13e3791646ac4a6295326bae6831be05921edfbcb362de48dfd37b12e74c227dfad768d',
             },
         },
@@ -45,7 +54,8 @@ export default {
                 path: "m/44'/1815'/0'/0/0",
             },
             result: {
-                publicKey:
+                xpub: 'b90fb812a2268e9569ff1172e8daed1da3dc7e72c7bded7c5bcb7282039f90d5fd8e71c1543de2cdc7f7623130c5f2cceb53549055fa1f5bc88199989e08cce7',
+                displayablePublicKey:
                     'b90fb812a2268e9569ff1172e8daed1da3dc7e72c7bded7c5bcb7282039f90d5fd8e71c1543de2cdc7f7623130c5f2cceb53549055fa1f5bc88199989e08cce7',
             },
         },
@@ -55,7 +65,8 @@ export default {
                 path: "m/1852'/1815'/0'",
             },
             result: {
-                publicKey:
+                xpub: 'd507c8f866691bd96e131334c355188b1a1d0b2fa0ab11545075aab332d77d9eb19657ad13ee581b56b0f8d744d66ca356b93d42fe176b3de007d53e9c4c4e7a',
+                displayablePublicKey:
                     'd507c8f866691bd96e131334c355188b1a1d0b2fa0ab11545075aab332d77d9eb19657ad13ee581b56b0f8d744d66ca356b93d42fe176b3de007d53e9c4c4e7a',
             },
         },
@@ -65,7 +76,8 @@ export default {
                 path: "m/1852'/1815'/0'/0/0",
             },
             result: {
-                publicKey:
+                xpub: '5d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c1f123474e140a2c360b01f0fa66f2f22e2e965a5b07a80358cf75f77abbd66088',
+                displayablePublicKey:
                     '5d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c1f123474e140a2c360b01f0fa66f2f22e2e965a5b07a80358cf75f77abbd66088',
             },
         },
@@ -76,13 +88,10 @@ export default {
                 showOnTrezor: true,
             },
             result: {
-                publicKey:
-                    'd507c8f866691bd96e131334c355188b1a1d0b2fa0ab11545075aab332d77d9eb19657ad13ee581b56b0f8d744d66ca356b93d42fe176b3de007d53e9c4c4e7a',
+                xpub: showOnTrezorDisplayablePublicKey,
+                displayablePublicKey: showOnTrezorDisplayablePublicKey,
             },
-            // FW body shows the 128-hex extended public key (currently the
-            // `publicKey` field; in v10 this same value is exposed as `xpub`).
-            // Assert a stable prefix that fits inside the smallest-screen capture.
-            deviceScreen: 'd507c8f866691bd96e131334c355188b1a1d0b2f',
+            deviceScreen: showOnTrezorDeviceScreen,
             deviceScreenSkip: ['1', '<2.7.0'],
         },
     ].map(t => ({ ...t, legacyResults: [legacyResults.minConnectVersion] })),

--- a/packages/connect/e2e/__fixtures__/ethereumGetPublicKey.ts
+++ b/packages/connect/e2e/__fixtures__/ethereumGetPublicKey.ts
@@ -13,6 +13,7 @@ const generatedTests = commonFixtures.tests.flatMap(({ parameters, result }) => 
         chainCode: result.chain_code,
         publicKey: result.public_key,
         xpub: result.xpub,
+        displayablePublicKey: result.xpub,
     },
 }));
 

--- a/packages/connect/e2e/__fixtures__/getPublicKey.ts
+++ b/packages/connect/e2e/__fixtures__/getPublicKey.ts
@@ -1,3 +1,20 @@
+// p2tr showOnTrezor: FW renders the descriptor in `h`-notation, while
+// `displayablePublicKey` mirrors `xpubSegwit` in `'`-notation. They differ in
+// path-notation, so deviceScreen and displayablePublicKey are declared
+// separately to make the divergence visible.
+const p2trDisplayablePublicKey = `tr([95d8f670/86'/0'/0']xpub6D1saVFSZYgqXCXDfc5m2KdPXUsBXC12E3WntXXzWGJB8dEBr3CGR62emtC8sxJRVRSmBKbtJubuaaGEvZeeCEWaPaYvD9iJwp2Ky7sZws7/<0;1>/*)`;
+const p2trDeviceScreen = /tr\(\[95d8f670\/86h\/0h\/0h\]xpub6D1saVFSZYg/;
+
+// bech32 / p2pkh showOnTrezor: FW renders the same string returned in
+// `displayablePublicKey`. deviceScreen is a stable prefix.
+const bech32DisplayablePublicKey =
+    'zpub6qSSRL9wLd6LNee7qjDEuULWccP5Vbm5nuX4geBu8zMCQBWsF5Jo5UswLVxFzcbCMr2yQPG27ZhDs1cUGKVH1RmqkG1PFHkEXyHG7EV3ogY';
+const bech32DeviceScreen = bech32DisplayablePublicKey.slice(0, 37);
+
+const p2pkhDisplayablePublicKey =
+    'xpub6D1weXBcFAo8CqBbpP4TbH5sxQH8ZkqC5pDEvJ95rNNBZC9zrKmZP2fXMuve7ZRBe18pWQQsGg68jkq24mZchHwYENd8cCiSb71u3KD4AFH';
+const p2pkhDeviceScreen = p2pkhDisplayablePublicKey.slice(0, 37);
+
 export default {
     method: 'getPublicKey',
     setup: {
@@ -14,6 +31,7 @@ export default {
                 xpub: 'xpub6D1saVFSZYgqXCXDfc5m2KdPXUsBXC12E3WntXXzWGJB8dEBr3CGR62emtC8sxJRVRSmBKbtJubuaaGEvZeeCEWaPaYvD9iJwp2Ky7sZws7',
                 xpubSegwit: `tr([95d8f670/86'/0'/0']xpub6D1saVFSZYgqXCXDfc5m2KdPXUsBXC12E3WntXXzWGJB8dEBr3CGR62emtC8sxJRVRSmBKbtJubuaaGEvZeeCEWaPaYvD9iJwp2Ky7sZws7/<0;1>/*)`,
                 descriptor: `tr([95d8f670/86h/0h/0h]xpub6D1saVFSZYgqXCXDfc5m2KdPXUsBXC12E3WntXXzWGJB8dEBr3CGR62emtC8sxJRVRSmBKbtJubuaaGEvZeeCEWaPaYvD9iJwp2Ky7sZws7/<0;1>/*)#htg5lhe3`,
+                displayablePublicKey: `tr([95d8f670/86'/0'/0']xpub6D1saVFSZYgqXCXDfc5m2KdPXUsBXC12E3WntXXzWGJB8dEBr3CGR62emtC8sxJRVRSmBKbtJubuaaGEvZeeCEWaPaYvD9iJwp2Ky7sZws7/<0;1>/*)`,
             },
             legacyResults: [
                 {
@@ -34,6 +52,8 @@ export default {
                     'zpub6qSSRL9wLd6LNee7qjDEuULWccP5Vbm5nuX4geBu8zMCQBWsF5Jo5UswLVxFzcbCMr2yQPG27ZhDs1cUGKVH1RmqkG1PFHkEXyHG7EV3ogY',
                 descriptor:
                     'wpkh([95d8f670/84h/0h/0h]xpub6Bmuozp73G1Ng4FtB1dzVJ9WGg6BcMn5xgUd7rQ8NybSHytQjkyfqMZfJ635zoHMYZoMuS4uCEz86SPLpvfFQxQe1acY5U7FzX9yL5DyRAe/<0;1>/*)#78czyhf0',
+                displayablePublicKey:
+                    'zpub6qSSRL9wLd6LNee7qjDEuULWccP5Vbm5nuX4geBu8zMCQBWsF5Jo5UswLVxFzcbCMr2yQPG27ZhDs1cUGKVH1RmqkG1PFHkEXyHG7EV3ogY',
             },
             get legacyResults() {
                 const { descriptor, ...payload } = this.result;
@@ -53,6 +73,8 @@ export default {
                     'ypub6Y5EDdQK9nQzpNeMtgXxhBB3SoLk2SyR2MFLQYsBkAusAHpaQNxTTwefgnL9G3oFGrRS9VkVvyY1SaApFAzQPZ99wto5etdReeE3XFkkMZt',
                 descriptor:
                     'sh(wpkh([95d8f670/49h/0h/0h]xpub6DExuxjQ16sWy5TF4KkLV65YGqCJ5pyv7Ej7d9yJNAXz7C1M9intqszXfaNZG99KsDJdQ29wUKBTZHZFXUaPbKTZ5Z6f4yowNvAQ8fEJw2G/<0;1>/*))#euxgwkh5',
+                displayablePublicKey:
+                    'ypub6Y5EDdQK9nQzpNeMtgXxhBB3SoLk2SyR2MFLQYsBkAusAHpaQNxTTwefgnL9G3oFGrRS9VkVvyY1SaApFAzQPZ99wto5etdReeE3XFkkMZt',
             },
             get legacyResults() {
                 const { descriptor, ...payload } = this.result;
@@ -72,6 +94,8 @@ export default {
                     'ypub6Y5EDdQK9nQzpNeMtgXxhBB3SoLk2SyR2MFLQYsBkAusAHpaQNxTTwefgnL9G3oFGrRS9VkVvyY1SaApFAzQPZ99wto5etdReeE3XFkkMZt',
                 descriptor:
                     'sh(wpkh([95d8f670/49h/0h/0h]xpub6DExuxjQ16sWy5TF4KkLV65YGqCJ5pyv7Ej7d9yJNAXz7C1M9intqszXfaNZG99KsDJdQ29wUKBTZHZFXUaPbKTZ5Z6f4yowNvAQ8fEJw2G/<0;1>/*))#euxgwkh5',
+                displayablePublicKey:
+                    'ypub6Y5EDdQK9nQzpNeMtgXxhBB3SoLk2SyR2MFLQYsBkAusAHpaQNxTTwefgnL9G3oFGrRS9VkVvyY1SaApFAzQPZ99wto5etdReeE3XFkkMZt',
             },
             get legacyResults() {
                 const { descriptor, ...payload } = this.result;
@@ -89,6 +113,8 @@ export default {
                 xpub: 'xpub6D1weXBcFAo8CqBbpP4TbH5sxQH8ZkqC5pDEvJ95rNNBZC9zrKmZP2fXMuve7ZRBe18pWQQsGg68jkq24mZchHwYENd8cCiSb71u3KD4AFH',
                 descriptor:
                     'pkh([95d8f670/44h/0h/0h]xpub6D1weXBcFAo8CqBbpP4TbH5sxQH8ZkqC5pDEvJ95rNNBZC9zrKmZP2fXMuve7ZRBe18pWQQsGg68jkq24mZchHwYENd8cCiSb71u3KD4AFH/<0;1>/*)#k60fe5pm',
+                displayablePublicKey:
+                    'xpub6D1weXBcFAo8CqBbpP4TbH5sxQH8ZkqC5pDEvJ95rNNBZC9zrKmZP2fXMuve7ZRBe18pWQQsGg68jkq24mZchHwYENd8cCiSb71u3KD4AFH',
             },
             get legacyResults() {
                 const { descriptor, ...payload } = this.result;
@@ -105,12 +131,11 @@ export default {
             },
             result: {
                 xpub: 'xpub6D1saVFSZYgqXCXDfc5m2KdPXUsBXC12E3WntXXzWGJB8dEBr3CGR62emtC8sxJRVRSmBKbtJubuaaGEvZeeCEWaPaYvD9iJwp2Ky7sZws7',
-                xpubSegwit: `tr([95d8f670/86'/0'/0']xpub6D1saVFSZYgqXCXDfc5m2KdPXUsBXC12E3WntXXzWGJB8dEBr3CGR62emtC8sxJRVRSmBKbtJubuaaGEvZeeCEWaPaYvD9iJwp2Ky7sZws7/<0;1>/*)`,
+                xpubSegwit: p2trDisplayablePublicKey,
                 descriptor: `tr([95d8f670/86h/0h/0h]xpub6D1saVFSZYgqXCXDfc5m2KdPXUsBXC12E3WntXXzWGJB8dEBr3CGR62emtC8sxJRVRSmBKbtJubuaaGEvZeeCEWaPaYvD9iJwp2Ky7sZws7/<0;1>/*)#htg5lhe3`,
+                displayablePublicKey: p2trDisplayablePublicKey,
             },
-            // FW screen body shows the descriptor in `h`-notation, bare (no /<0;1>/*).
-            // Match a stable prefix that fits inside the smallest-screen capture.
-            deviceScreen: /tr\(\[95d8f670\/86h\/0h\/0h\]xpub6D1saVFSZYg/,
+            deviceScreen: p2trDeviceScreen,
             // T1B1 emulator's getScreenContent returns a placeholder; older T2T1 FW
             // doesn't render descriptors.
             deviceScreenSkip: ['1', '<2.7.0'],
@@ -130,14 +155,12 @@ export default {
             },
             result: {
                 xpub: 'xpub6Bmuozp73G1Ng4FtB1dzVJ9WGg6BcMn5xgUd7rQ8NybSHytQjkyfqMZfJ635zoHMYZoMuS4uCEz86SPLpvfFQxQe1acY5U7FzX9yL5DyRAe',
-                xpubSegwit:
-                    'zpub6qSSRL9wLd6LNee7qjDEuULWccP5Vbm5nuX4geBu8zMCQBWsF5Jo5UswLVxFzcbCMr2yQPG27ZhDs1cUGKVH1RmqkG1PFHkEXyHG7EV3ogY',
+                xpubSegwit: bech32DisplayablePublicKey,
                 descriptor:
                     'wpkh([95d8f670/84h/0h/0h]xpub6Bmuozp73G1Ng4FtB1dzVJ9WGg6BcMn5xgUd7rQ8NybSHytQjkyfqMZfJ635zoHMYZoMuS4uCEz86SPLpvfFQxQe1acY5U7FzX9yL5DyRAe/<0;1>/*)#78czyhf0',
+                displayablePublicKey: bech32DisplayablePublicKey,
             },
-            // FW body shows the full zpub; assert a stable prefix that fits inside
-            // the smallest-screen capture window.
-            deviceScreen: 'zpub6qSSRL9wLd6LNee7qjDEuULWccP5Vbm5n',
+            deviceScreen: bech32DeviceScreen,
             deviceScreenSkip: ['1', '<2.7.0'],
             get legacyResults() {
                 const { descriptor, ...payload } = this.result;
@@ -153,13 +176,12 @@ export default {
                 showOnTrezor: true,
             },
             result: {
-                xpub: 'xpub6D1weXBcFAo8CqBbpP4TbH5sxQH8ZkqC5pDEvJ95rNNBZC9zrKmZP2fXMuve7ZRBe18pWQQsGg68jkq24mZchHwYENd8cCiSb71u3KD4AFH',
+                xpub: p2pkhDisplayablePublicKey,
                 descriptor:
                     'pkh([95d8f670/44h/0h/0h]xpub6D1weXBcFAo8CqBbpP4TbH5sxQH8ZkqC5pDEvJ95rNNBZC9zrKmZP2fXMuve7ZRBe18pWQQsGg68jkq24mZchHwYENd8cCiSb71u3KD4AFH/<0;1>/*)#k60fe5pm',
+                displayablePublicKey: p2pkhDisplayablePublicKey,
             },
-            // FW body shows the full xpub; assert a stable prefix that fits inside
-            // the smallest-screen capture window.
-            deviceScreen: 'xpub6D1weXBcFAo8CqBbpP4TbH5sxQH8ZkqC5',
+            deviceScreen: p2pkhDeviceScreen,
             deviceScreenSkip: ['1', '<2.7.0'],
             get legacyResults() {
                 const { descriptor, ...payload } = this.result;

--- a/packages/connect/e2e/__fixtures__/solanaGetPublicKey.ts
+++ b/packages/connect/e2e/__fixtures__/solanaGetPublicKey.ts
@@ -7,6 +7,12 @@ const legacyResults = [
     },
 ];
 
+// m/44'/501'/0' showOnTrezor: FW renders the base58 form returned in
+// `publicKeyBase58` / `displayablePublicKey`. deviceScreen is a stable prefix
+// that fits inside the smallest-screen capture.
+const showOnTrezorDisplayablePublicKey = '4UR47Kp4FxGJiJZZGSPAzXqRgMmZ27oVfGhHoLmcHakE';
+const showOnTrezorDeviceScreen = showOnTrezorDisplayablePublicKey.slice(0, 34);
+
 export default {
     method: 'solanaGetPublicKey',
     setup: {
@@ -20,6 +26,8 @@ export default {
             },
             result: {
                 publicKey: '0ebf3b4a5e8efc65c508f1c813377a650f655814db3b23472bdcde5f2aeaa7a3',
+                publicKeyBase58: 'zZqNUDNijfbMXFy2wVCdJSm9MeMfxBMdxBqseSuiSW6',
+                displayablePublicKey: 'zZqNUDNijfbMXFy2wVCdJSm9MeMfxBMdxBqseSuiSW6',
             },
             legacyResults,
         },
@@ -30,6 +38,8 @@ export default {
             },
             result: {
                 publicKey: '3398f0abc4f8ec2f62435a78d8f4f3219b47b04f268798d2ed2260da0b4de45f',
+                publicKeyBase58: '4UR47Kp4FxGJiJZZGSPAzXqRgMmZ27oVfGhHoLmcHakE',
+                displayablePublicKey: '4UR47Kp4FxGJiJZZGSPAzXqRgMmZ27oVfGhHoLmcHakE',
             },
             legacyResults,
         },
@@ -40,6 +50,8 @@ export default {
             },
             result: {
                 publicKey: '00d1699dcb1811b50bb0055f13044463128242e37a463b52f6c97a1f6eef88ad',
+                publicKeyBase58: '14CCvQzQzHCVgZM3j9soPnXuJXh1RmCfwLVUcdfbZVBS',
+                displayablePublicKey: '14CCvQzQzHCVgZM3j9soPnXuJXh1RmCfwLVUcdfbZVBS',
             },
             legacyResults,
         },
@@ -51,10 +63,10 @@ export default {
             },
             result: {
                 publicKey: '3398f0abc4f8ec2f62435a78d8f4f3219b47b04f268798d2ed2260da0b4de45f',
+                publicKeyBase58: showOnTrezorDisplayablePublicKey,
+                displayablePublicKey: showOnTrezorDisplayablePublicKey,
             },
-            // FW shows the base58 form (in v10 exposed as `publicKeyBase58`).
-            // Assert a stable prefix that fits inside the smallest-screen capture.
-            deviceScreen: '4UR47Kp4FxGJiJZZGSPAzXqRgMmZ27oVfG',
+            deviceScreen: showOnTrezorDeviceScreen,
             deviceScreenSkip: ['1', '<2.7.0'],
             legacyResults,
         },

--- a/packages/connect/e2e/__fixtures__/tezosGetPublicKey.ts
+++ b/packages/connect/e2e/__fixtures__/tezosGetPublicKey.ts
@@ -6,6 +6,12 @@ const legacyResults = [
     },
 ];
 
+// m/44'/1729'/0' showOnTrezor: FW renders the edpk… form, the same value
+// returned in `publicKey` / `displayablePublicKey`. deviceScreen is a stable
+// prefix that fits inside the smallest-screen capture.
+const showOnTrezorDisplayablePublicKey = 'edpkuxZ5W8c2jmcaGuCFZxRDSWxS7hp98zcwj2YpUZkJWs5F7UMuF6';
+const showOnTrezorDeviceScreen = showOnTrezorDisplayablePublicKey.slice(0, 39);
+
 export default {
     method: 'tezosGetPublicKey',
     setup: {
@@ -20,6 +26,7 @@ export default {
             },
             result: {
                 publicKey: 'edpkuxZ5W8c2jmcaGuCFZxRDSWxS7hp98zcwj2YpUZkJWs5F7UMuF6',
+                displayablePublicKey: 'edpkuxZ5W8c2jmcaGuCFZxRDSWxS7hp98zcwj2YpUZkJWs5F7UMuF6',
             },
         },
         {
@@ -30,6 +37,7 @@ export default {
             },
             result: {
                 publicKey: 'edpkuVKVFyqTnp4axajmxTnCcSHN7v1kRhVpBC25GEZQVT2ZzSpdJY',
+                displayablePublicKey: 'edpkuVKVFyqTnp4axajmxTnCcSHN7v1kRhVpBC25GEZQVT2ZzSpdJY',
             },
         },
         {
@@ -55,11 +63,10 @@ export default {
                 showOnTrezor: true,
             },
             result: {
-                publicKey: 'edpkuxZ5W8c2jmcaGuCFZxRDSWxS7hp98zcwj2YpUZkJWs5F7UMuF6',
+                publicKey: showOnTrezorDisplayablePublicKey,
+                displayablePublicKey: showOnTrezorDisplayablePublicKey,
             },
-            // FW shows the edpk… form (same value as `publicKey`). Assert a stable
-            // prefix that fits inside the smallest-screen capture.
-            deviceScreen: 'edpkuxZ5W8c2jmcaGuCFZxRDSWxS7hp98zcwj2Y',
+            deviceScreen: showOnTrezorDeviceScreen,
             deviceScreenSkip: ['1', '<2.7.0'],
         },
     ].map(fixture => ({ ...fixture, legacyResults })),

--- a/packages/connect/src/api/cardano/api/cardanoGetPublicKey.ts
+++ b/packages/connect/src/api/cardano/api/cardanoGetPublicKey.ts
@@ -86,7 +86,9 @@ export default class CardanoGetPublicKey extends AbstractMethod<'cardanoGetPubli
             responses.push({
                 path: batch.address_n,
                 serializedPath: getSerializedPath(batch.address_n),
-                publicKey: message.xpub,
+                publicKey: message.node.public_key,
+                xpub: message.xpub,
+                displayablePublicKey: message.xpub,
                 node: message.node,
             });
 

--- a/packages/connect/src/api/ethereum/api/ethereumGetPublicKey.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumGetPublicKey.ts
@@ -93,6 +93,7 @@ export default class EthereumGetPublicKey extends AbstractMethod<'ethereumGetPub
                 publicKey: publicKey.node.public_key,
                 fingerprint: publicKey.node.fingerprint,
                 depth: publicKey.node.depth,
+                displayablePublicKey: publicKey.xpub,
             };
 
             responses.push(response);

--- a/packages/connect/src/api/solana/api/solanaGetPublicKey.ts
+++ b/packages/connect/src/api/solana/api/solanaGetPublicKey.ts
@@ -70,11 +70,13 @@ export default class SolanaGetPublicKey extends AbstractMethod<
         for (let i = 0; i < this.params.length; i++) {
             const batch = this.params[i];
             const { message } = await cmd.typedCall('SolanaGetPublicKey', 'SolanaPublicKey', batch);
+            const publicKeyBase58 = base58.encode(Buffer.from(message.public_key, 'hex'));
             responses.push({
                 path: batch.address_n,
                 serializedPath: getSerializedPath(batch.address_n),
                 publicKey: message.public_key,
-                publicKeyBase58: base58.encode(Buffer.from(message.public_key, 'hex')),
+                publicKeyBase58,
+                displayablePublicKey: publicKeyBase58,
             });
 
             if (this.hasBundle) {

--- a/packages/connect/src/api/tezos/api/tezosGetPublicKey.ts
+++ b/packages/connect/src/api/tezos/api/tezosGetPublicKey.ts
@@ -77,6 +77,7 @@ export default class TezosGetPublicKey extends AbstractMethod<
                 path: batch.address_n,
                 serializedPath: getSerializedPath(batch.address_n),
                 publicKey: message.public_key,
+                displayablePublicKey: message.public_key,
             });
 
             if (this.hasBundle) {

--- a/packages/connect/src/device/DeviceCommands.ts
+++ b/packages/connect/src/device/DeviceCommands.ts
@@ -98,31 +98,35 @@ export const DeviceCommands = (deviceTypedCall: TypedCallProvider) => {
             publicKey = hdnodeUtils.xpubDerive(resKey, childKey, suffix, network, coinInfo.network);
         }
 
+        const xpub =
+            network !== coinInfo.network
+                ? hdnodeUtils.convertXpub(publicKey.xpub, network, coinInfo.network)
+                : publicKey.xpub;
+        const xpubSegwit = network !== coinInfo.network ? publicKey.xpub : undefined;
+
         const response: HDNodeResponse = {
             path,
             serializedPath: getSerializedPath(path),
             childNum: publicKey.node.child_num,
-            xpub: publicKey.xpub,
+            xpub,
             chainCode: publicKey.node.chain_code,
             publicKey: publicKey.node.public_key,
             fingerprint: publicKey.node.fingerprint,
             rootFingerprint: publicKey.root_fingerprint,
             depth: publicKey.node.depth,
             descriptor: publicKey.descriptor,
+            displayablePublicKey: xpubSegwit ?? xpub,
+            ...(xpubSegwit !== undefined && { xpubSegwit }),
         };
 
-        if (network !== coinInfo.network) {
-            response.xpubSegwit = response.xpub;
-            response.xpub = hdnodeUtils.convertXpub(publicKey.xpub, network, coinInfo.network);
-        }
-
         if (isTaprootPath(path)) {
-            const { checksum, xpub: xpubSegwit } = resolveDescriptorForTaproot({
+            const { checksum, xpub: taprootXpubSegwit } = resolveDescriptorForTaproot({
                 response,
                 publicKey,
             });
-            response.xpubSegwit = xpubSegwit;
+            response.xpubSegwit = taprootXpubSegwit;
             response.descriptorChecksum = checksum;
+            response.displayablePublicKey = taprootXpubSegwit;
         }
 
         return response;

--- a/packages/connect/src/device/__tests__/resolveDescriptorForTaproot.test.ts
+++ b/packages/connect/src/device/__tests__/resolveDescriptorForTaproot.test.ts
@@ -12,6 +12,8 @@ const originalResponse: HDNodeResponse = {
     publicKey: '0349ef2fb24926afb58adf0a405ad74dd19e766485b19044477bbb067deff2ce64',
     fingerprint: 1998437481,
     depth: 3,
+    displayablePublicKey:
+        'xpub6CXYpDGLuWpjqFXRTbo8LMYVsiiRjwWiDY7iwDkq1mk4GDYE7TWmSBCnNmbcVYQK4T56RZRRwhCAG7ucTBHAG2rhWHpXdMQtkZVDeVuv33p',
 };
 
 const publicKey: Messages.PublicKey = {

--- a/suite-common/connect-popup/src/methodHooks/addressConfirmation.ts
+++ b/suite-common/connect-popup/src/methodHooks/addressConfirmation.ts
@@ -1,5 +1,4 @@
-import { type Address, type CallMethodKeys, type SolanaPublicKey } from '@trezor/connect';
-import { type HDNodeResponse } from '@trezor/connect-common/src/types/api/getPublicKey';
+import { type Address, type CallMethodKeys, type PublicKey } from '@trezor/connect';
 
 import { connectPopupActions } from '../connectPopupActions';
 import { getPermissionDeferred } from '../connectPopupPromiseManager';
@@ -55,28 +54,19 @@ export async function postCallHook<M extends CallMethodKeys>({
     if (methods.includes(method) && response.success) {
         const bundledResponse = (
             Array.isArray(response.payload) ? response.payload : [response.payload]
-        ) as Address[] | HDNodeResponse[];
+        ) as (Address | PublicKey)[];
         const addresses = bundledResponse.map((item, index) => {
             const validatePayload =
                 'bundle' in originalPayload && Array.isArray(originalPayload.bundle)
                     ? originalPayload.bundle[index]
                     : originalPayload;
-            const displayAddress = () => {
-                if ('address' in item) return item.address;
-
-                // NOTE: it's possible in some cases there will be a mismatch between the public key format on the device and the one in the app
-                // For BTC
-                if (method === 'getPublicKey') return item.xpubSegwit || item.xpub;
-                // For SOL
-                if (method === 'solanaGetPublicKey')
-                    return (item as any as SolanaPublicKey).publicKeyBase58;
-
-                // For other altcoins
-                return item.publicKey;
-            };
+            // `displayablePublicKey` is the per-coin canonical user-facing
+            // representation populated by `@trezor/connect` (xpubSegwit/xpub for
+            // Bitcoin, base58 for Solana, hex for Tezos, etc.).
+            const displayAddress = 'address' in item ? item.address : item.displayablePublicKey;
 
             return {
-                address: displayAddress(),
+                address: displayAddress,
                 validated: 'not-started' as const,
                 loading: false,
                 validatePayload,


### PR DESCRIPTION
## Why

Follow-up to #27283. That PR worked around per-coin divergence in `*GetPublicKey` response types via `as any` casts and method-name branching inside `addressConfirmation`. The root cause was that `getPublicKey` (BTC), `ethereumGetPublicKey`, `cardanoGetPublicKey`, `solanaGetPublicKey`, and `tezosGetPublicKey` each returned a structurally different response, with no cross-coin canonical "show this to the user" field. Since v10 is a major release, this PR fixes the API instead of casting around it.

> Adjacent docs/test debt for `outputDescriptorBip380` was extracted to a separate PR: #27304.
>
> The `getAccountDescriptor` `path` shape alignment + `legacyXpub` removal — originally bundled here — was extracted into its own PR with proper motivation: **#27381**. The two PRs are independent and can land in either order.
>
> **Reviewer asked whether `displayablePublicKey` should match what the firmware actually displays** ([review comment](https://github.com/trezor/trezor-suite/pull/27299#pullrequestreview-4265041158)). The intent is yes. To verify it mechanically from e2e, the screen-capture primitive is being added in a prerequisite PR: **#27765**. Once that lands, this PR will add per-coin `deviceScreen` fixture annotations.

## The payoff (the only meaningful behavioral change to review)

[`suite-common/connect-popup/src/methodHooks/addressConfirmation.ts`](https://github.com/trezor/trezor-suite/blob/mroz22/unify-pubkey-return/suite-common/connect-popup/src/methodHooks/addressConfirmation.ts) — the original casts replaced with one structural read.

**Before** (#27283):
```ts
const displayAddress = () => {
    if ('address' in item) return item.address;
    // For BTC
    if (method === 'getPublicKey') return item.xpubSegwit || item.xpub;
    // For SOL
    if (method === 'solanaGetPublicKey')
        return (item as any as SolanaPublicKey).publicKeyBase58;
    // For other altcoins
    return item.publicKey;
};
```

**After** (this PR):
```ts
const displayAddress = 'address' in item ? item.address : item.displayablePublicKey;
```

No casts, no method-name branching, no `SolanaPublicKey` / `HDNodeResponse` imports. Connect now guarantees `displayablePublicKey: string` on every public-key response, populated with the canonical user-facing form per coin.

## Type-level changes — what reviewers should diff against

### 1. New required `displayablePublicKey: string` on the shared `PublicKey` base

[`packages/connect-common/src/types/params.ts`](https://github.com/trezor/trezor-suite/blob/mroz22/unify-pubkey-return/packages/connect-common/src/types/params.ts)

```ts
export const PublicKey = Type.Object({
    publicKey: Type.String(),
    path: Type.Array(Type.Number()),
    serializedPath: Type.String(),
    displayablePublicKey: Type.String(), // NEW
});
```

The base stays minimal — only fields populated for *every* coin. Per-coin extras live on per-coin response types where they're already declared.

### 2. Per-coin `displayablePublicKey` value (runtime contract)

| Coin | `displayablePublicKey` is set to | Source |
|---|---|---|
| Bitcoin (`getPublicKey`) | `xpubSegwit ?? xpub` (matches the requested scriptType — ypub/zpub for SegWit, `tr(...)` for Taproot) | [`DeviceCommands.ts`](https://github.com/trezor/trezor-suite/blob/mroz22/unify-pubkey-return/packages/connect/src/device/DeviceCommands.ts) |
| Ethereum (`ethereumGetPublicKey`) | `xpub` | [`ethereumGetPublicKey.ts`](https://github.com/trezor/trezor-suite/blob/mroz22/unify-pubkey-return/packages/connect/src/api/ethereum/api/ethereumGetPublicKey.ts) |
| Cardano (`cardanoGetPublicKey`) | `xpub` | [`cardanoGetPublicKey.ts`](https://github.com/trezor/trezor-suite/blob/mroz22/unify-pubkey-return/packages/connect/src/api/cardano/api/cardanoGetPublicKey.ts) |
| Solana (`solanaGetPublicKey`) | base58 form (= `publicKeyBase58`) | [`solanaGetPublicKey.ts`](https://github.com/trezor/trezor-suite/blob/mroz22/unify-pubkey-return/packages/connect/src/api/solana/api/solanaGetPublicKey.ts) |
| Tezos (`tezosGetPublicKey`) | base58check `edpk…` (= `publicKey`) | [`tezosGetPublicKey.ts`](https://github.com/trezor/trezor-suite/blob/mroz22/unify-pubkey-return/packages/connect/src/api/tezos/api/tezosGetPublicKey.ts) |

### 3. Cardano: `publicKey` semantics aligned with other coins

Cardano was the outlier — its `publicKey` field carried an xpub (128 hex chars) while every other coin's `publicKey` is a raw compressed pubkey.

| Field | Before | After |
|---|---|---|
| `publicKey` | xpub (128 hex chars) | raw 32-byte hex (64 chars) |
| `xpub` | — | xpub (128 hex chars) — **new explicit field** |
| `displayablePublicKey` | — | xpub (= `xpub`) |

Per-coin code paths (`coinjoinAccountActions.ts`, etc.) already read Cardano's xpub from elsewhere; nothing in the monorepo breaks. External consumers reading `cardanoGetPublicKey().payload.publicKey` and expecting an xpub need to switch to `.xpub` (or `.displayablePublicKey`).

[`CardanoPublicKey` type](https://github.com/trezor/trezor-suite/blob/mroz22/unify-pubkey-return/packages/connect-common/src/types/api/cardano/index.ts).

## Verification

- [x] `yarn workspace @trezor/connect-common type-check` — clean
- [x] `yarn workspace @trezor/connect type-check` — clean (only pre-existing errors from missing `submodules/trezor-common` fixtures)
- [x] `yarn workspace @trezor/connect-common lint:js` — clean
- [x] `yarn prettier --check` on touched paths — clean
- [x] `displayablePublicKey` asserted in all five `*GetPublicKey` e2e fixtures (`getPublicKey.ts`, `ethereumGetPublicKey.ts`, `cardanoGetPublicKey.ts`, `solanaGetPublicKey.ts`, `tezosGetPublicKey.ts`); `publicKeyBase58` also added to Solana fixtures since it was missing
- [ ] e2e: trigger `getPublicKey`, `ethereumGetPublicKey`, `solanaGetPublicKey`, `cardanoGetPublicKey`, `tezosGetPublicKey` via connect popup; confirm address-confirmation modal renders the right canonical key per coin
- [ ] e2e: `cardanoGetPublicKey` fixture suite (assertions moved from `publicKey` → `xpub`, values unchanged)

## Breaking changes ([CHANGELOG entry](https://github.com/trezor/trezor-suite/blob/mroz22/unify-pubkey-return/packages/connect/CHANGELOG.md#breaking-changes))

- `cardanoGetPublicKey.publicKey` semantics changed from xpub → raw hex. Use `xpub` (or `displayablePublicKey`) for the extended key.

## Out of scope

- `getAccountDescriptor` `path: string` → `number[]` + `serializedPath` + `legacyXpub` removal: see **#27381**.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/unify-pubkey-return&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/unify-pubkey-return&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/unify-pubkey-return&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/unify-pubkey-return/web/](https://dev.suite.sldev.cz/suite-web/mroz22/unify-pubkey-return/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-18T08:31:12.518Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->