### PR TITLE
fix(suite): Hide ready on for btc only FW

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ActivateAssetsModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ActivateAssetsModal.tsx
@@ -135,7 +135,7 @@ export const ActivateAssetsModal = ({ onCancel }: ActivateAssetsModalProps) => {
                             isDisabled={isApplyPending}
                             data-testid="@modal/activate-assets/save"
                         >
-                            <Translation id="TR_ADD" />
+                            <Translation id="TR_SAVE" />
                         </Modal.Button>
                     ) : null
                 }

--- a/packages/suite/src/views/dashboard/PortfolioCard/EmptyWallet.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/EmptyWallet.tsx
@@ -1,6 +1,7 @@
 import { events } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { goto } from '@suite/router';
+import { selectHasBitcoinOnlyFirmware } from '@suite-common/device';
 import { selectEnabledNetworks } from '@suite-common/wallet-core';
 import { Button, Column, H3, Illustration, Paragraph, Row, Text } from '@trezor/components';
 import { CoinLogo } from '@trezor/product-components';
@@ -12,6 +13,7 @@ export const EmptyWallet = () => {
     const dispatch = useDispatch();
     const analytics = useAnalytics();
     const enabledNetworks = useSelector(selectEnabledNetworks);
+    const isBitcoinOnlyFirmware = useSelector(selectHasBitcoinOnlyFirmware);
 
     const handleReceive = () => {
         analytics.report({
@@ -42,7 +44,7 @@ export const EmptyWallet = () => {
             <Text intent="neutral" priority="secondary" typographyStyle="body-sm">
                 <Translation id="TR_DASHBOARD_EMPTY_WALLET_DESC" />
             </Text>
-            {enabledNetworks.length > 0 && (
+            {enabledNetworks.length > 0 && !isBitcoinOnlyFirmware && (
                 <Row gap={8} flexWrap="wrap" margin={{ top: 12 }}>
                     <Paragraph intent="neutral" priority="secondary" typographyStyle="body-sm">
                         <Translation id="TR_READY_ON" />:


### PR DESCRIPTION
- change add to save in activate network modal
- hide "ready on" for btc only firmware

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Related: https://github.com/trezor/trezor-suite/pull/26782

## Screenshots:

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect two UI components: ActivateAssetsModal (the modal for enabling new coin networks) and EmptyWallet (the empty dashboard state in the PortfolioCard). The primary risk is breaking the coin activation flow and the empty wallet dashboard experience. The coins.test.ts and assets.test.ts tests are the most critical as they directly exercise both changed components. EmptyWallet.tsx maps to 99 tests via static analysis, indicating it's a broadly imported component; most of those tests only transitively pass through it during dashboard load and don't specifically test its behavior, so only tests that explicitly interact with the empty state or activation modal are recommended.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ActivateAssetsModal.tsx`
- `packages/suite/src/views/dashboard/PortfolioCard/EmptyWallet.tsx`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — This test directly exercises the 'Enable more coins' modal (ActivateAssetsModal) and verifies that a newly enabled asset (ETH) appears correctly after activation. The test calls enableNetworkViaActivateAssetsModal and verifyAssetContents, which directly use the ActivateAssetsModal component that was changed.
- `suite/e2e/tests/settings/coins.test.ts` — This test activates mainnet assets via the 'Activate Assets' modal from the dashboard empty state, directly exercising the ActivateAssetsModal component. It also tests the empty wallet dashboard state (EmptyWallet component) by verifying TR_YOUR_WALLET_IS_READY_WHAT header, TR_DASHBOARD_ACTIVATE_ASSETS_DESC description, and TR_DASHBOARD_GET_STARTED button — all likely rendered by EmptyWallet.tsx.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — This test navigates through the dashboard after enabling BTC and verifies balance display across portfolio, assets, and device switcher. While it doesn't directly test ActivateAssetsModal or EmptyWallet, EmptyWallet.tsx is in the PortfolioCard path and changes there could affect the dashboard rendering flow that this test validates.
- `suite/e2e/tests/suite/db-migration.test.ts` — This test exercises the coin activation flow via enableNetworkViaActivateAssetsModal from assetsSection after database migration, directly testing the ActivateAssetsModal. It also checks discovery empty state on the dashboard which may involve the EmptyWallet component.
- `suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts` — This test completes wallet creation and then enables networks via enableNetworkViaActivateAssetsModal on the dashboard, directly exercising the ActivateAssetsModal component after reaching the empty wallet state.

</details>

_Updated: 2026-05-06T18:38:44.385Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=hide-ready-on-for-btc-only&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=hide-ready-on-for-btc-only&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-06T18:44:02.246Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-06T18:42:22.567Z • 13 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/hide-ready-on-for-btc-only/web/](https://dev.suite.sldev.cz/suite-web/hide-ready-on-for-btc-only/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->