### PR TITLE
fix(e2e): More efficient and safe android e2e setup

### DIFF
--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -190,9 +190,9 @@ export const createImportedDeviceThunk = createThunk<
     undefined,
     { rejectValue: { error: 'already-created' } }
 >(`${DEVICE_MODULE_PREFIX}/createImportedDevice`, (_, { dispatch, getState, rejectWithValue }) => {
-    const device = selectDeviceById(getState(), PORTFOLIO_TRACKER_DEVICE_ID);
-
-    if (device) return rejectWithValue({ error: 'already-created' });
+    if (selectDeviceById(getState(), PORTFOLIO_TRACKER_DEVICE_ID)) {
+        return rejectWithValue({ error: 'already-created' });
+    }
 
     dispatch(
         deviceActions.createDeviceInstance({
@@ -200,7 +200,11 @@ export const createImportedDeviceThunk = createThunk<
         }),
     );
 
-    dispatch(selectDeviceThunk({ device: portfolioTrackerDevice }));
+    const selectedDevice = selectSelectedDevice(getState());
+
+    if (selectedDevice === undefined) {
+        dispatch(selectDeviceThunk({ device: portfolioTrackerDevice }));
+    }
 });
 
 type ConfirmAddressOnDeviceThunk = {

--- a/suite-native/app/e2e/fixtures/btcDiscoveryFinishedStateT3T1.ts
+++ b/suite-native/app/e2e/fixtures/btcDiscoveryFinishedStateT3T1.ts
@@ -115,13 +115,14 @@ export const btcDiscoveryFinishedStateT3T1: PreloadedState = {
                 name: 'Trezor Safe 5',
                 descriptor: {
                     apiType: 'usb',
+                    id: '127.0.0.1:21324',
                 },
                 type: 'acquired',
                 id: '7ED4F891C5F1098B60B881DE',
                 label: 'Trezor T - Tester',
                 state: {
                     deriveCardano: false,
-                    sessionId: '86034a5d2d85aecea8a4c045e73f3a9d1a3c69abb15c43bd5c2e12bd0bf6cf9b',
+                    sessionId: '01',
                     staticSessionId:
                         'mt5WPmXL77AJwhCPPv6Gct3UtiuVUMieXJ@7ED4F891C5F1098B60B881DE:0',
                 },

--- a/suite-native/app/e2e/jest.perTestFile.teardown.ts
+++ b/suite-native/app/e2e/jest.perTestFile.teardown.ts
@@ -1,6 +1,6 @@
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
-const TEARDOWN_TIMEOUT = 5_000;
+const TEARDOWN_TIMEOUT = 30_000;
 
 // We want to stop trezor at two places:
 // 1) afterAll - to cover normal test run teardowns
@@ -33,5 +33,6 @@ afterAll(async () => {
 });
 
 beforeEach(async () => {
+    await device.terminateApp();
     await stopTrezorUserEnv();
 });

--- a/suite-native/app/e2e/pageObjects/deviceManagerActions.ts
+++ b/suite-native/app/e2e/pageObjects/deviceManagerActions.ts
@@ -27,11 +27,14 @@ class DeviceManagerActions {
 
     async assertDeviceSwitcherState({
         title,
+        timeout,
     }: {
         title: 'Connected' | 'Disconnected' | 'Hi there!';
+        timeout?: number;
     }) {
         await waitForVisible(
             element(by.id('@device-manager/device-switch').withDescendant(by.text(title))),
+            { timeout },
         );
     }
 }

--- a/suite-native/app/e2e/support/setup.ts
+++ b/suite-native/app/e2e/support/setup.ts
@@ -85,6 +85,33 @@ const isDebugTestBuild = async () => {
     return isDebugBuild;
 };
 
+const waitForBridgeReady = async ({ retries = 20, intervalMs = 500 } = {}) => {
+    for (let i = 0; i < retries; i++) {
+        try {
+            const response = await fetch('http://127.0.0.1:21325/', { method: 'POST' });
+            if (response.ok) return;
+        } catch {
+            // bridge not ready yet
+        }
+        await new Promise(resolve => setTimeout(resolve, intervalMs));
+    }
+    throw new Error('Trezor bridge did not become ready in time');
+};
+
+const waitForDeviceEnumerated = async ({ retries = 60, intervalMs = 1000 } = {}) => {
+    for (let i = 0; i < retries; i++) {
+        try {
+            const response = await fetch('http://127.0.0.1:21325/enumerate', { method: 'POST' });
+            const devices = await response.json();
+            if (Array.isArray(devices) && devices.length > 0) return;
+        } catch {
+            // bridge not ready yet
+        }
+        await new Promise(resolve => setTimeout(resolve, intervalMs));
+    }
+    throw new Error('No device visible to Trezor bridge after enumerate polling');
+};
+
 const wipeAppData = async () => {
     await device.uninstallApp();
     await device.installApp();
@@ -117,6 +144,11 @@ export const openApp = async ({
         });
     }
 
+    if (getModelFromEnv() === Model.T3W1) {
+        await onDevicePrompt.allowConnectToTrezor();
+        await onDeviceOnboarding.enterTHPPairingCode();
+    }
+
     if (launchArgs.preloadedState) {
         // wait for preloaded state to be applied
         await appIsFullyLoaded();
@@ -138,8 +170,7 @@ export const prepareTrezorEmulator = async ({
     seed = MNEMONICS.mnemonic_immune,
     passphrase_protection = false,
     model = getModelFromEnv(),
-    args,
-}: PrepareTrezorEmulatorProps & { args?: LaunchArguments } = {}) => {
+}: PrepareTrezorEmulatorProps = {}) => {
     if (platform === 'android') {
         const { currentTestName, testPath } = jestExpect.getState();
         await TrezorUserEnvLink.logTestDetails(
@@ -158,14 +189,8 @@ export const prepareTrezorEmulator = async ({
             });
         }
         await TrezorUserEnvLink.startBridge('node-bridge');
-    }
-    // ATM we need to terminate app, start without new instance in order for the emulator to connect to the app
-    await device.terminateApp();
-    await openApp({ newInstance: false, wipeData: false, args });
-
-    if (getModelFromEnv() === Model.T3W1) {
-        await onDevicePrompt.allowConnectToTrezor();
-        await onDeviceOnboarding.enterTHPPairingCode();
+        await waitForBridgeReady();
+        await waitForDeviceEnumerated();
     }
 };
 

--- a/suite-native/app/e2e/tests/coinEnabling.test.ts
+++ b/suite-native/app/e2e/tests/coinEnabling.test.ts
@@ -13,8 +13,8 @@ const preloadedState = preparePreloadedReduxState(onboardingCompletedState);
 
 describe('Coin enabling [@androidOnly @T3T1 @T3W1]', () => {
     beforeEach(async () => {
-        await openApp({ args: { preloadedState } });
         await prepareTrezorEmulator();
+        await openApp({ args: { preloadedState } });
     });
 
     it('Coin Enabling', async () => {

--- a/suite-native/app/e2e/tests/deeplinkPopup.test.ts
+++ b/suite-native/app/e2e/tests/deeplinkPopup.test.ts
@@ -7,6 +7,7 @@ import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 import { btcDiscoveryFinishedStateT3T1 } from '../fixtures/btcDiscoveryFinishedStateT3T1';
 import { deviceAutoEjectState } from '../fixtures/deviceAutoEjectState';
 import { onboardingCompletedState } from '../fixtures/onboardingCompletedState';
+import { onDeviceManager } from '../pageObjects/deviceManagerActions';
 import { DeepLinkServer } from '../support/deepLinkServer';
 import { openApp, preparePreloadedReduxState, prepareTrezorEmulator } from '../support/setup';
 import { waitForVisible } from '../support/utils';
@@ -41,8 +42,10 @@ describe('Deeplink connect popup. [@androidOnly @T3T1]', () => {
     });
 
     beforeEach(async () => {
-        await openApp({ args: { preloadedState } });
         await prepareTrezorEmulator();
+        await openApp({ args: { preloadedState } });
+        await onDeviceManager.assertDeviceSwitcherState({ title: 'Connected' });
+
         // This `TrezorConnect` instance here is pretending to be the integrator or @trezor/connect-mobile
         await TrezorConnect.init({
             manifest: {

--- a/suite-native/app/e2e/tests/deviceOnboarding.test.ts
+++ b/suite-native/app/e2e/tests/deviceOnboarding.test.ts
@@ -29,8 +29,8 @@ const LONG_RUNNING_TEST_TIMEOUT = 7 * 60 * 1000; // [ms]
 
 describe('Device onboarding [@androidOnly @smoke @T3T1 @T3W1]', () => {
     beforeEach(async () => {
-        await openApp({ args: { preloadedState } });
         await prepareTrezorEmulator({ seed: '' });
+        await openApp({ args: { preloadedState } });
         await onDeviceOnboarding.proceedToCreateOrRecoverCrossroads();
     });
 

--- a/suite-native/app/e2e/tests/deviceSettingsT1B1.test.ts
+++ b/suite-native/app/e2e/tests/deviceSettingsT1B1.test.ts
@@ -14,8 +14,8 @@ const preloadedStateT1B1 = preparePreloadedReduxState(
 
 describe('Device Settings T1B1 [@androidOnly @T1B1]', () => {
     beforeEach(async () => {
-        await openApp({ args: { preloadedState: preloadedStateT1B1 } });
         await prepareTrezorEmulator({ model: Model.T1B1 });
+        await openApp({ args: { preloadedState: preloadedStateT1B1 } });
         await onDeviceManager.tapDeviceSwitch();
         await onDeviceManager.tapDeviceSettingsButton();
     });

--- a/suite-native/app/e2e/tests/deviceSettingsT3T1.test.ts
+++ b/suite-native/app/e2e/tests/deviceSettingsT3T1.test.ts
@@ -16,8 +16,8 @@ const preloadedStateT3T1 = preparePreloadedReduxState(
 
 describe('Device settings T3T1 [@androidOnly @T3T1]', () => {
     beforeEach(async () => {
-        await openApp({ args: { preloadedState: preloadedStateT3T1 } });
         await prepareTrezorEmulator({ model: Model.T3T1 });
+        await openApp({ args: { preloadedState: preloadedStateT3T1 } });
         await onDeviceManager.assertDeviceSwitcherState({ title: 'Connected' });
         await onDeviceManager.tapDeviceSwitch();
         await onDeviceManager.tapDeviceSettingsButton();

--- a/suite-native/app/e2e/tests/ejectWallets.test.ts
+++ b/suite-native/app/e2e/tests/ejectWallets.test.ts
@@ -26,15 +26,14 @@ const navigateToEjectWallets = async () => {
 
 describe('Eject wallets [@androidOnly @T3T1 @T3W1]', () => {
     beforeEach(async () => {
-        await openApp({ args: { preloadedState } });
         await prepareTrezorEmulator();
+        await openApp({ args: { preloadedState } });
+        await onDeviceManager.assertDeviceSwitcherState({ title: 'Connected' });
     });
 
     // Two devices are displayed in device manager, one connected and one disconnected
     it('Eject single wallet with disconnected device', async () => {
-        await onDeviceManager.assertDeviceSwitcherState({ title: 'Connected' });
         await TrezorUserEnvLink.stopEmu();
-
         await onDeviceManager.assertDeviceSwitcherState({ title: 'Disconnected' });
         await navigateToEjectWallets();
         await onSettings.ejectSingleWallet();
@@ -48,7 +47,6 @@ describe('Eject wallets [@androidOnly @T3T1 @T3W1]', () => {
 
     // Two devices are displayed in device manager, one connected and one disconnected
     it('Eject single wallet with connected device', async () => {
-        await onDeviceManager.assertDeviceSwitcherState({ title: 'Connected' });
         await navigateToEjectWallets();
         await onSettings.ejectSingleWallet();
 
@@ -62,7 +60,6 @@ describe('Eject wallets [@androidOnly @T3T1 @T3W1]', () => {
     });
 
     it('Auto eject settings toggle switch', async () => {
-        await onDeviceManager.assertDeviceSwitcherState({ title: 'Connected' });
         await navigateToEjectWallets();
 
         await onSettings.toggleAutoEject();

--- a/suite-native/app/e2e/tests/firmwareUpdateRequired.test.ts
+++ b/suite-native/app/e2e/tests/firmwareUpdateRequired.test.ts
@@ -11,15 +11,14 @@ const preloadedStateT3T1 = preparePreloadedReduxState(
 
 describe('FW update required [@androidOnly @T3T1]', () => {
     beforeEach(async () => {
-        await openApp({ args: { preloadedState: preloadedStateT3T1 } });
-        await prepareTrezorEmulator({
-            version: '2.8.10',
-            args: { isFirmwareUpdateEnabled: true },
+        await prepareTrezorEmulator({ version: '2.8.10' });
+        await openApp({
+            args: { preloadedState: preloadedStateT3T1, isFirmwareUpdateEnabled: true },
         });
+        await onDeviceManager.assertDeviceSwitcherState({ title: 'Connected' });
     });
 
     test('Device Check Backup is possible from firmware update', async () => {
-        await onDeviceManager.assertDeviceSwitcherState({ title: 'Connected' });
         await onDeviceManager.tapDeviceSwitch();
         await onDeviceManager.tapDeviceSettingsButton();
         await onDeviceSettings.tapUpdateFirmwareButton();

--- a/suite-native/app/e2e/tests/onboardAndConnect.test.ts
+++ b/suite-native/app/e2e/tests/onboardAndConnect.test.ts
@@ -5,8 +5,8 @@ import { waitForVisible } from '../support/utils';
 
 describe('Go through onboarding and connect Trezor. [@androidOnly @T3T1]', () => {
     beforeEach(async () => {
-        await openApp({});
         await prepareTrezorEmulator();
+        await openApp({});
     });
 
     it('Navigate to dashboard', async () => {

--- a/suite-native/app/e2e/tests/passphraseFlow.test.ts
+++ b/suite-native/app/e2e/tests/passphraseFlow.test.ts
@@ -72,8 +72,8 @@ describe('passphrase flow [@androidOnly @smoke @T3T1 @T3W1]', () => {
 
     describe('with passphrase not allowed on Trezor', () => {
         beforeEach(async () => {
-            await openApp({ args: { preloadedState } });
             await prepareTrezorEmulator({ passphrase_protection: true });
+            await openApp({ args: { preloadedState } });
             await onDeviceManager.assertDeviceSwitcherState({ title: 'Connected' });
         });
 
@@ -102,8 +102,9 @@ describe('passphrase flow [@androidOnly @smoke @T3T1 @T3W1]', () => {
 
     describe('with passphrase already allowed on Trezor', () => {
         beforeEach(async () => {
-            await openApp({ args: { preloadedState } });
             await prepareTrezorEmulator({ passphrase_protection: true });
+            await openApp({ args: { preloadedState } });
+            await onDeviceManager.assertDeviceSwitcherState({ title: 'Connected' });
         });
 
         it('Open empty passphrase wallet', async () => {

--- a/suite-native/app/e2e/tests/receive.test.ts
+++ b/suite-native/app/e2e/tests/receive.test.ts
@@ -5,6 +5,7 @@ import { btcDiscoveryFinishedStateT3W1 } from '../fixtures/btcDiscoveryFinishedS
 import { onboardingCompletedState } from '../fixtures/onboardingCompletedState';
 import { onAccountDetail } from '../pageObjects/accountDetailActions';
 import { onAccountReceive } from '../pageObjects/accountReceiveActions';
+import { onDeviceManager } from '../pageObjects/deviceManagerActions';
 import { onHome } from '../pageObjects/homeActions';
 import { onMyAssets } from '../pageObjects/myAssetsActions';
 import { onTabBar } from '../pageObjects/tabBarActions';
@@ -20,8 +21,9 @@ const preloadedState = preparePreloadedReduxState(
 
 describe('Receive [@androidOnly @smoke @T3T1 @T3W1]', () => {
     beforeEach(async () => {
-        await openApp({ args: { preloadedState } });
         await prepareTrezorEmulator();
+        await openApp({ args: { preloadedState } });
+        await onDeviceManager.assertDeviceSwitcherState({ title: 'Connected' });
     });
 
     it('Generate device confirmed receive address.', async () => {

--- a/suite-native/app/e2e/tests/send.test.ts
+++ b/suite-native/app/e2e/tests/send.test.ts
@@ -68,8 +68,8 @@ describe('Send transaction flow. [@androidOnly @smoke @T3T1 @T3W1]', () => {
     });
 
     beforeEach(async () => {
-        await openApp({ args: { preloadedState } });
         await prepareTrezorEmulator();
+        await openApp({ args: { preloadedState } });
 
         await onHome.waitForScreen();
         await onTabBar.navigateToMyAssets();

--- a/suite-native/app/e2e/tests/suiteSync.test.ts
+++ b/suite-native/app/e2e/tests/suiteSync.test.ts
@@ -81,12 +81,12 @@ describe.skip('Suite Sync - Labelling [@androidOnly @T3T1 @smoke]', () => {
     beforeEach(async () => {
         await checkEvoluRelayServerRunning();
         logToRelayDocker(`STARTING: ${jestExpect.getState().currentTestName!}`);
-        await openApp({ args: { preloadedState } });
-        logToRelayDocker(`APP RESTARTED: ${jestExpect.getState().currentTestName!}`);
         await wipeAndRestartEvoluRelayServer();
         logToRelayDocker(`RELAY WIPED: ${jestExpect.getState().currentTestName!}`);
         evoluClient = new NativeEvoluClient();
         await prepareTrezorEmulator({ seed: 'mnemonic_immune' });
+        await openApp({ args: { preloadedState } });
+        logToRelayDocker(`APP RESTARTED: ${jestExpect.getState().currentTestName!}`);
         await onDeviceManager.assertDeviceSwitcherState({ title: 'Connected' });
     }, 240_000);
 

--- a/suite-native/app/e2e/tests/tradingExchangeFlow.test.ts
+++ b/suite-native/app/e2e/tests/tradingExchangeFlow.test.ts
@@ -48,11 +48,11 @@ describe('Trade Exchange [@androidOnly]', () => {
         });
 
         beforeEach(async () => {
-            await openApp({ args: { preloadedState: preloadedStateWithTrezor } });
             await prepareTrezorEmulator({
                 seed: MNEMONICS.mnemonic_academic,
                 passphrase_protection: true,
             });
+            await openApp({ args: { preloadedState: preloadedStateWithTrezor } });
             await waitForVisible(by.text('Connected'));
             await onPassphrase.openPassphraseWallet(passphrase);
             await onHome.waitForScreen();
@@ -88,11 +88,11 @@ describe('Trade Exchange [@androidOnly]', () => {
         });
 
         beforeEach(async () => {
-            await openApp({ args: { preloadedState: preloadedStateWithTrezor } });
             await prepareTrezorEmulator({
                 seed: MNEMONICS.mnemonic_academic,
                 passphrase_protection: true,
             });
+            await openApp({ args: { preloadedState: preloadedStateWithTrezor } });
             await waitForVisible(by.text('Connected'));
             await onPassphrase.openPassphraseWallet(passphrase);
             await tradingExchangeActions.openForm();

--- a/suite-native/app/e2e/tests/tradingSellFlow.test.ts
+++ b/suite-native/app/e2e/tests/tradingSellFlow.test.ts
@@ -48,11 +48,11 @@ describe('Trade Sell [@androidOnly]', () => {
         });
 
         beforeEach(async () => {
-            await openApp({ args: { preloadedState: preloadedStateWithTrezor } });
             await prepareTrezorEmulator({
                 seed: MNEMONICS.mnemonic_academic,
                 passphrase_protection: true,
             });
+            await openApp({ args: { preloadedState: preloadedStateWithTrezor } });
             await waitForVisible(by.text('Connected'));
             await onPassphrase.openPassphraseWallet(passphrase);
             await onHome.waitForScreen();
@@ -88,11 +88,11 @@ describe('Trade Sell [@androidOnly]', () => {
         });
 
         beforeEach(async () => {
-            await openApp({ args: { preloadedState: preloadedStateWithTrezor } });
             await prepareTrezorEmulator({
                 seed: MNEMONICS.mnemonic_academic,
                 passphrase_protection: true,
             });
+            await openApp({ args: { preloadedState: preloadedStateWithTrezor } });
             await waitForVisible(by.text('Connected'));
             await onPassphrase.openPassphraseWallet(passphrase);
             await tradingSellActions.openForm();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-e2e-android-setup&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-android-setup&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-android-setup&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-07T18:26:10.156Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-12T08:39:30.926Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-e2e-android-setup/web/](https://dev.suite.sldev.cz/suite-web/fix-e2e-android-setup/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->