### PR TITLE
feat(suite): refactor MDC & DAC reactivity to depend on persisted data

### DIFF
--- a/packages/suite/src/middlewares/onboarding/__tests__/onboardingMiddleware.test.ts
+++ b/packages/suite/src/middlewares/onboarding/__tests__/onboardingMiddleware.test.ts
@@ -1,5 +1,6 @@
 import { modalReducer } from '@suite/modal';
 import { routerAppChanged, routerReducer } from '@suite/router';
+import { firmwareInitialState } from '@suite-common/firmware';
 
 import onboardingMiddlewares from 'src/middlewares/onboarding';
 import onboardingReducer from 'src/reducers/onboarding/index';
@@ -24,6 +25,7 @@ const getInitialState = (
     suite?: Partial<SuiteState>,
     onboarding?: Partial<OnboardingState>,
 ) => ({
+    firmware: firmwareInitialState,
     suite: {
         ...suiteReducer(undefined, { type: 'foo' } as any),
         ...suite,

--- a/packages/suite/src/middlewares/onboarding/onboardingMiddleware.ts
+++ b/packages/suite/src/middlewares/onboarding/onboardingMiddleware.ts
@@ -14,12 +14,17 @@ const onboardingMiddleware =
     (action: Action): Action => {
         const isFwInstallationDone =
             firmwareActions.setStatus.match(action) && action.payload === 'done';
+        const isOnboardingActive = api.getState().onboarding.isActive;
+        const doesDeviceNeedPairing = api.getState().firmware.status === 'thp-pairing';
 
-        if (
-            isFwInstallationDone &&
-            api.getState().onboarding.isActive &&
-            api.getState().firmware.status === 'thp-pairing'
-        ) {
+        // Firmware installation finished = it is not a device that just connected with FW already install, we can
+        // consider it known and skip the "Firmware already installed, have you used this device before?" modal.
+        if (isFwInstallationDone && isOnboardingActive) {
+            const device = api.getState().device.selectedDevice;
+            api.dispatch(deviceActions.setManualDeviceCheckSuccess({ deviceId: device?.id }));
+        }
+
+        if (isFwInstallationDone && isOnboardingActive && doesDeviceNeedPairing) {
             // After the THP pairing is finished we want to jump to the next step automatically.
             // User already drifted away from the installation flow and is not aware that THP is actually in the middle
             // of the Firmware installation.

--- a/packages/suite/src/middlewares/suite/__tests__/redirectMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/__tests__/redirectMiddleware.test.ts
@@ -1,8 +1,13 @@
 import { locksInitialState, locksReducer } from '@suite/locks';
 import { modalReducer } from '@suite/modal';
 import { goto, routerReducer } from '@suite/router';
+import { suiteSettingsInitialState } from '@suite/settings';
 import { deviceActions, prepareDeviceReducer } from '@suite-common/device';
-import { mockConnectDevice, mockSuiteDevice } from '@suite-common/suite-types/mocks';
+import {
+    defaultDevicePersistentData,
+    mockConnectDevice,
+    mockSuiteDevice,
+} from '@suite-common/suite-types/mocks';
 import { extraDependenciesCommonMock } from '@suite-common/test-utils';
 import { DEVICE } from '@trezor/connect';
 
@@ -32,6 +37,7 @@ const getInitialState = (
     router?: Partial<RouterState>,
     modal?: Partial<ModalState>,
 ) => ({
+    suiteSettings: suiteSettingsInitialState,
     suite: {
         ...suiteReducer(undefined, { type: 'foo' } as any),
         ...suite,
@@ -95,7 +101,9 @@ describe('redirectMiddleware', () => {
         });
 
         it('DEVICE.CONNECT firmware=required', () => {
-            const store = initStore(getInitialState());
+            const store = initStore(
+                getInitialState(undefined, { persistentDeviceData: [defaultDevicePersistentData] }),
+            );
 
             const connectDevice = mockConnectDevice({ mode: 'normal', firmware: 'required' });
             store.dispatch({ type: DEVICE.CONNECT, payload: { device: connectDevice } });
@@ -120,6 +128,7 @@ describe('redirectMiddleware', () => {
                                 device_id: 'previous-device',
                             },
                         ),
+                        persistentDeviceData: [defaultDevicePersistentData],
                     },
                     {
                         app: 'wallet',

--- a/packages/suite/src/middlewares/suite/redirectMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/redirectMiddleware.ts
@@ -12,6 +12,8 @@ import { deviceActions, selectDevices, selectSelectedDevice } from '@suite-commo
 
 import { type Action, type AppState, type Dispatch, type TrezorDevice } from 'src/types/suite';
 
+import { selectShouldDisplaySecurityCheck } from '../../selectors/suite/securityCheckSelectors';
+
 const handleDeviceRedirect = (dispatch: Dispatch, state: AppState, device?: TrezorDevice) => {
     // no device, no redirect
     if (!device || !device.features) {
@@ -26,16 +28,16 @@ const handleDeviceRedirect = (dispatch: Dispatch, state: AppState, device?: Trez
         return;
     }
 
-    // device is not initialized, redirect to onboarding
-    if (device.mode === 'initialize') {
-        dispatch(goto({ routeName: 'suite-start' }));
-    }
+    const shouldDisplaySecurityCheck = selectShouldDisplaySecurityCheck(state, device);
+    const isDeviceInitializing = device.mode === 'initialize';
+
     // firmware none (T2T1) or unknown (T1B1) indicates freshly unpacked device
-    if (
+    const isFreshDevice =
         device.mode === 'bootloader' &&
         device.features &&
-        device.features.firmware_present === false
-    ) {
+        device.features.firmware_present === false;
+
+    if (shouldDisplaySecurityCheck || isDeviceInitializing || isFreshDevice) {
         dispatch(goto({ routeName: 'suite-start' }));
     }
     // device firmware update required, redirect to "firmware update"

--- a/packages/suite/src/selectors/suite/securityCheckSelectors.ts
+++ b/packages/suite/src/selectors/suite/securityCheckSelectors.ts
@@ -1,0 +1,67 @@
+import {
+    selectIsDeviceAuthenticityCheckEnabled,
+    selectIsUnlockedBootloaderAllowed,
+} from '@suite/settings';
+import {
+    selectDeviceAuthenticityByDeviceId,
+    selectDevices,
+    selectShouldDoDeviceManualCheck,
+} from '@suite-common/device';
+import { SUPPORTS_DEVICE_AUTHENTICITY_CHECK } from '@suite-common/suite-constants';
+import { isDeviceAcquired } from '@suite-common/suite-utils';
+
+import type { AppState, TrezorDevice } from 'src/types/suite';
+
+export const selectShouldCheckDeviceAuthenticity = (
+    state: AppState,
+    device?: TrezorDevice,
+): boolean => {
+    // It isn't possible to perform DAC for unacquired or bootloader devices.
+    if (!isDeviceAcquired(device)) return false;
+    if (device.mode === 'bootloader') return false;
+    // Uninitialized device will go through onboarding, and DAC is one of the steps.
+    if (device.mode === 'initialize') return false;
+
+    const persistedResult = selectDeviceAuthenticityByDeviceId(state, device.id);
+    // DAC already succeeded in the past for this device, so no need to check again.
+    if (persistedResult?.valid === true) return false;
+    // If DAC has failed in the past, we want to keep showing it until it succeeds, so we handle it as if it hadn't been
+    // performed yet (user can meanwhile change settings that would allow debug keys, unlocked bootloader).
+
+    const isDeviceAuthenticityCheckEnabled = selectIsDeviceAuthenticityCheckEnabled(state);
+    const isUnlockedBootloaderAllowed = selectIsUnlockedBootloaderAllowed(state);
+
+    // DAC *always* fails if bootloader is unlocked. So if user allowed it by settings, we skip the check, knowing it would fail otherwise.
+    const isAllowedDebugDevice =
+        isUnlockedBootloaderAllowed && device.features.bootloader_locked === false;
+
+    return (
+        SUPPORTS_DEVICE_AUTHENTICITY_CHECK[device.features.internal_model] &&
+        isDeviceAuthenticityCheckEnabled &&
+        !isAllowedDebugDevice
+    );
+};
+
+/**
+ * Whether SecurityCheck modal should be displayed for those checks that are not considered final, so they rerun again, but
+ * need a user prompt to be performed (e.g. manual device check, device authenticity check).
+ * For checks which are final, see selectShouldDisplayDeviceCompromised.
+ *
+ * - Manual Device Check: always reversible by user action
+ * - Device Authenticity Check: when failed result has been persisted, check will be redone
+ */
+export const selectShouldDisplaySecurityCheck = (
+    state: AppState,
+    device: TrezorDevice,
+): boolean => {
+    const shouldDoManualDeviceCheck = selectShouldDoDeviceManualCheck(state, device.id);
+    const shouldDoDeviceAuthenticityCheck = selectShouldCheckDeviceAuthenticity(state, device);
+
+    return shouldDoManualDeviceCheck || shouldDoDeviceAuthenticityCheck;
+};
+
+export const selectAllDevicesRequiringSecurityCheck = (state: AppState): TrezorDevice[] => {
+    const devices = selectDevices(state);
+
+    return devices.filter(device => selectShouldDisplaySecurityCheck(state, device));
+};

--- a/packages/suite/src/selectors/suite/suiteAuthenticityChecksSelectors.ts
+++ b/packages/suite/src/selectors/suite/suiteAuthenticityChecksSelectors.ts
@@ -123,6 +123,15 @@ export const selectIsDeviceInvariabilityEnabledAndFailed = (state: AppState) => 
     );
 };
 
+/**
+ * Whether Device Compromised modal should be displayed based on checks that run automatically, or persisted from the past.
+ * This is only displayed for checks where the "compromised" result is considered final, as derived from current app state.
+ * This includes checks that rerun automatically, but not checks that will prompt user again (see selectShouldDisplaySecurityCheck).
+ *
+ * - FW revision and hash check: they always rerun when a device is connected, so a persisted result from the past will be updated.
+ * - Entropy check: once a result is persisted, it can never be changed
+ * - Id check and invariability check: not even a procedure, they're only derived from app state
+ */
 export const selectShouldDisplayDeviceCompromised = (state: AppState): boolean => {
     // Entropy check won't be performed if disabled but we must also check it here to avoid showing the UI when the failed state is stored in database.
     const isEntropyCheckEnabledAndFailed = selectIsEntropyCheckEnabledAndFailed(state);

--- a/packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/SecurityCheck.tsx
+++ b/packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/SecurityCheck.tsx
@@ -1,17 +1,14 @@
 import { useEffect, useMemo, useState } from 'react';
 
 import { events } from '@suite/analytics';
-import { selectFlags } from '@suite/flags';
 import { Translation } from '@suite/intl';
 import { selectRecoveryStatus } from '@suite/recovery';
 import { goto } from '@suite/router';
 import {
-    selectIsDeviceAuthenticityCheckEnabled,
-    selectIsUnlockedBootloaderAllowed,
-} from '@suite/settings';
-import { deviceActions, selectDevices, selectSelectedDevice } from '@suite-common/device';
-import { SUPPORTS_DEVICE_AUTHENTICITY_CHECK } from '@suite-common/suite-constants';
-import { type AcquiredDevice } from '@suite-common/suite-types';
+    deviceActions,
+    selectSelectedDevice,
+    selectShouldDoDeviceManualCheck,
+} from '@suite-common/device';
 import {
     Box,
     Card,
@@ -42,6 +39,10 @@ import { SecurityCheckLayout } from 'src/components/suite/SecurityCheck/Security
 import { ContactSupport } from 'src/components/suite/SecurityCheck/deviceCompromisedCtas';
 import { useDispatch, useLayoutSize, useOnboarding, useSelector } from 'src/hooks/suite';
 import { selectIsOnboardingActive } from 'src/reducers/onboarding/onboardingReducer';
+import {
+    selectAllDevicesRequiringSecurityCheck,
+    selectShouldCheckDeviceAuthenticity,
+} from 'src/selectors/suite/securityCheckSelectors';
 import { ContentFlex } from 'src/support/suite/ContentFlex';
 import { useAnalytics } from 'src/support/useAnalytics';
 
@@ -101,17 +102,9 @@ const getNoFirmwareChecklist = (isBelowTablet: boolean) =>
         },
     ] as const satisfies SecurityChecklistItem[];
 
-type SecurityCheckContentProps = {
-    goToDeviceAuthentication: () => void;
-    goToSuiteOrNextDevice: () => void;
-    shouldAuthenticateSelectedDevice: boolean;
-};
+type ManualDeviceCheckProps = { onConfirm: () => void };
 
-const SecurityCheckContent = ({
-    goToDeviceAuthentication,
-    goToSuiteOrNextDevice,
-    shouldAuthenticateSelectedDevice,
-}: SecurityCheckContentProps) => {
+const ManualDeviceCheck = ({ onConfirm }: ManualDeviceCheckProps) => {
     const analytics = useAnalytics();
     const { isBelowTablet } = useLayoutSize();
     const recoveryStatus = useSelector(selectRecoveryStatus);
@@ -145,11 +138,7 @@ const SecurityCheckContent = ({
     const toggleIsDeviceRejected = () => setIsFailed(current => !current);
     const handleContinueButtonClick = () => {
         dispatch(deviceActions.setManualDeviceCheckSuccess({ deviceId }));
-        if (shouldAuthenticateSelectedDevice) {
-            goToDeviceAuthentication();
-        } else {
-            goToSuiteOrNextDevice();
-        }
+        onConfirm();
     };
 
     const handleSetupButtonClick = () => {
@@ -279,68 +268,65 @@ const SecurityCheckContent = ({
 
 export const SecurityCheck = () => {
     const selectedDevice = useSelector(selectSelectedDevice);
-    const devices = useSelector(selectDevices);
-    const { initialRun } = useSelector(selectFlags);
-    const isDeviceAuthenticityCheckEnabled = useSelector(selectIsDeviceAuthenticityCheckEnabled);
-    const isUnlockedBootloaderAllowed = useSelector(selectIsUnlockedBootloaderAllowed);
+    const selectedDeviceId = selectedDevice?.id;
     const dispatch = useDispatch();
     const { goToSuite } = useOnboarding();
-    const [isAuthenticityCheckStep, setIsAuthenticityCheckStep] = useState(false);
     const [checkedDevices, setCheckedDevices] = useState<string[]>([]);
 
-    const isDebugDevice = (device: AcquiredDevice) =>
-        isUnlockedBootloaderAllowed && device.features.bootloader_locked === false;
+    const shouldDisplayManualDeviceCheck = useSelector(state =>
+        selectShouldDoDeviceManualCheck(state, selectedDeviceId),
+    );
+    const shouldDisplayDeviceAuthenticityCheck = useSelector(state =>
+        selectShouldCheckDeviceAuthenticity(state, selectedDevice),
+    );
 
-    const shouldAuthenticateSelectedDevice =
-        !!selectedDevice?.features?.internal_model &&
-        SUPPORTS_DEVICE_AUTHENTICITY_CHECK[selectedDevice.features.internal_model] &&
-        initialRun &&
-        isDeviceAuthenticityCheckEnabled &&
-        !isDebugDevice(selectedDevice);
+    // This cannot be decided only based on redux state, because the Authenticity Check screen has a result screen,
+    // so after the check itself is complete (not needed as per redux state) we need to stay on it.
+    const [isAuthenticityCheckStep, setIsAuthenticityCheckStep] = useState(
+        // Edge case: start at Device Authenticity step if it is required, and Manual Device Check has already been done.
+        !shouldDisplayManualDeviceCheck && shouldDisplayDeviceAuthenticityCheck,
+    );
 
-    // If there are multiple devices connected, check all of them before continuing to Suite.
-    const goToSuiteOrNextDevice = (onSelectNext?: () => void) => {
-        const nextDeviceToCheck = devices
-            .filter(device => device.id !== selectedDevice?.id)
-            .find(device => device.id && !checkedDevices.includes(device.id));
+    const allDevicesRequiringSecurityCheck = useSelector(selectAllDevicesRequiringSecurityCheck);
+
+    // Finish up the Security Check – but if there are multiple devices eligible for either
+    // Manual Device Check or Device Authenticity check, check all of them before continuing to Suite.
+    const goToSuiteOrNextDevice = () => {
+        const nextDeviceToCheck = allDevicesRequiringSecurityCheck.find(
+            ({ id }) => !!id && id !== selectedDeviceId && !checkedDevices.includes(id),
+        );
 
         if (nextDeviceToCheck !== undefined) {
-            onSelectNext?.();
-            setCheckedDevices(prev => [...prev, selectedDevice?.id ?? '']); // Device ID must be available as firmware is already installed.
+            setIsAuthenticityCheckStep(false); // Next device → reset to first step (it might not even support DAC)
+            setCheckedDevices(prev => [...prev, selectedDeviceId ?? '']); // Device ID must be available as firmware is already installed.
             dispatch(deviceActions.selectDevice(nextDeviceToCheck));
         } else {
             goToSuite();
         }
     };
 
-    // Edge case:
-    // Devices A and B are connected, only device A supports authenticity check.
-    // Device A disconnects while on the first screen of the check.
-    useEffect(() => {
-        if (isAuthenticityCheckStep && !shouldAuthenticateSelectedDevice) {
-            setIsAuthenticityCheckStep(false);
+    // Finish up the Security Check unless there is still Device Authenticity Check needed to be done.
+    const onManualDeviceCheckConfirm = () => {
+        if (shouldDisplayDeviceAuthenticityCheck) {
+            setIsAuthenticityCheckStep(true);
+        } else {
+            goToSuiteOrNextDevice();
         }
-    }, [isAuthenticityCheckStep, shouldAuthenticateSelectedDevice]);
+    };
 
+    // Device Authenticity Check is the 2nd step
     if (isAuthenticityCheckStep) {
         return (
             <Box padding={{ top: 40 }} width="100%">
-                <DeviceAuthenticityStep
-                    goToNext={() => goToSuiteOrNextDevice(() => setIsAuthenticityCheckStep(false))}
-                />
+                <DeviceAuthenticityStep goToNext={goToSuiteOrNextDevice} />
             </Box>
         );
     }
 
-    const goToDeviceAuthentication = () => setIsAuthenticityCheckStep(true);
-
+    // Manual Device Check is the 1st step (and default view on this page)
     return (
         <Card paddingType="large">
-            <SecurityCheckContent
-                goToDeviceAuthentication={goToDeviceAuthentication}
-                goToSuiteOrNextDevice={goToSuiteOrNextDevice}
-                shouldAuthenticateSelectedDevice={shouldAuthenticateSelectedDevice}
-            />
+            <ManualDeviceCheck onConfirm={onManualDeviceCheckConfirm} />
         </Card>
     );
 };

--- a/packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/SecurityCheck.tsx
+++ b/packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/SecurityCheck.tsx
@@ -237,7 +237,7 @@ const ManualDeviceCheck = ({ onConfirm }: ManualDeviceCheckProps) => {
                 </SecurityCheckButton>
                 {initialized ? (
                     <SecurityCheckButton
-                        data-testid="@onboarding/complete-onboarding"
+                        data-testid="@onboarding/confirm-manual-device-check"
                         onClick={handleContinueButtonClick}
                         intent="brand"
                     >

--- a/suite-common/device/src/deviceSelectors.ts
+++ b/suite-common/device/src/deviceSelectors.ts
@@ -73,6 +73,12 @@ export const selectEntropyCheckResultByDeviceId = createMemoizedSelector(
     persistentDeviceData => persistentDeviceData?.lastEntropyCheckResult,
 );
 
+export const selectShouldDoDeviceManualCheck = createMemoizedSelector(
+    [selectPersistentDeviceDataById, (_state, deviceId: TrezorDevice['id']) => deviceId],
+    (persistentDeviceData, deviceId) =>
+        typeof deviceId === 'string' && persistentDeviceData?.manualCheckResult?.success !== true,
+);
+
 // Use in tests only! See deviceReducer for the property definition.
 export const selectSimulatedEntropyCheckFail = (state: DeviceRootState) =>
     state.device.simulatedEntropyCheckFail;
@@ -338,11 +344,11 @@ export const selectDeviceById = createMemoizedSelector(
     (devices, deviceId) => devices.find(device => device.id === deviceId),
 );
 
-export const selectDeviceAuthenticity = (state: DeviceRootState) =>
-    state.device.persistentDeviceData;
-
 export const selectDeviceAuthenticityByDeviceId = createMemoizedSelector(
-    [(_state: DeviceRootState, deviceId: TrezorDevice['id']) => deviceId, selectDeviceAuthenticity],
+    [
+        (_state: DeviceRootState, deviceId: TrezorDevice['id']) => deviceId,
+        selectPersistentDeviceData,
+    ],
     (deviceId, persistentDeviceData) =>
         deviceId
             ? persistentDeviceData.find(data => data.device_id === deviceId)?.authenticityResult

--- a/suite-common/suite-types/mocks/mockDevicePersistentData.ts
+++ b/suite-common/suite-types/mocks/mockDevicePersistentData.ts
@@ -12,4 +12,5 @@ export const defaultDevicePersistentData: PersistentDeviceData = {
     firmwareVersion: null,
     lastConnectedVia: null,
     delegatedIdentityKey: null,
+    manualCheckResult: { success: true },
 };

--- a/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
+++ b/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
@@ -113,7 +113,6 @@ export class OnboardingPage {
         if (this.device.hasTHP) {
             await this.devicePrompt.allowConnectToTrezor();
             await this.enterTHPPairingCode();
-            await this.enableAutoconnect();
         }
     }
 
@@ -125,8 +124,9 @@ export class OnboardingPage {
         await this.analyticsSection.continueButton.click();
 
         await this.pairTHP();
-
         await this.completeOnboardingButton.click();
+        await this.enableAutoconnect();
+
         if (this.device.hasSecureElement && this.device.model !== Model.T3W1) {
             await this.passThroughAuthenticityCheck();
         }
@@ -140,10 +140,12 @@ export class OnboardingPage {
 
     @step()
     async enableAutoconnect() {
-        await this.settingsPage.navigateTo('device');
-        await this.settingsPage.deviceTab.autoconnectSwitch.click();
-        await this.devicePrompt.allowConnectToTrezor();
-        await this.settingsPage.closeSettings();
+        if (this.device.hasTHP) {
+            await this.settingsPage.navigateTo('device');
+            await this.settingsPage.deviceTab.autoconnectSwitch.click();
+            await this.devicePrompt.allowConnectToTrezor();
+            await this.settingsPage.closeSettings();
+        }
     }
 
     @step()

--- a/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
+++ b/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
@@ -22,7 +22,7 @@ export class OnboardingPage {
     readonly tutorial: TutorialSection;
 
     readonly welcomeBody: Locator;
-    readonly completeOnboardingButton: Locator;
+    readonly confirmManualDeviceCheckButton: Locator;
     readonly connectDevicePrompt: Locator;
     readonly authenticityStartButton: Locator;
     readonly authenticityContinueButton: Locator;
@@ -56,7 +56,9 @@ export class OnboardingPage {
         this.pin = new PinSection(page);
 
         this.welcomeBody = this.page.getByTestId('@welcome-layout/body');
-        this.completeOnboardingButton = this.page.getByTestId('@onboarding/complete-onboarding');
+        this.confirmManualDeviceCheckButton = this.page.getByTestId(
+            '@onboarding/confirm-manual-device-check',
+        );
         this.connectDevicePrompt = this.page.getByTestId('@connect-device-prompt');
         this.authenticityStartButton = this.page.getByTestId('@authenticity-check/start-button');
         this.authenticityContinueButton = this.page.getByTestId(
@@ -124,7 +126,7 @@ export class OnboardingPage {
         await this.analyticsSection.continueButton.click();
 
         await this.pairTHP();
-        await this.completeOnboardingButton.click();
+        await this.confirmManualDeviceCheckButton.click();
         await this.enableAutoconnect();
 
         if (this.device.hasSecureElement && this.device.model !== Model.T3W1) {

--- a/suite/e2e/support/pageObjects/settings/settingsPage.ts
+++ b/suite/e2e/support/pageObjects/settings/settingsPage.ts
@@ -122,7 +122,7 @@ export class SettingsPage {
             '@settings/early-access-confirm-button',
         );
         this.earlyAccessSkipButton = this.page.getByTestId('@settings/early-access-skip-button');
-        this.settingsCloseButton = this.page.getByTestId('@suite/menu/suite-start');
+        this.settingsCloseButton = this.page.getByTestId('@suite/menu/suite-index');
         this.modal = this.page.modal;
         this.modalCloseButton = this.page.getByTestId('@modal/close-button');
         this.deviceLabelInput = this.page.getByTestId('@settings/device/label-input');

--- a/suite/e2e/tests/analytics/events.test.ts
+++ b/suite/e2e/tests/analytics/events.test.ts
@@ -163,7 +163,7 @@ test.describe('Analytics Events', { tag: ['@webOnly', '@T3W1', '@T3T1', '@smoke'
             await settingsPage.analyticsSwitch.click();
             await settingsPage.closeSettings();
             await page.reload();
-            await onboardingPage.completeOnboardingButton.click();
+            await onboardingPage.confirmManualDeviceCheckButton.click();
         });
 
         await test.step('Wait for analytics events and validate event types', async () => {

--- a/suite/e2e/tests/analytics/toggle.test.ts
+++ b/suite/e2e/tests/analytics/toggle.test.ts
@@ -53,7 +53,7 @@ test.describe(
                     await onboardingPage.enableAutoconnect();
                 }
 
-                await onboardingPage.completeOnboardingButton.click();
+                await onboardingPage.confirmManualDeviceCheckButton.click();
             });
 
             await test.step('Reload app and check analytics state', async () => {
@@ -150,7 +150,7 @@ test.describe(
                     await devicePrompt.allowConnectToTrezor();
                     await onboardingPage.enterTHPPairingCode();
                 }
-                await onboardingPage.completeOnboardingButton.click();
+                await onboardingPage.confirmManualDeviceCheckButton.click();
             });
 
             await test.step('Go to settings and disable analytics', async () => {

--- a/suite/e2e/tests/onboarding/analytics-consent.test.ts
+++ b/suite/e2e/tests/onboarding/analytics-consent.test.ts
@@ -25,7 +25,7 @@ test.describe('Onboarding - analytics consent', { tag: ['@webOnly', '@T3W1', '@T
             await onboardingPage.enterTHPPairingCode();
         }
 
-        await onboardingPage.completeOnboardingButton.click();
+        await onboardingPage.confirmManualDeviceCheckButton.click();
 
         await expect(dashboardPage.suiteLayout).toBeVisible();
         await settingsPage.changeNetworks({ enableNetworks: ['btc'] });

--- a/suite/e2e/tests/suite/initial-run.test.ts
+++ b/suite/e2e/tests/suite/initial-run.test.ts
@@ -38,14 +38,14 @@ test.describe('Suite initial run', { tag: ['@T3W1', '@T3T1'] }, () => {
             await onboardingPage.enterTHPPairingCode();
         }
 
-        await expect(page.getByTestId('@onboarding/complete-onboarding')).toBeVisible();
+        await expect(page.getByTestId('@onboarding/confirm-manual-device-check')).toBeVisible();
 
         await page.reload();
 
         await onboardingPage.verifySuiteIsLoaded();
         optionallyDismissFwHashCheckError(page);
         await expect(analyticsSection.toggleSwitch).toBeHidden();
-        await expect(onboardingPage.completeOnboardingButton).toBeVisible();
+        await expect(onboardingPage.confirmManualDeviceCheckButton).toBeVisible();
     });
 
     test('Once user passed trough, skips initial run and shows connect-device modal', async ({


### PR DESCRIPTION
## Description

aa

## Notes for QA

I'll write that shortly.

## Related Issue

Resolve https://github.com/trezor/trezor-suite-private/issues/148
Resolve https://github.com/trezor/trezor-suite/pull/27361

## Screenshots:

#### Happy paths
[factory-reset Model One](https://github.com/user-attachments/assets/1f2eb187-33d9-4381-b464-f6dacfabc710)
[factory-reset Trezor Safe](https://github.com/user-attachments/assets/76b730ea-2158-4c69-b640-4a235c3eaab8)
[FW already installed Model One](https://github.com/user-attachments/assets/dc11794b-ce8a-46fe-83e1-4b4adec51776)
[Fully initialized Trezor Safe](https://github.com/user-attachments/assets/8e0a7d18-5864-4ed0-b7df-60df9f998670)
[Fully initialized Model T](https://github.com/user-attachments/assets/9d558ee2-721b-44fd-9cc1-14996db5f39f)

#### Device Compromised
[DAC onboarding fail, then success](https://github.com/user-attachments/assets/a2527cb4-bdcd-4c73-bb4a-25fcf26a3000)
[FW already installed Trezor Safe unlocked BL](https://github.com/user-attachments/assets/22c4696e-bb78-417b-8c0e-ca6d93de1cec)
[MDC rejection is reversible](https://github.com/user-attachments/assets/74d46899-ba70-4551-af66-10538e338659)
[Already initialized Trezor Safe MDC, then DAC fails, then DAC success](https://github.com/user-attachments/assets/fe3b0a9d-197e-4119-b0ec-268cf70b6c65) (this is important that DAC failure is never permanent, like e.g. entropy check, but always retriable, because you can change settings that affect it)

#### Edge cases (happy)
[Connecting bootloader](https://github.com/user-attachments/assets/b65d6dd4-ebae-4be7-afb8-1809a57c4313) (nothing changed, nothing happens)
[initialized Trezor Safe, but MDC done already](https://github.com/user-attachments/assets/86e81eaf-aad0-45a9-a773-b6df91a3d398)
[multiple devices - Model One, Trezor Safe](https://github.com/user-attachments/assets/ccf46d52-5d8b-4789-8bc8-ed86cde95cff) (ends with DAC)
[multiple devices - Model One, Trezor Safe, Model T](https://github.com/user-attachments/assets/61e9244d-c1fc-4969-b6a1-e3089118adac) (ends with MDC)


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/MDC-DAC-when-connecting&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/MDC-DAC-when-connecting&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/MDC-DAC-when-connecting&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/MDC-DAC-when-connecting/web/](https://dev.suite.sldev.cz/suite-web/feat/MDC-DAC-when-connecting/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-07T11:35:21.084Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-07T11:34:13.711Z • 11 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->