### PR TITLE
refactor(connect): promote MethodPermission/MethodInfo to public API

### DIFF
--- a/packages/connect-common/src/types/index.ts
+++ b/packages/connect-common/src/types/index.ts
@@ -4,6 +4,7 @@ export * from './coinInfo';
 export * from './device';
 export * from './fees';
 export type * from './firmware';
+export type * from './method';
 export * from './params';
 export * from './settings';
 

--- a/packages/connect-common/src/types/method.ts
+++ b/packages/connect-common/src/types/method.ts
@@ -1,0 +1,32 @@
+import type { UiRequestConfirmation } from '../events/ui-request';
+import type { PrecomposeResultFinal } from './api/composeTransaction';
+
+/**
+ * Permission category requested by a `@trezor/connect` method.
+ *
+ * Methods declare which permissions they require via
+ * `AbstractMethod.requiredPermissions`. The connect popup groups requested
+ * permissions by category and asks the user to grant access to a host (e.g.
+ * read public data, sign a transaction, manage the device, push to network).
+ */
+export type MethodPermission = 'read' | 'write' | 'management' | 'push_tx';
+
+/**
+ * Static and runtime metadata describing a `@trezor/connect` method call.
+ *
+ * Returned by `AbstractMethod.getMethodInfo()` and consumed by the connect
+ * popup and host integrations to render the permission/confirmation UI and
+ * decide whether a method needs the device, popup or device-state checks.
+ */
+export type MethodInfo = {
+    // Static fields.
+    useUi: boolean;
+    useDevice: boolean;
+    useDeviceState: boolean;
+    name: string;
+    requiredPermissions: MethodPermission[];
+    // Available after init.
+    info: string;
+    precomposed?: PrecomposeResultFinal;
+    confirmation?: UiRequestConfirmation['payload'];
+};

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -6,6 +6,8 @@ import type {
     CoreEventMessage,
     DeviceState,
     FirmwareCapability,
+    MethodInfo,
+    MethodPermission,
     PrecomposeResultFinal,
     StaticSessionId,
     UiRequestButtonData,
@@ -19,28 +21,19 @@ import type { Device } from '../device/Device';
 import type { UiPromiseCreator } from '../events/ui-promise';
 
 export { DEFAULT_FIRMWARE_RANGE };
+// TODO: drop this re-export and migrate the ~50 internal `packages/connect/src/api/**`
+// imports to pull `MethodPermission` / `MethodInfo` directly from `@trezor/connect-common`.
+// Kept here as a transitional shim to keep this PR focused on the public-surface change;
+// the cleanup will follow up alongside the deep-import ESLint guardrail (#27376).
+export type { MethodInfo, MethodPermission };
 
 export type Payload<M> = Extract<CallMethodPayload, { method: M }> & { override?: boolean };
 export type MethodReturnType<M extends CallMethodPayload['method']> = CallMethodResponse<M>;
 
-export type MethodPermission = 'read' | 'write' | 'management' | 'push_tx';
 export type DeviceMode =
     | typeof UI_REQUEST.SEEDLESS
     | typeof UI_REQUEST.BOOTLOADER
     | typeof UI_REQUEST.INITIALIZE;
-
-export type MethodInfo = {
-    // static fields
-    useUi: boolean;
-    useDevice: boolean;
-    useDeviceState: boolean;
-    name: string;
-    requiredPermissions: MethodPermission[];
-    // available after init
-    info: string;
-    precomposed?: PrecomposeResultFinal;
-    confirmation?: UiRequestConfirmation['payload'];
-};
 
 export type MethodContext = {
     sendCoreMessage: (message: CoreEventMessage) => void;

--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -9,8 +9,9 @@ import TrezorConnect, {
     type CallMethodKeys,
     type CallMethodParams,
     type CallMethodPayload,
+    type MethodInfo,
+    type MethodPermission,
 } from '@trezor/connect';
-import { type MethodInfo, type MethodPermission } from '@trezor/connect/src/core/AbstractMethod';
 import { connectCallableMethods } from '@trezor/connect-common';
 import { TypedError, serializeError } from '@trezor/connect-common/src/constants/errors';
 import { DEEPLINK_VERSION } from '@trezor/connect-common/src/data/version';

--- a/suite-common/connect-popup/src/connectPopupTypes.ts
+++ b/suite-common/connect-popup/src/connectPopupTypes.ts
@@ -1,6 +1,5 @@
 import { type AccountKey, type TxSimulationAction } from '@suite-common/wallet-types';
-import { type CallMethodKeys } from '@trezor/connect';
-import { type MethodPermission } from '@trezor/connect/src/core/AbstractMethod';
+import { type CallMethodKeys, type MethodPermission } from '@trezor/connect';
 import { type SerializedError } from '@trezor/connect-common/src/constants/errors';
 
 export type ManifestPartial = {

--- a/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
@@ -11,8 +11,8 @@ import type {
     CallMethodKeys,
     EthereumSignTransaction,
     EthereumSignTypedData,
+    MethodInfo,
 } from '@trezor/connect';
-import { type MethodInfo } from '@trezor/connect/src/core/AbstractMethod';
 import { getSerializedPath, validatePath } from '@trezor/connect/src/utils/pathUtils';
 
 import { connectPopupActions } from '../connectPopupActions';

--- a/suite-native/module-connect-popup/src/components/PermissionConfirmation.tsx
+++ b/suite-native/module-connect-popup/src/components/PermissionConfirmation.tsx
@@ -18,7 +18,7 @@ import {
 } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';
 import { Translation, type TxKeyPath } from '@suite-native/intl';
-import { type MethodPermission } from '@trezor/connect/src/core/AbstractMethod';
+import { type MethodPermission } from '@trezor/connect';
 
 import { ConnectAppIcon } from '../components/ConnectAppIcon';
 


### PR DESCRIPTION
## Summary

Narrows `@trezor/connect`'s public API surface by promoting `MethodPermission` and `MethodInfo` to the package barrel. They were de-facto public types but only reachable through deep-path imports (`@trezor/connect/src/core/AbstractMethod`). After this change, the four consumer files import them from `@trezor/connect`, and the deep-import bypass is gone for these two types.

## Source issue

Refs #27374 (Part 1 of the umbrella tracked in #23235).

## Implementation notes

- New file `packages/connect-common/src/types/method.ts` is the canonical home for both types (both already depend only on types that live in `@trezor/connect-common`: `PrecomposeResultFinal`, `UiRequestConfirmation`). Each type now carries a JSDoc explaining its purpose — the first slice of the documentation work tracked in #23235.
- `packages/connect-common/src/types/index.ts` re-exports the new module via `export type * from './method';`. This automatically makes the types public on `@trezor/connect`, `@trezor/connect-web` and `@trezor/connect-webextension` because `packages/connect/src/exports.ts` already does `export * from '@trezor/connect-common'`.
- `packages/connect/src/core/AbstractMethod.ts` now imports `MethodPermission` and `MethodInfo` from `@trezor/connect-common` and re-exports them, so the ~50 internal connect modules that import them via `../core/AbstractMethod` need no change. Dependency direction is preserved (connect-common is foundational to connect).
- Updated four consumers — three were called out explicitly in the issue, plus a fourth (`suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts`) that the audit count mentions:
  - `suite-common/connect-popup/src/connectPopupThunks.ts`
  - `suite-common/connect-popup/src/connectPopupTypes.ts`
  - `suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts`
  - `suite-native/module-connect-popup/src/components/PermissionConfirmation.tsx`

`grep -rn "from '@trezor/connect/src/core/AbstractMethod'"` on the workspace returns no remaining matches.

The Part 3 ESLint guardrail and Part 4 forbidden-deps configs are intentionally not in this PR — they are tracked separately in #27376 and #27377.

## Review guide

- `packages/connect-common/src/types/method.ts` — verify the JSDoc is accurate and the type definitions are byte-identical to the originals from `AbstractMethod.ts`.
- `packages/connect/src/core/AbstractMethod.ts` — verify the import + re-export keep the existing internal API stable. `DeviceMode` stays here intentionally (the issue scope is only `MethodPermission` and `MethodInfo`).
- The four consumers — verify they consolidate cleanly into a single `@trezor/connect` import.

## Validation

- `yarn workspace @trezor/connect-common type-check` — passes.
- `yarn g:tsc --build packages/connect/tsconfig.lib.json` (connect src-only build) — passes.
- `yarn g:eslint` on all changed files — passes.
- `yarn dedupe --check` — no changes.
- `yarn workspace @suite-common/connect-popup type-check` and a `yarn g:tsc --build` over the consumer projects surface a large set of pre-existing `TS6305` "output file has not been built" errors and `TS2307` errors for missing `submodules/trezor-common/...` fixture JSON — these reproduce on `develop` without my changes (the sandbox cannot fetch git submodules and project-reference outputs are stale). Once submodules are present and project references are built locally, the consumer packages should type-check; please re-run on a fresh checkout if you want a clean signal.
- Manual connect-popup permission UI flow not run in this environment.

## Remaining work / open questions

- Manual verification of the connect-popup permission UI flow (issue's verification step) was not possible in the sandbox; please confirm during review or in CI.
- Parts 2–4 follow in separate PRs against #27375, #27376, #27377.


---
_Generated by [Claude Code](https://claude.ai/code/session_016Bk3JYHRJHqoJFK6C6w7GL)_

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes span the TrezorConnect method infrastructure (AbstractMethod.ts, connect-common types), the connect-popup layer (thunks, types, and an Ethereum-specific method hook), and a native mobile permission confirmation component. The highest risk is in the TrezorConnect popup and method execution flows, which are directly tested by the trezor-connect E2E tests. Ethereum transaction signing is specifically targeted by the ethereumSignTransaction hook change, making ETH/EVM send tests important. The native mobile PermissionConfirmation component and connect-common type changes have no E2E test coverage in the suite.

<details><summary><b>Changed files (7)</b></summary>

- `packages/connect-common/src/types/index.ts`
- `packages/connect-common/src/types/method.ts`
- `packages/connect/src/core/AbstractMethod.ts`
- `suite-common/connect-popup/src/connectPopupThunks.ts`
- `suite-common/connect-popup/src/connectPopupTypes.ts`
- `suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts`
- `suite-native/module-connect-popup/src/components/PermissionConfirmation.tsx`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — This test directly exercises Ethereum transaction signing through TrezorConnect, which is the exact flow affected by changes to ethereumSignTransaction.ts method hook and connectPopupThunks.ts. Changes to the method hook or popup types could break the permission/confirmation flow.
- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test exercises the full TrezorConnect popup flow including permissions, address confirmation, and cancellation — directly testing the connect-popup infrastructure modified in connectPopupThunks.ts and connectPopupTypes.ts. Changes to AbstractMethod could also affect how methods are dispatched through the popup.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — This test covers the webextension variant of the TrezorConnect popup flow, exercising the same connect-popup thunks and permission confirmation logic that was modified. It validates permissions modal, address confirmation, and cancellation flows through the popup infrastructure.

</details>

<details><summary>🟡 <b>Medium priority (8)</b></summary>

- `suite/e2e/tests/trezor-connect/error.test.ts` — This test validates error handling when TrezorConnect receives invalid parameters (e.g., invalid derivation path for ethereumGetAddress). Changes to AbstractMethod.ts could affect how method validation and error propagation work in the connect popup error flow.
- `suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts` — This test exercises Ethereum message signing through TrezorConnect with connect permissions modal confirmation. Changes to AbstractMethod and connectPopupThunks could affect the permission granting and method execution flow for Ethereum methods.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — This test covers getAddress through TrezorConnect with permission modals and device confirmation. Changes to AbstractMethod.ts affect the base class for all TrezorConnect methods, and connectPopupThunks changes affect how permissions are handled.
- `suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — This test exercises TrezorConnect.getAccountInfo with the permissions modal and account selection. Changes to AbstractMethod and connectPopupThunks directly affect method dispatch and the permission confirmation flow.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — This test validates the full TrezorConnect permissions lifecycle (granting, remembering, forgetting). Changes to connectPopupThunks.ts and connectPopupTypes.ts directly affect how permissions are processed and stored in the popup flow.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — This test covers Bitcoin transaction signing through TrezorConnect with permissions and multi-step device confirmation. Changes to AbstractMethod affect the method base class, and connectPopupThunks changes affect the permission flow.
- `suite/e2e/tests/wallet/send-eth.test.ts` — This test exercises the full Ethereum send flow including custom gas fees and device confirmation. The ethereumSignTransaction method hook changes could affect how transaction parameters are processed and displayed during the send confirmation.
- `suite/e2e/tests/wallet/send-base.test.ts` — This test covers sending on Base (an EVM chain) with custom gas fees and device confirmation. The ethereumSignTransaction method hook is used for EVM transaction signing, so changes there could affect the Base send flow.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/connect-common/src/types/index.ts`
- `packages/connect-common/src/types/method.ts`
- `suite-native/module-connect-popup/src/components/PermissionConfirmation.tsx`

_Updated: 2026-05-05T19:27:20.950Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=claude/blissful-dirac-FoTcX&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=claude/blissful-dirac-FoTcX&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=claude/blissful-dirac-FoTcX&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/claude/blissful-dirac-FoTcX/web/](https://dev.suite.sldev.cz/suite-web/claude/blissful-dirac-FoTcX/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-05T19:32:00.523Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-05T19:30:53.732Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->