### PR TITLE
Merkle rewards minor changes

### DIFF
--- a/packages/suite/src/components/earn/dashboard/utils/earnYieldUtils.ts
+++ b/packages/suite/src/components/earn/dashboard/utils/earnYieldUtils.ts
@@ -1,5 +1,5 @@
 import { ChainAddressKey } from '@suite-common/earn-stablecoin-api';
-import { getNetworkByEvmChainId, isEarnYieldClaimSupported } from '@suite-common/wallet-config';
+import { getNetworkByEvmChainId } from '@suite-common/wallet-config';
 import { type Account, asBaseCurrencyAmount } from '@suite-common/wallet-types';
 import { BigNumber } from '@trezor/utils';
 
@@ -18,7 +18,6 @@ export const getClaimableAccounts = ({
     Object.entries(rewards).flatMap(([key, accountRewards]) => {
         const { chainId, address } = ChainAddressKey.parse(key);
         const network = getNetworkByEvmChainId(chainId);
-
         const account = visibleAccounts.find(
             a =>
                 a.symbol === network?.symbol &&
@@ -29,20 +28,7 @@ export const getClaimableAccounts = ({
             return [];
         }
 
-        if (!network || !isEarnYieldClaimSupported(network.symbol)) {
-            return [];
-        }
-
-        const claimableRewards = accountRewards.filter(reward =>
-            new BigNumber(reward.claimable).gt(0),
-        );
-
-        if (claimableRewards.length === 0) {
-            return [];
-        }
-
-        const hasAnyFiatAmount = claimableRewards.some(reward => reward.fiat.claimable !== null);
-        const totalFiatAmount = claimableRewards.reduce(
+        const totalFiatAmount = accountRewards.reduce(
             (total, reward) => total.plus(reward.fiat.claimable ?? '0'),
             new BigNumber(0),
         );
@@ -50,7 +36,9 @@ export const getClaimableAccounts = ({
         return [
             {
                 account,
-                totalFiatAmount: hasAnyFiatAmount ? asBaseCurrencyAmount(totalFiatAmount) : null,
+                totalFiatAmount: totalFiatAmount.isPositive()
+                    ? asBaseCurrencyAmount(totalFiatAmount)
+                    : null,
             },
         ];
     });

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx
@@ -66,14 +66,27 @@ export const EarnYieldTable = () => {
     const merkleRewardsSources = useMemo(
         () =>
             yieldAccountOpportunities.flatMap(opportunity => {
-                if (!opportunity.account || !isEarnYieldClaimSupported(opportunity.networkSymbol)) {
+                const { networkSymbol, account } = opportunity;
+                if (
+                    !(
+                        isEarnYieldClaimSupported(networkSymbol) &&
+                        account &&
+                        account.networkType === 'ethereum'
+                    )
+                ) {
+                    return [];
+                }
+
+                const isApproveTx = Number(account.misc.nonce) === 0;
+
+                if (isApproveTx) {
                     return [];
                 }
 
                 return [
                     {
-                        networkSymbol: opportunity.networkSymbol,
-                        address: opportunity.account.descriptor,
+                        networkSymbol,
+                        address: account.descriptor,
                     },
                 ];
             }),

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx
@@ -66,12 +66,7 @@ export const EarnYieldTable = () => {
     const merkleRewardsSources = useMemo(
         () =>
             yieldAccountOpportunities.flatMap(opportunity => {
-                // Merkl rewards are claimable only for accounts that already hold a vault position.
-                if (
-                    !opportunity.hasVaultPosition ||
-                    !opportunity.account ||
-                    !isEarnYieldClaimSupported(opportunity.networkSymbol)
-                ) {
+                if (!opportunity.account || !isEarnYieldClaimSupported(opportunity.networkSymbol)) {
                     return [];
                 }
 

--- a/packages/suite/src/components/earn/dashboard/yield/hooks/useMerkleRewards.ts
+++ b/packages/suite/src/components/earn/dashboard/yield/hooks/useMerkleRewards.ts
@@ -41,7 +41,7 @@ import { useDispatch, useSelector } from 'src/hooks/suite';
 
 export type MerkleRewardWithFiat =
     MerkleRewardsByChainAndAddress[keyof MerkleRewardsByChainAndAddress][number] & {
-        claimable: string;
+        claimable: BaseCurrencyAmount;
         fiat: {
             amount: BaseCurrencyAmount | null;
             claimed: BaseCurrencyAmount | null;
@@ -50,10 +50,7 @@ export type MerkleRewardWithFiat =
         };
     };
 
-export type MerkleRewardsWithFiatRecord = Record<
-    keyof MerkleRewardsByChainAndAddress,
-    MerkleRewardWithFiat[]
->;
+export type MerkleRewardsWithFiatRecord = Record<string, MerkleRewardWithFiat[]>;
 
 export type MerkleRewardsSource = {
     networkSymbol: NetworkSymbol;
@@ -84,7 +81,7 @@ function extendMerkleRewardsWithFiat(
     currentFiatRates: RatesByKey | undefined,
 ) {
     const toFiatFromSubunits = (
-        valueInSubunits: string | null,
+        valueInSubunits: BigNumber | string | null,
         decimals: number,
         rate: number | undefined,
     ) => {
@@ -94,7 +91,11 @@ function extendMerkleRewardsWithFiat(
 
         return toFiatCurrency({
             amount: subunitsToUnits({
-                value: asAmountSubunit(new BigNumber(valueInSubunits)),
+                value: asAmountSubunit(
+                    typeof valueInSubunits === 'string'
+                        ? new BigNumber(valueInSubunits)
+                        : valueInSubunits,
+                ),
                 decimals,
             }),
             rate,
@@ -108,10 +109,9 @@ function extendMerkleRewardsWithFiat(
             const network = getNetworkByEvmChainId(chainId);
 
             const rewardsWithFiat = rewards.map(reward => {
-                const claimable = new BigNumber(reward.amount)
-                    .minus(reward.claimed)
-                    .minus(reward.pending)
-                    .toFixed();
+                const claimable = asBaseCurrencyAmount(
+                    new BigNumber(reward.amount).minus(reward.claimed).minus(reward.pending),
+                );
 
                 if (!network) {
                     return {
@@ -211,7 +211,7 @@ export function useMerkleRewards(sources: MerkleRewardsSource[]) {
             new BigNumber(0),
         );
 
-        return new BigNumber(result.toFixed(2));
+        return asBaseCurrencyAmount(new BigNumber(result.toFixed(2)));
     }, [rewardsWithFiat]);
 
     return {
@@ -220,7 +220,7 @@ export function useMerkleRewards(sources: MerkleRewardsSource[]) {
             data: {
                 rewards: rewardsWithFiat,
                 totalRewardsToClaim: {
-                    value: asBaseCurrencyAmount(totalRewardsToClaim),
+                    value: totalRewardsToClaim,
                     currency: baseCurrency,
                 },
             },

--- a/suite-common/earn-stablecoin-api/src/hooks/useGetMerkleRewards.ts
+++ b/suite-common/earn-stablecoin-api/src/hooks/useGetMerkleRewards.ts
@@ -113,6 +113,7 @@ export function useGetMerkleRewards<Address extends string>(
             const fetcher = merkleHttpClient('/v1/users/:address/rewards', {
                 method: 'GET',
                 schema: merkleRewardsResponseSchema,
+                cache: 'no-store',
             });
 
             const requests = queryEntries.map(entry =>

--- a/suite-common/wallet-config/src/earnRewardsProvider.ts
+++ b/suite-common/wallet-config/src/earnRewardsProvider.ts
@@ -4,6 +4,7 @@ const MERKL_XYZ_CONTRACT: Partial<Record<NetworkSymbol, `0x${string}`>> = {
     eth: '0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae',
     arb: '0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae',
     base: '0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae',
+    op: '0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae',
 };
 
 export const isEarnYieldClaimSupported = (networkSymbol: NetworkSymbol) =>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* fix: fetch merkle rewards for accounts without positions (I.e. if user has already withdrew it, then there's still must be a way to claim the funds.)
* fix: don't use http cache for merkle rewards (also the CF worker was fixed not to use the CF cache for rewards EP)
*  add merkle rewards contract address for op network

## Related Issue

Resolve #27317

## Screenshot

<img width="783" height="622" alt="Snímek obrazovky 2026-05-05 v 11 08 44" src="https://github.com/user-attachments/assets/8cad5d45-90f5-441b-b39a-6f255b485e5a" />
<img width="652" height="350" alt="Snímek obrazovky 2026-05-05 v 11 08 53" src="https://github.com/user-attachments/assets/1c833c6d-4fdc-4c2f-9429-46f657dbed0d" />

And yes, there's should be better EP in the worker for fetching those rewards (task here: [Extend merkle rewards worker - add EP for aggregated rewards](https://github.com/trezor/cloudflare-workers/issues/39))

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies two files: an earn yield table UI component and a hook for fetching Merkle rewards in the stablecoin earn API. The EarnYieldTable.tsx maps to 121 tests, indicating it's a broadly imported component — most of those tests are unlikely to exercise earn/yield-specific functionality. The useGetMerkleRewards hook has no static test coverage. The overall risk is moderate; the changes are focused on the earn/staking feature area, but there are no dedicated E2E tests for the earn yield table or Merkle rewards functionality. Only tests that specifically interact with staking/earn dashboard flows are recommended.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx`
- `suite-common/earn-stablecoin-api/src/hooks/useGetMerkleRewards.ts`

</details>

**Recommended tests (2)**

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/analytics/staking-events.test.ts` — This test covers staking navigation analytics from both the account menu and dashboard assets section. EarnYieldTable.tsx is part of the earn/dashboard yield UI, and changes to it could affect how staking/earn navigation flows work from the dashboard, potentially impacting the StakingNavigate analytics events.
- `suite/e2e/tests/dashboard/assets.test.ts` — This test verifies the dashboard assets section including table and grid views, enabling coins, and verifying asset contents. EarnYieldTable.tsx is a dashboard yield component that could affect how assets or earn-related data renders on the dashboard.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/earn-stablecoin-api/src/hooks/useGetMerkleRewards.ts`

_Updated: 2026-05-05T08:43:52.081Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/merkle-rewards-2&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/merkle-rewards-2&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/merkle-rewards-2&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-05T08:48:44.295Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-05T09:52:17.374Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/merkle-rewards-2/web/](https://dev.suite.sldev.cz/suite-web/fix/merkle-rewards-2/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->