### PR TITLE
Feat: persist Manual Device Check result

### DIFF
--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -330,6 +330,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                     deviceActions.deviceChanged,
                     deviceActions.setEntropyCheckResult,
                     deviceActions.setDeviceAuthenticityResult,
+                    deviceActions.setManualDeviceCheckSuccess,
                     deviceActions.clearDevicePersistentData,
                     deviceActions.forgetDevicePersistentData,
                 )(action)

--- a/packages/suite/src/storage/CHANGELOG.md
+++ b/packages/suite/src/storage/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 26.5.0
 
 - reset Ethereum account nonces to `-1` in order to force account refresh for DeFi tokens
+- backfill `manualCheckResult` to all `persistentDeviceData` entries (all previously known devices assumed confirmed)
 
 ## 26.4.0.2
 

--- a/packages/suite/src/storage/migrations/versions/26.5.0.2.ts
+++ b/packages/suite/src/storage/migrations/versions/26.5.0.2.ts
@@ -1,0 +1,17 @@
+import { createMigration } from '@suite/idb-migration-utils';
+
+import { type SuiteDBSchema } from 'src/storage/definitions';
+
+// Backfill successful `manualCheckResult` to all `persistentDeviceData` entries (all previously known devices are assumed confirmed)
+export default createMigration<SuiteDBSchema>('26.5.0.2', async (_, tx) => {
+    const store = tx.objectStore('persistentDeviceData');
+    const data = await store.get('persistentDeviceData');
+    if (!Array.isArray(data)) return;
+
+    const updated = data.map(entry => ({
+        ...entry,
+        manualCheckResult: { success: true as const },
+    }));
+
+    await store.put(updated, 'persistentDeviceData');
+});

--- a/packages/suite/src/storage/migrations/versions/index.ts
+++ b/packages/suite/src/storage/migrations/versions/index.ts
@@ -20,3 +20,4 @@ export { default as m26_4_0_1 } from './26.4.0.1';
 export { default as m26_4_0_2 } from './26.4.0.2';
 export { default as m26_5_0 } from './26.5.0';
 export { default as m26_5_0_1 } from './26.5.0.1';
+export { default as m26_5_0_2 } from './26.5.0.2';

--- a/packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/SecurityCheck.tsx
+++ b/packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/SecurityCheck.tsx
@@ -116,6 +116,7 @@ const SecurityCheckContent = ({
     const { isBelowTablet } = useLayoutSize();
     const recoveryStatus = useSelector(selectRecoveryStatus);
     const device = useSelector(selectSelectedDevice);
+    const deviceId = device?.id;
     const deviceModel = device?.features?.internal_model || DeviceModelInternal.UNKNOWN;
     const isOnboardingActive = useSelector(selectIsOnboardingActive);
     const [isFailed, setIsFailed] = useState(false);
@@ -141,8 +142,9 @@ const SecurityCheckContent = ({
         ? firmwareInstalledChecklist
         : getNoFirmwareChecklist(isBelowTablet);
 
-    const toggleView = () => setIsFailed(current => !current);
+    const toggleIsDeviceRejected = () => setIsFailed(current => !current);
     const handleContinueButtonClick = () => {
+        dispatch(deviceActions.setManualDeviceCheckSuccess({ deviceId }));
         if (shouldAuthenticateSelectedDevice) {
             goToDeviceAuthentication();
         } else {
@@ -151,6 +153,7 @@ const SecurityCheckContent = ({
     };
 
     const handleSetupButtonClick = () => {
+        dispatch(deviceActions.setManualDeviceCheckSuccess({ deviceId }));
         analytics.report({
             type: events.deviceSetupStartedEvent.name,
             payload: {
@@ -190,7 +193,11 @@ const SecurityCheckContent = ({
         <SecurityCheckFail
             ctaSection={
                 <>
-                    <SecurityCheckButton intent="neutral" priority="secondary" onClick={toggleView}>
+                    <SecurityCheckButton
+                        intent="neutral"
+                        priority="secondary"
+                        onClick={toggleIsDeviceRejected}
+                    >
                         <Translation id="TR_BACK" />
                     </SecurityCheckButton>
                     <ContactSupport supportUrl={supportUrl} />
@@ -214,7 +221,7 @@ const SecurityCheckContent = ({
                     priority="secondary"
                     size="small"
                     isUnderlined
-                    onClick={toggleView}
+                    onClick={toggleIsDeviceRejected}
                 >
                     <Translation id="TR_CONNECTED_DIFFERENT_DEVICE" />
                 </TextButton>
@@ -232,7 +239,11 @@ const SecurityCheckContent = ({
                 gap={12}
                 margin={{ top: 48 }}
             >
-                <SecurityCheckButton intent="neutral" priority="secondary" onClick={toggleView}>
+                <SecurityCheckButton
+                    intent="neutral"
+                    priority="secondary"
+                    onClick={toggleIsDeviceRejected}
+                >
                     <Translation id={secondaryButtonText} />
                 </SecurityCheckButton>
                 {initialized ? (

--- a/suite-common/device/src/deviceActions.ts
+++ b/suite-common/device/src/deviceActions.ts
@@ -158,6 +158,11 @@ const setDeviceAuthenticityResult = createAction(
     }),
 );
 
+const setManualDeviceCheckSuccess = createAction(
+    `${DEVICE_MODULE_PREFIX}/setManualDeviceCheckSuccess`,
+    (payload: { deviceId: TrezorDevice['id'] }) => ({ payload }),
+);
+
 // Use in tests only! See deviceReducer for the property definition.
 const setSimulatedEntropyCheckFail = createAction(
     `${DEVICE_MODULE_PREFIX}/setSimulatedEntropyCheckFail`,
@@ -188,5 +193,6 @@ export const deviceActions = {
     setDiscovered,
     devicePushNotification,
     setDeviceAuthenticityResult,
+    setManualDeviceCheckSuccess,
     setSimulatedEntropyCheckFail,
 };

--- a/suite-common/device/src/deviceReducer.ts
+++ b/suite-common/device/src/deviceReducer.ts
@@ -30,6 +30,7 @@ export type DeviceReducerState = {
     /**
      * Because we have `devices` as merged DEVICE+WALLET we persist
      * data that are DEVICE only here to separate them.
+     * TODO consider extracting to a subreducer persistentDeviceDataReducer
      */
     persistentDeviceData: PersistentDeviceData[]; // is an array since there is not a single primary id, device can be matched by various criteria
 
@@ -556,6 +557,18 @@ export const setDeviceAuthenticity = (
     data.authenticityResult = result;
 };
 
+export const setManualDeviceCheckSuccess = (
+    draft: DeviceReducerState,
+    deviceId: TrezorDevice['id'],
+) => {
+    const data = draft.persistentDeviceData.find(
+        persistentDeviceData => persistentDeviceData.device_id === deviceId,
+    );
+    // expected to exist; device must have been connected or changed for this action to happen
+    if (data === undefined) return;
+    data.manualCheckResult = { success: true };
+};
+
 // called after successful wipeDevice
 const requestDeviceReconnect = (draft: DeviceReducerState) => {
     // only acquired devices
@@ -658,6 +671,9 @@ export const prepareDeviceReducer = createReducerWithExtraDeps(
             .addCase(deviceActions.setDeviceAuthenticityResult, (state, { payload }) => {
                 // nullish deviceId is impossible unless meta checks (id) are disabled. If it is nullish, it's no-op.
                 setDeviceAuthenticity(state, payload.deviceId, payload.result);
+            })
+            .addCase(deviceActions.setManualDeviceCheckSuccess, (state, { payload }) => {
+                setManualDeviceCheckSuccess(state, payload.deviceId);
             })
             .addCase(deviceActions.dismissFirmwareAuthenticityCheck, (state, { payload }) => {
                 if (!state.dismissedSecurityChecks) {

--- a/suite-common/suite-types/src/device.ts
+++ b/suite-common/suite-types/src/device.ts
@@ -95,6 +95,9 @@ type PersistedFeatureKey = UnionSubset<
     | 'initialized'
 >;
 
+// Only successful result is persisted, because rejection by user is treated the same as check not done yet → check will pop up.
+export type ManualCheckResult = { success: true };
+
 export type PersistentDeviceData = Pick<AcquiredDevice, PersistedDeviceKey> &
     Pick<Features, PersistedFeatureKey> & {
         firmwareVersion: VersionArray | null;
@@ -102,6 +105,7 @@ export type PersistentDeviceData = Pick<AcquiredDevice, PersistedDeviceKey> &
         lastEntropyCheckResult?: EntropyCheckResult;
         delegatedIdentityKey: EncryptedHex<DelegatedIdentityKey> | null;
         descriptor?: AcquiredDevice['descriptor'];
+        manualCheckResult?: ManualCheckResult;
         authenticityResult?: StoredAuthenticateDeviceResult;
     };
 

--- a/suite-native/module-device-onboarding/src/screens/UninitializedDeviceLandingScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/UninitializedDeviceLandingScreen.tsx
@@ -1,11 +1,13 @@
 import { useEffect } from 'react';
 import { Platform } from 'react-native';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { useSetAtom } from 'jotai';
 
 import {
+    deviceActions,
     selectHasDeviceFirmwareInstalled,
+    selectSelectedDevice,
     selectShouldOfferUpdateFirmware,
 } from '@suite-common/device';
 import { events } from '@suite-native/analytics';
@@ -65,10 +67,13 @@ export const UninitializedDeviceLandingScreen = ({
     DeviceOnboardingStackRoutes.UninitializedDeviceLanding,
     RootStackParamList
 >) => {
+    const dispatch = useDispatch();
     const analytics = useAnalytics();
     const deviceModel = params.deviceModel as SetupSupportingDeviceModel;
     const hasDeviceFirmwareInstalled = useSelector(selectHasDeviceFirmwareInstalled);
     const shouldOfferUpdateFirmware = useSelector(selectShouldOfferUpdateFirmware);
+    const device = useSelector(selectSelectedDevice);
+    const deviceId = device?.id;
 
     const resetOnboardingAnalytics = useSetAtom(resetOnboardingAnalyticsAtom);
     const updateOnboardingAnalytics = useSetAtom(updateOnboardingAnalyticsAtom);
@@ -77,6 +82,7 @@ export const UninitializedDeviceLandingScreen = ({
         useNavigateToNextScreenAfterFirmwareInstallation();
 
     const handleConfirmButtonPress = () => {
+        dispatch(deviceActions.setManualDeviceCheckSuccess({ deviceId }));
         if (hasDeviceFirmwareInstalled) {
             if (shouldOfferUpdateFirmware) {
                 navigation.replace(DeviceOnboardingStackRoutes.ConfirmFirmwareUpdate);

--- a/suite-native/state/src/reducers.ts
+++ b/suite-native/state/src/reducers.ts
@@ -49,6 +49,7 @@ import { appSettingsPersistWhitelist, appSettingsReducer } from '@suite-native/s
 import {
     type MMKVStorageDep,
     backfillDeviceAuthenticityChecks,
+    backfillManualCheckResult,
     backfillPortfolioTrackerUnavailableCapabilities,
     blockchainPersistTransform,
     bluetoothPersistTransform,
@@ -231,7 +232,7 @@ export const prepareRootReducers = (deps: PrepareRootReducersDeps) => {
         reducer: deviceReducer,
         persistedKeys: ['devices', 'persistentDeviceData'],
         key: 'devices',
-        version: 4,
+        version: 5,
         transforms: [devicePersistTransform],
         migrations: {
             2: (oldState: any /* FIXME */) => {
@@ -256,6 +257,14 @@ export const prepareRootReducers = (deps: PrepareRootReducersDeps) => {
                 );
 
                 return { ...oldState, devices: migratedDevices };
+            },
+            5: (oldState: any /* FIXME */) => {
+                if (!oldState?.persistentDeviceData) return oldState;
+                const migratedPersistentDeviceData = backfillManualCheckResult(
+                    oldState.persistentDeviceData,
+                );
+
+                return { ...oldState, persistentDeviceData: migratedPersistentDeviceData };
             },
         },
         storage: deps.mmkvStorage,

--- a/suite-native/storage/src/index.ts
+++ b/suite-native/storage/src/index.ts
@@ -12,6 +12,7 @@ export * from './migrations/account/v3';
 export * from './migrations/device/v2';
 export * from './migrations/device/v3';
 export * from './migrations/device/v4';
+export * from './migrations/device/v5';
 export * from './migrations/wallet/transactions/v2';
 export * from './migrations/wallet/accounts/v2';
 export * from './migrations/wallet/accounts/v3';

--- a/suite-native/storage/src/migrations/device/v5.ts
+++ b/suite-native/storage/src/migrations/device/v5.ts
@@ -1,0 +1,9 @@
+import { type PersistentDeviceData } from '@suite-common/suite-types';
+
+export const backfillManualCheckResult = (
+    persistentDeviceData: PersistentDeviceData[],
+): PersistentDeviceData[] =>
+    persistentDeviceData.map(entry => ({
+        ...entry,
+        manualCheckResult: { success: true },
+    }));


### PR DESCRIPTION
## Description

Purely technical preparation for soon-to-be-implemented https://github.com/trezor/trezor-suite-private/issues/148

- persist Manual Device Check success (MDC) to `persistentDeviceData`
- in MDC screens both Desktop & Native, persist the success
- Migrate to backfill success for all `persistentDeviceData` entries
  - it is a soft assumption you have seen the device before, though there could also be an uninitialized device, those will be always checked during Onboarding

## Notes for QA

N/A, we don't do anything with this new data.

Only check that 26.4 → 26.5 migrations work on Desktop, Web, Mobile (can be done as part of the release checks)

## Related Issue

Part of https://github.com/trezor/trezor-suite-private/issues/148

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/persist-MDC-result&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/persist-MDC-result&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/persist-MDC-result&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-05T11:03:42.973Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-05T11:02:18.515Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/persist-MDC-result/web/](https://dev.suite.sldev.cz/suite-web/feat/persist-MDC-result/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->