### PR TITLE
fix(components): prevent click event propagation in Tooltip component

### DIFF
--- a/packages/components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/components/src/components/Tooltip/Tooltip.tsx
@@ -128,6 +128,7 @@ export const Tooltip = ({
                 style={{ zIndex }}
                 arrowRender={hasArrow ? TooltipArrow : undefined}
                 appendTo={appendTo}
+                onClick={e => e.stopPropagation()}
             >
                 <ThemeProvider theme={{ variant: 'dark', ...intermediaryTheme.dark }}>
                     <TooltipBox

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFeesHeader.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFeesHeader.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 
 import { Translation, type TranslationKey } from '@suite/intl';
-import { Icon, Link, Row, Text, Tooltip } from '@trezor/components';
+import { Row, Text, TextButton, Tooltip } from '@trezor/components';
 import { type TypographyStyle } from '@trezor/theme';
 import { HELP_CENTER_TRANSACTION_FEES_URL } from '@trezor/urls';
 
@@ -51,10 +51,14 @@ export function CollapsibleFeesHeader({
             <Tooltip
                 addon={
                     networkType === 'ethereum' && (
-                        <Link href={HELP_CENTER_TRANSACTION_FEES_URL} target="_blank">
-                            <Icon size={12} intent="warning" name="lightbulb" />
+                        <TextButton
+                            size="small"
+                            intent="neutral"
+                            priority="secondary"
+                            href={HELP_CENTER_TRANSACTION_FEES_URL}
+                        >
                             <Translation id="TR_LEARN" />
-                        </Link>
+                        </TextButton>
                     )
                 }
                 hasIcon


### PR DESCRIPTION
## Notes for QA

Fixed tooltip click triggering max fee collapsible section

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies two UI components: Tooltip (a very broad shared component used by 121+ tests) and CollapsibleFeesHeader (a fee-related component used in send/swap/sell/staking flows). The Tooltip change is extremely broad and without knowing the specific nature of the change, it's impractical to test every consumer. The CollapsibleFeesHeader change is more targeted and directly affects fee display in trading, staking, and send flows. The recommended strategy focuses on tests that directly exercise fee-related UI interactions, prioritizing tests that set custom fees and verify fee display, as these are most likely to be affected by changes to the fee header component.

<details><summary><b>Changed files (2)</b></summary>

- `packages/components/src/components/Tooltip/Tooltip.tsx`
- `packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFeesHeader.tsx`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — CollapsibleFeesHeader is directly used in the swap fees flow for Bitcoin. This test exercises custom fee settings during swap transactions, which renders the CollapsibleFees component including the changed header.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — CollapsibleFeesHeader is directly used in the swap fees flow for Ethereum. This test verifies custom gas fee settings (gas limit, max fee per gas, max priority fee per gas) which are rendered within the CollapsibleFees component.
- `suite/e2e/tests/staking/staking-form.test.ts` — The staking form test validates fee display and input interactions for ETH staking. CollapsibleFeesHeader is part of the fee section rendered in staking forms, making this a direct consumer of the changed component.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — This test directly exercises fee-related UI in the sell form, including custom fee rate configuration for Bitcoin and fraction/percentage buttons. CollapsibleFeesHeader renders the fee selection header in the sell flow.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/wallet/send-base.test.ts` — This test verifies custom Ethereum fee settings (gas limit, max fee per gas, max priority fee per gas) during a send transaction on Base network. The CollapsibleFeesHeader is rendered in the send form's fee section.
- `suite/e2e/tests/wallet/send-eth.test.ts` — This test verifies custom Ethereum gas fee configuration in the ETH send form. The CollapsibleFeesHeader component is part of the fee UI rendered when setting custom fees.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — The sell Bitcoin flow calculates and displays Bitcoin fees, which involves the CollapsibleFees component. The test verifies fee calculation and display during the sell confirmation.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — This test sets custom Ethereum transaction fees (gas limit, max fee per gas, max priority fee per gas) when selling ETH, directly interacting with the CollapsibleFees component.
- `suite/e2e/tests/trading/sell-solana.test.ts` — The Solana sell flow includes fee display (maxFee, maxFeeFiat fields) rendered through the CollapsibleFees component. The test verifies fee fields are visible and correctly calculated.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — The ETH initial staking flow includes fee display in the staking confirmation modal. CollapsibleFeesHeader is part of the fee section shown during the staking transaction review.
- `suite/e2e/tests/trading/swap-coins.test.ts` — The SOL-to-BTC swap flow includes fee display and confirmation. CollapsibleFeesHeader is rendered in the swap confirmation showing transaction fees.

</details>

_Updated: 2026-05-05T09:08:28.468Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/tooltip-click-propagation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/tooltip-click-propagation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-05T09:13:01.837Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-05T09:11:53.793Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/tooltip-click-propagation/web/](https://dev.suite.sldev.cz/suite-web/fix/tooltip-click-propagation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->