### PR TITLE
Feat/support for alpha deployment type

### DIFF
--- a/.github/actions/release-connect-npm/action.yml
+++ b/.github/actions/release-connect-npm/action.yml
@@ -2,10 +2,11 @@ name: "NPM Connect Deploy Action"
 description: "Releases to NPM any Connect package or Trezor dependency"
 inputs:
   deploymentType:
-    description: "Specifies the deployment type for the npm package. Choose 'beta' for pre-release versions that are not ready for production use, and 'production' for stable versions intended for end-users."
+    description: "Specifies the deployment type for the npm package. Use 'alpha' for early prereleases, 'beta' for prereleases close to production, and 'latest' for stable versions intended for end-users."
     required: true
     type: choice
     options:
+      - alpha
       - beta
       - latest
   packageName:

--- a/.github/workflows/release-connect-npm.yml
+++ b/.github/workflows/release-connect-npm.yml
@@ -103,7 +103,9 @@ jobs:
         if: matrix.package != 'no-packages-to-release'
         id: set_deployment_type
         run: |
-          if [ "${{ needs.identify-release-packages.outputs.deploymentType }}" == "canary" ]; then
+          if [ "${{ needs.identify-release-packages.outputs.deploymentType }}" == "alpha" ]; then
+            echo "DEPLOYMENT_TYPE=alpha" >> $GITHUB_ENV
+          elif [ "${{ needs.identify-release-packages.outputs.deploymentType }}" == "canary" ]; then
             echo "DEPLOYMENT_TYPE=beta" >> $GITHUB_ENV
           else
             echo "DEPLOYMENT_TYPE=latest" >> $GITHUB_ENV
@@ -134,7 +136,9 @@ jobs:
       - name: Set deployment type
         id: set_deployment_type
         run: |
-          if [ "${{ needs.identify-release-packages.outputs.deploymentType }}" == "canary" ]; then
+          if [ "${{ needs.identify-release-packages.outputs.deploymentType }}" == "alpha" ]; then
+            echo "DEPLOYMENT_TYPE=alpha" >> $GITHUB_ENV
+          elif [ "${{ needs.identify-release-packages.outputs.deploymentType }}" == "canary" ]; then
             echo "DEPLOYMENT_TYPE=beta" >> $GITHUB_ENV
           else
             echo "DEPLOYMENT_TYPE=latest" >> $GITHUB_ENV

--- a/.github/workflows/release-connect-v10-production.yml
+++ b/.github/workflows/release-connect-v10-production.yml
@@ -8,10 +8,11 @@ on:
   workflow_dispatch:
     inputs:
       deploymentType:
-        description: "Select the deployment type. (example: canary, stable)"
+        description: "Select the deployment type. (example: alpha, canary, stable)"
         required: true
         type: choice
         options:
+          - alpha
           - canary
           - stable
 

--- a/.github/workflows/release-connect-v9-production.yml
+++ b/.github/workflows/release-connect-v9-production.yml
@@ -8,10 +8,11 @@ on:
   workflow_dispatch:
     inputs:
       deploymentType:
-        description: "Select the deployment type. (example: canary, stable)"
+        description: "Select the deployment type. (example: alpha, canary, stable)"
         required: true
         type: choice
         options:
+          - alpha
           - canary
           - stable
 

--- a/scripts/ci/check-packages-same-deployment-type.ts
+++ b/scripts/ci/check-packages-same-deployment-type.ts
@@ -6,13 +6,19 @@ const checkVersions = (packages: string[], deploymentType: string): void => {
     const versions = packages.map(packageName => getLocalVersion(packageName));
 
     const isCorrectType = versions.every(version => {
-        const isBeta = semver.prerelease(version);
-        return (deploymentType === 'canary' && isBeta) || (deploymentType === 'stable' && !isBeta);
+        const prerelease = semver.prerelease(version);
+        const releaseType = prerelease
+            ? prerelease[0] === 'alpha'
+                ? 'alpha'
+                : 'canary'
+            : 'stable';
+
+        return deploymentType === releaseType;
     });
 
     if (!isCorrectType) {
         console.error(
-            `Mixed deployment types detected. All versions should be either "stable" or "canary".`,
+            `Mixed deployment types detected. All versions should be "stable", "alpha", or "canary".`,
         );
         process.exit(1);
     } else {

--- a/scripts/ci/check-version.js
+++ b/scripts/ci/check-version.js
@@ -9,13 +9,13 @@ const args = process.argv.slice(2);
 
 if (args.length < 2)
     throw new Error(
-        'Version check script requires 2 parameters: package name and dist tag (beta | latest)',
+        'Version check script requires 2 parameters: package name and dist tag (alpha | beta | latest)',
     );
 
 const [packageName, distTag] = args;
 
-if (!['latest', 'beta'].includes(distTag)) {
-    throw new Error('distTag (3rd parameter) must be either "beta" or "latest"');
+if (!['latest', 'beta', 'alpha'].includes(distTag)) {
+    throw new Error('distTag (3rd parameter) must be "alpha", "beta", or "latest"');
 }
 
 const ROOT = path.join(import.meta.dirname, '..', '..');

--- a/scripts/ci/determine-deployment-type.ts
+++ b/scripts/ci/determine-deployment-type.ts
@@ -2,13 +2,20 @@ import semver from 'semver';
 
 const version = process.argv[2];
 
-let deploymentType;
-if (semver.prerelease(version)) {
-    deploymentType = 'canary';
-} else if (semver.minor(version) || semver.major(version)) {
-    deploymentType = 'stable';
-} else {
+const parsedVersion = semver.valid(version);
+if (!parsedVersion) {
     throw new Error(`Invalid version: ${version}`);
+}
+
+const prerelease = semver.prerelease(parsedVersion);
+
+let deploymentType: 'stable' | 'canary' | 'alpha';
+if (prerelease?.[0] === 'alpha') {
+    deploymentType = 'alpha';
+} else if (prerelease) {
+    deploymentType = 'canary';
+} else {
+    deploymentType = 'stable';
 }
 
 process.stdout.write(deploymentType);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Preparing the CI to be able to deploy alpha deployments types.

## Notes for QA

Nothing to test, CI deployment changes.

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are all CI scripts (`scripts/ci/check-packages-same-deployment-type.ts`, `scripts/ci/check-version.js`, `scripts/ci/determine-deployment-type.ts`) that are used exclusively in the CI/CD pipeline for version checking and deployment type determination. They are not part of the application runtime, are not imported by any application source code, and have no static or inferred connection to any E2E test. No E2E tests exercise CI script functionality. The risk of regression to user-facing behavior is negligible, and no E2E tests are recommended.

<details><summary><b>Changed files (3)</b></summary>

- `scripts/ci/check-packages-same-deployment-type.ts`
- `scripts/ci/check-version.js`
- `scripts/ci/determine-deployment-type.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (3)**
- `scripts/ci/check-packages-same-deployment-type.ts`
- `scripts/ci/check-version.js`
- `scripts/ci/determine-deployment-type.ts`

_Updated: 2026-05-07T08:18:26.087Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/support-for-alpha-deployment-type&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/support-for-alpha-deployment-type&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-07T08:23:39.960Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-07T08:21:53.409Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/support-for-alpha-deployment-type/web/](https://dev.suite.sldev.cz/suite-web/feat/support-for-alpha-deployment-type/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->