### PR TITLE
feat(suite): Update swap/receive copy

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal/GlobalReceiveModal.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal/GlobalReceiveModal.tsx
@@ -4,8 +4,7 @@ import { events } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
-import { CardList, Column, IconCircle, Link, Modal, Paragraph, Row } from '@trezor/components';
-import { HOW_TO_CHOOSE_RIGHT_NETWORK_URL } from '@trezor/urls';
+import { CardList, Column, IconCircle, Modal, Paragraph, Row } from '@trezor/components';
 
 import { useModal } from 'src/components/suite/asset-picker/hooks/useModal';
 import { AddAccountModal } from 'src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal';
@@ -14,10 +13,10 @@ import { globalSendReceiveFilters } from 'src/slices/wallet/globalSendReceiveFil
 import { useAnalytics } from 'src/support/useAnalytics';
 import { type Account, type AccountItemType } from 'src/types/wallet';
 
+import { AssetSearchWithNetworkFilter } from '../AssetSearchWithNetworkFilter/AssetSearchWithNetworkFilter';
 import { GlobalReceiveAccountListItem } from './components/GlobalReceiveAccountListItem';
 import { useAccountsOptions } from './hooks/useAccountsOptions';
 import { useFilterAccounts } from './hooks/useFilterAccounts';
-import { AssetSearchWithNetworkFilter } from '../AssetSearchWithNetworkFilter/AssetSearchWithNetworkFilter';
 
 type GlobalReceiveModalProps = {
     onCancel: (filledSearch: boolean) => void;
@@ -41,16 +40,7 @@ export const GlobalReceiveModal = ({ onCancel, onSubmit }: GlobalReceiveModalPro
         <>
             <Modal
                 heading={<Translation id="TR_RECEIVE" />}
-                description={
-                    <Translation
-                        id="TR_RECEIVE_DESCRIPTION"
-                        values={{
-                            a: (...chunks) => (
-                                <Link href={HOW_TO_CHOOSE_RIGHT_NETWORK_URL}>{chunks}</Link>
-                            ),
-                        }}
-                    />
-                }
+                description={<Translation id="TR_RECEIVE_DESCRIPTION" />}
                 onCancel={() => onCancel(filledSearch)}
                 width={480}
                 maxHeight={640}

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/AssetPickerModal/AssetPickerModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/AssetPickerModal/AssetPickerModal.tsx
@@ -2,8 +2,9 @@ import { memo, useCallback, useState } from 'react';
 
 import { type TranslationKey } from '@suite/intl';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { Box, Divider } from '@trezor/components';
+import { Box, Divider, Link } from '@trezor/components';
 import { TopAssets } from '@trezor/product-components';
+import { HOW_TO_CHOOSE_RIGHT_NETWORK_URL } from '@trezor/urls';
 
 import {
     AssetGroupLabel,
@@ -16,12 +17,12 @@ import { ASSET_ROW_HEIGHT } from 'src/components/suite/asset-picker/constants';
 import { useSearchFilter } from 'src/components/suite/asset-picker/hooks';
 
 import { AssetListWrapper } from './AssetListWrapper';
+import { AssetSearchWithNetworkFilter } from '../../TradingFormInputAssetPicker';
 import {
     type TradingAssetListItem,
     useBuildTradingAssetOptions,
 } from './hooks/useBuildTradingAssetOptions';
 import { type UseUpdateFormInputProps, useUpdateFormInput } from './hooks/useUpdateFormInput';
-import { AssetSearchWithNetworkFilter } from '../../TradingFormInputAssetPicker';
 
 export type AssetPickerModalProps = {
     closeModal: () => void;
@@ -100,7 +101,16 @@ export const AssetPickerModal = memo(function AssetPickerModalInner({
     );
 
     return (
-        <AssetsModal onClose={closeModal} heading={{ id: heading }}>
+        <AssetsModal
+            onClose={closeModal}
+            heading={{ id: heading }}
+            description={{
+                id: 'TR_SWAP_TO_NETWORK_DESCRIPTION',
+                values: {
+                    a: (...chunks) => <Link href={HOW_TO_CHOOSE_RIGHT_NETWORK_URL}>{chunks}</Link>,
+                },
+            }}
+        >
             <AssetSearchWithNetworkFilter
                 placeholder="TR_ASSET_PICKER_SEARCH_PLACEHOLDER"
                 search={search}

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -2979,8 +2979,12 @@ export const messages = defineMessages({
         id: 'TR_RECEIVE',
     },
     TR_RECEIVE_DESCRIPTION: {
-        defaultMessage: 'Learn how to <a>choose the right network</a> to receive your tokens',
+        defaultMessage: 'Choose an account to receive assets into',
         id: 'TR_RECEIVE_DESCRIPTION',
+    },
+    TR_SWAP_TO_NETWORK_DESCRIPTION: {
+        defaultMessage: 'Learn how to <a>choose the right network</a> to receive your tokens',
+        id: 'TR_SWAP_TO_NETWORK_DESCRIPTION',
     },
     TR_RECEIVE_SEARCH: {
         defaultMessage: 'Search account',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

changes here: https://www.figma.com/design/ml1MMwVqi5NG3kcjSJpA1Z/Releases?node-id=8-927&t=wQD54qsqPPzE18xg-0

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect three files: the GlobalReceiveModal component, the trading AssetPickerModal component, and the shared messages.ts internationalization file. The GlobalReceiveModal is directly tested by the global-receive-send test. The AssetPickerModal is directly exercised by multiple trading/buy tests. The messages.ts file is a broad shared utility (no static coverage data) used across the entire application, but since the other two changed files are UI components with clear test coverage, the risk is well-contained. Focus testing on the global receive/send flow and trading buy flows that use the asset picker, with medium-priority coverage for swap and sell flows that share the trading form infrastructure.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal/GlobalReceiveModal.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/AssetPickerModal/AssetPickerModal.tsx`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test directly exercises the GlobalReceiveModal component that was changed. It opens the global receive modal, selects accounts via the asset picker, reveals addresses, and verifies the flow end-to-end. Any regression in GlobalReceiveModal.tsx would be caught here.
- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — This test exercises the buy trading flow including the asset picker modal, which is the AssetPickerModal.tsx component that was changed. It fills buy forms, selects assets, and validates quotes. Direct coverage of the changed component.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — This test opens the trading panel, selects Ethereum as the buy asset through the asset picker (AssetPickerModal), and completes a buy flow. Directly exercises the changed AssetPickerModal component.
- `suite/e2e/tests/trading/buy-negative.test.ts` — This test explicitly interacts with the asset picker buy modal (tradingPage.assetPicker.openBuyModal) and validates form states. It directly exercises the changed AssetPickerModal component.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — This test selects a specific token (Jupiter) from the asset picker with network and search filters, directly exercising AssetPickerModal's filtering and selection capabilities.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — This test navigates to buy/sell/swap forms from multiple entry points and verifies the correct cryptocurrency is shown. It touches the asset picker and trading form components, which include the changed AssetPickerModal.
- `suite/e2e/tests/dashboard/assets.test.ts` — This test initiates buy actions from the dashboard assets section which navigates to the trading page, and it enables coins via an activate assets modal. It touches both the trading asset picker flow and is mapped to both changed component files.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — This test validates sell form inputs and is statically mapped to AssetPickerModal. While primarily focused on sell form validation, the sell form uses similar trading form infrastructure that includes the asset picker.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — This swap test fills in a swap form with sell/buy asset selection, which shares the TradingForm infrastructure with the changed AssetPickerModal. Statically mapped to the changed file.
- `suite/e2e/tests/trading/swap-coins.test.ts` — This test fills swap forms with asset selection for SOL to BTC, exercising the trading form infrastructure that includes the changed AssetPickerModal component.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — This test specifically fills a swap form with a buy asset on a disabled network, directly testing the asset picker's handling of disabled network assets. Statically mapped to AssetPickerModal.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/intl/src/messages.ts`

_Updated: 2026-05-05T15:29:40.152Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=update-swap-receive-copy&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=update-swap-receive-copy&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/update-swap-receive-copy/web/](https://dev.suite.sldev.cz/suite-web/update-swap-receive-copy/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-05T15:35:11.272Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-05T15:34:00.502Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->