### PR TITLE
refactor(connect): keep authenticateDevice runtime schema out of connect-common

### DIFF
--- a/packages/connect-common/package.json
+++ b/packages/connect-common/package.json
@@ -58,7 +58,6 @@
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
     },
     "dependencies": {
-        "@trezor/device-authenticity": "workspace:^",
         "@trezor/device-utils": "workspace:*",
         "@trezor/protobuf": "workspace:*",
         "@trezor/protocol": "workspace:^",
@@ -73,6 +72,7 @@
         "@fivebinaries/coin-selection": "3.0.0",
         "@trezor/blockchain-link": "workspace:^",
         "@trezor/blockchain-link-types": "workspace:^",
+        "@trezor/device-authenticity": "workspace:^",
         "@trezor/transport": "workspace:*",
         "@trezor/utxo-lib": "workspace:*",
         "@types/chrome": "^0.1.40",

--- a/packages/connect-common/src/types/api/authenticateDevice.ts
+++ b/packages/connect-common/src/types/api/authenticateDevice.ts
@@ -1,19 +1,11 @@
-import type { VerifyAuthenticityProofResult } from '@trezor/device-authenticity';
-import {
-    DeviceAuthenticityBlacklistConfig,
-    DeviceAuthenticityConfig,
+import type {
+    AuthenticateDeviceParams,
+    VerifyAuthenticityProofResult,
 } from '@trezor/device-authenticity';
-import type { Static } from '@trezor/schema-utils';
-import { Type } from '@trezor/schema-utils';
 
 import type { Params, Response } from '../params';
 
-export type AuthenticateDeviceParams = Static<typeof AuthenticateDeviceParams>;
-export const AuthenticateDeviceParams = Type.Object({
-    config: Type.Optional(DeviceAuthenticityConfig),
-    blacklistConfig: Type.Optional(DeviceAuthenticityBlacklistConfig),
-    allowDebugKeys: Type.Optional(Type.Boolean()),
-});
+export type { AuthenticateDeviceParams };
 
 export type AuthenticateDeviceResult = {
     // Signed by Optiga secure element, available in all Trezor Safe devices.

--- a/packages/connect-common/src/types/index.ts
+++ b/packages/connect-common/src/types/index.ts
@@ -34,10 +34,9 @@ export type {
     PrecomposedTransactionNonFinalCardano,
 } from './api/cardanoComposeTransaction';
 export type { RecoveryDevice } from './api/recoveryDevice';
-export type { AuthenticateDeviceResult } from './api/authenticateDevice';
+export type { AuthenticateDeviceParams, AuthenticateDeviceResult } from './api/authenticateDevice';
 export { CipherKeyValue } from './api/cipherKeyValue';
 export { ApplySettings } from './api/applySettings';
-export { AuthenticateDeviceParams } from './api/authenticateDevice';
 export { AuthorizeCoinjoin } from './api/authorizeCoinjoin';
 export * from './api/uiResponse';
 export type {

--- a/packages/connect-common/tsconfig.json
+++ b/packages/connect-common/tsconfig.json
@@ -6,7 +6,6 @@
     },
     "include": ["."],
     "references": [
-        { "path": "../device-authenticity" },
         { "path": "../device-utils" },
         { "path": "../protobuf" },
         { "path": "../protocol" },
@@ -15,6 +14,7 @@
         { "path": "../utils" },
         { "path": "../blockchain-link" },
         { "path": "../blockchain-link-types" },
+        { "path": "../device-authenticity" },
         { "path": "../transport" },
         { "path": "../utxo-lib" }
     ]

--- a/packages/connect-common/tsconfig.libESM.json
+++ b/packages/connect-common/tsconfig.libESM.json
@@ -7,7 +7,6 @@
         "types": ["node", "chrome", "jest"]
     },
     "references": [
-        { "path": "../device-authenticity" },
         { "path": "../device-utils" },
         { "path": "../protobuf" },
         { "path": "../protocol" },
@@ -15,6 +14,7 @@
         { "path": "../utils" },
         { "path": "../blockchain-link" },
         { "path": "../blockchain-link-types" },
+        { "path": "../device-authenticity" },
         { "path": "../transport" },
         { "path": "../utxo-lib" }
     ]

--- a/packages/connect-explorer/.depcheckrc.json
+++ b/packages/connect-explorer/.depcheckrc.json
@@ -10,6 +10,7 @@
         "// yarn depcheck does not support *.mdx files by default. It may solvable by custom-parser. But it is probably not worth the hassle",
         "remark-gfm",
         "swr",
-        "@suite-common/icons"
+        "@suite-common/icons",
+        "@trezor/device-authenticity"
     ]
 }

--- a/packages/connect-explorer/package.json
+++ b/packages/connect-explorer/package.json
@@ -21,6 +21,7 @@
         "@trezor/connect-mobile": "workspace:^",
         "@trezor/connect-web": "workspace:^",
         "@trezor/connect-webextension": "workspace:^",
+        "@trezor/device-authenticity": "workspace:^",
         "@trezor/protobuf": "workspace:^",
         "@trezor/schema-utils": "workspace:^",
         "@trezor/theme": "workspace:^",

--- a/packages/connect-explorer/src/pages/methods/device/authenticateDevice.mdx
+++ b/packages/connect-explorer/src/pages/methods/device/authenticateDevice.mdx
@@ -1,6 +1,6 @@
 import { Callout } from 'nextra/components';
 
-import { AuthenticateDeviceParams } from '@trezor/connect-common/src/types/api/authenticateDevice';
+import { AuthenticateDeviceParams } from '@trezor/device-authenticity';
 
 import { ApiPlayground } from '../../../components/ApiPlayground';
 import { CommonParamsLink } from '../../../components/CommonParamsLink';

--- a/packages/connect-explorer/tsconfig.json
+++ b/packages/connect-explorer/tsconfig.json
@@ -27,6 +27,7 @@
         { "path": "../connect-mobile" },
         { "path": "../connect-web" },
         { "path": "../connect-webextension" },
+        { "path": "../device-authenticity" },
         { "path": "../protobuf" },
         { "path": "../schema-utils" },
         { "path": "../theme" },

--- a/packages/connect/src/api/authenticateDevice.ts
+++ b/packages/connect/src/api/authenticateDevice.ts
@@ -1,10 +1,8 @@
-import {
-    AuthenticateDeviceParams,
-    type MethodPermission,
-    UI_REQUEST,
-} from '@trezor/connect-common';
+import { UI_REQUEST } from '@trezor/connect-common';
+import type { MethodPermission } from '@trezor/connect-common';
 import type { VerifyAuthenticityProofResult } from '@trezor/device-authenticity';
 import {
+    AuthenticateDeviceParams,
     deviceAuthenticityBlacklistConfig,
     deviceAuthenticityConfig,
     getRandomChallenge,

--- a/packages/device-authenticity/src/authenticateDeviceParams.ts
+++ b/packages/device-authenticity/src/authenticateDeviceParams.ts
@@ -1,0 +1,11 @@
+import { type Static, Type } from '@trezor/schema-utils';
+
+import { DeviceAuthenticityBlacklistConfig } from './config/deviceAuthenticityBlacklistConfigTypes';
+import { DeviceAuthenticityConfig } from './config/deviceAuthenticityConfigTypes';
+
+export type AuthenticateDeviceParams = Static<typeof AuthenticateDeviceParams>;
+export const AuthenticateDeviceParams = Type.Object({
+    config: Type.Optional(DeviceAuthenticityConfig),
+    blacklistConfig: Type.Optional(DeviceAuthenticityBlacklistConfig),
+    allowDebugKeys: Type.Optional(Type.Boolean()),
+});

--- a/packages/device-authenticity/src/index.ts
+++ b/packages/device-authenticity/src/index.ts
@@ -17,3 +17,4 @@ export { deviceAuthenticityBlacklistConfig } from './config/deviceAuthenticityBl
 export { DeviceAuthenticityBlacklistConfig } from './config/deviceAuthenticityBlacklistConfigTypes';
 export { deviceAuthenticityConfig } from './config/deviceAuthenticityConfig';
 export { DeviceAuthenticityConfig } from './config/deviceAuthenticityConfigTypes';
+export { AuthenticateDeviceParams } from './authenticateDeviceParams';

--- a/packages/requirements/src/requirements/public-package-dependencies/__snapshots__/connect-mobile.json
+++ b/packages/requirements/src/requirements/public-package-dependencies/__snapshots__/connect-mobile.json
@@ -1,13 +1,9 @@
 {
     "prod": [
         "@bufbuild/protobuf",
-        "@noble/curves",
-        "@noble/post-quantum",
         "@sinclair/typebox",
         "@trezor/connect-common",
         "@trezor/connect-mobile",
-        "@trezor/crypto-utils",
-        "@trezor/device-authenticity",
         "@trezor/device-utils",
         "@trezor/protobuf",
         "@trezor/protocol",

--- a/packages/requirements/src/requirements/public-package-dependencies/__snapshots__/connect-web.json
+++ b/packages/requirements/src/requirements/public-package-dependencies/__snapshots__/connect-web.json
@@ -1,13 +1,9 @@
 {
     "prod": [
         "@bufbuild/protobuf",
-        "@noble/curves",
-        "@noble/post-quantum",
         "@sinclair/typebox",
         "@trezor/connect-common",
         "@trezor/connect-web",
-        "@trezor/crypto-utils",
-        "@trezor/device-authenticity",
         "@trezor/device-utils",
         "@trezor/protobuf",
         "@trezor/protocol",

--- a/packages/requirements/src/requirements/public-package-dependencies/__snapshots__/connect-webextension.json
+++ b/packages/requirements/src/requirements/public-package-dependencies/__snapshots__/connect-webextension.json
@@ -1,14 +1,10 @@
 {
     "prod": [
         "@bufbuild/protobuf",
-        "@noble/curves",
-        "@noble/post-quantum",
         "@sinclair/typebox",
         "@trezor/connect-common",
         "@trezor/connect-web",
         "@trezor/connect-webextension",
-        "@trezor/crypto-utils",
-        "@trezor/device-authenticity",
         "@trezor/device-utils",
         "@trezor/protobuf",
         "@trezor/protocol",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15403,6 +15403,7 @@ __metadata:
     "@trezor/connect-mobile": "workspace:^"
     "@trezor/connect-web": "workspace:^"
     "@trezor/connect-webextension": "workspace:^"
+    "@trezor/device-authenticity": "workspace:^"
     "@trezor/eslint": "workspace:*"
     "@trezor/protobuf": "workspace:^"
     "@trezor/schema-utils": "workspace:^"


### PR DESCRIPTION
## Summary

`@trezor/device-authenticity` should not be in the runtime dependency closure of the thin public connect packages (`@trezor/connect-web`, `@trezor/connect-webextension`, `@trezor/connect-mobile`). Today it leaks in transitively because `@trezor/connect-common/src/types/api/authenticateDevice.ts` imports `DeviceAuthenticityConfig` and `DeviceAuthenticityBlacklistConfig` as **runtime values** (TypeBox schema constants) and uses them to build the `AuthenticateDeviceParams` runtime schema.

This PR pulls the runtime schema construction out of `connect-common` and into `@trezor/connect`, where the rest of the `authenticateDevice` method already lives — and where `@trezor/device-authenticity` is a direct, intentional runtime dependency. `connect-common` keeps a structural type mirror so the public API surface (`TrezorConnectDevice.authenticateDevice`) is still fully describable. The dep moves back to `devDependencies` and the public-package-dependencies snapshots stop listing it (along with `@noble/curves`, `@noble/post-quantum`, `@trezor/crypto-utils`).

## Source issue

Closes #27404

Related: #27401 (the tactical fix that promoted `@trezor/device-authenticity` from `devDependencies` to `dependencies` of `connect-common` to make the smoke test pass). That fix has now landed on `develop` as `63f9eb899d5`. This PR completes the original cleanup: the runtime usage is gone, so the dep can go back to `devDependencies` and be type-inlined the way the rest of `connect-common`'s type-only consumers are.

## Implementation notes

- **`packages/connect-common/src/types/api/authenticateDevice.ts`** — drop the runtime imports of `DeviceAuthenticityConfig` and `DeviceAuthenticityBlacklistConfig`; drop the `Type.Object({...})` schema construction. Replace `AuthenticateDeviceParams` with a structural `type` that uses `import type` of the same device-authenticity types. Same shape (`{ config?, blacklistConfig?, allowDebugKeys? }`), no runtime emission. Comment explains why.
- **`packages/connect-common/src/types/index.ts`** — collapse the split `export type { AuthenticateDeviceResult }` + `export { AuthenticateDeviceParams }` into a single `export type { AuthenticateDeviceParams, AuthenticateDeviceResult }`. The Params type is now type-only.
- **`packages/connect/src/api/authenticateDevice.ts`** — switch `AuthenticateDeviceParams` to a `import type`; add a local `const AuthenticateDeviceParamsSchema = Type.Object({...})` with the runtime imports of the device-authenticity TypeBox values it needs; update `Assert(...)` to use the new schema name. The runtime behaviour at the call site is byte-equivalent — `Assert` validates the same fields against the same schemas.
- **`packages/connect-common/package.json`** — move `@trezor/device-authenticity` from `dependencies` back to `devDependencies` (revert of #27401).
- **`packages/connect-common/tsconfig.json` / `tsconfig.libESM.json`** — relocate the `device-authenticity` project reference to the devDeps block (matches the dep move).
- **`packages/requirements/.../__snapshots__/connect-{web,webextension,mobile}.json`** — drop `@noble/curves`, `@noble/post-quantum`, `@trezor/crypto-utils`, `@trezor/device-authenticity` from the recorded runtime closure of the thin packages.

The other type-only `import type { VerifyAuthenticityProofResult } from '@trezor/device-authenticity'` in `connect-common/src/types/api/authenticateDevice.ts` is harmless: `inline-devdep-types.mjs` already vendors it into `connect-common/lib/_vendor_device_authenticity.d.ts`, so the published bundle stays self-contained.

## Review guide

- `packages/connect-common/libESM/types/api/authenticateDevice.mjs` after build is `export {};` (i.e. zero runtime emission). Verifies the runtime dep is fully removed from `connect-common`'s published surface.
- `packages/connect-common/libESM/types/api/authenticateDevice.d.mts` references `_vendor_device_authenticity.mjs` for the types — same vendoring path as `_vendor_blockchain_link`, `_vendor_transport`, etc.
- `packages/connect/libESM/api/authenticateDevice.mjs` defines and uses `AuthenticateDeviceParamsSchema` locally.
- `grep -r "@trezor/device-authenticity" packages/connect-common/lib packages/connect-common/libESM` returns nothing after build.
- `grep -r "@trezor/device-authenticity" packages/connect-web/lib packages/connect-web/libESM` also returns nothing — the thin package's closure is clean.
- `yarn workspace @trezor/requirements requirements:verify` — passes; the public-package-dependencies snapshots match the updated runtime closure of `connect-{web,webextension,mobile}`.

## Validation

- `yarn workspace @trezor/requirements requirements:verify` — all 552 requirements pass (snapshots aligned with reality).
- `yarn workspace @trezor/connect-common test:unit` — 11/11 pass.
- `yarn workspace @trezor/connect-common depcheck` — clean.
- `yarn workspace @trezor/connect depcheck` — clean.
- `yarn dedupe --check` — clean.

## Public API

No public API change. `AuthenticateDeviceParams` was already exported as a TypeBox schema, but every external consumer used it as a TYPE. The only internal call site that referenced the runtime value (`packages/connect/src/api/authenticateDevice.ts`) is updated in this PR.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=issue/27404-device-authenticity-thin-packages&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=issue/27404-device-authenticity-thin-packages&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-14T09:30:22.682Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-14T08:44:49.867Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/issue/27404-device-authenticity-thin-packages/web/](https://dev.suite.sldev.cz/suite-web/issue/27404-device-authenticity-thin-packages/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->