### PR TITLE
fix(suite): skip no-op nearbyDevicesUpdate dispatches

### DIFF
--- a/packages/suite/src/actions/bluetooth/__tests__/removeNonResponsiveNearbyDevicesThunk.test.ts
+++ b/packages/suite/src/actions/bluetooth/__tests__/removeNonResponsiveNearbyDevicesThunk.test.ts
@@ -1,0 +1,70 @@
+import { combineReducers } from '@reduxjs/toolkit';
+
+import { bluetoothActions } from '@suite-common/bluetooth';
+import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
+import { asBluetoothDeviceId } from '@trezor/connect';
+
+import { type DesktopBluetoothDevice } from '../DesktopBluetoothDevice';
+import { bluetoothSlice, initialDesktopBluetoothState } from '../desktopBluetoothReducer';
+import { removeNonResponsiveNearbyDevicesThunk } from '../removeNonResponsiveNearbyDevicesThunk';
+import { createMockedBluetoothDevice } from './createMockedBluetoothDevice';
+
+const NOW = 8_000;
+
+const bluetoothReducer = bluetoothSlice.prepareReducer(extraDependenciesCommonMock);
+
+const responsiveDevice: DesktopBluetoothDevice = createMockedBluetoothDevice({
+    id: asBluetoothDeviceId('responsive'),
+    name: 'Responsive',
+    lastUpdatedTimestamp: NOW - 500,
+    connectionStatus: { type: 'paired' },
+});
+
+const nonResponsiveDevice: DesktopBluetoothDevice = createMockedBluetoothDevice({
+    id: asBluetoothDeviceId('non-responsive'),
+    name: 'NonResponsive',
+    lastUpdatedTimestamp: NOW - 60_000,
+    connectionStatus: { type: 'paired' },
+});
+
+const buildStore = (nearbyDevices: DesktopBluetoothDevice[]) =>
+    configureMockStore({
+        extra: {},
+        reducer: combineReducers({ bluetooth: bluetoothReducer }),
+        preloadedState: {
+            bluetooth: { ...initialDesktopBluetoothState, nearbyDevices },
+        },
+    });
+
+describe('removeNonResponsiveNearbyDevicesThunk', () => {
+    beforeAll(() => {
+        jest.spyOn(Date, 'now').mockReturnValue(NOW);
+    });
+
+    afterAll(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('does not dispatch nearbyDevicesUpdateAction when nothing is filtered out', () => {
+        const store = buildStore([responsiveDevice]);
+
+        store.dispatch(removeNonResponsiveNearbyDevicesThunk());
+
+        const updateActions = store
+            .getActions()
+            .filter(action => action.type === bluetoothActions.nearbyDevicesUpdateAction.type);
+        expect(updateActions).toHaveLength(0);
+    });
+
+    it('dispatches nearbyDevicesUpdateAction when at least one device is filtered out', () => {
+        const store = buildStore([responsiveDevice, nonResponsiveDevice]);
+
+        store.dispatch(removeNonResponsiveNearbyDevicesThunk());
+
+        const updateActions = store
+            .getActions()
+            .filter(action => action.type === bluetoothActions.nearbyDevicesUpdateAction.type);
+        expect(updateActions).toHaveLength(1);
+        expect(updateActions[0].payload.nearbyDevices).toEqual([responsiveDevice]);
+    });
+});

--- a/packages/suite/src/actions/bluetooth/removeNonResponsiveNearbyDevicesThunk.ts
+++ b/packages/suite/src/actions/bluetooth/removeNonResponsiveNearbyDevicesThunk.ts
@@ -8,10 +8,14 @@ export const removeNonResponsiveNearbyDevicesThunk = createThunk<void, void>(
     `${BLUETOOTH_PREFIX}/removeNonResponsiveNearbyDevicesThunk`,
     (_, { dispatch, getState }) => {
         const nearbyDevices = selectNearbyDevices<DesktopBluetoothDevice>(getState());
+        const filtered = filterOutNonResponsiveDevices(nearbyDevices);
+
+        // filterOutNonResponsiveDevices only removes entries, so equal lengths means equal contents
+        if (filtered.length === nearbyDevices.length) return;
 
         dispatch(
             bluetoothActions.nearbyDevicesUpdateAction({
-                nearbyDevices: filterOutNonResponsiveDevices(nearbyDevices),
+                nearbyDevices: filtered,
             }),
         );
     },


### PR DESCRIPTION
## Description

`removeNonResponsiveNearbyDevicesThunk` is dispatched every second from `useBluetoothScanning` while the BT connection modal is open. Previously it always dispatched `nearbyDevicesUpdateAction`, even when no devices were actually filtered out. The reducer would then replace `state.nearbyDevices` with a fresh array reference, invalidating selector memoization and causing reducer + render work across all subscribed components for nothing.

`filterOutNonResponsiveDevices` is a pure `.filter()` that only removes entries — it never adds or transforms — so equal input/output lengths means identical contents. We skip the dispatch in that case.

Found while doing a broader BT stack analysis for #21386. This is one of several small follow-ups that will be filed separately.

## Notes for QA

- Open the BT connection modal and verify nothing visibly changes in the device list behavior — known and nearby devices should still appear/disappear at the same cadence as before.
- Devices that go silent (move out of range, are powered off) should still be filtered out within a few seconds, same as before.

## Related Issue

Refs #21386

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are limited to a Bluetooth-related thunk (`removeNonResponsiveNearbyDevicesThunk.ts`) and its corresponding unit test file. The thunk is part of the Bluetooth actions module which is transitively imported by the entire Suite application (hence the 121 static test mappings), but none of the 121 E2E tests exercise Bluetooth-specific functionality based on the LLM analysis. The unit test file (`__tests__/removeNonResponsiveNearbyDevicesThunk.test.ts`) has no static E2E coverage and is itself a unit test, not an E2E test. Since no E2E test directly tests Bluetooth device removal behavior, and the change is in a narrowly-scoped Bluetooth thunk that is unlikely to affect any of the mapped E2E flows (analytics, backup, onboarding, trading, etc.), no E2E tests need to be run for this change.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/actions/bluetooth/__tests__/removeNonResponsiveNearbyDevicesThunk.test.ts`
- `packages/suite/src/actions/bluetooth/removeNonResponsiveNearbyDevicesThunk.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/actions/bluetooth/__tests__/removeNonResponsiveNearbyDevicesThunk.test.ts`
- `packages/suite/src/actions/bluetooth/removeNonResponsiveNearbyDevicesThunk.ts`

_Updated: 2026-05-06T08:19:11.460Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/bt-skip-noop-dispatch&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/bt-skip-noop-dispatch&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-06T08:23:59.901Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-06T08:22:42.784Z • 11 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/bt-skip-noop-dispatch/web/](https://dev.suite.sldev.cz/suite-web/mroz22/bt-skip-noop-dispatch/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->