### PR TITLE
docs(connect): document outputDescriptorBip380 on getAccountDescriptor

### DIFF
--- a/packages/connect-common/src/types/api/__tests__/bitcoin.ts
+++ b/packages/connect-common/src/types/api/__tests__/bitcoin.ts
@@ -627,6 +627,7 @@ export const getAccountDescriptor = async (api: TrezorConnect) => {
         payload.descriptor.toLowerCase();
         payload.path.toLowerCase();
         payload.legacyXpub?.toLowerCase();
+        payload.outputDescriptorBip380?.toLowerCase();
     }
 
     const bundle = await api.getAccountDescriptor({

--- a/packages/connect-explorer/src/pages/methods/other/getAccountDescriptor.mdx
+++ b/packages/connect-explorer/src/pages/methods/other/getAccountDescriptor.mdx
@@ -72,7 +72,7 @@ TrezorConnect.getAccountDescriptor({
         path: string,                         // serialized path
         descriptor: string,                   // account public key
         legacyXpub?: string,                  // (optional) account public key in legacy format (only for segwit and segwit native accounts)
-
+        outputDescriptorBip380?: string,      // (optional) Bitcoin-only BIP380 output descriptor
     }
 }
 ```


### PR DESCRIPTION
## Summary

Tiny docs/test debt fill spotted while reviewing #27299.

The `outputDescriptorBip380?: string` field has been part of `GetAccountDescriptorResponse` since firmware 2.6.5 (the runtime in [`packages/connect/src/api/getAccountDescriptor.ts`](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/api/getAccountDescriptor.ts) builds it from `legacyXpub` for older firmware). It was, however, missing from:

1. The public docs response example for `getAccountDescriptor` in [`connect-explorer/src/pages/methods/other/getAccountDescriptor.mdx`](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-explorer/src/pages/methods/other/getAccountDescriptor.mdx) — readers couldn't tell from docs that the field exists on the response.
2. The optional-field coverage in the `getAccountDescriptor` type-test ([`connect-common/src/types/api/__tests__/bitcoin.ts`](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/src/types/api/__tests__/bitcoin.ts)) — every other optional field on the response was exercised.

Two-line additive change, no runtime impact.

## Test plan

- [x] `yarn workspace @trezor/connect-common type-check` — clean
- [x] `yarn workspace @trezor/connect-common lint:js` — clean

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/output-descriptor-bip380-docs/web/](https://dev.suite.sldev.cz/suite-web/mroz22/output-descriptor-bip380-docs/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/output-descriptor-bip380-docs&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy Negative scenarios > Buy form handles input limits and empty quotes | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-04T13:12:16.991Z • 12 test(s) total_
<!-- QUARANTINE-LIST:web:END -->