### PR TITLE
fix(trading): prevent double-clicks during approval signing

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModal.tsx
@@ -8,6 +8,7 @@ import { getDisplaySymbol } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { Banner, Box, Column, Modal, Row } from '@trezor/components';
 import { CoinLogo } from '@trezor/product-components';
+import { useAsyncClickHandler } from '@trezor/react-utils';
 import { borders } from '@trezor/theme';
 
 import { AccountLabeling } from 'src/components/suite/labeling';
@@ -35,6 +36,7 @@ interface ApproveModalProps {
 export const ApproveModal = (props: ApproveModalProps) => {
     const { account, provider, spender, cryptoId, logoSourceType } = props;
     const { device } = useDevice();
+    const { handleClick, disabled: isConfirmInProgress } = useAsyncClickHandler();
     const context = useAllowanceModal({ ...props, type: 'APPROVE' });
 
     const {
@@ -71,9 +73,9 @@ export const ApproveModal = (props: ApproveModalProps) => {
                 bottomContent={
                     <>
                         <Modal.Button
-                            isLoading={isLoading}
-                            isDisabled={!device?.connected || !canSubmit}
-                            onClick={confirmAndSend}
+                            isLoading={isLoading || isConfirmInProgress}
+                            isDisabled={!device?.connected || !canSubmit || isConfirmInProgress}
+                            onClick={() => handleClick(confirmAndSend)}
                         >
                             <Translation id="TR_CONTINUE" />
                         </Modal.Button>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/RevokeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/RevokeModal.tsx
@@ -9,6 +9,7 @@ import { type Account } from '@suite-common/wallet-types';
 import { isAllowanceUnlimited } from '@suite-common/wallet-utils';
 import { Banner, Box, Column, Icon, Modal, Row, Text } from '@trezor/components';
 import { CoinLogo } from '@trezor/product-components';
+import { useAsyncClickHandler } from '@trezor/react-utils';
 import { borders } from '@trezor/theme';
 
 import { AccountLabeling } from 'src/components/suite/labeling';
@@ -35,6 +36,7 @@ interface RevokeModalProps {
 export const RevokeModal = (props: RevokeModalProps) => {
     const { account, provider, spender, cryptoId, logoSourceType, preapprovedAmount } = props;
     const { device } = useDevice();
+    const { handleClick, disabled: isConfirmInProgress } = useAsyncClickHandler();
 
     const context = useAllowanceModal({
         ...props,
@@ -76,9 +78,9 @@ export const RevokeModal = (props: RevokeModalProps) => {
                 bottomContent={
                     <>
                         <Modal.Button
-                            isLoading={isLoading}
-                            isDisabled={!device?.connected || !canSubmit}
-                            onClick={confirmAndSend}
+                            isLoading={isLoading || isConfirmInProgress}
+                            isDisabled={!device?.connected || !canSubmit || isConfirmInProgress}
+                            onClick={() => handleClick(confirmAndSend)}
                         >
                             <Translation id="TR_CONTINUE" />
                         </Modal.Button>

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react';
-
 import styled, { type DefaultTheme } from 'styled-components';
 
 import { events } from '@suite/analytics';
@@ -15,6 +13,7 @@ import {
 import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { Banner, Button, Column } from '@trezor/components';
 import { PendingTransactionInfo } from '@trezor/product-components';
+import { useAsyncClickHandler } from '@trezor/react-utils';
 
 import { Address } from 'src/components/suite/Address';
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -60,10 +59,13 @@ export const TradingFormApproval = () => {
 
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
 
-    const [isApproveButtonLoading, setIsApproveButtonLoading] = useState(false);
-    const [isRevokeButtonLoading, setIsRevokeButtonLoading] = useState(false);
-    const [isSwapButtonLoading, setIsSwapButtonLoading] = useState(false);
-    const [isRefreshButtonLoading, setIsRefreshButtonLoading] = useState(false);
+    const { handleClick: handleApproveClick, disabled: isApproveButtonLoading } =
+        useAsyncClickHandler();
+    const { handleClick: handleRevokeClick, disabled: isRevokeButtonLoading } =
+        useAsyncClickHandler();
+    const { handleClick: handleSwapClick, disabled: isSwapButtonLoading } = useAsyncClickHandler();
+    const { handleClick: handleRefreshClick, disabled: isRefreshButtonLoading } =
+        useAsyncClickHandler();
 
     const { cryptoIdToSymbolAndContractAddress } = useTradingUtils();
 
@@ -89,11 +91,9 @@ export const TradingFormApproval = () => {
         });
 
         allowanceState.setApprovalType('APPROVE');
-        setIsApproveButtonLoading(true);
 
         await approveTransaction(selectedQuote);
 
-        setIsApproveButtonLoading(false);
         context.setIsApproval(true);
         allowanceState.openApproveModal();
     };
@@ -113,11 +113,9 @@ export const TradingFormApproval = () => {
         });
 
         allowanceState.setApprovalType('REVOKE');
-        setIsRevokeButtonLoading(true);
 
         await revokeApproval(selectedQuote);
 
-        setIsRevokeButtonLoading(false);
         context.setIsApproval(true);
         allowanceState.openRevokeModal();
     };
@@ -136,14 +134,10 @@ export const TradingFormApproval = () => {
             },
         });
 
-        setIsSwapButtonLoading(true);
-
         const newTrade = await confirmApproval({
             trade: { ...selectedQuote, status: 'CONFIRM', approvalType: undefined },
             receiveAddress: selectedQuote.receiveAddress,
         });
-
-        setIsSwapButtonLoading(false);
 
         if (!newTrade || newTrade.status === 'ERROR') {
             return;
@@ -162,12 +156,8 @@ export const TradingFormApproval = () => {
             },
         });
 
-        setIsRefreshButtonLoading(true);
-
         resetSelectedOffer();
         await refreshQuotes();
-
-        setIsRefreshButtonLoading(false);
     };
 
     const isApproveButtonDisabled =
@@ -212,7 +202,7 @@ export const TradingFormApproval = () => {
                             {!isIncreasingAllowanceSupported ? (
                                 <>
                                     <Button
-                                        onClick={onRevokeClick}
+                                        onClick={() => handleRevokeClick(onRevokeClick)}
                                         intent="brand"
                                         size="large"
                                         width="100%"
@@ -233,7 +223,9 @@ export const TradingFormApproval = () => {
                             ) : (
                                 <>
                                     <Button
-                                        onClick={onApproveTransactionClick}
+                                        onClick={() =>
+                                            handleApproveClick(onApproveTransactionClick)
+                                        }
                                         intent="brand"
                                         size="large"
                                         width="100%"
@@ -256,7 +248,7 @@ export const TradingFormApproval = () => {
                                             isApproveButtonDisabled ||
                                             isApproveButtonLoading
                                                 ? null
-                                                : onRevokeClick()
+                                                : handleRevokeClick(onRevokeClick)
                                         }
                                         $disabled={
                                             isRevokeButtonDisabled || isApproveButtonDisabled
@@ -269,7 +261,7 @@ export const TradingFormApproval = () => {
                         </>
                     ) : (
                         <Button
-                            onClick={onApproveTransactionClick}
+                            onClick={() => handleApproveClick(onApproveTransactionClick)}
                             intent="brand"
                             size="large"
                             width="100%"
@@ -285,7 +277,7 @@ export const TradingFormApproval = () => {
             {approvalStep === 'APPROVED' && (
                 <>
                     <Button
-                        onClick={onProceedToSwapClick}
+                        onClick={() => handleSwapClick(onProceedToSwapClick)}
                         intent="brand"
                         size="large"
                         width="100%"
@@ -302,7 +294,7 @@ export const TradingFormApproval = () => {
                             isSwapButtonDisabled ||
                             isSwapButtonLoading
                                 ? null
-                                : onRevokeClick()
+                                : handleRevokeClick(onRevokeClick)
                         }
                         $disabled={isRevokeButtonDisabled || isSwapButtonDisabled}
                     >
@@ -319,7 +311,7 @@ export const TradingFormApproval = () => {
 
             {(!approvalStep || approvalStep === 'ERROR') && (
                 <Button
-                    onClick={onRefreshClick}
+                    onClick={() => handleRefreshClick(onRefreshClick)}
                     intent="brand"
                     size="large"
                     width="100%"


### PR DESCRIPTION
## Description

- Guard the Approve and Revoke modal Continue buttons with `useAsyncClickHandler` so repeated clicks cannot queue concurrent approval signing.
- Replace manual loading state in `TradingFormApproval` approve, revoke, swap, and refresh actions with `useAsyncClickHandler`.
- Keep approval action buttons in a consistent disabled/loading state during async handling.

## Notes for QA

- Open a DEX swap that requires token approval, trigger Approve or Revoke, and try clicking the action again while device confirmation is pending; only one signing flow should start and the button should stay disabled/loading.
- Reject the signing on device or make the request fail, then retry the same action; the button should become usable again and start a single new signing flow.

## Related Issue

Resolve #23866

## Screenshots:

N/A

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect token allowance/approval UI components (ApproveModal, RevokeModal, TradingFormApproval) used in the trading/swap flow. The highest risk is in swap tests involving tokens, where the approval flow is directly exercised. Buy and sell tests for non-token assets, navigation tests, and the dashboard assets test are unlikely to exercise the approval modals directly and are omitted. The recommended strategy is to prioritize token swap tests (coin-to-token, token-to-coin, token-to-token) as high priority, with coin-to-coin swaps and token sell flows as medium priority since they share the form infrastructure.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModal.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/RevokeModal.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — This test exercises the swap flow involving token approval, which directly uses TradingFormApproval.tsx and the ApproveModal.tsx for token allowance. Swapping a coin to a token (SOL to USDC) requires token approval steps that exercise the changed components.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Swapping a token (USDT) to a coin (BTC) involves token allowance approval flows. The TradingFormApproval component and ApproveModal/RevokeModal are directly involved in the token swap approval step before executing the trade.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Token-to-token swaps (USDT to USDC) require token approval/allowance management. The TradingFormApproval component orchestrates the approve/revoke flow which is central to this test's swap execution path.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/trading/swap-coins.test.ts` — Coin-to-coin swaps (SOL to BTC) may not always trigger token approval, but the swap flow shares the TradingFormApproval component in its rendering path. Changes could affect the swap confirmation flow even when approval is not needed.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Ethereum swap with custom fees involves the trading form flow where TradingFormApproval may be rendered for ERC-20 token swaps. The ETH-to-BTC swap path shares the form infrastructure with the approval component.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — BTC-to-ETH swap exercises the trading form where TradingFormApproval is part of the component tree. While Bitcoin swaps may not trigger approval, the shared form infrastructure could be affected by changes.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Selling an ERC-20 token (USDC) may involve token allowance approval before the sell transaction can proceed. The ApproveModal and TradingFormApproval components are in the rendering path for token sell flows.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — This test swaps a token (USDT on Solana) to a disabled network asset, exercising the swap form flow that includes TradingFormApproval in its component hierarchy for token-based swaps.
- `suite/e2e/tests/trading-live/live-swap-coin-to-token.test.ts` — Live swap from SOL to USDC on Base exercises the real swap flow including token approval steps. The TradingFormApproval component is in the critical path for coin-to-token swaps.
- `suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts` — Live swap from SPL token (USDT) to SOL exercises the real swap trading flow where TradingFormApproval handles token allowance. Changes to the approval components could break this live flow.

</details>

_Updated: 2026-05-07T08:20:14.463Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trading-approval-signing-double-click&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-07T08:25:10.982Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->