### PR TITLE
fix(trading): correct preselection when coins are not loaded

### DIFF
--- a/packages/react-utils/jest.config.js
+++ b/packages/react-utils/jest.config.js
@@ -1,0 +1,6 @@
+const baseConfig = require('../../jest.config.base.swc');
+
+module.exports = {
+    ...baseConfig,
+    testEnvironment: 'jsdom',
+};

--- a/packages/react-utils/package.json
+++ b/packages/react-utils/package.json
@@ -8,11 +8,17 @@
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "type-check": "yarn g:tsc --build",
-        "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
+        "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "test:unit": "yarn g:jest"
     },
     "dependencies": {
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
         "react": "19.2.4"
+    },
+    "devDependencies": {
+        "@testing-library/react": "^16.3.2",
+        "@types/react": "19.2.14",
+        "react-dom": "19.2.4"
     }
 }

--- a/packages/react-utils/src/hooks/__tests__/useFreshRef.test.ts
+++ b/packages/react-utils/src/hooks/__tests__/useFreshRef.test.ts
@@ -1,0 +1,36 @@
+import { renderHook } from '@testing-library/react';
+
+import { useFreshRef } from '../useFreshRef';
+
+describe('useFreshRef', () => {
+    it('sets ref.current to the latest value on the initial render', () => {
+        const { result } = renderHook(() => useFreshRef('first'));
+
+        expect(result.current.current).toBe('first');
+    });
+
+    it('updates ref.current synchronously when the value changes on rerender', () => {
+        const { result, rerender } = renderHook(({ value }) => useFreshRef(value), {
+            initialProps: { value: 0 },
+        });
+
+        expect(result.current.current).toBe(0);
+
+        rerender({ value: 1 });
+
+        expect(result.current.current).toBe(1);
+    });
+
+    it('returns the same ref object across rerenders', () => {
+        const { result, rerender } = renderHook(({ value }) => useFreshRef(value), {
+            initialProps: { value: 'a' },
+        });
+
+        const firstRef = result.current;
+
+        rerender({ value: 'b' });
+
+        expect(result.current).toBe(firstRef);
+        expect(result.current.current).toBe('b');
+    });
+});

--- a/packages/react-utils/src/hooks/useCurrentRef.ts
+++ b/packages/react-utils/src/hooks/useCurrentRef.ts
@@ -1,5 +1,15 @@
 import { useEffect, useRef } from 'react';
 
+/**
+ * Returns a ref whose `current` is set to `value` in an effect after commit, not during render.
+ *
+ * Unlike `useFreshRef`, reads of `ref.current` during the render pass still see the previous
+ * value until effects run. Prefer `useFreshRef` when callers need the latest value synchronously
+ * during render (for example inside `useMemo`).
+ *
+ * @param value The value to assign to `ref.current` when it changes.
+ * @returns A stable ref object; `current` tracks `value` after commit.
+ */
 export function useCurrentRef<T>(value: T) {
     const ref = useRef<T>(value);
 

--- a/packages/react-utils/src/hooks/useFreshRef.ts
+++ b/packages/react-utils/src/hooks/useFreshRef.ts
@@ -1,0 +1,18 @@
+import { useRef } from 'react';
+
+/**
+ * Returns a ref whose `current` is set to `value` synchronously during render.
+ *
+ * Use this when code reads `ref.current` in the same render (for example inside `useMemo` or
+ * callbacks invoked during render). For values that should update only after commit, use
+ * `useCurrentRef` instead.
+ *
+ * @param value The value to mirror into `ref.current` on every render.
+ * @returns A stable ref object; `current` always matches `value` for the current render.
+ */
+export function useFreshRef<T>(value: T) {
+    const ref = useRef<T>(value);
+    ref.current = value;
+
+    return ref;
+}

--- a/packages/react-utils/src/index.ts
+++ b/packages/react-utils/src/index.ts
@@ -11,3 +11,4 @@ export { usePreviousDefined } from './hooks/usePreviousDefined';
 export { useTextareaCursorPosition } from './hooks/useTextareaCursorPosition';
 export * from './hooks/timer';
 export * from './hooks/useCurrentRef';
+export * from './hooks/useFreshRef';

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingBuyFormDefaultValues.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingBuyFormDefaultValues.ts
@@ -12,6 +12,7 @@ import {
     getDefaultCountrySubdivision,
     getSupportedFiatCurrencyWithFallback,
     regional,
+    selectTradingInfo,
     useTradingAssets,
 } from '@suite-common/trading';
 import { selectBaseCurrency } from '@suite-common/wallet-core';
@@ -25,6 +26,7 @@ export const useTradingBuyFormDefaultValues = (
     buyInfo: TradingBuyInfoSelector | undefined,
 ): TradingBuyFormDefaultValuesProps => {
     const { isTorEnabled } = useSelector(selectTorState);
+    const { coins } = useSelector(selectTradingInfo);
     const { createAssetOptionFromCryptoId } = useTradingAssets();
 
     const country = !isTorEnabled
@@ -37,10 +39,14 @@ export const useTradingBuyFormDefaultValues = (
         [buyInfo?.buyInfo?.subdivision],
     );
 
-    const defaultCrypto = useMemo(
-        () => createAssetOptionFromCryptoId(cryptoId),
-        [createAssetOptionFromCryptoId, cryptoId],
-    );
+    const defaultCrypto = useMemo(() => {
+        // coins is read via ref inside createAssetOptionFromCryptoId (stable callback);
+        // referencing it here keeps the linter active while ensuring recompute after API load.
+        void coins;
+
+        return createAssetOptionFromCryptoId(cryptoId);
+    }, [createAssetOptionFromCryptoId, cryptoId, coins]);
+
     const defaultPaymentMethod: TradingPaymentMethodListProps = useMemo(
         () => ({
             value: TRADING_DEFAULT_PAYMENT_METHOD,

--- a/suite-common/trading/src/hooks/useCoinsAndPlatforms.ts
+++ b/suite-common/trading/src/hooks/useCoinsAndPlatforms.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 
-import { useCurrentRef } from '@trezor/react-utils';
+import { useFreshRef } from '@trezor/react-utils';
 
 import { useSelector } from './useSelector';
 import { selectTradingInfo } from '../selectors/tradingSelectors';
@@ -9,7 +9,7 @@ export function useCoinsAndPlatforms() {
     const info = useSelector(selectTradingInfo);
 
     // Prevent unnecessary re-renders
-    const infoRef = useCurrentRef(info);
+    const infoRef = useFreshRef(info);
 
     const getCoinsAndPlatforms = useCallback(() => {
         const coins = infoRef.current.coins ?? {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -16392,9 +16392,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/react-utils@workspace:packages/react-utils"
   dependencies:
+    "@testing-library/react": "npm:^16.3.2"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
+    "@types/react": "npm:19.2.14"
     react: "npm:19.2.4"
+    react-dom: "npm:19.2.4"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
**Trading default crypto when Invity data loads late**
Partner coin data was often missing on first visit, so the buy form fell back to the network base asset. Default crypto now tracks coins when the trading slice updates after load.

**Stale ref reads during the same render**
`useCurrentRef` updates `ref.current `in an effect (after commit), so anything that reads the ref in the same render as a Redux update (e.g. `useMemo` around `createAssetOptionFromCryptoId`) could see old trading info.

__What I did:__

- Added `useFreshRef`: sets ref.current during render so callers see the latest value in that render.
`useCurrentRef` stays effect-based for existing call sites.
- `useCoinsAndPlatforms` uses useFreshRef for the trading info snapshot so `getCoinsAndPlatforms()` matches the current Redux state when invoked from memoized / stable-callback paths.
- Unit tests for `useFreshRef` in `@trezor/react-utils`.

## Related Issue 

Resolve #27322 



<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to useTradingBuyFormDefaultValues.ts, which controls default/initial values for the trading buy form. This is a focused change with clear blast radius: all buy-related trading tests are at high risk since they depend on correct form initialization. Sell and navigation tests have lower risk but share some trading infrastructure. The dashboard/assets test was statically mapped but its buy-button interaction is shallow and unlikely to be affected by default value changes, so it was omitted.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/hooks/wallet/trading/form/useTradingBuyFormDefaultValues.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — This test directly exercises the buy form flow for Bitcoin, which relies on useTradingBuyFormDefaultValues to populate initial form state. Changes to default values could cause the form to initialize incorrectly, breaking the entire buy flow including quote fetching and trade confirmation.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — This test covers the Ethereum buy flow which depends on buy form default values for initialization. The test fills in the buy form, selects assets, and confirms trades — all of which depend on correct default form state from useTradingBuyFormDefaultValues.
- `suite/e2e/tests/trading/buy-negative.test.ts` — This test validates buy form validation behavior (min/max amounts, empty quotes). It loads the buy form and checks input states, which directly depend on how useTradingBuyFormDefaultValues initializes the form — e.g., the initial fiat amount input being empty.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — This test exercises buying a Solana SPL token, including switching between fiat/crypto input modes and selecting token assets. The buy form initialization via useTradingBuyFormDefaultValues is critical for the form to render correctly with the right default currency and input mode.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — This test verifies that navigating to the Buy form from various entry points (dashboard, account, global header, tokens) opens the correct form. While it doesn't deeply exercise form logic, it verifies the buy form opens and displays the correct cryptocurrency, which depends on default values initialization.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trading/sell-inputs.test.ts` — This test focuses on sell form input validation, not buy form defaults. However, it shares trading infrastructure and the trading page object. The static mapping links it, but the sell form uses different default value hooks, making a regression unlikely but not impossible if shared trading form utilities were affected.
- `suite/e2e/tests/trading/sell-solana.test.ts` — This test covers the Solana sell flow. While statically linked to the changed file, sell forms use separate default value hooks. A regression would only occur if the change inadvertently affected shared trading form state or imports used by the sell flow.

</details>

_Updated: 2026-05-05T14:54:17.471Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=27322-buy-in-stablecoin-yield-do-not-work-on-first-try&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=27322-buy-in-stablecoin-yield-do-not-work-on-first-try&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=27322-buy-in-stablecoin-yield-do-not-work-on-first-try&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-05T14:59:46.031Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-05T20:28:58.992Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/27322-buy-in-stablecoin-yield-do-not-work-on-first-try/web/](https://dev.suite.sldev.cz/suite-web/27322-buy-in-stablecoin-yield-do-not-work-on-first-try/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->