### PR TITLE
chore(suite-native): react-native-gesture-handler upgrade

### DIFF
--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -143,7 +143,7 @@
         "react-native": "0.83.2",
         "react-native-ble-plx": "3.5.1",
         "react-native-edge-to-edge": "1.7.0",
-        "react-native-gesture-handler": "2.30.0",
+        "react-native-gesture-handler": "2.31.1",
         "react-native-get-random-values": "^2.0.0",
         "react-native-keyboard-controller": "1.20.7",
         "react-native-launch-arguments": "^4.1.1",

--- a/suite-native/atoms/package.json
+++ b/suite-native/atoms/package.json
@@ -37,7 +37,7 @@
         "lottie-react-native": "7.3.5",
         "react": "19.2.4",
         "react-native": "0.83.2",
-        "react-native-gesture-handler": "2.30.0",
+        "react-native-gesture-handler": "2.31.1",
         "react-native-keyboard-controller": "1.20.7",
         "react-native-reanimated": "~4.2.1",
         "react-native-safe-area-context": "5.6.2",

--- a/suite-native/confirm-on-trezor/package.json
+++ b/suite-native/confirm-on-trezor/package.json
@@ -25,7 +25,7 @@
         "expo-linear-gradient": "~55.0.8",
         "react": "19.2.4",
         "react-native": "0.83.2",
-        "react-native-gesture-handler": "2.30.0",
+        "react-native-gesture-handler": "2.31.1",
         "react-native-reanimated": "~4.2.1"
     }
 }

--- a/suite-native/device/package.json
+++ b/suite-native/device/package.json
@@ -64,7 +64,7 @@
         "jotai": "2.17.1",
         "react": "19.2.4",
         "react-native": "0.83.2",
-        "react-native-gesture-handler": "2.30.0",
+        "react-native-gesture-handler": "2.31.1",
         "react-native-reanimated": "~4.2.1",
         "react-native-svg": "15.15.3",
         "react-redux": "9.2.0",

--- a/suite-native/module-trading/package.json
+++ b/suite-native/module-trading/package.json
@@ -84,7 +84,7 @@
         "react": "19.2.4",
         "react-intl": "^8.1.3",
         "react-native": "0.83.2",
-        "react-native-gesture-handler": "2.30.0",
+        "react-native-gesture-handler": "2.31.1",
         "react-native-reanimated": "~4.2.1",
         "react-native-safe-area-context": "5.6.2",
         "react-redux": "9.2.0"

--- a/suite-native/react-native-graph/package.json
+++ b/suite-native/react-native-graph/package.json
@@ -17,7 +17,7 @@
         "@types/react": "19.2.14",
         "react": "19.2.4",
         "react-native": "0.83.2",
-        "react-native-gesture-handler": "2.30.0",
+        "react-native-gesture-handler": "2.31.1",
         "react-native-reanimated": "~4.2.1"
     },
     "devDependencies": {

--- a/suite-native/receive/package.json
+++ b/suite-native/receive/package.json
@@ -49,7 +49,7 @@
         "@trezor/urls": "workspace:*",
         "react": "19.2.4",
         "react-native": "0.83.2",
-        "react-native-gesture-handler": "2.30.0",
+        "react-native-gesture-handler": "2.31.1",
         "react-native-reanimated": "~4.2.1",
         "react-redux": "9.2.0",
         "type-fest": "5.5.0"

--- a/suite-native/swipeable-walkthrough/package.json
+++ b/suite-native/swipeable-walkthrough/package.json
@@ -17,7 +17,7 @@
         "jotai": "2.17.1",
         "react": "19.2.4",
         "react-native": "0.83.2",
-        "react-native-gesture-handler": "2.30.0",
+        "react-native-gesture-handler": "2.31.1",
         "react-native-reanimated": "~4.2.1",
         "react-native-safe-area-context": "5.6.2"
     }

--- a/suite-native/trading-atoms/package.json
+++ b/suite-native/trading-atoms/package.json
@@ -29,7 +29,7 @@
         "@trezor/type-utils": "workspace:*",
         "react": "19.2.4",
         "react-native": "0.83.2",
-        "react-native-gesture-handler": "2.30.0",
+        "react-native-gesture-handler": "2.31.1",
         "react-native-reanimated": "~4.2.1",
         "type-fest": "5.5.0"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -12272,7 +12272,7 @@ __metadata:
     react-native: "npm:0.83.2"
     react-native-ble-plx: "npm:3.5.1"
     react-native-edge-to-edge: "npm:1.7.0"
-    react-native-gesture-handler: "npm:2.30.0"
+    react-native-gesture-handler: "npm:2.31.1"
     react-native-get-random-values: "npm:^2.0.0"
     react-native-keyboard-controller: "npm:1.20.7"
     react-native-launch-arguments: "npm:^4.1.1"
@@ -12373,7 +12373,7 @@ __metadata:
     lottie-react-native: "npm:7.3.5"
     react: "npm:19.2.4"
     react-native: "npm:0.83.2"
-    react-native-gesture-handler: "npm:2.30.0"
+    react-native-gesture-handler: "npm:2.31.1"
     react-native-keyboard-controller: "npm:1.20.7"
     react-native-reanimated: "npm:~4.2.1"
     react-native-safe-area-context: "npm:5.6.2"
@@ -12527,7 +12527,7 @@ __metadata:
     expo-linear-gradient: "npm:~55.0.8"
     react: "npm:19.2.4"
     react-native: "npm:0.83.2"
-    react-native-gesture-handler: "npm:2.30.0"
+    react-native-gesture-handler: "npm:2.31.1"
     react-native-reanimated: "npm:~4.2.1"
   languageName: unknown
   linkType: soft
@@ -12710,7 +12710,7 @@ __metadata:
     jotai: "npm:2.17.1"
     react: "npm:19.2.4"
     react-native: "npm:0.83.2"
-    react-native-gesture-handler: "npm:2.30.0"
+    react-native-gesture-handler: "npm:2.31.1"
     react-native-reanimated: "npm:~4.2.1"
     react-native-svg: "npm:15.15.3"
     react-redux: "npm:9.2.0"
@@ -13957,7 +13957,7 @@ __metadata:
     react: "npm:19.2.4"
     react-intl: "npm:^8.1.3"
     react-native: "npm:0.83.2"
-    react-native-gesture-handler: "npm:2.30.0"
+    react-native-gesture-handler: "npm:2.31.1"
     react-native-reanimated: "npm:~4.2.1"
     react-native-safe-area-context: "npm:5.6.2"
     react-redux: "npm:9.2.0"
@@ -14107,7 +14107,7 @@ __metadata:
     "@types/react": "npm:19.2.14"
     react: "npm:19.2.4"
     react-native: "npm:0.83.2"
-    react-native-gesture-handler: "npm:2.30.0"
+    react-native-gesture-handler: "npm:2.31.1"
     react-native-reanimated: "npm:~4.2.1"
   languageName: unknown
   linkType: soft
@@ -14154,7 +14154,7 @@ __metadata:
     "@trezor/urls": "workspace:*"
     react: "npm:19.2.4"
     react-native: "npm:0.83.2"
-    react-native-gesture-handler: "npm:2.30.0"
+    react-native-gesture-handler: "npm:2.31.1"
     react-native-reanimated: "npm:~4.2.1"
     react-redux: "npm:9.2.0"
     type-fest: "npm:5.5.0"
@@ -14408,7 +14408,7 @@ __metadata:
     jotai: "npm:2.17.1"
     react: "npm:19.2.4"
     react-native: "npm:0.83.2"
-    react-native-gesture-handler: "npm:2.30.0"
+    react-native-gesture-handler: "npm:2.31.1"
     react-native-reanimated: "npm:~4.2.1"
     react-native-safe-area-context: "npm:5.6.2"
   languageName: unknown
@@ -14568,7 +14568,7 @@ __metadata:
     "@types/invity-api": "npm:^1.1.15"
     react: "npm:19.2.4"
     react-native: "npm:0.83.2"
-    react-native-gesture-handler: "npm:2.30.0"
+    react-native-gesture-handler: "npm:2.31.1"
     react-native-reanimated: "npm:~4.2.1"
     type-fest: "npm:5.5.0"
   languageName: unknown
@@ -18090,6 +18090,15 @@ __metadata:
   peerDependencies:
     "@types/react": ^19.2.0
   checksum: 10/616c4a8aee250ea05fb1e7b98e7e00475dd3a6c1c30d7be18b4b93caba832f4203106b3a496a6b147e5acc2da14575eca47bce234c633bca1f8430ef8ffb234a
+  languageName: node
+  linkType: hard
+
+"@types/react-test-renderer@npm:^19.1.0":
+  version: 19.1.0
+  resolution: "@types/react-test-renderer@npm:19.1.0"
+  dependencies:
+    "@types/react": "npm:*"
+  checksum: 10/2ef3aec0f2fd638902cda606d70c8531d66f8e8944334427986b99dcac9755ee60b700c5c3a19ac354680f9c45669e98077b84f79cac60e950bdb7d38aebffde
   languageName: node
   linkType: hard
 
@@ -40364,17 +40373,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-gesture-handler@npm:2.30.0":
-  version: 2.30.0
-  resolution: "react-native-gesture-handler@npm:2.30.0"
+"react-native-gesture-handler@npm:2.31.1":
+  version: 2.31.1
+  resolution: "react-native-gesture-handler@npm:2.31.1"
   dependencies:
     "@egjs/hammerjs": "npm:^2.0.17"
+    "@types/react-test-renderer": "npm:^19.1.0"
     hoist-non-react-statics: "npm:^3.3.0"
     invariant: "npm:^2.2.4"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10/242b1eb29202bc9fc7bf0271c3da102559adc9f2810441465b6d78c1a8ed8f65bdd91335957c841a4716f796be3e7b87d1d55629d6803ea12e1be832d89c946c
+  checksum: 10/0f02d989fddae1a59f3595b8039da04e8332206e0e8f7e05548b1ab2e57b6efa1b37d634ac8e5cc85b1844363a78f2f1400ace26164319b2140e994b0e779ea3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Upgrade `react-native-gesture-handler` because the older version was causing build problems with newest xcode (`26.4.1`).

Edit: Turns out the xcode build problem was something local on my side, but I would probably merge anyway. 

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/upgrade-react-native-gesture-handler&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/upgrade-react-native-gesture-handler&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/upgrade-react-native-gesture-handler&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy Negative scenarios > Buy form handles input limits and empty quotes | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-04T13:03:08.600Z • 12 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-04T13:01:49.283Z • 13 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/upgrade-react-native-gesture-handler/web/](https://dev.suite.sldev.cz/suite-web/chore/upgrade-react-native-gesture-handler/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->