### PR TITLE
feat(connect): handle EthereumDefinitionRequest

### DIFF
--- a/packages/connect/e2e/__fixtures__/ethereumSignTransactionDefinitions.ts
+++ b/packages/connect/e2e/__fixtures__/ethereumSignTransactionDefinitions.ts
@@ -1,0 +1,30 @@
+export default {
+    method: 'ethereumSignTransaction',
+    setup: {
+        mnemonic: 'mnemonic_all',
+    },
+    tests: [
+        {
+            // Uniswap V3 Universal Router — exactInputSingle (WETH → USDT).
+            // The router contract triggers an EthereumDefinitionRequest with func_sig
+            // so the device can request a display-format definition for the call.
+            // We fetch definitions from data.trezor.io and respond with EthereumDefinitionAck.
+            description: 'Uniswap V3 exactInputSingle',
+            params: {
+                path: "m/44'/60'/0'",
+                transaction: {
+                    nonce: '0x0',
+                    gasPrice: '0x14',
+                    gasLimit: '0x14',
+                    to: '0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45',
+                    value: '0x0',
+                    chainId: 1,
+                    data: '0x04e45aaf000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2000000000000000000000000dac17f958d2ee523a2206206994597c13d831ec70000000000000000000000000000000000000000000000000000000000000bb800000000000000000000000051117eb63623aee74a39b63bd9efa3a728800dbb000000000000000000000000000000000000000000000000002386f26fc1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+                },
+            },
+            result: {},
+            deviceScreen: 'Send0.01WETHMinimumtoReceive0USDTUniswapfee0.3%',
+            deviceScreenSkip: ['1', '<2.12.1'],
+        },
+    ],
+} satisfies TestCase;

--- a/packages/connect/e2e/__fixtures__/index.ts
+++ b/packages/connect/e2e/__fixtures__/index.ts
@@ -14,6 +14,7 @@ export { default as ethereumSignMessage } from './ethereumSignMessage';
 export { default as ethereumSignTransaction } from './ethereumSignTransaction';
 export { default as ethereumSignTransactionEip155 } from './ethereumSignTransactionEip155';
 export { default as ethereumSignTransactionEip1559 } from './ethereumSignTransactionEip1559';
+export { default as ethereumSignTransactionDefinitions } from './ethereumSignTransactionDefinitions';
 export { default as ethereumSignTypedData } from './ethereumSignTypedData';
 export { default as ethereumVerifyMessage } from './ethereumVerifyMessage';
 export { default as getAccountInfo } from './getAccountInfo';

--- a/packages/connect/src/api/ethereum/ethereumSignTx.ts
+++ b/packages/connect/src/api/ethereum/ethereumSignTx.ts
@@ -1,4 +1,4 @@
-// origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/helpers/ethereumSignTx.js
+/* eslint-disable @typescript-eslint/no-use-before-define */
 
 import type { Common } from '@ethereumjs/common';
 import { Hardfork, Mainnet, createCustomCommon } from '@ethereumjs/common';
@@ -14,6 +14,7 @@ import type {
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import type { MessagesSchema } from '@trezor/protobuf';
 
+import { getEthereumDefinitions } from './ethereumDefinitions';
 import type { TypedCall } from '../../device/DeviceCommands';
 import { addHexPrefix, deepTransform } from '../../utils/formatUtils';
 
@@ -27,16 +28,18 @@ const splitString = (str?: string, len?: number) => {
     return [first, second];
 };
 
-const processTxRequest = async (
+type TxSignature = { v: `0x${string}`; r: `0x${string}`; s: `0x${string}` };
+
+type TxFlowResponse =
+    | { type: 'EthereumTxRequest'; message: PROTO.EthereumTxRequest }
+    | { type: 'EthereumDefinitionRequest'; message: PROTO.EthereumDefinitionRequest };
+
+async function processTxRequest(
     typedCall: TypedCall,
     request: PROTO.EthereumTxRequest,
     data?: string,
     chain_id?: number,
-): Promise<{
-    v: `0x${string}`;
-    r: `0x${string}`;
-    s: `0x${string}`;
-}> => {
+): Promise<TxSignature> {
     if (!request.data_length) {
         let v = request.signature_v;
         const r = request.signature_r;
@@ -59,10 +62,47 @@ const processTxRequest = async (
     }
 
     const [first, rest] = splitString(data, request.data_length * 2);
-    const response = await typedCall('EthereumTxAck', 'EthereumTxRequest', { data_chunk: first });
+    const nextResponse = await typedCall(
+        'EthereumTxAck',
+        ['EthereumTxRequest', 'EthereumDefinitionRequest'],
+        { data_chunk: first },
+    );
 
-    return processTxRequest(typedCall, response.message, rest, chain_id);
-};
+    return handleTxFlowResponse(typedCall, nextResponse, rest, chain_id);
+}
+
+async function processDefinitionRequest(
+    typedCall: TypedCall,
+    request: PROTO.EthereumDefinitionRequest,
+    data?: string,
+    chain_id?: number,
+): Promise<TxSignature> {
+    const definitions = await getEthereumDefinitions({
+        chainId: request.chain_id,
+        contractAddress: request.token_address.toLowerCase(),
+    });
+
+    const nextResponse = await typedCall(
+        'EthereumDefinitionAck',
+        ['EthereumTxRequest', 'EthereumDefinitionRequest'],
+        { definitions },
+    );
+
+    return handleTxFlowResponse(typedCall, nextResponse, data, chain_id);
+}
+
+function handleTxFlowResponse(
+    typedCall: TypedCall,
+    response: TxFlowResponse,
+    data?: string,
+    chain_id?: number,
+): Promise<TxSignature> {
+    if (response.type === 'EthereumDefinitionRequest') {
+        return processDefinitionRequest(typedCall, response.message, data, chain_id);
+    }
+
+    return processTxRequest(typedCall, response.message, data, chain_id);
+}
 
 const deepHexPrefix = deepTransform(addHexPrefix);
 
@@ -154,6 +194,7 @@ export const ethereumSignTx = async (
         definitions,
         chunkify,
         payment_req,
+        supports_definition_request: true,
     };
 
     if (length !== 0) {
@@ -171,9 +212,13 @@ export const ethereumSignTx = async (
         };
     }
 
-    const response = await typedCall('EthereumSignTx', 'EthereumTxRequest', message);
+    const response = await typedCall(
+        'EthereumSignTx',
+        ['EthereumTxRequest', 'EthereumDefinitionRequest'],
+        message,
+    );
 
-    return processTxRequest(typedCall, response.message, rest, chain_id);
+    return handleTxFlowResponse(typedCall, response, rest, chain_id);
 };
 
 export const ethereumSignTxEIP1559 = async (
@@ -215,9 +260,14 @@ export const ethereumSignTxEIP1559 = async (
         definitions,
         chunkify,
         payment_req,
+        supports_definition_request: true,
     };
 
-    const response = await typedCall('EthereumSignTxEIP1559', 'EthereumTxRequest', message);
+    const response = await typedCall(
+        'EthereumSignTxEIP1559',
+        ['EthereumTxRequest', 'EthereumDefinitionRequest'],
+        message,
+    );
 
-    return processTxRequest(typedCall, response.message, rest);
+    return handleTxFlowResponse(typedCall, response, rest);
 };


### PR DESCRIPTION
## Description

Connect side implementation of https://github.com/trezor/trezor-firmware/pull/6798

This adds handling of a new message `EthereumDefinitionRequest`, using which the FW can ask Connect for additional token definitions. 

Supported since FW 2.12.1

## Notes for QA

Should be covered by Connect E2E, but for manual test you can use the following data with `ethereumSignTransaction` in Explorer:

```
{
  "nonce": "0x0",
  "gasPrice": "0x14",
  "gasLimit": "0x14",
  "to": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
  "chainId": 1,
  "value": "0x0",
  "data": "0xa9059cbb000000000000000000000000D6971aabeDC7f2A8113679199FE374aE1B1Aea96000000000000000000000000000000000000000000000000000000000097f6b2"
}
```

and it should show clearsigned Uniswap WETH / USDT swap 

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=eth-definition-request&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=eth-definition-request&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=eth-definition-request&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-05T13:01:48.635Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-05T13:00:09.338Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/eth-definition-request/web/](https://dev.suite.sldev.cz/suite-web/eth-definition-request/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->