### PR TITLE
fix(product-components): simplify click handling and remove unused props in EditableText

### DIFF
--- a/packages/product-components/src/components/EditableText/EditableText.tsx
+++ b/packages/product-components/src/components/EditableText/EditableText.tsx
@@ -54,7 +54,6 @@ const EditableContainer = styled.span<{
     $isEditable: boolean;
     $isEmpty: boolean;
     $placeholder: string | undefined;
-    $isDisabled: boolean;
     $hasDisplayValue: boolean;
     $isActive: boolean;
 }>`
@@ -111,7 +110,6 @@ type ContainerProps = {
     $gap: SpacingValuesNew;
     $isActive: boolean;
     $isAlwaysActive: boolean;
-    $isDisabled: boolean;
 } & TransientProps<AllowedFrameProps>;
 
 const Container = styled.span<ContainerProps>`
@@ -127,7 +125,7 @@ const Container = styled.span<ContainerProps>`
     box-sizing: content-box;
     padding: var(--padding);
     padding-left: ${({ $gap }) => $gap}px;
-    cursor: ${({ $isDisabled }) => ($isDisabled ? 'inherit' : 'pointer')};
+    cursor: ${({ $isAlwaysActive }) => ($isAlwaysActive ? 'pointer' : 'inherit')};
 
     &::before {
         content: '';
@@ -341,15 +339,19 @@ export const EditableText = ({
 
     const handleContainerClick = useCallback(
         (e: React.MouseEvent<HTMLElement>) => {
-            e.stopPropagation();
-
             if (isEditable) {
+                e.stopPropagation();
+
                 return;
             }
 
-            handleEdit();
+            if (isAlwaysActive) {
+                e.stopPropagation();
+
+                handleEdit();
+            }
         },
-        [handleEdit, isEditable],
+        [handleEdit, isEditable, isAlwaysActive],
     );
 
     const handlePaste = (e: React.ClipboardEvent<HTMLElement>) => {
@@ -376,7 +378,11 @@ export const EditableText = ({
 
         const handleOuterClick = (e: MouseEvent) => {
             if (!containerRef?.current?.contains(e.target as Node)) {
-                handleCancel();
+                if (isDirty) {
+                    handleSave();
+                } else {
+                    handleCancel();
+                }
             }
         };
 
@@ -385,7 +391,7 @@ export const EditableText = ({
         return () => {
             document.removeEventListener('click', handleOuterClick);
         };
-    }, [isEditable, handleCancel]);
+    }, [isEditable, handleCancel, handleSave, isDirty]);
 
     useShortcuts({ isEditable, isDirty, handleSave, handleCancel });
 
@@ -399,7 +405,6 @@ export const EditableText = ({
             $gap={gap}
             $isActive={isActive && !isDisabled}
             $isAlwaysActive={isAlwaysActive && !isDisabled}
-            $isDisabled={isDisabled}
             {...frameProps}
         >
             {leftAddon && (
@@ -438,7 +443,6 @@ export const EditableText = ({
                         $placeholder={placeholder}
                         $isEmpty={isEmpty}
                         $isEditable={isEditable}
-                        $isDisabled={isDisabled}
                         $isActive={isActive}
                         $hasDisplayValue={hasDisplayValue}
                         autoCapitalize="off"


### PR DESCRIPTION
## Notes for QA
When editing labels, clicking outside the label will save the current value, not discard it like before. To edit a label, the edit button has to be clicked, not just the label itself.

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to the EditableText component in the product-components package. This component is used across the application for inline label editing (account labels, wallet labels, address labels, output labels) in the metadata/labeling feature. While it statically maps to 121 tests due to broad transitive imports, the actual risk is concentrated in tests that directly exercise label editing workflows. The recommended strategy focuses on metadata/labeling tests that perform inline edit operations (type, submit, cancel, remove) since those are the primary consumers of EditableText's interactive behavior.

<details><summary><b>Changed files (1)</b></summary>

- `packages/product-components/src/components/EditableText/EditableText.tsx`

</details>

**Recommended tests (14)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/metadata/legacy/account-metadata.test.ts` — This test directly exercises EditableText functionality through account label editing (click edit button, type new name, press Enter/submit/Escape). The EditableText component is the core UI for inline label editing, and this test covers multiple editing behaviors including submit-by-enter, submit-by-button, cancel-by-escape, and label removal.
- `suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — This test exercises output label editing via EditableText - adding labels, editing via Enter, editing via submit button, and canceling edits. These are direct interactions with the EditableText component's input and submit/cancel behaviors.
- `suite/e2e/tests/metadata/legacy/wallet-metadata.test.ts` — This test edits wallet labels via the device switcher, directly using EditableText for inline label editing (fillLabelInput, successIconIsVisible). It covers standard and hidden wallet label editing and persistence across reloads.
- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — This test creates new labels for accounts, wallets, addresses, and outputs - all of which use the EditableText component for inline editing. It directly exercises the label change flow through the EditableText UI.
- `suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts` — This test removes labels for accounts, wallets, addresses, and outputs. Label removal involves clearing the EditableText input and submitting, directly exercising the component's empty-value handling behavior.

</details>

<details><summary>🟡 <b>Medium priority (9)</b></summary>

- `suite/e2e/tests/metadata/legacy/address-metadata.test.ts` — This test adds and edits address labels using the metadata labeling UI, which relies on EditableText for inline address label editing. It covers add-label and edit-label flows with success icon verification.
- `suite/e2e/tests/metadata/legacy/dropbox-api-errors.test.ts` — This test exercises label editing with error scenarios (malformed token, rate limiting, corrupted metadata). The EditableText component is used to trigger label saves that interact with the Dropbox API, and the test verifies label state after errors.
- `suite/e2e/tests/metadata/legacy/metadata-lifecycle.test.ts` — This test covers the full metadata lifecycle including adding labels to accounts (via EditableText), enabling/disabling labeling, and verifying label persistence across device ejection and re-onboarding scenarios.
- `suite/e2e/tests/metadata/legacy/remembered-device.test.ts` — This test exercises label editing on remembered devices including editing labels after device disconnect. It uses EditableText to edit labels and verifies label state after provider connect/disconnect cycles.
- `suite/e2e/tests/metadata/legacy/switching-providers.test.ts` — This test adds custom labels via EditableText when switching between Dropbox and Google metadata providers, verifying that the label editing UI works correctly across provider transitions.
- `suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts` — This test edits account labels using EditableText (change label, verify success icon) as part of migrating from legacy Dropbox labeling to Suite Sync. The label editing interaction directly uses the changed component.
- `suite/e2e/tests/metadata/legacy/interval-fetching.test.ts` — This test verifies that account labels fetched from cloud providers are displayed correctly and update on interval. The labels are rendered through components that use EditableText for display and editing.
- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — This test sets labels on multiple wallets and accounts via EditableText, covering the label editing flow across standard and passphrase wallets with Suite Sync enabled.
- `suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — This test verifies that labels synced from the Evolu relay are displayed correctly for accounts, wallets, addresses, and outputs. The display of these labels involves the EditableText component.

</details>

_Updated: 2026-05-05T10:23:47.884Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/labels-are-discarded-on-blur-when-not-explicitly-confirmed&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/labels-are-discarded-on-blur-when-not-explicitly-confirmed&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-05T10:28:25.500Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-05T10:27:15.026Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/labels-are-discarded-on-blur-when-not-explicitly-confirmed/web/](https://dev.suite.sldev.cz/suite-web/fix/labels-are-discarded-on-blur-when-not-explicitly-confirmed/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->