### PR TITLE
fix(e2e): Increased timeout for deviceOnboarding android e2e test

### DIFF
--- a/suite-native/app/e2e/tests/deviceOnboarding.test.ts
+++ b/suite-native/app/e2e/tests/deviceOnboarding.test.ts
@@ -25,7 +25,7 @@ const preloadedState = preparePreloadedReduxState(
     btcCoinEnabled,
 );
 
-const LONG_RUNNING_TEST_TIMEOUT = 5 * 60 * 1000; // [ms]
+const LONG_RUNNING_TEST_TIMEOUT = 7 * 60 * 1000; // [ms]
 
 describe('Device onboarding [@androidOnly @smoke @T3T1 @T3W1]', () => {
     beforeEach(async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This is smelly and we are discussing real underlying issues on Slack, but let's see if even more time actually helps or not.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-e2e-android-nightly&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->