### PR TITLE
fix(trading): prevent sell amount reset on percent clicks

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts
@@ -15,7 +15,6 @@ import { COMPOSE_ERROR_TYPES } from '@suite-common/wallet-constants';
 import { selectAccounts, selectRawNetworkFeeInfo } from '@suite-common/wallet-core';
 import { AddressDisplayOptions } from '@suite-common/wallet-types';
 import { getConvertedOrDefaultFeeInfo } from '@suite-common/wallet-utils';
-import { BigNumber } from '@trezor/utils';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useCompose } from 'src/hooks/wallet/form/useCompose';
@@ -60,6 +59,7 @@ export const useTradingComposeTransaction = <T extends TradingSellExchangeFormPr
     const initState = useMemo(() => ({ account, network, feeInfo }), [account, network, feeInfo]);
     const outputAddress = values?.outputs?.[0].address;
     const [state, setState] = useState<TradingUseComposeTransactionStateProps>(initState);
+    const [shouldUpdateMaxAmount, setShouldUpdateMaxAmount] = useState(true);
 
     // sub-hook, Composing transaction
     const {
@@ -150,20 +150,16 @@ export const useTradingComposeTransaction = <T extends TradingSellExchangeFormPr
         }
 
         if (composed.type === 'final' || composed.type === 'nonfinal') {
-            const currentOutputAmount = values.outputs?.[0]?.amount;
-
-            if (typeof setMaxOutputId === 'number' && composed.max) {
-                const currentBN = new BigNumber(currentOutputAmount || '0');
-                const composedMaxBN = new BigNumber(composed.max);
-
-                if (!currentBN.isEqualTo(composedMaxBN)) {
-                    setShowReserveBanner(true);
-                    setValue(TRADING_FORM_OUTPUT_AMOUNT, composed.max, {
-                        shouldValidate: true,
-                        shouldDirty: true,
-                    });
-                }
+            if (typeof setMaxOutputId === 'number' && composed.max && shouldUpdateMaxAmount) {
+                setShouldUpdateMaxAmount(false);
+                setShowReserveBanner(true);
+                setValue(TRADING_FORM_OUTPUT_AMOUNT, composed.max, {
+                    shouldValidate: true,
+                    shouldDirty: true,
+                });
                 clearErrors(TRADING_FORM_OUTPUT_AMOUNT);
+            } else {
+                setShouldUpdateMaxAmount(true);
             }
 
             dispatch(

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
@@ -272,19 +272,16 @@ export const useTradingFormActions = <T extends TradingSellExchangeFormProps>({
                 : maxAmount;
 
             setValue(TRADING_FORM_OUTPUT_AMOUNT, cryptoInputValue, { shouldDirty: true });
+        } else {
+            setValue(TRADING_FORM_OUTPUT_AMOUNT, '', { shouldDirty: true });
         }
 
         setValue(TRADING_FORM_OUTPUT_MAX, 0, { shouldDirty: true });
+        setValue(TRADING_FORM_OUTPUT_FIAT, '', { shouldDirty: true });
         clearErrors([TRADING_FORM_OUTPUT_FIAT, TRADING_FORM_OUTPUT_AMOUNT]);
 
         setFractionButton(1);
-
-        if (type === 'exchange') {
-            dispatch(tradingExchangeActions.saveSelectedQuote(undefined));
-        }
-
         composeRequest(TRADING_FORM_OUTPUT_AMOUNT);
-        setValue(TRADING_FORM_OUTPUT_FIAT, '', { shouldDirty: true });
     };
 
     // call change handler on every change of text inputs with debounce

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -200,7 +200,9 @@ export const useTradingExchangeForm = ({
     const isAmountEmpty = output?.amount === '';
     const noProviders = Object.keys(exchangeInfo?.providerInfos ?? {}).length === 0;
     const isInitialDataLoading = !exchangeInfo?.providerInfos;
-
+    const isFormLoading = isInitialDataLoading || formState.isSubmitting || isLoading;
+    const isFormInvalid = !(formIsValid && hasValues) || !isReceiveAddressFormValid;
+    const isLoadingOrInvalid = noProviders || isFormLoading || isFormInvalid;
     const { getAssetDecimals } = useTradingAssetDecimals();
     const decimals = useMemo(
         () =>
@@ -238,10 +240,6 @@ export const useTradingExchangeForm = ({
         methods,
         setShowReserveBanner,
     });
-
-    const isFormLoading = isInitialDataLoading || formState.isSubmitting || isLoading;
-    const isFormInvalid = !(formIsValid && hasValues) || !isReceiveAddressFormValid;
-    const isLoadingOrInvalid = noProviders || isFormLoading || isFormInvalid;
 
     const { toggleAmountInCrypto } = useTradingCurrencySwitcher({
         account,

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
@@ -176,7 +176,9 @@ export const useTradingSellForm = ({
     const isAmountEmpty = output?.amount === '';
     const noProviders = Object.keys(sellInfo?.providerInfos ?? {}).length === 0;
     const isInitialDataLoading = !sellInfo?.providerInfos;
-
+    const isFormLoading = isInitialDataLoading || formState.isSubmitting || isLoading;
+    const isFormInvalid = !(formIsValid && hasValues);
+    const isLoadingOrInvalid = noProviders || isFormLoading || isFormInvalid;
     const quotesByPaymentMethod = getTradingQuotesByPaymentMethod<TradingSellType>(
         quotes,
         values?.paymentMethod?.value ?? '',
@@ -210,11 +212,6 @@ export const useTradingSellForm = ({
         methods,
         setShowReserveBanner,
     });
-
-    const isFormLoading =
-        isInitialDataLoading || formState.isSubmitting || isLoading || isComposing;
-    const isFormInvalid = !(formIsValid && hasValues);
-    const isLoadingOrInvalid = noProviders || isFormLoading || isFormInvalid;
 
     const { toggleAmountInCrypto } = useTradingCurrencySwitcher<TradingSellFormProps>({
         account,

--- a/suite-common/trading/src/reducers/__tests__/tradingReducerExtended.test.ts
+++ b/suite-common/trading/src/reducers/__tests__/tradingReducerExtended.test.ts
@@ -115,40 +115,6 @@ describe('Testing trading reducer', () => {
         );
     });
 
-    it('sellThunks.handleRequestThunk.pending should clear payment methods and set isLoading to true', () => {
-        const store = configureMockStore({
-            extra: {},
-            reducer: combineReducers({
-                wallet: combineReducers({
-                    trading: tradingReducer,
-                }),
-            }),
-            preloadedState: {
-                wallet: {
-                    trading: {
-                        ...initialState,
-                        info: { paymentMethods: [{ value: 'creditCard', label: 'Credit Card' }] },
-                        sell: {
-                            ...sellInitialState,
-                            isLoading: false,
-                        },
-                    },
-                },
-            },
-        });
-
-        store.dispatch({ type: sellThunks.handleRequestThunk.pending.type });
-
-        expect(store.getState().wallet.trading.sell).toEqual(
-            expect.objectContaining({
-                isLoading: true,
-            }),
-        );
-        expect(store.getState().wallet.trading.info).toEqual(
-            expect.objectContaining({ paymentMethods: [] }),
-        );
-    });
-
     describe('action delegation', () => {
         let store: ReturnType<
             typeof configureMockStore<{ wallet: { trading: typeof initialState } }>

--- a/suite-common/trading/src/reducers/tradingReducer.ts
+++ b/suite-common/trading/src/reducers/tradingReducer.ts
@@ -58,7 +58,6 @@ const tradingSlice = createSliceWithExtraDeps({
             })
             .addCase(sellThunks.handleRequestThunk.pending, state => {
                 state.sell.isLoading = true;
-                state.info.paymentMethods = [];
             })
             .addCase(sellThunks.handleRequestThunk.fulfilled, state => {
                 state.sell.isLoading = false;


### PR DESCRIPTION
This reverts commit dbb1440c43f52de80ee7ec291c71362fa9ec7f05.


<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are focused on trading/coinmarket functionality: form hooks for sell and exchange (swap) flows, the compose transaction hook shared by sell/swap, common form actions, and the trading Redux reducer. The highest risk is in sell and swap E2E flows that directly exercise transaction composition, fee calculation, and form state management. Buy flows are lower risk since they don't compose send transactions, but could be affected by reducer changes. The unit test file (tradingReducerExtended.test.ts) has no E2E coverage mapping but is a unit test that should be run via the unit test suite rather than E2E. Testing strategy should prioritize sell and swap tests that verify transaction composition and fee handling.

<details><summary><b>Changed files (6)</b></summary>

- `packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts`
- `packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts`
- `packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts`
- `packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts`
- `suite-common/trading/src/reducers/__tests__/tradingReducerExtended.test.ts`
- `suite-common/trading/src/reducers/tradingReducer.ts`

</details>

**Recommended tests (18)**

<details><summary>🔴 <b>High priority (7)</b></summary>

- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — This test directly exercises the sell form flow for Bitcoin, which uses useTradingSellForm.ts and useTradingComposeTransaction.ts for composing the sell transaction and form actions. Changes to these hooks could break fee calculation, form submission, or transaction composition in the sell flow.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — This test covers selling Ethereum with custom gas fees, directly exercising useTradingSellForm.ts and useTradingComposeTransaction.ts for Ethereum transaction composition. Changes to form actions and compose transaction hooks affect fee setting and transaction confirmation.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — This test validates sell form input validation (decimal limits, not enough funds, percentage buttons, max calculations) which directly depends on useTradingSellForm.ts and useTradingComposeTransaction.ts for computing amounts and validating inputs.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Tests the complete Solana sell flow including form filling, quote selection, device confirmation, and transaction sending. This directly uses useTradingSellForm.ts and the compose transaction hook for Solana-specific transaction handling.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Tests the full swap flow (SOL to BTC) including form filling, transaction composition, device confirmation, and status tracking. The swap flow uses useTradingExchangeForm.ts and useTradingComposeTransaction.ts, and reads composedTransactionInfo from the trading reducer.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — This test explicitly verifies Redux state 'wallet.trading.composedTransactionInfo' which is managed by tradingReducer.ts, and exercises custom Bitcoin fee settings during swap, directly using useTradingExchangeForm.ts and useTradingComposeTransaction.ts.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests custom Ethereum gas fee settings during swap and verifies wallet.trading.composedTransactionInfo Redux state from tradingReducer.ts. Directly exercises useTradingExchangeForm.ts and the compose transaction hook.

</details>

<details><summary>🟡 <b>Medium priority (8)</b></summary>

- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Tests selling an ERC-20 token (USDC) through the sell flow, which uses useTradingSellForm.ts for token-specific sell form handling and compose transaction for ERC-20 transfers.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Tests swapping SOL to USDC token across networks, using useTradingExchangeForm.ts for the swap form and compose transaction for building the send transaction. Cross-network token swaps may exercise different code paths in the exchange form hook.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Tests swapping a Solana token (USDT) to BTC, exercising useTradingExchangeForm.ts for token-to-coin swap and the compose transaction hook for token transfer construction.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Tests swapping SPL tokens (USDT to USDC on Solana), which exercises useTradingExchangeForm.ts for token-to-token swap form logic and compose transaction for SPL token transfers.
- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — The buy flow uses the tradingReducer for managing trading state and may indirectly use form actions. While buy doesn't compose send transactions, changes to the reducer could affect buy flow state management.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — Tests the ETH buy flow which relies on tradingReducer for state management. Changes to the reducer could affect how buy quotes and trade confirmations are processed.
- `suite/e2e/tests/trading/navigation.test.ts` — Tests navigation to Buy/Sell/Swap forms from various entry points. If the trading form hooks or reducer changes affect form initialization, navigation could break or forms could fail to render properly.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — Tests swap form behavior when the receive network is disabled, which exercises useTradingExchangeForm.ts edge case handling for disabled networks in the swap form.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/trading/buy-negative.test.ts` — Tests buy form input validation (min/max amounts, no quotes). While the buy form doesn't use compose transaction directly, changes to tradingFormActions could affect form validation behavior.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — Tests buying a Solana SPL token. The buy flow is less directly affected by compose transaction changes, but tradingReducer changes could affect state handling for token buys.
- `suite/e2e/tests/trading/swap-history.test.ts` — Tests viewing swap transaction history which reads from the trading reducer state. Changes to tradingReducer.ts could affect how historical trades are stored or retrieved.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/trading/src/reducers/__tests__/tradingReducerExtended.test.ts`

_Updated: 2026-05-06T09:24:17.370Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/trading-sell-input-reset-26163/web/](https://dev.suite.sldev.cz/suite-web/fix/trading-sell-input-reset-26163/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trading-sell-input-reset-26163&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trading-sell-input-reset-26163&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/trading-sell-input-reset-26163&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-06T09:28:34.490Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-06T09:27:28.070Z • 11 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->