### PR TITLE
Multiple yield fixes

### DIFF
--- a/packages/suite/src/components/earn/yield/claim/YieldClaim.tsx
+++ b/packages/suite/src/components/earn/yield/claim/YieldClaim.tsx
@@ -16,6 +16,7 @@ import { type Account } from '@suite-common/wallet-types';
 import { Banner, Button, Card, Column, Text } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
 
+import { setConnectionModal, setConnectionMode } from 'src/actions/device/deviceSlice';
 import { claimMerkleRewardsThunk } from 'src/actions/wallet/stablecoinYieldSigningThunks';
 import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -96,7 +97,16 @@ export const YieldClaim = ({ account }: YieldClaimProps) => {
     });
 
     const handleClaim = async () => {
-        if (!account || !flowKey || !isDeviceConnected || claimableRewards.length === 0) return;
+        if (!account || !flowKey || claimableRewards.length === 0) return;
+
+        if (!isDeviceConnected) {
+            if (device?.descriptor?.apiType === 'bluetooth') {
+                dispatch(setConnectionMode('bluetooth'));
+            }
+            dispatch(setConnectionModal(true));
+
+            return;
+        }
 
         analytics.report({
             type: events.yieldClaimEvent.name,
@@ -209,8 +219,7 @@ export const YieldClaim = ({ account }: YieldClaimProps) => {
                             isDisabled={
                                 merkleRewardsQuery.isLoading ||
                                 claimableRewards.length === 0 ||
-                                isClaiming ||
-                                !isDeviceConnected
+                                isClaiming
                             }
                             isLoading={isClaimSubmitting}
                             onClick={handleClaim}

--- a/packages/suite/src/components/earn/yield/claim/YieldClaim.tsx
+++ b/packages/suite/src/components/earn/yield/claim/YieldClaim.tsx
@@ -45,10 +45,10 @@ export const YieldClaim = ({ account }: YieldClaimProps) => {
     const claimSession = useSelector(state =>
         selectStablecoinYieldSession(state, 'claim', flowKey),
     );
-    const isClaiming =
+    const isClaimSubmitting =
         claimSession.action.isSubmitting ||
-        !!claimSession.action.pendingTransaction ||
         (!!yieldTxReview.precomposedTx && yieldTxReview.accountKey === account?.key);
+    const isClaiming = isClaimSubmitting || !!claimSession.action.pendingTransaction;
     const isDeviceConnected = !!device?.connected && device.available;
     const isClaimSupported = !!account && isEarnYieldClaimSupported(account.symbol);
 
@@ -212,7 +212,7 @@ export const YieldClaim = ({ account }: YieldClaimProps) => {
                                 isClaiming ||
                                 !isDeviceConnected
                             }
-                            isLoading={isClaiming}
+                            isLoading={isClaimSubmitting}
                             onClick={handleClaim}
                         >
                             <Translation id="TR_EARN_YIELD_CLAIM" />

--- a/packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx
@@ -58,6 +58,7 @@ export type YieldApproveStepProps = {
     variant: 'active' | 'done';
     summaryValue: ReactNode;
     isDisabled?: boolean;
+    isLoading?: boolean;
     /** Current on-chain allowance amount fetched by RPC. */
     approvedAmount?: string;
     isApprovedAmountLoading?: boolean;
@@ -79,6 +80,7 @@ export const YieldApproveStep = ({
     variant,
     summaryValue,
     isDisabled = false,
+    isLoading = false,
     approvedAmount,
     isApprovedAmountLoading = false,
     hasApprovedAmountError = false,
@@ -99,7 +101,7 @@ export const YieldApproveStep = ({
     });
     const approvedAmountValue = approvedAmount ?? '0';
     const shouldEnableRevoke =
-        canRevokeAllowance && !isApprovedAmountLoading && !hasApprovedAmountError;
+        canRevokeAllowance && !isApprovedAmountLoading && !hasApprovedAmountError && !isLoading;
     const onRevokeClick = shouldEnableRevoke ? onRevoke : undefined;
 
     switch (variant) {
@@ -135,11 +137,12 @@ export const YieldApproveStep = ({
                         width="100%"
                         onClick={onApprovalSubmit}
                         isDisabled={isDisabled || !!pendingApproveTransaction || !onApprovalSubmit}
+                        isLoading={isLoading}
                     >
                         <Translation id={approveButtonId} />
                     </Button>
 
-                    {approvalAction === 'revoke' && (
+                    {approvalAction === 'revoke' && !isDisabled && (
                         <Banner
                             intent="warning"
                             icon="warning"

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { type UseFormReturn, useForm } from 'react-hook-form';
 
+import { useDevice } from '@suite/device';
 import { type TranslationKey } from '@suite/intl';
 import { openModal } from '@suite/modal';
 import { type EarnParams } from '@suite/router';
@@ -28,6 +29,7 @@ import { getConvertedOrDefaultFeeInfo } from '@suite-common/wallet-utils';
 import type { BulletListItemState } from '@trezor/components';
 import { useCurrentRef } from '@trezor/react-utils';
 
+import { setConnectionModal, setConnectionMode } from 'src/actions/device/deviceSlice';
 import { submitYieldActionThunk } from 'src/actions/wallet/stablecoinYieldSigningThunks';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
@@ -111,6 +113,7 @@ export const useYieldFlow = ({
     flowType,
 }: UseYieldFlowProps): UseYieldFlowResult => {
     const dispatch = useDispatch();
+    const { device } = useDevice();
     const methods = useForm<YieldFlowFormValues>({
         defaultValues: {
             amountInput: '',
@@ -282,7 +285,22 @@ export const useYieldFlow = ({
         [methodsRef],
     );
 
+    const openDeviceConnectionModal = useCallback(() => {
+        if (device?.descriptor?.apiType === 'bluetooth') {
+            dispatch(setConnectionMode('bluetooth'));
+        }
+        dispatch(setConnectionModal(true));
+    }, [device, dispatch]);
+
+    const isDeviceConnected = !!device?.connected && !!device?.available;
+
     const submitApprove = useCallback(() => {
+        if (!isDeviceConnected) {
+            openDeviceConnectionModal();
+
+            return;
+        }
+
         if (!token || !receiptToken || !vault) {
             dispatch(
                 stablecoinYieldActions.setError({
@@ -305,9 +323,26 @@ export const useYieldFlow = ({
                 amount,
             }),
         );
-    }, [account, flowKey, flowType, receiptToken, dispatch, token, vault, methodsRef]);
+    }, [
+        account,
+        flowKey,
+        flowType,
+        receiptToken,
+        dispatch,
+        token,
+        vault,
+        methodsRef,
+        isDeviceConnected,
+        openDeviceConnectionModal,
+    ]);
 
     const revokeAllowance = useCallback(() => {
+        if (!isDeviceConnected) {
+            openDeviceConnectionModal();
+
+            return;
+        }
+
         if (!token || !receiptToken || !vault) {
             dispatch(
                 stablecoinYieldActions.setError({
@@ -342,6 +377,8 @@ export const useYieldFlow = ({
         vault,
         methodsRef,
         session.approval.allowanceAmount,
+        isDeviceConnected,
+        openDeviceConnectionModal,
     ]);
 
     const liveAmount = methods.watch('amountInput');
@@ -365,6 +402,12 @@ export const useYieldFlow = ({
     }, [approvalAction, revokeAllowance, submitApprove]);
 
     const submitAction = useCallback(() => {
+        if (!isDeviceConnected) {
+            openDeviceConnectionModal();
+
+            return;
+        }
+
         if (!token || !receiptToken || !vault) {
             dispatch(
                 stablecoinYieldActions.setError({
@@ -387,7 +430,18 @@ export const useYieldFlow = ({
                 amount,
             }),
         );
-    }, [account, flowKey, flowType, receiptToken, dispatch, token, vault, methodsRef]);
+    }, [
+        account,
+        flowKey,
+        flowType,
+        receiptToken,
+        dispatch,
+        token,
+        vault,
+        methodsRef,
+        isDeviceConnected,
+        openDeviceConnectionModal,
+    ]);
 
     const handleApproveModalCancel = useCallback(async () => {
         await dispatch(

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -405,7 +405,8 @@ export const useYieldFlow = ({
         [dispatch, flowKey, flowType],
     );
 
-    const isAmountEmpty = !liveAmount;
+    const isAmountEmpty =
+        !liveAmount || !isAmountGreaterThan({ amount: liveAmount, threshold: '0' });
     const allowanceAmount = session.approval.allowanceAmount ?? '0';
     const canRevokeAllowance = isAmountGreaterThan({ amount: allowanceAmount, threshold: '0' });
     const isAmountTooHigh = isAmountGreaterThan({ amount: liveAmount, threshold: maxAmount });

--- a/packages/suite/src/components/earn/yield/supply/YieldSupplyForm.tsx
+++ b/packages/suite/src/components/earn/yield/supply/YieldSupplyForm.tsx
@@ -24,7 +24,6 @@ export const YieldSupplyForm = () => {
         token,
         receiptToken,
         apy,
-        liveAmount,
         completedAmount,
         completedReceiptAmount,
         maxAmount,
@@ -232,7 +231,7 @@ export const YieldSupplyForm = () => {
                                             ) : undefined
                                         }
                                         isDisabled={
-                                            !liveAmount || isAmountTooHigh || isSubmittingApprove
+                                            isAmountEmpty || isAmountTooHigh || isSubmittingApprove
                                         }
                                         isLoading={isSubmittingApprove}
                                         pendingApproveTransaction={approvalPendingTransaction}

--- a/packages/suite/src/components/earn/yield/supply/YieldSupplyForm.tsx
+++ b/packages/suite/src/components/earn/yield/supply/YieldSupplyForm.tsx
@@ -234,6 +234,7 @@ export const YieldSupplyForm = () => {
                                         isDisabled={
                                             !liveAmount || isAmountTooHigh || isSubmittingApprove
                                         }
+                                        isLoading={isSubmittingApprove}
                                         pendingApproveTransaction={approvalPendingTransaction}
                                         onMaxClick={() => setAmountInput(maxAmount)}
                                         onApprovalSubmit={handleOnApprovalSubmit}

--- a/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
+++ b/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
@@ -21,12 +21,12 @@ export const YieldWithdrawForm = () => {
         token,
         receiptToken,
         maxAmount,
-        liveAmount,
         completedAmount,
         completedReceiptAmount,
         errorMessage,
         pendingTransaction,
         actionNetworkFeeWarning,
+        isAmountEmpty,
         isAmountTooHigh,
         isSubmittingAction,
         setAmountInput,
@@ -128,7 +128,7 @@ export const YieldWithdrawForm = () => {
                                     />
                                 ) : undefined
                             }
-                            isDisabled={!liveAmount || isAmountTooHigh || isSubmittingAction}
+                            isDisabled={isAmountEmpty || isAmountTooHigh || isSubmittingAction}
                             isPending={isSubmittingAction}
                             pendingTransaction={withdrawPendingTransaction}
                             onMaxClick={() => setAmountInput(maxAmount)}

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
@@ -172,8 +172,11 @@ const getOutputTitle = (
             return <Translation id={contractTitle} />;
         case 'address':
         case 'regular_legacy':
-            if (evmTxType === 'supply' || evmTxType === 'withdraw') {
-                return <Translation id="TR_EARN_YIELD_VAULT" />;
+            if (evmTxType === 'supply') {
+                return <Translation id="TR_EARN_YIELD_DEPOSIT_TO" />;
+            }
+            if (evmTxType === 'withdraw') {
+                return <Translation id="TR_EARN_YIELD_REDEEM_FROM" />;
             }
 
             return <Translation id={translation ? translation.label : 'TR_RECIPIENT_ADDRESS'} />;
@@ -333,7 +336,7 @@ const getOutputLines = ({
                         {
                             id: 'address',
                             type: 'default',
-                            value,
+                            value: translationString('TR_EARN_YIELD_VAULT_NAME', { vault: value }),
                         },
                     ];
                 }

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.ts
@@ -368,6 +368,7 @@ export const submitYieldRevokeThunk = createThunk(
         const fallbackSpender = approval.approvedSpender ?? getAllowanceSpender(flowData);
 
         dispatch(stablecoinYieldActions.clearError({ flowType, flowKey }));
+        dispatch(stablecoinYieldActions.startSubmittingApproval({ flowType, flowKey }));
 
         try {
             const { response, verification } = await submitYieldOpportunity({
@@ -429,6 +430,8 @@ export const submitYieldRevokeThunk = createThunk(
             if (!isRevokeModalOpen) {
                 setYieldGenericError({ dispatch, flowType, flowKey });
             }
+        } finally {
+            dispatch(stablecoinYieldActions.finishSubmittingApproval({ flowType, flowKey }));
         }
     },
 );

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -9745,9 +9745,17 @@ export const messages = defineMessages({
         id: 'TR_EARN_YIELD_REVIEW_WITHDRAW_DESCRIPTION',
         defaultMessage: 'Review details to redeem from vault',
     },
-    TR_EARN_YIELD_VAULT: {
-        id: 'TR_EARN_YIELD_VAULT',
-        defaultMessage: 'Vault',
+    TR_EARN_YIELD_DEPOSIT_TO: {
+        id: 'TR_EARN_YIELD_DEPOSIT_TO',
+        defaultMessage: 'Deposit to',
+    },
+    TR_EARN_YIELD_REDEEM_FROM: {
+        id: 'TR_EARN_YIELD_REDEEM_FROM',
+        defaultMessage: 'Redeem from',
+    },
+    TR_EARN_YIELD_VAULT_NAME: {
+        id: 'TR_EARN_YIELD_VAULT_NAME',
+        defaultMessage: '{vault} Vault',
     },
     TR_EARN_YIELD_REVIEW_SUPPLY_AMOUNT: {
         id: 'TR_EARN_YIELD_REVIEW_SUPPLY_AMOUNT',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Resolved multiple issues:
- Deposit/Withdraw modal is now correctly aligned with the device
- "Connect device" modal is shown when device is disconnected while submitting the action
- Update loading states of the buttons
- Prevent yield actions with 0 amount

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27331
Resolve https://github.com/trezor/trezor-suite/issues/27327
Resolve https://github.com/trezor/trezor-suite/issues/27329
Resolve https://github.com/trezor/trezor-suite/issues/27316
Resolve https://github.com/trezor/trezor-suite/issues/27328

## Screenshots:
<img width="619" height="770" alt="image" src="https://github.com/user-attachments/assets/a0acdaee-5db0-415d-a26f-f04a41798cab" />

<img width="573" height="336" alt="image" src="https://github.com/user-attachments/assets/72c47502-4a97-4660-afe4-d367a1803e40" />


https://github.com/user-attachments/assets/47346517-2306-41b0-a5f1-ff0daedf4117


<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/yield-loading-states/web/](https://dev.suite.sldev.cz/suite-web/feat/yield-loading-states/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/yield-loading-states&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/yield-loading-states&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/yield-loading-states&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-07T08:06:51.161Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-07T08:05:57.158Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->