### PR TITLE
Put POPUP.CLOSE in it's place and bring to live new event CORE_CALL_CANCEL

### DIFF
--- a/packages/connect-common/src/events/call.ts
+++ b/packages/connect-common/src/events/call.ts
@@ -1,4 +1,4 @@
-import type { CORE_CALL } from './core-call';
+import type { CORE_CALL, CORE_CALL_CANCEL } from './core-call';
 import { type SerializedError, serializeError } from '../constants/errors';
 import type { DeviceState, DeviceUniquePath } from '../types';
 import type { TrezorConnect, TrezorConnectManagement } from '../types/api';
@@ -60,6 +60,11 @@ export interface CoreCallMessage {
     id: string;
     type: typeof CORE_CALL;
     payload: CallMethodPayload;
+}
+
+export interface CoreCallCancelMessage {
+    type: typeof CORE_CALL_CANCEL;
+    payload: { reason?: string } | null;
 }
 
 export const RESPONSE_EVENT = 'RESPONSE_EVENT';

--- a/packages/connect-common/src/events/core-call.ts
+++ b/packages/connect-common/src/events/core-call.ts
@@ -1,2 +1,5 @@
 // Request to execute a Connect method in Core
 export const CORE_CALL = 'iframe-call' as const; // Keep old name for backward compatibility.
+
+// Request to cancel an in-progress Core method call
+export const CORE_CALL_CANCEL = 'core-call-cancel' as const;

--- a/packages/connect-common/src/events/core.ts
+++ b/packages/connect-common/src/events/core.ts
@@ -1,7 +1,7 @@
 import type { Err } from '@trezor/type-utils';
 
 import type { BlockchainEventMessage } from './blockchain';
-import type { CoreCallMessage, MethodResponseMessage } from './call';
+import type { CoreCallCancelMessage, CoreCallMessage, MethodResponseMessage } from './call';
 import type { DeviceEventMessage } from './device';
 import type { PopupClosedMessage, PopupEventMessage } from './popup';
 import type {
@@ -19,6 +19,7 @@ export const CORE_EVENT = 'CORE_EVENT';
 
 export type CoreRequestMessage =
     | PopupClosedMessage
+    | CoreCallCancelMessage
     | TransportDisableWebUSB
     | TransportSetTransports
     | TransportRequestWebUSBDevice

--- a/packages/connect-web/src/impl/core-in-suite-desktop.ts
+++ b/packages/connect-web/src/impl/core-in-suite-desktop.ts
@@ -1,6 +1,7 @@
 import * as ERRORS from '@trezor/connect-common/src/constants/errors';
 import {
     CORE_CALL,
+    CORE_CALL_CANCEL,
     type CallMethodAnyResponse,
     type CallMethodPayload,
     POPUP,
@@ -30,10 +31,10 @@ export class CoreInSuiteDesktop implements ConnectImpl {
         return Promise.resolve(undefined);
     }
 
-    public cancel(_error?: string) {
+    public cancel(reason?: string) {
         this.ws.sendMessage({
-            type: POPUP.CLOSED,
-            payload: { error: _error },
+            type: CORE_CALL_CANCEL,
+            payload: reason ? { reason } : null,
         });
     }
 

--- a/packages/connect-web/src/impl/core-in-suite-web.ts
+++ b/packages/connect-web/src/impl/core-in-suite-web.ts
@@ -1,9 +1,9 @@
 import * as ERRORS from '@trezor/connect-common/src/constants/errors';
 import {
     CORE_CALL,
+    CORE_CALL_CANCEL,
     type CallMethodAnyResponse,
     type CallMethodPayload,
-    POPUP,
     createErrorMessage,
 } from '@trezor/connect-common/src/events';
 import type { ConnectImpl, ConnectImplSettings } from '@trezor/connect-common/src/impl/dynamic';
@@ -32,8 +32,8 @@ export class CoreInSuiteWeb implements ConnectImpl {
         return Promise.resolve(undefined);
     }
 
-    public cancel(error?: string) {
-        this.logger.debug('cancel', error);
+    public cancel(reason?: string) {
+        this.logger.debug('cancel', reason);
 
         // Flush any pending outgoing messages so that the cancel is not
         // delayed behind queued sends (relevant for the webextension
@@ -41,8 +41,8 @@ export class CoreInSuiteWeb implements ConnectImpl {
         this._popupManager?.channel?.clearPendingSends();
         this._popupManager?.channel?.postMessage(
             {
-                type: POPUP.CLOSED,
-                payload: error ? { error } : {},
+                type: CORE_CALL_CANCEL,
+                payload: reason ? { reason } : null,
             },
             { usePromise: false },
         );

--- a/packages/connect-webextension/src/index.ts
+++ b/packages/connect-webextension/src/index.ts
@@ -1,6 +1,6 @@
 // note: at the moment, there is something in the root of @trezor/connect-common that pulls entire PROTO runtime, thus
 // these targeted imports
-import { POPUP } from '@trezor/connect-common/src/events';
+import { CORE_CALL_CANCEL, POPUP } from '@trezor/connect-common/src/events';
 import { factory } from '@trezor/connect-common/src/factory';
 import { type ConnectDynamicSettings } from '@trezor/connect-common/src/impl/dynamic';
 import { TrezorConnectDynamic } from '@trezor/connect-common/src/impl/dynamic';
@@ -34,7 +34,7 @@ const initProxyChannel = () => {
         type: string;
         method: keyof typeof TrezorConnect;
         settings: ConnectDynamicSettings;
-        error?: string;
+        reason?: string;
     }>({
         name: 'trezor-connect-proxy',
         channel: {
@@ -51,10 +51,10 @@ const initProxyChannel = () => {
     channel.on('message', message => {
         const { id, payload, type } = message;
 
-        // Handle cancel/close before the payload guard — cancel messages
-        // may carry no meaningful payload.
-        if (type === POPUP.CLOSED) {
-            TrezorConnect.cancel(payload?.error);
+        // Handle cancel before the payload guard — cancel messages may
+        // carry no meaningful payload.
+        if (type === CORE_CALL_CANCEL) {
+            TrezorConnect.cancel(payload?.reason);
 
             return;
         }

--- a/packages/connect-webextension/src/index.ts
+++ b/packages/connect-webextension/src/index.ts
@@ -35,6 +35,8 @@ const initProxyChannel = () => {
         method: keyof typeof TrezorConnect;
         settings: ConnectDynamicSettings;
         reason?: string;
+        // We need `error` field for backward compatibility, for connect10 with older clients.
+        error?: string;
     }>({
         name: 'trezor-connect-proxy',
         channel: {
@@ -53,6 +55,11 @@ const initProxyChannel = () => {
 
         // Handle cancel before the payload guard — cancel messages may
         // carry no meaningful payload.
+        if (type === POPUP.CLOSED) {
+            TrezorConnect.cancel(payload?.error);
+
+            return;
+        }
         if (type === CORE_CALL_CANCEL) {
             TrezorConnect.cancel(payload?.reason);
 

--- a/packages/connect-webextension/src/proxy/index.ts
+++ b/packages/connect-webextension/src/proxy/index.ts
@@ -1,5 +1,10 @@
 import { ERRORS, WEBEXTENSION } from '@trezor/connect-common/src/constants';
-import { CORE_CALL, type CallMethod, POPUP } from '@trezor/connect-common/src/events';
+import {
+    CORE_CALL,
+    CORE_CALL_CANCEL,
+    type CallMethod,
+    POPUP,
+} from '@trezor/connect-common/src/events';
 import { createErrorMessage } from '@trezor/connect-common/src/events';
 import { factory } from '@trezor/connect-common/src/factory';
 import { type ConnectDynamicSettings } from '@trezor/connect-common/src/impl/dynamic';
@@ -16,12 +21,12 @@ const dispose = () => {
     return Promise.resolve(undefined);
 };
 
-const cancel = (error?: string) => {
+const cancel = (reason?: string) => {
     if (_channel) {
         _channel.postMessage(
             {
-                type: POPUP.CLOSED,
-                payload: error ? { error } : {},
+                type: CORE_CALL_CANCEL,
+                payload: reason ? { reason } : null,
             },
             { usePromise: false },
         );

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -3,6 +3,7 @@ import EventEmitter from 'events';
 
 import {
     CORE_CALL,
+    CORE_CALL_CANCEL,
     CORE_EVENT,
     DEVICE,
     POPUP,
@@ -23,6 +24,7 @@ import type {
     TransportInfo,
 } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
+import type { TrezorError } from '@trezor/connect-common/src/constants/errors';
 import { parseLocalFirmwares } from '@trezor/connect-common/src/data/connectSettings';
 import {
     type LogWriter,
@@ -640,17 +642,12 @@ const registerDeviceEvents =
         device.on(DEVICE.THP_PAIRING_STATUS_CHANGED, onThpPhaseChangedHandler(device, context));
     };
 
-/**
- * Handle popup closed by user.
- * @returns {void}
- * @memberof Core
- */
-const onPopupClosed = (context: CoreContext, customErrorMessage?: string) => {
+// Shared cancel/interrupt routine. The caller decides which TrezorError to use,
+// which determines whether the consumer sees Method_Interrupted (popup closed)
+// or Method_Cancel (explicit cancel() call).
+const abortRunningCall = (context: CoreContext, error: TrezorError) => {
     const { uiPromises, deviceList, callMethods, resetWaitForFirstMethod, sendCoreMessage } =
         context;
-    const error = customErrorMessage
-        ? ERRORS.TypedError('Method_Cancel', customErrorMessage)
-        : ERRORS.TypedError('Method_Interrupted');
     // Device was already acquired. Try to interrupt running action which will throw error from onCall try/catch block
     if (deviceList.isConnected() && deviceList.getDeviceCount() > 0) {
         deviceList.getAllDevices().forEach(d => {
@@ -672,6 +669,16 @@ const onPopupClosed = (context: CoreContext, customErrorMessage?: string) => {
         uiPromises.rejectAll(error);
     }
     cleanup(context);
+};
+
+// Handle genuine popup window close (always produces Method_Interrupted)
+const onPopupClosed = (context: CoreContext) => {
+    abortRunningCall(context, ERRORS.TypedError('Method_Interrupted'));
+};
+
+// Handle an explicit cancel() call (always produces Method_Cancel)
+const onCallCancel = (context: CoreContext, reason?: string) => {
+    abortRunningCall(context, ERRORS.TypedError('Method_Cancel', reason));
 };
 
 const initDeviceList = (context: CoreContext) => {
@@ -768,10 +775,11 @@ export class Core extends EventEmitter {
 
         switch (message.type) {
             case POPUP.CLOSED:
-                onPopupClosed(
-                    this.getCoreContext(),
-                    message.payload ? message.payload.error : null,
-                );
+                onPopupClosed(this.getCoreContext());
+                break;
+
+            case CORE_CALL_CANCEL:
+                onCallCancel(this.getCoreContext(), message.payload?.reason);
                 break;
 
             case TRANSPORT.DISABLE_WEBUSB: {

--- a/packages/connect/src/impl/core-in-module.ts
+++ b/packages/connect/src/impl/core-in-module.ts
@@ -1,8 +1,8 @@
 import {
     BLOCKCHAIN_EVENT,
     CORE_CALL,
+    CORE_CALL_CANCEL,
     DEVICE_EVENT,
-    POPUP,
     RESPONSE_EVENT,
     TRANSPORT_EVENT,
     UI_EVENT,
@@ -177,8 +177,8 @@ export abstract class CoreInModule implements ConnectFactoryDependencies<Connect
         this.handleCoreMessage(response);
     }
 
-    public cancel(error?: string) {
-        this.handleCoreMessage({ type: POPUP.CLOSED, payload: error ? { error } : null });
+    public cancel(reason?: string) {
+        this.handleCoreMessage({ type: CORE_CALL_CANCEL, payload: reason ? { reason } : null });
     }
 
     public dispose() {

--- a/packages/suite-desktop-core/src/libs/connect-ws.ts
+++ b/packages/suite-desktop-core/src/libs/connect-ws.ts
@@ -2,10 +2,11 @@ import { WebSocketServer } from 'ws';
 
 import {
     CORE_CALL,
+    CORE_CALL_CANCEL,
+    type CoreCallCancelMessage,
     type CoreCallMessage,
     type Manifest,
     POPUP,
-    type PopupClosedMessage,
     type PopupHandshake,
 } from '@trezor/connect';
 import { parseManifest, parseVersion } from '@trezor/connect-common/src/data/connectSettings';
@@ -26,7 +27,7 @@ const LOG_PREFIX = 'connect-ws';
 type IncomingMessage =
     | (CoreCallMessage & { id: string })
     | (PopupHandshake & { id: string })
-    | (PopupClosedMessage & { id: string })
+    | (CoreCallCancelMessage & { id: string })
     | { type: 'ping'; id: string };
 
 const validateIncomingMessage = (message: any): message is IncomingMessage => {
@@ -47,7 +48,7 @@ const validateIncomingMessage = (message: any): message is IncomingMessage => {
         return true;
     }
 
-    if (message.type === POPUP.CLOSED) {
+    if (message.type === CORE_CALL_CANCEL) {
         return true;
     }
 
@@ -137,9 +138,9 @@ export const exposeConnectWs = ({
                 manifest = parseManifest(message.payload.settings.manifest);
                 version = parseVersion(message.payload.settings.version);
                 ws.send(JSON.stringify({ id: message.id, type: POPUP.HANDSHAKE, payload: 'ok' }));
-            } else if (message.type === POPUP.CLOSED) {
+            } else if (message.type === CORE_CALL_CANCEL) {
                 mainWindowProxy.getInstance()?.webContents.send('connect-popup/cancel', {
-                    error: message.payload?.error,
+                    error: message.payload?.reason,
                 });
             } else if (message.type === CORE_CALL) {
                 if (!processOnPort) {

--- a/packages/suite-desktop-core/src/libs/connect-ws.ts
+++ b/packages/suite-desktop-core/src/libs/connect-ws.ts
@@ -7,6 +7,7 @@ import {
     type CoreCallMessage,
     type Manifest,
     POPUP,
+    type PopupClosedMessage,
     type PopupHandshake,
 } from '@trezor/connect';
 import { parseManifest, parseVersion } from '@trezor/connect-common/src/data/connectSettings';
@@ -27,6 +28,7 @@ const LOG_PREFIX = 'connect-ws';
 type IncomingMessage =
     | (CoreCallMessage & { id: string })
     | (PopupHandshake & { id: string })
+    | (PopupClosedMessage & { id: string })
     | (CoreCallCancelMessage & { id: string })
     | { type: 'ping'; id: string };
 
@@ -49,6 +51,11 @@ const validateIncomingMessage = (message: any): message is IncomingMessage => {
     }
 
     if (message.type === CORE_CALL_CANCEL) {
+        return true;
+    }
+
+    // We need to handle `POPUP.CLOSED` for backward compatibility, for connect10 with older clients.
+    if (message.type === POPUP.CLOSED) {
         return true;
     }
 
@@ -138,6 +145,10 @@ export const exposeConnectWs = ({
                 manifest = parseManifest(message.payload.settings.manifest);
                 version = parseVersion(message.payload.settings.version);
                 ws.send(JSON.stringify({ id: message.id, type: POPUP.HANDSHAKE, payload: 'ok' }));
+            } else if (message.type === POPUP.CLOSED) {
+                mainWindowProxy.getInstance()?.webContents.send('connect-popup/cancel', {
+                    error: message.payload?.error,
+                });
             } else if (message.type === CORE_CALL_CANCEL) {
                 mainWindowProxy.getInstance()?.webContents.send('connect-popup/cancel', {
                     error: message.payload?.reason,

--- a/packages/suite/src/support/suite/useConnectPopup.tsx
+++ b/packages/suite/src/support/suite/useConnectPopup.tsx
@@ -11,6 +11,7 @@ import {
 } from '@suite-common/connect-popup';
 import {
     CORE_CALL,
+    CORE_CALL_CANCEL,
     type CallMethodKeys,
     POPUP,
     RESPONSE_EVENT,
@@ -31,7 +32,7 @@ export type ConnectPopupMessage =
           version: string;
       }
     | { type: typeof CORE_CALL; id: string; payload: { method: string; [key: string]: unknown } }
-    | { type: typeof POPUP.CLOSED; payload?: { error?: string } };
+    | { type: typeof CORE_CALL_CANCEL; payload?: { reason?: string } | null };
 
 /** Outgoing message shape. */
 export type ConnectPopupOutgoingMessage = Record<string, unknown> & { type: string };
@@ -51,7 +52,7 @@ export interface ConnectPopupLink {
 
 /**
  * Shared hook that implements the common connect popup protocol:
- * channel handshake, POPUP.HANDSHAKE, CORE_CALL dispatch, POPUP.CLOSED,
+ * channel handshake, POPUP.HANDSHAKE, CORE_CALL dispatch, CORE_CALL_CANCEL,
  * sending POPUP.CORE_LOADED when suite is ready, and replying to handshake.
  *
  * Link-specific concerns (how messages arrive / are sent) are delegated
@@ -119,8 +120,8 @@ export const useConnectPopup = (
                 });
 
                 setResponseSent(true);
-            } else if (event.type === POPUP.CLOSED) {
-                dispatch(connectPopupCancelThunk(event.payload ?? {}));
+            } else if (event.type === CORE_CALL_CANCEL) {
+                dispatch(connectPopupCancelThunk({ error: event.payload?.reason }));
             }
         };
 

--- a/packages/suite/src/support/suite/useConnectPopup.tsx
+++ b/packages/suite/src/support/suite/useConnectPopup.tsx
@@ -32,6 +32,7 @@ export type ConnectPopupMessage =
           version: string;
       }
     | { type: typeof CORE_CALL; id: string; payload: { method: string; [key: string]: unknown } }
+    | { type: typeof POPUP.CLOSED; payload?: { error?: string } | null }
     | { type: typeof CORE_CALL_CANCEL; payload?: { reason?: string } | null };
 
 /** Outgoing message shape. */
@@ -52,7 +53,7 @@ export interface ConnectPopupLink {
 
 /**
  * Shared hook that implements the common connect popup protocol:
- * channel handshake, POPUP.HANDSHAKE, CORE_CALL dispatch, CORE_CALL_CANCEL,
+ * channel handshake, POPUP.HANDSHAKE, CORE_CALL dispatch, POPUP.CLOSED/CORE_CALL_CANCEL,
  * sending POPUP.CORE_LOADED when suite is ready, and replying to handshake.
  *
  * Link-specific concerns (how messages arrive / are sent) are delegated
@@ -120,6 +121,8 @@ export const useConnectPopup = (
                 });
 
                 setResponseSent(true);
+            } else if (event.type === POPUP.CLOSED) {
+                dispatch(connectPopupCancelThunk({ error: event.payload?.error }));
             } else if (event.type === CORE_CALL_CANCEL) {
                 dispatch(connectPopupCancelThunk({ error: event.payload?.reason }));
             }

--- a/packages/suite/src/support/suite/useConnectPopupWeb.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupWeb.tsx
@@ -133,6 +133,7 @@ export const useConnectPopupWeb = () => {
             if (
                 data.type === 'channel-handshake-request' ||
                 data.type === POPUP.HANDSHAKE ||
+                data.type === POPUP.CLOSED ||
                 data.type === CORE_CALL_CANCEL ||
                 data.type === CORE_CALL
             ) {

--- a/packages/suite/src/support/suite/useConnectPopupWeb.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupWeb.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { connectPopupActions } from '@suite-common/connect-popup';
-import { CORE_CALL, POPUP } from '@trezor/connect';
+import { CORE_CALL, CORE_CALL_CANCEL, POPUP } from '@trezor/connect';
 
 import { useDispatch } from 'src/hooks/suite';
 
@@ -133,7 +133,7 @@ export const useConnectPopupWeb = () => {
             if (
                 data.type === 'channel-handshake-request' ||
                 data.type === POPUP.HANDSHAKE ||
-                data.type === POPUP.CLOSED ||
+                data.type === CORE_CALL_CANCEL ||
                 data.type === CORE_CALL
             ) {
                 const normalized: ConnectPopupMessage =


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The event `POPUP.CLOSED` has been misused for long time, since in most of the cases it is not used when popup is closed but it is used to cancel a method that is currently going on. 

This PR leaves the event `POPUP.CLOSED` where it makes sense but it creates new core event `CORE_CALL_CANCEL` that is used in cases when the reason is to cancel an ongoing method.

I paid attention to not break backward compatibility with clients that still use `POPUP.CLOSED`.

## Notes for QA

Double check that situations when users initiates some action that requires communication with device and it is cancel let's say before it is completed. For instance, user request for new address and it gets the address displayed in device, but before accepting or canceling in device user cancels it in Suite or in 3rd party app or connect explorer.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27083
