### PR TITLE
chore(earn-stablecoin-api): more chain ids in merkle rewards request

### DIFF
--- a/suite-common/earn-stablecoin-api/src/hooks/useGetMerkleRewards.ts
+++ b/suite-common/earn-stablecoin-api/src/hooks/useGetMerkleRewards.ts
@@ -116,38 +116,36 @@ export function useGetMerkleRewards<Address extends string>(
                 cache: 'no-store',
             });
 
-            const requests = queryEntries.map(entry =>
-                fetcher({
-                    routeParams: { address: entry.address },
-                    params: {
-                        chainId: entry.chainId,
-                        claimableOnly: true,
-                    },
-                }),
+            // Group requested chainIds by address so each address triggers a single batched
+            // HTTP request (Merkl accepts a comma-separated `chainId` list).
+            const chainIdsByAddress = queryEntries.reduce<Record<Address, number[]>>(
+                (acc, { address, chainId }) => {
+                    (acc[address] ??= []).push(chainId);
+
+                    return acc;
+                },
+                {} as Record<Address, number[]>,
             );
 
-            const usersChainRewards = await Promise.all(requests);
+            const requests = Object.entries(chainIdsByAddress).map(async entry => {
+                const [address, chainIds] = entry as [Address, number[]];
 
-            // Link the response with the query entries, flatten the rewards, select needed fields
-            const rewardsResult = usersChainRewards.map((userChainRewards, index) => {
-                const { address, chainId } = queryEntries[index];
+                const userChainRewards = await fetcher({
+                    routeParams: { address },
+                    params: {
+                        chainId: chainIds.join(','),
+                        claimableOnly: true,
+                    },
+                });
 
-                return {
-                    address,
-                    chainId,
-                    rewards: userChainRewards
-                        .map(chainRewards =>
-                            chainRewards.rewards.map(reward => {
-                                const { token, proofs, amount, claimed, pending, root } = reward;
-
-                                return { token, proofs, amount, claimed, pending, root };
-                            }),
-                        )
-                        .flat(1),
-                };
+                return { address, userChainRewards };
             });
 
-            const rewardsByChainAndAddress = rewardsResult.reduce<
+            const responses = await Promise.all(requests);
+
+            // Initialize every requested key with an empty array so consumers see all
+            // (chainId, address) pairs even when Merkl omits chains with no rewards.
+            const rewardsByChainAndAddress = queryEntries.reduce<
                 Record<
                     ReturnType<typeof ChainAddressKey.compose>,
                     Pick<
@@ -155,13 +153,25 @@ export function useGetMerkleRewards<Address extends string>(
                         'token' | 'proofs' | 'amount' | 'claimed' | 'pending' | 'root'
                     >[]
                 >
-            >((result, { address, chainId, rewards }) => {
-                const key = ChainAddressKey.compose(chainId, address);
-
-                result[key] = rewards;
+            >((result, { address, chainId }) => {
+                result[ChainAddressKey.compose(chainId, address)] = [];
 
                 return result;
             }, {});
+
+            for (const { address, userChainRewards } of responses) {
+                for (const chainRewards of userChainRewards) {
+                    const key = ChainAddressKey.compose(chainRewards.chain.id, address);
+
+                    if (key in rewardsByChainAndAddress) {
+                        rewardsByChainAndAddress[key] = chainRewards.rewards.map(reward => {
+                            const { token, proofs, amount, claimed, pending, root } = reward;
+
+                            return { token, proofs, amount, claimed, pending, root };
+                        });
+                    }
+                }
+            }
 
             return rewardsByChainAndAddress;
         },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- needs fix of cloudflare worker to accept more chain ids https://github.com/trezor/cloudflare-workers/pull/40#pullrequestreview-4244153621

## Notes for QA

- test that claiming rewards still work and that it shows all rewards available

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27446

## Screenshots:



<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file `suite-common/earn-stablecoin-api/src/hooks/useGetMerkleRewards.ts` is a hook related to the earn/stablecoin API for Merkle rewards functionality. No tests statically map to this file, and after reviewing all available E2E test descriptions, none of the existing tests exercise stablecoin-specific or Merkle rewards functionality. The existing staking tests cover ETH, SOL, and ADA staking via Everstake but do not interact with stablecoin earn/Merkle reward flows. This change has no E2E test coverage and represents low regression risk to existing E2E-tested features, though the lack of coverage means the changed functionality itself is untested at the E2E level.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/earn-stablecoin-api/src/hooks/useGetMerkleRewards.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `suite-common/earn-stablecoin-api/src/hooks/useGetMerkleRewards.ts`

_Updated: 2026-05-07T12:06:10.759Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/merkl-more-chains&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/merkl-more-chains&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/merkl-more-chains&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-07T12:11:28.973Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-07T12:09:48.737Z • 11 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/merkl-more-chains/web/](https://dev.suite.sldev.cz/suite-web/chore/merkl-more-chains/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->