### PR TITLE
style(suite): Change reset app button intent to warning

### DIFF
--- a/packages/suite/src/views/settings/SettingsGeneral/ClearStorage.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/ClearStorage.tsx
@@ -27,7 +27,7 @@ export const ClearStorage = () => {
                     <ActionColumn>
                         <ActionButton
                             onClick={handleClick}
-                            intent="brand"
+                            intent="warning"
                             data-testid="@settings/reset-app-button"
                         >
                             <Translation id="TR_CLEAR_STORAGE" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<img width="1489" height="864" alt="image" src="https://github.com/user-attachments/assets/ec74f8fb-149e-417d-81d4-98436b906dee" />


<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is limited to a single component (ClearStorage.tsx) within the SettingsGeneral view. This component maps to 91 tests via static analysis, indicating it is transitively imported by the broad SettingsGeneral page used in many test setup flows. However, ClearStorage is a narrow, self-contained feature (clearing app storage) that most tests only encounter as part of the settings page layout. No test in the provided analysis directly exercises the "clear storage" functionality itself, so there is likely a gap in direct E2E coverage. The recommended strategy is to run the general settings test as the most relevant, with the application-log test as a secondary check for settings page stability.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/views/settings/SettingsGeneral/ClearStorage.tsx`

</details>

**Recommended tests (2)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/settings/general.test.ts` — ClearStorage is a component on the SettingsGeneral page. The general settings test navigates to and interacts with the Settings application/general page, which is the direct parent view containing the ClearStorage component. Changes to ClearStorage could affect the settings page layout or behavior.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/settings/application-log.test.ts` — This test navigates to Settings > General page where ClearStorage lives. While it focuses on the application log modal, changes to ClearStorage could theoretically affect the settings page rendering or layout that this test depends on.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/views/settings/SettingsGeneral/ClearStorage.tsx`

_Updated: 2026-05-06T09:37:13.792Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/update-clear-storage-button-intent/web/](https://dev.suite.sldev.cz/suite-web/update-clear-storage-button-intent/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=update-clear-storage-button-intent&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=update-clear-storage-button-intent&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-06T09:42:17.818Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-06T09:41:06.560Z • 11 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->