### PR TITLE
fix: return correct device value on applyDeviceStatesThunk.fullfiled

### DIFF
--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -149,6 +149,14 @@ export const applyDeviceStatesThunk = createThunk<
                     }),
                 );
                 dispatch(deviceActions.setRememberDevice({ device, remember }));
+
+                // select the device after deviceReducer updates it (it's a new object reference)
+                const newlyAddedDevice = selectDeviceByStaticSessionId(getState(), staticSessionId);
+                if (newlyAddedDevice === undefined) {
+                    return rejectWithValue('applyDeviceStatesThunk: newly added device not found');
+                }
+
+                return fulfillWithValue({ device: newlyAddedDevice });
             } else {
                 dispatch(
                     deviceActions.addAuthorizedDevice({
@@ -165,9 +173,9 @@ export const applyDeviceStatesThunk = createThunk<
                     return rejectWithValue('applyDeviceStatesThunk: newly added device not found');
                 }
                 dispatch(selectDeviceThunk({ device: newlyAddedDevice }));
-            }
 
-            return fulfillWithValue({ device });
+                return fulfillWithValue({ device: newlyAddedDevice });
+            }
         } catch (error) {
             console.error('applyDeviceStatesThunk error', error);
 


### PR DESCRIPTION
Resolves https://github.com/trezor/trezor-suite/pull/26882#issuecomment-4344696152

Thunk now returns correct - re-selected device. 

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies two distinct areas: the discovery thunks (discoveryThunks.ts) which is a core piece of the wallet discovery pipeline, and the metadata middleware (metadataMiddleware.ts) which handles labeling/metadata actions. The discovery change is high-risk since it maps to 121 tests and affects how accounts are discovered across all coin types — but only tests that directly exercise discovery behavior are recommended at high/medium priority. The metadata middleware change has no static test coverage but clearly affects all metadata/labeling tests. The recommended strategy focuses on discovery-specific tests and the full metadata test suite, with highest priority given to tests that directly validate discovery completion and metadata lifecycle.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/wallet-core/src/discovery/discoveryThunks.ts`
- `suite/metadata/src/metadataMiddleware.ts`

</details>

**Recommended tests (23)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/general/wallet-discovery.test.ts` — This test directly exercises wallet discovery functionality — ejecting a wallet, adding a standard wallet, and verifying BTC balance after discovery. Changes to discoveryThunks.ts directly affect the discovery process that this test validates end-to-end.
- `suite/e2e/tests/wallet/discovery.test.ts` — This test activates multiple coins (BTC, LTC, ETH, ETC, BCH, DOGE, ADA, XRP, ZEC), triggers discovery, verifies Redux discovery status transitions (starting → complete), and checks that discovery survives a page reload. This directly tests the core discovery logic modified in discoveryThunks.ts.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test configures custom Blockbook backends for BTC and LTC, then verifies that account discovery completes successfully and the dashboard graph appears. It directly exercises the discovery pipeline changed in discoveryThunks.ts.
- `suite/e2e/tests/metadata/legacy/interval-fetching.test.ts` — This test validates that metadata labels are periodically re-fetched from cloud providers (Google, Dropbox) and updated in the UI. The metadataMiddleware.ts change could directly affect how metadata fetch intervals are triggered and processed, and this test explicitly depends on FETCH_INTERVAL from metadata constants.
- `suite/e2e/tests/metadata/legacy/account-metadata.test.ts` — This test exercises the full metadata labeling lifecycle — enabling Dropbox provider, editing/saving/discarding/removing account labels, and searching by label. The metadataMiddleware.ts change could affect how metadata actions are intercepted and processed in the middleware pipeline.
- `suite/e2e/tests/metadata/legacy/metadata-lifecycle.test.ts` — This test covers the full metadata lifecycle including enabling/disabling labeling, adding labels across wallets, ejecting devices, and re-enabling labeling. Changes to metadataMiddleware.ts directly impact how these metadata state transitions are handled.

</details>

<details><summary>🟡 <b>Medium priority (15)</b></summary>

- `suite/e2e/tests/metadata/legacy/remembered-device.test.ts` — This test validates metadata behavior on remembered devices — connecting/disconnecting providers, re-initiating metadata flow with saved device keys, and editing labels offline. The middleware change could affect how metadata actions are routed for remembered devices.
- `suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — This test covers output labeling with Dropbox provider — adding, editing, canceling labels on transaction outputs and verifying CSV export. Changes to metadataMiddleware.ts could affect how output label save/edit actions are intercepted.
- `suite/e2e/tests/metadata/legacy/address-metadata.test.ts` — This test adds and edits address labels using Google metadata provider. The metadataMiddleware change could affect how address labeling actions are processed through the middleware.
- `suite/e2e/tests/metadata/legacy/switching-providers.test.ts` — This test switches between Dropbox and Google metadata providers while managing labels. The middleware change could affect how provider switching and label persistence actions are handled.
- `suite/e2e/tests/metadata/legacy/dropbox-api-errors.test.ts` — This test validates error handling for Dropbox API failures (malformed tokens, rate limits, corrupted files). The metadataMiddleware change could affect how these error conditions are caught and propagated.
- `suite/e2e/tests/metadata/legacy/google-api-errors.test.ts` — This test validates error handling when Google API returns 401 errors during metadata provider initialization. Changes to the middleware could affect how authentication errors are handled.
- `suite/e2e/tests/metadata/legacy/wallet-metadata.test.ts` — This test covers wallet-level labeling (standard and hidden wallets) with persistence across reloads via Dropbox. The middleware change could affect how wallet label actions are processed.
- `suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts` — This test validates migration from legacy Dropbox labeling to Suite Sync (Evolu). The metadataMiddleware change could affect how legacy label actions are intercepted during the migration flow.
- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — This test creates account, wallet, address, and output labels via Suite Sync and verifies they sync to the Evolu Relay server. The middleware change could affect how label creation actions are processed.
- `suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — This test verifies that labels are synced from the Evolu relay server to the Suite client. The middleware change could affect how incoming sync data is processed.
- `suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts` — This test removes all label types (account, wallet, address, output) and verifies null values sync to the relay. The middleware change could affect how label removal actions are handled.
- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — This test manages labels across multiple passphrase wallets with Suite Sync enabled/declined. The middleware change could affect how metadata actions are routed for different wallet contexts.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test enables coins, configures custom backends, and verifies discovery completes or shows errors. It exercises the discovery pipeline through custom backend configurations, which is relevant to discoveryThunks.ts changes.
- `suite/e2e/tests/settings/electrum.test.ts` — This test configures an Electrum backend for RegTest and verifies discovery completes with correct balance. It exercises the discovery flow with an alternative backend type, relevant to discoveryThunks.ts changes.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts` — This test verifies that discovery fails gracefully when the app is offline, checking for a discovery-failed error element. Changes to discoveryThunks.ts could affect how discovery failure states are handled and displayed.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/settings/coins.test.ts` — This test activates coins via an Activate Assets modal and verifies enabled/disabled states. It triggers discovery indirectly through coin activation, which could be affected by discoveryThunks.ts changes.
- `suite/e2e/tests/dashboard/assets.test.ts` — This test enables ETH via the Activate Assets modal and waits for discovery to complete (discoveryShouldFinish). Discovery completion is directly dependent on the changed discoveryThunks.ts.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/metadata/src/metadataMiddleware.ts`

_Updated: 2026-05-07T08:58:39.539Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-metadata-middleware&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-metadata-middleware&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-metadata-middleware&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-07T09:06:15.915Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-07T09:04:43.764Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-metadata-middleware/web/](https://dev.suite.sldev.cz/suite-web/fix-metadata-middleware/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->