### PR TITLE
fix(ci): Autoquarantine actions have expiration

### DIFF
--- a/packages/e2e-utils/src/quarantineBot/api.ts
+++ b/packages/e2e-utils/src/quarantineBot/api.ts
@@ -1,11 +1,15 @@
 import { type computeStats, normalizeTitlePath } from './actions';
-import { AUTO_QUARANTINE_PREFIX, EXPLORER_LOOKBACK_DAYS } from './config';
+import {
+    AUTO_QUARANTINE_PREFIX,
+    EXPLORER_LOOKBACK_DAYS,
+    QUARANTINE_EXPIRATION_DAYS,
+} from './config';
 import { createAction, currentsRequest, getActions } from '../currentsApi/api';
 import type { Action, TestExplorerItem, TestsExplorerResponse } from '../currentsApi/types';
 import { debug } from '../logger';
 
 export async function getAutoQuarantineActions(projectId: string): Promise<Action[]> {
-    const actions = await getActions(projectId);
+    const actions = await getActions(projectId, 'active');
 
     return actions.filter(
         a => a.name.startsWith(AUTO_QUARANTINE_PREFIX) && a.action.some(r => r.op === 'quarantine'),
@@ -22,6 +26,9 @@ function postQuarantineAction(
     description: string,
 ): Promise<Action> {
     const name = `${AUTO_QUARANTINE_PREFIX} ${titlePath.join(' > ').slice(0, 80)}`;
+    const expiresAfter = new Date(
+        Date.now() + QUARANTINE_EXPIRATION_DAYS * 24 * 60 * 60 * 1000,
+    ).toISOString();
 
     return createAction(projectId, {
         name,
@@ -31,6 +38,7 @@ function postQuarantineAction(
             op: 'AND',
             cond: [{ type: 'titlePath', op: 'incAll', value: titlePath }],
         },
+        expiresAfter,
     });
 }
 

--- a/packages/e2e-utils/src/quarantineBot/config.ts
+++ b/packages/e2e-utils/src/quarantineBot/config.ts
@@ -4,6 +4,8 @@ export const EXPLORER_LOOKBACK_DAYS = 2; // window used by Tests Explorer to dis
 
 export const AUTO_QUARANTINE_PREFIX = '[auto-quarantine]';
 
+export const QUARANTINE_EXPIRATION_DAYS = 7; // auto-quarantine actions expire after this many days
+
 /**
  * Heuristic thresholds
  */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are in `packages/e2e-utils/src/quarantineBot/` — specifically `api.ts` and `config.ts`. These files are part of the quarantine bot infrastructure used for managing flaky/quarantined tests in the CI system itself. They are not part of the application source code, UI components, or any user-facing functionality. No E2E test in the analyzed suite exercises quarantine bot behavior, and none of the LLM-analyzed tests reference quarantineBot in their source hints or behaviors. The risk of regression to user-facing functionality is negligible, so no E2E tests need to be run for this change.

<details><summary><b>Changed files (2)</b></summary>

- `packages/e2e-utils/src/quarantineBot/api.ts`
- `packages/e2e-utils/src/quarantineBot/config.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (2)**
- `packages/e2e-utils/src/quarantineBot/api.ts`
- `packages/e2e-utils/src/quarantineBot/config.ts`

_Updated: 2026-05-06T07:22:31.276Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-ci-autoquarantine-expire&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-ci-autoquarantine-expire&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-06T07:27:11.352Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-06T07:25:13.570Z • 11 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-ci-autoquarantine-expire/web/](https://dev.suite.sldev.cz/suite-web/fix-ci-autoquarantine-expire/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->