### PR TITLE
fix(suite): auto-close firmware update modal and show success toast

### DIFF
--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
@@ -668,6 +668,13 @@ export const NotificationRenderer = ({
                 message: 'TR_FIRMWARE_LANGUAGE_CHANGED',
             });
 
+        case 'firmware-update-success':
+            return renderNotificationView(render, notification, {
+                variant: 'success',
+                message: 'TOAST_FIRMWARE_UPDATE_SUCCESS',
+                icon: 'check',
+            });
+
         case 'firmware-language-fetch-error':
             return renderNotificationView(render, notification, {
                 variant: 'error',

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
@@ -613,6 +613,13 @@ export const NotificationRenderer = ({
                 message: 'TR_FIRMWARE_LANGUAGE_CHANGED',
             });
 
+        case 'firmware-update-success':
+            return renderNotificationView(render, notification, {
+                variant: 'success',
+                message: 'TOAST_FIRMWARE_UPDATE_SUCCESS',
+                icon: 'check',
+            });
+
         case 'firmware-language-fetch-error':
             return renderNotificationView(render, notification, {
                 variant: 'error',

--- a/packages/suite/src/views/firmware/FirmwareModal.tsx
+++ b/packages/suite/src/views/firmware/FirmwareModal.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useState } from 'react';
+import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 
 import {
     useFirmwareDesktopUpdate,
@@ -8,6 +8,7 @@ import { closeModal } from '@suite/modal';
 import { closeModalApp } from '@suite/router';
 import { ThpPairingStep } from '@suite/thp';
 import { selectSelectedDevice } from '@suite-common/device';
+import { notificationsActions } from '@suite-common/toast-notifications';
 import { acquireDevice } from '@suite-common/wallet-core';
 import { Modal } from '@trezor/components';
 import { exhaustive } from '@trezor/type-utils';
@@ -20,6 +21,8 @@ import { StepDone } from './Steps/StepDone';
 import { StepError } from './Steps/StepError';
 import { StepInitial } from './Steps/StepInitial';
 import { StepStarted } from './Steps/StepStarted';
+
+const AUTO_CLOSE_AFTER_DONE_MS = 2000;
 
 type FirmwareModalProps = {
     children: ReactNode;
@@ -47,14 +50,26 @@ export const FirmwareModal = ({
     // It can be canceled only via `trezorCancel`
     const isCancelable = ['initial', 'check-seed', 'done', 'error'].includes(status);
 
-    const handleClose = () => {
+    const handleClose = useCallback(() => {
         if (device?.status !== 'available') {
             dispatch(acquireDevice({ requestedDevice: device }));
         }
         dispatch(closeModal());
         dispatch(closeModalApp());
         resetReducer();
-    };
+    }, [device, dispatch, resetReducer]);
+
+    const handleCloseRef = useRef(handleClose);
+    handleCloseRef.current = handleClose;
+
+    useEffect(() => {
+        if (status !== 'done') return;
+
+        dispatch(notificationsActions.addToast({ type: 'firmware-update-success' }));
+        const timeoutId = setTimeout(() => handleCloseRef.current(), AUTO_CLOSE_AFTER_DONE_MS);
+
+        return () => clearTimeout(timeoutId);
+    }, [status, dispatch]);
 
     const getContent = () => {
         switch (status) {

--- a/suite-common/toast-notifications/src/types.ts
+++ b/suite-common/toast-notifications/src/types.ts
@@ -134,6 +134,7 @@ export type ToastPayload<TranslationKey extends UnknownTranslationKey = UnknownT
               | 'coinjoin-interrupted'
               | 'firmware-language-changed'
               | 'firmware-language-fetch-error'
+              | 'firmware-update-success'
               | 'estimated-fee-error'
               | 'not-enough-funds-error'
               | 'could-not-parse-csv'

--- a/suite-common/toast-notifications/src/types.ts
+++ b/suite-common/toast-notifications/src/types.ts
@@ -130,6 +130,7 @@ export type ToastPayload<TranslationKey extends UnknownTranslationKey = UnknownT
               | 'coinjoin-interrupted'
               | 'firmware-language-changed'
               | 'firmware-language-fetch-error'
+              | 'firmware-update-success'
               | 'estimated-fee-error'
               | 'not-enough-funds-error'
               | 'could-not-parse-csv'

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -4036,6 +4036,10 @@ export const messages = defineMessages({
         id: 'TOAST_QR_INCORRECT_ADDRESS',
         defaultMessage: 'QR code contains invalid address for this account',
     },
+    TOAST_FIRMWARE_UPDATE_SUCCESS: {
+        id: 'TOAST_FIRMWARE_UPDATE_SUCCESS',
+        defaultMessage: 'Firmware updated successfully',
+    },
     TOAST_QR_INCORRECT_COIN_SCHEME_PROTOCOL: {
         id: 'TOAST_QR_INCORRECT_COIN_SCHEME_PROTOCOL',
         defaultMessage: 'QR code is defined for {coin} account',

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -3844,6 +3844,10 @@ export const messages = defineMessages({
         id: 'TOAST_QR_INCORRECT_ADDRESS',
         defaultMessage: 'QR code contains invalid address for this account',
     },
+    TOAST_FIRMWARE_UPDATE_SUCCESS: {
+        id: 'TOAST_FIRMWARE_UPDATE_SUCCESS',
+        defaultMessage: 'Firmware updated successfully',
+    },
     TOAST_QR_INCORRECT_COIN_SCHEME_PROTOCOL: {
         id: 'TOAST_QR_INCORRECT_COIN_SCHEME_PROTOCOL',
         defaultMessage: 'QR code is defined for {coin} account',


### PR DESCRIPTION
## Summary

Fixes the standalone firmware update modal staying open after the update completes (issue #27307). The modal now auto-closes 2s after `status === 'done'` and a success toast is shown.

- Add toast type `firmware-update-success` (`TOAST_FIRMWARE_UPDATE_SUCCESS`: "Firmware updated successfully").
- `FirmwareModal`: dispatch the toast on transition to `done` and `setTimeout(handleClose, 2000)`. Cleanup clears the timer on user-initiated close, status change, or unmount. `handleClose` is wrapped in `useCallback`; a ref is used inside the timer to avoid re-firing when `device` changes during the 2s window.

Onboarding flow is intentionally **not** touched — it keeps the manual **Continue** button and does not show the toast.

Closes #27307

## Screenshots

https://github.com/user-attachments/assets/44200559-00ef-4fb0-8009-47a9168b90c6

## Test plan

- [ ] Standalone update via **Settings -> Device -> Firmware Version -> Update**: progress fills -> "Completed" state visible briefly -> modal auto-closes after ~2s -> success toast appears.
- [ ] Same flow via `firmware-type` and `firmware-custom` routes (same modal).
- [ ] Manual close during the 2s window works without errors / double-close.
- [ ] Onboarding firmware step regression: still shows manual **Continue** button, no toast.

<!-- PREVIEW-LINKS:SECTION:START -->
<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/fw-update-flow/web/](https://dev.suite.sldev.cz/suite-web/mroz22/fw-update-flow/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/fw-update-flow&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/fw-update-flow&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-10T11:14:06.376Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-10T11:13:43.927Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes touch four files: FirmwareModal.tsx (firmware update view), NotificationRenderer.tsx (toast/notification rendering), toast-notifications/types.ts (notification type definitions), and messages.ts (i18n translation strings). The first three files each map to 129 tests, indicating they are broadly shared infrastructure. The key risk areas are: (1) firmware modal rendering/behavior, and (2) toast notification display across the app. The recommended strategy focuses on tests that directly exercise firmware modals or explicitly assert on specific toast notifications, rather than running the full 129-test suite. messages.ts has no static coverage data but is used pervasively; tests asserting on specific translation keys in toast messages provide indirect coverage.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx`
- `packages/suite/src/views/firmware/FirmwareModal.tsx`
- `suite-common/toast-notifications/src/types.ts`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (13)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/firmware/custom-firmware.test.ts` — Directly exercises FirmwareModal.tsx which is one of the changed files. The test installs custom firmware through the Settings > Device tab, which renders the firmware modal component. Any regression in FirmwareModal would be caught here.
- `suite/e2e/tests/backup/t2t1-fail.test.ts` — Directly asserts on toast notifications (backup-failed toast, error banner) and notification rendering. Changes to NotificationRenderer.tsx and toast-notifications/types.ts could break toast display for failed backup scenarios.

</details>

<details><summary>🟡 <b>Medium priority (8)</b></summary>

- `suite/e2e/tests/backup/t2t1-success.test.ts` — Tests the backup flow which involves toast notifications and analytics events for backup completion. Changes to notification types could affect the backup success notification rendering.
- `suite/e2e/tests/onboarding/firmware-check.test.ts` — Tests firmware readiness detection during onboarding, which flows through the firmware views. Changes to FirmwareModal.tsx could affect how firmware status is presented during onboarding.
- `suite/e2e/tests/settings/passphrase.test.ts` — Explicitly asserts that a '@toast/settings-applied' toast notification appears and then disappears. Changes to NotificationRenderer or toast notification types could break this toast lifecycle behavior.
- `suite/e2e/tests/settings/t1b1-device-settings.test.ts` — Asserts on toast notifications for PIN changes (pin-changed, pin-mismatch). Changes to NotificationRenderer and toast types directly affect whether these toasts render correctly.
- `suite/e2e/tests/settings/t2t1-device-settings.test.ts` — Tests opening/closing the firmware update modal directly, which exercises FirmwareModal.tsx. Also tests device name change which may trigger toast notifications.
- `suite/e2e/tests/settings/t3b1-device-settings.test.ts` — Tests opening/closing the firmware update modal on T3B1, directly exercising the changed FirmwareModal.tsx component.
- `suite/e2e/tests/suite/bug-report-form.test.ts` — Asserts on '@toast/user-feedback-send-success' toast visibility after submitting a bug report. Changes to notification rendering and toast types could break this assertion.
- `suite/e2e/tests/wallet/send-doge.test.ts` — Explicitly asserts on '@toast/sign-tx-error' toast notification with specific error text. Changes to NotificationRenderer and toast types could break error toast rendering.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/metadata/legacy/dropbox-api-errors.test.ts` — Asserts on '@toast/error' toast notification for Dropbox API failures. Changes to NotificationRenderer could affect how error toasts are rendered, though the test is primarily about metadata error handling.
- `suite/e2e/tests/settings/forget-device.test.ts` — Verifies toast notification for device forgotten confirmation (verifyToastDeviceForgotten). Changes to toast types and notification renderer could affect this specific toast.
- `suite/e2e/tests/wallet/receive.test.ts` — Asserts on 'Copied to clipboard' toast notification after copying an address. Changes to notification rendering could affect toast visibility.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/intl/src/messages.ts`

_Updated: 2026-07-10T11:11:07.946Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->