### PR TITLE
fix(address-validator): fixing native web storybook (JSBigInt duplicated error)

### DIFF
--- a/packages/address-validator/src/crypto/biginteger.ts
+++ b/packages/address-validator/src/crypto/biginteger.ts
@@ -19,7 +19,7 @@
 */
 const moduleExports: { JSBigInt?: any } = {};
 
-(function (exports) {
+(function (mod) {
     /*
         Class: BigInteger
         An arbitrarily-large integer.
@@ -1461,7 +1461,7 @@ const moduleExports: { JSBigInt?: any } = {};
         })();
     })();
 
-    exports.JSBigInt = BigInteger; // exports.BigInteger changed to exports.JSBigInt
+    mod.JSBigInt = BigInteger; // exports.BigInteger changed to exports.JSBigInt
 })(moduleExports);
 
 export const JSBigInt = moduleExports.JSBigInt;


### PR DESCRIPTION
## Description

- Renamed the IIFE parameter in `biginteger.ts` from `exports` to `mod` 

`biginteger.ts` wraps the entire vendored BigInteger library in an IIFE and assigns the result to a plain object, then re-exports via ESM:

```js
(function (exports) {
    ...
    exports.JSBigInt = BigInteger;  // just writing to a local variable
})(moduleExports);

export const JSBigInt = moduleExports.JSBigInt;  // the real ESM export
```

esbuild recognises `exports` as a local function parameter and ignored it. oxc (Vite) treats any `exports.X =` assignment as a CJS module export, so it generated a second export named `JSBigInt` — conflicting with the explicit ESM export below it.

The resulting `SyntaxError: Duplicate export of 'JSBigInt'` was crashing the native storybook web build after the address-validator mock was removed.

## Related Issue
Broken by commit https://github.com/trezor/trezor-suite/commit/1afa30d187c3caa2522859ad9ed5aaf254d7d5eb


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/address-validator-duplicate-jsbigint-export&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/address-validator-duplicate-jsbigint-export&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-05T12:24:52.865Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-05T12:23:31.438Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/address-validator-duplicate-jsbigint-export/web/](https://dev.suite.sldev.cz/suite-web/fix/address-validator-duplicate-jsbigint-export/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->