### PR TITLE
chore(earn): stablecoin yield various updates

### DIFF
--- a/packages/product-components/src/components/AssetLogo/AssetLogo.stories.tsx
+++ b/packages/product-components/src/components/AssetLogo/AssetLogo.stories.tsx
@@ -48,6 +48,9 @@ const meta: Meta<AssetLogoProps> = {
         shouldTryToFetch: {
             control: { type: 'boolean' },
         },
+        isBordered: {
+            control: { type: 'boolean' },
+        },
     },
 };
 
@@ -60,6 +63,7 @@ export const NativeCoin: StoryObj<AssetLogoProps> = {
         placeholder: 'ETH',
         shouldTryToFetch: true,
         showNetworkIcon: false,
+        isBordered: true,
         ...getFramePropsStory(allowedAssetLogoFrameProps).args,
     },
 };
@@ -72,6 +76,7 @@ export const Token: StoryObj<AssetLogoProps> = {
         placeholder: 'USDC',
         shouldTryToFetch: true,
         showNetworkIcon: true,
+        isBordered: true,
         ...getFramePropsStory(allowedAssetLogoFrameProps).args,
     },
 };

--- a/packages/product-components/src/components/AssetLogo/AssetLogoWithId.tsx
+++ b/packages/product-components/src/components/AssetLogo/AssetLogoWithId.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { type NetworkSymbol, type NetworkSymbolExtended } from '@suite-common/wallet-config';
 import { getAssetLogoContractAddresses } from '@suite-common/wallet-utils/src/tokenUtils';
@@ -49,6 +49,7 @@ type AssetLogoBaseProps = AllowedFrameProps & {
     'data-testid'?: string;
     showNetworkIcon?: boolean;
     customLogoUrl?: string;
+    isBordered?: boolean;
 };
 
 export type AssetLogoProps = AssetLogoBaseProps & {
@@ -69,12 +70,16 @@ const Container = styled.div<TransientProps<AllowedFrameProps> & { $size: number
     ${withFrameProps}
 `;
 
-const Logo = styled.img<{ $size: number; $elevation: Elevation }>`
+const Logo = styled.img<{ $size: number; $elevation: Elevation; $isBordered: boolean }>`
     width: ${({ $size }) => $size}px;
     height: ${({ $size }) => $size}px;
     border-radius: ${borders.radii.full};
-    box-shadow: inset 0 0 0 1px ${mapElevationToBorder};
-    background-color: ${mapElevationToBackground};
+    ${({ $isBordered }) =>
+        $isBordered &&
+        css<{ $elevation: Elevation }>`
+            box-shadow: inset 0 0 0 1px ${mapElevationToBorder};
+            background-color: ${mapElevationToBackground};
+        `}
 `;
 
 const StyledNetworkIcon = styled(NetworkIcon)`
@@ -86,6 +91,7 @@ const StyledNetworkIcon = styled(NetworkIcon)`
 
 interface LogoProps extends React.ImgHTMLAttributes<HTMLImageElement> {
     $size: number;
+    $isBordered: boolean;
 }
 
 const ElevatedLogo = (props: LogoProps) => {
@@ -104,6 +110,7 @@ export const AssetLogoWithId = ({
     placeholderWithTooltip = true,
     showNetworkIcon = false,
     customLogoUrl,
+    isBordered = true,
     'data-testid': dataTest,
     ...rest
 }: AssetLogoWithIdProps) => {
@@ -244,6 +251,7 @@ export const AssetLogoWithId = ({
                         loading="lazy"
                         decoding="async"
                         $size={size}
+                        $isBordered={isBordered}
                         data-testid={dataTest}
                         alt={placeholder}
                         onLoad={handleOnLoad}

--- a/packages/suite/src/components/earn/dashboard/common/EarnAccountCell.tsx
+++ b/packages/suite/src/components/earn/dashboard/common/EarnAccountCell.tsx
@@ -4,7 +4,7 @@ import { type TokenDto } from '@suite-common/earn-stablecoin-api';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { Column, Row } from '@trezor/components';
-import { AssetLogo } from '@trezor/product-components';
+import { AssetLogo, CoinLogo } from '@trezor/product-components';
 
 import { EarnAccountCellDetails } from './EarnAccountCellDetails';
 import { type EarnTokenBalance } from './types';
@@ -33,13 +33,18 @@ export const EarnAccountCell = ({
     return (
         <Row gap={16} cursor="inherit">
             <Column alignItems="center">
-                <AssetLogo
-                    placeholder={iconToken?.symbol || iconToken?.name || ''}
-                    symbol={networkSymbol}
-                    contractAddress={iconToken?.address ?? null}
-                    showNetworkIcon={showAssetNetworkIcon}
-                    size={32}
-                />
+                {iconToken ? (
+                    <AssetLogo
+                        placeholder={iconToken.symbol || iconToken.name || ''}
+                        symbol={networkSymbol}
+                        contractAddress={iconToken.address ?? null}
+                        showNetworkIcon={showAssetNetworkIcon}
+                        size={32}
+                        isBordered={false}
+                    />
+                ) : (
+                    <CoinLogo symbol={networkSymbol} type="token" size={32} />
+                )}
             </Column>
 
             <Column flex="1" overflow="hidden" gap={2}>

--- a/packages/suite/src/components/earn/dashboard/utils/earnYieldUtils.ts
+++ b/packages/suite/src/components/earn/dashboard/utils/earnYieldUtils.ts
@@ -16,6 +16,15 @@ export const getClaimableAccounts = ({
     visibleAccounts,
 }: GetClaimableAccountsParams): EarnYieldClaimableAccount[] =>
     Object.entries(rewards).flatMap(([key, accountRewards]) => {
+        const totalClaimable = accountRewards.reduce(
+            (total, reward) => total.plus(reward.claimable),
+            new BigNumber(0),
+        );
+
+        if (!totalClaimable.gt(0)) {
+            return [];
+        }
+
         const { chainId, address } = ChainAddressKey.parse(key);
         const network = getNetworkByEvmChainId(chainId);
         const account = visibleAccounts.find(

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx
@@ -224,14 +224,7 @@ export const EarnYieldAccountOpportunity = ({ opportunity }: EarnYieldAccountOpp
                         symbol={opportunity.networkSymbol}
                         iconToken={opportunity.vault.token}
                         showAssetNetworkIcon
-                        subtitle={
-                            <Translation
-                                id="TR_EARN_VAULT_NAME"
-                                values={{
-                                    vaultName: opportunity.vault.outputToken?.name ?? '',
-                                }}
-                            />
-                        }
+                        subtitle={opportunity.vault.outputToken?.name ?? ''}
                         tokenBalance={{
                             value: opportunity.additionalSupplyAmount,
                             symbol: opportunity.suppliedSymbol,

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyBreakdown.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyBreakdown.tsx
@@ -50,6 +50,7 @@ export const EarnYieldApyBreakdown = ({
                         contractAddress={reward.token.address}
                         showNetworkIcon
                         size={20}
+                        isBordered={false}
                     />
                     <Column flex="1">
                         <Text typographyStyle="body-sm">{reward.token.symbol}</Text>

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyBreakdown.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyBreakdown.tsx
@@ -1,5 +1,10 @@
 import { Translation, type TranslationKey } from '@suite/intl';
-import { type RewardDto, type RewardDtoYieldSource } from '@suite-common/earn-stablecoin-api';
+import {
+    type RewardDto,
+    type RewardDtoYieldSource,
+    type TokenDto,
+    sortRewardsByUnderlyingToken,
+} from '@suite-common/earn-stablecoin-api';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { getApyPercent } from '@suite-common/wallet-utils';
 import { Column, Icon, Row, Text } from '@trezor/components';
@@ -8,32 +13,27 @@ import { AssetLogo } from '@trezor/product-components';
 type EarnYieldApyBreakdownProps = {
     rewards: RewardDto[];
     networkSymbol: NetworkSymbol;
+    underlyingToken: TokenDto | undefined;
 };
 
 const getYieldSourceTranslationId = (yieldSource: RewardDtoYieldSource): TranslationKey | null => {
     switch (yieldSource) {
-        case 'vault':
         case 'lending_interest':
             return 'TR_EARN_YIELD_APY_SOURCE_LENDING_INTEREST';
         case 'protocol_incentive':
-        case 'points':
             return 'TR_EARN_YIELD_APY_SOURCE_PROTOCOL_INCENTIVE';
         default:
             return null;
     }
 };
 
-const sortRewards = (rewards: RewardDto[]) =>
-    rewards.toSorted((a, b) => {
-        if (a.yieldSource === 'vault') return -1;
-        if (b.yieldSource === 'vault') return 1;
-
-        return b.rate - a.rate;
-    });
-
-export const EarnYieldApyBreakdown = ({ rewards, networkSymbol }: EarnYieldApyBreakdownProps) => (
+export const EarnYieldApyBreakdown = ({
+    rewards,
+    networkSymbol,
+    underlyingToken,
+}: EarnYieldApyBreakdownProps) => (
     <Column gap={16} padding={{ vertical: 10, horizontal: 8 }}>
-        {sortRewards(rewards).map((reward, index) => {
+        {sortRewardsByUnderlyingToken(rewards, underlyingToken).map((reward, index) => {
             const ratePercent = getApyPercent(reward.rate);
             const translationId = getYieldSourceTranslationId(reward.yieldSource);
             const description = translationId ? (

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyTooltip.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyTooltip.tsx
@@ -33,7 +33,13 @@ export const EarnYieldApyTooltip = ({
 
     return (
         <Tooltip
-            content={<EarnYieldApyBreakdown rewards={rewards} networkSymbol={networkSymbol} />}
+            content={
+                <EarnYieldApyBreakdown
+                    rewards={rewards}
+                    networkSymbol={networkSymbol}
+                    underlyingToken={vault.token}
+                />
+            }
             maxWidth={600}
             placement="top"
             hasArrow

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldInactiveVaultOpportunity.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldInactiveVaultOpportunity.tsx
@@ -47,14 +47,7 @@ export const EarnYieldInactiveVaultOpportunity = ({
                     symbol={opportunity.networkSymbol}
                     iconToken={opportunity.vault.token}
                     showAssetNetworkIcon
-                    subtitle={
-                        <Translation
-                            id="TR_EARN_VAULT_NAME"
-                            values={{
-                                vaultName: opportunity.vault.outputToken?.name ?? '',
-                            }}
-                        />
-                    }
+                    subtitle={opportunity.vault.outputToken?.name ?? ''}
                 />
             </Table.Cell>
 

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx
@@ -77,9 +77,9 @@ export const EarnYieldTable = () => {
                     return [];
                 }
 
-                const isApproveTx = Number(account.misc.nonce) === 0;
+                const isEmptyAccount = Number(account.misc.nonce ?? 0) < 1;
 
-                if (isApproveTx) {
+                if (isEmptyAccount) {
                     return [];
                 }
 
@@ -135,19 +135,23 @@ export const EarnYieldTable = () => {
                     <EarnFeatureDisabledBanner content={content} />
                 ) : (
                     <Column gap={16} alignItems="center">
-                        <EarnYieldClaimRewardsBanner
-                            value={merkleRewardsQuery.data.totalRewardsToClaim.value}
-                            currency={merkleRewardsQuery.data.totalRewardsToClaim.currency}
-                            isValueLoading={merkleRewardsQuery.isLoading}
-                            isClaimDisabled={isClaimDisabled}
-                            onClaim={() => setIsClaimModalOpen(true)}
-                        />
-                        {isClaimModalOpen && (
-                            <EarnYieldClaimSelectAccountModal
-                                claimableAccounts={claimableAccounts}
-                                onSelect={handleClaimableAccountSelect}
-                                onClose={() => setIsClaimModalOpen(false)}
-                            />
+                        {(isYieldActive || claimableAccounts.length > 0) && (
+                            <>
+                                <EarnYieldClaimRewardsBanner
+                                    value={merkleRewardsQuery.data.totalRewardsToClaim.value}
+                                    currency={merkleRewardsQuery.data.totalRewardsToClaim.currency}
+                                    isValueLoading={merkleRewardsQuery.isLoading}
+                                    isClaimDisabled={isClaimDisabled}
+                                    onClaim={() => setIsClaimModalOpen(true)}
+                                />
+                                {isClaimModalOpen && (
+                                    <EarnYieldClaimSelectAccountModal
+                                        claimableAccounts={claimableAccounts}
+                                        onSelect={handleClaimableAccountSelect}
+                                        onClose={() => setIsClaimModalOpen(false)}
+                                    />
+                                )}
+                            </>
                         )}
                         <Card paddingType="none">
                             <Table isRowHighlightedOnHover margin={{ top: 8 }}>

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/components/YieldEarnInANutshellHighlights.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/components/YieldEarnInANutshellHighlights.tsx
@@ -22,7 +22,10 @@ export const YieldEarnInANutshellHighlights = ({
         {
             icon: 'lockSimple',
             content: (
-                <Translation id="TR_EARN_YIELD_NUTSHELL_AMOUNT_LOCKED" values={{ supplySymbol }} />
+                <Translation
+                    id="TR_EARN_YIELD_NUTSHELL_DEPOSITED_AMOUNT"
+                    values={{ supplySymbol }}
+                />
             ),
         },
         {
@@ -53,7 +56,7 @@ export const YieldEarnInANutshellHighlights = ({
                       icon: 'plusCircle' as const,
                       content: (
                           <Translation
-                              id="TR_EARN_YIELD_NUTSHELL_PROTOCOL_REWARDS"
+                              id="TR_EARN_YIELD_NUTSHELL_CLAIM_REWARDS"
                               values={{
                                   rewardsSymbol: (
                                       <FormattedList type="conjunction" value={rewardsSymbols} />

--- a/packages/suite/src/components/earn/modals/EarnProviderConsent/YieldEarnProviderConsentModal.tsx
+++ b/packages/suite/src/components/earn/modals/EarnProviderConsent/YieldEarnProviderConsentModal.tsx
@@ -9,7 +9,9 @@ import { selectTradingCoinSymbolByCryptoId, toTokenCryptoId } from '@suite-commo
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils';
+import { MORPHO_DISCLAIMER_URL, TREZOR_SUITE_TOS_URL } from '@trezor/urls';
 
+import { TrezorLink } from 'src/components/suite/TrezorLink';
 import { useSelector } from 'src/hooks/suite';
 import { useAnalytics } from 'src/support/useAnalytics';
 
@@ -98,23 +100,24 @@ export const YieldEarnProviderConsentModal = ({
     return (
         <EarnProviderConsentModalLayout
             heading={<Translation id="TR_EARN_SUPPLY_TOKEN" values={{ symbol: supplySymbol }} />}
-            description={
-                <Translation
-                    id="TR_EARN_YOUR_SUPPLIED_FUNDS_MAINTAINED"
-                    values={{ providerName }}
-                />
-            }
             banners={
                 <YieldProviderConsentBanners
                     networkType={account.networkType}
-                    displaySymbol={supplySymbol}
                     providerName={providerName}
                 />
             }
             consentText={
                 <Translation
-                    id="TR_EARN_CONSENT_TO_SUPPLY_WITH_PROVIDER"
-                    values={{ providerName }}
+                    id="TR_EARN_CONSENT_PROTOCOL_TERMS_AND_DISCLAIMER"
+                    values={{
+                        providerName,
+                        tos: chunks => (
+                            <TrezorLink href={TREZOR_SUITE_TOS_URL}>{chunks}</TrezorLink>
+                        ),
+                        disclaimer: chunks => (
+                            <TrezorLink href={MORPHO_DISCLAIMER_URL}>{chunks}</TrezorLink>
+                        ),
+                    }}
                 />
             }
             onConfirm={handleOnConfirm}

--- a/packages/suite/src/components/earn/modals/EarnProviderConsent/components/EarnProviderConsentModalLayout.tsx
+++ b/packages/suite/src/components/earn/modals/EarnProviderConsent/components/EarnProviderConsentModalLayout.tsx
@@ -10,7 +10,7 @@ import { useSelector } from 'src/hooks/suite';
 
 interface EarnProviderConsentModalLayoutProps {
     heading: ReactNode;
-    description: ReactNode;
+    description?: ReactNode;
     banners: ReactNode;
     consentText: ReactNode;
     onConfirm: () => void;

--- a/packages/suite/src/components/earn/modals/EarnProviderConsent/components/YieldProviderConsentBanners.tsx
+++ b/packages/suite/src/components/earn/modals/EarnProviderConsent/components/YieldProviderConsentBanners.tsx
@@ -6,13 +6,11 @@ import { exhaustive } from '@trezor/type-utils';
 
 interface YieldProviderConsentBannersProps {
     networkType: NetworkType;
-    displaySymbol: string;
     providerName: string;
 }
 
 export const YieldProviderConsentBanners = ({
     networkType,
-    displaySymbol,
     providerName,
 }: YieldProviderConsentBannersProps) => {
     if (!isStakingNetworkType(networkType)) return null;
@@ -28,34 +26,20 @@ export const YieldProviderConsentBanners = ({
                         intent="info"
                         description={
                             <Translation
-                                id="TR_EARN_SUPPLY_PROVIDER_MANAGES"
-                                values={{
-                                    providerName,
-                                    networkDisplaySymbol: displaySymbol,
-                                    t: text => <strong>{text}</strong>,
-                                }}
+                                id="TR_EARN_SUPPLY_RECEIPT_TOKENS_INFO"
+                                values={{ providerName }}
                             />
                         }
                     />
                     <Banner
                         icon="shieldWarningFilled"
                         intent="info"
-                        description={
-                            <Translation
-                                id="TR_EARN_SUPPLY_PROVIDER_NO_LIABILITY"
-                                values={{ providerName }}
-                            />
-                        }
+                        description={<Translation id="TR_EARN_SUPPLY_FULL_CONTROL_INFO" />}
                     />
                     <Banner
                         icon="warningCircleFilled"
                         intent="info"
-                        description={
-                            <Translation
-                                id="TR_EARN_SUPPLY_PROVIDER_SMART_CONTRACT_RISK"
-                                values={{ providerName }}
-                            />
-                        }
+                        description={<Translation id="TR_EARN_SUPPLY_PROTOCOL_RISKS_INFO" />}
                     />
                 </>
             );

--- a/packages/suite/src/components/earn/yield/common/YieldApprovedAmountCard.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldApprovedAmountCard.tsx
@@ -32,6 +32,7 @@ export const YieldApprovedAmountCard = ({
                     contractAddress={token.contractAddress ?? null}
                     placeholder={token.symbol}
                     showNetworkIcon
+                    isBordered={false}
                 />
                 <ApprovedAmountValue
                     amount={amount}

--- a/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
@@ -101,7 +101,7 @@ export const YieldPageHeader = ({ analyticsStep, account, routeParams }: YieldPa
                         )}
                         <Column gap={2} overflow="hidden">
                             <Text typographyStyle="body-md-strong" ellipsisLineCount={1}>
-                                <Translation id="TR_EARN_VAULT_NAME" values={{ vaultName }} />
+                                {vaultName}
                             </Text>
                             {account && (
                                 <AccountLabel

--- a/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
@@ -97,6 +97,7 @@ export const YieldPageHeader = ({ analyticsStep, account, routeParams }: YieldPa
                                 contractAddress={vault?.token?.address}
                                 showNetworkIcon
                                 size={32}
+                                isBordered={false}
                             />
                         )}
                         <Column gap={2} overflow="hidden">

--- a/packages/suite/src/components/earn/yield/common/YieldRewardItem.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldRewardItem.tsx
@@ -26,6 +26,7 @@ export const YieldRewardItem = ({
                 contractAddress={tokenAddress}
                 placeholder={tokenSymbol}
                 size={24}
+                isBordered={false}
             />
             <HiddenPlaceholder>
                 <Text typographyStyle="body-md-strong">

--- a/packages/suite/src/components/earn/yield/common/YieldTokenValue.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldTokenValue.tsx
@@ -27,6 +27,7 @@ export const YieldTokenValue = ({ token, amount }: YieldTokenValueProps) => {
                 contractAddress={token.contractAddress}
                 placeholder={token.symbol}
                 showNetworkIcon
+                isBordered={false}
             />
             <Text typographyStyle="body-md-strong">
                 <FormattedCryptoAmount value={roundedAmount} symbol={token.symbol} />

--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -34,6 +34,7 @@ export const DOCS_ANALYTICS_URL: Url = withPlatformUtm(
 
 export const TREZOR_SUITE_TOS_URL: Url = 'https://trezor.io/documents/suite_terms_of_use.pdf';
 export const TREZOR_TRADING_LEARN_MORE_URL: Url = 'https://trezor.io/trade-features';
+export const MORPHO_DISCLAIMER_URL: Url = 'https://morpho.org/disclaimers/';
 
 // =====================
 // 🆘 SUPPORT

--- a/suite-common/earn-stablecoin-api/src/index.ts
+++ b/suite-common/earn-stablecoin-api/src/index.ts
@@ -8,3 +8,4 @@ export * from './hooks/useExitYieldOpportunity';
 export * from './hooks/useSubmitTxHash';
 export * from './hooks/useGetMerkleRewards';
 export * from './constants/vaults';
+export * from './utils/sortRewardsByUnderlyingToken';

--- a/suite-common/earn-stablecoin-api/src/tests/utils/sortRewardsByUnderlyingToken.test.ts
+++ b/suite-common/earn-stablecoin-api/src/tests/utils/sortRewardsByUnderlyingToken.test.ts
@@ -1,0 +1,87 @@
+import { type RewardDto, type TokenDto } from '../../api';
+import { sortRewardsByUnderlyingToken } from '../../utils/sortRewardsByUnderlyingToken';
+
+const USDC: TokenDto = {
+    symbol: 'USDC',
+    name: 'USD Coin',
+    decimals: 6,
+    network: 'ethereum',
+    address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+};
+
+const MORPHO: TokenDto = {
+    symbol: 'MORPHO',
+    name: 'Morpho',
+    decimals: 18,
+    network: 'ethereum',
+    address: '0x58d97b57bb95320f9a05dc918aef65434969c2b2',
+};
+
+const ARB: TokenDto = {
+    symbol: 'ARB',
+    name: 'Arbitrum',
+    decimals: 18,
+    network: 'arbitrum',
+    address: '0x912ce59144191c1204e64559fe8253a0e49e6548',
+};
+
+const reward = (
+    token: TokenDto,
+    yieldSource: RewardDto['yieldSource'],
+    rate: number,
+): RewardDto => ({ token, yieldSource, rate, rateType: 'APY' });
+
+describe('sortRewardsByUnderlyingToken', () => {
+    it('puts the underlying-asset reward first', () => {
+        const underlying = reward(USDC, 'lending_interest', 0.04);
+        const incentive = reward(MORPHO, 'protocol_incentive', 0.1);
+
+        expect(sortRewardsByUnderlyingToken([incentive, underlying], USDC)).toEqual([
+            underlying,
+            incentive,
+        ]);
+    });
+
+    it('matches underlying token by address case-insensitively', () => {
+        const underlyingToken: TokenDto = { ...USDC, address: USDC.address!.toUpperCase() };
+        const underlying = reward(USDC, 'lending_interest', 0.04);
+        const incentive = reward(MORPHO, 'protocol_incentive', 0.5);
+
+        const [first] = sortRewardsByUnderlyingToken([incentive, underlying], underlyingToken);
+
+        expect(first).toBe(underlying);
+    });
+
+    it('sorts non-underlying rewards by rate descending', () => {
+        const underlying = reward(USDC, 'lending_interest', 0.04);
+        const incentiveHigh = reward(MORPHO, 'protocol_incentive', 0.2);
+        const incentiveLow = reward(ARB, 'protocol_incentive', 0.01);
+
+        const sorted = sortRewardsByUnderlyingToken(
+            [incentiveLow, incentiveHigh, underlying],
+            USDC,
+        );
+
+        expect(sorted).toEqual([underlying, incentiveHigh, incentiveLow]);
+    });
+
+    it('falls back to rate-only sort when underlying is missing from rewards', () => {
+        const incentiveHigh = reward(MORPHO, 'protocol_incentive', 0.2);
+        const incentiveLow = reward(ARB, 'protocol_incentive', 0.01);
+
+        expect(sortRewardsByUnderlyingToken([incentiveLow, incentiveHigh], USDC)).toEqual([
+            incentiveHigh,
+            incentiveLow,
+        ]);
+    });
+
+    it('falls back to rate-only sort when underlyingToken is undefined', () => {
+        const lending = reward(USDC, 'lending_interest', 0.04);
+        const incentive = reward(MORPHO, 'protocol_incentive', 0.2);
+
+        expect(sortRewardsByUnderlyingToken([lending, incentive], undefined)).toEqual([
+            incentive,
+            lending,
+        ]);
+    });
+});

--- a/suite-common/earn-stablecoin-api/src/utils/sortRewardsByUnderlyingToken.ts
+++ b/suite-common/earn-stablecoin-api/src/utils/sortRewardsByUnderlyingToken.ts
@@ -1,0 +1,29 @@
+import { type RewardDto, type TokenDto } from '../api/yieldxyz';
+
+const isSameToken = (a: TokenDto, b: TokenDto) => {
+    if (a.address && b.address) {
+        return a.address.toLowerCase() === b.address.toLowerCase();
+    }
+
+    if (!a.address && !b.address) {
+        return a.network === b.network && a.symbol === b.symbol;
+    }
+
+    return false;
+};
+
+export const sortRewardsByUnderlyingToken = (
+    rewards: RewardDto[],
+    underlyingToken: TokenDto | undefined,
+) =>
+    rewards.toSorted((a, b) => {
+        if (underlyingToken) {
+            const isAUnderlying = isSameToken(a.token, underlyingToken);
+            const isBUnderlying = isSameToken(b.token, underlyingToken);
+
+            if (isAUnderlying && !isBUnderlying) return -1;
+            if (isBUnderlying && !isAUnderlying) return 1;
+        }
+
+        return b.rate - a.rate;
+    });

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2330,7 +2330,6 @@ export const messages = {
     earn: {
         staking: 'Staking',
         stablecoinYield: 'Stablecoin yield',
-        vaultName: '{vaultName} Vault',
         portfolioTracker: {
             alert: {
                 title: 'Staking is disabled in the portfolio tracker',

--- a/suite-native/module-accounts-management/src/components/StablecoinYieldApyBreakdown.tsx
+++ b/suite-native/module-accounts-management/src/components/StablecoinYieldApyBreakdown.tsx
@@ -1,6 +1,10 @@
 import { useMemo } from 'react';
 
-import { type RewardDto } from '@suite-common/earn-stablecoin-api';
+import {
+    type RewardDto,
+    type TokenDto,
+    sortRewardsByUnderlyingToken,
+} from '@suite-common/earn-stablecoin-api';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type TokenAddress } from '@suite-common/wallet-types';
 import { getApyPercent } from '@suite-common/wallet-utils';
@@ -8,11 +12,12 @@ import { Box, HStack, Text, VStack } from '@suite-native/atoms';
 import { CryptoIconWithNetwork, Icon, cryptoIconSizes } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 
-import { getApyBreakdownDescriptionKey, sortApyRewards } from '../utils';
+import { getApyBreakdownDescriptionKey } from '../utils';
 
 type StablecoinYieldApyBreakdownProps = {
     networkSymbol: NetworkSymbol;
     rewards: RewardDto[];
+    underlyingToken: TokenDto | undefined;
 };
 
 type RewardRowProps = {
@@ -60,8 +65,12 @@ const RewardRow = ({ reward, networkSymbol }: RewardRowProps) => {
 export const StablecoinYieldApyBreakdown = ({
     networkSymbol,
     rewards,
+    underlyingToken,
 }: StablecoinYieldApyBreakdownProps) => {
-    const sortedRewards = useMemo(() => sortApyRewards(rewards), [rewards]);
+    const sortedRewards = useMemo(
+        () => sortRewardsByUnderlyingToken(rewards, underlyingToken),
+        [rewards, underlyingToken],
+    );
 
     return (
         <Box testID="@account-detail/stablecoin-yield/apy-breakdown-sheet">

--- a/suite-native/module-accounts-management/src/components/StablecoinYieldTokenOverview.tsx
+++ b/suite-native/module-accounts-management/src/components/StablecoinYieldTokenOverview.tsx
@@ -107,6 +107,7 @@ export const StablecoinYieldTokenOverview = ({
                 <StablecoinYieldApyBreakdown
                     networkSymbol={account.symbol}
                     rewards={vault.rewardRate.components}
+                    underlyingToken={vault.token}
                 />
             ),
             textAlign: 'center',

--- a/suite-native/module-accounts-management/src/components/StablecoinYieldTokenOverview.tsx
+++ b/suite-native/module-accounts-management/src/components/StablecoinYieldTokenOverview.tsx
@@ -94,11 +94,7 @@ export const StablecoinYieldTokenOverview = ({
         }
 
         showAlert({
-            title: vault.outputToken?.name ? (
-                <Translation id="earn.vaultName" values={{ vaultName: vault.outputToken.name }} />
-            ) : (
-                ''
-            ),
+            title: vault.outputToken?.name ?? '',
             description: translate(
                 'moduleAccounts.accountDetail.stablecoinYield.apyBreakdown.apyLabel',
                 { apy },
@@ -171,16 +167,7 @@ export const StablecoinYieldTokenOverview = ({
                         <Text variant="body-sm" color="contentSecondary">
                             <Translation id="moduleAccounts.accountDetail.stablecoinYield.vault" />
                         </Text>
-                        <Text variant="body-sm">
-                            {vault.outputToken?.name ? (
-                                <Translation
-                                    id="earn.vaultName"
-                                    values={{ vaultName: vault.outputToken.name }}
-                                />
-                            ) : (
-                                ''
-                            )}
-                        </Text>
+                        <Text variant="body-sm">{vault.outputToken?.name ?? ''}</Text>
                     </HStack>
                     <CardDivider />
                     <PressableOpacity

--- a/suite-native/module-accounts-management/src/utils.ts
+++ b/suite-native/module-accounts-management/src/utils.ts
@@ -1,28 +1,13 @@
-import { type RewardDto, type RewardDtoYieldSource } from '@suite-common/earn-stablecoin-api';
+import { type RewardDtoYieldSource } from '@suite-common/earn-stablecoin-api';
 import { type TxKeyPath } from '@suite-native/intl';
-
-export const sortApyRewards = (rewards: RewardDto[]) =>
-    rewards.toSorted((rewardA, rewardB) => {
-        if (rewardA.yieldSource === 'vault') {
-            return -1;
-        }
-
-        if (rewardB.yieldSource === 'vault') {
-            return 1;
-        }
-
-        return rewardB.rate - rewardA.rate;
-    });
 
 export const getApyBreakdownDescriptionKey = (
     yieldSource: RewardDtoYieldSource,
 ): TxKeyPath | null => {
     switch (yieldSource) {
-        case 'vault':
         case 'lending_interest':
             return 'moduleAccounts.accountDetail.stablecoinYield.apyBreakdown.autoCompounded';
         case 'protocol_incentive':
-        case 'points':
             return 'moduleAccounts.accountDetail.stablecoinYield.apyBreakdown.manualCompound';
         default:
             return null;

--- a/suite-native/module-earn/src/hooks/useStablecoinYieldListData.ts
+++ b/suite-native/module-earn/src/hooks/useStablecoinYieldListData.ts
@@ -8,7 +8,6 @@ import {
     selectVisibleDeviceAccounts,
 } from '@suite-common/wallet-core';
 import { toTokenAddress, toTokenSymbol } from '@suite-common/wallet-types';
-import { useTranslate } from '@suite-native/intl';
 
 import {
     type EarnPromoListDataItem,
@@ -31,7 +30,6 @@ type UseStablecoinYieldListDataReturn = {
 export const useStablecoinYieldListData = () => {
     const accounts = useSelector(selectVisibleDeviceAccounts);
     const isDebugEnabled = useStablecoinYieldFlag();
-    const { translate } = useTranslate();
 
     const { yieldOpportunities, isLoading } = useAllYieldOpportunities({
         enabled: isDebugEnabled,
@@ -89,9 +87,7 @@ export const useStablecoinYieldListData = () => {
             const defaultYieldItem: StablecoinYieldEarnItem = {
                 id: vault.id,
                 type: 'stablecoin-yield',
-                vaultName: vault.outputToken?.name
-                    ? translate('earn.vaultName', { vaultName: vault.outputToken.name })
-                    : '',
+                vaultName: vault.outputToken?.name ?? '',
                 tokenSymbol: stablecoinSymbol,
                 networkSymbol: network.symbol,
                 contractAddress: tokenContractAddress,
@@ -135,5 +131,5 @@ export const useStablecoinYieldListData = () => {
         const promoListData: EarnPromoListDataItem[] = ['stablecoin-yield', ...promoItems];
 
         return { activeItems, promoListData };
-    }, [accounts, yieldOpportunities, isDebugEnabled, isLoading, translate]);
+    }, [accounts, yieldOpportunities, isDebugEnabled, isLoading]);
 };

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -9681,10 +9681,6 @@ export const messages = defineMessages({
         id: 'TR_EARN_STABLECOIN_YIELD_TITLE',
         defaultMessage: 'Stablecoin yield',
     },
-    TR_EARN_VAULT_NAME: {
-        id: 'TR_EARN_VAULT_NAME',
-        defaultMessage: '{vaultName} Vault',
-    },
     TR_EARN_YIELD_PENDING_SUPPLY: {
         id: 'TR_EARN_YIELD_PENDING_SUPPLY',
         defaultMessage: 'Confirming deposit...',
@@ -10076,10 +10072,10 @@ export const messages = defineMessages({
         id: 'TR_EARN_SUPPLYING_IN_A_NUTSHELL',
         defaultMessage: 'Stablecoin yield explained',
     },
-    TR_EARN_YIELD_NUTSHELL_AMOUNT_LOCKED: {
-        id: 'TR_EARN_YIELD_NUTSHELL_AMOUNT_LOCKED',
+    TR_EARN_YIELD_NUTSHELL_DEPOSITED_AMOUNT: {
+        id: 'TR_EARN_YIELD_NUTSHELL_DEPOSITED_AMOUNT',
         defaultMessage:
-            'The deposited amount of {supplySymbol} is locked until you withdraw it. Withdrawal is instant.',
+            'The deposited amount of {supplySymbol} is always available. Withdrawal is instant.',
     },
     TR_EARN_YIELD_NUTSHELL_COMPOUND_INTEREST: {
         id: 'TR_EARN_YIELD_NUTSHELL_COMPOUND_INTEREST',
@@ -10090,10 +10086,10 @@ export const messages = defineMessages({
         defaultMessage:
             'Deposit {supplySymbol} to receive {vaultSymbol} tokens. These tokens represent your vault position.',
     },
-    TR_EARN_YIELD_NUTSHELL_PROTOCOL_REWARDS: {
-        id: 'TR_EARN_YIELD_NUTSHELL_PROTOCOL_REWARDS',
+    TR_EARN_YIELD_NUTSHELL_CLAIM_REWARDS: {
+        id: 'TR_EARN_YIELD_NUTSHELL_CLAIM_REWARDS',
         defaultMessage:
-            'You will earn {rewardsSymbol} tokens as rewards. These must be claimed separately.',
+            "You'll earn {rewardsSymbol} tokens as rewards. These could be temporary & must be claimed separately.",
     },
     TR_EARN_YIELD_APPROVE_SPENDING_TRANSACTION: {
         id: 'TR_EARN_YIELD_APPROVE_SPENDING_TRANSACTION',
@@ -10123,24 +10119,25 @@ export const messages = defineMessages({
         id: 'TR_EARN_SUPPLY_TOKEN',
         defaultMessage: 'Deposit {symbol}',
     },
-    TR_EARN_SUPPLY_PROVIDER_MANAGES: {
-        id: 'TR_EARN_SUPPLY_PROVIDER_MANAGES',
+    TR_EARN_SUPPLY_RECEIPT_TOKENS_INFO: {
+        id: 'TR_EARN_SUPPLY_RECEIPT_TOKENS_INFO',
         defaultMessage:
-            '{providerName} maintains and protects your deposited {networkDisplaySymbol} with their smart contracts, infrastructure, and technology.',
+            "Your tokens will be transferred to the {providerName} protocol's smart contracts. You'll receive receipt tokens representing your proportional claim on the vault's assets.",
     },
-    TR_EARN_SUPPLY_PROVIDER_NO_LIABILITY: {
-        id: 'TR_EARN_SUPPLY_PROVIDER_NO_LIABILITY',
+    TR_EARN_SUPPLY_FULL_CONTROL_INFO: {
+        id: 'TR_EARN_SUPPLY_FULL_CONTROL_INFO',
         defaultMessage:
-            "When depositing, the responsibility for your funds' security transitions from your Trezor to {providerName}.",
+            'You keep full control. Your Trezor stays the signer. You can withdraw anytime, subject to vault liquidity.',
     },
-    TR_EARN_SUPPLY_PROVIDER_SMART_CONTRACT_RISK: {
-        id: 'TR_EARN_SUPPLY_PROVIDER_SMART_CONTRACT_RISK',
+    TR_EARN_SUPPLY_PROTOCOL_RISKS_INFO: {
+        id: 'TR_EARN_SUPPLY_PROTOCOL_RISKS_INFO',
         defaultMessage:
-            "Depositing assets involves smart contract risks. {providerName} applies rigorous security measures, but can't guarantee against all losses.",
+            'Smart contract, oracle, and curator risks apply. Yield is variable and not guaranteed.',
     },
-    TR_EARN_CONSENT_TO_SUPPLY_WITH_PROVIDER: {
-        id: 'TR_EARN_CONSENT_TO_SUPPLY_WITH_PROVIDER',
-        defaultMessage: 'I acknowledge and consent to deposit with {providerName}.',
+    TR_EARN_CONSENT_PROTOCOL_TERMS_AND_DISCLAIMER: {
+        id: 'TR_EARN_CONSENT_PROTOCOL_TERMS_AND_DISCLAIMER',
+        defaultMessage:
+            "Accessing the {providerName} Protocol through this app is governed by Trezor's <tos>Terms of Use</tos> and <disclaimer>{providerName}'s Disclaimer</disclaimer>.",
     },
     TR_EARN_PROVIDER_UPDATE: {
         id: 'TR_EARN_PROVIDER_UPDATE',
@@ -10594,10 +10591,6 @@ export const messages = defineMessages({
     TR_EARN_YOUR_STAKED_FUNDS_MAINTAINED: {
         id: 'TR_EARN_YOUR_STAKED_FUNDS_MAINTAINED',
         defaultMessage: 'Your staked funds are maintained by {providerName}.',
-    },
-    TR_EARN_YOUR_SUPPLIED_FUNDS_MAINTAINED: {
-        id: 'TR_EARN_YOUR_SUPPLIED_FUNDS_MAINTAINED',
-        defaultMessage: 'Your deposited funds are maintained by {providerName}.',
     },
     TR_EARN_STAKE_EVERSTAKE_MANAGES: {
         id: 'TR_EARN_STAKE_EVERSTAKE_MANAGES',


### PR DESCRIPTION
## Description

- claim banner is not visible when there are no rewards when user is not yielding
- APY rewards are sorted in rewards tooltip, supply token always first
- texts updated in nutshell and maintained modal
- staking logos are svg
- stablecoin yield logos does not have border
- accounts without rewards are filtered from claim 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27319
Resolve https://github.com/trezor/trezor-suite/issues/27318
Resolve https://github.com/trezor/trezor-suite/issues/27315
Resolve https://github.com/trezor/trezor-suite/issues/27323
Resolve https://github.com/trezor/trezor-suite/issues/27320
Resolve #27408


## Screenshots:

<img width="1320" height="904" alt="Screenshot 2026-05-06 at 15 09 51" src="https://github.com/user-attachments/assets/aaee2a5d-296d-47e0-bb53-913f5b4e3b88" />

<img width="470" height="540" alt="Screenshot 2026-05-06 at 15 24 08" src="https://github.com/user-attachments/assets/514d1f24-6d95-4714-9a04-39a4d77d77a0" />

<img width="691" height="572" alt="Screenshot 2026-05-06 at 15 28 10" src="https://github.com/user-attachments/assets/f07b3d61-ccbb-4031-b923-a20b4993c405" />
<img width="704" height="322" alt="Screenshot 2026-05-06 at 15 51 33" src="https://github.com/user-attachments/assets/277ceed2-cd56-4509-bc3b-8e9659afe3fa" />



<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/stablecoin-yield-udpates&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/stablecoin-yield-udpates&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/stablecoin-yield-udpates&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-06T13:03:46.225Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-06T13:59:50.852Z • 13 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/stablecoin-yield-udpates/web/](https://dev.suite.sldev.cz/suite-web/feat/stablecoin-yield-udpates/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->