### PR TITLE
fix(suite-native): metro resolutions hack

### DIFF
--- a/suite-native/app/metro.config.js
+++ b/suite-native/app/metro.config.js
@@ -5,8 +5,17 @@ const { withRozeniteReduxDevTools } = require('@rozenite/redux-devtools-plugin/m
 const { getSentryExpoConfig } = require('@sentry/react-native/metro');
 const { withStorybook } = require('@storybook/react-native/metro/withStorybook');
 const { mergeConfig } = require('metro-config');
+const path = require('path');
 
 const { metroSecureResolver } = require('@trezor/bundler-security/src/metroSecureResolver');
+
+// Metro recursively follows nested node_modules symlinks and gets stuck
+// We need to ignore nested monorepo dependencies
+const monorepoRoot = path.resolve(__dirname, '../..');
+const escRoot = monorepoRoot.replace(/[/\\^$*+?.()|[\]{}]/g, '\\$&');
+const NESTED_WORKSPACE_NM = new RegExp(
+    `^${escRoot}/(?!suite-native/app/).+/node_modules/(?:@suite-native|@suite-common|@trezor)/`,
+);
 
 // Learn more https://docs.expo.io/guides/customizing-metro
 
@@ -32,7 +41,7 @@ const config = {
     },
     resolver: {
         unstable_enablePackageExports: false,
-        blockList: [/libDev/],
+        blockList: [/libDev/, NESTED_WORKSPACE_NM],
         extraNodeModules: {
             // modules needed for trezor-connect
             crypto: require.resolve('crypto-browserify'),


### PR DESCRIPTION
## Description

I was unable to run Expo dev server, Metro was always getting stuck. 
After a bit of debugging, it turned out that it was stuck following deeply nested symlinks between monorepo modules. Such as this: `suite-native/transactions/node_modules/@suite-common/wallet-core/node_modules/@suite-common/thp/node_modules/@suite-common/toast-notifications/node_modules/@suite-common/test-utils/node_modules/@suite-common/redux-utils/node_modules/@suite-common/suite-rbf-labels-migrations-types/node_modules/@suite-common/suite-sync-types/node_modules/@suite-common/suite-types/node_modules/@suite-common/wallet-types/node_modules/@trezor/connect/node_modules/@trezor/connect-common/node_modules/@trezor/blockchain-link/node_modules/@stellar/stellar-sdk`

I blacklisted these paths, since there is no reason to resolve them using this symlink, they should be resolved from the root. 

## Notes for QA

Dev tooling only change

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fck-metro&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->