### PR TITLE
fix(suite-common): set device remember flag during discovery

### DIFF
--- a/packages/suite/src/reducers/suite/__fixtures__/deviceReducer.ts
+++ b/packages/suite/src/reducers/suite/__fixtures__/deviceReducer.ts
@@ -33,7 +33,6 @@ const connect: Fixture<
                     device: mockConnectDevice({
                         path: '1',
                     }),
-                    isAutoEjectEnabled: false,
                 },
             },
         ],
@@ -61,7 +60,6 @@ const connect: Fixture<
                     device: mockConnectDevice({
                         path: '1',
                     }),
-                    isAutoEjectEnabled: false,
                 },
             },
         ],
@@ -95,7 +93,6 @@ const connect: Fixture<
                     device: mockConnectDevice({
                         path: '1',
                     }),
-                    isAutoEjectEnabled: false,
                 },
             },
         ],
@@ -124,7 +121,6 @@ const connect: Fixture<
                     device: mockConnectDevice({
                         path: '1',
                     }),
-                    isAutoEjectEnabled: false,
                 },
             },
         ],
@@ -159,7 +155,6 @@ const connect: Fixture<
                     device: mockConnectDevice({
                         path: '1',
                     }),
-                    isAutoEjectEnabled: false,
                 },
             },
         ],
@@ -197,7 +192,6 @@ const connect: Fixture<
                     device: mockConnectDevice({
                         path: '1',
                     }),
-                    isAutoEjectEnabled: false,
                 },
             },
         ],
@@ -220,7 +214,6 @@ const connect: Fixture<
                         type: 'unacquired',
                         path: '1',
                     }),
-                    isAutoEjectEnabled: false,
                 },
             },
         ],
@@ -250,7 +243,6 @@ const connect: Fixture<
                         type: 'unacquired',
                         path: '1',
                     }),
-                    isAutoEjectEnabled: false,
                 },
             },
         ],
@@ -284,7 +276,6 @@ const connect: Fixture<
                         status: 'thp-locked',
                         path: '1',
                     }),
-                    isAutoEjectEnabled: false,
                 },
             },
         ],

--- a/suite-common/bluetooth/tests/bluetoothReducer.test.ts
+++ b/suite-common/bluetooth/tests/bluetoothReducer.test.ts
@@ -143,7 +143,6 @@ describe('bluetoothReducer', () => {
         store.dispatch(
             deviceActions.connectDevice({
                 device: trezorDevice as Device,
-                isAutoEjectEnabled: false,
             }),
         );
         expect(store.getState().bluetooth.knownDevices).toEqual([nearbyDevice]);

--- a/suite-common/device/src/deviceActions.ts
+++ b/suite-common/device/src/deviceActions.ts
@@ -22,14 +22,12 @@ export const DEVICE_MODULE_PREFIX = '@suite/device';
 
 export type DeviceConnectActionPayload = {
     device: Device;
-    isAutoEjectEnabled: boolean;
 };
 
 export type DeviceStateActionPayload = {
     device: AcquiredDevice;
     state: DeviceState & { staticSessionId: StaticSessionId };
     useEmptyPassphrase: boolean;
-    isAutoEjectEnabled: boolean;
 };
 
 const connectDevice = createAction(DEVICE.CONNECT, (payload: DeviceConnectActionPayload) => ({

--- a/suite-common/device/src/deviceReducer.ts
+++ b/suite-common/device/src/deviceReducer.ts
@@ -17,7 +17,6 @@ import { type Err } from '@trezor/type-utils';
 
 import { type DeviceStateActionPayload, deviceActions } from './deviceActions';
 import { PORTFOLIO_TRACKER_DEVICE_ID } from './deviceConstants';
-import { shouldDeviceBeRemembered } from './deviceUtils';
 
 export type DeviceReducerState = {
     /**
@@ -119,11 +118,7 @@ const merge = (
  * @param {Device} device
  * @returns
  */
-const connectDevice = (
-    draft: DeviceReducerState,
-    { state, ...device }: Device,
-    { isAutoEjectEnabled }: { isAutoEjectEnabled: boolean },
-) => {
+const connectDevice = (draft: DeviceReducerState, { state, ...device }: Device) => {
     const currentTime = new Date().getTime();
 
     const deviceCommonFields = {
@@ -201,7 +196,7 @@ const connectDevice = (
         ...deviceCommonFields,
         state,
         useEmptyPassphrase: undefined,
-        remember: shouldDeviceBeRemembered({ isAutoEjectEnabled, device }),
+        remember: false,
         temporaryRemember: false,
         available: true,
         instance: deviceInstance,
@@ -325,7 +320,7 @@ const changeDevice = (
 
 const addAuthorizedDevice = (
     draft: DeviceReducerState,
-    { device, state, useEmptyPassphrase, isAutoEjectEnabled }: DeviceStateActionPayload,
+    { device, state, useEmptyPassphrase }: DeviceStateActionPayload,
 ) => {
     const { discovered, ...oldDevice } = device;
     const newDevice = {
@@ -334,7 +329,6 @@ const addAuthorizedDevice = (
         instance: deviceUtils.getNewInstanceNumber(draft.devices, device),
         walletNumber: deviceUtils.getNewWalletNumber(draft.devices, device),
         useEmptyPassphrase,
-        remember: shouldDeviceBeRemembered({ isAutoEjectEnabled, device }),
         state,
     };
 
@@ -343,7 +337,7 @@ const addAuthorizedDevice = (
 
 const setDeviceState = (
     draft: DeviceReducerState,
-    { device, state, useEmptyPassphrase, isAutoEjectEnabled }: DeviceStateActionPayload,
+    { device, state, useEmptyPassphrase }: DeviceStateActionPayload,
 ) => {
     // change only acquired devices
     if (!device.features) return;
@@ -366,8 +360,6 @@ const setDeviceState = (
     affectedDevice[0].useEmptyPassphrase = useEmptyPassphrase;
     affectedDevice[0].walletNumber = deviceUtils.getNewWalletNumber(draft.devices, device);
     delete affectedDevice[0].discovered;
-
-    affectedDevice[0].remember = shouldDeviceBeRemembered({ isAutoEjectEnabled, device });
 };
 
 /**
@@ -720,8 +712,8 @@ export const prepareDeviceReducer = createReducerWithExtraDeps(
             })
             .addMatcher(
                 isAnyOf(deviceActions.connectDevice, deviceActions.connectUnacquiredDevice),
-                (state, { payload: { device, isAutoEjectEnabled } }) => {
-                    connectDevice(state, device, { isAutoEjectEnabled });
+                (state, { payload: { device } }) => {
+                    connectDevice(state, device);
                     updatePersistentDeviceData(state, device);
                 },
             );

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -296,26 +296,15 @@ type DeviceConnectThunksParams = {
 export const deviceConnectThunks = createThunk<void, DeviceConnectThunksParams, void>(
     `${DEVICE_MODULE_PREFIX}/deviceConnectThunk`,
     ({ type, device }, { dispatch, getState }) => {
-        const isAutoEjectEnabled = selectIsDeviceAutoEjectEnabled(getState());
         // TODO (THP phase): Using selectIsFirmwareInstallationRunning = (hidden) circular dependency.
         const isFwInstallation = selectIsFirmwareInstallationRunning(getState());
         switch (type) {
             case DEVICE.CONNECT:
-                dispatch(
-                    deviceActions.connectDevice({
-                        device,
-                        isAutoEjectEnabled,
-                    }),
-                );
+                dispatch(deviceActions.connectDevice({ device }));
                 dispatch(selectNewlyConnectedDeviceThunk({ device }));
                 break;
             case DEVICE.CONNECT_UNACQUIRED:
-                dispatch(
-                    deviceActions.connectUnacquiredDevice({
-                        device,
-                        isAutoEjectEnabled,
-                    }),
-                );
+                dispatch(deviceActions.connectUnacquiredDevice({ device }));
                 if (getIsThpDevice(device) && !isFwInstallation) {
                     // This needs to be re-selected to convert Device to TrezorDevice.
                     const requestedDevice = selectDevices(getState()).find(

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -7,6 +7,7 @@ import {
     selectDevices,
     selectEntropyCheckResultByDeviceId,
     selectSelectedDevice,
+    shouldDeviceBeRemembered,
 } from '@suite-common/device';
 import {
     type AnyAction,
@@ -137,6 +138,7 @@ export const applyDeviceStatesThunk = createThunk<
 
             // now we expect that there is exactly one device without state - meaning that we want to update its state
             const isAutoEjectEnabled = selectIsDeviceAutoEjectEnabled(getState());
+            const remember = shouldDeviceBeRemembered({ isAutoEjectEnabled, device });
 
             if (devicesByPathWithoutState.length === 1) {
                 dispatch(
@@ -144,18 +146,18 @@ export const applyDeviceStatesThunk = createThunk<
                         device,
                         state: newDeviceState,
                         useEmptyPassphrase,
-                        isAutoEjectEnabled,
                     }),
                 );
+                dispatch(deviceActions.setRememberDevice({ device, remember }));
             } else {
                 dispatch(
                     deviceActions.addAuthorizedDevice({
                         device,
                         state: newDeviceState,
                         useEmptyPassphrase,
-                        isAutoEjectEnabled,
                     }),
                 );
+                dispatch(deviceActions.setRememberDevice({ device, remember }));
 
                 // select the device after deviceReducer updates it (it's a new object reference)
                 const newlyAddedDevice = selectDeviceByStaticSessionId(getState(), staticSessionId);
@@ -724,13 +726,11 @@ export const runAdditionalDiscoveryThunk = createThunk(
         assertStaticSessionId(deviceStateResponse.payload.state);
 
         if (device.useEmptyPassphrase) {
-            const isAutoEjectEnabled = selectIsDeviceAutoEjectEnabled(getState());
             dispatch(
                 deviceActions.setDeviceState({
                     device,
                     state: deviceStateResponse.payload.state,
                     useEmptyPassphrase: device.useEmptyPassphrase,
-                    isAutoEjectEnabled,
                 }),
             );
         }


### PR DESCRIPTION
- The `remember` flag set do `false` when a device is connected.
- Once discovery starts, the `remember` flag is updated based on user's configuration.
- This ensures a connected device is not remembered until discovery runs.

This change is required before the network activation is triggered from dashboard.

Required for #27339.

## Notes for QA

On mobile, it's currently not possible to get to dashboard with a device connected but no network selected. Just make sure the app behaves as expected, i.e. auto-eject works.

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes span three core shared modules: deviceActions, deviceReducer (device state management), and discoveryThunks (wallet discovery logic), plus a Bluetooth reducer test file. Since deviceActions/deviceReducer/discoveryThunks each map to 121+ tests, they are broad global dependencies requiring focused test selection. The highest risk is in wallet discovery flows (discoveryThunks changes) and device state management (deviceReducer/deviceActions changes). Priority testing should focus on discovery-specific tests and device state transition tests, with secondary coverage for session management and error handling paths.

<details><summary><b>Changed files (4)</b></summary>

- `suite-common/bluetooth/tests/bluetoothReducer.test.ts`
- `suite-common/device/src/deviceActions.ts`
- `suite-common/device/src/deviceReducer.ts`
- `suite-common/wallet-core/src/discovery/discoveryThunks.ts`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/general/wallet-discovery.test.ts` — This test directly exercises wallet discovery (ejecting wallet, adding standard wallet, checking BTC balance), which is the core functionality of discoveryThunks.ts. Changes to discovery logic or device actions/reducer could cause discovery to fail or return incorrect results.
- `suite/e2e/tests/wallet/discovery.test.ts` — This test activates multiple coins and verifies discovery completes successfully, including checking Redux wallet.discovery status transitions and page reload resilience. It directly validates the discoveryThunks.ts changes and depends on correct device state management from deviceReducer/deviceActions.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test configures custom Blockbook backends and verifies discovery completes successfully with a dashboard graph displayed. It exercises the discovery pipeline end-to-end which is directly affected by discoveryThunks.ts changes.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts` — This test specifically validates that discovery fails gracefully when offline, checking for a discovery-failed description element. Changes to discoveryThunks.ts could affect error handling paths during offline discovery.
- `suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts` — This test directly dispatches deviceActions.setSimulatedEntropyCheckFail via Redux store, testing the entropy check failure handling. Changes to deviceActions.ts could break this action or its effects on device state.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test enables coins, configures custom backends, and verifies discovery completion (discoveryShouldFinish). It also checks discovery error states when a wrong backend is used. Both paths exercise discoveryThunks.ts logic.
- `suite/e2e/tests/settings/electrum.test.ts` — This test configures an Electrum backend and verifies discovery finishes successfully with correct account balance display. It validates the discovery pipeline through discoveryThunks.ts with a non-standard backend type.
- `suite/e2e/tests/dashboard/assets.test.ts` — This test enables coins via an Activate Assets modal and waits for discovery to finish (discoveryShouldFinish). Changes to discoveryThunks.ts could prevent new coins from being properly discovered after activation.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test validates device session management (session stealing, 'Use Here' status, solving issues). Changes to deviceReducer.ts and deviceActions.ts directly affect device connection state tracking and session management that this test verifies.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/backup/t2t1-fail.test.ts` — This test simulates device disconnect/reconnect during backup, checking device status transitions. Changes to deviceReducer could affect how disconnect/reconnect states are managed, though backup-specific logic is less likely impacted.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — This test verifies device disconnect/reconnect behavior with passphrase wallets, checking deviceDisconnectedStatus and passphrase caching. Changes to deviceReducer.ts could affect device connection state tracking used in this flow.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/bluetooth/tests/bluetoothReducer.test.ts`

_Updated: 2026-05-04T12:20:23.658Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/common/device-remember-during-discovery&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/common/device-remember-during-discovery&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/common/device-remember-during-discovery&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy Negative scenarios > Buy form handles input limits and empty quotes | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-04T13:21:47.725Z • 12 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-05T12:05:20.201Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/common/device-remember-during-discovery/web/](https://dev.suite.sldev.cz/suite-web/fix/common/device-remember-during-discovery/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->