### PR TITLE
Stablecoin yield - tx simulation (withdraw, claim)

### DIFF
--- a/packages/eslint/src/localRulesConfig.mjs
+++ b/packages/eslint/src/localRulesConfig.mjs
@@ -29,6 +29,7 @@ const publishableTrezorPackages = [
     '@trezor/utils',
     '@trezor/utxo-lib',
     '@trezor/websocket-client',
+    '@suite-common/schemas',
 ];
 
 /** @type {Config[]} */

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -51,6 +51,7 @@
         "@suite-common/platform-encryption": "workspace:*",
         "@suite-common/react-query": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",
+        "@suite-common/schemas": "workspace:^",
         "@suite-common/sentry": "workspace:*",
         "@suite-common/staking": "workspace:*",
         "@suite-common/staking-solana": "workspace:*",

--- a/packages/suite/src/actions/wallet/stablecoinYieldSigningThunks.ts
+++ b/packages/suite/src/actions/wallet/stablecoinYieldSigningThunks.ts
@@ -3,7 +3,7 @@ import { fromWei } from 'web3-utils';
 import { closeModal, openDeferredModal, preserveModal } from '@suite/modal';
 import { asEvmAddress, buildClaim } from '@suite-common/calldata';
 import { selectSelectedDevice } from '@suite-common/device';
-import { type SupplyTxSimulationParams } from '@suite-common/earn-stablecoin/src/tx-simulation';
+import { type StablecoinYieldTxSimulationParams } from '@suite-common/earn-stablecoin/src/tx-simulation';
 import {
     type TransactionDto,
     flattenEvmFees,
@@ -430,7 +430,7 @@ export const submitYieldActionThunk = createThunk(
                     data: {
                         unsignedSupplyTx: actionTransaction.unsignedTransaction,
                         account: flowData.account,
-                    } satisfies SupplyTxSimulationParams,
+                    } satisfies StablecoinYieldTxSimulationParams,
                 }),
             );
 

--- a/packages/suite/src/actions/wallet/stablecoinYieldSigningThunks.ts
+++ b/packages/suite/src/actions/wallet/stablecoinYieldSigningThunks.ts
@@ -338,8 +338,8 @@ const sendYieldTransaction = async ({
         );
 
         return pushResponse.payload;
-        // eslint-disable-next-line no-useless-catch
     } catch (error) {
+        console.error(error);
         throw error;
     } finally {
         dispatch(stablecoinYieldActions.discardTransaction());
@@ -418,31 +418,27 @@ export const submitYieldActionThunk = createThunk(
                 return;
             }
 
-            let selectedFee: EvmSelectedFee | null = null;
+            if (typeof actionTransaction.unsignedTransaction !== 'string') {
+                setYieldGenericError({ dispatch, flowType, flowKey });
 
-            if (flowType === 'supply') {
-                if (typeof actionTransaction.unsignedTransaction !== 'string') {
-                    setYieldGenericError({ dispatch, flowType, flowKey });
-
-                    return;
-                }
-
-                const userAcceptedTxSimulation = await dispatch(
-                    openDeferredModal({
-                        type: 'earn-yield-tx-simulation',
-                        data: {
-                            unsignedSupplyTx: actionTransaction.unsignedTransaction,
-                            account: flowData.account,
-                        } satisfies SupplyTxSimulationParams,
-                    }),
-                );
-
-                if (userAcceptedTxSimulation?.value === false) {
-                    return;
-                }
-
-                selectedFee = userAcceptedTxSimulation?.selectedFee ?? null;
+                return;
             }
+
+            const userAcceptedTxSimulation = await dispatch(
+                openDeferredModal({
+                    type: 'earn-yield-tx-simulation',
+                    data: {
+                        unsignedSupplyTx: actionTransaction.unsignedTransaction,
+                        account: flowData.account,
+                    } satisfies SupplyTxSimulationParams,
+                }),
+            );
+
+            if (userAcceptedTxSimulation?.value === false) {
+                return;
+            }
+
+            const selectedFee = userAcceptedTxSimulation?.selectedFee ?? null;
 
             const isWithdraw = flowType === 'withdraw';
             const reviewAmount = isWithdraw ? requestAmount : amount;

--- a/packages/suite/src/actions/wallet/stablecoinYieldSigningThunks.ts
+++ b/packages/suite/src/actions/wallet/stablecoinYieldSigningThunks.ts
@@ -1,4 +1,4 @@
-import { fromWei } from 'web3-utils';
+import { fromWei, hexToNumberString, numberToHex } from 'web3-utils';
 
 import { closeModal, openDeferredModal, preserveModal } from '@suite/modal';
 import { asEvmAddress, buildClaim } from '@suite-common/calldata';
@@ -6,12 +6,16 @@ import { selectSelectedDevice } from '@suite-common/device';
 import { type StablecoinYieldTxSimulationParams } from '@suite-common/earn-stablecoin/src/tx-simulation';
 import {
     type TransactionDto,
-    flattenEvmFees,
-    parseEvmFee,
     parseUnsignedEvmTransactionForSigning,
     submitTransactionHash,
 } from '@suite-common/earn-stablecoin-api';
 import { createThunk } from '@suite-common/redux-utils';
+import {
+    type EvmFeeHex,
+    type EvmHexString,
+    flattenEvmFees,
+    parseEvmFeeHex,
+} from '@suite-common/schemas/src/evm';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import {
     type NetworkSymbol,
@@ -39,6 +43,7 @@ import {
 import { ethereumGetCurrentNonceThunk } from '@suite-common/wallet-core/src/send/sendFormEthereumThunks';
 import {
     type Account,
+    type AccountDescriptor,
     AddressDisplayOptions,
     type EvmSelectedFee,
     type FormState,
@@ -49,10 +54,14 @@ import {
     convertAmountUnitsToSubunits,
     getAccountIdentity,
     getContractAddressForNetworkSymbol,
-    prepareEthereumTransaction,
+    sanitizeHex,
     strip,
 } from '@suite-common/wallet-utils';
-import TrezorConnect, { type EthereumSignTransaction, type TokenInfo } from '@trezor/connect';
+import TrezorConnect, {
+    type EthereumSignTransaction,
+    type StaticSessionId,
+    type TokenInfo,
+} from '@trezor/connect';
 import { BigNumber } from '@trezor/utils';
 
 import type { MerkleRewardWithFiat } from 'src/components/earn/dashboard/yield/hooks/useMerkleRewards';
@@ -249,7 +258,7 @@ const sendYieldTransaction = async ({
         throw new Error('Unsupported yield transaction payload.');
     }
 
-    const parsedSelectedFee = parseEvmFee(selectedFee ?? parsedTx);
+    const parsedSelectedFee = parseEvmFeeHex(selectedFee ?? parsedTx);
 
     if (!parsedSelectedFee) {
         throw new Error('Fee information is missing for the transaction.');
@@ -428,7 +437,8 @@ export const submitYieldActionThunk = createThunk(
                 openDeferredModal({
                     type: 'earn-yield-tx-simulation',
                     data: {
-                        unsignedSupplyTx: actionTransaction.unsignedTransaction,
+                        flow: flowType,
+                        unsignedTx: actionTransaction.unsignedTransaction,
                         account: flowData.account,
                     } satisfies StablecoinYieldTxSimulationParams,
                 }),
@@ -508,47 +518,35 @@ export const submitYieldActionThunk = createThunk(
 );
 
 type BuildClaimReviewStateParams = {
-    data: string;
-    contractAddress: `0x${string}`;
-    gasLimit: BigNumber;
-    gasPrice?: BigNumber;
-    maxFeePerGas?: BigNumber;
-    maxPriorityFeePerGas?: BigNumber;
-    baseFeePerGas?: BigNumber;
+    data: EvmHexString;
+    contractAddress: EvmHexString;
+    fee: EvmFeeHex;
 };
 
 const buildClaimReviewState = ({
     data,
     contractAddress,
-    gasLimit,
-    gasPrice,
-    maxFeePerGas,
-    maxPriorityFeePerGas,
-    baseFeePerGas,
+    fee,
 }: BuildClaimReviewStateParams): BuildYieldReviewStateResult => {
-    const feePrice = maxFeePerGas ?? gasPrice;
+    const feePriceWei = new BigNumber(
+        hexToNumberString(fee.type === 'eip1559' ? fee.maxFeePerGas : fee.gasPrice),
+    );
+    const feeLimitWei = hexToNumberString(fee.gasLimit);
+    const feeWei = new BigNumber(feeLimitWei).multipliedBy(feePriceWei).toFixed(0);
 
-    if (typeof feePrice === 'undefined') {
-        throw new Error('Fee price is missing.');
-    }
+    const feePerUnitGwei = fromWei(feePriceWei.toFixed(0), 'gwei');
+    const eip1559Fields: {
+        maxFeePerGasGwei?: PrecomposedTransactionFinal['maxFeePerGas'];
+        maxPriorityFeePerGasGwei?: PrecomposedTransactionFinal['maxPriorityFeePerGas'];
+        baseFeePerGasGwei?: FormState['baseFeePerGas'];
+    } = {};
 
-    const feeWei = gasLimit.multipliedBy(feePrice).toFixed(0);
-    let eip1559TransactionFields: Partial<
-        Pick<PrecomposedTransactionFinal, 'maxFeePerGas' | 'maxPriorityFeePerGas'>
-    > = {};
-    let eip1559FormFields: Pick<FormState, 'baseFeePerGas'> = {};
-
-    if (typeof maxFeePerGas !== 'undefined' && typeof maxPriorityFeePerGas !== 'undefined') {
-        eip1559TransactionFields = {
-            maxFeePerGas: fromWei(maxFeePerGas.toFixed(0), 'gwei'),
-            maxPriorityFeePerGas: fromWei(maxPriorityFeePerGas.toFixed(0), 'gwei'),
-        };
-        eip1559FormFields = {
-            baseFeePerGas:
-                typeof baseFeePerGas !== 'undefined'
-                    ? fromWei(baseFeePerGas.toFixed(0), 'gwei')
-                    : undefined,
-        };
+    if (fee.type === 'eip1559') {
+        Object.assign(eip1559Fields, {
+            maxFeePerGasGwei: fromWei(hexToNumberString(fee.maxFeePerGas), 'gwei'),
+            maxPriorityFeePerGasGwei: fromWei(hexToNumberString(fee.maxPriorityFeePerGas), 'gwei'),
+            baseFeePerGasGwei: fromWei(hexToNumberString(fee.baseFeePerGas), 'gwei'),
+        });
     }
 
     const formState: FormState = {
@@ -564,10 +562,11 @@ const buildClaimReviewState = ({
             },
         ],
         selectedFee: 'custom',
-        feePerUnit: fromWei(feePrice.toFixed(0), 'gwei'),
-        feeLimit: gasLimit.toFixed(0),
-        ...eip1559TransactionFields,
-        ...eip1559FormFields,
+        feePerUnit: feePerUnitGwei,
+        feeLimit: feeLimitWei,
+        maxFeePerGas: eip1559Fields.maxFeePerGasGwei,
+        maxPriorityFeePerGas: eip1559Fields.maxPriorityFeePerGasGwei,
+        baseFeePerGas: eip1559Fields.baseFeePerGasGwei,
         options: ['broadcast', 'transactionData'],
         transactionData: data,
         isCoinControlEnabled: false,
@@ -577,63 +576,20 @@ const buildClaimReviewState = ({
 
     const precomposedTransaction: PrecomposedTransactionFinal = {
         type: 'final',
-        fee: feeWei,
-        feePerByte: fromWei(feePrice.toFixed(0), 'gwei'),
-        feeLimit: gasLimit.toFixed(0),
-        totalSpent: feeWei,
         bytes: 0,
         inputs: [],
         outputs: [{ address: contractAddress, amount: '0' }],
         outputsPermutation: [0],
-        ...eip1559TransactionFields,
+
+        totalSpent: feeWei,
+        fee: feeWei,
+        feePerByte: feePerUnitGwei,
+        feeLimit: feeLimitWei,
+        maxFeePerGas: eip1559Fields.maxFeePerGasGwei,
+        maxPriorityFeePerGas: eip1559Fields.maxPriorityFeePerGasGwei,
     };
 
     return { formState, precomposedTransaction };
-};
-
-type ClaimEstimateFeeLevel = {
-    feePerUnit?: string;
-    feeLimit?: string;
-    eip1559?: {
-        baseFeePerGas?: string;
-        medium?: {
-            maxFeePerGas?: string;
-            maxPriorityFeePerGas?: string;
-        };
-    };
-};
-
-type ClaimFeeFields = {
-    gasLimit: BigNumber;
-    gasPrice?: BigNumber;
-    maxFeePerGas?: BigNumber;
-    maxPriorityFeePerGas?: BigNumber;
-    baseFeePerGas?: BigNumber;
-};
-
-const getClaimFeeFields = (feeLevel: ClaimEstimateFeeLevel): ClaimFeeFields => {
-    const gasLimit = new BigNumber(feeLevel.feeLimit ?? ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT);
-    const eip1559MediumFee = feeLevel.eip1559?.medium;
-
-    if (eip1559MediumFee?.maxFeePerGas && eip1559MediumFee.maxPriorityFeePerGas) {
-        return {
-            gasLimit,
-            maxFeePerGas: new BigNumber(eip1559MediumFee.maxFeePerGas),
-            maxPriorityFeePerGas: new BigNumber(eip1559MediumFee.maxPriorityFeePerGas),
-            baseFeePerGas: feeLevel.eip1559?.baseFeePerGas
-                ? new BigNumber(feeLevel.eip1559.baseFeePerGas)
-                : undefined,
-        };
-    }
-
-    if (!feeLevel.feePerUnit) {
-        throw new Error('Fee per unit is missing.');
-    }
-
-    return {
-        gasLimit,
-        gasPrice: new BigNumber(feeLevel.feePerUnit),
-    };
 };
 
 export const cancelSignYieldTx = createThunk(
@@ -648,6 +604,60 @@ export const cancelSignYieldTx = createThunk(
         dispatch(closeModal());
     },
 );
+
+interface GetEstimatedClaimFeeParams {
+    networkSymbol: NetworkSymbol;
+    from: AccountDescriptor;
+    to: EvmHexString;
+    data: EvmHexString;
+    deviceState: StaticSessionId;
+    value?: EvmHexString;
+}
+
+async function getEstimatedFee({
+    networkSymbol,
+    from,
+    to,
+    data,
+    deviceState,
+    value = '0x0',
+}: GetEstimatedClaimFeeParams) {
+    const estimatedFee = await TrezorConnect.blockchainEstimateFee({
+        coin: networkSymbol,
+        identity: deviceState,
+        request: {
+            blocks: [2],
+            specific: { from, to, data, value },
+        },
+    });
+
+    if (!estimatedFee.success) {
+        throw new Error('Failed to estimate fee for claim transaction.');
+    }
+
+    const feeLevel = estimatedFee.payload.levels[0];
+
+    if (!feeLevel) {
+        throw new Error('No fee level available.');
+    }
+
+    const gasLimit = feeLevel.feeLimit ?? ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT;
+    const eip1559MediumFee = feeLevel.eip1559?.medium;
+
+    if (eip1559MediumFee && feeLevel.eip1559) {
+        return {
+            maxFeePerGas: eip1559MediumFee.maxFeePerGas,
+            maxPriorityFeePerGas: eip1559MediumFee.maxPriorityFeePerGas,
+            baseFeePerGas: feeLevel.eip1559.baseFeePerGas,
+            gasLimit,
+        };
+    }
+
+    return {
+        gasPrice: feeLevel.feePerUnit,
+        gasLimit,
+    };
+}
 
 type ClaimMerkleRewardsParams = {
     account: Account;
@@ -701,42 +711,59 @@ export const claimMerkleRewardsThunk = createThunk(
                 { sender },
             );
 
-            if (!claimResult.isValid || !claimResult.data) {
+            if (!claimResult.isValid) {
                 throw new Error('Failed to build claim calldata.');
             }
 
-            const estimatedFee = await TrezorConnect.blockchainEstimateFee({
-                coin: account.symbol,
-                request: {
-                    blocks: [2],
-                    specific: {
-                        from: account.descriptor,
-                        to: merklXyzContractAddress,
-                        data: claimResult.data,
-                    },
-                },
+            const estimatedFeeTask = getEstimatedFee({
+                networkSymbol: account.symbol,
+                deviceState: account.deviceState,
+                from: account.descriptor,
+                to: merklXyzContractAddress,
+                data: claimResult.data,
             });
 
-            if (!estimatedFee.success) {
-                throw new Error('Failed to estimate fee for claim transaction.');
-            }
-
-            const feeLevel = estimatedFee.payload.levels[0];
-
-            if (!feeLevel) {
-                throw new Error('No fee level available.');
-            }
-
-            const claimFeeFields = getClaimFeeFields(feeLevel);
-
-            const { nonce } = await dispatch(
+            const nonceTask = dispatch(
                 ethereumGetCurrentNonceThunk({ selectedAccount: account }),
             ).unwrap();
 
-            const { formState, precomposedTransaction } = buildClaimReviewState({
+            const [estimatedFee, { nonce }] = await Promise.all([estimatedFeeTask, nonceTask]);
+
+            const unsignedClaimTx = {
+                to: merklXyzContractAddress,
                 data: claimResult.data,
-                contractAddress: merklXyzContractAddress,
-                ...claimFeeFields,
+                chainId: network.chainId,
+                maxPriorityFeePerGas: estimatedFee.maxPriorityFeePerGas,
+                maxFeePerGas: estimatedFee.maxFeePerGas,
+                gasLimit: estimatedFee.gasLimit,
+                nonce,
+            };
+
+            const userAcceptedTxSimulation = await dispatch(
+                openDeferredModal({
+                    type: 'earn-yield-tx-simulation',
+                    data: {
+                        flow: 'claim',
+                        account,
+                        unsignedTx: unsignedClaimTx,
+                    } satisfies StablecoinYieldTxSimulationParams,
+                }),
+            );
+
+            if (userAcceptedTxSimulation?.value === false) {
+                return;
+            }
+
+            const parsedSelectedFee = parseEvmFeeHex(userAcceptedTxSimulation?.selectedFee);
+
+            if (!parsedSelectedFee) {
+                throw new Error('Fee information is missing for the transaction.');
+            }
+
+            const { formState, precomposedTransaction } = buildClaimReviewState({
+                data: unsignedClaimTx.data,
+                contractAddress: unsignedClaimTx.to,
+                fee: parsedSelectedFee,
             });
 
             dispatch(
@@ -746,33 +773,6 @@ export const claimMerkleRewardsThunk = createThunk(
                     accountKey: account.key,
                 }),
             );
-
-            const commonTxFields = {
-                to: merklXyzContractAddress,
-                amount: '0',
-                chainId: network.chainId,
-                nonce,
-                gasLimit: claimFeeFields.gasLimit.toFixed(0),
-                data: claimResult.data,
-            };
-            const { gasPrice, maxFeePerGas, maxPriorityFeePerGas } = claimFeeFields;
-
-            const hasEip1559Fees = maxFeePerGas !== undefined && maxPriorityFeePerGas !== undefined;
-
-            if (!hasEip1559Fees && gasPrice === undefined) {
-                throw new Error('Gas price is missing.');
-            }
-
-            const transactionForSigning: EthereumSignTransaction['transaction'] = hasEip1559Fees
-                ? prepareEthereumTransaction({
-                      ...commonTxFields,
-                      maxFeePerGas: fromWei(maxFeePerGas.toFixed(0), 'gwei'),
-                      maxPriorityFeePerGas: fromWei(maxPriorityFeePerGas.toFixed(0), 'gwei'),
-                  })
-                : prepareEthereumTransaction({
-                      ...commonTxFields,
-                      gasPrice: fromWei(gasPrice!.toFixed(0), 'gwei'),
-                  });
 
             try {
                 dispatch(preserveModal());
@@ -785,7 +785,22 @@ export const claimMerkleRewardsThunk = createThunk(
                         useEmptyPassphrase: device.useEmptyPassphrase,
                     },
                     path: account.path,
-                    transaction: transactionForSigning,
+                    transaction: {
+                        to: unsignedClaimTx.to,
+                        chainId: unsignedClaimTx.chainId,
+                        value: '0x0',
+                        nonce: numberToHex(unsignedClaimTx.nonce),
+                        data: sanitizeHex(unsignedClaimTx.data),
+                        gasLimit: parsedSelectedFee.gasLimit,
+                        ...(parsedSelectedFee.type === 'eip1559'
+                            ? {
+                                  maxFeePerGas: parsedSelectedFee.maxFeePerGas,
+                                  maxPriorityFeePerGas: parsedSelectedFee.maxPriorityFeePerGas,
+                              }
+                            : {
+                                  gasPrice: parsedSelectedFee.gasPrice,
+                              }),
+                    },
                     chunkify: addressDisplayType === AddressDisplayOptions.CHUNKED,
                 });
 
@@ -854,9 +869,14 @@ export const claimMerkleRewardsThunk = createThunk(
                 );
 
                 return pushResponse.payload;
+                // eslint-disable-next-line no-useless-catch
+            } catch (error) {
+                throw error;
             } finally {
                 dispatch(stablecoinYieldActions.discardTransaction());
             }
+        } catch (error) {
+            console.error(error);
         } finally {
             dispatch(stablecoinYieldActions.finishSubmittingAction({ flowType: 'claim', flowKey }));
         }

--- a/packages/suite/src/components/earn/yield/common/YieldActionStep.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldActionStep.tsx
@@ -29,6 +29,7 @@ export type YieldActionStepProps = {
     token: YieldFlowDisplayToken;
     summaryValue: ReactNode;
     isDisabled?: boolean;
+    isPending?: boolean;
     warning?: ReactNode;
     networkFeeWarning?: ReactNode;
     pendingTransaction?: YieldPendingTransactionState;
@@ -42,6 +43,7 @@ export const YieldActionStep = ({
     token,
     summaryValue,
     isDisabled = false,
+    isPending = false,
     warning,
     networkFeeWarning,
     pendingTransaction,
@@ -74,7 +76,8 @@ export const YieldActionStep = ({
                 size="large"
                 width="100%"
                 onClick={onSubmit}
-                isDisabled={isDisabled || !!pendingTransaction}
+                isDisabled={isDisabled}
+                isLoading={isPending}
             >
                 <Translation id={submitTranslationId} />
             </Button>

--- a/packages/suite/src/components/earn/yield/supply/YieldSupplyForm.tsx
+++ b/packages/suite/src/components/earn/yield/supply/YieldSupplyForm.tsx
@@ -276,6 +276,7 @@ export const YieldSupplyForm = () => {
                                                 isApprovalInsufficient ||
                                                 isSubmittingAction
                                             }
+                                            isPending={isSubmittingAction}
                                             pendingTransaction={supplyPendingTransaction}
                                             onMaxClick={() => setAmountInput(maxAmount)}
                                             onSubmit={handleOnSupply}

--- a/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
+++ b/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
@@ -129,6 +129,7 @@ export const YieldWithdrawForm = () => {
                                 ) : undefined
                             }
                             isDisabled={!liveAmount || isAmountTooHigh || isSubmittingAction}
+                            isPending={isSubmittingAction}
                             pendingTransaction={withdrawPendingTransaction}
                             onMaxClick={() => setAmountInput(maxAmount)}
                             onSubmit={handleOnWithdraw}

--- a/packages/suite/src/components/tx-simulation/common/hooks/useEvmTxSimulationFeesForm.ts
+++ b/packages/suite/src/components/tx-simulation/common/hooks/useEvmTxSimulationFeesForm.ts
@@ -8,11 +8,7 @@ import { type NetworkSymbol, type NetworkType } from '@suite-common/wallet-confi
 import { ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT } from '@suite-common/wallet-constants';
 import { selectRawNetworkFeeInfo } from '@suite-common/wallet-core';
 import { type EvmSelectedFee } from '@suite-common/wallet-types';
-import {
-    getConvertedOrDefaultFeeInfo,
-    hasEip1559MaxPriorityFee,
-    isEip1559,
-} from '@suite-common/wallet-utils';
+import { getConvertedOrDefaultFeeInfo } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
 
 import { useSelector } from 'src/hooks/suite';
@@ -94,9 +90,14 @@ export function useEvmTxSimulationFeesForm({
             maxFeePerGas: values.maxFeePerGas ?? selectedFeeInfo?.maxFeePerGas,
             maxPriorityFeePerGas:
                 values.maxPriorityFeePerGas ?? selectedFeeInfo?.maxPriorityFeePerGas,
+            baseFeePerGas: values.baseFeePerGas ?? selectedFeeInfo?.baseFeePerGas,
         };
 
-        if (isEip1559(eip1559payload) && hasEip1559MaxPriorityFee(eip1559payload)) {
+        if (
+            eip1559payload.maxFeePerGas &&
+            eip1559payload.maxPriorityFeePerGas &&
+            eip1559payload.baseFeePerGas
+        ) {
             return {
                 type: 'eip1559',
                 gasLimit: numberToHex(values.feeLimit),
@@ -104,6 +105,7 @@ export function useEvmTxSimulationFeesForm({
                 maxPriorityFeePerGas: numberToHex(
                     toWei(eip1559payload.maxPriorityFeePerGas, 'gwei'),
                 ),
+                baseFeePerGas: numberToHex(toWei(eip1559payload.baseFeePerGas, 'gwei')),
             };
         }
 

--- a/packages/suite/src/components/tx-simulation/earn-stablecoin/EarnYieldTxSimulationModal.tsx
+++ b/packages/suite/src/components/tx-simulation/earn-stablecoin/EarnYieldTxSimulationModal.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 
 import { type UserContextModalType } from '@suite/modal';
-import { composeSupplyTxSimmulationAction } from '@suite-common/earn-stablecoin/src/tx-simulation';
+import { composeStablecoinYieldTxSimmulationAction } from '@suite-common/earn-stablecoin/src/tx-simulation';
 import { selectAccountByKey } from '@suite-common/wallet-core';
 
 import { useSelector } from 'src/hooks/suite';
@@ -20,7 +20,7 @@ export function EarnYieldTxSimulationModal({
     decision,
     closeModal,
 }: EarnYieldTxSimulationModalProps) {
-    const parsedData = useMemo(() => composeSupplyTxSimmulationAction(data), [data]);
+    const parsedData = useMemo(() => composeStablecoinYieldTxSimmulationAction(data), [data]);
     const account = useSelector(state =>
         parsedData ? selectAccountByKey(state, parsedData.accountKey) : null,
     );

--- a/packages/suite/src/components/tx-simulation/earn-stablecoin/EarnYieldTxSimulationModal.tsx
+++ b/packages/suite/src/components/tx-simulation/earn-stablecoin/EarnYieldTxSimulationModal.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 
 import { type UserContextModalType } from '@suite/modal';
-import { composeStablecoinYieldTxSimmulationAction } from '@suite-common/earn-stablecoin/src/tx-simulation';
+import { composeStablecoinYieldTxSimulationAction } from '@suite-common/earn-stablecoin/src/tx-simulation';
 import { selectAccountByKey } from '@suite-common/wallet-core';
 
 import { useSelector } from 'src/hooks/suite';
@@ -20,7 +20,7 @@ export function EarnYieldTxSimulationModal({
     decision,
     closeModal,
 }: EarnYieldTxSimulationModalProps) {
-    const parsedData = useMemo(() => composeStablecoinYieldTxSimmulationAction(data), [data]);
+    const parsedData = useMemo(() => composeStablecoinYieldTxSimulationAction(data), [data]);
     const account = useSelector(state =>
         parsedData ? selectAccountByKey(state, parsedData.accountKey) : null,
     );

--- a/packages/suite/tsconfig.json
+++ b/packages/suite/tsconfig.json
@@ -84,6 +84,7 @@
         {
             "path": "../../suite-common/redux-utils"
         },
+        { "path": "../../suite-common/schemas" },
         { "path": "../../suite-common/sentry" },
         { "path": "../../suite-common/staking" },
         {

--- a/suite-common/earn-stablecoin-api/package.json
+++ b/suite-common/earn-stablecoin-api/package.json
@@ -23,6 +23,7 @@
         "@suite-common/calldata": "workspace:^",
         "@suite-common/http-client": "workspace:^",
         "@suite-common/react-query": "workspace:^",
+        "@suite-common/schemas": "workspace:^",
         "@trezor/env-utils": "workspace:*",
         "@trezor/utils": "workspace:^",
         "zod": "4.3.6"

--- a/suite-common/earn-stablecoin-api/src/verification/enter.ts
+++ b/suite-common/earn-stablecoin-api/src/verification/enter.ts
@@ -66,7 +66,13 @@ export const verifyEnterTransactions = (
 ): VerificationStatus => {
     const vaultAddress = EVM_VAULT_ADDRESSES[yieldId];
 
-    if (!vaultAddress) return 'failure';
+    if (!vaultAddress) {
+        console.error(
+            new Error(`Yield with id ${yieldId} does not have a corresponding vault address`),
+        );
+
+        return 'failure';
+    }
 
     const amountBigInt = BigInt(
         new BigNumber(amount).times(new BigNumber(10).pow(decimals)).toFixed(0),

--- a/suite-common/earn-stablecoin-api/src/verification/exit.ts
+++ b/suite-common/earn-stablecoin-api/src/verification/exit.ts
@@ -59,7 +59,13 @@ export const verifyExitTransactions = (
 ): VerificationStatus => {
     const vaultAddress = EVM_VAULT_ADDRESSES[yieldId];
 
-    if (!vaultAddress) return 'failure';
+    if (!vaultAddress) {
+        console.error(
+            new Error(`Yield with id ${yieldId} does not have a corresponding vault address`),
+        );
+
+        return 'failure';
+    }
 
     const statuses = response.data.transactions.map(tx =>
         getTransactionStatus(tx, vaultAddress, address),

--- a/suite-common/earn-stablecoin-api/src/verification/schema.ts
+++ b/suite-common/earn-stablecoin-api/src/verification/schema.ts
@@ -1,11 +1,6 @@
 import { z } from 'zod';
 
-const evmHexString = z
-    .string()
-    .startsWith('0x')
-    .transform(s => s as `0x${string}`);
-
-const evmNumberLike = z.union([z.number(), evmHexString]);
+import { evmHexString, evmNumberLike } from '@suite-common/schemas/src/evm';
 
 export const UnsignedEvmTransactionSchema = z.object({
     from: evmHexString,
@@ -55,52 +50,3 @@ export const parseUnsignedEvmTransactionForSigning = (
         return null;
     }
 };
-
-export const EvmFeeSchema = z.union([
-    z.object({
-        type: z.literal('eip1559'),
-        maxFeePerGas: evmHexString,
-        maxPriorityFeePerGas: evmHexString,
-        gasLimit: evmHexString,
-    }),
-    z.object({
-        type: z.literal('legacy'),
-        gasPrice: evmHexString,
-        gasLimit: evmHexString,
-    }),
-]);
-
-type EvmFee = z.infer<typeof EvmFeeSchema>;
-type EvmFeeType<Type extends EvmFee['type']> = Extract<EvmFee, { type: Type }>;
-
-export function parseEvmFee(raw: unknown) {
-    const result = EvmFeeSchema.safeParse(raw);
-
-    return result.success ? result.data : null;
-}
-
-export function flattenEvmFees(fee: EvmFee) {
-    const result: Pick<EvmFee, 'gasLimit'> & {
-        gasPrice?: EvmFeeType<'legacy'>['gasPrice'];
-        maxFeePerGas?: EvmFeeType<'eip1559'>['maxFeePerGas'];
-        maxPriorityFeePerGas?: EvmFeeType<'eip1559'>['maxPriorityFeePerGas'];
-    } = {
-        gasLimit: fee.gasLimit,
-    };
-
-    switch (fee.type) {
-        case 'eip1559':
-            Object.assign(result, {
-                maxFeePerGas: fee.maxFeePerGas,
-                maxPriorityFeePerGas: fee.maxPriorityFeePerGas,
-            });
-            break;
-        case 'legacy':
-            Object.assign(result, {
-                gasPrice: fee.gasPrice,
-            });
-            break;
-    }
-
-    return result;
-}

--- a/suite-common/earn-stablecoin-api/tsconfig.json
+++ b/suite-common/earn-stablecoin-api/tsconfig.json
@@ -5,6 +5,7 @@
         { "path": "../calldata" },
         { "path": "../http-client" },
         { "path": "../react-query" },
+        { "path": "../schemas" },
         { "path": "../../packages/env-utils" },
         { "path": "../../packages/utils" }
     ]

--- a/suite-common/earn-stablecoin/package.json
+++ b/suite-common/earn-stablecoin/package.json
@@ -12,8 +12,10 @@
     },
     "dependencies": {
         "@suite-common/earn-stablecoin-api": "workspace:^",
+        "@suite-common/schemas": "workspace:^",
         "@suite-common/wallet-config": "workspace:^",
         "@suite-common/wallet-types": "workspace:^",
+        "@trezor/connect-common": "workspace:^",
         "zod": "4.3.6"
     }
 }

--- a/suite-common/earn-stablecoin/src/tx-simulation/index.ts
+++ b/suite-common/earn-stablecoin/src/tx-simulation/index.ts
@@ -1,1 +1,1 @@
-export * from './supplyTxSimulationTrigger';
+export * from './txSimulationAction';

--- a/suite-common/earn-stablecoin/src/tx-simulation/txSimulationAction.ts
+++ b/suite-common/earn-stablecoin/src/tx-simulation/txSimulationAction.ts
@@ -8,7 +8,7 @@ import {
 } from '@suite-common/wallet-config';
 import { type AccountKey, type TxSimulationMethod } from '@suite-common/wallet-types';
 
-const supplyTxSimulationParams = z.strictObject({
+const stablecoinYieldTxSimulationParams = z.strictObject({
     account: z.object({
         key: z.string(),
         networkType: z.enum(networksCollection.map(n => n.networkType)),
@@ -19,10 +19,10 @@ const supplyTxSimulationParams = z.strictObject({
     unsignedSupplyTx: z.string(),
 });
 
-export type SupplyTxSimulationParams = z.infer<typeof supplyTxSimulationParams>;
+export type StablecoinYieldTxSimulationParams = z.infer<typeof stablecoinYieldTxSimulationParams>;
 
-export function composeSupplyTxSimmulationAction(unknownParams: unknown) {
-    const parsedParams = supplyTxSimulationParams.safeParse(unknownParams);
+export function composeStablecoinYieldTxSimmulationAction(unknownParams: unknown) {
+    const parsedParams = stablecoinYieldTxSimulationParams.safeParse(unknownParams);
 
     if (!parsedParams.success) {
         return null;

--- a/suite-common/earn-stablecoin/src/tx-simulation/txSimulationAction.ts
+++ b/suite-common/earn-stablecoin/src/tx-simulation/txSimulationAction.ts
@@ -1,70 +1,129 @@
 import z from 'zod';
 
-import { parseUnsignedEvmTransactionForSigning } from '@suite-common/earn-stablecoin-api';
+import { UnsignedEvmTransactionForSigningSchema } from '@suite-common/earn-stablecoin-api';
+import { evmHexString } from '@suite-common/schemas/src/evm';
 import {
     getNetwork,
     networkSymbolCollection,
     networksCollection,
 } from '@suite-common/wallet-config';
 import { type AccountKey, type TxSimulationMethod } from '@suite-common/wallet-types';
+import { type EthereumSignTransaction } from '@trezor/connect-common';
 
-const stablecoinYieldTxSimulationParams = z.strictObject({
-    account: z.object({
-        key: z.string(),
-        networkType: z.enum(networksCollection.map(n => n.networkType)),
-        symbol: z.enum(networkSymbolCollection),
-        descriptor: z.string(),
-        path: z.string(),
-    }),
-    unsignedSupplyTx: z.string(),
+const partialAccount = z.object({
+    key: z.string(),
+    networkType: z.enum(networksCollection.map(n => n.networkType)),
+    symbol: z.enum(networkSymbolCollection),
+    descriptor: z.string(),
+    path: z.string(),
 });
+
+const stablecoinYieldTxSimulationParams = z.discriminatedUnion('flow', [
+    z.strictObject({
+        flow: z.union([z.literal('supply'), z.literal('withdraw')]),
+        account: partialAccount,
+        unsignedTx: z.string(),
+    }),
+    z.strictObject({
+        flow: z.literal('claim'),
+        account: partialAccount,
+        unsignedTx: z.object({
+            to: evmHexString,
+            data: evmHexString,
+            chainId: z.number(),
+            gasLimit: z.string(),
+            maxFeePerGas: z.string().optional(),
+            maxPriorityFeePerGas: z.string().optional(),
+            nonce: z.union([z.number(), z.string()]).transform(value => value.toString()),
+        }),
+    }),
+]);
 
 export type StablecoinYieldTxSimulationParams = z.infer<typeof stablecoinYieldTxSimulationParams>;
 
-export function composeStablecoinYieldTxSimmulationAction(unknownParams: unknown) {
-    const parsedParams = stablecoinYieldTxSimulationParams.safeParse(unknownParams);
+function composeUnsignedEvmTx(
+    params: StablecoinYieldTxSimulationParams,
+): EthereumSignTransaction['transaction'] {
+    switch (params.flow) {
+        case 'supply':
+        case 'withdraw': {
+            const {
+                to,
+                value = '0x0',
+                data,
+                chainId,
+                gasLimit,
+                maxFeePerGas = '0x0',
+                maxPriorityFeePerGas = '0x0',
+                nonce,
+            } = UnsignedEvmTransactionForSigningSchema.parse(JSON.parse(params.unsignedTx));
 
-    if (!parsedParams.success) {
-        return null;
-    }
-
-    const unsignedSupplyTx = parseUnsignedEvmTransactionForSigning(
-        parsedParams.data.unsignedSupplyTx,
-    );
-
-    if (!unsignedSupplyTx) {
-        return null;
-    }
-
-    const { account } = parsedParams.data;
-    const network = getNetwork(account.symbol);
-
-    switch (network.networkType) {
-        case 'ethereum': {
             return {
-                accountKey: account.key as AccountKey,
-                action: {
-                    method: 'ethereumSignTransaction',
-                    fromAddress: account.descriptor,
-                    sourceOrigin: globalThis.location.origin,
-                    payload: {
-                        path: account.path,
-                        transaction: {
-                            to: unsignedSupplyTx.to,
-                            value: '0x0',
-                            data: unsignedSupplyTx.data,
-                            chainId: unsignedSupplyTx.chainId,
-                            gasLimit: unsignedSupplyTx.gasLimit,
-                            maxFeePerGas: unsignedSupplyTx.maxFeePerGas ?? '0x0',
-                            maxPriorityFeePerGas: unsignedSupplyTx.maxPriorityFeePerGas ?? '0x0',
-                            nonce: unsignedSupplyTx.nonce.toString(),
-                        },
-                    },
-                } satisfies TxSimulationMethod<'ethereumSignTransaction'>,
+                to,
+                value,
+                data,
+                chainId,
+                gasLimit,
+                maxFeePerGas,
+                maxPriorityFeePerGas,
+                nonce: nonce.toString(),
             };
         }
 
-        default:
-            return null;
+        case 'claim': {
+            const {
+                to,
+                data,
+                chainId,
+                gasLimit,
+                maxFeePerGas = '0x0',
+                maxPriorityFeePerGas = '0x0',
+                nonce,
+            } = params.unsignedTx;
+
+            return {
+                to,
+                value: '0x0',
+                data,
+                chainId,
+                gasLimit,
+                maxFeePerGas,
+                maxPriorityFeePerGas,
+                nonce,
+            };
+        }
+    }
+}
+
+export function composeStablecoinYieldTxSimulationAction(unknownParams: unknown) {
+    try {
+        const parsedParams = stablecoinYieldTxSimulationParams.parse(unknownParams);
+        const unsignedTx = composeUnsignedEvmTx(parsedParams);
+        const { account } = parsedParams;
+        const network = getNetwork(account.symbol);
+
+        switch (network.networkType) {
+            case 'ethereum': {
+                return {
+                    accountKey: account.key as AccountKey,
+                    action: {
+                        method: 'ethereumSignTransaction',
+                        fromAddress: account.descriptor,
+                        sourceOrigin: globalThis.location.origin,
+                        payload: {
+                            path: account.path,
+                            transaction: unsignedTx,
+                        },
+                    } satisfies TxSimulationMethod<'ethereumSignTransaction'>,
+                };
+            }
+
+            default:
+                throw new Error(`Unsupported network type: ${network.networkType}`);
+        }
+    } catch (error) {
+        console.error(error);
+
+        return null;
     }
 }

--- a/suite-common/earn-stablecoin/tsconfig.json
+++ b/suite-common/earn-stablecoin/tsconfig.json
@@ -3,7 +3,11 @@
     "compilerOptions": { "outDir": "libDev" },
     "references": [
         { "path": "../earn-stablecoin-api" },
+        { "path": "../schemas" },
         { "path": "../wallet-config" },
-        { "path": "../wallet-types" }
+        { "path": "../wallet-types" },
+        {
+            "path": "../../packages/connect-common"
+        }
     ]
 }

--- a/suite-common/schemas/package.json
+++ b/suite-common/schemas/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "@suite-common/schemas",
+    "version": "1.0.0",
+    "private": true,
+    "license": "See LICENSE.md in repo root",
+    "sideEffects": false,
+    "main": "src/index",
+    "scripts": {
+        "depcheck": "yarn g:depcheck",
+        "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "type-check": "yarn g:tsc --build"
+    },
+    "dependencies": {
+        "zod": "4.3.6"
+    }
+}

--- a/suite-common/schemas/src/evm/fees/index.ts
+++ b/suite-common/schemas/src/evm/fees/index.ts
@@ -1,0 +1,62 @@
+import z from 'zod';
+
+import { evmHexString } from '../general';
+
+const EvmFeeHexSchema = z.union([
+    z.object({
+        type: z.literal('eip1559'),
+        maxFeePerGas: evmHexString,
+        maxPriorityFeePerGas: evmHexString,
+        gasLimit: evmHexString,
+        baseFeePerGas: evmHexString,
+    }),
+    z.object({
+        type: z.literal('legacy'),
+        gasPrice: evmHexString,
+        gasLimit: evmHexString,
+    }),
+]);
+
+export type EvmFeeHex = z.infer<typeof EvmFeeHexSchema>;
+type EvmFeeHexType<Type extends EvmFeeHex['type']> = Extract<EvmFeeHex, { type: Type }>;
+
+/**
+ * Sort out fee fields based on the tx type (legacy vs EIP1559)
+ */
+export function parseEvmFeeHex(raw: unknown) {
+    const result = EvmFeeHexSchema.safeParse(raw);
+
+    return result.success ? result.data : null;
+}
+
+/**
+ * Remove tx type and put all fee fields on the same level for easier form handling
+ */
+export function flattenEvmFees(fee: EvmFeeHex) {
+    const result: {
+        gasLimit: EvmFeeHex['gasLimit'];
+        gasPrice?: EvmFeeHexType<'legacy'>['gasPrice'];
+        maxFeePerGas?: EvmFeeHexType<'eip1559'>['maxFeePerGas'];
+        maxPriorityFeePerGas?: EvmFeeHexType<'eip1559'>['maxPriorityFeePerGas'];
+        baseFeePerGas?: EvmFeeHexType<'eip1559'>['baseFeePerGas'];
+    } = {
+        gasLimit: fee.gasLimit,
+    };
+
+    switch (fee.type) {
+        case 'eip1559':
+            Object.assign(result, {
+                maxFeePerGas: fee.maxFeePerGas,
+                maxPriorityFeePerGas: fee.maxPriorityFeePerGas,
+                baseFeePerGas: fee.baseFeePerGas,
+            });
+            break;
+        case 'legacy':
+            Object.assign(result, {
+                gasPrice: fee.gasPrice,
+            });
+            break;
+    }
+
+    return result;
+}

--- a/suite-common/schemas/src/evm/general/index.ts
+++ b/suite-common/schemas/src/evm/general/index.ts
@@ -1,0 +1,10 @@
+import z from 'zod';
+
+export const evmHexString = z
+    .string()
+    .startsWith('0x')
+    .transform(s => s as `0x${string}`);
+
+export type EvmHexString = z.infer<typeof evmHexString>;
+
+export const evmNumberLike = z.union([z.number(), evmHexString]);

--- a/suite-common/schemas/src/evm/index.ts
+++ b/suite-common/schemas/src/evm/index.ts
@@ -1,0 +1,2 @@
+export * from './general';
+export * from './fees';

--- a/suite-common/schemas/tsconfig.json
+++ b/suite-common/schemas/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": { "outDir": "libDev" },
+    "references": []
+}

--- a/suite-common/wallet-types/src/fees.ts
+++ b/suite-common/wallet-types/src/fees.ts
@@ -3,6 +3,7 @@ export type EvmSelectedFee =
           type: 'eip1559';
           maxFeePerGas: string;
           maxPriorityFeePerGas: string;
+          baseFeePerGas: string;
           gasLimit: string;
       }
     | {

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -196,14 +196,14 @@ export const prepareEthereumTransaction = (
             gasPrice: undefined,
             maxFeePerGas: numberToHex(toWei(txInfo.maxFeePerGas, 'gwei')),
             maxPriorityFeePerGas: numberToHex(toWei(txInfo.maxPriorityFeePerGas || '0', 'gwei')),
-        } as EthereumTransactionEIP1559;
+        } satisfies EthereumTransactionEIP1559;
     } else if (txInfo.gasPrice) {
         result = {
             ...commonTxData,
             gasPrice: numberToHex(toWei(txInfo.gasPrice, 'gwei')),
             maxFeePerGas: undefined,
             maxPriorityFeePerGas: undefined,
-        } as EthereumTransaction;
+        } satisfies EthereumTransaction;
     } else {
         throw new Error('No gas price or maxFeePerGas and maxPriorityFeePerGas provided');
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11123,6 +11123,7 @@ __metadata:
     "@suite-common/calldata": "workspace:^"
     "@suite-common/http-client": "workspace:^"
     "@suite-common/react-query": "workspace:^"
+    "@suite-common/schemas": "workspace:^"
     "@trezor/env-utils": "workspace:*"
     "@trezor/utils": "workspace:^"
     orval: "npm:8.8.0"
@@ -11136,8 +11137,10 @@ __metadata:
   resolution: "@suite-common/earn-stablecoin@workspace:suite-common/earn-stablecoin"
   dependencies:
     "@suite-common/earn-stablecoin-api": "workspace:^"
+    "@suite-common/schemas": "workspace:^"
     "@suite-common/wallet-config": "workspace:^"
     "@suite-common/wallet-types": "workspace:^"
+    "@trezor/connect-common": "workspace:^"
     zod: "npm:4.3.6"
   languageName: unknown
   linkType: soft
@@ -11437,6 +11440,14 @@ __metadata:
     redux: "npm:^5.0.1"
     redux-thunk: "npm:^3.1.0"
     reselect: "npm:5.1.1"
+  languageName: unknown
+  linkType: soft
+
+"@suite-common/schemas@workspace:^, @suite-common/schemas@workspace:suite-common/schemas":
+  version: 0.0.0-use.local
+  resolution: "@suite-common/schemas@workspace:suite-common/schemas"
+  dependencies:
+    zod: "npm:4.3.6"
   languageName: unknown
   linkType: soft
 
@@ -16817,6 +16828,7 @@ __metadata:
     "@suite-common/platform-encryption": "workspace:*"
     "@suite-common/react-query": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
+    "@suite-common/schemas": "workspace:^"
     "@suite-common/sentry": "workspace:*"
     "@suite-common/staking": "workspace:*"
     "@suite-common/staking-solana": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Integrate TX simulation to the withdraw & claim flows.
- Refactor the claim flow (try to simplify it little bit but there's much more space to continue in that direction): `packages/suite/src/actions/wallet/stablecoinYieldSigningThunks.ts`
- Add general package for schemas (and their inferred types): `@suite-common/schemas`.

## Notes for QA

TX simulation is now avail. in withdraw & claim flows.

## Related Issue

Resolve #27314
Resolve #27313

## Screenshots:

<img width="691" height="694" alt="Snímek obrazovky 2026-05-06 v 15 27 45" src="https://github.com/user-attachments/assets/6d595d9f-47d4-43a3-9dcc-78116020b824" />
<img width="666" height="491" alt="Snímek obrazovky 2026-05-06 v 15 27 59" src="https://github.com/user-attachments/assets/e42e4b85-9a6c-4611-9574-1cd4204effe8" />



<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/tx-simulation-3&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/tx-simulation-3&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/tx-simulation-3&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-06T13:43:37.101Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-06T13:42:25.957Z • 13 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/tx-simulation-3/web/](https://dev.suite.sldev.cz/suite-web/feat/tx-simulation-3/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->