### PR TITLE
chore(earn): new structure of token protocols

### DIFF
--- a/packages/blockchain-link-types/src/blockbook-api.ts
+++ b/packages/blockchain-link-types/src/blockbook-api.ts
@@ -337,8 +337,8 @@ export interface Token {
     totalReceived?: string;
     /** Total amount of tokens sent. */
     totalSent?: string;
-    /** Optional protocol-specific enrichments requested by the caller. */
-    protocols?: ContractInfoProtocols;
+    /** Protocol identifiers the contract participates in (e.g., "erc4626"); for fresh per-vault data, use getContractInfo. */
+    protocols?: TokenProtocols;
 }
 export interface Address {
     /** Current page index. */
@@ -405,6 +405,7 @@ export interface Address {
         | { payloadType: string; payload?: any };
 }
 export type ContractInfoProtocol = 'erc4626';
+export type TokenProtocols = ContractInfoProtocol[];
 export interface ContractInfoProtocols {
     /** ERC4626 vault details when explicitly requested and detected. */
     erc4626?: Erc4626Token;

--- a/packages/blockchain-link-types/src/common.ts
+++ b/packages/blockchain-link-types/src/common.ts
@@ -1,11 +1,7 @@
 import type { SocksProxyAgentOptions } from 'socks-proxy-agent';
 
 import type { BaseCurrencyCode } from './baseCurrency';
-import type {
-    ContractInfoProtocols,
-    TronAccountExtraData,
-    TronChainExtraData,
-} from './blockbook-api';
+import type { TokenProtocols, TronAccountExtraData, TronChainExtraData } from './blockbook-api';
 
 /* Shared types — canonical definitions used by both common and backend-specific modules */
 
@@ -327,7 +323,7 @@ export interface TokenInfo {
     accounts?: TokenAccount[];
     policyId?: string;
     fingerprint?: string;
-    protocols?: ContractInfoProtocols;
+    protocols?: TokenProtocols;
 }
 
 /**

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
@@ -30,6 +30,7 @@ import {
     fromBaseCurrencyToCryptoUnit,
     getCryptoAmountWithReserve,
     getDecimalsForBaseCurrency,
+    isErc4626,
     isZero,
 } from '@suite-common/wallet-utils';
 import { BigNumber, isChanged } from '@trezor/utils';
@@ -94,7 +95,7 @@ export const useTradingFormActions = <T extends TradingSellExchangeFormProps>({
         cryptoId: sendCryptoSelect?.id,
         amount: sendCryptoAccount?.balance,
         fiatCurrency: getValues().outputs?.[0]?.currency?.value || undefined,
-        isErc4626: !!tokenData?.protocols?.erc4626,
+        isErc4626: !!tokenData && isErc4626(tokenData),
     });
 
     const { getAssetDecimals } = useTradingAssetDecimals();

--- a/packages/suite/src/views/wallet/send/Outputs/Amount/BaseCurrencyInput.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/BaseCurrencyInput.tsx
@@ -200,7 +200,7 @@ export const BaseCurrencyInput = ({
                             {
                                 symbol: account.symbol,
                                 tokenAddress: token?.contract as TokenAddress,
-                                protocols: token?.protocols?.erc4626 ? ['erc4626'] : undefined,
+                                protocols: token?.protocols,
                             },
                         ],
                         baseCurrencyCode: selected.value as BaseCurrencyCode,

--- a/packages/suite/src/views/wallet/send/Outputs/TokenSelect/SelectTokenAssetModal/SelectTokenAssetModal.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/TokenSelect/SelectTokenAssetModal/SelectTokenAssetModal.tsx
@@ -92,7 +92,7 @@ export function SelectTokenAssetModal({
                     {
                         symbol: account.symbol,
                         tokenAddress: (newlySelectedToken?.contract || '') as TokenAddress,
-                        protocols: newlySelectedToken?.protocols?.erc4626 ? ['erc4626'] : undefined,
+                        protocols: newlySelectedToken?.protocols,
                     },
                 ],
                 baseCurrencyCode: currencyValue.value as BaseCurrencyCode,

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerInput/AssetPickerInputBalance.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerInput/AssetPickerInputBalance.tsx
@@ -6,6 +6,7 @@ import {
     type TradingExchangeFormProps,
     type TradingSellFormProps,
 } from '@suite-common/trading';
+import { isErc4626 } from '@suite-common/wallet-utils';
 import { Row } from '@trezor/components';
 
 import { useTradingAssetDecimals } from 'src/hooks/wallet/trading/form/common/useTradingAssetDecimals';
@@ -54,7 +55,7 @@ export const AssetPickerInputBalance = memo(function AssetPickerInputBalance({
         amount,
         cryptoId: value?.id,
         fiatCurrency: getValues('outputs')?.[0]?.currency?.value || undefined,
-        isErc4626: !!accountOrToken?.token?.protocols?.erc4626,
+        isErc4626: !!accountOrToken?.token && isErc4626(accountOrToken.token),
     });
 
     if (!fiatValues || !value) {

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesMiddleware.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesMiddleware.ts
@@ -111,7 +111,7 @@ export const prepareFiatRatesMiddleware = createMiddlewareWithExtraDeps(
             const tokenTickers = tokens.map(token => ({
                 symbol,
                 tokenAddress: token.contract as TokenAddress,
-                protocols: token.protocols?.erc4626 ? ['erc4626'] : undefined,
+                protocols: token.protocols,
             })) satisfies TickerId[];
             // include main account fiat rate ticker
             const tickers = [...tokenTickers, { symbol }];

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesSelectors.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesSelectors.ts
@@ -103,7 +103,7 @@ export const selectTickerFromAccounts = (
                         ({
                             symbol: account.symbol,
                             tokenAddress: token.contract as TokenAddress,
-                            protocols: token.protocols?.erc4626 ? ['erc4626'] : undefined,
+                            protocols: token.protocols,
                         }) satisfies TickerId,
                 ),
         ]),

--- a/suite-common/wallet-utils/src/tokenUtils.ts
+++ b/suite-common/wallet-utils/src/tokenUtils.ts
@@ -112,4 +112,4 @@ const PRESERVE_TOKEN_SYMBOL_CASE_STANDARDS: ReadonlySet<TokenStandard> = new Set
 export const shouldUppercaseTokenSymbol = (token: TokenInfo) =>
     token.standard ? !PRESERVE_TOKEN_SYMBOL_CASE_STANDARDS.has(token.standard) : true;
 
-export const isErc4626 = (token: TokenInfo) => !!token.protocols?.erc4626;
+export const isErc4626 = (token: TokenInfo) => !!token.protocols?.includes('erc4626');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- previous structure was too heavy for RPC nodes and the data were not used
- suite has to be reset or EVM networks disabled and activated again

Blockbook https://github.com/trezor/blockbook/pull/1502

~https://base-b3.trezor.io/~
~https://eth-b8.trezor.io/~

Released everywhere

Resolve #27491

## Screenshots:

<img width="1140" height="630" alt="Screenshot 2026-05-11 at 9 26 51" src="https://github.com/user-attachments/assets/a5f2c9e5-fa73-4389-a4a2-50acb31a79f0" />



<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/erc4626&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/erc4626&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/erc4626&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-06T13:00:59.473Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-06T12:59:53.626Z • 13 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/erc4626/web/](https://dev.suite.sldev.cz/suite-web/chore/erc4626/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->