### PR TITLE
chore(wallet): add diagnostic logs for unknown BTC pending tx

### DIFF
--- a/packages/blockchain-link-utils/src/blockbook.ts
+++ b/packages/blockchain-link-utils/src/blockbook.ts
@@ -272,6 +272,30 @@ export const transformTransaction = (
         type = 'unknown';
         amount = tx.value;
         targets = [];
+        // [btc-unknown-tx-debug] 'unknown' is the catch-all the categorizer falls back to when it cannot
+        // tell whether the tx is recv/sent/self for this account — for an account's own tx that is never a
+        // desired outcome, it is a hole in our categorization (we show "something" rather than dropping it).
+        // We log every such case EXCEPT calls that pass no account context at all — transformTransaction(tx)
+        // by id (prev/ref-tx during signing, CoinControl UTXO detail): there is no account to compare
+        // against, so `type` is an unused placeholder that is never shown, not a categorization miss, and
+        // logging it would only flood Sentry. When account context WAS provided (an addresses object or a
+        // descriptor), an 'unknown' is a genuine gap worth capturing — including the anomalous case where
+        // the supplied addresses were empty (myAddressesCount === 0).
+        // Intentionally no txid / addresses / descriptor: these reach Sentry and could deanonymize the user.
+        if (addressesOrDescriptor !== undefined) {
+            console.error('[btc-unknown-tx-debug] transformTransaction → type=unknown', {
+                isPending: !tx.blockHeight || tx.blockHeight <= 0,
+                myAddressesCount: myAddresses.length,
+                vinCount: inputs.length,
+                voutCount: outputs.length,
+                vinWithAddressesCount: inputs.filter(
+                    v => Array.isArray(v.addresses) && v.addresses.length > 0,
+                ).length,
+                voutWithAddressesCount: outputs.filter(
+                    v => Array.isArray(v.addresses) && v.addresses.length > 0,
+                ).length,
+            });
+        }
     }
 
     type = isTxFailed(tx) ? 'failed' : type;

--- a/packages/blockchain-link-utils/src/tests/blockbook.test.ts
+++ b/packages/blockchain-link-utils/src/tests/blockbook.test.ts
@@ -13,6 +13,15 @@ describe('blockbook/utils', () => {
     });
 
     describe('transformTransaction', () => {
+        // [btc-unknown-tx-debug] transformTransaction emits a temporary console.error when it classifies
+        // a tx as 'unknown' with account context. Silence the JestCustomEnv console.error trap for these
+        // classification fixtures (the only console.error in transformTransaction is that diagnostic).
+        beforeEach(() => {
+            jest.spyOn(console, 'error').mockImplementation(() => {});
+        });
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
         fixtures.transformTransaction.forEach(f => {
             it(f.description, () => {
                 // @ts-expect-error incorrect params

--- a/packages/blockchain-link/tests/unit/getAccountInfo.test.ts
+++ b/packages/blockchain-link/tests/unit/getAccountInfo.test.ts
@@ -26,6 +26,16 @@ workers.forEach(instance => {
         beforeAll(setup);
         afterAll(teardown);
 
+        // [btc-unknown-tx-debug] getAccountInfo parses tx history through transformTransaction, which
+        // emits a temporary console.error for txs classified as 'unknown' with account context. Silence
+        // the JestCustomEnv console.error trap for these fixtures.
+        beforeEach(() => {
+            jest.spyOn(console, 'error').mockImplementation(() => {});
+        });
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
         fixtures[instance.name].forEach(f => {
             it(f.description, async () => {
                 server.setFixtures(f.serverFixtures);

--- a/packages/blockchain-link/tests/unit/notifications.test.ts
+++ b/packages/blockchain-link/tests/unit/notifications.test.ts
@@ -41,6 +41,16 @@ workers.forEach(instance => {
             beforeAll(setup);
             afterAll(teardown);
 
+            // [btc-unknown-tx-debug] notification txs are parsed through transformTransaction, which emits
+            // a temporary console.error for txs classified as 'unknown' with account context. Silence the
+            // JestCustomEnv console.error trap for these fixtures.
+            beforeEach(() => {
+                jest.spyOn(console, 'error').mockImplementation(() => {});
+            });
+            afterEach(() => {
+                jest.restoreAllMocks();
+            });
+
             // NOTE: do not skip any test because id's sequence must be continuous!
             fixtures[instance.name].notifyAddresses.forEach((f, id) => {
                 it(f.description, async () => {

--- a/packages/connect/src/api/bitcoin/createPendingTx.ts
+++ b/packages/connect/src/api/bitcoin/createPendingTx.ts
@@ -33,6 +33,37 @@ export const createPendingTransaction = (
             .map(address => address.address);
     };
 
+    const vin = inputs.map((ins, n) => {
+        const matched = findAddress(ins);
+        const hasAddressN = Array.isArray(ins.address_n) && ins.address_n.length > 0;
+
+        // [btc-unknown-tx-debug] address_n on this input did not match any address in
+        // account.addresses (unused/used/change). Downstream, blockbookUtils.transformTransaction
+        // will not recognize the input as ours, which can cascade to type='unknown' for the
+        // optimistic pending tx created right after signing. See addFakePendingTxThunk in
+        // suite-common/wallet-core/src/transactions/transactionsThunks.ts.
+        // Intentionally no txid / address_n / addresses: these reach Sentry and could deanonymize the user.
+        if (hasAddressN && matched.length === 0) {
+            console.error(
+                '[btc-unknown-tx-debug] createPendingTransaction → input has no matching address',
+                {
+                    inputIndex: n,
+                    knownAddressesCount: allAddresses.length,
+                },
+            );
+        }
+
+        return {
+            n,
+            txid: ins.prev_hash,
+            vout: ins.prev_index,
+            isAddress: true,
+            addresses: matched,
+            value: ins.amount.toString(),
+            sequence: ins.sequence,
+        };
+    });
+
     return {
         txid: tx.getId(),
         hex: tx.toHex(),
@@ -44,15 +75,7 @@ export const createPendingTransaction = (
         value: valueOut.toString(),
         valueIn: valueIn.toString(),
         fees: valueIn.minus(valueOut).toString(),
-        vin: inputs.map((ins, n) => ({
-            n,
-            txid: ins.prev_hash,
-            vout: ins.prev_index,
-            isAddress: true,
-            addresses: findAddress(ins),
-            value: ins.amount.toString(),
-            sequence: ins.sequence,
-        })),
+        vin,
         vout: outputs.map((out, n) => {
             let transformedAddresses: string[] = [];
 

--- a/suite-common/wallet-core/src/send/sendFormBitcoinThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormBitcoinThunks.ts
@@ -27,6 +27,8 @@ import TrezorConnect, {
     type SignTransaction,
     type SignedTransaction,
 } from '@trezor/connect';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports -- temporary diagnostic; getSerializedPath is not re-exported from the @trezor/connect public barrel
+import { getSerializedPath } from '@trezor/connect/src/utils/pathUtils';
 import { BigNumber, isArrayMember } from '@trezor/utils';
 
 import { SEND_MODULE_PREFIX } from './sendFormConstants';
@@ -334,6 +336,40 @@ export const signBitcoinSendFormTransactionThunk = createThunk<
         if (isArrayMember(selectedAccount.symbol, BITCOIN_ONLY_SYMBOLS)) {
             // nVersion, use 2 as it enables BIP68 + seems to be the most commonly used (= harder to fingerprint the Trezor)
             signEnhancement.version = 2;
+        }
+
+        const accountAddressPaths = new Set(
+            selectedAccount.addresses
+                ? selectedAccount.addresses.change
+                      .concat(selectedAccount.addresses.used, selectedAccount.addresses.unused)
+                      .map(({ path }) => path)
+                : [],
+        );
+        const inputPaths = precomposedTransaction.inputs
+            .map(input =>
+                Array.isArray(input.address_n) && input.address_n.length > 0
+                    ? getSerializedPath(input.address_n)
+                    : undefined,
+            )
+            .filter((path): path is string => typeof path === 'string');
+        const unmatchedInputPathCount = inputPaths.filter(
+            path => !accountAddressPaths.has(path),
+        ).length;
+
+        if (unmatchedInputPathCount > 0) {
+            // [btc-unknown-tx-debug] the selected account does not contain paths used by the tx inputs.
+            // This can make Connect build a pending tx with wrong or empty vin addresses, which can then
+            // classify the optimistic pending tx incorrectly before the backend response arrives.
+            // Intentionally no paths / addresses / descriptor / txid: these reach Sentry and could
+            // deanonymize the user. accountType + symbol are low-cardinality, non-PII.
+            console.error('[btc-unknown-tx-debug] signBitcoin → input paths missing in account', {
+                accountType: selectedAccount.accountType,
+                symbol: selectedAccount.symbol,
+                inputCount: precomposedTransaction.inputs.length,
+                inputsWithAddressNCount: inputPaths.length,
+                knownAddressesCount: accountAddressPaths.size,
+                unmatchedInputPathCount,
+            });
         }
 
         const signPayload: Params<SignTransaction> = {

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -180,6 +180,35 @@ export const addFakePendingTxThunk = createThunk(
                     signedTransaction,
                     affectedAccount.addresses ?? affectedAccount.descriptor,
                 );
+                if (affectedAccountTransaction.type === 'unknown') {
+                    const unusedCount = affectedAccount.addresses?.unused.length ?? 0;
+                    const usedCount = affectedAccount.addresses?.used.length ?? 0;
+                    const changeCount = affectedAccount.addresses?.change.length ?? 0;
+                    // [btc-unknown-tx-debug] the just-signed BTC tx was classified as 'unknown' before
+                    // even reaching the backend. The user will see "Unknown transaction" in the list
+                    // until the backend response replaces this entry. This is the clean, send-path-only
+                    // smoking gun (see also the createPendingTx.ts and blockbook.ts logs for upstream
+                    // detail). The payload reaches Sentry as event.extra.arguments[1]; the bug is rare
+                    // enough to triage per-event, and mobile-vs-desktop frequency is already split by
+                    // Sentry project (native vs desktop/web DSN), so tags are not needed here.
+                    // emptyAddresses separates the two leading hypotheses at a glance:
+                    //   true  -> no addresses at classification time (account addresses absent)
+                    //   false -> addresses present but nothing matched (path mismatch: gap-limit / taproot)
+                    // Intentionally no txid / accountKey / descriptor / raw addresses: these reach Sentry
+                    // and could deanonymize the user. accountType + symbol are low-cardinality, non-PII.
+                    console.error(
+                        '[btc-unknown-tx-debug] addFakePendingTxThunk → prepending tx has type=unknown',
+                        {
+                            accountType: affectedAccount.accountType,
+                            symbol: affectedAccount.symbol,
+                            hasAddresses: Boolean(affectedAccount.addresses),
+                            emptyAddresses: unusedCount + usedCount + changeCount === 0,
+                            unusedCount,
+                            usedCount,
+                            changeCount,
+                        },
+                    );
+                }
                 const prependingTx = { ...affectedAccountTransaction, deadline: blockHeight + 2 };
                 dispatch(
                     transactionsActions.addTransaction({


### PR DESCRIPTION
## Summary

After sending a Bitcoin transaction via the Suite send form, the just-broadcast tx shows up in the transaction list as **"Unknown transaction"** instead of "Sending …". Reproduced **on both suite-native (mobile) and suite-desktop**, so this is a **platform-agnostic** classification bug, not a mobile-only timing race.

This PR ships **no fix**. It adds four temporary `console.error` statements, all tagged `[btc-unknown-tx-debug]`, along the send → classify → insert path, so we can confirm *which* hypothesis below is the actual root cause from real reproductions before changing behavior. The logging was reviewed for Sentry usability, log-site noise, and PII before landing.

> **Log level.** Sentry's `captureConsoleIntegration` is configured with `levels: ['error']` on all surfaces (`packages/suite-web/src/sentry.ts`, `packages/suite-desktop-ui/src/sentry.ts`, `packages/suite-desktop-core/src/libs/sentry.ts`, `suite-native/sentry/src/sentry.ts`), so `console.warn` is dropped — `console.error` is required.

> **PII.** Payloads exclude `txid` (searchable on a blockchain explorer; links to xpub), `account.key` (deviceState + descriptor), derivation paths and raw addresses. Only low-cardinality counters, booleans, `accountType` and `symbol` are sent.

## How a tx becomes `type: 'unknown'`

After signing, Suite optimistically inserts a "fake pending" tx via `addFakePendingTxThunk` (`suite-common/wallet-core/src/transactions/transactionsThunks.ts`), which calls `blockbookUtils.transformTransaction(signedTransaction, account.addresses)`. `signedTransaction` was produced by `createPendingTransaction` (`packages/connect/src/api/bitcoin/createPendingTx.ts`), which fills `vin[i].addresses` by matching each input's `address_n` against the addresses **snapshot passed to `signTransaction`**. `transformTransaction` then classifies the tx using **`account.addresses` read fresh from the store**.

`transformTransaction` returns `'unknown'` only when **neither the inputs nor the outputs** match the account's addresses. A normal send keeps a change output back to the account, which would match → `'sent'`/`'self'`. So a true `'unknown'` requires **both** the spent inputs *and* the change output to fail matching. Note the two distinct address sources (connect's sign-time snapshot vs the store at classification) — a divergence between them is itself a candidate cause. `'unknown'` is never a desired outcome for an account's own tx; it is the catch-all fallback (so the tx still shows up rather than being dropped).

The UI (`packages/suite/src/components/wallet/TransactionItem/TransactionHeader.tsx`) renders `'TR_UNKNOWN_TRANSACTION'` for `type === 'unknown'` regardless of `isPending`, so the user sees "Unknown transaction" until the backend syncs and replaces the entry.

## The four log sites (a funnel; all shared → fire on both desktop and mobile)

The BTC path is gated by `networkType === 'bitcoin'`, **not** by platform, and the connect / blockbook code is shared, so every log fires on desktop as well as mobile.

1. **`sendFormBitcoinThunks.ts`** (`signBitcoin → input paths missing in account`) — **before signing**, in Suite. Compares the composed tx's input paths against the selected account's address paths; logs when the account does not contain the paths the inputs spend. Earliest signal of a path mismatch, entirely Suite-side, PII-free. Payload: `accountType`, `symbol`, `inputCount`, `inputsWithAddressNCount`, `knownAddressesCount`, `unmatchedInputPathCount`.
2. **`createPendingTx.ts`** (`createPendingTransaction → input has no matching address`) — post-sign, connect. Per input that has an `address_n` yet matches no address in the snapshot passed to `signTransaction` (inputs without `address_n` are foreign — e.g. coinjoin participants — and are skipped to avoid a burst). Payload: `inputIndex`, `knownAddressesCount` (snapshot size).
3. **`blockbook.ts`** (`transformTransaction → type=unknown`) — the classification itself. Guarded on `addressesOrDescriptor !== undefined`: `transformTransaction` is also called as a pure parser with no account context (`getTransaction`-by-id: prev/ref-tx during signing, CoinControl detail), where `type` is an unused placeholder that is never shown — logging it would only flood Sentry. With account context an `'unknown'` is always a real categorization gap worth capturing, including the empty-addresses case (`myAddressesCount === 0`). Payload: `isPending`, `myAddressesCount`, `vinCount`, `voutCount`, `vinWithAddressesCount`, `voutWithAddressesCount`.
4. **`transactionsThunks.ts`** (`addFakePendingTxThunk → prepending tx has type=unknown`) — the optimistic insert, the **send-path-only smoking gun** and primary metric. Payload: `accountType`, `symbol`, `hasAddresses`, `emptyAddresses` (the key discriminator), per-bucket counts (`unusedCount`/`usedCount`/`changeCount`).

## Hypotheses and how we verify each

All produce the same user-visible symptom; the logs are designed to tell them apart from a single reproduction's events.

### H1 — Path mismatch (most likely)
The spent input — and the change output — use a derivation path **not in `account.addresses`**: gap-limit (index beyond the loaded set), taproot script-type/path encoding, coinjoin-derived paths, or a change index past the loaded range. Addresses exist and are populated; the *specific* path just isn't among them.
**Verify:** log #4 `emptyAddresses: false`, `hasAddresses: true`; logs #1 and #2 fire with `knownAddressesCount > 0`; log #3 fires with `vinWithAddressesCount: 0` / `voutWithAddressesCount: 0`. log #2 `knownAddressesCount` ≈ log #4 bucket sum (snapshot was not behind the store → rules out H2). Correlate with taproot / coinjoin / send-max reproductions.

### H2 — Stale or divergent address snapshot during signing
The addresses snapshot handed to `signTransaction` is older than the account by the time the tx is built — a WS push or discovery extended `account.addresses.used/change` during the 10–60 s on-device confirmation, so a freshly-used input/change address isn't in the snapshot connect matched against (even though it's in the store now).
**Verify:** same surface as H1 (`emptyAddresses: false`, logs #1/#2 fire), but the giveaway is **log #2 `knownAddressesCount` < log #4 bucket sum** — the sign-time snapshot held fewer addresses than the store at insert. Correlate with a long signing delay / concurrent discovery in the same session.

### H3 — Absent / empty addresses at classification time
`account.addresses` is empty or missing, so nothing can match. Either the `addresses` object is empty, or it is undefined and the bare `descriptor` (xpub) is used as the fallback (which can never match real BTC addresses). *(The mobile "signed before redux-persist rehydrated" sub-case was considered but effectively ruled out: `PersistGate` gates the UI until rehydration, you cannot sign for an account that isn't in state, and the bug also occurs on desktop, which has no redux-persist. So it is not instrumented.)*
**Verify:** log #4 `emptyAddresses: true`; `hasAddresses: false` marks the descriptor-fallback sub-case; logs #1/#2/#3 fire with `knownAddressesCount: 0` / `myAddressesCount: 0`. Tell-tale: if log #4 shows `emptyAddresses: true` but log #1 did **not** fire, addresses were present at sign time but gone at insert → a store regression (clear / account swap), not a path issue.

### H4 — Backend-vs-optimistic race / reducer ordering (lower priority; partially instrumented)
The original report mentioned the entry **alternating** between "pending" and "unknown" — the optimistic tx and the backend-returned tx coexisting, with the reducer / `analyzeTransactions` preserve-pair logic keeping a wrongly-typed version.
**Verify:** these logs confirm whether the **optimistic** tx is the `unknown` one (log #4 fires). If it does, the root cause is upstream address-matching (H1–H3) and any flicker is a secondary reducer effect; if log #4 does **not** fire yet the user still sees "unknown", the bad classification comes from the backend path / reducer and needs separate reducer-level instrumentation (out of scope here).

### Decision table

| Signal | H1 path mismatch | H2 stale snapshot | H3 absent addresses | H4 backend race |
|---|---|---|---|---|
| log #4 fires (optimistic unknown) | yes | yes | yes | **no** |
| log #4 `emptyAddresses` | `false` | `false` | `true` | — |
| `knownAddressesCount` (#1 / #2) | `> 0` | `> 0` | `0` | — |
| log #2 `knownAddressesCount` vs #4 buckets | ≈ equal | **#2 < buckets** | both `0` | — |

## What this gives us in Sentry

- **Frequency (absolute):** log #4 uses a constant message string, so all occurrences group into a single Sentry issue whose event count is the frequency over time.
- **Platform breakdown:** suite-native and desktop/web report to **separate Sentry projects** (native DSN `…/4504214699245568` vs desktop/web `…/5193825`), so mobile vs desktop is read by comparing the same issue across projects. Within the desktop/web project, electron (desktop) vs browser (web) is distinguishable via the SDK's automatic runtime/os context — no custom tag needed.
- **Why (per event):** the payload lands in `event.extra.arguments`. Sentry does not index `extra`, so it is not aggregatable, but the discriminators above are read per event, which is enough to route a reproduction to H1–H4.

**Deliberately *not* done** (would exceed a temporary diagnostic): promoting the discriminators to Sentry **tags** (would require adding `@suite-common/sentry` as a dependency of the core `@suite-common/wallet-core` package plus a lockfile change), and adding a dedicated **analytics event** (a data-pipeline / schema change). Both become worthwhile only if volume makes per-event triage impractical or a true *rate* (% of BTC sends, segmented by platform) is needed — analytics is the better tool for the latter.

> **Caveat for interpretation.** Counts are a lower bound: events are consent-gated (`allowReport !== true` → dropped), excluded from dev/debug builds, and capped at 100/hour/session. The team's own debug builds will not report unless `EXPO_PUBLIC_IS_SENTRY_ON_DEBUG_BUILD_ENABLED=true`.

## Code references

- Pre-sign path check: `suite-common/wallet-core/src/send/sendFormBitcoinThunks.ts` (`signBitcoinSendFormTransactionThunk`)
- Pre-broadcast tx construction: `packages/connect/src/api/bitcoin/createPendingTx.ts`
- Type classification: `packages/blockchain-link-utils/src/blockbook.ts`
- Optimistic insertion: `suite-common/wallet-core/src/transactions/transactionsThunks.ts` (`addFakePendingTxThunk`)
- Header rendering: `packages/suite/src/components/wallet/TransactionItem/TransactionHeader.tsx`

## Test plan

- [ ] Send a small BTC tx through the send form on **both desktop and mobile**; check whether any `[btc-unknown-tx-debug]` log fires.
- [ ] Target H1: reproduce on fresh / newly-discovered, coinjoin and taproot accounts, and with a send-max (change-less) tx.
- [ ] Target H2: sign with a deliberately long on-device delay while discovery / an incoming tx extends the account; compare log #2 `knownAddressesCount` against log #4 bucket sum.
- [ ] Target H3: inspect `emptyAddresses` / `hasAddresses` on log #4 and `knownAddressesCount: 0` on logs #1/#2.
- [ ] Target H4: confirm whether log #4 fires when the symptom shows; if it does not, the cause is backend/reducer-side.
- [ ] Confirm no logs fire for a normal incoming/outgoing BTC tx on a well-established account.
- [ ] Revert this PR (or replace with a proper fix) once root cause is confirmed.

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
<!-- Auto-updated by the test-selector bot on each push. -->
<!-- LLM-TEST-SELECTOR:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/btc-unknown-tx-bug/web/](https://dev.suite.sldev.cz/suite-web/mroz22/btc-unknown-tx-bug/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/btc-unknown-tx-bug&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-02T13:14:17.725Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->