### PR TITLE
fix(suite-native): fix banners UI in support screen

### DIFF
--- a/suite-native/atoms/src/index.ts
+++ b/suite-native/atoms/src/index.ts
@@ -82,6 +82,7 @@ export * from './Sheet/hooks/useBottomSheetModal';
 export * from './AnimatedDoubleView/AnimatedDoubleView';
 export * from './AnimatedDoubleView/AnimatedDoubleInput';
 export * from './Pressable';
+export * from './useTapGesture';
 export * from './SegmentedControl';
 export * from './ProgressBar';
 

--- a/suite-native/module-settings/src/components/AboutUsBanners.tsx
+++ b/suite-native/module-settings/src/components/AboutUsBanners.tsx
@@ -9,7 +9,7 @@ import { TREZOR_INSTAGRAM_URL, TREZOR_TIKTOK_URL, TREZOR_X_URL } from '@trezor/u
 
 const cardStyle = prepareNativeStyle<{ backgroundColor: Color }>((utils, { backgroundColor }) => ({
     paddingHorizontal: utils.spacings.sp24,
-    paddingVertical: utils.spacings.sp24 * 2,
+    paddingVertical: utils.spacings.sp24,
     backgroundColor: utils.colors[backgroundColor],
 }));
 
@@ -37,10 +37,10 @@ export const AboutUsBanners = () => {
                     })}
                 >
                     <VStack spacing="sp24" style={applyStyle(stackStyle)}>
-                        <Icon color="contentButtonBrandPrimary" name="trezorLogo" />
+                        <Icon color="contentPrimaryInverse" name="trezorLogo" />
                         <Text
                             textAlign="center"
-                            color="contentButtonBrandPrimary"
+                            color="contentPrimaryInverse"
                             variant="headline-sm"
                             style={applyStyle(trezorDescriptionTextStyle)}
                         >
@@ -65,35 +65,24 @@ export const AboutUsBanners = () => {
                         <HStack spacing="sp24">
                             <IconButton
                                 intent="neutral"
-                                priority="secondary"
+                                priority="primary"
+                                isInverse={true}
                                 iconName="twitterLogo"
-                                accessibilityRole="link"
-                                accessibilityLabel="X"
                                 onPress={() => openLink(TREZOR_X_URL, { enforce: true })}
                             />
                             <IconButton
                                 intent="neutral"
-                                priority="secondary"
+                                priority="primary"
+                                isInverse={true}
                                 iconName="tiktokLogo"
-                                accessibilityRole="link"
-                                accessibilityLabel="tiktok"
-                                onPress={() =>
-                                    openLink(TREZOR_TIKTOK_URL, {
-                                        enforce: true,
-                                    })
-                                }
+                                onPress={() => openLink(TREZOR_TIKTOK_URL, { enforce: true })}
                             />
                             <IconButton
                                 intent="neutral"
-                                priority="secondary"
+                                priority="primary"
+                                isInverse={true}
                                 iconName="instagramLogo"
-                                accessibilityRole="link"
-                                accessibilityLabel="instagram"
-                                onPress={() =>
-                                    openLink(TREZOR_INSTAGRAM_URL, {
-                                        enforce: true,
-                                    })
-                                }
+                                onPress={() => openLink(TREZOR_INSTAGRAM_URL, { enforce: true })}
                             />
                         </HStack>
                     </VStack>


### PR DESCRIPTION
## Description


- fix the three `IconButton` usages in `AboutUsBanners` with correct color variants
- color of about us banners texts fixed
- banners paddings adjusted

## Notes for QA

- Open Settings → About Us screen
- Verify three social icons (X, TikTok, Instagram) render correctly
- Tap each icon — should animate (opacity fade) and open the respective link in the browser

## Related Issue

Resolve #27341

## Screenshots:
<img width="361" height="756" alt="Screenshot 2026-05-11 at 06 50 39" src="https://github.com/user-attachments/assets/4a3971f6-3357-4104-8e56-57823239572c" />


<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are all within the `suite-native` package (mobile/native app), specifically modifying `module-settings` components (AboutUsBanners.tsx, SocialsIcon.tsx), the atoms index re-export, and a package.json. All E2E tests in the repository are for the desktop/web Suite application (under `suite/e2e/tests/`), not the native mobile app. None of these tests exercise native-specific UI components like AboutUsBanners or SocialsIcon, and there is no static or inferred test coverage mapping these native-only changes to any existing E2E test. The risk of regression to the web/desktop Suite is negligible since these changes are scoped entirely to the native app layer. No E2E tests need to be run.

<details><summary><b>Changed files (4)</b></summary>

- `suite-native/atoms/src/index.ts`
- `suite-native/module-settings/package.json`
- `suite-native/module-settings/src/components/AboutUsBanners.tsx`
- `suite-native/module-settings/src/components/SocialsIcon.tsx`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (4)**
- `suite-native/atoms/src/index.ts`
- `suite-native/module-settings/package.json`
- `suite-native/module-settings/src/components/AboutUsBanners.tsx`
- `suite-native/module-settings/src/components/SocialsIcon.tsx`

_Updated: 2026-05-05T07:38:17.651Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/settings-socials-icon-component&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/settings-socials-icon-component&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-05T07:52:34.069Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/settings-socials-icon-component/web/](https://dev.suite.sldev.cz/suite-web/feat/settings-socials-icon-component/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->