### PR TITLE
Validate vault addresses for enter/exit yield

### DIFF
--- a/suite-common/earn-stablecoin-api/src/constants/vaults.ts
+++ b/suite-common/earn-stablecoin-api/src/constants/vaults.ts
@@ -1,14 +1,8 @@
 // Temporary, it'll come from the API in the future,
 // but for now to be able to validate Yield.xyz data we need it hardcoded
 export const EVM_VAULT_ADDRESSES: Record<string, `0x${string}`> = {
-    'ethereum-usdc-steakusdc-0xbeef01735c132ada46aa9aa4c54623caa92a64cb-4626-vault':
-        '0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB',
-    'ethereum-usdt-steakusdt-0xbeef047a543e45807105e51a8bbefcc5950fcfba-4626-vault':
-        '0xbEef047a543E45807105E51A8BBEFCc5950fcfBa',
-    'arbitrum-usdc-steakusdc-0x250cf7c82bac7cb6cf899b6052979d4b5ba1f9ca-4626-vault':
-        '0x250CF7c82bAc7cB6cf899b6052979d4B5BA1f9ca',
-    'base-usdc-steakusdc-0xbeefe94c8ad530842bfe7d8b397938ffc1cb83b2-4626-vault':
-        '0xBEEFE94c8aD530842bfE7d8B397938fFc1cb83b2',
-    'ethereum-usdc-wgtusdc-0x8fee7605f78195379a977426ee5e0bab1eac2aec-third-party-oav':
-        '0x8fee7605f78195379a977426ee5E0BAb1eAc2aeC',
+    'ethereum-usdt-steakusdt-0xe4db1c5a1b709ce4d2ada6985d9d506e58f73829-third-party-oav':
+        '0xe4db1c5a1b709ce4d2ada6985d9d506e58f73829',
+    'ethereum-usdc-steakusdc-0xde6c23e561f3e55846207ec45a91b777e0f7c889-third-party-oav':
+        '0xde6c23e561f3e55846207ec45a91b777e0f7c889',
 };

--- a/suite-common/earn-stablecoin-api/src/tests/verification/enter.test.ts
+++ b/suite-common/earn-stablecoin-api/src/tests/verification/enter.test.ts
@@ -1,16 +1,17 @@
 import { type EnterYieldResponseSuccess, TransactionDtoType } from '../../api';
 import { verifyEnterTransactions } from '../../verification/enter';
 
-const YIELD_ID = 'ethereum-usdt-steakusdt-0xbeef047a543e45807105e51a8bbefcc5950fcfba-4626-vault';
+const YIELD_ID =
+    'ethereum-usdt-steakusdt-0xe4db1c5a1b709ce4d2ada6985d9d506e58f73829-third-party-oav';
 const ADDRESS = '0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3';
 const AMOUNT = '1';
 const DECIMALS = 6;
 
 const APPROVAL_UNSIGNED_TX =
-    '{"from":"0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3","gasLimit":"0xe563","to":"0xdac17f958d2ee523a2206206994597c13d831ec7","data":"0x095ea7b3000000000000000000000000beef047a543e45807105e51a8bbefcc5950fcfba00000000000000000000000000000000000000000000000000000000000f4240","nonce":664,"type":2,"maxFeePerGas":"0x0ee6b280","maxPriorityFeePerGas":"0x054e0840","chainId":1}';
+    '{"from":"0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3","gasLimit":"0xe563","to":"0xdac17f958d2ee523a2206206994597c13d831ec7","data":"0x095ea7b3000000000000000000000000e4db1c5a1b709ce4d2ada6985d9d506e58f7382900000000000000000000000000000000000000000000000000000000000f4240","nonce":664,"type":2,"maxFeePerGas":"0x0ee6b280","maxPriorityFeePerGas":"0x054e0840","chainId":1}';
 
 const SUPPLY_UNSIGNED_TX =
-    '{"from":"0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3","gasLimit":"0x124f80","to":"0xbEef047a543E45807105E51A8BBEFCc5950fcfBa","data":"0x6e553f6500000000000000000000000000000000000000000000000000000000000f42400000000000000000000000009ea3721b5bf3b64b4418c38b603154d2d597fae3","nonce":664,"type":2,"maxFeePerGas":"0x0ee6b280","maxPriorityFeePerGas":"0x054e0840","chainId":1}';
+    '{"from":"0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3","gasLimit":"0x124f80","to":"0xe4db1c5a1b709ce4d2ada6985d9d506e58f73829","data":"0x6e553f6500000000000000000000000000000000000000000000000000000000000f42400000000000000000000000009ea3721b5bf3b64b4418c38b603154d2d597fae3","nonce":664,"type":2,"maxFeePerGas":"0x0ee6b280","maxPriorityFeePerGas":"0x054e0840","chainId":1}';
 
 const mockResponse = (transactions: { type: TransactionDtoType; unsignedTransaction: unknown }[]) =>
     ({ data: { transactions } }) as unknown as EnterYieldResponseSuccess;

--- a/suite-common/earn-stablecoin-api/src/tests/verification/enter.test.ts
+++ b/suite-common/earn-stablecoin-api/src/tests/verification/enter.test.ts
@@ -64,7 +64,7 @@ describe('verifyEnterTransactions', () => {
         ).toBe('skipped');
     });
 
-    it('returns skipped when vault is not in constants', () => {
+    it('returns failure when vault is not in constants', () => {
         const response = mockResponse([
             { type: TransactionDtoType.APPROVAL, unsignedTransaction: APPROVAL_UNSIGNED_TX },
             { type: TransactionDtoType.SUPPLY, unsignedTransaction: SUPPLY_UNSIGNED_TX },
@@ -77,7 +77,7 @@ describe('verifyEnterTransactions', () => {
                 amount: AMOUNT,
                 decimals: DECIMALS,
             }),
-        ).toBe('skipped');
+        ).toBe('failure');
     });
 
     it('returns failure when amount does not match', () => {

--- a/suite-common/earn-stablecoin-api/src/tests/verification/exit.test.ts
+++ b/suite-common/earn-stablecoin-api/src/tests/verification/exit.test.ts
@@ -58,13 +58,13 @@ describe('verifyExitTransactions', () => {
         );
     });
 
-    it('returns skipped when vault is not in constants', () => {
+    it('returns failure when vault is not in constants', () => {
         const response = mockResponse([
             { type: TransactionDtoType.WITHDRAW, unsignedTransaction: WITHDRAW_UNSIGNED_TX },
         ]);
 
         expect(
             verifyExitTransactions(response, { yieldId: 'unknown-yield-id', address: ADDRESS }),
-        ).toBe('skipped');
+        ).toBe('failure');
     });
 });

--- a/suite-common/earn-stablecoin-api/src/tests/verification/exit.test.ts
+++ b/suite-common/earn-stablecoin-api/src/tests/verification/exit.test.ts
@@ -1,11 +1,12 @@
 import { type ExitYieldResponseSuccess, TransactionDtoType } from '../../api';
 import { verifyExitTransactions } from '../../verification/exit';
 
-const YIELD_ID = 'ethereum-usdt-steakusdt-0xbeef047a543e45807105e51a8bbefcc5950fcfba-4626-vault';
+const YIELD_ID =
+    'ethereum-usdt-steakusdt-0xe4db1c5a1b709ce4d2ada6985d9d506e58f73829-third-party-oav';
 const ADDRESS = '0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3';
 
 const WITHDRAW_UNSIGNED_TX =
-    '{"from":"0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3","gasLimit":"0x071918","to":"0xbEef047a543E45807105E51A8BBEFCc5950fcfBa","data":"0xba0876520000000000000000000000000000000000000000000000000c7a27dbf69bc4850000000000000000000000009ea3721b5bf3b64b4418c38b603154d2d597fae30000000000000000000000009ea3721b5bf3b64b4418c38b603154d2d597fae3","nonce":667,"type":2,"maxFeePerGas":"0x17d78400","maxPriorityFeePerGas":"0x054e0840","chainId":1}';
+    '{"from":"0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3","gasLimit":"0x071918","to":"0xe4db1c5a1b709ce4d2ada6985d9d506e58f73829","data":"0xba0876520000000000000000000000000000000000000000000000000c7a27dbf69bc4850000000000000000000000009ea3721b5bf3b64b4418c38b603154d2d597fae30000000000000000000000009ea3721b5bf3b64b4418c38b603154d2d597fae3","nonce":667,"type":2,"maxFeePerGas":"0x17d78400","maxPriorityFeePerGas":"0x054e0840","chainId":1}';
 
 const mockResponse = (transactions: { type: TransactionDtoType; unsignedTransaction: unknown }[]) =>
     ({ data: { transactions } }) as unknown as ExitYieldResponseSuccess;

--- a/suite-common/earn-stablecoin-api/src/verification/enter.ts
+++ b/suite-common/earn-stablecoin-api/src/verification/enter.ts
@@ -39,7 +39,7 @@ const verifySupply = (
 
 const getTransactionStatus = (
     tx: EnterYieldResponseSuccess['data']['transactions'][number],
-    vaultAddress: `0x${string}` | undefined,
+    vaultAddress: `0x${string}`,
     address: `0x${string}`,
     amountBigInt: bigint,
 ): TransactionVerificationStatus => {
@@ -47,7 +47,7 @@ const getTransactionStatus = (
 
     const parsed = parseUnsignedEvmTransaction(tx.unsignedTransaction);
 
-    if (!parsed || !vaultAddress) return 'skipped';
+    if (!parsed) return 'failed';
 
     switch (tx.type) {
         case TransactionDtoType.APPROVAL:
@@ -65,6 +65,9 @@ export const verifyEnterTransactions = (
     { yieldId, address, amount, decimals }: VerifyEnterTransactionsParams,
 ): VerificationStatus => {
     const vaultAddress = EVM_VAULT_ADDRESSES[yieldId];
+
+    if (!vaultAddress) return 'failure';
+
     const amountBigInt = BigInt(
         new BigNumber(amount).times(new BigNumber(10).pow(decimals)).toFixed(0),
     );

--- a/suite-common/earn-stablecoin-api/src/verification/exit.ts
+++ b/suite-common/earn-stablecoin-api/src/verification/exit.ts
@@ -38,12 +38,12 @@ const verifyRedeem = (
 
 const getTransactionStatus = (
     tx: ExitYieldResponseSuccess['data']['transactions'][number],
-    vaultAddress: `0x${string}` | undefined,
+    vaultAddress: `0x${string}`,
     address: string,
 ): TransactionVerificationStatus => {
     const parsed = parseUnsignedEvmTransaction(tx.unsignedTransaction);
 
-    if (!parsed || !vaultAddress) return 'skipped';
+    if (!parsed) return 'failed';
 
     switch (tx.type) {
         case TransactionDtoType.WITHDRAW:
@@ -58,6 +58,8 @@ export const verifyExitTransactions = (
     { yieldId, address }: VerifyExitTransactionsParams,
 ): VerificationStatus => {
     const vaultAddress = EVM_VAULT_ADDRESSES[yieldId];
+
+    if (!vaultAddress) return 'failure';
 
     const statuses = response.data.transactions.map(tx =>
         getTransactionStatus(tx, vaultAddress, address),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`verifyEnterTransactions` and `verifyExitTransactions` no longer skip validation when vault is missing from `EVM_VAULT_ADDRESSES`.

## Notes for QA

It shouldn't be possible to approve/supply/redeem to other vault than Trezor's

## Related Issue

Resolve #27335

## Screenshots:

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are all within `suite-common/earn-stablecoin-api/`, covering vault constants and enter/exit verification logic along with their unit tests. This is a self-contained library module for stablecoin earn/vault functionality. No E2E tests statically reference these files, and none of the analyzed E2E tests exercise stablecoin-specific vault verification flows (enter/exit). The existing staking E2E tests cover ETH, SOL, and ADA staking via Everstake — a fundamentally different code path from stablecoin vault verification. The unit tests (`enter.test.ts`, `exit.test.ts`) within the changed package itself provide the primary test coverage. No E2E tests need to be run for this change.

<details><summary><b>Changed files (5)</b></summary>

- `suite-common/earn-stablecoin-api/src/constants/vaults.ts`
- `suite-common/earn-stablecoin-api/src/tests/verification/enter.test.ts`
- `suite-common/earn-stablecoin-api/src/tests/verification/exit.test.ts`
- `suite-common/earn-stablecoin-api/src/verification/enter.ts`
- `suite-common/earn-stablecoin-api/src/verification/exit.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (5)**
- `suite-common/earn-stablecoin-api/src/constants/vaults.ts`
- `suite-common/earn-stablecoin-api/src/tests/verification/enter.test.ts`
- `suite-common/earn-stablecoin-api/src/tests/verification/exit.test.ts`
- `suite-common/earn-stablecoin-api/src/verification/enter.ts`
- `suite-common/earn-stablecoin-api/src/verification/exit.ts`

_Updated: 2026-05-05T17:36:09.459Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/validate-vaults&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/validate-vaults&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/validate-vaults&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-05T17:41:07.318Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-05T17:40:08.676Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/validate-vaults/web/](https://dev.suite.sldev.cz/suite-web/feat/validate-vaults/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->