### PR TITLE
chore(connect-explorer): hide "Edit this page" link

### DIFF
--- a/packages/connect-explorer/theme.config.tsx
+++ b/packages/connect-explorer/theme.config.tsx
@@ -42,6 +42,9 @@ const config: DocsThemeConfig = {
     footer: {
         text: 'Copyright belongs to Trezor company s.r.o. All rights reserved.',
     },
+    editLink: {
+        component: null,
+    },
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- Disable the "Edit this page" link shown in the connect-explorer TOC by setting `editLink.component` to `null` in `theme.config.tsx` (officially supported via `connect-explorer-theme`).

https://dev.suite.sldev.cz/connect/mroz22/remove-edit-page-btn/

## Test plan
- [x] Run connect-explore and verify the "Edit this page" link no longer appears in the right-hand TOC sidebar.
- [x] Verify other TOC meta items (feedback link, back-to-top) still render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/remove-edit-page-btn/web/](https://dev.suite.sldev.cz/suite-web/mroz22/remove-edit-page-btn/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/remove-edit-page-btn&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-06T08:21:53.586Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->