### PR TITLE
chore(earn): claim rewards controllable by network features

### DIFF
--- a/packages/suite/src/components/earn/dashboard/staking/hooks/__tests__/useStakingAccountsVisibility.test.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/hooks/__tests__/useStakingAccountsVisibility.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 
 import { type Account } from '@suite-common/wallet-types';
 
@@ -115,6 +115,267 @@ describe('useStakingAccountsVisibility', () => {
             );
 
             expect(result.current.hasAnyRewardsData).toBe(true);
+        });
+    });
+
+    describe('insufficient funds fallback', () => {
+        it('should pick the lowest-index account per network when no account has rewards data', () => {
+            mockGetAccountTotalStakingBalance.mockReturnValue('0');
+
+            const { result } = renderHook(() =>
+                useStakingAccountsVisibility({
+                    ...defaultProps,
+                    stakingAccounts: [
+                        createMockAccount({
+                            key: 'eth-2' as Account['key'],
+                            symbol: 'eth',
+                            index: 2,
+                            formattedBalance: '0',
+                        }),
+                        createMockAccount({
+                            key: 'eth-1' as Account['key'],
+                            symbol: 'eth',
+                            index: 1,
+                            formattedBalance: '0',
+                        }),
+                        createMockAccount({
+                            key: 'eth-0' as Account['key'],
+                            symbol: 'eth',
+                            index: 0,
+                            formattedBalance: '0',
+                        }),
+                        createMockAccount({
+                            key: 'sol-3' as Account['key'],
+                            symbol: 'sol',
+                            networkType: 'solana',
+                            index: 3,
+                            formattedBalance: '0',
+                        }),
+                        createMockAccount({
+                            key: 'sol-0' as Account['key'],
+                            symbol: 'sol',
+                            networkType: 'solana',
+                            index: 0,
+                            formattedBalance: '0',
+                        }),
+                    ],
+                }),
+            );
+
+            const ethFallback = result.current.displayedAccounts.find(
+                account => account.symbol === 'eth',
+            );
+            const solFallback = result.current.displayedAccounts.find(
+                account => account.symbol === 'sol',
+            );
+
+            expect(ethFallback?.key).toBe('eth-0');
+            expect(solFallback?.key).toBe('sol-0');
+        });
+
+        it('should still pick the lowest-index account when input order is reversed by network', () => {
+            mockGetAccountTotalStakingBalance.mockReturnValue('0');
+
+            const { result } = renderHook(() =>
+                useStakingAccountsVisibility({
+                    ...defaultProps,
+                    stakingAccounts: [
+                        createMockAccount({
+                            key: 'ada-5' as Account['key'],
+                            symbol: 'ada',
+                            networkType: 'cardano',
+                            index: 5,
+                            formattedBalance: '0',
+                        }),
+                        createMockAccount({
+                            key: 'ada-1' as Account['key'],
+                            symbol: 'ada',
+                            networkType: 'cardano',
+                            index: 1,
+                            formattedBalance: '0',
+                        }),
+                    ],
+                }),
+            );
+
+            const adaFallback = result.current.displayedAccounts.find(
+                account => account.symbol === 'ada',
+            );
+
+            expect(adaFallback?.key).toBe('ada-1');
+        });
+
+        it('should pick the lowest-index account when insufficient balances are equal but non-zero', () => {
+            mockGetAccountTotalStakingBalance.mockReturnValue('0');
+
+            const { result } = renderHook(() =>
+                useStakingAccountsVisibility({
+                    ...defaultProps,
+                    stakingAccounts: [
+                        createMockAccount({
+                            key: 'eth-2' as Account['key'],
+                            symbol: 'eth',
+                            index: 2,
+                            formattedBalance: '0.005',
+                        }),
+                        createMockAccount({
+                            key: 'eth-1' as Account['key'],
+                            symbol: 'eth',
+                            index: 1,
+                            formattedBalance: '0.005',
+                        }),
+                        createMockAccount({
+                            key: 'eth-0' as Account['key'],
+                            symbol: 'eth',
+                            index: 0,
+                            formattedBalance: '0.005',
+                        }),
+                    ],
+                }),
+            );
+
+            const ethFallback = result.current.displayedAccounts.find(
+                account => account.symbol === 'eth',
+            );
+
+            expect(ethFallback?.key).toBe('eth-0');
+        });
+
+        it('should prefer normal accountType over legacy when balances are equal but non-zero', () => {
+            mockGetAccountTotalStakingBalance.mockReturnValue('0');
+
+            const equalBalance = '0.5';
+            const { result } = renderHook(() =>
+                useStakingAccountsVisibility({
+                    ...defaultProps,
+                    stakingAccounts: [
+                        createMockAccount({
+                            key: 'ada-legacy-0' as Account['key'],
+                            symbol: 'ada',
+                            networkType: 'cardano',
+                            accountType: 'legacy',
+                            index: 0,
+                            formattedBalance: equalBalance,
+                        }),
+                        createMockAccount({
+                            key: 'ada-normal-3' as Account['key'],
+                            symbol: 'ada',
+                            networkType: 'cardano',
+                            accountType: 'normal',
+                            index: 3,
+                            formattedBalance: equalBalance,
+                        }),
+                        createMockAccount({
+                            key: 'ada-ledger-1' as Account['key'],
+                            symbol: 'ada',
+                            networkType: 'cardano',
+                            accountType: 'ledger',
+                            index: 1,
+                            formattedBalance: equalBalance,
+                        }),
+                    ],
+                }),
+            );
+
+            const adaFallback = result.current.displayedAccounts.find(
+                account => account.symbol === 'ada',
+            );
+
+            expect(adaFallback?.key).toBe('ada-normal-3');
+        });
+
+        it('should group insufficient-funds accounts by network and sort them by index in expanded view', () => {
+            mockGetAccountTotalStakingBalance.mockReturnValue('0');
+
+            const { result } = renderHook(() =>
+                useStakingAccountsVisibility({
+                    ...defaultProps,
+                    stakingAccounts: [
+                        createMockAccount({
+                            key: 'eth-8' as Account['key'],
+                            symbol: 'eth',
+                            index: 8,
+                            formattedBalance: '0',
+                        }),
+                        createMockAccount({
+                            key: 'eth-7' as Account['key'],
+                            symbol: 'eth',
+                            index: 7,
+                            formattedBalance: '0',
+                        }),
+                        createMockAccount({
+                            key: 'sol-1' as Account['key'],
+                            symbol: 'sol',
+                            networkType: 'solana',
+                            index: 1,
+                            formattedBalance: '0',
+                        }),
+                        createMockAccount({
+                            key: 'eth-9' as Account['key'],
+                            symbol: 'eth',
+                            index: 9,
+                            formattedBalance: '0',
+                        }),
+                        createMockAccount({
+                            key: 'ada-0' as Account['key'],
+                            symbol: 'ada',
+                            networkType: 'cardano',
+                            index: 0,
+                            formattedBalance: '0',
+                        }),
+                    ],
+                }),
+            );
+
+            act(() => {
+                result.current.toggleExpanded();
+            });
+
+            const orderedKeys = result.current.displayedAccounts.map(account => account.key);
+
+            expect(orderedKeys).toEqual(['eth-7', 'eth-8', 'eth-9', 'sol-1', 'ada-0']);
+        });
+
+        it('should prefer normal accountType over legacy/ledger even when index is higher', () => {
+            mockGetAccountTotalStakingBalance.mockReturnValue('0');
+
+            const { result } = renderHook(() =>
+                useStakingAccountsVisibility({
+                    ...defaultProps,
+                    stakingAccounts: [
+                        createMockAccount({
+                            key: 'ada-ledger-0' as Account['key'],
+                            symbol: 'ada',
+                            networkType: 'cardano',
+                            accountType: 'ledger',
+                            index: 0,
+                            formattedBalance: '0',
+                        }),
+                        createMockAccount({
+                            key: 'ada-legacy-0' as Account['key'],
+                            symbol: 'ada',
+                            networkType: 'cardano',
+                            accountType: 'legacy',
+                            index: 0,
+                            formattedBalance: '0',
+                        }),
+                        createMockAccount({
+                            key: 'ada-normal-5' as Account['key'],
+                            symbol: 'ada',
+                            networkType: 'cardano',
+                            accountType: 'normal',
+                            index: 5,
+                            formattedBalance: '0',
+                        }),
+                    ],
+                }),
+            );
+
+            const adaFallback = result.current.displayedAccounts.find(
+                account => account.symbol === 'ada',
+            );
+
+            expect(adaFallback?.key).toBe('ada-normal-5');
         });
     });
 });

--- a/packages/suite/src/components/earn/dashboard/staking/hooks/useStakingAccountsVisibility.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/hooks/useStakingAccountsVisibility.tsx
@@ -5,6 +5,7 @@ import { type Account } from '@suite-common/wallet-types';
 import {
     getAccountTotalStakingBalance,
     getStakingLimitsByNetworkSymbol,
+    sortByCoin,
     toFiatCurrency,
 } from '@suite-common/wallet-utils';
 import { BigNumber, arrayPartition } from '@trezor/utils';
@@ -110,8 +111,7 @@ export const useStakingAccountsVisibility = ({
         const hasSolBaseAccount = alwaysVisibleAccounts.some(account => account.symbol === 'sol');
         const hasAdaBaseAccount = alwaysVisibleAccounts.some(account => account.symbol === 'ada');
 
-        const sortedInsufficientFundsAccounts =
-            accountsInsufficientFunds.toSorted(sortAccountsByBalance);
+        const sortedInsufficientFundsAccounts = sortByCoin([...accountsInsufficientFunds]);
 
         const additionalAccounts: Account[] = [];
 
@@ -139,21 +139,20 @@ export const useStakingAccountsVisibility = ({
             if (account) additionalAccounts.push(account);
         }
 
-        return additionalAccounts.toSorted(sortAccountsByBalance);
+        return sortByCoin([...additionalAccounts]);
     }, [
         alwaysVisibleAccounts,
         accountsInsufficientFunds,
         ethNotActivated,
         solNotActivated,
         adaNotActivated,
-        sortAccountsByBalance,
     ]);
 
     const collapsedAccounts = [...alwaysVisibleAccounts, ...collapsedInsufficientFundsAccounts];
 
     const expandedAccounts = [
         ...alwaysVisibleAccounts,
-        ...accountsInsufficientFunds.toSorted(sortAccountsByBalance),
+        ...sortByCoin([...accountsInsufficientFunds]),
     ];
 
     const displayedAccounts = isExpanded ? expandedAccounts : collapsedAccounts;

--- a/packages/suite/src/components/earn/dashboard/utils/__tests__/earnYieldUtils.test.ts
+++ b/packages/suite/src/components/earn/dashboard/utils/__tests__/earnYieldUtils.test.ts
@@ -1,0 +1,236 @@
+import { type Account } from '@suite-common/wallet-types';
+
+import {
+    compareYieldRowsByAvailableBalanceDesc,
+    compareYieldRowsByNetworkOnly,
+    compareYieldRowsBySuppliedAmountDesc,
+    compareYieldRowsByTokenNetworkOrder,
+} from '../earnYieldUtils';
+
+type Row = {
+    id: string;
+    account?: Pick<Account, 'symbol' | 'accountType' | 'index'>;
+    suppliedSymbol?: string;
+};
+
+const row = (
+    id: string,
+    symbol: Account['symbol'],
+    index: number,
+    accountType: Account['accountType'] = 'normal',
+    suppliedSymbol?: string,
+): Row => ({
+    id,
+    account: { symbol, accountType, index },
+    suppliedSymbol,
+});
+
+describe('compareYieldRowsByNetworkOnly', () => {
+    it('groups rows by network in networkSymbolCollection order', () => {
+        const sorted = [
+            row('op-0', 'op', 0),
+            row('eth-0', 'eth', 0),
+            row('op-1', 'op', 1),
+            row('eth-1', 'eth', 1),
+        ].toSorted(compareYieldRowsByNetworkOnly);
+
+        const symbols = sorted.map(r => r.account?.symbol);
+        expect(symbols.lastIndexOf('eth')).toBeLessThan(symbols.indexOf('op'));
+    });
+
+    it('preserves input order within the same network (stable sort)', () => {
+        const sorted = [
+            row('eth-3', 'eth', 3),
+            row('eth-0', 'eth', 0),
+            row('eth-2', 'eth', 2),
+        ].toSorted(compareYieldRowsByNetworkOnly);
+
+        expect(sorted.map(r => r.id)).toEqual(['eth-3', 'eth-0', 'eth-2']);
+    });
+
+    it('keeps suppliedAmount-desc within each network when chained with compareYieldRowsBySuppliedAmountDesc', () => {
+        const rows = [
+            {
+                id: 'eth-0-50',
+                account: { symbol: 'eth' as const, accountType: 'normal' as const, index: 0 },
+                suppliedAmount: '50',
+            },
+            {
+                id: 'op-0-75',
+                account: { symbol: 'op' as const, accountType: 'normal' as const, index: 0 },
+                suppliedAmount: '75',
+            },
+            {
+                id: 'eth-1-100',
+                account: { symbol: 'eth' as const, accountType: 'normal' as const, index: 1 },
+                suppliedAmount: '100',
+            },
+            {
+                id: 'op-1-25',
+                account: { symbol: 'op' as const, accountType: 'normal' as const, index: 1 },
+                suppliedAmount: '25',
+            },
+        ];
+
+        const sorted = rows
+            .toSorted(compareYieldRowsBySuppliedAmountDesc)
+            .toSorted(compareYieldRowsByNetworkOnly);
+
+        expect(sorted.map(r => r.id)).toEqual(['eth-1-100', 'eth-0-50', 'op-0-75', 'op-1-25']);
+    });
+
+    it('treats rows without an account as equal (no reordering)', () => {
+        const rows: Row[] = [
+            { id: 'a' },
+            row('eth-0', 'eth', 0),
+            { id: 'b' },
+            row('eth-1', 'eth', 1),
+        ];
+
+        const sorted = rows.toSorted(compareYieldRowsByNetworkOnly);
+
+        expect(sorted.map(r => r.id)).toEqual(['a', 'eth-0', 'b', 'eth-1']);
+    });
+});
+
+describe('compareYieldRowsByTokenNetworkOrder', () => {
+    it('groups by network → token → accountType → index so legacy/ledger rows stay with normal rows on the same token', () => {
+        const sorted = [
+            row('eth-1-legacy-usdc', 'eth', 1, 'legacy', 'usdc'),
+            row('eth-9-normal-usdt', 'eth', 9, 'normal', 'usdt'),
+            row('eth-1-ledger-usdc', 'eth', 1, 'ledger', 'usdc'),
+            row('eth-1-normal-usdc', 'eth', 1, 'normal', 'usdc'),
+            row('eth-9-ledger-usdt', 'eth', 9, 'ledger', 'usdt'),
+            row('eth-1-normal-usdt', 'eth', 1, 'normal', 'usdt'),
+        ].toSorted(compareYieldRowsByTokenNetworkOrder);
+
+        // ETH accountTypes config: { ledger, legacy }. 'normal' indexOf returns -1 → sorts first.
+        // Token (alphabetical) → accountType (normal → ledger → legacy) → index.
+        expect(sorted.map(r => r.id)).toEqual([
+            // USDC block
+            'eth-1-normal-usdc',
+            'eth-1-ledger-usdc',
+            'eth-1-legacy-usdc',
+            // USDT block
+            'eth-1-normal-usdt',
+            'eth-9-normal-usdt',
+            'eth-9-ledger-usdt',
+        ]);
+    });
+
+    it('puts normal account #9 before legacy account #1 (accountType beats index)', () => {
+        const sorted = [
+            row('eth-1-legacy-usdt', 'eth', 1, 'legacy', 'usdt'),
+            row('eth-9-normal-usdt', 'eth', 9, 'normal', 'usdt'),
+        ].toSorted(compareYieldRowsByTokenNetworkOrder);
+
+        expect(sorted.map(r => r.id)).toEqual(['eth-9-normal-usdt', 'eth-1-legacy-usdt']);
+    });
+
+    it('puts ledger account #9 before legacy account #1 (accountType config order: ledger before legacy)', () => {
+        const sorted = [
+            row('eth-1-legacy-usdt', 'eth', 1, 'legacy', 'usdt'),
+            row('eth-9-ledger-usdt', 'eth', 9, 'ledger', 'usdt'),
+        ].toSorted(compareYieldRowsByTokenNetworkOrder);
+
+        expect(sorted.map(r => r.id)).toEqual(['eth-9-ledger-usdt', 'eth-1-legacy-usdt']);
+    });
+
+    it('groups all USDT together within an accountType block (token before index)', () => {
+        const sorted = [
+            row('eth-3-normal-usdt', 'eth', 3, 'normal', 'usdt'),
+            row('eth-1-normal-usdc', 'eth', 1, 'normal', 'usdc'),
+            row('eth-1-normal-usdt', 'eth', 1, 'normal', 'usdt'),
+            row('eth-5-normal-usdc', 'eth', 5, 'normal', 'usdc'),
+        ].toSorted(compareYieldRowsByTokenNetworkOrder);
+
+        expect(sorted.map(r => r.id)).toEqual([
+            'eth-1-normal-usdc',
+            'eth-5-normal-usdc',
+            'eth-1-normal-usdt',
+            'eth-3-normal-usdt',
+        ]);
+    });
+});
+
+describe('yield table 3-bucket ordering', () => {
+    it('renders deposited (suppliedAmount-desc by network), then depositable + no-balance (both share network → accountType → token → index)', () => {
+        const depositedBaseRow = (
+            id: string,
+            symbol: 'eth' | 'op',
+            index: number,
+            suppliedAmount: string,
+        ) => ({
+            id,
+            account: { symbol, accountType: 'normal' as const, index },
+            suppliedAmount,
+        });
+
+        const depositableBaseRow = (
+            id: string,
+            symbol: 'eth' | 'op',
+            accountType: Account['accountType'],
+            index: number,
+            suppliedSymbol: string,
+            additionalSupplyAmount: string,
+        ) => ({
+            id,
+            account: { symbol, accountType, index, formattedBalance: '0' },
+            suppliedSymbol,
+            additionalSupplyAmount,
+            matchedInputToken: {},
+        });
+
+        const depositedRows = [
+            depositedBaseRow('eth-2-deposited-200', 'eth', 2, '200'),
+            depositedBaseRow('eth-0-deposited-500', 'eth', 0, '500'),
+            depositedBaseRow('op-3-deposited-100', 'op', 3, '100'),
+        ];
+        const depositableRows = [
+            depositableBaseRow('eth-3-depositable-normal-usdt', 'eth', 'normal', 3, 'usdt', '50'),
+            depositableBaseRow('eth-0-depositable-normal-usdc', 'eth', 'normal', 0, 'usdc', '300'),
+            depositableBaseRow('eth-1-depositable-ledger-usdt', 'eth', 'ledger', 1, 'usdt', '10'),
+            depositableBaseRow('op-0-depositable-normal-usdc', 'op', 'normal', 0, 'usdc', '75'),
+        ];
+        const noBalanceRows = [
+            row('eth-7-no-balance-normal-usdt', 'eth', 7, 'normal', 'usdt'),
+            row('eth-1-no-balance-normal-usdc', 'eth', 1, 'normal', 'usdc'),
+            row('eth-1-no-balance-legacy-usdc', 'eth', 1, 'legacy', 'usdc'),
+            row('op-2-no-balance-normal-usdc', 'op', 2, 'normal', 'usdc'),
+            row('eth-1-no-balance-ledger-usdt', 'eth', 1, 'ledger', 'usdt'),
+            row('eth-4-no-balance-normal-usdc', 'eth', 4, 'normal', 'usdc'),
+        ];
+
+        const ordered = [
+            ...depositedRows
+                .toSorted(compareYieldRowsBySuppliedAmountDesc)
+                .toSorted(compareYieldRowsByNetworkOnly),
+            ...depositableRows
+                .toSorted(compareYieldRowsByAvailableBalanceDesc)
+                .toSorted(compareYieldRowsByTokenNetworkOrder),
+            ...noBalanceRows.toSorted(compareYieldRowsByTokenNetworkOrder),
+        ];
+
+        expect(ordered.map(r => r.id)).toEqual([
+            // deposited (group 1): suppliedAmount-desc within network
+            'eth-0-deposited-500',
+            'eth-2-deposited-200',
+            'op-3-deposited-100',
+            // depositable (group 2): network → token → accountType → index
+            'eth-0-depositable-normal-usdc',
+            'eth-3-depositable-normal-usdt',
+            'eth-1-depositable-ledger-usdt',
+            'op-0-depositable-normal-usdc',
+            // no-balance (group 3): same chain as depositable — same network+token grouped together
+            //   ETH USDC block (normal by index, then legacy)
+            'eth-1-no-balance-normal-usdc',
+            'eth-4-no-balance-normal-usdc',
+            'eth-1-no-balance-legacy-usdc',
+            //   ETH USDT block (normal, then ledger)
+            'eth-7-no-balance-normal-usdt',
+            'eth-1-no-balance-ledger-usdt',
+            //   OP USDC block
+            'op-2-no-balance-normal-usdc',
+        ]);
+    });
+});

--- a/packages/suite/src/components/earn/dashboard/utils/earnYieldUtils.ts
+++ b/packages/suite/src/components/earn/dashboard/utils/earnYieldUtils.ts
@@ -1,5 +1,10 @@
 import { ChainAddressKey } from '@suite-common/earn-stablecoin-api';
-import { getNetworkByEvmChainId } from '@suite-common/wallet-config';
+import {
+    type AccountType,
+    getNetworkByEvmChainId,
+    networkSymbolCollection,
+    networks,
+} from '@suite-common/wallet-config';
 import { type Account, asBaseCurrencyAmount } from '@suite-common/wallet-types';
 import { BigNumber } from '@trezor/utils';
 
@@ -79,3 +84,50 @@ export const compareYieldRowsByAvailableBalanceDesc = (
     new BigNumber(getYieldAvailableBalanceForSorting(b)).comparedTo(
         getYieldAvailableBalanceForSorting(a),
     ) ?? 0;
+
+type YieldRowWithAccount = {
+    account?: Pick<Account, 'symbol' | 'accountType' | 'index'>;
+    suppliedSymbol?: string;
+};
+
+/**
+ * Groups rows by network only (in networkSymbolCollection order). Used for the deposited and
+ * deposit buckets so a stable secondary sort by balance/supplied amount actually controls
+ * the within-network order.
+ */
+export const compareYieldRowsByNetworkOnly = (a: YieldRowWithAccount, b: YieldRowWithAccount) => {
+    if (!a.account || !b.account) return 0;
+
+    const aSymbolIndex = networkSymbolCollection.indexOf(a.account.symbol);
+    const bSymbolIndex = networkSymbolCollection.indexOf(b.account.symbol);
+
+    return aSymbolIndex - bSymbolIndex;
+};
+
+/**
+ * Groups by network → token symbol → account type → account index. Used for the depositable
+ * and no-balance buckets so rows on the same network and token stay together regardless of
+ * account type (normal/legacy/ledger).
+ */
+export const compareYieldRowsByTokenNetworkOrder = (
+    a: YieldRowWithAccount,
+    b: YieldRowWithAccount,
+) => {
+    if (!a.account || !b.account) return 0;
+
+    const aSymbolIndex = networkSymbolCollection.indexOf(a.account.symbol);
+    const bSymbolIndex = networkSymbolCollection.indexOf(b.account.symbol);
+    if (aSymbolIndex !== bSymbolIndex) return aSymbolIndex - bSymbolIndex;
+
+    if (a.suppliedSymbol && b.suppliedSymbol && a.suppliedSymbol !== b.suppliedSymbol) {
+        return a.suppliedSymbol.localeCompare(b.suppliedSymbol);
+    }
+
+    const network = networks[a.account.symbol];
+    const orderedAccountTypes = Object.keys(network.accountTypes) as AccountType[];
+    const aAccountTypeIndex = orderedAccountTypes.indexOf(a.account.accountType);
+    const bAccountTypeIndex = orderedAccountTypes.indexOf(b.account.accountType);
+    if (aAccountTypeIndex !== bAccountTypeIndex) return aAccountTypeIndex - bAccountTypeIndex;
+
+    return a.account.index - b.account.index;
+};

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 
 import { Translation } from '@suite/intl';
 import { goto } from '@suite/router';
+import { selectIsDebugModeActive } from '@suite/settings';
 import { Context } from '@suite-common/message-system';
 import { NORMAL_ACCOUNT_TYPE, isEarnYieldClaimSupported } from '@suite-common/wallet-config';
 import { selectVisibleDeviceAccounts } from '@suite-common/wallet-core';
@@ -33,6 +34,7 @@ export const EarnYieldTable = () => {
         useMessageSystemEarnDashboard('yield');
     const [isClaimModalOpen, setIsClaimModalOpen] = useState(false);
 
+    const isDebugMode = useSelector(selectIsDebugModeActive);
     const visibleAccounts = useSelector(selectVisibleDeviceAccounts);
     const visibleAccountSymbols = useMemo(() => {
         const normalAccounts = visibleAccounts.filter(
@@ -69,7 +71,7 @@ export const EarnYieldTable = () => {
                 const { networkSymbol, account } = opportunity;
                 if (
                     !(
-                        isEarnYieldClaimSupported(networkSymbol) &&
+                        isEarnYieldClaimSupported(networkSymbol, { isDebugMode }) &&
                         account &&
                         account.networkType === 'ethereum'
                     )
@@ -77,7 +79,8 @@ export const EarnYieldTable = () => {
                     return [];
                 }
 
-                const isEmptyAccount = Number(account.misc.nonce ?? 0) < 1;
+                // account with nonce 1 sent only 1 tx (when user supplies, first tx is approval)
+                const isEmptyAccount = Number(account?.misc?.nonce ?? 0) <= 1;
 
                 if (isEmptyAccount) {
                     return [];
@@ -90,7 +93,7 @@ export const EarnYieldTable = () => {
                     },
                 ];
             }),
-        [yieldAccountOpportunities],
+        [yieldAccountOpportunities, isDebugMode],
     );
     const { merkleRewardsQuery } = useMerkleRewards(merkleRewardsSources);
     const { rewards } = merkleRewardsQuery.data;

--- a/packages/suite/src/components/earn/dashboard/yield/hooks/__tests__/useYieldAccountsVisibility.test.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/hooks/__tests__/useYieldAccountsVisibility.test.tsx
@@ -1,0 +1,230 @@
+import { renderHook } from '@testing-library/react';
+
+import { type Account } from '@suite-common/wallet-types';
+
+import { type YieldAccountOpportunity } from '../../types';
+import { useYieldAccountsVisibility } from '../useYieldAccountsVisibility';
+
+const createMockAccount = (overrides: Partial<Account>): Account =>
+    ({
+        key: 'default-key',
+        index: 0,
+        symbol: 'eth',
+        networkType: 'ethereum',
+        accountType: 'normal',
+        formattedBalance: '0',
+        descriptor: '0x123',
+        tokens: [],
+        ...overrides,
+    }) as Account;
+
+const createMockOpportunity = (
+    account: Account,
+    vaultId: string,
+    hasRewardsData = false,
+): YieldAccountOpportunity =>
+    ({
+        key: `${vaultId}:${account.key}`,
+        account,
+        networkSymbol: account.symbol,
+        vault: { id: vaultId } as YieldAccountOpportunity['vault'],
+        matchedInputToken: undefined,
+        hasVaultPosition: false,
+        hasRewardsData,
+        suppliedAmount: '0',
+        additionalSupplyAmount: '0',
+        suppliedSymbol: 'usdc' as YieldAccountOpportunity['suppliedSymbol'],
+        suppliedContractAddress: null,
+        apyPercentage: 5,
+    }) as YieldAccountOpportunity;
+
+describe('useYieldAccountsVisibility', () => {
+    describe('vault fallback selection', () => {
+        it('should pick the lowest-index account as fallback when no opportunity has rewards data', () => {
+            const eth2 = createMockAccount({
+                key: 'eth-2' as Account['key'],
+                index: 2,
+            });
+            const eth1 = createMockAccount({
+                key: 'eth-1' as Account['key'],
+                index: 1,
+            });
+            const eth0 = createMockAccount({
+                key: 'eth-0' as Account['key'],
+                index: 0,
+            });
+
+            const yieldAccountOpportunities = [
+                createMockOpportunity(eth2, 'vault-a'),
+                createMockOpportunity(eth1, 'vault-a'),
+                createMockOpportunity(eth0, 'vault-a'),
+            ];
+
+            const { result } = renderHook(() =>
+                useYieldAccountsVisibility({ yieldAccountOpportunities }),
+            );
+
+            expect(result.current.displayedYieldAccountOpportunities).toHaveLength(1);
+            expect(result.current.displayedYieldAccountOpportunities[0].account?.key).toBe('eth-0');
+            expect(result.current.hasHiddenYieldAccountOpportunities).toBe(true);
+        });
+
+        it('should pick the same account across all vaults on the same network', () => {
+            const eth2 = createMockAccount({
+                key: 'eth-2' as Account['key'],
+                index: 2,
+            });
+            const eth0 = createMockAccount({
+                key: 'eth-0' as Account['key'],
+                index: 0,
+            });
+
+            const yieldAccountOpportunities = [
+                createMockOpportunity(eth2, 'vault-a'),
+                createMockOpportunity(eth0, 'vault-a'),
+                createMockOpportunity(eth2, 'vault-b'),
+                createMockOpportunity(eth0, 'vault-b'),
+            ];
+
+            const { result } = renderHook(() =>
+                useYieldAccountsVisibility({ yieldAccountOpportunities }),
+            );
+
+            const fallbackKeys = result.current.displayedYieldAccountOpportunities.map(
+                opportunity => opportunity.account?.key,
+            );
+
+            expect(fallbackKeys).toEqual(['eth-0', 'eth-0']);
+        });
+
+        it('should pick the lowest-index account when accounts have equal non-zero token balances', () => {
+            const eth2 = createMockAccount({
+                key: 'eth-2' as Account['key'],
+                index: 2,
+            });
+            const eth1 = createMockAccount({
+                key: 'eth-1' as Account['key'],
+                index: 1,
+            });
+            const eth0 = createMockAccount({
+                key: 'eth-0' as Account['key'],
+                index: 0,
+            });
+
+            const equalAvailableBalance = '10';
+            const yieldAccountOpportunities = [
+                {
+                    ...createMockOpportunity(eth2, 'vault-a'),
+                    additionalSupplyAmount: equalAvailableBalance,
+                },
+                {
+                    ...createMockOpportunity(eth1, 'vault-a'),
+                    additionalSupplyAmount: equalAvailableBalance,
+                },
+                {
+                    ...createMockOpportunity(eth0, 'vault-a'),
+                    additionalSupplyAmount: equalAvailableBalance,
+                },
+            ];
+
+            const { result } = renderHook(() =>
+                useYieldAccountsVisibility({ yieldAccountOpportunities }),
+            );
+
+            expect(result.current.displayedYieldAccountOpportunities).toHaveLength(1);
+            expect(result.current.displayedYieldAccountOpportunities[0].account?.key).toBe('eth-0');
+        });
+
+        it('should prefer normal accountType over ledger when balances are equal but non-zero', () => {
+            const baseLedger0 = createMockAccount({
+                key: 'base-ledger-0' as Account['key'],
+                symbol: 'base',
+                networkType: 'ethereum',
+                accountType: 'ledger',
+                index: 0,
+            });
+            const baseNormal3 = createMockAccount({
+                key: 'base-normal-3' as Account['key'],
+                symbol: 'base',
+                networkType: 'ethereum',
+                accountType: 'normal',
+                index: 3,
+            });
+
+            const equalAvailableBalance = '10';
+            const yieldAccountOpportunities = [
+                {
+                    ...createMockOpportunity(baseLedger0, 'vault-a'),
+                    additionalSupplyAmount: equalAvailableBalance,
+                },
+                {
+                    ...createMockOpportunity(baseNormal3, 'vault-a'),
+                    additionalSupplyAmount: equalAvailableBalance,
+                },
+            ];
+
+            const { result } = renderHook(() =>
+                useYieldAccountsVisibility({ yieldAccountOpportunities }),
+            );
+
+            expect(result.current.displayedYieldAccountOpportunities).toHaveLength(1);
+            expect(result.current.displayedYieldAccountOpportunities[0].account?.key).toBe(
+                'base-normal-3',
+            );
+        });
+
+        it('should prefer normal accountType over ledger even when index is higher', () => {
+            const baseLedger0 = createMockAccount({
+                key: 'base-ledger-0' as Account['key'],
+                symbol: 'base',
+                networkType: 'ethereum',
+                accountType: 'ledger',
+                index: 0,
+            });
+            const baseNormal5 = createMockAccount({
+                key: 'base-normal-5' as Account['key'],
+                symbol: 'base',
+                networkType: 'ethereum',
+                accountType: 'normal',
+                index: 5,
+            });
+
+            const yieldAccountOpportunities = [
+                createMockOpportunity(baseLedger0, 'vault-a'),
+                createMockOpportunity(baseNormal5, 'vault-a'),
+            ];
+
+            const { result } = renderHook(() =>
+                useYieldAccountsVisibility({ yieldAccountOpportunities }),
+            );
+
+            expect(result.current.displayedYieldAccountOpportunities).toHaveLength(1);
+            expect(result.current.displayedYieldAccountOpportunities[0].account?.key).toBe(
+                'base-normal-5',
+            );
+        });
+
+        it('should keep the opportunity with rewards data and not add a fallback for that vault', () => {
+            const eth2 = createMockAccount({
+                key: 'eth-2' as Account['key'],
+                index: 2,
+            });
+            const eth0 = createMockAccount({
+                key: 'eth-0' as Account['key'],
+                index: 0,
+            });
+
+            const yieldAccountOpportunities = [
+                createMockOpportunity(eth2, 'vault-a', true),
+                createMockOpportunity(eth0, 'vault-a'),
+            ];
+
+            const { result } = renderHook(() =>
+                useYieldAccountsVisibility({ yieldAccountOpportunities }),
+            );
+
+            expect(result.current.displayedYieldAccountOpportunities).toHaveLength(1);
+            expect(result.current.displayedYieldAccountOpportunities[0].account?.key).toBe('eth-2');
+        });
+    });
+});

--- a/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldAccountsVisibility.ts
+++ b/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldAccountsVisibility.ts
@@ -1,5 +1,8 @@
 import { useCallback, useMemo, useState } from 'react';
 
+import { type Account } from '@suite-common/wallet-types';
+import { sortByCoin } from '@suite-common/wallet-utils';
+
 import { type YieldAccountOpportunity } from '../types';
 
 type UseYieldAccountsVisibilityProps = {
@@ -31,9 +34,19 @@ export const useYieldAccountsVisibility = ({
                 return;
             }
 
-            const fallbackOpportunity = yieldAccountOpportunities.find(
+            const vaultOpportunities = yieldAccountOpportunities.filter(
                 opportunity => opportunity.vault.id === vaultId,
             );
+            const vaultAccounts = vaultOpportunities
+                .map(opportunity => opportunity.account)
+                .filter((account): account is Account => account !== undefined);
+            const [firstAccountByCoinOrder] = sortByCoin([...vaultAccounts]);
+
+            const fallbackOpportunity = firstAccountByCoinOrder
+                ? vaultOpportunities.find(
+                      opportunity => opportunity.account?.key === firstAccountByCoinOrder.key,
+                  )
+                : vaultOpportunities[0];
 
             if (fallbackOpportunity) {
                 visibleOpportunityKeys.add(fallbackOpportunity.key);

--- a/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldTableData.ts
+++ b/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldTableData.ts
@@ -1,11 +1,7 @@
 import { useMemo } from 'react';
 
 import { type TokenDto, type YieldDto } from '@suite-common/earn-stablecoin-api';
-import {
-    NORMAL_ACCOUNT_TYPE,
-    type NetworkSymbol,
-    getNetworkByYieldXyzId,
-} from '@suite-common/wallet-config';
+import { type NetworkSymbol, getNetworkByYieldXyzId } from '@suite-common/wallet-config';
 import {
     doTokensMatch,
     getConvertedOutputTokenBalanceToInputTokenAmount,
@@ -123,9 +119,7 @@ export const useYieldTableData = ({
             }
 
             const networkAccounts = visibleAccounts.filter(
-                account =>
-                    account.accountType === NORMAL_ACCOUNT_TYPE &&
-                    account.symbol === network.symbol,
+                account => account.symbol === network.symbol,
             );
 
             return networkAccounts.map(account => ({

--- a/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldTableData.ts
+++ b/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldTableData.ts
@@ -19,7 +19,9 @@ import { useSelector } from 'src/hooks/suite';
 
 import {
     compareYieldRowsByAvailableBalanceDesc,
+    compareYieldRowsByNetworkOnly,
     compareYieldRowsBySuppliedAmountDesc,
+    compareYieldRowsByTokenNetworkOrder,
 } from '../../utils/earnYieldUtils';
 import {
     type YieldAccountOpportunity,
@@ -141,12 +143,12 @@ export const useYieldTableData = ({
         });
 
         const activeOpportunities: YieldAccountOpportunity[] = [];
-        const supplyableOpportunities: YieldAccountOpportunity[] = [];
-        const buyOnlyOpportunities: YieldAccountOpportunity[] = [];
+        const depositableOpportunities: YieldAccountOpportunity[] = [];
+        const noBalanceOpportunities: YieldAccountOpportunity[] = [];
 
         allOpportunities.forEach(opportunity => {
             const hasMatchedInputToken = opportunity.matchedInputToken !== undefined;
-            const hasSupplyableBalance = new BigNumber(opportunity.additionalSupplyAmount).gt(0);
+            const hasDepositableBalance = new BigNumber(opportunity.additionalSupplyAmount).gt(0);
 
             if (opportunity.hasVaultPosition) {
                 activeOpportunities.push(opportunity);
@@ -154,19 +156,23 @@ export const useYieldTableData = ({
                 return;
             }
 
-            if (hasMatchedInputToken && hasSupplyableBalance) {
-                supplyableOpportunities.push(opportunity);
+            if (hasMatchedInputToken && hasDepositableBalance) {
+                depositableOpportunities.push(opportunity);
 
                 return;
             }
 
-            buyOnlyOpportunities.push(opportunity);
+            noBalanceOpportunities.push(opportunity);
         });
 
         return [
-            ...activeOpportunities.toSorted(compareYieldRowsBySuppliedAmountDesc),
-            ...supplyableOpportunities.toSorted(compareYieldRowsByAvailableBalanceDesc),
-            ...buyOnlyOpportunities.toSorted(compareYieldRowsByAvailableBalanceDesc),
+            ...activeOpportunities
+                .toSorted(compareYieldRowsBySuppliedAmountDesc)
+                .toSorted(compareYieldRowsByNetworkOnly),
+            ...depositableOpportunities
+                .toSorted(compareYieldRowsByAvailableBalanceDesc)
+                .toSorted(compareYieldRowsByTokenNetworkOrder),
+            ...noBalanceOpportunities.toSorted(compareYieldRowsByTokenNetworkOrder),
         ];
     }, [availableVaults, visibleAccounts, visibleAccountSymbols]);
 

--- a/packages/suite/src/components/earn/yield/claim/YieldClaim.tsx
+++ b/packages/suite/src/components/earn/yield/claim/YieldClaim.tsx
@@ -4,6 +4,7 @@ import { events } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
+import { selectIsDebugModeActive } from '@suite/settings';
 import { ChainAddressKey } from '@suite-common/earn-stablecoin-api';
 import { Context } from '@suite-common/message-system';
 import { isEarnYieldClaimSupported } from '@suite-common/wallet-config';
@@ -46,12 +47,14 @@ export const YieldClaim = ({ account }: YieldClaimProps) => {
     const claimSession = useSelector(state =>
         selectStablecoinYieldSession(state, 'claim', flowKey),
     );
+    const isDebugMode = useSelector(selectIsDebugModeActive);
     const isClaimSubmitting =
         claimSession.action.isSubmitting ||
         (!!yieldTxReview.precomposedTx && yieldTxReview.accountKey === account?.key);
     const isClaiming = isClaimSubmitting || !!claimSession.action.pendingTransaction;
     const isDeviceConnected = !!device?.connected && device.available;
-    const isClaimSupported = !!account && isEarnYieldClaimSupported(account.symbol);
+    const isClaimSupported =
+        !!account && isEarnYieldClaimSupported(account.symbol, { isDebugMode });
 
     const merkleRewardsSources = useMemo(
         () =>

--- a/suite-common/wallet-config/src/earnRewardsProvider.ts
+++ b/suite-common/wallet-config/src/earnRewardsProvider.ts
@@ -1,4 +1,5 @@
 import { type NetworkSymbol } from './types';
+import { getNetworkFeatures } from './utils';
 
 const MERKL_XYZ_CONTRACT: Partial<Record<NetworkSymbol, `0x${string}`>> = {
     eth: '0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae',
@@ -7,8 +8,16 @@ const MERKL_XYZ_CONTRACT: Partial<Record<NetworkSymbol, `0x${string}`>> = {
     op: '0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae',
 };
 
-export const isEarnYieldClaimSupported = (networkSymbol: NetworkSymbol) =>
-    MERKL_XYZ_CONTRACT[networkSymbol] !== undefined;
+export const isEarnYieldClaimSupported = (
+    networkSymbol: NetworkSymbol,
+    { isDebugMode = false }: { isDebugMode?: boolean } = {},
+) => {
+    if (isDebugMode) {
+        return MERKL_XYZ_CONTRACT[networkSymbol] !== undefined;
+    }
+
+    return getNetworkFeatures(networkSymbol).includes('claim-rewards');
+};
 
 export const getEarnYieldClaimContractAddress = (networkSymbol: NetworkSymbol) =>
     MERKL_XYZ_CONTRACT[networkSymbol];

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -63,6 +63,7 @@ export const networks = {
             'eip1559',
             'mev-protection',
             'graph',
+            'claim-rewards',
         ],
         backendTypes: ['blockbook', 'evm-rpc'],
         accountTypes: {

--- a/suite-common/wallet-config/src/types.ts
+++ b/suite-common/wallet-config/src/types.ts
@@ -81,7 +81,8 @@ export type NetworkFeature =
     | 'nft-definitions'
     | 'eip1559'
     | 'mev-protection'
-    | 'graph';
+    | 'graph'
+    | 'claim-rewards';
 
 type Level = `/${number}'`;
 type MaybeApostrophe = `'` | '';

--- a/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
@@ -243,6 +243,7 @@ describe('account utils', () => {
             'eip1559',
             'mev-protection',
             'graph',
+            'claim-rewards',
         ]);
         expect(getNetworkAccountFeatures(coinjoinAcc)).toEqual(['rbf', 'amount-unit']);
         // when account does not have features defined, take them from root network object


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- claim only for ETH, for other networks under debug mode
- better sort staking accounts
- better sort yielding accounts
- do not filter non-normal accounts from yielding

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #27458
Resolve #27321 
Resolve https://github.com/trezor/trezor-suite/issues/27330

## Screenshots:
Debug
<img width="710" height="466" alt="Screenshot 2026-05-07 at 14 10 04" src="https://github.com/user-attachments/assets/626147e7-e8a9-4b05-b952-d21a97869bd2" />

Non-debug
<img width="729" height="305" alt="Screenshot 2026-05-07 at 14 10 17" src="https://github.com/user-attachments/assets/2f3b1c6a-537f-46ef-bc20-05e8b1efe0f6" />

Now
- first accounts
<img width="1272" height="526" alt="Screenshot 2026-05-07 at 14 17 50" src="https://github.com/user-attachments/assets/d1147f02-c537-4ccc-abe3-a41c9ddf879b" />

Before
<img width="1271" height="494" alt="Screenshot 2026-05-07 at 14 19 44" src="https://github.com/user-attachments/assets/071124a4-6c4e-4be5-8eec-a62f108ab10e" />


Now
- before mix numbers + no ledger/legacy accs
<img width="1255" height="1174" alt="Screenshot 2026-05-07 at 14 18 23" src="https://github.com/user-attachments/assets/12013918-8b00-436b-9014-b9bf018a9a30" />

Before
<img width="1256" height="1200" alt="Screenshot 2026-05-07 at 14 20 09" src="https://github.com/user-attachments/assets/5c98a026-8d22-406e-87ec-a2e00751f72e" />


Now
- mess before
<img width="1245" height="991" alt="Screenshot 2026-05-07 at 14 18 46" src="https://github.com/user-attachments/assets/e66d93b2-c3c2-42d4-882c-84ac224bf9c9" />

Before
<img width="1280" height="1016" alt="Screenshot 2026-05-07 at 14 20 34" src="https://github.com/user-attachments/assets/d170cb65-5d7a-4056-9f7f-9a5f7a6568e5" />

Now
- mess before
<img width="1236" height="1012" alt="Screenshot 2026-05-07 at 14 18 57" src="https://github.com/user-attachments/assets/068c6054-b97c-4d52-826a-744e680f9548" />

Before
<img width="1262" height="868" alt="Screenshot 2026-05-07 at 14 21 04" src="https://github.com/user-attachments/assets/d7c61f76-1500-448f-9c60-3cb2047a7020" />



<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/stables-2&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/stables-2&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/stables-2&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-07T10:23:22.113Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-07T10:21:13.065Z • 11 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/stables-2/web/](https://dev.suite.sldev.cz/suite-web/feat/stables-2/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->