### PR TITLE
fix(trading): styles in TradingOffersModal

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingOffers/TradingOffersModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingOffers/TradingOffersModal.tsx
@@ -1,6 +1,6 @@
 import { Translation } from '@suite/intl';
 import { type TradingTradeType } from '@suite-common/trading';
-import { Modal } from '@trezor/components';
+import { Box, Modal } from '@trezor/components';
 
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { isTradingExchangeContext } from 'src/utils/wallet/trading/tradingTypingUtils';
@@ -36,11 +36,13 @@ export const TradingOffersModal = ({ onClose, onSelect }: TradingOffersModalProp
             width={600}
             height={680}
         >
-            {isTradingExchangeContext(context) ? (
-                <TradingOffersModalExchange onSelect={handleSelect} />
-            ) : (
-                <TradingOffersModalGroup quotes={deduplicatedQuotes} onSelect={handleSelect} />
-            )}
+            <Box padding={{ bottom: 16 }}>
+                {isTradingExchangeContext(context) ? (
+                    <TradingOffersModalExchange onSelect={handleSelect} />
+                ) : (
+                    <TradingOffersModalGroup quotes={deduplicatedQuotes} onSelect={handleSelect} />
+                )}
+            </Box>
         </Modal>
     );
 };

--- a/packages/suite/src/views/wallet/trading/common/TradingUtils/TradingUtilsKyc.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingUtils/TradingUtilsKyc.tsx
@@ -62,7 +62,7 @@ export const TradingUtilsKyc = ({
                         size={12}
                         data-testid="@trading/kyc/dex"
                     />
-                    <Text typographyStyle="body-xs" color="contentBrand">
+                    <Text typographyStyle="body-sm" color="contentBrand">
                         <Translation id="TR_TRADING_KYC_ANONYMOUS" />
                     </Text>
                 </Row>
@@ -80,7 +80,7 @@ export const TradingUtilsKyc = ({
         return (
             <Tooltip content={kycPolicyTranslation} placement="bottom">
                 <TooltipText>
-                    <Text color="contentWarning" typographyStyle="body-xs">
+                    <Text color="contentWarning" typographyStyle="body-sm">
                         <Row gap={4}>
                             <Icon name="identificationCard" color="contentWarning" size={12} />
                             <Translation id={kycTitle} />

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -1226,7 +1226,7 @@ export const messages = defineMessages({
         id: 'TR_TRADING_KYC_NO_KYC',
     },
     TR_TRADING_KYC_ANONYMOUS: {
-        defaultMessage: 'Anonymous.',
+        defaultMessage: 'Anonymous',
         id: 'TR_TRADING_KYC_ANONYMOUS',
     },
 


### PR DESCRIPTION
## Description

- add bottom spacing inside the compare offers modal content
- increase trading KYC badge text size to match the updated modal styling
- remove the trailing period from the Anonymous label

## Notes for QA

- check all mentioned above

## Related Issue

Resolve #27041

## Screenshots:

<img width="647" height="707" alt="image" src="https://github.com/user-attachments/assets/e7f7bfc3-1820-4209-9219-0f905f08f31c" />


N/A

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies two trading-specific UI components (TradingOffersModal and TradingUtilsKyc) and the global messages file. The highest risk is in the trading offers flow where the modal and KYC utility are directly rendered during buy/sell/swap offer selection and confirmation. The messages.ts file is a broad dependency but changes there are most likely to surface in trading flows given the other two changed files. The recommended strategy prioritizes one representative test per trading type (buy, sell, swap) at high priority, with additional network/token variants at medium priority for broader coverage.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/views/wallet/trading/common/TradingOffers/TradingOffersModal.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingUtils/TradingUtilsKyc.tsx`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — TradingOffersModal.tsx is directly part of the trading offers flow. This test exercises the full buy flow including viewing offers, confirming trades, and transaction details — all of which render through the offers modal component. The buy-bitcoin test also statically maps to TradingUtilsKyc.tsx.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — The sell-bitcoin test exercises the full sell flow including offer selection and confirmation, which renders through TradingOffersModal. It also statically maps to TradingUtilsKyc.tsx which may display KYC-related information during the sell confirmation flow.
- `suite/e2e/tests/trading/swap-coins.test.ts` — The swap-coins test covers the full swap offer flow including best offer selection, confirmation, and transaction detail — all rendered through the TradingOffersModal. It statically maps to TradingUtilsKyc.tsx and exercises the offers comparison modal.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/trading/sell-ethereum.test.ts` — This test covers the Ethereum sell flow with custom gas fees and offer confirmation, exercising TradingOffersModal for quote display. Statically mapped to TradingUtilsKyc.tsx. Provides coverage for a different network path (ETH vs BTC).
- `suite/e2e/tests/trading/sell-solana.test.ts` — Covers the Solana sell flow including offer comparison modal where the user selects a non-best offer — directly exercising TradingOffersModal functionality. Statically mapped to TradingUtilsKyc.tsx.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Tests cross-network token swap (SOL to USDC on ETH) with best offer selection and confirmation. Exercises TradingOffersModal for offer display and confirmation. Statically mapped to TradingUtilsKyc.tsx.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Tests selling an ERC-20 token (USDC), exercising the offers modal for token-specific sell flow. Statically mapped to TradingUtilsKyc.tsx and provides ERC-20 token coverage distinct from native coin sells.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Tests token-to-coin swap (USDT to BTC) including best offer display and confirmation through TradingOffersModal. Statically mapped to TradingUtilsKyc.tsx.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — Tests buying ETH including best offer quote display and trade confirmation, which render through TradingOffersModal. Inferred coverage for TradingOffersModal since it's part of the trading offers flow, even though not statically mapped.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Tests BTC-to-ETH swap with custom fee settings. While it touches the swap offer selection flow (TradingOffersModal), its primary focus is fee calculation. Statically mapped to TradingUtilsKyc.tsx but fee-focused tests are less likely affected by KYC/modal changes.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests ETH-to-BTC swap with custom Ethereum gas fee settings. Statically mapped to TradingUtilsKyc.tsx but primarily validates fee display rather than offers modal or KYC flows.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/intl/src/messages.ts`

_Updated: 2026-05-06T12:24:38.838Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/27041/offers-modal-styles&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/27041/offers-modal-styles&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-06T12:33:15.940Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-06T12:31:40.509Z • 13 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/27041/offers-modal-styles/web/](https://dev.suite.sldev.cz/suite-web/fix/27041/offers-modal-styles/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->