### PR TITLE
Fix vite worker loader

### DIFF
--- a/packages/connect/e2e/vitest.config.ts
+++ b/packages/connect/e2e/vitest.config.ts
@@ -8,6 +8,53 @@ import { type Plugin, defineConfig } from 'vitest/config';
 const isWebProject = process.env.VITEST_PROJECT === 'browser';
 const nodeRequire = createRequire(import.meta.url);
 
+const alias = [
+    {
+        find: '@trezor/blockchain-link',
+        replacement: path.resolve(__dirname, '../../blockchain-link'),
+    },
+];
+
+// Plugin to resolve bare module specifiers (e.g. @trezor/blockchain-link/src/workers/blockbook)
+// inside new Worker(new URL(..., import.meta.url)) calls.
+// In dev mode, Vite doesn't bundle — the browser constructs the URL at runtime and has no way to
+// resolve bare package specifiers, so we must expand them to /@fs/ paths that the dev server
+// can serve directly. In production, rolldown resolves them through the alias config at build time.
+const resolveWorkerUrlsPlugin = (): Plugin => ({
+    name: 'resolve-worker-urls',
+    enforce: 'pre',
+    apply: 'serve',
+    transform(code) {
+        if (!code.includes('new Worker') || !code.includes('import.meta.url')) return null;
+
+        let changed = false;
+        const transformed = code.replace(
+            /new URL\(\s*(?:\/\*.*?\*\/)?\s*(['"])(@[^'"]+)\1,\s*import\.meta\.url,?\s*\)/gm,
+            (match, _quote, specifier) => {
+                for (const a of alias) {
+                    if (
+                        typeof a.find === 'string' &&
+                        typeof a.replacement === 'string' &&
+                        specifier.startsWith(a.find)
+                    ) {
+                        const rest = specifier.slice(a.find.length);
+                        const abs = a.replacement + rest;
+                        // Append index.ts if no file extension present
+                        const withExt = /\.[cm]?[jt]sx?$/.test(abs) ? abs : `${abs}/index.ts`;
+                        changed = true;
+
+                        return `new URL('/@fs${withExt}', import.meta.url)`;
+                    }
+                }
+
+                return match;
+            },
+        );
+
+        return changed ? { code: transformed, map: null } : null;
+    },
+});
+
 /**
  * Vite plugin that provides the TX_CACHE data as a virtual module.
  * In Node environment, __txcache__/index.js uses fs.readdirSync which works fine.
@@ -175,6 +222,7 @@ export default defineConfig(
             },
             plugins: [
                 txCachePlugin(),
+                resolveWorkerUrlsPlugin(),
                 ...(isWebProject
                     ? [
                           wasm(),

--- a/packages/suite-build/vite.config.mts
+++ b/packages/suite-build/vite.config.mts
@@ -390,7 +390,7 @@ const resolveWorkerUrlsPlugin = (): Plugin => ({
 
         let changed = false;
         const transformed = code.replace(
-            /new URL\((['"])(@[^'"]+)\1,\s*import\.meta\.url\)/g,
+            /new URL\(\s*(?:\/\*.*?\*\/)?\s*(['"])(@[^'"]+)\1,\s*import\.meta\.url,?\s*\)/gm,
             (match, _quote, specifier) => {
                 for (const a of alias) {
                     if (


### PR DESCRIPTION
## Description

Fix vite configs so they're not handling only
```new URL('@some-package', import.meta.url)```
but also
```new URL(/* comment */ '@some-package', import.meta.url)```.

Also fixes nightly connect web tests.

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** No relevant source file changes detected against origin/develop.

_No test recommendations found._

_Updated: 2026-05-06T12:36:56.371Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/vite-workers-plugin&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/vite-workers-plugin&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/vite-workers-plugin&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-06T12:42:32.200Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-06T12:41:20.896Z • 13 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/vite-workers-plugin/web/](https://dev.suite.sldev.cz/suite-web/fix/vite-workers-plugin/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->