### PR TITLE
fix(suite-native-27390): adjust currency icon, remove additional border from Residence picker

### DIFF
--- a/suite-native/module-trading/src/components/general/FiatCurrencyIcon.tsx
+++ b/suite-native/module-trading/src/components/general/FiatCurrencyIcon.tsx
@@ -1,7 +1,8 @@
 import { type FiatCurrencyCode } from 'invity-api';
 
 import { getFiatCurrencyFlag } from '@suite-common/flags';
-import { Flag, RoundedIcon, type RoundedIconSize } from '@suite-native/atoms';
+import { Flag, type RoundedIconSize } from '@suite-native/atoms';
+import { Icon } from '@suite-native/icons';
 
 export type FiatCurrencyIconProps = {
     size: 'extraSmall' | 'small' | 'medium';
@@ -18,15 +19,12 @@ export const FiatCurrencyIcon = ({ size, value }: FiatCurrencyIconProps) => {
     const flag = getFiatCurrencyFlag(value);
 
     return flag ? (
-        <RoundedIcon intent="neutral" size={fiatIconSizes[size]}>
-            <Flag country={flag} />
-        </RoundedIcon>
+        <Flag country={flag} size={fiatIconSizes[size]} />
     ) : (
-        <RoundedIcon
-            testID="@trading/fiat-currency-icon-fallback"
+        <Icon
             name="coin"
-            intent="neutral"
             size={fiatIconSizes[size]}
+            testID="@trading/fiat-currency-icon-fallback"
         />
     );
 };

--- a/suite-native/module-trading/src/components/general/FiatCurrencySheet/FiatCurrencyListItem.tsx
+++ b/suite-native/module-trading/src/components/general/FiatCurrencySheet/FiatCurrencyListItem.tsx
@@ -22,7 +22,7 @@ export const FiatCurrencyListItem = ({
     <Pressable onPress={onPress} accessibilityRole="button" accessibilityLabel={label}>
         <HStack alignItems="center" spacing="sp12" paddingVertical="sp12" justifyContent="center">
             <Box justifyContent="center">
-                <FiatCurrencyIcon size="medium" value={value} />
+                <FiatCurrencyIcon size="small" value={value} />
             </Box>
             <VStack flex={1} spacing={0}>
                 <Text variant="body-md" color="contentPrimary">

--- a/suite-native/trading-residence/src/components/TradingLocationPickers.tsx
+++ b/suite-native/trading-residence/src/components/TradingLocationPickers.tsx
@@ -15,7 +15,7 @@ export type TradingLocationPickersProps = {
 export const TradingLocationPickers = ({
     context,
     testID,
-    hasCountrySubdivisionBottomBorder = true,
+    hasCountrySubdivisionBottomBorder = false,
 }: TradingLocationPickersProps) => {
     const { watch } = useFormContext<TradingLocationFormValues>();
     const selectedCountry = watch('country');

--- a/suite-native/trading-residence/src/components/TradingLocationSettings.tsx
+++ b/suite-native/trading-residence/src/components/TradingLocationSettings.tsx
@@ -47,7 +47,6 @@ export const TradingLocationSettings = ({ context, children }: TradingLocationSe
                                     <TradingLocationPickers
                                         context={context}
                                         testID="@trading-residence"
-                                        hasCountrySubdivisionBottomBorder={false}
                                     />
                                 </Card>
                                 <TradingAvailability />


### PR DESCRIPTION
## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/27390

## Screenshots:
<img width="360"  alt="simulator_screenshot_65618637-455A-446B-ADDE-F2C26B355402" src="https://github.com/user-attachments/assets/50355cb8-9c15-469e-b93a-6c1fbc402d2a" />
<img width="482" height="948" alt="image" src="https://github.com/user-attachments/assets/bca11386-5f73-4dbc-8cde-1850f1c26cbe" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/27390-remove-double-border-flag-container&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->