### PR TITLE
fix(connect-common): publish @trezor/device-authenticity dependency

### DIFF
--- a/packages/connect-common/package.json
+++ b/packages/connect-common/package.json
@@ -86,6 +86,7 @@
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
     },
     "dependencies": {
+        "@trezor/device-authenticity": "workspace:^",
         "@trezor/device-utils": "workspace:*",
         "@trezor/protobuf": "workspace:*",
         "@trezor/protocol": "workspace:^",
@@ -100,7 +101,6 @@
         "@fivebinaries/coin-selection": "3.0.0",
         "@trezor/blockchain-link": "workspace:^",
         "@trezor/blockchain-link-types": "workspace:^",
-        "@trezor/device-authenticity": "workspace:^",
         "@trezor/transport": "workspace:*",
         "@trezor/utxo-lib": "workspace:*",
         "@types/chrome": "^0.1.40",

--- a/packages/connect-common/tsconfig.json
+++ b/packages/connect-common/tsconfig.json
@@ -6,6 +6,7 @@
     },
     "include": ["."],
     "references": [
+        { "path": "../device-authenticity" },
         { "path": "../device-utils" },
         { "path": "../protobuf" },
         { "path": "../protocol" },
@@ -14,7 +15,6 @@
         { "path": "../utils" },
         { "path": "../blockchain-link" },
         { "path": "../blockchain-link-types" },
-        { "path": "../device-authenticity" },
         { "path": "../transport" },
         { "path": "../utxo-lib" }
     ]

--- a/packages/connect-common/tsconfig.lib.json
+++ b/packages/connect-common/tsconfig.lib.json
@@ -8,6 +8,9 @@
     "include": ["./src"],
     "references": [
         {
+            "path": "../device-authenticity"
+        },
+        {
             "path": "../device-utils"
         },
         {
@@ -27,9 +30,6 @@
         },
         {
             "path": "../blockchain-link-types"
-        },
-        {
-            "path": "../device-authenticity"
         },
         {
             "path": "../transport"

--- a/packages/connect-common/tsconfig.libESM.json
+++ b/packages/connect-common/tsconfig.libESM.json
@@ -8,6 +8,9 @@
     },
     "references": [
         {
+            "path": "../device-authenticity"
+        },
+        {
             "path": "../device-utils"
         },
         {
@@ -27,9 +30,6 @@
         },
         {
             "path": "../blockchain-link-types"
-        },
-        {
-            "path": "../device-authenticity"
         },
         {
             "path": "../transport"

--- a/packages/requirements/src/requirements/public-package-dependencies/__snapshots__/connect-mobile.json
+++ b/packages/requirements/src/requirements/public-package-dependencies/__snapshots__/connect-mobile.json
@@ -1,9 +1,13 @@
 {
     "prod": [
         "@bufbuild/protobuf",
+        "@noble/curves",
+        "@noble/post-quantum",
         "@sinclair/typebox",
         "@trezor/connect-common",
         "@trezor/connect-mobile",
+        "@trezor/crypto-utils",
+        "@trezor/device-authenticity",
         "@trezor/device-utils",
         "@trezor/protobuf",
         "@trezor/protocol",

--- a/packages/requirements/src/requirements/public-package-dependencies/__snapshots__/connect-web.json
+++ b/packages/requirements/src/requirements/public-package-dependencies/__snapshots__/connect-web.json
@@ -1,9 +1,13 @@
 {
     "prod": [
         "@bufbuild/protobuf",
+        "@noble/curves",
+        "@noble/post-quantum",
         "@sinclair/typebox",
         "@trezor/connect-common",
         "@trezor/connect-web",
+        "@trezor/crypto-utils",
+        "@trezor/device-authenticity",
         "@trezor/device-utils",
         "@trezor/protobuf",
         "@trezor/protocol",

--- a/packages/requirements/src/requirements/public-package-dependencies/__snapshots__/connect-webextension.json
+++ b/packages/requirements/src/requirements/public-package-dependencies/__snapshots__/connect-webextension.json
@@ -1,10 +1,14 @@
 {
     "prod": [
         "@bufbuild/protobuf",
+        "@noble/curves",
+        "@noble/post-quantum",
         "@sinclair/typebox",
         "@trezor/connect-common",
         "@trezor/connect-web",
         "@trezor/connect-webextension",
+        "@trezor/crypto-utils",
+        "@trezor/device-authenticity",
         "@trezor/device-utils",
         "@trezor/protobuf",
         "@trezor/protocol",


### PR DESCRIPTION
## Summary

Move `@trezor/device-authenticity` from `devDependencies` to `dependencies` in `@trezor/connect-common` so it ships with the published package.

## Why this is needed

`connect-common` imports two values from `@trezor/device-authenticity` as **runtime** values, not as types:

[`packages/connect-common/src/types/api/authenticateDevice.ts`](https://github.com/trezor/trezor-suite/blob/902d9d4195cc8d2631b7acfba178c914b16d061b/packages/connect-common/src/types/api/authenticateDevice.ts#L1-L16)

```ts
import type { VerifyAuthenticityProofResult } from '@trezor/device-authenticity';
import {
    DeviceAuthenticityBlacklistConfig,
    DeviceAuthenticityConfig,
} from '@trezor/device-authenticity';
...
export const AuthenticateDeviceParams = Type.Object({
    config: Type.Optional(DeviceAuthenticityConfig),
    blacklistConfig: Type.Optional(DeviceAuthenticityBlacklistConfig),
    ...
});
```

`DeviceAuthenticityConfig` and `DeviceAuthenticityBlacklistConfig` are TypeBox schemas exported as runtime constants:

[`packages/device-authenticity/src/config/deviceAuthenticityConfigTypes.ts#L37`](https://github.com/trezor/trezor-suite/blob/902d9d4195cc8d2631b7acfba178c914b16d061b/packages/device-authenticity/src/config/deviceAuthenticityConfigTypes.ts#L37)

```ts
export const DeviceAuthenticityConfig = Type.Intersect([...]);
```

The call `Type.Optional(DeviceAuthenticityConfig)` is a top-level runtime expression. The schema is evaluated when the module is loaded, so the dependency must be present in the consumer's `node_modules` at runtime, not only at type-check time.

## Why no CI check caught this earlier

1. **Yarn workspaces hoist everything.** Inside the monorepo, every package can resolve every other package regardless of how it is declared, so type-check, lint, jest and dev builds all pass with the dep in `devDependencies`.

2. **`scripts/inline-devdep-types.mjs`** inlines types from `devDependencies` directly into the published `.d.ts` files, so post-publish type-check also passes. That mechanism is intended for type-only cases, but it masked this one because the imported symbols happen to also exist as runtime values.

3. **The pre-existing install smoke test** installed `@trezor/connect` and `@trezor/connect-web` together in a single fixture. `@trezor/connect` does declare `@trezor/device-authenticity` directly in its [`dependencies`](https://github.com/trezor/trezor-suite/blob/902d9d4195cc8d2631b7acfba178c914b16d061b/packages/connect/package.json#L127), so npm hoisted it into the shared `node_modules` and `connect-common` resolved it transitively. The smoke test passed by accident.

4. **What finally caught it** is the new isolated `connect-web` CJS smoke added in #27396. [`packages/connect-web/package.json`](https://github.com/trezor/trezor-suite/blob/902d9d4195cc8d2631b7acfba178c914b16d061b/packages/connect-web/package.json#L59-L63) only depends on `connect-common`, `utils` and `websocket-client`, no `device-authenticity`. With `@trezor/connect` removed from the fixture, the transitive resolution chain breaks and `import` of `@trezor/connect-web` fails at module load with `Cannot find module '@trezor/device-authenticity'` (the failure path runs through `connect-common/lib/types/api/authenticateDevice.js`).

## Related PRs

- #27396 — `test(connect): split install smoke tests`. The split that exposed this missing dependency. Originally bundled this same fix; extracted here for a clean, focused change.
- #27303 — `feat(connect): partially drop CommonJS output from publish set`. Shares the same publish-set / consumer-install surface area; this fix lands the missing runtime dep ahead of further publish-pipeline changes.

## Test plan

- [ ] `yarn workspace @trezor/connect-common build:lib` succeeds
- [ ] After merging #27396, the isolated `run_connect_web_cjs_smoke` step passes against a freshly packed `@trezor/connect-common`

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/connect-common-publish-device-authenticity/web/](https://dev.suite.sldev.cz/suite-web/mroz22/connect-common-publish-device-authenticity/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/connect-common-publish-device-authenticity&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/connect-common-publish-device-authenticity&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-06T11:02:22.508Z • 11 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-06T10:10:13.433Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->