### PR TITLE
refactor(suite-native): import UI_REQUEST from @trezor/connect barrel

### DIFF
--- a/suite-native/device-authorization/src/__tests__/deviceAuthorizationSlice.test.ts
+++ b/suite-native/device-authorization/src/__tests__/deviceAuthorizationSlice.test.ts
@@ -1,5 +1,5 @@
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
-import { UI_REQUEST } from '@trezor/connect/src/exports';
+import { UI_REQUEST } from '@trezor/connect';
 
 import {
     type DeviceAuthorizationState,

--- a/suite-native/device-authorization/src/deviceAuthorizationSlice.ts
+++ b/suite-native/device-authorization/src/deviceAuthorizationSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit';
 
-import { UI_REQUEST } from '@trezor/connect/src/exports';
+import { UI_REQUEST } from '@trezor/connect';
 
 import {
     isFlowEndingButtonRequest,

--- a/suite-native/device-authorization/src/utils.ts
+++ b/suite-native/device-authorization/src/utils.ts
@@ -1,7 +1,7 @@
 import { type UnknownAction } from '@reduxjs/toolkit';
 
-import { UI_REQUEST } from '@trezor/connect/src/exports';
-import type { UiRequestDeviceAction } from '@trezor/connect/src/exports';
+import { UI_REQUEST } from '@trezor/connect';
+import type { UiRequestDeviceAction } from '@trezor/connect';
 import { isNotNullOrUndefined } from '@trezor/utils';
 
 export const pinButtonRequestCodes = [


### PR DESCRIPTION
## Summary

Three files in `suite-native/device-authorization` deep-imported `UI_REQUEST` (and the type `UiRequestDeviceAction`) from `@trezor/connect/src/exports` instead of the package barrel `@trezor/connect`. This PR fixes the import path; no logic changes.

`UI_REQUEST` and `UiRequestDeviceAction` are already part of the public surface — they live in `@trezor/connect-common` and `@trezor/connect/src/exports.ts` re-exports `@trezor/connect-common`, which `@trezor/connect/src/index.ts` re-exports in turn. The deep path was an accidental bypass of the barrel.

Was there any reason to import via exports? Maybe lakc of tree shaking somewhere in the suite-native build stack? 

## Source issue

Closes #27375

Sub-task of #23235.

## Implementation notes

- `suite-native/device-authorization/src/utils.ts` — `import { UI_REQUEST } from '@trezor/connect/src/exports'` and `import type { UiRequestDeviceAction } from '@trezor/connect/src/exports'` → `from '@trezor/connect'` for both.
- `suite-native/device-authorization/src/deviceAuthorizationSlice.ts` — same change for `UI_REQUEST`.
- `suite-native/device-authorization/src/__tests__/deviceAuthorizationSlice.test.ts` — same change for `UI_REQUEST`.

No package.json changes; no public API changes; no behavioural changes.

## Remaining work / open questions

None — the issue's scope is fully covered. Parts 1 (#27374, see #27389), 3 (#27376) and 4 (#27377) of the umbrella are tracked separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_0144sCJL1ZC53wX6XKiqh9M8)_

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=issue/27375-ui-request-deep-import&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->