### PR TITLE
refactor(connect): drop transitional MethodPermission/MethodInfo re-export

### DIFF
--- a/packages/connect/src/api/applyFlags.ts
+++ b/packages/connect/src/api/applyFlags.ts
@@ -1,9 +1,10 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/ApplyFlags.js
 
+import { type MethodPermission } from '@trezor/connect-common';
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 
 export default class ApplyFlags extends AbstractMethod<'applyFlags', PROTO.ApplyFlags> {

--- a/packages/connect/src/api/applySettings.ts
+++ b/packages/connect/src/api/applySettings.ts
@@ -1,10 +1,13 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/ApplySettings.js
 
-import { ApplySettings as ApplySettingsSchema } from '@trezor/connect-common';
+import {
+    ApplySettings as ApplySettingsSchema,
+    type MethodPermission,
+} from '@trezor/connect-common';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 
 export default class ApplySettings extends AbstractMethod<'applySettings', PROTO.ApplySettings> {

--- a/packages/connect/src/api/authenticateDevice.ts
+++ b/packages/connect/src/api/authenticateDevice.ts
@@ -1,4 +1,8 @@
-import { AuthenticateDeviceParams, UI_REQUEST } from '@trezor/connect-common';
+import {
+    AuthenticateDeviceParams,
+    type MethodPermission,
+    UI_REQUEST,
+} from '@trezor/connect-common';
 import type { VerifyAuthenticityProofResult } from '@trezor/device-authenticity';
 import {
     deviceAuthenticityBlacklistConfig,
@@ -10,7 +14,7 @@ import {
 } from '@trezor/device-authenticity';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 
 export default class AuthenticateDevice extends AbstractMethod<

--- a/packages/connect/src/api/authorizeCoinjoin.ts
+++ b/packages/connect/src/api/authorizeCoinjoin.ts
@@ -1,8 +1,11 @@
-import { AuthorizeCoinjoin as AuthorizeCoinjoinSchema } from '@trezor/connect-common';
+import {
+    AuthorizeCoinjoin as AuthorizeCoinjoinSchema,
+    type MethodPermission,
+} from '@trezor/connect-common';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { getBitcoinNetwork } from '../data/coinInfo';
 import { getScriptType, validatePath } from '../utils/pathUtils';

--- a/packages/connect/src/api/backupDevice.ts
+++ b/packages/connect/src/api/backupDevice.ts
@@ -1,9 +1,10 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/BackupDevice.js
 
+import { type MethodPermission } from '@trezor/connect-common';
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 
 export default class BackupDevice extends AbstractMethod<'backupDevice', PROTO.BackupDevice> {

--- a/packages/connect/src/api/bleUnpair.ts
+++ b/packages/connect/src/api/bleUnpair.ts
@@ -1,10 +1,10 @@
-import { UI_REQUEST } from '@trezor/connect-common';
+import { type MethodPermission, UI_REQUEST } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 import { TRANSPORT_ERROR } from '@trezor/transport';
 
-import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 
 export default class BleUnpair extends AbstractMethod<'bleUnpair', PROTO.BleUnpair> {

--- a/packages/connect/src/api/blockchainDisconnect.ts
+++ b/packages/connect/src/api/blockchainDisconnect.ts
@@ -1,12 +1,12 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/blockchain/BlockchainDisconnect.js
 
-import type { CoinInfo } from '@trezor/connect-common';
+import type { CoinInfo, MethodPermission } from '@trezor/connect-common';
 import { CoinObj } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
 import { findBackend, isBackendSupported } from '../backend/BlockchainLink';
-import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { getCoinInfo } from '../data/coinInfo';
 

--- a/packages/connect/src/api/blockchainEstimateFee.ts
+++ b/packages/connect/src/api/blockchainEstimateFee.ts
@@ -1,12 +1,11 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/blockchain/BlockchainEstimateFee.js
 
-import type { CoinInfo } from '@trezor/connect-common';
+import type { CoinInfo, MethodPermission } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 
 import type {
     MethodContext,
     MethodMessage,
-    MethodPermission,
     MethodReturnType,
     Payload,
 } from '../core/AbstractMethod';

--- a/packages/connect/src/api/blockchainEvmRpcCall.ts
+++ b/packages/connect/src/api/blockchainEvmRpcCall.ts
@@ -1,13 +1,8 @@
-import type { CoinInfo } from '@trezor/connect-common';
+import type { CoinInfo, MethodPermission } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
-import type {
-    MethodContext,
-    MethodMessage,
-    MethodPermission,
-    Payload,
-} from '../core/AbstractMethod';
+import type { MethodContext, MethodMessage, Payload } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { getCoinInfo } from '../data/coinInfo';

--- a/packages/connect/src/api/blockchainGetAccountBalanceHistory.ts
+++ b/packages/connect/src/api/blockchainGetAccountBalanceHistory.ts
@@ -1,14 +1,9 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/blockchain/BlockchainGetAccountBalanceHistory.js
 
-import type { CoinInfo } from '@trezor/connect-common';
+import type { CoinInfo, MethodPermission } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 
-import type {
-    MethodContext,
-    MethodMessage,
-    MethodPermission,
-    Payload,
-} from '../core/AbstractMethod';
+import type { MethodContext, MethodMessage, Payload } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';

--- a/packages/connect/src/api/blockchainGetContractInfo.ts
+++ b/packages/connect/src/api/blockchainGetContractInfo.ts
@@ -1,13 +1,8 @@
-import type { CoinInfo } from '@trezor/connect-common';
+import type { CoinInfo, MethodPermission } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
-import type {
-    MethodContext,
-    MethodMessage,
-    MethodPermission,
-    Payload,
-} from '../core/AbstractMethod';
+import type { MethodContext, MethodMessage, Payload } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { getCoinInfo } from '../data/coinInfo';
 import { validateParams } from './common/paramsValidator';

--- a/packages/connect/src/api/blockchainGetCurrentFiatRates.ts
+++ b/packages/connect/src/api/blockchainGetCurrentFiatRates.ts
@@ -1,14 +1,9 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/blockchain/BlockchainGetCurrentFiatRates.js
 
-import type { CoinInfo } from '@trezor/connect-common';
+import type { CoinInfo, MethodPermission } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 
-import type {
-    MethodContext,
-    MethodMessage,
-    MethodPermission,
-    Payload,
-} from '../core/AbstractMethod';
+import type { MethodContext, MethodMessage, Payload } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';

--- a/packages/connect/src/api/blockchainGetFiatRatesForTimestamps.ts
+++ b/packages/connect/src/api/blockchainGetFiatRatesForTimestamps.ts
@@ -1,14 +1,9 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/blockchain/BlockchainGetFiatRatesForTimestamps.js
 
-import type { CoinInfo } from '@trezor/connect-common';
+import type { CoinInfo, MethodPermission } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 
-import type {
-    MethodContext,
-    MethodMessage,
-    MethodPermission,
-    Payload,
-} from '../core/AbstractMethod';
+import type { MethodContext, MethodMessage, Payload } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';

--- a/packages/connect/src/api/blockchainGetInfo.ts
+++ b/packages/connect/src/api/blockchainGetInfo.ts
@@ -1,7 +1,7 @@
-import type { CoinInfo } from '@trezor/connect-common';
+import type { CoinInfo, MethodPermission } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 
-import type { MethodContext, MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodContext, MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';

--- a/packages/connect/src/api/blockchainGetTransactions.ts
+++ b/packages/connect/src/api/blockchainGetTransactions.ts
@@ -1,9 +1,9 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/blockchain/BlockchainGetTransactions.js
 
-import type { CoinInfo } from '@trezor/connect-common';
+import type { CoinInfo, MethodPermission } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 
-import type { MethodContext, MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodContext, MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';

--- a/packages/connect/src/api/blockchainSetCustomBackend.ts
+++ b/packages/connect/src/api/blockchainSetCustomBackend.ts
@@ -1,9 +1,9 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/blockchain/BlockchainSetCustomBackend.js
 
-import type { CoinInfo } from '@trezor/connect-common';
+import type { CoinInfo, MethodPermission } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 
-import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { reconnectAllBackends, setCustomBackend } from '../backend/BlockchainLink';

--- a/packages/connect/src/api/blockchainSubscribe.ts
+++ b/packages/connect/src/api/blockchainSubscribe.ts
@@ -1,14 +1,9 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/blockchain/BlockchainSubscribe.js
 
-import type { CoinInfo } from '@trezor/connect-common';
+import type { CoinInfo, MethodPermission } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 
-import type {
-    MethodContext,
-    MethodMessage,
-    MethodPermission,
-    Payload,
-} from '../core/AbstractMethod';
+import type { MethodContext, MethodMessage, Payload } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';

--- a/packages/connect/src/api/blockchainSubscribeFiatRates.ts
+++ b/packages/connect/src/api/blockchainSubscribeFiatRates.ts
@@ -1,14 +1,9 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/blockchain/BlockchainSubscribeFiatRates.js
 
-import type { CoinInfo } from '@trezor/connect-common';
+import type { CoinInfo, MethodPermission } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 
-import type {
-    MethodContext,
-    MethodMessage,
-    MethodPermission,
-    Payload,
-} from '../core/AbstractMethod';
+import type { MethodContext, MethodMessage, Payload } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';

--- a/packages/connect/src/api/blockchainUnsubscribe.ts
+++ b/packages/connect/src/api/blockchainUnsubscribe.ts
@@ -1,14 +1,9 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/blockchain/BlockchainUnsubscribe.js
 
-import type { CoinInfo } from '@trezor/connect-common';
+import type { CoinInfo, MethodPermission } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 
-import type {
-    MethodContext,
-    MethodMessage,
-    MethodPermission,
-    Payload,
-} from '../core/AbstractMethod';
+import type { MethodContext, MethodMessage, Payload } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';

--- a/packages/connect/src/api/blockchainUnsubscribeFiatRates.ts
+++ b/packages/connect/src/api/blockchainUnsubscribeFiatRates.ts
@@ -1,9 +1,9 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/blockchain/BlockchainUnsubscribeFiatRates.js
 
-import type { CoinInfo } from '@trezor/connect-common';
+import type { CoinInfo, MethodPermission } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 
-import type { MethodContext, MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodContext, MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';

--- a/packages/connect/src/api/blockchainValidateEvmRpcUrl.ts
+++ b/packages/connect/src/api/blockchainValidateEvmRpcUrl.ts
@@ -1,7 +1,8 @@
 import { BlockchainLink } from '@trezor/blockchain-link';
 import { MESSAGES, type ResponseTypes } from '@trezor/blockchain-link-types';
+import { type MethodPermission } from '@trezor/connect-common';
 
-import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { EvmRpcWorker } from '../workers/workers';
 import { validateParams } from './common/paramsValidator';

--- a/packages/connect/src/api/cancelCoinjoinAuthorization.ts
+++ b/packages/connect/src/api/cancelCoinjoinAuthorization.ts
@@ -1,7 +1,10 @@
-import { CancelCoinjoinAuthorization as CancelCoinjoinAuthorizationSchema } from '@trezor/connect-common';
+import {
+    CancelCoinjoinAuthorization as CancelCoinjoinAuthorizationSchema,
+    type MethodPermission,
+} from '@trezor/connect-common';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 
 export default class CancelCoinjoinAuthorization extends AbstractMethod<'cancelCoinjoinAuthorization'> {

--- a/packages/connect/src/api/cardano/api/cardanoComposeTransaction.ts
+++ b/packages/connect/src/api/cardano/api/cardanoComposeTransaction.ts
@@ -1,5 +1,6 @@
 import { CoinSelectionError, trezorUtils } from '@fivebinaries/coin-selection';
 
+import { type MethodPermission } from '@trezor/connect-common';
 import {
     type CardanoComposeTransactionParams,
     CardanoComposeTransactionParamsSchema,
@@ -7,7 +8,7 @@ import {
 } from '@trezor/connect-common/src/types/api/cardanoComposeTransaction';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodMessage, MethodPermission } from '../../../core/AbstractMethod';
+import type { MethodMessage } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { composeTxPlan } from '../cardanoUtils';
 

--- a/packages/connect/src/api/cardano/api/cardanoGetAddress.ts
+++ b/packages/connect/src/api/cardano/api/cardanoGetAddress.ts
@@ -3,6 +3,7 @@
 import {
     Bundle,
     CardanoGetAddress as CardanoGetAddressSchema,
+    type MethodPermission,
     UI_REQUEST,
     createUiMessage,
 } from '@trezor/connect-common';
@@ -10,12 +11,7 @@ import { ERRORS } from '@trezor/connect-common/src/constants';
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type {
-    MethodContext,
-    MethodMessage,
-    MethodPermission,
-    MethodReturnType,
-} from '../../../core/AbstractMethod';
+import type { MethodContext, MethodMessage, MethodReturnType } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { fromHardened, getSerializedPath } from '../../../utils/pathUtils';

--- a/packages/connect/src/api/cardano/api/cardanoGetNativeScriptHash.ts
+++ b/packages/connect/src/api/cardano/api/cardanoGetNativeScriptHash.ts
@@ -1,11 +1,12 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/CardanoGetNativeScriptHash.js
 
+import { type MethodPermission } from '@trezor/connect-common';
 import type { CardanoNativeScript } from '@trezor/connect-common/src/types/api/cardano';
 import { CardanoGetNativeScriptHash as CardanoGetNativeScriptHashSchema } from '@trezor/connect-common/src/types/api/cardano';
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodMessage, MethodPermission } from '../../../core/AbstractMethod';
+import type { MethodMessage } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath } from '../../../utils/pathUtils';

--- a/packages/connect/src/api/cardano/api/cardanoGetPublicKey.ts
+++ b/packages/connect/src/api/cardano/api/cardanoGetPublicKey.ts
@@ -3,18 +3,14 @@
 import {
     Bundle,
     CardanoGetPublicKey as CardanoGetPublicKeySchema,
+    type MethodPermission,
     UI_REQUEST,
     createUiMessage,
 } from '@trezor/connect-common';
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type {
-    MethodContext,
-    MethodMessage,
-    MethodPermission,
-    MethodReturnType,
-} from '../../../core/AbstractMethod';
+import type { MethodContext, MethodMessage, MethodReturnType } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { fromHardened, getSerializedPath, validatePath } from '../../../utils/pathUtils';

--- a/packages/connect/src/api/cardano/api/cardanoSignMessage.ts
+++ b/packages/connect/src/api/cardano/api/cardanoSignMessage.ts
@@ -1,6 +1,6 @@
 import * as cbor from 'cbor';
 
-import { CARDANO } from '@trezor/connect-common';
+import { CARDANO, type MethodPermission } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import {
     type CardanoMessageHeaders,
@@ -10,7 +10,7 @@ import {
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodMessage, MethodPermission } from '../../../core/AbstractMethod';
+import type { MethodMessage } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { hasHexPrefix, isHexString } from '../../../utils/formatUtils';

--- a/packages/connect/src/api/cardano/api/cardanoSignTransaction.ts
+++ b/packages/connect/src/api/cardano/api/cardanoSignTransaction.ts
@@ -10,12 +10,13 @@ import {
     CardanoSignTransaction as CardanoSignTransactionSchema,
     type CardanoSignedTxData,
     type CardanoSignedTxWitness,
+    type MethodPermission,
 } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert, Type } from '@trezor/schema-utils';
 
-import type { MethodMessage, MethodPermission } from '../../../core/AbstractMethod';
+import type { MethodMessage } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath } from '../../../utils/pathUtils';

--- a/packages/connect/src/api/changeLanguage.ts
+++ b/packages/connect/src/api/changeLanguage.ts
@@ -1,9 +1,13 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/ChangeLanguage.js
 
-import { ChangeLanguage as ChangeLanguageSchema, UI_REQUEST } from '@trezor/connect-common';
+import {
+    ChangeLanguage as ChangeLanguageSchema,
+    type MethodPermission,
+    UI_REQUEST,
+} from '@trezor/connect-common';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { changeLanguage } from '../device/workflow/changeLanguage';
 

--- a/packages/connect/src/api/changePin.ts
+++ b/packages/connect/src/api/changePin.ts
@@ -1,9 +1,10 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/ChangePin.js
 
+import { type MethodPermission } from '@trezor/connect-common';
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 
 export default class ChangePin extends AbstractMethod<'changePin', PROTO.ChangePin> {

--- a/packages/connect/src/api/changeWipeCode.ts
+++ b/packages/connect/src/api/changeWipeCode.ts
@@ -1,6 +1,7 @@
+import { type MethodPermission } from '@trezor/connect-common';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 
-import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 

--- a/packages/connect/src/api/cipherKeyValue.ts
+++ b/packages/connect/src/api/cipherKeyValue.ts
@@ -2,6 +2,7 @@
 
 import {
     CipherKeyValue as CipherKeyValueSchema,
+    type MethodPermission,
     UI_REQUEST,
     createUiMessage,
 } from '@trezor/connect-common';
@@ -9,7 +10,7 @@ import { Bundle } from '@trezor/connect-common/src/types/params';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodContext, MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodContext, MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { bundlify } from './common/paramsValidator';
 import { validatePath } from '../utils/pathUtils';

--- a/packages/connect/src/api/common/AbstractMiscGetAddress.ts
+++ b/packages/connect/src/api/common/AbstractMiscGetAddress.ts
@@ -1,6 +1,7 @@
 import {
     Bundle,
     GetAddress as GetAddressSchema,
+    type MethodPermission,
     UI_REQUEST,
     createUiMessage,
 } from '@trezor/connect-common';
@@ -8,12 +9,7 @@ import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
 import { bundlify } from './paramsValidator';
-import type {
-    MethodContext,
-    MethodMessage,
-    MethodPermission,
-    MethodReturnType,
-} from '../../core/AbstractMethod';
+import type { MethodContext, MethodMessage, MethodReturnType } from '../../core/AbstractMethod';
 import { AbstractMethod } from '../../core/AbstractMethod';
 import { fromHardened, getSerializedPath, validatePath } from '../../utils/pathUtils';
 

--- a/packages/connect/src/api/composeTransaction.ts
+++ b/packages/connect/src/api/composeTransaction.ts
@@ -7,6 +7,7 @@ import {
     DEFAULT_SORTING_STRATEGY,
     type DiscoveryAccount,
     ERRORS,
+    type MethodPermission,
     type PrecomposeParams,
     type PrecomposedResult,
     type RefTransaction,
@@ -21,7 +22,7 @@ import { resolveAfter } from '@trezor/utils/src/resolveAfter';
 import type { ComposeOutput, TransactionInputOutputSortingStrategy } from '@trezor/utxo-lib';
 
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
-import type { MethodContext, MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodContext, MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { requestExistingAccounts } from './common/requestExistingAccounts';
 import { fixCoinInfoNetwork, getBitcoinNetwork } from '../data/coinInfo';

--- a/packages/connect/src/api/discoverAccounts.ts
+++ b/packages/connect/src/api/discoverAccounts.ts
@@ -11,6 +11,7 @@ import {
     ERRORS,
     type EntropyCheckResult,
     type FirmwareRange,
+    type MethodPermission,
     PAGING,
     UI_REQUEST,
     createUiMessage,
@@ -18,7 +19,7 @@ import {
 import { arrayPartition, getSynchronize, versionUtils } from '@trezor/utils';
 
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
-import type { MethodContext, MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodContext, MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { getCoinInfo } from '../data/coinInfo';
 import type { AccountDescriptor } from '../device/DeviceCommands';

--- a/packages/connect/src/api/ethereum/api/ethereumGetAddress.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumGetAddress.ts
@@ -6,16 +6,15 @@ import {
     UI_REQUEST,
     createUiMessage,
 } from '@trezor/connect-common';
-import type { EthereumNetworkInfoDefinitionValues, PROTO } from '@trezor/connect-common';
+import type {
+    EthereumNetworkInfoDefinitionValues,
+    MethodPermission,
+    PROTO,
+} from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
-import type {
-    MethodContext,
-    MethodMessage,
-    MethodPermission,
-    MethodReturnType,
-} from '../../../core/AbstractMethod';
+import type { MethodContext, MethodMessage, MethodReturnType } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getEthereumNetwork, getUniqueNetworks } from '../../../data/coinInfo';
 import { getNetworkLabel } from '../../../utils/ethereumUtils';

--- a/packages/connect/src/api/ethereum/api/ethereumGetPublicKey.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumGetPublicKey.ts
@@ -3,18 +3,14 @@ import {
     Bundle,
     type EthereumNetworkInfo,
     GetPublicKey as GetPublicKeySchema,
+    type MethodPermission,
     UI_REQUEST,
     createUiMessage,
 } from '@trezor/connect-common';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type {
-    MethodContext,
-    MethodMessage,
-    MethodPermission,
-    MethodReturnType,
-} from '../../../core/AbstractMethod';
+import type { MethodContext, MethodMessage, MethodReturnType } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getEthereumNetwork, getUniqueNetworks } from '../../../data/coinInfo';
 import { getNetworkLabel } from '../../../utils/ethereumUtils';

--- a/packages/connect/src/api/ethereum/api/ethereumSignMessage.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumSignMessage.ts
@@ -1,11 +1,11 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/EthereumSignMessage.js
 
-import type { EthereumNetworkInfo } from '@trezor/connect-common';
+import type { EthereumNetworkInfo, MethodPermission } from '@trezor/connect-common';
 import { EthereumSignMessage as EthereumSignMessageSchema } from '@trezor/connect-common';
 import type { MessagesSchema, MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodMessage, MethodPermission } from '../../../core/AbstractMethod';
+import type { MethodMessage } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getEthereumNetwork } from '../../../data/coinInfo';
 import { validateModelOneMessageSize } from '../../../device/validateMessageSize';

--- a/packages/connect/src/api/ethereum/api/ethereumSignTransaction.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumSignTransaction.ts
@@ -5,13 +5,14 @@ import type {
     EthereumNetworkInfoDefinitionValues,
     EthereumTransaction,
     EthereumTransactionEIP1559,
+    MethodPermission,
     TokenInfo,
 } from '@trezor/connect-common';
 import type { MessagesSchema } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 import { BigNumber } from '@trezor/utils';
 
-import type { MethodMessage, MethodPermission } from '../../../core/AbstractMethod';
+import type { MethodMessage } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getEthereumNetwork } from '../../../data/coinInfo';
 import { getNetworkLabel } from '../../../utils/ethereumUtils';

--- a/packages/connect/src/api/ethereum/api/ethereumSignTypedData.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumSignTypedData.ts
@@ -5,13 +5,13 @@ import {
     EthereumSignTypedData as EthereumSignTypedDataParams,
     EthereumSignTypedHash as EthereumSignTypedHashParams,
 } from '@trezor/connect-common';
-import type { EthereumSignTypedDataTypes, PROTO } from '@trezor/connect-common';
+import type { EthereumSignTypedDataTypes, MethodPermission, PROTO } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { DeviceModelInternal } from '@trezor/device-utils';
 import { MessagesSchema } from '@trezor/protobuf';
 import { Assert, Type } from '@trezor/schema-utils';
 
-import type { MethodMessage, MethodPermission } from '../../../core/AbstractMethod';
+import type { MethodMessage } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getEthereumNetwork } from '../../../data/coinInfo';
 import { getNetworkLabel } from '../../../utils/ethereumUtils';

--- a/packages/connect/src/api/ethereum/api/ethereumVerifyMessage.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumVerifyMessage.ts
@@ -1,10 +1,13 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/EthereumVerifyMessage.js
 
-import { EthereumVerifyMessage as EthereumVerifyMessageSchema } from '@trezor/connect-common';
+import {
+    EthereumVerifyMessage as EthereumVerifyMessageSchema,
+    type MethodPermission,
+} from '@trezor/connect-common';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodMessage, MethodPermission } from '../../../core/AbstractMethod';
+import type { MethodMessage } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { validateModelOneMessageSize } from '../../../device/validateMessageSize';
 import { messageToHex, stripHexPrefix } from '../../../utils/formatUtils';

--- a/packages/connect/src/api/evoluGetDelegatedIdentityKey.ts
+++ b/packages/connect/src/api/evoluGetDelegatedIdentityKey.ts
@@ -1,6 +1,7 @@
+import { type MethodPermission } from '@trezor/connect-common';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 
-import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 
 export default class EvoluGetDelegatedIdentityKey extends AbstractMethod<

--- a/packages/connect/src/api/evoluGetNode.ts
+++ b/packages/connect/src/api/evoluGetNode.ts
@@ -1,7 +1,8 @@
+import { type MethodPermission } from '@trezor/connect-common';
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 
 export default class EvoluGetNode extends AbstractMethod<'evoluGetNode', PROTO.EvoluGetNode> {

--- a/packages/connect/src/api/evoluSignRegistrationRequest.ts
+++ b/packages/connect/src/api/evoluSignRegistrationRequest.ts
@@ -1,7 +1,8 @@
+import { type MethodPermission } from '@trezor/connect-common';
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 
 export default class EvoluSignRegistrationRequest extends AbstractMethod<

--- a/packages/connect/src/api/getAccountDescriptor.ts
+++ b/packages/connect/src/api/getAccountDescriptor.ts
@@ -2,6 +2,7 @@ import type {
     CoinInfo,
     DerivationPath,
     GetAccountDescriptorResponse,
+    MethodPermission,
 } from '@trezor/connect-common';
 import {
     Bundle,
@@ -13,12 +14,7 @@ import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
 import { bundlify } from './common/paramsValidator';
-import type {
-    MethodContext,
-    MethodMessage,
-    MethodPermission,
-    MethodReturnType,
-} from '../core/AbstractMethod';
+import type { MethodContext, MethodMessage, MethodReturnType } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { getCoinInfo } from '../data/coinInfo';
 import { getAccountLabel } from '../utils/accountUtils';

--- a/packages/connect/src/api/getAccountInfo.ts
+++ b/packages/connect/src/api/getAccountInfo.ts
@@ -8,17 +8,13 @@ import type {
     DerivationPath,
     DiscoveryAccount,
     GetAccountInfo as GetAccountInfoParams,
+    MethodPermission,
 } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { resolveAfter } from '@trezor/utils/src/resolveAfter';
 
 import { type Blockchain, initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
-import type {
-    MethodContext,
-    MethodMessage,
-    MethodPermission,
-    MethodReturnType,
-} from '../core/AbstractMethod';
+import type { MethodContext, MethodMessage, MethodReturnType } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { getCoinInfo } from '../data/coinInfo';
 import { Discovery } from './common/Discovery';

--- a/packages/connect/src/api/getAddress.ts
+++ b/packages/connect/src/api/getAddress.ts
@@ -1,18 +1,18 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/GetAddress.js
 
-import { type BitcoinNetworkInfo, Bundle, type PROTO } from '@trezor/connect-common';
+import {
+    type BitcoinNetworkInfo,
+    Bundle,
+    type MethodPermission,
+    type PROTO,
+} from '@trezor/connect-common';
 import { UI_REQUEST, createUiMessage } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { GetAddress as GetAddressSchema } from '@trezor/connect-common/src/types/api/getAddress';
 import { Assert } from '@trezor/schema-utils';
 
 import { bundlify, validateCoinPath } from './common/paramsValidator';
-import type {
-    MethodContext,
-    MethodMessage,
-    MethodPermission,
-    MethodReturnType,
-} from '../core/AbstractMethod';
+import type { MethodContext, MethodMessage, MethodReturnType } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { fixCoinInfoNetwork, getBitcoinNetwork, getUniqueNetworks } from '../data/coinInfo';
 import { getLabel, getSerializedPath, validatePath } from '../utils/pathUtils';

--- a/packages/connect/src/api/getCoinInfo.ts
+++ b/packages/connect/src/api/getCoinInfo.ts
@@ -1,11 +1,11 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/GetCoinInfo.js
 
-import type { CoinInfo } from '@trezor/connect-common';
+import type { CoinInfo, MethodPermission } from '@trezor/connect-common';
 import { CoinObj } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { getCoinInfo } from '../data/coinInfo';
 

--- a/packages/connect/src/api/getDeviceState.ts
+++ b/packages/connect/src/api/getDeviceState.ts
@@ -1,8 +1,8 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/GetDeviceState.js
 
+import { type MethodPermission } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 
-import type { MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 
 export default class GetDeviceState extends AbstractMethod<'getDeviceState'> {

--- a/packages/connect/src/api/getFeatures.ts
+++ b/packages/connect/src/api/getFeatures.ts
@@ -1,8 +1,8 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/GetFeatures.js
 
-import { UI_REQUEST } from '@trezor/connect-common';
+import { type MethodPermission, UI_REQUEST } from '@trezor/connect-common';
 
-import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 
 export default class GetFeatures extends AbstractMethod<'getFeatures'> {

--- a/packages/connect/src/api/getFirmwareHash.ts
+++ b/packages/connect/src/api/getFirmwareHash.ts
@@ -1,8 +1,8 @@
-import { UI_REQUEST } from '@trezor/connect-common';
+import { type MethodPermission, UI_REQUEST } from '@trezor/connect-common';
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 
 export default class GetFirmwareHash extends AbstractMethod<

--- a/packages/connect/src/api/getNonce.ts
+++ b/packages/connect/src/api/getNonce.ts
@@ -1,4 +1,6 @@
-import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import { type MethodPermission } from '@trezor/connect-common';
+
+import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 
 export default class GetNonce extends AbstractMethod<'getNonce'> {

--- a/packages/connect/src/api/getOwnershipId.ts
+++ b/packages/connect/src/api/getOwnershipId.ts
@@ -1,6 +1,7 @@
 import {
     Bundle,
     GetOwnershipId as GetOwnershipIdSchema,
+    type MethodPermission,
     UI_REQUEST,
     createUiMessage,
 } from '@trezor/connect-common';
@@ -8,12 +9,7 @@ import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
 import { bundlify } from './common/paramsValidator';
-import type {
-    MethodContext,
-    MethodMessage,
-    MethodPermission,
-    MethodReturnType,
-} from '../core/AbstractMethod';
+import type { MethodContext, MethodMessage, MethodReturnType } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { getBitcoinNetwork } from '../data/coinInfo';
 import { getScriptType, getSerializedPath, validatePath } from '../utils/pathUtils';

--- a/packages/connect/src/api/getOwnershipProof.ts
+++ b/packages/connect/src/api/getOwnershipProof.ts
@@ -1,6 +1,7 @@
 import {
     Bundle,
     GetOwnershipProof as GetOwnershipProofSchema,
+    type MethodPermission,
     UI_REQUEST,
     createUiMessage,
 } from '@trezor/connect-common';
@@ -8,12 +9,7 @@ import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
 import { bundlify } from './common/paramsValidator';
-import type {
-    MethodContext,
-    MethodMessage,
-    MethodPermission,
-    MethodReturnType,
-} from '../core/AbstractMethod';
+import type { MethodContext, MethodMessage, MethodReturnType } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { getBitcoinNetwork } from '../data/coinInfo';
 import { getScriptType, getSerializedPath, validatePath } from '../utils/pathUtils';

--- a/packages/connect/src/api/getPublicKey.ts
+++ b/packages/connect/src/api/getPublicKey.ts
@@ -1,6 +1,6 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/GetPublicKey.js
 
-import type { BitcoinNetworkInfo } from '@trezor/connect-common';
+import type { BitcoinNetworkInfo, MethodPermission } from '@trezor/connect-common';
 import {
     Bundle,
     GetPublicKey as GetPublicKeySchema,
@@ -10,12 +10,7 @@ import {
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type {
-    MethodContext,
-    MethodMessage,
-    MethodPermission,
-    MethodReturnType,
-} from '../core/AbstractMethod';
+import type { MethodContext, MethodMessage, MethodReturnType } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { getBitcoinNetwork } from '../data/coinInfo';
 import { bundlify, validateCoinPath } from './common/paramsValidator';

--- a/packages/connect/src/api/getSettings.ts
+++ b/packages/connect/src/api/getSettings.ts
@@ -1,6 +1,8 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/GetSettings.js
 
-import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import { type MethodPermission } from '@trezor/connect-common';
+
+import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import * as settingsStore from '../data/settingsStore';
 

--- a/packages/connect/src/api/loadDevice.ts
+++ b/packages/connect/src/api/loadDevice.ts
@@ -1,8 +1,8 @@
-import { UI_REQUEST } from '@trezor/connect-common';
+import { type MethodPermission, UI_REQUEST } from '@trezor/connect-common';
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 
 export default class LoadDevice extends AbstractMethod<'loadDevice', PROTO.LoadDevice> {

--- a/packages/connect/src/api/monero/api/moneroGetAddress.ts
+++ b/packages/connect/src/api/monero/api/moneroGetAddress.ts
@@ -1,9 +1,10 @@
 // Monero GetAddress implementation
+import { type MethodPermission } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import type { Address } from '@trezor/connect-common/src/types/params';
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 
-import type { MethodMessage, MethodPermission } from '../../../core/AbstractMethod';
+import type { MethodMessage } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { HD_HARDENED, getSerializedPath, validatePath } from '../../../utils/pathUtils';

--- a/packages/connect/src/api/monero/api/moneroGetWatchKey.ts
+++ b/packages/connect/src/api/monero/api/moneroGetWatchKey.ts
@@ -1,9 +1,9 @@
 // Monero GetWatchKey implementation
-import type { MoneroWatchKey } from '@trezor/connect-common';
+import type { MethodPermission, MoneroWatchKey } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 
-import type { MethodMessage, MethodPermission } from '../../../core/AbstractMethod';
+import type { MethodMessage } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { HD_HARDENED, validatePath } from '../../../utils/pathUtils';

--- a/packages/connect/src/api/monero/api/moneroKeyImageSync.ts
+++ b/packages/connect/src/api/monero/api/moneroKeyImageSync.ts
@@ -1,11 +1,15 @@
 import { keccak_256 } from '@noble/hashes/sha3.js';
 import { hexToBytes } from '@noble/hashes/utils.js';
 
-import type { MoneroExportedKeyImage, MoneroKeyImageSyncResult } from '@trezor/connect-common';
+import type {
+    MethodPermission,
+    MoneroExportedKeyImage,
+    MoneroKeyImageSyncResult,
+} from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 
-import type { MethodMessage, MethodPermission } from '../../../core/AbstractMethod';
+import type { MethodMessage } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { HD_HARDENED, validatePath } from '../../../utils/pathUtils';

--- a/packages/connect/src/api/monero/api/moneroSignTransaction.ts
+++ b/packages/connect/src/api/monero/api/moneroSignTransaction.ts
@@ -1,11 +1,7 @@
-import type { PROTO } from '@trezor/connect-common';
+import type { MethodPermission, PROTO } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 
-import type {
-    MethodMessage,
-    MethodPermission,
-    MethodReturnType,
-} from '../../../core/AbstractMethod';
+import type { MethodMessage, MethodReturnType } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { HD_HARDENED, validatePath } from '../../../utils/pathUtils';

--- a/packages/connect/src/api/pushTransaction.ts
+++ b/packages/connect/src/api/pushTransaction.ts
@@ -1,12 +1,12 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/PushTransaction.js
 
-import type { CoinInfo } from '@trezor/connect-common';
+import type { CoinInfo, MethodPermission } from '@trezor/connect-common';
 import { PushTransaction as PushTransactionSchema } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
-import type { MethodContext, MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodContext, MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { getCoinInfo } from '../data/coinInfo';
 

--- a/packages/connect/src/api/recoveryDevice.ts
+++ b/packages/connect/src/api/recoveryDevice.ts
@@ -1,11 +1,11 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/RecoveryDevice.js
 
-import { UI_REQUEST } from '@trezor/connect-common';
+import { type MethodPermission, UI_REQUEST } from '@trezor/connect-common';
 import { RecoveryDevice as RecoveryDeviceSchema } from '@trezor/connect-common/src/types/api/recoveryDevice';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 
 export default class RecoveryDevice extends AbstractMethod<'recoveryDevice', PROTO.RecoveryDevice> {

--- a/packages/connect/src/api/requestLogin.ts
+++ b/packages/connect/src/api/requestLogin.ts
@@ -1,11 +1,11 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/RequestLogin.js
 
-import type { ConnectSettings } from '@trezor/connect-common';
+import type { ConnectSettings, MethodPermission } from '@trezor/connect-common';
 import { RequestLoginSchema } from '@trezor/connect-common';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import * as settingsStore from '../data/settingsStore';
 

--- a/packages/connect/src/api/resetDevice.ts
+++ b/packages/connect/src/api/resetDevice.ts
@@ -1,5 +1,5 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/ResetDevice.js
-import { UI_REQUEST } from '@trezor/connect-common';
+import { type MethodPermission, UI_REQUEST } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { TransportError } from '@trezor/connect-common/src/constants/errors';
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
@@ -7,7 +7,7 @@ import { Assert } from '@trezor/schema-utils';
 import { getRandomInt } from '@trezor/utils';
 
 import { generateEntropy, verifyEntropy } from '../api/firmware/verifyEntropy';
-import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validatePath } from '../utils/pathUtils';
 import { calculateXPubHashes } from './firmware/calculateXPubHash';

--- a/packages/connect/src/api/ripple/api/rippleSignTransaction.ts
+++ b/packages/connect/src/api/ripple/api/rippleSignTransaction.ts
@@ -1,10 +1,13 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/RippleSignTransaction.js
 
-import { RippleSignTransaction as RippleSignTransactionSchema } from '@trezor/connect-common';
+import {
+    type MethodPermission,
+    RippleSignTransaction as RippleSignTransactionSchema,
+} from '@trezor/connect-common';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodMessage, MethodPermission } from '../../../core/AbstractMethod';
+import type { MethodMessage } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath } from '../../../utils/pathUtils';

--- a/packages/connect/src/api/setBrightness.ts
+++ b/packages/connect/src/api/setBrightness.ts
@@ -1,9 +1,10 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/SetBrightness.js
 
+import { type MethodPermission } from '@trezor/connect-common';
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 
 export default class SetBrightness extends AbstractMethod<'setBrightness', PROTO.SetBrightness> {

--- a/packages/connect/src/api/setBusy.ts
+++ b/packages/connect/src/api/setBusy.ts
@@ -1,7 +1,7 @@
-import { DEVICE, createDeviceMessage } from '@trezor/connect-common';
+import { DEVICE, type MethodPermission, createDeviceMessage } from '@trezor/connect-common';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 
-import type { MethodContext, MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodContext, MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 
 export default class SetBusy extends AbstractMethod<'setBusy', PROTO.SetBusy> {

--- a/packages/connect/src/api/showDeviceTutorial.ts
+++ b/packages/connect/src/api/showDeviceTutorial.ts
@@ -1,6 +1,6 @@
-import { UI_REQUEST } from '@trezor/connect-common';
+import { type MethodPermission, UI_REQUEST } from '@trezor/connect-common';
 
-import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 
 export default class ShowDeviceTutorial extends AbstractMethod<'showDeviceTutorial'> {

--- a/packages/connect/src/api/signMessage.ts
+++ b/packages/connect/src/api/signMessage.ts
@@ -1,11 +1,11 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/SignMessage.js
 
-import type { BitcoinNetworkInfo } from '@trezor/connect-common';
+import type { BitcoinNetworkInfo, MethodPermission } from '@trezor/connect-common';
 import { SignMessage as SignMessageSchema } from '@trezor/connect-common';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateCoinPath } from './common/paramsValidator';
 import { getBitcoinNetwork } from '../data/coinInfo';

--- a/packages/connect/src/api/signTransaction.ts
+++ b/packages/connect/src/api/signTransaction.ts
@@ -3,6 +3,7 @@
 import type {
     AccountAddresses,
     BitcoinNetworkInfo,
+    MethodPermission,
     PROTO,
     RefTransaction,
     TransactionOptions,
@@ -31,7 +32,7 @@ import {
 } from './bitcoin';
 import type { Blockchain } from '../backend/BlockchainLink';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
-import type { MethodContext, MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodContext, MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { getBitcoinNetwork } from '../data/coinInfo';
 import { getLabel } from '../utils/pathUtils';

--- a/packages/connect/src/api/solana/api/solanaComposeTransaction.ts
+++ b/packages/connect/src/api/solana/api/solanaComposeTransaction.ts
@@ -1,11 +1,11 @@
 import { SYSTEM_PROGRAM_PUBLIC_KEY } from '@trezor/blockchain-link-utils/src/solana';
-import type { CoinInfo } from '@trezor/connect-common';
+import type { CoinInfo, MethodPermission } from '@trezor/connect-common';
 import { SolanaComposeTransaction as SolanaComposeTransactionSchema } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
 import { initBlockchain, isBackendSupported } from '../../../backend/BlockchainLink';
-import type { MethodContext, MethodMessage, MethodPermission } from '../../../core/AbstractMethod';
+import type { MethodContext, MethodMessage } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getCoinInfo } from '../../../data/coinInfo';
 import {

--- a/packages/connect/src/api/solana/api/solanaGetPublicKey.ts
+++ b/packages/connect/src/api/solana/api/solanaGetPublicKey.ts
@@ -6,15 +6,10 @@ import {
     UI_REQUEST,
     createUiMessage,
 } from '@trezor/connect-common';
-import type { PROTO } from '@trezor/connect-common';
+import type { MethodPermission, PROTO } from '@trezor/connect-common';
 import { Assert } from '@trezor/schema-utils';
 
-import type {
-    MethodContext,
-    MethodMessage,
-    MethodPermission,
-    MethodReturnType,
-} from '../../../core/AbstractMethod';
+import type { MethodContext, MethodMessage, MethodReturnType } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { fromHardened, getSerializedPath, validatePath } from '../../../utils/pathUtils';

--- a/packages/connect/src/api/solana/api/solanaSignTransaction.ts
+++ b/packages/connect/src/api/solana/api/solanaSignTransaction.ts
@@ -30,12 +30,12 @@ import {
     SolanaSignTransaction as SolanaSignTransactionSchema,
     SolanaTxAdditionalInfo,
 } from '@trezor/connect-common';
-import type { PROTO, TokenInfo } from '@trezor/connect-common';
+import type { MethodPermission, PROTO, TokenInfo } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 import { BigNumber } from '@trezor/utils';
 
-import type { MethodMessage, MethodPermission } from '../../../core/AbstractMethod';
+import type { MethodMessage } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath } from '../../../utils/pathUtils';

--- a/packages/connect/src/api/stellar/api/stellarSignTransaction.ts
+++ b/packages/connect/src/api/stellar/api/stellarSignTransaction.ts
@@ -1,11 +1,11 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/StellarSignTransaction.js
 
 import { StellarSignTransaction as StellarSignTransactionSchema } from '@trezor/connect-common';
-import type { PROTO, StellarTransaction } from '@trezor/connect-common';
+import type { MethodPermission, PROTO, StellarTransaction } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodMessage, MethodPermission } from '../../../core/AbstractMethod';
+import type { MethodMessage } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath } from '../../../utils/pathUtils';

--- a/packages/connect/src/api/telemetryGet.ts
+++ b/packages/connect/src/api/telemetryGet.ts
@@ -1,7 +1,8 @@
+import { type MethodPermission } from '@trezor/connect-common';
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 
 export default class TelemetryGet extends AbstractMethod<'telemetryGet', PROTO.TelemetryGet> {

--- a/packages/connect/src/api/tezos/api/tezosGetPublicKey.ts
+++ b/packages/connect/src/api/tezos/api/tezosGetPublicKey.ts
@@ -3,18 +3,14 @@
 import {
     Bundle,
     GetPublicKey as GetPublicKeySchema,
+    type MethodPermission,
     UI_REQUEST,
     createUiMessage,
 } from '@trezor/connect-common';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type {
-    MethodContext,
-    MethodMessage,
-    MethodPermission,
-    MethodReturnType,
-} from '../../../core/AbstractMethod';
+import type { MethodContext, MethodMessage, MethodReturnType } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { fromHardened, getSerializedPath, validatePath } from '../../../utils/pathUtils';

--- a/packages/connect/src/api/tezos/api/tezosSignTransaction.ts
+++ b/packages/connect/src/api/tezos/api/tezosSignTransaction.ts
@@ -1,10 +1,11 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/TezosSignTransaction.js
 
+import { type MethodPermission } from '@trezor/connect-common';
 import { TezosSignTransaction as TezosSignTransactionSchema } from '@trezor/connect-common/src/types/api/tezos';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodMessage, MethodPermission } from '../../../core/AbstractMethod';
+import type { MethodMessage } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath } from '../../../utils/pathUtils';

--- a/packages/connect/src/api/thpGetCredentials.ts
+++ b/packages/connect/src/api/thpGetCredentials.ts
@@ -1,7 +1,7 @@
-import { DEVICE, UI_REQUEST } from '@trezor/connect-common';
+import { DEVICE, type MethodPermission, UI_REQUEST } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 
-import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import * as settingsStore from '../data/settingsStore';
 import { getThpCredentials } from '../device/thp';

--- a/packages/connect/src/api/thpRemoveCredentials.ts
+++ b/packages/connect/src/api/thpRemoveCredentials.ts
@@ -1,7 +1,7 @@
-import { UI_REQUEST } from '@trezor/connect-common';
+import { type MethodPermission, UI_REQUEST } from '@trezor/connect-common';
 import type { ThpCredentials } from '@trezor/protocol';
 
-import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import * as settingsStore from '../data/settingsStore';
 

--- a/packages/connect/src/api/tron/api/tronComposeTransaction.ts
+++ b/packages/connect/src/api/tron/api/tronComposeTransaction.ts
@@ -1,9 +1,10 @@
 import { bytesToHex } from '@noble/hashes/utils.js';
 
+import { type MethodPermission } from '@trezor/connect-common';
 import { TronComposeTransaction as TronComposeTransactionSchema } from '@trezor/connect-common/src/types/api/tron';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodMessage, MethodPermission } from '../../../core/AbstractMethod';
+import type { MethodMessage } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { TRON_BANDWIDTH_FORMULA_OVERHEAD, encodeTronContractRawData } from '../tronEncode';
 

--- a/packages/connect/src/api/tron/api/tronSignTransaction.ts
+++ b/packages/connect/src/api/tron/api/tronSignTransaction.ts
@@ -2,6 +2,7 @@ import { bytesToHex } from '@noble/hashes/utils.js';
 
 import { TronSignTransaction as TronSignTransactionSchema } from '@trezor/connect-common';
 import type {
+    MethodPermission,
     PROTO,
     TronContractInput,
     TronContracts,
@@ -10,7 +11,7 @@ import type {
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodMessage, MethodPermission } from '../../../core/AbstractMethod';
+import type { MethodMessage } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { validatePath } from '../../../utils/pathUtils';
 import { encodeTronContractRawData } from '../tronEncode';

--- a/packages/connect/src/api/unlockPath.ts
+++ b/packages/connect/src/api/unlockPath.ts
@@ -1,8 +1,8 @@
-import { UnlockPathParams } from '@trezor/connect-common';
+import { type MethodPermission, UnlockPathParams } from '@trezor/connect-common';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validatePath } from '../utils/pathUtils';
 

--- a/packages/connect/src/api/verifyMessage.ts
+++ b/packages/connect/src/api/verifyMessage.ts
@@ -1,11 +1,11 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/VerifyMessage.js
 
 import { VerifyMessage as VerifyMessageSchema } from '@trezor/connect-common';
-import type { CoinInfo, PROTO } from '@trezor/connect-common';
+import type { CoinInfo, MethodPermission, PROTO } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { getBitcoinNetwork } from '../data/coinInfo';
 import { validateModelOneMessageSize } from '../device/validateMessageSize';

--- a/packages/connect/src/api/wipeDevice.ts
+++ b/packages/connect/src/api/wipeDevice.ts
@@ -1,8 +1,8 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/WipeDevice.js
 
-import { DEVICE, UI_REQUEST } from '@trezor/connect-common';
+import { DEVICE, type MethodPermission, UI_REQUEST } from '@trezor/connect-common';
 
-import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
+import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import type { Device } from '../device/Device';
 

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -21,11 +21,6 @@ import type { Device } from '../device/Device';
 import type { UiPromiseCreator } from '../events/ui-promise';
 
 export { DEFAULT_FIRMWARE_RANGE };
-// TODO: drop this re-export and migrate the ~50 internal `packages/connect/src/api/**`
-// imports to pull `MethodPermission` / `MethodInfo` directly from `@trezor/connect-common`.
-// Kept here as a transitional shim to keep this PR focused on the public-surface change;
-// the cleanup will follow up alongside the deep-import ESLint guardrail (#27376).
-export type { MethodInfo, MethodPermission };
 
 export type Payload<M> = Extract<CallMethodPayload, { method: M }> & { override?: boolean };
 export type MethodReturnType<M extends CallMethodPayload['method']> = CallMethodResponse<M>;


### PR DESCRIPTION
## Summary

Follow-up to #27389 (refs #27374): drops the transitional re-export

```ts
// packages/connect/src/core/AbstractMethod.ts
export type { MethodInfo, MethodPermission };
```

and migrates the ~85 internal `packages/connect/src/api/**` consumers
to import these two types directly from the `@trezor/connect-common`
package barrel where they now live.

`MethodPermission` and `MethodInfo` were promoted to the public API
in #27389 (file `packages/connect-common/src/types/method.ts`). The
re-export was kept then to keep that PR focused on the public surface
change. This PR completes the cleanup so that:

- `core/AbstractMethod.ts` is no longer a re-export shim for these
  two types.
- internal `connect/src/api/**` files reach for `@trezor/connect-common`
  the same way the external public consumers do.

## Source issue

Resolves #27435

## Implementation notes

- Pure import-path refactor. No behavior change. No public API change.
- The `MethodInfo`/`MethodPermission` types themselves still live in
  `@trezor/connect-common/src/types/method.ts` (added in #27389) and
  are re-exported by both `@trezor/connect-common` and `@trezor/connect`
  package barrels.
- The migration was performed by a one-shot codemod that:
  1. Removes `MethodPermission`/`MethodInfo` from each
     `import [type] { ... } from '../core/AbstractMethod'` line,
     leaving any sibling identifiers (`MethodMessage`, `MethodContext`,
     `MethodReturnType`, …) untouched. If the AbstractMethod import
     becomes empty, the line is dropped.
  2. Adds the migrated types to an existing
     `@trezor/connect-common` import in the file. Preference order:
     - merge into an existing `import type { … } from '@trezor/connect-common'`
       as plain (non-prefixed) members,
     - else merge into an existing
       `import { … } from '@trezor/connect-common'`
       with inline `type` modifiers (`type MethodPermission`),
     - else create a fresh `import { type MethodPermission } from '@trezor/connect-common'`.
  3. Preserves the original member order if the existing list was
     ASCII-sorted; otherwise appends at the end.
- Followed by `prettier --write` and `eslint --fix` on the changed
  files to settle line-wrapping and `import/order`.
- 86 files changed in `packages/connect/src/`; net **−44 lines**
  (more concise imports because both types now share the
  `@trezor/connect-common` import line that was already present in
  most files).

## Review guide

- `packages/connect/src/core/AbstractMethod.ts` — only the
  `export type { MethodInfo, MethodPermission }` line and its TODO
  comment are removed.
- The remaining 85 files are mechanical import edits — pick any 2–3
  to spot-check (e.g. a tiny one like `applyFlags.ts` and a multi-import
  one like `getAccountDescriptor.ts`).
- `git log -p packages/connect/src/core/AbstractMethod.ts` shows that
  this PR cleanly reverts only the shim part of #27389 — the type
  definitions in `@trezor/connect-common` are untouched.

## Remaining work / open questions

None. The TODO referenced in the deleted comment (deep-import ESLint
guardrail) is tracked separately in #27376 and is not blocked by this
change.


---
_Generated by [Claude Code](https://claude.ai/code/session_011NQyVo9NCZqonp6CjB4cZN)_

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/issue/27435-remove-method-types-reexport/web/](https://dev.suite.sldev.cz/suite-web/issue/27435-remove-method-types-reexport/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=issue/27435-remove-method-types-reexport&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=issue/27435-remove-method-types-reexport&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-06T19:48:24.592Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->