### PR TITLE
fix(suite): security check layout

### DIFF
--- a/packages/suite/src/components/firmware/ProgressCheck/FirmwareInstallationProgressCheckFail.tsx
+++ b/packages/suite/src/components/firmware/ProgressCheck/FirmwareInstallationProgressCheckFail.tsx
@@ -1,7 +1,7 @@
 import { Translation } from '@suite/intl';
-import { Button } from '@trezor/components';
 import { TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_URL } from '@trezor/urls';
 
+import { SecurityCheckButton } from '../../suite/SecurityCheck/SecurityCheckButton';
 import { SecurityCheckFail } from '../../suite/SecurityCheck/SecurityCheckFail';
 import { hardFailureChecklistItems } from '../../suite/SecurityCheck/checklistItems';
 import { ContactSupport } from '../../suite/SecurityCheck/deviceCompromisedCtas';
@@ -23,9 +23,9 @@ export const FirmwareInstallationProgressCheckFail = ({
         checklistItems={hardFailureChecklistItems}
         ctaSection={
             <>
-                <Button intent="neutral" priority="secondary" onClick={toggleView} size="large">
+                <SecurityCheckButton intent="neutral" priority="secondary" onClick={toggleView}>
                     <Translation id="TR_BACK" />
-                </Button>
+                </SecurityCheckButton>
                 <ContactSupport supportUrl={supportUrl} />
             </>
         }

--- a/packages/suite/src/components/suite/SecurityCheck/SecurityCheckButton.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/SecurityCheckButton.tsx
@@ -1,0 +1,21 @@
+import { Button, type ButtonProps } from '@trezor/components';
+import { breakpoints } from '@trezor/theme';
+
+import { useIsContentBelowBreakpoint } from 'src/support/suite/ContentFlex';
+
+type SecurityCheckButtonProps = Omit<ButtonProps, 'minWidth' | 'maxWidth' | 'size' | 'width'>;
+
+export const SecurityCheckButton = ({ ...props }: SecurityCheckButtonProps) => {
+    const isContentBelowBreakpoint = useIsContentBelowBreakpoint(breakpoints.tablet);
+
+    return (
+        <Button
+            {...props}
+            size="large"
+            flex="1"
+            maxWidth={isContentBelowBreakpoint ? undefined : 'fit-content'}
+            minWidth={isContentBelowBreakpoint ? undefined : 180}
+            width={isContentBelowBreakpoint ? '100%' : undefined}
+        />
+    );
+};

--- a/packages/suite/src/components/suite/SecurityCheck/SecurityCheckFail.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/SecurityCheckFail.tsx
@@ -1,9 +1,10 @@
 import { type ReactNode } from 'react';
 
 import { Translation, type TranslationKey } from '@suite/intl';
-import { Column, Divider, H2, Paragraph, Row } from '@trezor/components';
-import { spacings } from '@trezor/theme';
+import { Column, Divider, H2, Paragraph } from '@trezor/components';
+import { breakpoints } from '@trezor/theme';
 
+import { ContentFlex } from 'src/support/suite/ContentFlex';
 import { SecurityChecklist } from 'src/views/onboarding/steps/DeviceAuthenticityStep/SecurityChecklist';
 import { type SecurityChecklistItem } from 'src/views/onboarding/steps/DeviceAuthenticityStep/types';
 
@@ -26,7 +27,7 @@ export const SecurityCheckFail = ({
     useCompromisedImage = true,
 }: SecurityCheckFailProps) => (
     <SecurityCheckLayout isFailed={useCompromisedImage}>
-        <Column gap={spacings.sm} padding={{ top: spacings.xs }}>
+        <Column gap={12} padding={{ top: 8 }}>
             <H2>
                 <Translation id={heading} />
             </H2>
@@ -34,10 +35,16 @@ export const SecurityCheckFail = ({
                 <Translation id={text} />
             </Paragraph>
         </Column>
-        <Divider margin={{ vertical: spacings.xl }} />
+        <Divider margin={{ vertical: 32 }} />
         <SecurityChecklist items={checklistItems} />
-        <Row flexWrap="wrap" gap={spacings.xl} width="100%" margin={{ top: spacings.xxxxl }}>
+        <ContentFlex
+            breakpoint={breakpoints.tablet}
+            alignItems="center"
+            gap={12}
+            margin={{ top: 48 }}
+            width="100%"
+        >
             {ctaSection}
-        </Row>
+        </ContentFlex>
     </SecurityCheckLayout>
 );

--- a/packages/suite/src/components/suite/SecurityCheck/SecurityCheckLayout.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/SecurityCheckLayout.tsx
@@ -1,5 +1,5 @@
 import { selectSelectedDevice } from '@suite-common/device';
-import { Box, Column, Grid, Image } from '@trezor/components';
+import { Box, Column, Image } from '@trezor/components';
 import { DeviceModelInternal, getDeviceColorVariant } from '@trezor/device-utils';
 import type { ModelFor } from '@trezor/product-components';
 import {
@@ -7,10 +7,10 @@ import {
     DeviceWithScene,
     getLargeModelImagePath,
 } from '@trezor/product-components';
-import { borders, breakpoints, spacings } from '@trezor/theme';
+import { borders, breakpoints } from '@trezor/theme';
 
 import { useSelector } from 'src/hooks/suite';
-import { useResponsiveContext } from 'src/support/suite/ResponsiveContext';
+import { ContentFlex } from 'src/support/suite/ContentFlex';
 
 type SecurityCheckLayoutProps = {
     isFailed?: boolean;
@@ -34,7 +34,6 @@ export const SecurityCheckLayout = ({
     imageMode,
 }: SecurityCheckLayoutProps) => {
     const device = useSelector(selectSelectedDevice);
-    const { contentWidth } = useResponsiveContext();
     const model = getDeviceModel(device?.features?.internal_model);
     const isDeviceImageRotating = imageMode === 'ROTATE';
     const deviceUnitColor = getDeviceColorVariant(device);
@@ -55,15 +54,15 @@ export const SecurityCheckLayout = ({
         return <Image maxHeight={300} image={image} />;
     };
 
-    const isContentBelowTablet = !!(contentWidth && contentWidth < breakpoints.tablet);
-
     return (
-        <Grid columns={isContentBelowTablet ? '1fr' : '260px 1fr'} gap={spacings.xl} width="100%">
+        <ContentFlex breakpoint={breakpoints.tablet} gap={24} alignItems="center" width="100%">
             {model && (
                 <Box
                     backgroundColor="surfaceFillRaised"
                     borderRadius={borders.radii.sm}
-                    padding={spacings.xxl}
+                    padding={32}
+                    width="100%"
+                    maxWidth={260}
                 >
                     <Column height="100%" justifyContent="center" alignItems="center">
                         {isDeviceImageRotating ? (
@@ -80,7 +79,9 @@ export const SecurityCheckLayout = ({
                     </Column>
                 </Box>
             )}
-            <Column justifyContent="space-between">{children}</Column>
-        </Grid>
+            <Column justifyContent="space-between" flex="1" width="100%" overflow="hidden">
+                {children}
+            </Column>
+        </ContentFlex>
     );
 };

--- a/packages/suite/src/components/suite/SecurityCheck/deviceCompromisedCtas.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/deviceCompromisedCtas.tsx
@@ -1,7 +1,6 @@
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
 import { deviceActions } from '@suite-common/device';
-import { Button } from '@trezor/components';
 import {
     HELP_CENTER_ENTROPY_CHECK_URL,
     TREZOR_SUPPORT_DEVICE_AUTHENTICATION_FAILED_URL,
@@ -11,6 +10,8 @@ import {
 
 import { useDispatch } from 'src/hooks/suite';
 
+import { SecurityCheckButton } from './SecurityCheckButton';
+
 type ContactSupportProps = {
     supportUrl: Url;
 };
@@ -18,9 +19,9 @@ export const ContactSupport = ({ supportUrl }: ContactSupportProps) => {
     const chatUrl = `${supportUrl}#open-chat`;
 
     return (
-        <Button href={chatUrl} flex="1" size="large">
+        <SecurityCheckButton href={chatUrl}>
             <Translation id="TR_CONTACT_TREZOR_SUPPORT" />
-        </Button>
+        </SecurityCheckButton>
     );
 };
 
@@ -40,15 +41,14 @@ type DismissButtonProps = {
     onClick: () => void;
 };
 const DismissButton = ({ onClick }: DismissButtonProps) => (
-    <Button
+    <SecurityCheckButton
         intent="neutral"
         priority="secondary"
         onClick={onClick}
-        size="large"
         data-testid="@device-compromised/dismiss-button"
     >
         <Translation id="TR_DISMISS" />
-    </Button>
+    </SecurityCheckButton>
 );
 
 export const DismissFwAuthenticityCheckButton = () => {

--- a/packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/SecurityCheck.tsx
+++ b/packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/SecurityCheck.tsx
@@ -14,7 +14,6 @@ import { SUPPORTS_DEVICE_AUTHENTICITY_CHECK } from '@suite-common/suite-constant
 import { type AcquiredDevice } from '@suite-common/suite-types';
 import {
     Box,
-    Button,
     Card,
     Column,
     Divider,
@@ -27,7 +26,7 @@ import {
     Tooltip,
 } from '@trezor/components';
 import { DeviceModelInternal, models } from '@trezor/device-utils';
-import { breakpoints, spacings } from '@trezor/theme';
+import { breakpoints } from '@trezor/theme';
 import {
     TREZOR_RESELLERS_URL,
     TREZOR_SUPPORT_FW_ALREADY_INSTALLED,
@@ -37,13 +36,13 @@ import {
 
 import { Hologram } from 'src/components/onboarding/Hologram';
 import { TrezorLink } from 'src/components/suite';
+import { SecurityCheckButton } from 'src/components/suite/SecurityCheck/SecurityCheckButton';
 import { SecurityCheckFail } from 'src/components/suite/SecurityCheck/SecurityCheckFail';
 import { SecurityCheckLayout } from 'src/components/suite/SecurityCheck/SecurityCheckLayout';
 import { ContactSupport } from 'src/components/suite/SecurityCheck/deviceCompromisedCtas';
 import { useDispatch, useLayoutSize, useOnboarding, useSelector } from 'src/hooks/suite';
 import { selectIsOnboardingActive } from 'src/reducers/onboarding/onboardingReducer';
-import { ContentFlex, useIsContentBelowBreakpoint } from 'src/support/suite/ContentFlex';
-import { useResponsiveContext } from 'src/support/suite/ResponsiveContext';
+import { ContentFlex } from 'src/support/suite/ContentFlex';
 import { useAnalytics } from 'src/support/useAnalytics';
 
 import { SecurityChecklist } from './SecurityChecklist';
@@ -102,27 +101,6 @@ const getNoFirmwareChecklist = (isBelowTablet: boolean) =>
         },
     ] as const satisfies SecurityChecklistItem[];
 
-type ButtonFlexProps = {
-    children: React.ReactNode;
-};
-
-const ButtonFlex = ({ children }: ButtonFlexProps) => {
-    const isContentBelowBreakpoint = useIsContentBelowBreakpoint();
-
-    return (
-        <ContentFlex
-            isReversed={isContentBelowBreakpoint}
-            alignItems={isContentBelowBreakpoint ? 'center' : 'stretch'}
-            flexWrap="wrap"
-            gap={spacings.xl}
-            width="100%"
-            margin={{ top: spacings.xxxxl }}
-        >
-            {children}
-        </ContentFlex>
-    );
-};
-
 type SecurityCheckContentProps = {
     goToDeviceAuthentication: () => void;
     goToSuiteOrNextDevice: () => void;
@@ -140,7 +118,6 @@ const SecurityCheckContent = ({
     const device = useSelector(selectSelectedDevice);
     const deviceModel = device?.features?.internal_model || DeviceModelInternal.UNKNOWN;
     const isOnboardingActive = useSelector(selectIsOnboardingActive);
-    const { contentWidth } = useResponsiveContext();
     const [isFailed, setIsFailed] = useState(false);
 
     const { goToNextStep, rerun, updateAnalytics } = useOnboarding();
@@ -209,30 +186,22 @@ const SecurityCheckContent = ({
         [device],
     );
 
-    const isContentBelowMobile = !!(contentWidth && contentWidth < breakpoints.mobile);
-
     return isFailed ? (
         <SecurityCheckFail
             ctaSection={
-                <ButtonFlex>
-                    <Button
-                        intent="neutral"
-                        priority="secondary"
-                        onClick={toggleView}
-                        size={isContentBelowMobile ? 'medium' : 'large'}
-                        minWidth={100}
-                    >
+                <>
+                    <SecurityCheckButton intent="neutral" priority="secondary" onClick={toggleView}>
                         <Translation id="TR_BACK" />
-                    </Button>
+                    </SecurityCheckButton>
                     <ContactSupport supportUrl={supportUrl} />
-                </ButtonFlex>
+                </>
             }
             heading="TR_PLAY_IT_SAFE"
             text="TR_DEVICE_COMPROMISED_TEXT_SOFT"
         />
     ) : (
         <SecurityCheckLayout imageMode="ROTATE">
-            <Column gap={spacings.sm}>
+            <Column gap={12}>
                 <Paragraph intent="neutral" priority="secondary">
                     <Translation id="TR_YOU_HAVE_CONNECTED" />
                 </Paragraph>
@@ -250,33 +219,30 @@ const SecurityCheckContent = ({
                     <Translation id="TR_CONNECTED_DIFFERENT_DEVICE" />
                 </TextButton>
             </Column>
-            <Divider margin={{ vertical: spacings.xxl }} />
-            <Column gap={spacings.md}>
+            <Divider margin={{ vertical: 32 }} />
+            <Column gap={16}>
                 <H3>
                     <Translation id={headingText} />
                 </H3>
                 <SecurityChecklist items={checklistItems} />
             </Column>
-            <ButtonFlex>
-                <Button
-                    intent="neutral"
-                    priority="secondary"
-                    onClick={toggleView}
-                    size={isContentBelowMobile ? 'medium' : 'large'}
-                    minWidth={240}
-                >
+            <ContentFlex
+                breakpoint={breakpoints.tablet}
+                alignItems="center"
+                gap={12}
+                margin={{ top: 48 }}
+            >
+                <SecurityCheckButton intent="neutral" priority="secondary" onClick={toggleView}>
                     <Translation id={secondaryButtonText} />
-                </Button>
+                </SecurityCheckButton>
                 {initialized ? (
-                    <Button
+                    <SecurityCheckButton
                         data-testid="@onboarding/complete-onboarding"
                         onClick={handleContinueButtonClick}
-                        size="large"
                         intent="brand"
-                        minWidth={240}
                     >
                         <Translation id="TR_YES_CONTINUE" />
-                    </Button>
+                    </SecurityCheckButton>
                 ) : (
                     <Tooltip
                         content={
@@ -284,19 +250,18 @@ const SecurityCheckContent = ({
                                 <Translation id="TR_TAKES_N_MINUTES" />
                             </Note>
                         }
+                        width="100%"
                     >
-                        <Button
+                        <SecurityCheckButton
                             onClick={handleSetupButtonClick}
                             data-testid="@analytics/continue-button"
-                            size="large"
                             intent="brand"
-                            minWidth={240}
                         >
                             <Translation id={primaryButtonTopText} />
-                        </Button>
+                        </SecurityCheckButton>
                     </Tooltip>
                 )}
-            </ButtonFlex>
+            </ContentFlex>
         </SecurityCheckLayout>
     );
 };

--- a/packages/suite/src/views/settings/SettingsDevice/AuthenticateDevice/AuthenticateDeviceFailStep.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/AuthenticateDevice/AuthenticateDeviceFailStep.tsx
@@ -1,6 +1,7 @@
 import { Translation } from '@suite/intl';
-import { Button, Modal } from '@trezor/components';
+import { Modal } from '@trezor/components';
 
+import { SecurityCheckButton } from 'src/components/suite/SecurityCheck/SecurityCheckButton';
 import { SecurityCheckFail } from 'src/components/suite/SecurityCheck/SecurityCheckFail';
 import { AuthenticateDeviceSupportButton } from 'src/components/suite/SecurityCheck/deviceCompromisedCtas';
 
@@ -13,9 +14,13 @@ export const AuthenticateDeviceFailStep = ({ handleClose }: AuthenticateDeviceFa
             ctaSection={
                 <>
                     <AuthenticateDeviceSupportButton />
-                    <Button intent="neutral" priority="secondary" onClick={handleClose}>
+                    <SecurityCheckButton
+                        intent="neutral"
+                        priority="secondary"
+                        onClick={handleClose}
+                    >
                         <Translation id="TR_DISMISS" />
-                    </Button>
+                    </SecurityCheckButton>
                 </>
             }
             text="TR_DEVICE_COMPROMISED_DEVICE_AUTHENTICITY_TEXT"


### PR DESCRIPTION
## Notes for QA
Fix button behavior in security check layouts

## Screenshots:
<img width="1198" height="428" alt="Screenshot 2026-05-05 at 10 50 25" src="https://github.com/user-attachments/assets/6b5c6124-6d99-4e03-ac87-edf19c6c7856" />
<img width="1207" height="412" alt="Screenshot 2026-05-05 at 10 50 34" src="https://github.com/user-attachments/assets/e72c9235-c099-43df-a8fa-0b03c18ff0e5" />
<img width="627" height="827" alt="Screenshot 2026-05-05 at 10 51 07" src="https://github.com/user-attachments/assets/2d2feefe-4fe8-4dca-ae29-41f6340430d1" />

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are focused on security check and device compromised UI components used during onboarding (authenticity verification), firmware installation failure states, and device settings authentication failure. The highest risk is in the entropy check failure test which directly validates the device compromised modal. Medium risk exists in onboarding flows that pass through authenticity checks and firmware hash verification. Most of the 121 statically-mapped tests are false positives from transitive imports of these broadly-included components and should not be run. The AuthenticateDeviceFailStep in settings has no direct E2E test coverage.

<details><summary><b>Changed files (7)</b></summary>

- `packages/suite/src/components/firmware/ProgressCheck/FirmwareInstallationProgressCheckFail.tsx`
- `packages/suite/src/components/suite/SecurityCheck/SecurityCheckButton.tsx`
- `packages/suite/src/components/suite/SecurityCheck/SecurityCheckFail.tsx`
- `packages/suite/src/components/suite/SecurityCheck/SecurityCheckLayout.tsx`
- `packages/suite/src/components/suite/SecurityCheck/deviceCompromisedCtas.tsx`
- `packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/SecurityCheck.tsx`
- `packages/suite/src/views/settings/SettingsDevice/AuthenticateDevice/AuthenticateDeviceFailStep.tsx`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts` — This test directly exercises the 'device compromised' modal that appears during onboarding entropy check failures. The changed files SecurityCheckFail.tsx, SecurityCheckLayout.tsx, SecurityCheckButton.tsx, and deviceCompromisedCtas.tsx are core components of the device compromised/security check UI that this test validates (deviceCompromisedModal visibility).

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/firmware/custom-firmware.test.ts` — This test covers custom firmware installation which ends with a firmwareReconnectDevice element. The changed FirmwareInstallationProgressCheckFail.tsx is part of the firmware progress check flow, and firmware installation failures could surface through this component during the custom firmware install process.
- `suite/e2e/tests/suite/initial-run.test.ts` — This test covers the initial onboarding run including firmware hash check error dismissal via @device-compromised/dismiss-button. The SecurityCheck components and deviceCompromisedCtas.tsx directly provide the device compromised UI and dismiss functionality exercised during this flow.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts` — This test passes through the device authenticity check step during onboarding, which directly uses the SecurityCheck.tsx view from the DeviceAuthenticityStep. Changes to the security check UI components could affect this onboarding flow.
- `suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts` — This T3W1 onboarding test includes firmware hash check error dismissal (optionallyDismissFwHashCheckError) and THP pairing, both of which touch the SecurityCheck and device compromised UI components that were changed.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts` — This offline onboarding test passes through the authenticity check step during wallet creation, directly exercising the DeviceAuthenticityStep/SecurityCheck.tsx view and related security check components.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/views/settings/SettingsDevice/AuthenticateDevice/AuthenticateDeviceFailStep.tsx`
- `packages/suite/src/components/suite/SecurityCheck/SecurityCheckButton.tsx`

_Updated: 2026-05-05T08:55:24.514Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/czech-translation-overflows-on-the-button-to-contact-support-on-device-compromised-modal&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/czech-translation-overflows-on-the-button-to-contact-support-on-device-compromised-modal&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-05T09:16:23.760Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-05T09:15:13.541Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/czech-translation-overflows-on-the-button-to-contact-support-on-device-compromised-modal/web/](https://dev.suite.sldev.cz/suite-web/fix/czech-translation-overflows-on-the-button-to-contact-support-on-device-compromised-modal/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->