### PR TITLE
fix(suite): improve yield approval UX and unlimited allowance detection

### DIFF
--- a/packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx
@@ -6,7 +6,7 @@ import type {
     YieldFlowDisplayToken,
     YieldPendingTransactionState,
 } from '@suite-common/wallet-core';
-import { Button, Column } from '@trezor/components';
+import { Banner, Button, Column } from '@trezor/components';
 
 import { YieldAmountCard } from './YieldAmountCard';
 import { YieldApprovedAmountCard } from './YieldApprovedAmountCard';
@@ -27,7 +27,8 @@ const approveStepTranslationMap = {
 type ApproveButtonTranslationId =
     | 'TR_EARN_YIELD_REVOKE_APPROVAL'
     | 'TR_EARN_YIELD_INCREASE_APPROVAL'
-    | 'TR_APPROVE_DATA_TITLE';
+    | 'TR_APPROVE_DATA_TITLE'
+    | 'TR_CONTINUE';
 
 type GetApproveButtonTranslationIdParams = {
     approvalAction: YieldApprovalAction;
@@ -42,6 +43,10 @@ const getApproveButtonTranslationId = ({
 
     if (approvalAction === 'increase') {
         return 'TR_EARN_YIELD_INCREASE_APPROVAL';
+    }
+
+    if (approvalAction === 'continue') {
+        return 'TR_CONTINUE';
     }
 
     return 'TR_APPROVE_DATA_TITLE';
@@ -133,6 +138,16 @@ export const YieldApproveStep = ({
                     >
                         <Translation id={approveButtonId} />
                     </Button>
+
+                    {approvalAction === 'revoke' && (
+                        <Banner
+                            intent="warning"
+                            icon="warning"
+                            description={
+                                <Translation id="TR_EXCHANGE_APPROVAL_FORM_REVOKE_BANNER" />
+                            }
+                        />
+                    )}
 
                     {pendingApproveTransaction && (
                         <YieldPendingTransaction

--- a/packages/suite/src/components/earn/yield/yieldFlowUtils.ts
+++ b/packages/suite/src/components/earn/yield/yieldFlowUtils.ts
@@ -27,7 +27,7 @@ type GetYieldApprovalActionParams = {
     tokenContractAddress?: string | null;
 };
 
-export type YieldApprovalAction = 'approve' | 'increase' | 'revoke';
+export type YieldApprovalAction = 'approve' | 'continue' | 'increase' | 'revoke';
 
 export type YieldNetworkFeeWarning = {
     availableAmount: string;
@@ -85,17 +85,20 @@ export const getYieldApprovalAction = ({
     const allowanceAmountValue = new BigNumber(allowanceAmount || '0');
     const liveAmountValue = new BigNumber(liveAmount || '0');
     const hasAllowanceAmount = !!allowanceAmount && !allowanceAmountValue.isZero();
-    const isAmountChanged = hasAllowanceAmount && !liveAmountValue.eq(allowanceAmountValue);
     const isIncreasing = hasAllowanceAmount && liveAmountValue.gt(allowanceAmountValue);
     const needsZeroApprovalReset =
         !!tokenContractAddress && !tokenSupportsIncreasingAllowance(tokenContractAddress);
 
-    if (isRevokeRequired || (isAmountChanged && needsZeroApprovalReset)) {
+    if (isRevokeRequired || (isIncreasing && needsZeroApprovalReset)) {
         return 'revoke';
     }
 
     if (isIncreasing) {
         return 'increase';
+    }
+
+    if (hasAllowanceAmount) {
+        return 'continue';
     }
 
     return 'approve';

--- a/suite-common/wallet-utils/src/allowanceUtils.ts
+++ b/suite-common/wallet-utils/src/allowanceUtils.ts
@@ -7,4 +7,4 @@ import { unitsToSubunits } from './amountUtils';
 export const isAllowanceUnlimited = (amountUnits: string, decimals: number): boolean =>
     new BigNumber(
         unitsToSubunits({ value: asAmountUnit(new BigNumber(amountUnits)), decimals }),
-    ).eq(new BigNumber(UINT256_MAX));
+    ).gte(new BigNumber(UINT256_MAX).dividedBy(2).integerValue());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Show warning banner below "Revoke Approval" button in the yield approve step when the entered amount exceeds the current approval and the token requires a revoke before increase
- Show "Continue" instead of "Revoke Approval"/"Approve" if approval is sufficient
- Fix "Unlimited" approval display (now shows unlimited for amount >= UINT256_MAX / 2)

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #27325

## Screenshots:

<img width="546" height="497" alt="image" src="https://github.com/user-attachments/assets/73e5d543-a51e-45ab-805d-3c73bda2ceff" />

<img width="572" height="548" alt="image" src="https://github.com/user-attachments/assets/21d53ed4-d2fd-4abf-bde0-a2e1d6003bd1" />

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect three files in the earn/yield staking flow: the YieldApproveStep component (token approval UI), yieldFlowUtils (shared yield flow utilities), and allowanceUtils (token allowance calculation logic). The highest risk is to ETH staking flows where token approval is a critical step. SOL and ADA staking tests are medium priority as they share yield flow infrastructure but don't use EVM token approvals. The YieldApproveStep.tsx maps to 121 tests via static analysis, but this is because it's bundled into the app shell — only staking-specific tests actually exercise this component's functionality.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx`
- `packages/suite/src/components/earn/yield/yieldFlowUtils.ts`
- `suite-common/wallet-utils/src/allowanceUtils.ts`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — YieldApproveStep.tsx is part of the earn/yield flow, and yieldFlowUtils.ts directly supports yield operations. ETH staking tests exercise the earn/staking UI flow which includes approval steps. The allowanceUtils.ts changes could affect token approval logic used in ETH staking transactions.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Staking more ETH exercises the yield/earn flow which directly uses YieldApproveStep and yieldFlowUtils. The approve step is likely triggered when adding to an existing stake, and allowanceUtils changes could affect approval checks.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — Unstaking ETH is part of the earn/yield flow and exercises the full staking lifecycle including approval steps. Changes to YieldApproveStep and yieldFlowUtils directly impact the unstake and claim flows.
- `suite/e2e/tests/staking/staking-form.test.ts` — The staking form test validates ETH staking input, amounts, and form behavior which directly exercises the yield flow components. Changes to yieldFlowUtils could affect form validation or amount calculation logic.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — SOL staking exercises the earn/staking flow. While the approve step is more relevant to EVM chains, yieldFlowUtils changes could affect shared staking logic used across networks.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — SOL stake-more flow shares staking infrastructure with the yield components. Changes to yieldFlowUtils could affect the shared flow logic.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — SOL unstake flow exercises the earn/yield unstaking path. yieldFlowUtils changes may impact shared unstaking logic across networks.
- `suite/e2e/tests/staking/ada/stake.test.ts` — ADA staking exercises the earn/staking flow. While Cardano staking differs from EVM token approval, yieldFlowUtils changes could affect shared earn flow utilities.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — ADA unstaking exercises the earn flow path. Changes to yieldFlowUtils may affect shared logic used in the unstaking workflow.
- `suite/e2e/tests/staking/ada/claim.test.ts` — ADA claim rewards flow is part of the earn/staking feature. yieldFlowUtils changes could affect the claim flow logic shared across the earn feature.
- `suite/e2e/tests/analytics/staking-events.test.ts` — This test verifies analytics events for staking navigation. Changes to the yield/earn components could affect how staking navigation events are triggered, particularly if yieldFlowUtils changes alter routing or flow logic.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/staking/sol/rewards.test.ts` — SOL rewards display test covers staking dashboard amounts. While less directly related to the approve step, yieldFlowUtils changes could affect how rewards data is processed or displayed.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-common/wallet-utils/src/allowanceUtils.ts`
- `packages/suite/src/components/earn/yield/yieldFlowUtils.ts`

_Updated: 2026-05-06T11:50:16.181Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/vault-usdt-approvals/web/](https://dev.suite.sldev.cz/suite-web/feat/vault-usdt-approvals/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/vault-usdt-approvals&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/vault-usdt-approvals&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/vault-usdt-approvals&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-06T11:55:02.037Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-06T13:11:57.605Z • 13 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->