### PR TITLE
📱 Mobile swap wire navigation from confirming screen

### DIFF
--- a/suite-common/trading/src/thunks/exchange/__tests__/selectExchangeQuoteThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/selectExchangeQuoteThunk.test.ts
@@ -126,6 +126,60 @@ describe('selectExchangeQuoteThunk', () => {
         expect(store.getState().wallet.trading.exchange.selectedQuote).toEqual(quote);
     });
 
+    it('should save DEX quote when status is CONFIRM', async () => {
+        const { quote, state } = getDataMocks();
+        const dexQuote = { ...quote, isDex: true, status: 'CONFIRM' as const };
+        const { store, mockNextStep } = getMocks(state, { status: 'running' });
+
+        await store
+            .dispatch(
+                exchangeThunks.selectQuoteThunk({
+                    quote: dexQuote,
+                    nextStep: mockNextStep,
+                }),
+            )
+            .unwrap();
+
+        expect(mockNextStep).toHaveBeenCalledTimes(1);
+        expect(store.getState().wallet.trading.exchange.selectedQuote).toEqual(dexQuote);
+    });
+
+    it('should save DEX quote when status is SIGN_DATA', async () => {
+        const { quote, state } = getDataMocks();
+        const dexQuote = { ...quote, isDex: true, status: 'SIGN_DATA' as const };
+        const { store, mockNextStep } = getMocks(state, { status: 'running' });
+
+        await store
+            .dispatch(
+                exchangeThunks.selectQuoteThunk({
+                    quote: dexQuote,
+                    nextStep: mockNextStep,
+                }),
+            )
+            .unwrap();
+
+        expect(mockNextStep).toHaveBeenCalledTimes(1);
+        expect(store.getState().wallet.trading.exchange.selectedQuote).toEqual(dexQuote);
+    });
+
+    it('should not save DEX quote with other statuses but still call nextStep', async () => {
+        const { quote, state } = getDataMocks();
+        const dexQuote = { ...quote, isDex: true, status: 'APPROVAL_REQ' as const };
+        const { store, mockNextStep } = getMocks(state, { status: 'running' });
+
+        await store
+            .dispatch(
+                exchangeThunks.selectQuoteThunk({
+                    quote: dexQuote,
+                    nextStep: mockNextStep,
+                }),
+            )
+            .unwrap();
+
+        expect(mockNextStep).toHaveBeenCalledTimes(1);
+        expect(store.getState().wallet.trading.exchange.selectedQuote).toBeUndefined();
+    });
+
     describe('should not be possible to save selected quote', () => {
         it('when exchangeInfo is undefined', async () => {
             const { quote, state } = getDataMocks();

--- a/suite-common/trading/src/thunks/exchange/selectExchangeQuoteThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/selectExchangeQuoteThunk.ts
@@ -25,7 +25,7 @@ export const selectExchangeQuoteThunk = createThunk(
             return;
         }
 
-        if (!quote.isDex) {
+        if (!quote.isDex || quote.status === 'CONFIRM' || quote.status === 'SIGN_DATA') {
             dispatch(tradingExchangeActions.saveSelectedQuote(quote));
         }
 

--- a/suite-native/module-trading/src/components/exchange/Confirmation/ExchangeConfirmationTitle.tsx
+++ b/suite-native/module-trading/src/components/exchange/Confirmation/ExchangeConfirmationTitle.tsx
@@ -25,6 +25,7 @@ const TitleTranslation = ({ flowType }: { flowType: ConfirmingScreenFlowType }) 
         case 'approve':
             return <Translation id="moduleTrading.tradingConfirmationScreen.approveTitle" />;
         case 'revoke':
+        case 'revoke-and-approve':
             return <Translation id="moduleTrading.tradingConfirmationScreen.revokeTitle" />;
         default:
             return exhaustive(flowType);

--- a/suite-native/module-trading/src/components/exchange/Confirmation/__tests__/ExchangeConfirmationTitle.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Confirmation/__tests__/ExchangeConfirmationTitle.test.tsx
@@ -30,6 +30,18 @@ describe('ExchangeConfirmationTitle', () => {
         ).toBeOnTheScreen();
     });
 
+    it('should display revoke title when flowType is revoke-and-approve', () => {
+        const { getByText } = renderTitle({
+            flowType: 'revoke-and-approve',
+            isFailed: false,
+            isPending: true,
+        });
+
+        expect(
+            getByText(getTranslation('moduleTrading.tradingConfirmationScreen.revokeTitle')),
+        ).toBeOnTheScreen();
+    });
+
     it('should display subtitle', () => {
         const { getByText } = renderTitle({
             flowType: 'approve',

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeFlow.test.ts
@@ -9,7 +9,7 @@ import {
 } from '@suite-native/trading-fixtures';
 
 import { createTradingTestStore } from '../../../__tests__/tradingTestUtils';
-import { useExchangeFlow } from '../useExchangeFlow';
+import { type UseExchangeFlowProps, useExchangeFlow } from '../useExchangeFlow';
 
 const mockNavigate = jest.fn();
 
@@ -71,7 +71,13 @@ describe('useExchangeFlow', () => {
         });
     };
 
-    const renderUseExchangeFlow = ({ store }: { store: TestStore }) => {
+    const renderUseExchangeFlow = ({
+        store,
+        flowType,
+    }: {
+        store: TestStore;
+        flowType?: UseExchangeFlowProps['flowType'];
+    }) => {
         const reportMock = jest.fn();
 
         (useAnalytics as jest.Mock).mockReturnValue({
@@ -80,7 +86,8 @@ describe('useExchangeFlow', () => {
 
         return {
             reportMock,
-            result: renderHookWithStoreProvider(() => useExchangeFlow(), { store }).result,
+            result: renderHookWithStoreProvider(() => useExchangeFlow({ flowType }), { store })
+                .result,
         };
     };
 
@@ -281,6 +288,58 @@ describe('useExchangeFlow', () => {
 
             expect(mockNavigate).toHaveBeenCalledWith(TradingStackRoutes.TradingConfirming, {
                 flowType: 'approve',
+            });
+        });
+
+        it('should navigate with flowType revoke when quoteStatus is APPROVAL_PENDING and flowType is revoke', () => {
+            const tradingState = getInitializedTradingStateWithQuotes();
+            tradingState.exchange.tradingAccountKey = btc1AccountKey;
+            tradingState.exchange.receiveAccountKey = btc2AccountKey;
+            tradingState.exchange.selectedQuote = {
+                ...tradingState.exchange.quotes[0],
+                status: 'APPROVAL_PENDING',
+            };
+
+            const store = createTradingTestStore({
+                tradeType: 'exchange',
+                overrides: {
+                    wallet: {
+                        trading: tradingState,
+                        accounts: getMockAccounts(),
+                    },
+                },
+            });
+
+            renderUseExchangeFlow({ store, flowType: 'revoke' });
+
+            expect(mockNavigate).toHaveBeenCalledWith(TradingStackRoutes.TradingConfirming, {
+                flowType: 'revoke',
+            });
+        });
+
+        it('should navigate with flowType revoke-and-approve when quoteStatus is APPROVAL_PENDING and flowType is revoke-and-approve', () => {
+            const tradingState = getInitializedTradingStateWithQuotes();
+            tradingState.exchange.tradingAccountKey = btc1AccountKey;
+            tradingState.exchange.receiveAccountKey = btc2AccountKey;
+            tradingState.exchange.selectedQuote = {
+                ...tradingState.exchange.quotes[0],
+                status: 'APPROVAL_PENDING',
+            };
+
+            const store = createTradingTestStore({
+                tradeType: 'exchange',
+                overrides: {
+                    wallet: {
+                        trading: tradingState,
+                        accounts: getMockAccounts(),
+                    },
+                },
+            });
+
+            renderUseExchangeFlow({ store, flowType: 'revoke-and-approve' });
+
+            expect(mockNavigate).toHaveBeenCalledWith(TradingStackRoutes.TradingConfirming, {
+                flowType: 'revoke-and-approve',
             });
         });
 

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeFlow.tsx
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeFlow.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
@@ -10,7 +10,7 @@ import {
     selectTradingExchangeActiveQuote,
 } from '@suite-common/trading';
 import { events } from '@suite-native/analytics';
-import { TradingStackRoutes } from '@suite-native/navigation';
+import { type ExchangeFlowType, TradingStackRoutes } from '@suite-native/navigation';
 import { useAnalytics } from '@suite-native/services';
 import { buildTradingUrl, useBrowserAuth } from '@suite-native/trading-browser-auth';
 import { selectExchangeSelectedSendAccount } from '@suite-native/trading-state';
@@ -31,7 +31,11 @@ export type TradingExchangeSignAndSendTransactionProps = {
     onError: (error: TradingSendRejectedProps) => void;
 };
 
-export const useExchangeFlow = () => {
+export type UseExchangeFlowProps = {
+    flowType?: ExchangeFlowType;
+};
+
+export const useExchangeFlow = ({ flowType }: UseExchangeFlowProps = {}) => {
     const navigation =
         useNavigation<
             TradingStackNavigationProp<
@@ -51,11 +55,17 @@ export const useExchangeFlow = () => {
     useFocusEffect(
         useCallback(() => {
             if (quoteStatus === 'APPROVAL_PENDING') {
+                // 'swap' and undefined both map to 'approve': the approval tx
+                // is always the first step before a swap, so confirming it means approving.
+                const confirmingFlowType =
+                    flowType === 'revoke' || flowType === 'revoke-and-approve'
+                        ? flowType
+                        : 'approve';
                 navigation.navigate(TradingStackRoutes.TradingConfirming, {
-                    flowType: 'approve',
+                    flowType: confirmingFlowType,
                 });
             }
-        }, [quoteStatus, navigation]),
+        }, [quoteStatus, navigation, flowType]),
     );
 
     const getCommonFunctions = useCallback(
@@ -95,6 +105,8 @@ export const useExchangeFlow = () => {
         [openBrowserForFormData, analytics, quote],
     );
 
+    const baseCommonFunctions = useMemo(() => getCommonFunctions(), [getCommonFunctions]);
+
     const {
         txnErrorString,
         composeRequest,
@@ -105,9 +117,9 @@ export const useExchangeFlow = () => {
         isTransactionSendConsentRequested,
     } = useTradingTransaction({
         tradeType: 'exchange',
-        returnUrl: getCommonFunctions()?.returnUrl,
-        processResponseData: getCommonFunctions()?.processResponseData,
-        triggerAnalyticsTradeConfirmation: getCommonFunctions()?.triggerAnalyticsTradeConfirmation,
+        returnUrl: baseCommonFunctions?.returnUrl,
+        processResponseData: baseCommonFunctions?.processResponseData,
+        triggerAnalyticsTradeConfirmation: baseCommonFunctions?.triggerAnalyticsTradeConfirmation,
     });
 
     // changing trade state and initial confirmation

--- a/suite-native/module-trading/src/screens/TradingConfirmingScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingConfirmingScreen.tsx
@@ -1,19 +1,25 @@
-import { useCallback, useEffect } from 'react';
-import { useSelector } from 'react-redux';
+import { useCallback, useEffect, useRef } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { useFocusEffect } from '@react-navigation/native';
 
-import { selectTradingExchangeActiveQuote, useAllowanceTxTracking } from '@suite-common/trading';
+import {
+    selectTradingExchangeActiveQuote,
+    tradingExchangeActions,
+    useAllowanceTxTracking,
+} from '@suite-common/trading';
+import { sendFormActions } from '@suite-common/wallet-core';
 import {
     type RootStackParamList,
     Screen,
     type StackToStackCompositeScreenProps,
     type TradingStackParamList,
-    type TradingStackRoutes,
+    TradingStackRoutes,
 } from '@suite-native/navigation';
 import { useTransactionStatusOverride } from '@suite-native/trading-debug';
 import { selectExchangeSelectedSendAccount } from '@suite-native/trading-state';
 import { useTransactionDetails } from '@suite-native/transaction-management';
+import { exhaustive } from '@trezor/type-utils';
 
 import { ConfirmationQuoteDebugView } from '../components/exchange/Confirmation/ConfirmationQuoteDebugView';
 import { ExchangeConfirmationHeader } from '../components/exchange/Confirmation/ExchangeConfirmationHeader';
@@ -21,6 +27,7 @@ import { ExchangeConfirmationInfo } from '../components/exchange/Confirmation/Ex
 import { ExchangeConfirmationTitle } from '../components/exchange/Confirmation/ExchangeConfirmationTitle';
 import { ExploreInBlockchainButton } from '../components/exchange/Confirmation/ExploreInBlockchainButton';
 import { TradingDeviceConnectionGuard } from '../components/general/TradingDeviceConnectionGuard';
+import { useApprovalFlow } from '../hooks/exchange/Approval/useApprovalFlow';
 
 export type TradingConfirmingScreenProps = StackToStackCompositeScreenProps<
     TradingStackParamList,
@@ -34,18 +41,21 @@ export const TradingConfirmingScreen = ({
 }: TradingConfirmingScreenProps) => {
     const { flowType } = params;
 
+    const dispatch = useDispatch();
     const sendAccount = useSelector(selectExchangeSelectedSendAccount);
     const activeQuote = useSelector(selectTradingExchangeActiveQuote);
     const accountKey = sendAccount?.key ?? null;
     const approvalSendTxHash = activeQuote?.approvalSendTxHash;
 
+    const { confirmApproval } = useApprovalFlow();
+
+    const hasConfirmedRef = useRef(false);
+
     const {
         status: originalStatus,
         approvalTxid,
         setApprovalTxid,
-    } = useAllowanceTxTracking({
-        accountKey,
-    });
+    } = useAllowanceTxTracking({ accountKey });
 
     useEffect(() => {
         if (approvalSendTxHash) {
@@ -62,12 +72,83 @@ export const TradingConfirmingScreen = ({
 
     const { isConfirmed, isFailed, isPending } = status;
 
+    useEffect(() => {
+        const unsubscribe = navigation.addListener('beforeRemove', e => {
+            const { type, payload } = e.data.action as {
+                type: string;
+                payload?: { count?: number };
+            };
+            const isSingleBackPress =
+                type === 'GO_BACK' || (type === 'POP' && (payload?.count ?? 1) <= 1);
+
+            if (isSingleBackPress) {
+                dispatch(tradingExchangeActions.saveSelectedQuote(undefined));
+            }
+        });
+
+        return unsubscribe;
+    }, [dispatch, navigation]);
+
     useFocusEffect(
         useCallback(() => {
-            if (isConfirmed) {
-                navigation.popToTop();
-            }
-        }, [isConfirmed, navigation]),
+            if (!isConfirmed || !activeQuote || hasConfirmedRef.current) return;
+
+            hasConfirmedRef.current = true;
+
+            const handleConfirmed = async () => {
+                switch (flowType) {
+                    case 'approve': {
+                        let response = await confirmApproval(activeQuote);
+
+                        if (response?.status === 'APPROVAL_PENDING') {
+                            // we know it was confirmed, so we can set the status to CONFIRM even if it came as APPROVAL_PENDING
+                            // that is basically what api does (but it takes time)
+                            // so we need to do it here to avoid the approval screen transition through useExchangeFlow
+                            response = { ...response, status: 'CONFIRM' };
+                            dispatch(tradingExchangeActions.saveSelectedQuote(response));
+                        }
+
+                        if (!response) {
+                            // confirmApproval already sets the error state — stay on this screen.
+                            hasConfirmedRef.current = false;
+
+                            return;
+                        }
+
+                        dispatch(sendFormActions.dispose());
+                        navigation.popToTop();
+                        navigation.push(TradingStackRoutes.TradingExchangePreview, {
+                            isApproved: true,
+                        });
+                        break;
+                    }
+
+                    case 'revoke-and-approve':
+                        dispatch(sendFormActions.dispose());
+                        dispatch(tradingExchangeActions.saveSelectedQuote(undefined));
+                        // preselectedQuote is preserved in the store, so we can navigate to the approval screen with it
+                        navigation.popToTop();
+                        navigation.push(TradingStackRoutes.TradingExchangeApproval, {
+                            isRevoked: true,
+                        });
+                        break;
+
+                    case 'revoke':
+                        dispatch(sendFormActions.dispose());
+                        dispatch(tradingExchangeActions.saveSelectedQuote(undefined));
+                        dispatch(tradingExchangeActions.savePreselectedQuote(undefined));
+                        navigation.popToTop();
+                        break;
+
+                    default:
+                        exhaustive(flowType);
+                }
+            };
+
+            void handleConfirmed().catch(() => {
+                hasConfirmedRef.current = false;
+            });
+        }, [isConfirmed, activeQuote, flowType, confirmApproval, dispatch, navigation]),
     );
 
     return (

--- a/suite-native/module-trading/src/screens/TradingExchangeApprovalScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingExchangeApprovalScreen.tsx
@@ -35,6 +35,7 @@ type TradingExchangeApprovalScreenProps = StackToStackCompositeScreenProps<
 
 export const TradingExchangeApprovalScreen = ({
     route: { params },
+    navigation,
 }: TradingExchangeApprovalScreenProps) => {
     const { shouldIncreaseLimit, isRevoked } = params;
     const dispatch = useDispatch();
@@ -78,11 +79,14 @@ export const TradingExchangeApprovalScreen = ({
 
         hasConfirmedRef.current = true;
 
-        const quoteWithType = quote.approvalType
-            ? quote
-            : ({ ...quote, approvalType: 'MINIMAL' } satisfies ExchangeTrade);
+        // When arriving from a revoke-and-approve flow the quote still carries approvalType: 'ZERO'
+        // from the revoke step. Reset it to 'MINIMAL' so we sign an approval, not another revoke.
+        const needsTypeReset = !quote.approvalType || isRevoked;
+        const quoteWithType = needsTypeReset
+            ? ({ ...quote, approvalType: 'MINIMAL' } satisfies ExchangeTrade)
+            : quote;
 
-        if (!quote.approvalType) {
+        if (needsTypeReset) {
             dispatch(tradingExchangeActions.saveSelectedQuote(quoteWithType));
         }
 
@@ -101,14 +105,27 @@ export const TradingExchangeApprovalScreen = ({
         return () => {
             isActive = false;
         };
-    }, [quote, isReady, dispatch, confirmApproval]);
+    }, [quote, isReady, isRevoked, dispatch, confirmApproval]);
 
-    useEffect(
-        () => () => {
-            dispatch(tradingExchangeActions.saveSelectedQuote(undefined));
-        },
-        [dispatch],
-    );
+    useEffect(() => {
+        // Clear the selected quote only when the user navigates backward (back button / swipe back).
+        // popToTop() translates to POP with count > 1 — those removals are programmatic forward
+        // navigation so the quote must remain in Redux for the next screen to read it.
+        const unsubscribe = navigation.addListener('beforeRemove', e => {
+            const { type, payload } = e.data.action as {
+                type: string;
+                payload?: { count?: number };
+            };
+            const isSingleBackPress =
+                type === 'GO_BACK' || (type === 'POP' && (payload?.count ?? 1) <= 1);
+
+            if (isSingleBackPress) {
+                dispatch(tradingExchangeActions.saveSelectedQuote(undefined));
+            }
+        });
+
+        return unsubscribe;
+    }, [dispatch, navigation]);
 
     if (!quote) {
         return (

--- a/suite-native/module-trading/src/screens/TradingExchangeRevokeScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingExchangeRevokeScreen.tsx
@@ -35,6 +35,7 @@ type TradingExchangeRevokeScreenProps = StackToStackCompositeScreenProps<
 
 export const TradingExchangeRevokeScreen = ({
     route: { params },
+    navigation,
 }: TradingExchangeRevokeScreenProps) => {
     const { shouldIncreaseLimit } = params;
     const dispatch = useDispatch();
@@ -104,12 +105,25 @@ export const TradingExchangeRevokeScreen = ({
         };
     }, [quote, isReady, dispatch, confirmApproval]);
 
-    useEffect(
-        () => () => {
-            dispatch(tradingExchangeActions.saveSelectedQuote(undefined));
-        },
-        [dispatch],
-    );
+    useEffect(() => {
+        // Clear the selected quote only when the user navigates backward (back button / swipe back).
+        // popToTop() translates to POP with count > 1 — those removals are programmatic forward
+        // navigation so the quote must remain in Redux for the next screen to read it.
+        const unsubscribe = navigation.addListener('beforeRemove', e => {
+            const { type, payload } = e.data.action as {
+                type: string;
+                payload?: { count?: number };
+            };
+            const isSingleBackPress =
+                type === 'GO_BACK' || (type === 'POP' && (payload?.count ?? 1) <= 1);
+
+            if (isSingleBackPress) {
+                dispatch(tradingExchangeActions.saveSelectedQuote(undefined));
+            }
+        });
+
+        return unsubscribe;
+    }, [dispatch, navigation]);
 
     if (!quote) {
         return (
@@ -150,7 +164,7 @@ export const TradingExchangeRevokeScreen = ({
                     <ApprovalButton
                         isReady={isRevokeReady}
                         isDisabled={!!error}
-                        flowType="revoke"
+                        flowType={shouldIncreaseLimit ? 'revoke-and-approve' : 'revoke'}
                     />
                 }
             >

--- a/suite-native/module-trading/src/screens/TradingOutputsReviewScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingOutputsReviewScreen.tsx
@@ -20,7 +20,7 @@ export const TradingExchangeOutputsReviewScreen = ({
         signAndSendTransaction,
         isTransactionSendConsentRequested,
         resolveTransactionSendConsent,
-    } = useExchangeFlow();
+    } = useExchangeFlow({ flowType });
     const analyticsReportCallback = useExchangeAnalyticReportCallback();
 
     return (

--- a/suite-native/module-trading/src/screens/__tests__/TradingConfirmingScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingConfirmingScreen.test.tsx
@@ -1,8 +1,13 @@
-import { tradingExchangeActions, useAllowanceTxTracking } from '@suite-common/trading';
+import {
+    selectTradingExchangePreselectedQuote,
+    selectTradingExchangeSelectedQuote,
+    tradingExchangeActions,
+    useAllowanceTxTracking,
+} from '@suite-common/trading';
 import type { TransactionStatus } from '@suite-common/trading';
 import { getTranslation } from '@suite-native/intl';
 import { type TradingStackParamList, TradingStackRoutes } from '@suite-native/navigation';
-import { type TestStore, renderWithStoreProvider } from '@suite-native/test-utils-store';
+import { type TestStore, act, renderWithStoreProvider } from '@suite-native/test-utils-store';
 import { mockTransaction } from '@suite-native/tokens';
 import { exchangeQuotes } from '@suite-native/trading-fixtures';
 import { useTransactionDetails } from '@suite-native/transaction-management';
@@ -22,15 +27,35 @@ jest.mock('@suite-common/device', () => ({
     selectIsDeviceConnected: () => true,
 }));
 
+const mockConfirmApproval = jest.fn().mockResolvedValue({});
+
+jest.mock('../../hooks/exchange/Approval/useApprovalFlow', () => ({
+    useApprovalFlow: () => ({
+        confirmApproval: mockConfirmApproval,
+    }),
+}));
+
 const mockUseTransactionDetails = useTransactionDetails as jest.Mock;
 
 const testQuote = exchangeQuotes[0];
 
+const mockAddListener = jest.fn(
+    (
+        _event: string,
+        _listener: (e: {
+            data: { action: { type: string; payload?: { count?: number } } };
+        }) => void,
+    ) => jest.fn(),
+);
+
 const mockNavigation = {
     navigate: jest.fn(),
     goBack: jest.fn(),
+    dispatch: jest.fn(),
     popToTop: jest.fn(),
+    push: jest.fn(),
     setOptions: jest.fn(),
+    addListener: mockAddListener,
 } as any;
 
 let routeParams: TradingStackParamList[TradingStackRoutes.TradingConfirming] = {
@@ -84,6 +109,7 @@ describe('TradingConfirmingScreen', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
+        mockConfirmApproval.mockResolvedValue({});
         store = createTradingLightStore({ tradeType: 'exchange' });
         store.dispatch(tradingExchangeActions.saveSelectedQuote(testQuote));
         mockUseAllowanceTxTracking.mockReturnValue({
@@ -99,6 +125,12 @@ describe('TradingConfirmingScreen', () => {
             explorerUrl: null,
         });
     });
+
+    const confirmedStatus = {
+        status: { isConfirmed: true, isFailed: false, isPending: false } as TransactionStatus,
+        approvalTxid: 'some-txid',
+        setApprovalTxid: jest.fn(),
+    };
 
     it('should render approve header when variant is approve', () => {
         const { getByTestId } = renderScreen({ flowType: 'approve' });
@@ -120,22 +152,84 @@ describe('TradingConfirmingScreen', () => {
         );
     });
 
-    it('should call navigation.popToTop when transaction is confirmed', () => {
-        mockUseAllowanceTxTracking.mockReturnValue({
-            status: { isConfirmed: true, isFailed: false, isPending: false } as TransactionStatus,
-            approvalTxid: 'some-txid',
-            setApprovalTxid: jest.fn(),
-        });
-
-        renderScreen();
-
-        expect(mockNavigation.popToTop).toHaveBeenCalled();
-    });
-
-    it('should not call navigation.popToTop when transaction is not confirmed', () => {
+    it('should not navigate when transaction is not confirmed', () => {
         renderScreen();
 
         expect(mockNavigation.popToTop).not.toHaveBeenCalled();
+        expect(mockNavigation.push).not.toHaveBeenCalled();
+    });
+
+    it('approve: navigates to TradingExchangePreview after confirmApproval succeeds', async () => {
+        mockUseAllowanceTxTracking.mockReturnValue(confirmedStatus);
+
+        renderScreen({ flowType: 'approve' });
+
+        await act(async () => {
+            await Promise.resolve(); // flush confirmApproval promise
+        });
+
+        expect(mockNavigation.popToTop).toHaveBeenCalled();
+        expect(mockNavigation.push).toHaveBeenCalledWith(
+            TradingStackRoutes.TradingExchangePreview,
+            {
+                isApproved: true,
+            },
+        );
+    });
+
+    it('approve: saves quote with CONFIRM status when confirmApproval returns APPROVAL_PENDING', async () => {
+        mockUseAllowanceTxTracking.mockReturnValue(confirmedStatus);
+        mockConfirmApproval.mockResolvedValue({ ...testQuote, status: 'APPROVAL_PENDING' });
+
+        renderScreen({ flowType: 'approve' });
+
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(selectTradingExchangeSelectedQuote(store.getState())).toEqual(
+            expect.objectContaining({ status: 'CONFIRM' }),
+        );
+        expect(mockNavigation.popToTop).toHaveBeenCalled();
+    });
+
+    it('approve: does not navigate when confirmApproval fails', async () => {
+        mockUseAllowanceTxTracking.mockReturnValue(confirmedStatus);
+        mockConfirmApproval.mockResolvedValue(undefined);
+
+        renderScreen({ flowType: 'approve' });
+
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(mockNavigation.popToTop).not.toHaveBeenCalled();
+        expect(mockNavigation.push).not.toHaveBeenCalled();
+    });
+
+    it('revoke-and-approve: navigates to TradingExchangeApproval and clears selectedQuote', () => {
+        mockUseAllowanceTxTracking.mockReturnValue(confirmedStatus);
+
+        renderScreen({ flowType: 'revoke-and-approve' });
+
+        expect(mockNavigation.popToTop).toHaveBeenCalled();
+        expect(mockNavigation.push).toHaveBeenCalledWith(
+            TradingStackRoutes.TradingExchangeApproval,
+            { isRevoked: true },
+        );
+        expect(selectTradingExchangeSelectedQuote(store.getState())).toBeUndefined();
+    });
+
+    it('revoke: pops to top and clears selectedQuote and preselectedQuote', () => {
+        store.dispatch(tradingExchangeActions.savePreselectedQuote(testQuote));
+        mockUseAllowanceTxTracking.mockReturnValue(confirmedStatus);
+
+        renderScreen({ flowType: 'revoke' });
+
+        expect(mockNavigation.popToTop).toHaveBeenCalled();
+        expect(mockNavigation.push).not.toHaveBeenCalled();
+        expect(selectTradingExchangeSelectedQuote(store.getState())).toBeUndefined();
+        expect(selectTradingExchangePreselectedQuote(store.getState())).toBeUndefined();
     });
 
     it('should render the explore in blockchain button', () => {
@@ -160,5 +254,25 @@ describe('TradingConfirmingScreen', () => {
         const { getByText } = renderScreen();
 
         expect(getByText('Date')).toBeOnTheScreen();
+    });
+
+    it('should clear selected quote on back navigation', () => {
+        renderScreen();
+
+        const [, listener] =
+            mockAddListener.mock.calls.find(([event]) => event === 'beforeRemove') ?? [];
+        listener?.({ data: { action: { type: 'GO_BACK' } } });
+
+        expect(selectTradingExchangeSelectedQuote(store.getState())).toBeUndefined();
+    });
+
+    it('should not clear selected quote on programmatic popToTop (POP with count > 1)', () => {
+        renderScreen();
+
+        const [, listener] =
+            mockAddListener.mock.calls.find(([event]) => event === 'beforeRemove') ?? [];
+        listener?.({ data: { action: { type: 'POP', payload: { count: 3 } } } });
+
+        expect(selectTradingExchangeSelectedQuote(store.getState())).toEqual(testQuote);
     });
 });

--- a/suite-native/module-trading/src/screens/__tests__/TradingExchangeApprovalScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingExchangeApprovalScreen.test.tsx
@@ -37,6 +37,15 @@ jest.mock('../../hooks/exchange/Approval/useEvmApprovalFees', () => ({
     }),
 }));
 
+const mockAddListener = jest.fn(
+    (
+        _event: string,
+        _listener: (e: {
+            data: { action: { type: string; payload?: { count?: number } } };
+        }) => void,
+    ) => jest.fn(),
+);
+
 jest.mock('@react-navigation/native', () => ({
     ...jest.requireActual('@react-navigation/native'),
     useRoute: () =>
@@ -71,9 +80,12 @@ describe('TradingExchangeApprovalScreen', () => {
 
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
-    const renderScreen = () => {
+    const renderScreen = (params: Record<string, unknown> = {}) => {
         const result = renderWithTradingProvider(
-            <TradingExchangeApprovalScreen route={{ params: {} } as any} navigation={{} as any} />,
+            <TradingExchangeApprovalScreen
+                route={{ params } as any}
+                navigation={{ addListener: mockAddListener } as any}
+            />,
             { store, tradeType: 'exchange' },
         );
 
@@ -153,15 +165,39 @@ describe('TradingExchangeApprovalScreen', () => {
         expect(errorSpy).toHaveBeenCalledWith('No quote to confirm approval');
     });
 
-    it('should clear selected quote on unmount', () => {
+    it('should clear selected quote on back navigation', () => {
         store.dispatch(tradingExchangeActions.saveSelectedQuote(testQuote));
-        const { unmount: localUnmount } = renderScreen();
+        renderScreen();
 
-        localUnmount();
-        unmount = undefined;
+        // Simulate the beforeRemove event with a GO_BACK action (back button / swipe back).
+        const [, listener] =
+            mockAddListener.mock.calls.find(([event]) => event === 'beforeRemove') ?? [];
+        listener?.({ data: { action: { type: 'GO_BACK' } } });
 
         const selectedQuote = selectTradingExchangeSelectedQuote(store.getState());
         expect(selectedQuote).toBeUndefined();
+    });
+
+    it('should not clear selected quote on programmatic popToTop (POP with count > 1)', () => {
+        store.dispatch(tradingExchangeActions.saveSelectedQuote(testQuote));
+        renderScreen();
+
+        const [, listener] =
+            mockAddListener.mock.calls.find(([event]) => event === 'beforeRemove') ?? [];
+        listener?.({ data: { action: { type: 'POP', payload: { count: 3 } } } });
+
+        const selectedQuote = selectTradingExchangeSelectedQuote(store.getState());
+        expect(selectedQuote).toEqual({ ...testQuote, approvalType: 'MINIMAL' });
+    });
+
+    it('should render revoke success alert when isRevoked is true', () => {
+        const { getByText } = renderScreen({ isRevoked: true });
+
+        expect(
+            getByText(
+                getTranslation('moduleTrading.tradingExchangeApprovalScreen.revokeSuccessAlert'),
+            ),
+        ).toBeOnTheScreen();
     });
 
     it('should display device guard when device is not connected', () => {

--- a/suite-native/module-trading/src/screens/__tests__/TradingExchangeRevokeScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingExchangeRevokeScreen.test.tsx
@@ -35,6 +35,15 @@ jest.mock('../../hooks/exchange/Approval/useEvmApprovalFees', () => ({
     }),
 }));
 
+const mockAddListener = jest.fn(
+    (
+        _event: string,
+        _listener: (e: {
+            data: { action: { type: string; payload?: { count?: number } } };
+        }) => void,
+    ) => jest.fn(),
+);
+
 jest.mock('@react-navigation/native', () => ({
     ...jest.requireActual('@react-navigation/native'),
     useRoute: () =>
@@ -69,9 +78,12 @@ describe('TradingExchangeRevokeScreen', () => {
 
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
-    const renderScreen = () => {
+    const renderScreen = (params: Record<string, unknown> = {}) => {
         const result = renderWithTradingProvider(
-            <TradingExchangeRevokeScreen route={{ params: {} } as any} navigation={{} as any} />,
+            <TradingExchangeRevokeScreen
+                route={{ params } as any}
+                navigation={{ addListener: mockAddListener } as any}
+            />,
             { store, tradeType: 'exchange' },
         );
 
@@ -140,15 +152,39 @@ describe('TradingExchangeRevokeScreen', () => {
         expect(errorSpy).toHaveBeenCalledWith('No quote to revoke approval');
     });
 
-    it('should clear selected quote on unmount', () => {
+    it('should clear selected quote on back navigation', () => {
         store.dispatch(tradingExchangeActions.saveSelectedQuote(testQuote));
-        const { unmount: localUnmount } = renderScreen();
+        renderScreen();
 
-        localUnmount();
-        unmount = undefined;
+        // Simulate the beforeRemove event with a GO_BACK action (back button / swipe back).
+        const [, listener] =
+            mockAddListener.mock.calls.find(([event]) => event === 'beforeRemove') ?? [];
+        listener?.({ data: { action: { type: 'GO_BACK' } } });
 
         const selectedQuote = selectTradingExchangeSelectedQuote(store.getState());
         expect(selectedQuote).toBeUndefined();
+    });
+
+    it('should not clear selected quote on programmatic popToTop (POP with count > 1)', () => {
+        store.dispatch(tradingExchangeActions.saveSelectedQuote(testQuote));
+        renderScreen();
+
+        const [, listener] =
+            mockAddListener.mock.calls.find(([event]) => event === 'beforeRemove') ?? [];
+        listener?.({ data: { action: { type: 'POP', payload: { count: 3 } } } });
+
+        const selectedQuote = selectTradingExchangeSelectedQuote(store.getState());
+        expect(selectedQuote).toEqual({ ...testQuote, approvalType: 'ZERO' });
+    });
+
+    it('should render low limit info alert when shouldIncreaseLimit is true', () => {
+        const { getByText } = renderScreen({ shouldIncreaseLimit: true });
+
+        expect(
+            getByText(
+                getTranslation('moduleTrading.tradingExchangeRevokeScreen.lowLimitInfoAlert'),
+            ),
+        ).toBeOnTheScreen();
     });
 
     it('should display device guard when device is not connected', () => {

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -471,7 +471,7 @@ export type TransactionDetailStackParamList = {
     };
 };
 
-export type ConfirmingScreenFlowType = 'approve' | 'revoke';
+export type ConfirmingScreenFlowType = 'approve' | 'revoke' | 'revoke-and-approve';
 export type ExchangeFlowType = 'swap' | ConfirmingScreenFlowType;
 
 export type TradingStackParamList = {

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItem.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItem.tsx
@@ -34,7 +34,7 @@ const OutputLabel = ({
             if (flowType === 'approve') {
                 return <Translation id="transactionManagement.review.outputs.tokenApprovalLabel" />;
             }
-            if (flowType === 'revoke') {
+            if (flowType === 'revoke' || flowType === 'revoke-and-approve') {
                 return (
                     <Translation id="transactionManagement.review.outputs.tokenRevocationLabel" />
                 );
@@ -49,7 +49,7 @@ const OutputLabel = ({
             if (flowType === 'approve') {
                 return <Translation id="transactionManagement.review.outputs.approveToLabel" />;
             }
-            if (flowType === 'revoke') {
+            if (flowType === 'revoke' || flowType === 'revoke-and-approve') {
                 return (
                     <Translation id="transactionManagement.review.outputs.revokeApprovalFromLabel" />
                 );
@@ -63,7 +63,7 @@ const OutputLabel = ({
         case 'network':
             return <Translation id="transactionManagement.review.outputs.networkLabel" />;
         case 'approve_data':
-            if (flowType === 'revoke') {
+            if (flowType === 'revoke' || flowType === 'revoke-and-approve') {
                 return <Translation id="transactionManagement.review.outputs.revokeLabel" />;
             }
 

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemContent.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemContent.tsx
@@ -61,7 +61,7 @@ export const ReviewOutputItemContent = ({
                     </Text>
                 );
             }
-            if (flowType === 'revoke') {
+            if (flowType === 'revoke' || flowType === 'revoke-and-approve') {
                 return (
                     <Text variant="body-sm">
                         <Translation id="transactionManagement.review.outputs.tokenRevocationDescription" />
@@ -72,7 +72,11 @@ export const ReviewOutputItemContent = ({
             return <AddressFormatter value={value} format="full" variant="body-sm" />;
 
         case 'contract':
-            if (flowType === 'approve' || flowType === 'revoke') {
+            if (
+                flowType === 'approve' ||
+                flowType === 'revoke' ||
+                flowType === 'revoke-and-approve'
+            ) {
                 return <Text variant="body-sm">{value}</Text>;
             }
 
@@ -123,7 +127,7 @@ export const ReviewOutputItemContent = ({
                     </VStack>
                 );
             }
-            if (flowType === 'revoke' && token) {
+            if ((flowType === 'revoke' || flowType === 'revoke-and-approve') && token) {
                 return (
                     <VStack>
                         <HStack justifyContent="space-between">

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputSummaryItem.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputSummaryItem.tsx
@@ -56,7 +56,7 @@ const TokenEnabledValues = ({
 }: TokenEnabledValuesProps) => {
     let amount: string | undefined;
 
-    if (flowType !== 'approve' && flowType !== 'revoke') {
+    if (!flowType || flowType === 'swap') {
         amount = tokenContract ? totalSpent : BigNumber(totalSpent).minus(fee).toString();
     }
 

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputItem.test.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputItem.test.tsx
@@ -294,6 +294,82 @@ describe('ReviewOutputItem', () => {
         });
     });
 
+    describe('exchange revoke-and-approve flow', () => {
+        it('should render Token revoke for type "address"', () => {
+            const { getByTestId } = renderReviewOutputItem({
+                reviewOutput: {
+                    type: 'address',
+                    value: '0x1234567890abcdef1234567890abcdef12345678',
+                    state: 'active',
+                },
+                flowType: 'revoke-and-approve',
+            });
+
+            expect(getByTestId('review-output-card/title')).toHaveTextContent(
+                getTranslation('transactionManagement.review.outputs.tokenRevocationLabel'),
+            );
+            expect(getByTestId('review-output-card/content')).toHaveTextContent(
+                getTranslation('transactionManagement.review.outputs.tokenRevocationDescription'),
+            );
+        });
+
+        it('should render "Revoke approval from" for type "contract"', () => {
+            const { getByTestId } = renderReviewOutputItem({
+                reviewOutput: {
+                    state: undefined,
+                    type: 'contract',
+                    value: '1inch Aggregation Router V6',
+                },
+                flowType: 'revoke-and-approve',
+            });
+
+            expect(getByTestId('review-output-card/title')).toHaveTextContent(
+                getTranslation('transactionManagement.review.outputs.revokeApprovalFromLabel'),
+            );
+            expect(getByTestId('review-output-card/content')).toHaveTextContent(
+                '1inch Aggregation Router V6',
+            );
+        });
+
+        it('should render Revoke info for type "approve_data"', () => {
+            const { getByTestId } = renderReviewOutputItem({
+                reviewOutput: {
+                    state: undefined,
+                    token: {
+                        balance: '33.231005',
+                        contract: '0x98C23E9d8f34FEFb1B7BD6a91B7FF122F4e16F5c',
+                        decimals: 6,
+                        name: 'Aave Ethereum USDC',
+                        standard: 'ERC20',
+                        symbol: 'aEthUSDC',
+                    },
+                    type: 'approve_data',
+                    value: '20000000',
+                    value2: 'Ethereum',
+                },
+                flowType: 'revoke-and-approve',
+            });
+
+            const content = getByTestId('review-output-card/content');
+
+            expect(getByTestId('review-output-card/title')).toHaveTextContent(
+                getTranslation('transactionManagement.review.outputs.revokeLabel'),
+            );
+            expect(
+                within(content).getByText(
+                    getTranslation('transactionManagement.review.outputs.tokenLabel'),
+                ),
+            ).toBeTruthy();
+            expect(within(content).getByText('aEthUSDC')).toBeTruthy();
+            expect(
+                within(content).getByText(
+                    getTranslation('transactionManagement.review.outputs.chainLabel'),
+                ),
+            ).toBeTruthy();
+            expect(within(content).getByText('Ethereum')).toBeTruthy();
+        });
+    });
+
     describe('exchange revoke flow', () => {
         it('should render Token revoke for type "address"', () => {
             const { getByTestId } = renderReviewOutputItem({

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputSummaryItem.test.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputSummaryItem.test.tsx
@@ -89,31 +89,32 @@ describe('ReviewOutputSummaryItem', () => {
         ).toBeTruthy();
     });
 
-    it.each<'approve' | 'revoke'>(['approve', 'revoke'])(
-        'should not render "amount" for flowType "%s"',
-        flowType => {
-            const { getByText, queryByText } = renderReviewOutputSummaryItem({
-                summaryOutput: {
-                    totalSpent: '1000',
-                    fee: '10',
-                    state: 'active',
-                },
-                symbol: 'eth',
-                flowType,
-            });
+    it.each<'approve' | 'revoke' | 'revoke-and-approve'>([
+        'approve',
+        'revoke',
+        'revoke-and-approve',
+    ])('should not render "amount" for flowType "%s"', flowType => {
+        const { getByText, queryByText } = renderReviewOutputSummaryItem({
+            summaryOutput: {
+                totalSpent: '1000',
+                fee: '10',
+                state: 'active',
+            },
+            symbol: 'eth',
+            flowType,
+        });
 
-            expect(
-                queryByText(
-                    /ReviewOutputItemValues: \[transactionManagement\.review\.outputs\.summary\.amount\]/,
-                ),
-            ).toBeNull();
-            expect(
-                getByText(
-                    'ReviewOutputItemValues: [transactionManagement.review.outputs.summary.maxFee]-[10]',
-                ),
-            ).toBeTruthy();
-        },
-    );
+        expect(
+            queryByText(
+                /ReviewOutputItemValues: \[transactionManagement\.review\.outputs\.summary\.amount\]/,
+            ),
+        ).toBeNull();
+        expect(
+            getByText(
+                'ReviewOutputItemValues: [transactionManagement.review.outputs.summary.maxFee]-[10]',
+            ),
+        ).toBeTruthy();
+    });
 
     it('should render "amount" and "max fee" for USDC', () => {
         const { getByText } = renderReviewOutputSummaryItem({


### PR DESCRIPTION
- Adds exchange flow type `revoke-and-approve` for case of USDT on eth that needs revoke before increasing allowance.
- Adds transition for all exchange flow types: `approval -> swap` or in case of usdt `revoke -> approval -> swap`
- Enable actual dex swap if approved amount is sufficient 

## Notes for QA
- approval -> swap should work
- if not enough approved for usdt on eth: revoke -> approval -> swap
- Dex swap should work

## Related Issue

Resolve #27126 
Resolve #26438 
Resolve #27452 

## Screenshots:

https://github.com/user-attachments/assets/143f20a8-10da-44c5-a7e6-e91fd63b1315


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=27126-mobile-swap-wire-navigation-from-confirming-screen&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=27126-mobile-swap-wire-navigation-from-confirming-screen&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=27126-mobile-swap-wire-navigation-from-confirming-screen&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-07T20:51:11.256Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-07T20:50:45.109Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/27126-mobile-swap-wire-navigation-from-confirming-screen/web/](https://dev.suite.sldev.cz/suite-web/27126-mobile-swap-wire-navigation-from-confirming-screen/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->