### PR TITLE
Improve InlineAlertBox atom

### DIFF
--- a/suite-native/atoms/src/InlineAlertBox/AnimatedInlineAlertBox.tsx
+++ b/suite-native/atoms/src/InlineAlertBox/AnimatedInlineAlertBox.tsx
@@ -1,0 +1,9 @@
+import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
+
+import { InlineAlertBox, type InlineAlertBoxProps } from './InlineAlertBox';
+
+export const AnimatedInlineAlertBox = (props: InlineAlertBoxProps) => (
+    <Animated.View entering={FadeIn} exiting={FadeOut}>
+        <InlineAlertBox {...props} />
+    </Animated.View>
+);

--- a/suite-native/atoms/src/InlineAlertBox/InlineAlertBox.tsx
+++ b/suite-native/atoms/src/InlineAlertBox/InlineAlertBox.tsx
@@ -13,6 +13,7 @@ import {
     variantToColorMap,
     variantToIconName,
 } from './presets';
+import { IconButton } from '../Button/IconButton';
 
 const alertWrapperStyle = prepareNativeStyle<
     Omit<InlineAlertBoxStyles, 'buttonColorProps'> & { isButtonVisible: boolean }
@@ -36,6 +37,7 @@ export type InlineAlertBoxProps = Omit<BoxProps, 'style'> & {
     title: Exclude<ReactNode, null | undefined>;
     variant?: InlineAlertBoxVariant;
     buttonLabel?: ReactNode;
+    buttonIcon?: IconName;
     onButtonPress?: () => void;
     iconName?: IconName;
     viewLeft?: ReactNode;
@@ -45,6 +47,7 @@ export type InlineAlertBoxProps = Omit<BoxProps, 'style'> & {
 export const InlineAlertBox = ({
     title,
     buttonLabel,
+    buttonIcon,
     onButtonPress,
     iconName,
     buttonProps,
@@ -81,6 +84,14 @@ export const InlineAlertBox = ({
                 >
                     {buttonLabel}
                 </Button>
+            )}
+            {buttonIcon && (
+                <IconButton
+                    iconName={buttonIcon}
+                    size="medium"
+                    {...buttonColorProps}
+                    onPress={onButtonPress}
+                />
             )}
         </HStack>
     );

--- a/suite-native/atoms/src/InlineAlertBox/presets.ts
+++ b/suite-native/atoms/src/InlineAlertBox/presets.ts
@@ -37,7 +37,7 @@ export const variantToColorMap = {
     neutral: {
         backgroundColor: 'legacyBackgroundTertiaryDefaultOnElevation1',
         borderColor: 'legacyBackgroundTertiaryDefaultOnElevation0',
-        buttonColorProps: { intent: 'brand', priority: 'primary' },
+        buttonColorProps: { intent: 'neutral', priority: 'primary' },
     },
     critical: {
         backgroundColor: 'legacyBackgroundAlertRedSubtleOnElevation1',

--- a/suite-native/atoms/src/index.ts
+++ b/suite-native/atoms/src/index.ts
@@ -1,6 +1,7 @@
 export * from './Accordion/AccordionList';
 export * from './BaseAmountInputs';
 export * from './InlineAlertBox/InlineAlertBox';
+export * from './InlineAlertBox/AnimatedInlineAlertBox';
 export * from './InlineAlertText';
 export * from './Text';
 export * from './AnimatedBox';

--- a/suite-native/atoms/src/stories/AlertBoxes/InlineAlertBox.stories.tsx
+++ b/suite-native/atoms/src/stories/AlertBoxes/InlineAlertBox.stories.tsx
@@ -22,6 +22,7 @@ export const InlineAlertBox: InlineAlertBoxStory = {
     args: {
         title: 'Something very important to communicate.',
         buttonLabel: 'Button',
+        buttonIcon: undefined,
         variant: 'info',
         iconName: undefined,
         buttonProps: undefined,
@@ -32,6 +33,10 @@ export const InlineAlertBox: InlineAlertBoxStory = {
         },
         buttonLabel: {
             control: { type: 'text' },
+        },
+        buttonIcon: {
+            control: { type: 'select' },
+            options: ICON_NAMES,
         },
         viewLeft: {
             control: false,


### PR DESCRIPTION
* Tweaked `InlineAlertBox` atom to support an `IconButton`.
* Introduced `AnimatedInlineAlertBox` atom.
* Used `neutral` button intent for `neutral` `InlineAlertBox`.

Required for #27339.

## Screenshots:
<img width="1179" height="898" alt="image" src="https://github.com/user-attachments/assets/ea7da04a-c404-42ec-91ad-058088b7a2d3" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/inline-alert-box&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->