### PR TITLE
refactor: simplify redundant conditional and control-flow patterns

### DIFF
--- a/packages/analytics-docs/src/components/VersionsSidebar.tsx
+++ b/packages/analytics-docs/src/components/VersionsSidebar.tsx
@@ -39,7 +39,7 @@ const getChangeInfo = (event: EventDoc, version: string): ChangeInfo => {
     const isEventAddedInThisVersion = eventAddedVersion === version;
 
     const eventChanges = event.changelog?.entries?.filter(e => e.version === version);
-    if (eventChanges && eventChanges.length > 0) {
+    if (eventChanges?.length) {
         if (isEventAddedInThisVersion) {
             info.isEventAdded = true;
         } else {
@@ -49,7 +49,7 @@ const getChangeInfo = (event: EventDoc, version: string): ChangeInfo => {
 
     for (const [attrName, attrDoc] of Object.entries(event.attributes)) {
         const attrChanges = attrDoc.changelog?.entries?.filter(e => e.version === version);
-        if (attrChanges && attrChanges.length > 0) {
+        if (attrChanges?.length) {
             const attrAddedVersion = attrDoc.changelog?.addedInVersion;
             const isAttrAddedInThisVersion = attrAddedVersion === version;
 

--- a/packages/analytics-docs/src/utils/filterUtils.ts
+++ b/packages/analytics-docs/src/utils/filterUtils.ts
@@ -7,8 +7,8 @@ type AnalyticsJsonShape = {
 export const getEventsFromJson = (input: unknown): EventDoc[] => {
     const data = input as AnalyticsJsonShape;
 
-    if (!data || typeof data !== 'object') return [];
-    if (!data.events || typeof data.events !== 'object') return [];
+    if (!data || typeof data !== 'object' || !data.events || typeof data.events !== 'object')
+        return [];
 
     return Object.values(data.events);
 };

--- a/packages/analytics-docs/src/utils/useFilteredEvents.ts
+++ b/packages/analytics-docs/src/utils/useFilteredEvents.ts
@@ -76,7 +76,7 @@ export const useFilteredEvents = () => {
 
     const filteredEvents = useMemo(() => {
         const byPlatformAndQuery = allEvents
-            .filter(e => (platform === 'all' ? true : e.platform.includes(platform)))
+            .filter(e => platform === 'all' || e.platform.includes(platform))
             .filter(e =>
                 normalizedQuery
                     ? fuzzyMatch(normalizedQuery, e.name) ||

--- a/packages/analytics-docs/src/utils/useLatestReleases.ts
+++ b/packages/analytics-docs/src/utils/useLatestReleases.ts
@@ -48,8 +48,8 @@ export const useLatestReleases = (): {
                     const version = parseVersionFromTag(tag);
                     if (tag.includes('@mobile')) {
                         if (latestMobile === null) latestMobile = version;
-                    } else {
-                        if (latestDesktop === null) latestDesktop = version;
+                    } else if (latestDesktop === null) {
+                        latestDesktop = version;
                     }
                     if (latestDesktop !== null && latestMobile !== null) break;
                 }

--- a/packages/analytics-uploader/src/tests/analytics.test.ts
+++ b/packages/analytics-uploader/src/tests/analytics.test.ts
@@ -21,7 +21,7 @@ describe('analytics', () => {
         // @ts-expect-error
         jest.spyOn(global, 'fetch').mockImplementation(() => mockFetchPromise);
 
-        const timestamp = new Date().getTime();
+        const timestamp = Date.now();
         jest.spyOn(Date, 'now').mockImplementation(() => timestamp);
         jest.spyOn(console, 'error').mockImplementation(() => {});
 
@@ -72,7 +72,7 @@ describe('analytics', () => {
         // @ts-expect-error
         jest.spyOn(global, 'fetch').mockImplementation(() => mockFetchPromise);
 
-        const timestamp = new Date().getTime();
+        const timestamp = Date.now();
         jest.spyOn(Date, 'now').mockImplementation(() => timestamp);
         jest.spyOn(console, 'error').mockImplementation(() => {});
 

--- a/packages/blockchain-link-types/src/constants/errors.ts
+++ b/packages/blockchain-link-types/src/constants/errors.ts
@@ -27,7 +27,7 @@ export class CustomError extends Error {
         this.message = message;
 
         if (typeof codeOrMessage === 'string') {
-            const isPrefixed = codeOrMessage.indexOf(PREFIX) === 0;
+            const isPrefixed = codeOrMessage.startsWith(PREFIX);
             const code = isPrefixed ? codeOrMessage.substring(PREFIX.length) : codeOrMessage;
             const knownCode = Object.keys(ERROR).includes(code);
             if (isPrefixed || knownCode) {
@@ -36,7 +36,7 @@ export class CustomError extends Error {
                 if (codeMessage) {
                     if (this.message === '') {
                         this.message = codeMessage;
-                    } else if (message.indexOf('+') === 0) {
+                    } else if (message.startsWith('+')) {
                         this.message = `${codeMessage} ${message.substring(1)}`;
                     }
                 }

--- a/packages/blockchain-link/src/ui/index.ui.ts
+++ b/packages/blockchain-link/src/ui/index.ui.ts
@@ -265,7 +265,7 @@ const prepareResponse = (parent: HTMLElement, response: any, isError = false) =>
     const close = document.createElement('div');
     close.className = 'close';
     close.onclick = () => {
-        if (div.parentElement) div.parentElement.removeChild(div);
+        div.parentElement?.removeChild(div);
     };
     div.append(close);
     const pre = document.createElement('pre');

--- a/packages/blockchain-link/src/ui/utils.ts
+++ b/packages/blockchain-link/src/ui/utils.ts
@@ -2,7 +2,7 @@ export const onClear = () => {
     const responses = document.getElementsByClassName('response');
     while (responses.length) {
         const r = responses[0];
-        if (r.parentElement) r.parentElement.removeChild(r);
+        r.parentElement?.removeChild(r);
     }
 };
 

--- a/packages/blockchain-link/src/workers/electrum/client/electrum.ts
+++ b/packages/blockchain-link/src/workers/electrum/client/electrum.ts
@@ -93,7 +93,7 @@ export class ElectrumClient extends BatchingJsonRpcClient implements ElectrumAPI
     }
 
     request(method: string, ...params: any[]) {
-        this.timeLastCall = new Date().getTime();
+        this.timeLastCall = Date.now();
 
         return super.request(method, ...params);
     }
@@ -105,7 +105,7 @@ export class ElectrumClient extends BatchingJsonRpcClient implements ElectrumAPI
         this.keepAliveHandle = setInterval(async () => {
             if (
                 this.timeLastCall !== 0 &&
-                new Date().getTime() > this.timeLastCall + KEEP_ALIVE_INTERVAL / 2
+                Date.now() > this.timeLastCall + KEEP_ALIVE_INTERVAL / 2
             ) {
                 await (this as ElectrumAPI).request('server.ping').catch(err => {
                     console.error(`Ping to server failed: [${err}]`);

--- a/packages/blockchain-link/src/workers/electrum/sockets/base.ts
+++ b/packages/blockchain-link/src/workers/electrum/sockets/base.ts
@@ -37,8 +37,8 @@ export abstract class SocketBase implements ISocket {
     constructor({ host, port, timeout, keepAlive }: SocketConfig) {
         this.host = host;
         this.port = port;
-        this.timeout = timeout !== undefined ? timeout : TIMEOUT;
-        this.keepAlive = keepAlive !== undefined ? keepAlive : KEEP_ALIVE;
+        this.timeout = timeout ?? TIMEOUT;
+        this.keepAlive = keepAlive ?? KEEP_ALIVE;
     }
 
     async connect(listener: SocketListener) {

--- a/packages/blockchain-link/src/workers/evm-rpc/handlers/subscribe.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/handlers/subscribe.ts
@@ -63,16 +63,14 @@ export const subscribe = async (
 ): Promise<Responses.Subscribe> => {
     const { payload } = request;
 
-    let response: { subscribed: boolean };
-
-    if (payload.type === 'block') {
-        response = await subscribeBlock(request);
-    } else {
+    if (payload.type !== 'block') {
         throw new CustomError(
             'invalid_param',
             `Subscription type '${payload.type}' not supported by EVM RPC worker`,
         );
     }
+
+    const response = await subscribeBlock(request);
 
     return {
         type: RESPONSES.SUBSCRIBE,
@@ -83,16 +81,14 @@ export const subscribe = async (
 export const unsubscribe = (request: Request<MessageTypes.Unsubscribe>): Responses.Unsubscribe => {
     const { payload } = request;
 
-    let response: { subscribed: boolean };
-
-    if (payload.type === 'block') {
-        response = unsubscribeBlock(request);
-    } else {
+    if (payload.type !== 'block') {
         throw new CustomError(
             'invalid_param',
             `Unsubscription type '${payload.type}' not supported by EVM RPC worker`,
         );
     }
+
+    const response = unsubscribeBlock(request);
 
     return {
         type: RESPONSES.UNSUBSCRIBE,

--- a/packages/blockchain-link/src/workers/ripple/index.ts
+++ b/packages/blockchain-link/src/workers/ripple/index.ts
@@ -172,8 +172,8 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
     const response = await client.request({
         command: 'account_tx',
         account: payload.descriptor,
-        ledger_index_min: payload.from ? payload.from : undefined,
-        ledger_index_max: payload.to ? payload.to : undefined,
+        ledger_index_min: payload.from || undefined,
+        ledger_index_max: payload.to || undefined,
         limit: payload.pageSize || 25,
         marker: payload.marker,
         api_version: 2,

--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -62,7 +62,7 @@ const getAllSignatures = async (
             signature: info.signature,
             slot: info.slot,
         }));
-        lastSignature = signatures[signatures.length - 1];
+        lastSignature = signatures.at(-1);
         keepFetching = signatures.length === defaultValueLimit && fullHistory;
         allSignatures = [...allSignatures, ...signatures];
     }

--- a/packages/blockchain-link/tests/unit/subscribe.test.ts
+++ b/packages/blockchain-link/tests/unit/subscribe.test.ts
@@ -55,7 +55,7 @@ workers.forEach(instance => {
                     if (Array.isArray(request.accounts_proposed)) {
                         // unlike blockbook ripple is not clearing out whole state, it clears only requested one
                         request.accounts_proposed.forEach((address: string) => {
-                            const index = subscribedAddresses.findIndex(a => a === address);
+                            const index = subscribedAddresses.indexOf(address);
                             if (index >= 0) {
                                 subscribedAddresses.splice(index, 1);
                             }

--- a/packages/coinjoin/src/backend/CoinjoinMempoolController.ts
+++ b/packages/coinjoin/src/backend/CoinjoinMempoolController.ts
@@ -50,7 +50,7 @@ export class CoinjoinMempoolController implements MempoolControllerShape {
         this.onDisconnect = () => {
             this._status = 'stopped';
         };
-        this.lastPurge = new Date().getTime();
+        this.lastPurge = Date.now();
         this._status = 'stopped';
     }
 
@@ -126,7 +126,7 @@ export class CoinjoinMempoolController implements MempoolControllerShape {
                             addTx(txid),
                 ),
             );
-            this.lastPurge = new Date().getTime();
+            this.lastPurge = Date.now();
 
             return [...this.mempool.values()];
         }
@@ -159,7 +159,7 @@ export class CoinjoinMempoolController implements MempoolControllerShape {
             iteration++;
         }
 
-        this.lastPurge = new Date().getTime();
+        this.lastPurge = Date.now();
 
         return Array.from(set, txid => this.mempool.get(txid)!);
     }
@@ -177,7 +177,7 @@ export class CoinjoinMempoolController implements MempoolControllerShape {
     }
 
     async update(force?: boolean) {
-        const now = new Date().getTime();
+        const now = Date.now();
         if (now - this.lastPurge < MEMPOOL_PURGE_CYCLE && !force) return;
 
         const mempoolTxids = await this.client

--- a/packages/coinjoin/src/client/CoinjoinPrison.ts
+++ b/packages/coinjoin/src/client/CoinjoinPrison.ts
@@ -61,7 +61,7 @@ export class CoinjoinPrison
 
     detain(inmate: DetainObject, options: DetainOptions = {}) {
         const sentenceStart = Date.now();
-        const sentenceEnd = Date.now() + (options.sentenceEnd ? options.sentenceEnd : 6 * 60000);
+        const sentenceEnd = Date.now() + (options.sentenceEnd || 6 * 60000);
 
         let id: string;
         let type: CoinjoinPrisonInmate['type'];

--- a/packages/coinjoin/src/client/round/outputDecomposition.ts
+++ b/packages/coinjoin/src/client/round/outputDecomposition.ts
@@ -311,7 +311,7 @@ const createOutputsCredentials = async (params: CreateOutputsCredentials): Promi
         });
 
         // remove amount from list
-        const amountIndex = amounts.findIndex(a => a === amountPair.amount);
+        const amountIndex = amounts.indexOf(amountPair.amount);
         const updatedAmounts = amounts.slice(0);
         updatedAmounts.splice(amountIndex, 1);
 

--- a/packages/coinjoin/src/client/round/selectRound.ts
+++ b/packages/coinjoin/src/client/round/selectRound.ts
@@ -263,7 +263,7 @@ const selectInputsForBlameRound = ({
         const inputs: AliceShape[] = [];
         accountCandidates.forEach(account => {
             const utxos = account.blameOf ? account.blameOf[round.blameOf] : null;
-            if (utxos && utxos.length > 0) {
+            if (utxos?.length) {
                 logger.info(
                     `Found blame round for account ~~${account.accountKey}~~ with ${utxos.length} inputs`,
                 );

--- a/packages/coinjoin/src/client/round/selectRound.ts
+++ b/packages/coinjoin/src/client/round/selectRound.ts
@@ -400,7 +400,7 @@ export const selectInputsForRound = async ({
     }
 
     // get index of Round with maximum possible utxos
-    const roundIndex = sumUtxosInRounds.findIndex(count => count === maxUtxosInRound);
+    const roundIndex = sumUtxosInRounds.indexOf(maxUtxosInRound);
     const selectedRound = normalRounds[roundIndex];
 
     // setup new Round

--- a/packages/coinjoin/tests/client/analyzeTransactions.test.ts
+++ b/packages/coinjoin/tests/client/analyzeTransactions.test.ts
@@ -50,7 +50,7 @@ describe('analyzeTransactions', () => {
     });
 
     afterAll(() => {
-        if (server) server.close();
+        server?.close();
     });
 
     it('Regtest: simple analyze', async () => {

--- a/packages/coinjoin/tests/client/connectionConfirmation.test.ts
+++ b/packages/coinjoin/tests/client/connectionConfirmation.test.ts
@@ -28,7 +28,7 @@ describe('connectionConfirmation', () => {
     });
 
     afterAll(() => {
-        if (server) server.close();
+        server?.close();
     });
 
     it('try to confirm without registrationData', async () => {

--- a/packages/coinjoin/tests/client/coordinatorRequest.test.ts
+++ b/packages/coinjoin/tests/client/coordinatorRequest.test.ts
@@ -17,7 +17,7 @@ describe('http', () => {
     });
 
     afterAll(() => {
-        if (server) server.close();
+        server?.close();
     });
 
     it('with 500 error', async () => {

--- a/packages/coinjoin/tests/client/outputDecomposition.test.ts
+++ b/packages/coinjoin/tests/client/outputDecomposition.test.ts
@@ -16,7 +16,7 @@ describe('outputRegistration', () => {
     });
 
     afterAll(() => {
-        if (server) server.close();
+        server?.close();
     });
 
     it('outputDecomposition errors. missing data in input', async () => {

--- a/packages/coinjoin/tests/client/selectRound.test.ts
+++ b/packages/coinjoin/tests/client/selectRound.test.ts
@@ -48,7 +48,7 @@ describe('selectRound', () => {
 
     afterAll(() => {
         jest.clearAllMocks();
-        if (server) server.close();
+        server?.close();
     });
 
     it('no available candidates in status Rounds', async () => {

--- a/packages/components/src/components/GradientOverlay/GradientOverlay.tsx
+++ b/packages/components/src/components/GradientOverlay/GradientOverlay.tsx
@@ -26,10 +26,5 @@ export const Gradient = styled.div<{
 export const GradientOverlay = ({ hiddenFrom = '50%', forcedElevation }: GradientOverlayProps) => {
     const { parentElevation } = useElevation(forcedElevation);
 
-    return (
-        <Gradient
-            $elevation={forcedElevation === undefined ? parentElevation : forcedElevation}
-            $hiddenFrom={hiddenFrom}
-        />
-    );
+    return <Gradient $elevation={forcedElevation ?? parentElevation} $hiddenFrom={hiddenFrom} />;
 };

--- a/packages/components/src/components/InfoSegments/InfoSegments.tsx
+++ b/packages/components/src/components/InfoSegments/InfoSegments.tsx
@@ -34,7 +34,7 @@ export const InfoSegments = ({
     gap = 4,
     'data-testid': dataTestId,
 }: InfoSegmentsProps) => {
-    const validChildren = Children.toArray(children).filter(child => Boolean(child));
+    const validChildren = Children.toArray(children).filter(Boolean);
     const id = useId();
     const iconProps: Pick<IconProps, 'intent' | 'priority' | 'isDisabled'> = {
         intent: intent ?? 'neutral',

--- a/packages/components/src/components/Modal/Modal.tsx
+++ b/packages/components/src/components/Modal/Modal.tsx
@@ -165,7 +165,7 @@ const InnerModalBase = ({
                     <Box position={{ type: 'relative' }} overflow="hidden" flex="1">
                         <ShadowTop />
                         <ScrollContainer onScroll={onScroll} ref={scrollElementRef}>
-                            <Column padding={padding ? padding : spacings.md}>
+                            <Column padding={padding || spacings.md}>
                                 {iconName && (
                                     <Box
                                         margin={{

--- a/packages/components/src/components/buttons/utils.ts
+++ b/packages/components/src/components/buttons/utils.ts
@@ -30,7 +30,7 @@ export const pickButtonProps = ({
 
     return {
         as: isLink ? 'a' : 'button',
-        disabled: isLink ? false : isDisabled || isLoading,
+        disabled: !isLink && (isDisabled || isLoading),
         onPointerDown: handlePointerDown,
         onClick,
         type: isLink ? undefined : type,

--- a/packages/components/src/components/form/Input/Input.tsx
+++ b/packages/components/src/components/form/Input/Input.tsx
@@ -78,7 +78,7 @@ export const Input = ({
         return props;
     }, {} as InputHTMLProps);
 
-    const hasShowClearButton = showClearButton && !!value && value.length > 0;
+    const hasShowClearButton = showClearButton && !!value;
 
     return (
         <FormCell {...formCellProps} data-testid={dataTest}>

--- a/packages/components/src/components/form/Range/Range.tsx
+++ b/packages/components/src/components/form/Range/Range.tsx
@@ -44,9 +44,9 @@ const getProgress = (
             100;
 
         return progress;
-    } else {
-        return value > max ? 100 : 0;
     }
+
+    return value > max ? 100 : 0;
 };
 
 const getLinearGradient = (progress: number, theme: DefaultTheme, disabled?: boolean): string => {

--- a/packages/components/src/components/form/SelectBar/SelectBar.tsx
+++ b/packages/components/src/components/form/SelectBar/SelectBar.tsx
@@ -157,7 +157,7 @@ export const SelectBar = <V extends ValueTypes>({
             if (previousIndex >= 0) {
                 option = options[previousIndex];
             } else {
-                option = options[options.length - 1];
+                option = options.at(-1);
             }
         } else if (e.key === 'ArrowRight') {
             const previousIndex = selectedOptionIndex + 1;

--- a/packages/connect-cli/src/index.ts
+++ b/packages/connect-cli/src/index.ts
@@ -30,32 +30,32 @@ const waitForPairingTag = async (uiEvent: UiRequestThpPairing) => {
         }
 
         return resp;
-    } else {
-        const state = await debugLinkState(uiEvent.payload);
-        if (!state?.success) {
-            throw new Error('DebugLinkState missing: ' + state.error);
-        }
-        const { payload } = state;
-        if (payload.type !== 'DebugLinkPairingInfo') {
-            throw new Error(
-                'DebugLinkState missing, received ' + state.payload.type,
-                // state.payload.message,
-            );
-        }
-        const { code_entry_code, code_qr_code, nfc_secret_trezor } = payload.message;
-        if (selectedMethod === ThpPairingMethod.CodeEntry && code_entry_code) {
-            return Number(code_entry_code).toString().padStart(6, '0');
-        }
-        if (selectedMethod === ThpPairingMethod.QrCode && code_qr_code) {
-            // NOTE: qrcode throws from firmware: Pairing tag cancelled (Failure) ?
-            return code_qr_code;
-        }
-        if (selectedMethod === ThpPairingMethod.NFC && nfc_secret_trezor) {
-            return nfc_secret_trezor;
-        }
-
-        return 'unknown-tag';
     }
+
+    const state = await debugLinkState(uiEvent.payload);
+    if (!state?.success) {
+        throw new Error('DebugLinkState missing: ' + state.error);
+    }
+    const { payload } = state;
+    if (payload.type !== 'DebugLinkPairingInfo') {
+        throw new Error(
+            'DebugLinkState missing, received ' + state.payload.type,
+            // state.payload.message,
+        );
+    }
+    const { code_entry_code, code_qr_code, nfc_secret_trezor } = payload.message;
+    if (selectedMethod === ThpPairingMethod.CodeEntry && code_entry_code) {
+        return Number(code_entry_code).toString().padStart(6, '0');
+    }
+    if (selectedMethod === ThpPairingMethod.QrCode && code_qr_code) {
+        // NOTE: qrcode throws from firmware: Pairing tag cancelled (Failure) ?
+        return code_qr_code;
+    }
+    if (selectedMethod === ThpPairingMethod.NFC && nfc_secret_trezor) {
+        return nfc_secret_trezor;
+    }
+
+    return 'unknown-tag';
 };
 
 const cliStatePath = path.join(__dirname, 'thp-state.dat');

--- a/packages/connect-common/src/data/connectSettings.ts
+++ b/packages/connect-common/src/data/connectSettings.ts
@@ -20,7 +20,7 @@ const initialSettings: ConnectSettings = {
     transports: undefined,
     pendingTransportEvent: true,
     env: 'node',
-    timestamp: new Date().getTime(),
+    timestamp: Date.now(),
     sharedLogger: true,
     transportReconnect: true,
 };

--- a/packages/connect-common/src/data/connectSettings.ts
+++ b/packages/connect-common/src/data/connectSettings.ts
@@ -30,8 +30,8 @@ export const parseManifest = (manifest?: Manifest) => {
     if (typeof manifest.email !== 'string') return;
     if (typeof manifest.appUrl !== 'string') return;
     // todo [connect10]: appName should become required
-    if (typeof manifest.appName !== 'undefined' && typeof manifest.appName !== 'string') return;
-    if (typeof manifest.appIcon !== 'undefined' && typeof manifest.appIcon !== 'string') return;
+    if (manifest.appName !== undefined && typeof manifest.appName !== 'string') return;
+    if (manifest.appIcon !== undefined && typeof manifest.appIcon !== 'string') return;
 
     return {
         email: manifest.email,

--- a/packages/connect-common/src/impl/dynamic.ts
+++ b/packages/connect-common/src/impl/dynamic.ts
@@ -169,16 +169,16 @@ export class TrezorConnectDynamic implements ConnectFactoryDependencies<Record<n
 
         if (coreMode === 'suite-desktop') {
             return 'core-in-suite-desktop';
-        } else if (coreMode === 'suite-web') {
-            return 'core-in-suite-web';
-        } else {
-            if (coreMode && coreMode !== 'auto') {
-                console.warn(`Invalid coreMode: ${coreMode}`);
-            }
-
-            // TODO for webextension, default was previously core-in-suite-web
-            return 'core-in-suite-desktop';
         }
+        if (coreMode === 'suite-web') {
+            return 'core-in-suite-web';
+        }
+        if (coreMode && coreMode !== 'auto') {
+            console.warn(`Invalid coreMode: ${coreMode}`);
+        }
+
+        // TODO for webextension, default was previously core-in-suite-web
+        return 'core-in-suite-desktop';
     }
 
     private async handleBeforeCall() {

--- a/packages/connect-common/src/utils/urlUtils.ts
+++ b/packages/connect-common/src/utils/urlUtils.ts
@@ -15,7 +15,7 @@ export const getHost = (url: unknown) => {
         const parts = uri.split('.');
 
         // allow localhost subdomains
-        if (parts[parts.length - 1] === 'localhost') return 'localhost';
+        if (parts.at(-1) === 'localhost') return 'localhost';
 
         return parts.length > 2
             ? // slice subdomain

--- a/packages/connect-explorer-theme/src/components/sidebar.tsx
+++ b/packages/connect-explorer-theme/src/components/sidebar.tsx
@@ -93,11 +93,7 @@ export function Sidebar({
     const hasMenu = config.darkMode || hasI18n || config.sidebar.toggleButton;
     const getDataToggleAnimation = () => {
         if (showToggleAnimation) {
-            if (showSidebar) {
-                return 'show';
-            } else {
-                return 'hide';
-            }
+            return showSidebar ? 'show' : 'hide';
         }
 
         return 'off';

--- a/packages/connect-explorer-theme/src/utils/patch-normalize-pages.ts
+++ b/packages/connect-explorer-theme/src/utils/patch-normalize-pages.ts
@@ -20,9 +20,9 @@ const replaceMeta = (
                 item.children.flatMap(page => {
                     if (page.kind === 'Folder' || page.kind === 'MdxPage') {
                         return [mapping(page)];
-                    } else {
-                        return [];
                     }
+
+                    return [];
                 }),
             ),
         });

--- a/packages/connect-explorer/src/components/CodeEditor.tsx
+++ b/packages/connect-explorer/src/components/CodeEditor.tsx
@@ -25,7 +25,7 @@ export const CodeEditor = ({ code, codeChange, schema }: CodeEditorProps) => {
                 s.type = ['number', 'string'];
             }
             if (s.properties) {
-                Object.entries(s.properties).forEach(([_, v]) => {
+                Object.values(s.properties).forEach(v => {
                     inner(v);
                 });
             }

--- a/packages/connect-explorer/src/components/ParamsTable.tsx
+++ b/packages/connect-explorer/src/components/ParamsTable.tsx
@@ -119,14 +119,16 @@ export const ParamsTable = ({ schema, topLevelSchema, descriptions }: ParamsTabl
                 <ParamsTable key={i} schema={param} {...common} />
             </div>
         ));
-    } else if (schema[Kind] === 'Intersect') {
+    }
+    if (schema[Kind] === 'Intersect') {
         return schema.allOf?.map((param: TSchema, i: number) => (
             <div key={i}>
                 {i > 0 && <h3>and</h3>}
                 <ParamsTable schema={param} {...common} />
             </div>
         ));
-    } else if (schema[Kind] === 'Object') {
+    }
+    if (schema[Kind] === 'Object') {
         return Object.entries(schema.properties)?.map(([name, value]: [string, any]) => (
             <SingleParam
                 name={name}
@@ -137,13 +139,9 @@ export const ParamsTable = ({ schema, topLevelSchema, descriptions }: ParamsTabl
                 {...common}
             />
         ));
-    } else {
-        return (
-            <SingleParam
-                name=""
-                value={schema[Kind] === 'Array' ? schema.items : schema}
-                {...common}
-            />
-        );
     }
+
+    return (
+        <SingleParam name="" value={schema[Kind] === 'Array' ? schema.items : schema} {...common} />
+    );
 };

--- a/packages/connect-explorer/src/components/ParamsTable.tsx
+++ b/packages/connect-explorer/src/components/ParamsTable.tsx
@@ -37,7 +37,7 @@ const SingleParam = ({
         topLevelSchema?.[Kind] === 'Object' &&
         !isTopLevel &&
         value.$id &&
-        Object.entries(topLevelSchema.properties).some(([_, val]: any) => val.$id === value.$id)
+        Object.values(topLevelSchema.properties).some((val: any) => val.$id === value.$id)
     ) {
         // If the object is a reference to the top level object, don't show descendants
         hasDescendants = false;

--- a/packages/connect-explorer/src/components/fields/File.tsx
+++ b/packages/connect-explorer/src/components/fields/File.tsx
@@ -15,7 +15,7 @@ const File = ({ disabled, field, onChange }: FileProps) => {
     const onFilesAdded: ChangeEventHandler<HTMLInputElement> = evt => {
         if (disabled) return;
         const files = evt?.target.files;
-        if (!files || files.length === 0) return;
+        if (!files?.length) return;
         const file = files[0];
         const reader = new FileReader();
         reader.onload = event => {

--- a/packages/connect-explorer/src/components/fields/UnionWrapper.tsx
+++ b/packages/connect-explorer/src/components/fields/UnionWrapper.tsx
@@ -30,7 +30,7 @@ interface UnionWrapperProps {
 export const UnionWrapper = ({ field, onChange, children }: UnionWrapperProps) => (
     <Wrapper>
         <UnionHeader>
-            <p>{field.name ? field.name : 'Union'}</p>
+            <p>{field.name || 'Union'}</p>
             <SelectBar
                 selectedOption={0}
                 options={field.labels.map((label, index) => ({ value: index, label }))}

--- a/packages/connect-explorer/src/reducers/methodInit.ts
+++ b/packages/connect-explorer/src/reducers/methodInit.ts
@@ -36,10 +36,8 @@ const schemaToFields = (schema: TSchema, name = ''): Field<any>[] => {
                     optional: field.optional || schema[OptionalKind] === 'Optional',
                 };
                 // If the array is optional, set the items to an empty array by default
-                if (output.type === 'array') {
-                    if (output.optional) {
-                        output.items = [];
-                    }
+                if (output.type === 'array' && output.optional) {
+                    output.items = [];
                 }
 
                 return output;

--- a/packages/connect-explorer/src/reducers/methodReducer.ts
+++ b/packages/connect-explorer/src/reducers/methodReducer.ts
@@ -32,7 +32,7 @@ const findFieldsNested = (
     if (!schema) return undefined;
 
     const remainingPath = field.path?.slice(currentDepth);
-    if (!remainingPath || remainingPath.length === 0) {
+    if (!remainingPath?.length) {
         return schema.find(f => f.name === field.name);
     }
 

--- a/packages/connect-web/src/connectSettings.ts
+++ b/packages/connect-web/src/connectSettings.ts
@@ -1,5 +1,5 @@
 export const getEnv = () => {
-    if (typeof chrome !== 'undefined' && typeof chrome.runtime?.onConnect !== 'undefined') {
+    if (typeof chrome !== 'undefined' && chrome.runtime?.onConnect !== undefined) {
         return 'webextension';
     }
     if (typeof navigator !== 'undefined') {

--- a/packages/connect/e2e/run.ts
+++ b/packages/connect/e2e/run.ts
@@ -67,12 +67,7 @@ const getEmulatorOptions = (availableFirmwares: Firmwares) => {
             model,
         };
     } else {
-        let version;
-        if (firmwareArg) {
-            version = firmwareArg.endsWith('-latest') ? latest : firmwareArg;
-        } else {
-            version = latest;
-        }
+        const version = firmwareArg && !firmwareArg.endsWith('-latest') ? firmwareArg : latest;
         emulatorStartOpts = {
             type: 'emulator-start',
             wipe: true,

--- a/packages/connect/src/api/cardano/__tests__/cardanoUtils.test.ts
+++ b/packages/connect/src/api/cardano/__tests__/cardanoUtils.test.ts
@@ -4,7 +4,7 @@ import { composeTxPlan, getTtl, prepareCertificates, transformUtxos } from '../c
 describe('cardano utils', () => {
     let dateSpy: any;
     beforeAll(() => {
-        dateSpy = jest.spyOn(Date.prototype, 'getTime').mockReturnValue(1653394389512);
+        dateSpy = jest.spyOn(Date, 'now').mockReturnValue(1653394389512);
     });
 
     afterAll(() => {

--- a/packages/connect/src/api/cardano/api/cardanoGetAddress.ts
+++ b/packages/connect/src/api/cardano/api/cardanoGetAddress.ts
@@ -45,10 +45,7 @@ export default class CardanoGetAddress extends AbstractMethod<'cardanoGetAddress
                 address_parameters: addressParametersToProto(batch.addressParameters),
                 protocol_magic: batch.protocolMagic,
                 network_id: batch.networkId,
-                derivation_type:
-                    typeof batch.derivationType !== 'undefined'
-                        ? batch.derivationType
-                        : PROTO.CardanoDerivationType.ICARUS_TREZOR,
+                derivation_type: batch.derivationType ?? PROTO.CardanoDerivationType.ICARUS_TREZOR,
                 show_display: typeof batch.showOnTrezor === 'boolean' ? batch.showOnTrezor : true,
                 chunkify: typeof batch.chunkify === 'boolean' ? batch.chunkify : false,
             };

--- a/packages/connect/src/api/cardano/api/cardanoGetNativeScriptHash.ts
+++ b/packages/connect/src/api/cardano/api/cardanoGetNativeScriptHash.ts
@@ -54,10 +54,7 @@ export default class CardanoGetNativeScriptHash extends AbstractMethod<
         const params = {
             script: scriptToProto(payload.script),
             display_format: payload.displayFormat,
-            derivation_type:
-                typeof payload.derivationType !== 'undefined'
-                    ? payload.derivationType
-                    : PROTO.CardanoDerivationType.ICARUS_TREZOR,
+            derivation_type: payload.derivationType ?? PROTO.CardanoDerivationType.ICARUS_TREZOR,
         };
 
         super(message, params);

--- a/packages/connect/src/api/cardano/api/cardanoGetPublicKey.ts
+++ b/packages/connect/src/api/cardano/api/cardanoGetPublicKey.ts
@@ -33,10 +33,7 @@ export default class CardanoGetPublicKey extends AbstractMethod<'cardanoGetPubli
             const path = validatePath(batch.path, 3);
             const proto = {
                 address_n: path,
-                derivation_type:
-                    typeof batch.derivationType !== 'undefined'
-                        ? batch.derivationType
-                        : PROTO.CardanoDerivationType.ICARUS_TREZOR,
+                derivation_type: batch.derivationType ?? PROTO.CardanoDerivationType.ICARUS_TREZOR,
                 show_display: typeof batch.showOnTrezor === 'boolean' ? batch.showOnTrezor : false,
             };
 

--- a/packages/connect/src/api/cardano/api/cardanoSignTransaction.ts
+++ b/packages/connect/src/api/cardano/api/cardanoSignTransaction.ts
@@ -214,10 +214,7 @@ export default class CardanoSignTransaction extends AbstractMethod<
                 payload.signingMode,
             ),
             additionalWitnessRequests,
-            derivationType:
-                typeof payload.derivationType !== 'undefined'
-                    ? payload.derivationType
-                    : PROTO.CardanoDerivationType.ICARUS_TREZOR,
+            derivationType: payload.derivationType ?? PROTO.CardanoDerivationType.ICARUS_TREZOR,
             includeNetworkId: payload.includeNetworkId,
             tagCborSets: payload.tagCborSets,
             unsignedTx: 'unsignedTx' in payload ? payload.unsignedTx : undefined,

--- a/packages/connect/src/api/cardano/cardanoCertificate.ts
+++ b/packages/connect/src/api/cardano/cardanoCertificate.ts
@@ -156,43 +156,39 @@ export const transformCertificate = (
 ): CertificateWithPoolOwnersAndRelays => {
     Assert(CardanoCertificate, certificate);
 
-    if (certificate.type === PROTO.CardanoCertificateType.STAKE_DELEGATION) {
-        if (!certificate.pool) {
-            throw ERRORS.TypedError(
-                'Method_InvalidParameter',
-                'pool must be supplied for STAKE_DELEGATION',
-            );
-        }
-    }
-
-    if (certificate.type === PROTO.CardanoCertificateType.STAKE_POOL_REGISTRATION) {
-        if (!certificate.poolParameters) {
-            throw ERRORS.TypedError(
-                'Method_InvalidParameter',
-                'poolParameters must be supplied for STAKE_POOL_REGISTRATION',
-            );
-        }
+    if (certificate.type === PROTO.CardanoCertificateType.STAKE_DELEGATION && !certificate.pool) {
+        throw ERRORS.TypedError(
+            'Method_InvalidParameter',
+            'pool must be supplied for STAKE_DELEGATION',
+        );
     }
 
     if (
-        certificate.type === PROTO.CardanoCertificateType.STAKE_REGISTRATION_CONWAY ||
-        certificate.type === PROTO.CardanoCertificateType.STAKE_DEREGISTRATION_CONWAY
+        certificate.type === PROTO.CardanoCertificateType.STAKE_POOL_REGISTRATION &&
+        !certificate.poolParameters
     ) {
-        if (!certificate.deposit) {
-            throw ERRORS.TypedError(
-                'Method_InvalidParameter',
-                'deposit must be supplied for STAKE_REGISTRATION_CONWAY or STAKE_DEREGISTRATION_CONWAY',
-            );
-        }
+        throw ERRORS.TypedError(
+            'Method_InvalidParameter',
+            'poolParameters must be supplied for STAKE_POOL_REGISTRATION',
+        );
     }
 
-    if (certificate.type === PROTO.CardanoCertificateType.VOTE_DELEGATION) {
-        if (!certificate.dRep) {
-            throw ERRORS.TypedError(
-                'Method_InvalidParameter',
-                'dRep must be supplied for VOTE_DELEGATION',
-            );
-        }
+    if (
+        (certificate.type === PROTO.CardanoCertificateType.STAKE_REGISTRATION_CONWAY ||
+            certificate.type === PROTO.CardanoCertificateType.STAKE_DEREGISTRATION_CONWAY) &&
+        !certificate.deposit
+    ) {
+        throw ERRORS.TypedError(
+            'Method_InvalidParameter',
+            'deposit must be supplied for STAKE_REGISTRATION_CONWAY or STAKE_DEREGISTRATION_CONWAY',
+        );
+    }
+
+    if (certificate.type === PROTO.CardanoCertificateType.VOTE_DELEGATION && !certificate.dRep) {
+        throw ERRORS.TypedError(
+            'Method_InvalidParameter',
+            'dRep must be supplied for VOTE_DELEGATION',
+        );
     }
 
     const { poolParameters, poolOwners, poolRelays } = transformPoolParameters(

--- a/packages/connect/src/api/cardano/cardanoUtils.ts
+++ b/packages/connect/src/api/cardano/cardanoUtils.ts
@@ -94,7 +94,7 @@ export const getTtl = (testnet: boolean) => {
     // https://cardano.stackexchange.com/questions/491/calculate-timestamp-from-slot/494#494
     const shelleySlot = testnet ? 6192449 : 4924800;
     const shelleyTimestamp = testnet ? 1672848449 : 1596491091;
-    const currentTimestamp = Math.floor(new Date().getTime() / 1000);
+    const currentTimestamp = Math.floor(Date.now() / 1000);
     const currentSlot = shelleySlot + currentTimestamp - shelleyTimestamp;
 
     return currentSlot + CARDANO_DEFAULT_TTL_OFFSET;

--- a/packages/connect/src/api/changeLanguage.ts
+++ b/packages/connect/src/api/changeLanguage.ts
@@ -43,8 +43,8 @@ export default class ChangeLanguage extends AbstractMethod<'changeLanguage', Cha
 
         if (binary) {
             return changeLanguage({ device: this.getDevice(), binary });
-        } else {
-            return changeLanguage({ device: this.getDevice(), language });
         }
+
+        return changeLanguage({ device: this.getDevice(), language });
     }
 }

--- a/packages/connect/src/api/firmware/modifyFirmware.ts
+++ b/packages/connect/src/api/firmware/modifyFirmware.ts
@@ -27,8 +27,8 @@ export const stripFwHeaders = (fw: ArrayBuffer) => {
     const fwView = new Uint8Array(fw);
     // this condition was added in order to upload firmware process being equivalent as in trezorlib python code
     if (
-        String.fromCharCode(...Array.from(fwView.slice(0, 4))) === 'TRZR' &&
-        String.fromCharCode(...Array.from(fwView.slice(256, 260))) === 'TRZF'
+        String.fromCharCode(...fwView.slice(0, 4)) === 'TRZR' &&
+        String.fromCharCode(...fwView.slice(256, 260)) === 'TRZF'
     ) {
         return fw.slice(256);
     }

--- a/packages/connect/src/api/getAccountInfo.ts
+++ b/packages/connect/src/api/getAccountInfo.ts
@@ -121,42 +121,42 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
                     className: 'not-empty-css',
                 },
             };
-        } else {
-            const keys: {
-                [coin: string]: { coinInfo: CoinInfo; values: DerivationPath[] };
-            } = {};
-            this.params.forEach(b => {
-                if (!keys[b.coinInfo.label]) {
-                    keys[b.coinInfo.label] = {
-                        coinInfo: b.coinInfo,
-                        values: [],
-                    };
-                }
-                keys[b.coinInfo.label].values.push(b.descriptor || b.address_n);
-            });
-
-            // prepare html for popup
-            const str: string[] = [];
-            Object.keys(keys).forEach((k, _i, _a) => {
-                const details = keys[k];
-                details.values.forEach(acc => {
-                    // if (i === 0) str += this.params.length > 1 ? ': ' : ' ';
-                    // if (i > 0) str += ', ';
-                    str.push(k);
-                    str.push(' ');
-                    if (typeof acc === 'string') {
-                        str.push(acc);
-                    } else {
-                        str.push(getAccountLabel(acc, details.coinInfo));
-                    }
-                });
-            });
-
-            return {
-                view: 'export-account-info' as const,
-                label: `Export info for: ${str.join('')}`,
-            };
         }
+
+        const keys: {
+            [coin: string]: { coinInfo: CoinInfo; values: DerivationPath[] };
+        } = {};
+        this.params.forEach(b => {
+            if (!keys[b.coinInfo.label]) {
+                keys[b.coinInfo.label] = {
+                    coinInfo: b.coinInfo,
+                    values: [],
+                };
+            }
+            keys[b.coinInfo.label].values.push(b.descriptor || b.address_n);
+        });
+
+        // prepare html for popup
+        const str: string[] = [];
+        Object.keys(keys).forEach((k, _i, _a) => {
+            const details = keys[k];
+            details.values.forEach(acc => {
+                // if (i === 0) str += this.params.length > 1 ? ': ' : ' ';
+                // if (i > 0) str += ', ';
+                str.push(k);
+                str.push(' ');
+                if (typeof acc === 'string') {
+                    str.push(acc);
+                } else {
+                    str.push(getAccountLabel(acc, details.coinInfo));
+                }
+            });
+        });
+
+        return {
+            view: 'export-account-info' as const,
+            label: `Export info for: ${str.join('')}`,
+        };
     }
 
     async run(context: MethodContext) {

--- a/packages/connect/src/api/getOwnershipId.ts
+++ b/packages/connect/src/api/getOwnershipId.ts
@@ -35,7 +35,7 @@ export default class GetOwnershipId extends AbstractMethod<
 
             return {
                 address_n,
-                coin_name: coinInfo ? coinInfo.name : undefined,
+                coin_name: coinInfo?.name,
                 multisig: batch.multisig,
                 script_type,
             };

--- a/packages/connect/src/api/getOwnershipProof.ts
+++ b/packages/connect/src/api/getOwnershipProof.ts
@@ -35,7 +35,7 @@ export default class GetOwnershipProof extends AbstractMethod<
 
             return {
                 address_n,
-                coin_name: coinInfo ? coinInfo.name : undefined,
+                coin_name: coinInfo?.name,
                 multisig: batch.multisig,
                 script_type,
                 user_confirmation: batch.userConfirmation,

--- a/packages/connect/src/api/signMessage.ts
+++ b/packages/connect/src/api/signMessage.ts
@@ -41,7 +41,7 @@ export default class SignMessage extends AbstractMethod<'signMessage', Params> {
         const proto = {
             address_n: path,
             message: messageHex,
-            coin_name: coinInfo ? coinInfo.name : undefined,
+            coin_name: coinInfo?.name,
             script_type: scriptType && scriptType !== 'SPENDMULTISIG' ? scriptType : 'SPENDADDRESS', // script_type 'SPENDMULTISIG' throws Failure_FirmwareError
             no_script_type: payload.no_script_type,
         };

--- a/packages/connect/src/api/signTransaction.ts
+++ b/packages/connect/src/api/signTransaction.ts
@@ -198,19 +198,17 @@ export default class SignTransaction extends AbstractMethod<'signTransaction', P
             const inputsTotal: BigNumber = inputs.reduce((bn, input) => {
                 if (typeof input.amount === 'string') {
                     return bn.plus(input.amount);
-                } else {
-                    if (!refTxs) {
-                        throw ERRORS.TypedError(
-                            'Runtime',
-                            'refTxs are required for precomposed transaction info when input amount is not provided',
-                        );
-                    }
-                    const refTx = refTxs.find(tx => tx.hash === input.prev_hash);
-                    const refOutput =
-                        refTx?.outputs?.[input.prev_index] ??
-                        refTx?.bin_outputs?.[input.prev_index];
-                    if (refOutput) return bn.plus(refOutput.amount);
                 }
+                if (!refTxs) {
+                    throw ERRORS.TypedError(
+                        'Runtime',
+                        'refTxs are required for precomposed transaction info when input amount is not provided',
+                    );
+                }
+                const refTx = refTxs.find(tx => tx.hash === input.prev_hash);
+                const refOutput =
+                    refTx?.outputs?.[input.prev_index] ?? refTx?.bin_outputs?.[input.prev_index];
+                if (refOutput) return bn.plus(refOutput.amount);
 
                 return bn;
             }, new BigNumber(0));

--- a/packages/connect/src/api/solana/api/solanaSignTransaction.ts
+++ b/packages/connect/src/api/solana/api/solanaSignTransaction.ts
@@ -193,7 +193,7 @@ export default class SolanaSignTransaction extends AbstractMethod<'solanaSignTra
                 token,
                 // Countdown for blockhash-constrained transactions
                 createdTimestamp:
-                    'blockhash' in message.lifetimeConstraint ? new Date().getTime() : undefined,
+                    'blockhash' in message.lifetimeConstraint ? Date.now() : undefined,
             };
         } catch (e) {
             // Don't throw errors from this method

--- a/packages/connect/src/core/onCallFirmwareUpdate.ts
+++ b/packages/connect/src/core/onCallFirmwareUpdate.ts
@@ -304,17 +304,17 @@ const getInstallationParams = (device: Device, params: Params) => {
             updateFlowType: getUpdateFlowType(),
             btcOnly,
         };
-    } else {
-        // if device connected initially in bootloader mode:
-        // manual: false - device is already in bootloader, so this field doesn't matter
-        // upgrade: false - we don't know if supported, so take the safest route and don't use these features
-        return {
-            manual: false,
-            upgrade: false,
-            updateFlowType: 'unknown_flow' as const,
-            btcOnly,
-        };
     }
+
+    // if device connected initially in bootloader mode:
+    // manual: false - device is already in bootloader, so this field doesn't matter
+    // upgrade: false - we don't know if supported, so take the safest route and don't use these features
+    return {
+        manual: false,
+        upgrade: false,
+        updateFlowType: 'unknown_flow' as const,
+        btcOnly,
+    };
 };
 
 const getFwHeader = (binary: ArrayBuffer) => Buffer.from(binary.slice(0, 6000)).toString('hex');

--- a/packages/connect/src/data/firmwareInfo.ts
+++ b/packages/connect/src/data/firmwareInfo.ts
@@ -381,12 +381,12 @@ const calculateShouldOfferRelease = (
         // When deviceId is null, it means device is fresh so we always want to install latest FW,
         // unless rolloutProbability is 0, in that case we should never offer it.
         return rolloutProbability > 0;
-    } else {
-        // If deviceId is provided, use the deterministic approach.
-        const deterministicValueToCompare = getIntegerInRangeFromString(deviceId, 101);
-
-        return deterministicValueToCompare < rolloutProbability;
     }
+
+    // If deviceId is provided, use the deterministic approach.
+    const deterministicValueToCompare = getIntegerInRangeFromString(deviceId, 101);
+
+    return deterministicValueToCompare < rolloutProbability;
 };
 
 const getChangelog = (releases: FirmwareRelease[], features: StrictFeatures) => {

--- a/packages/connect/src/data/firmwareInfo.ts
+++ b/packages/connect/src/data/firmwareInfo.ts
@@ -328,7 +328,7 @@ const getIntermediaryMessageRelease = (features: Features) => {
     }
 
     const deviceIntermediaryReleases = config[features.internal_model];
-    if (!deviceIntermediaryReleases || deviceIntermediaryReleases.length === 0) {
+    if (!deviceIntermediaryReleases?.length) {
         // No intermediary releases are defined for this model.
         return;
     }

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -266,9 +266,9 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
                     );
 
                     return result;
-                } else {
-                    throw new Error(result.error.code);
                 }
+
+                throw new Error(result.error.code);
             })
             .finally(() => {
                 this.acquirePromise = undefined;

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -1011,7 +1011,7 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
                 name: this.name,
                 transportSessionOwner: this.sessionAcquired ? undefined : sessionOwner,
                 thp: this.getDeviceThp(),
-                status: this.busy ? this.busy : undefined,
+                status: this.busy || undefined,
             };
         }
         const defaultLabel = 'My Trezor';

--- a/packages/connect/src/device/DeviceCurrentSession.ts
+++ b/packages/connect/src/device/DeviceCurrentSession.ts
@@ -138,25 +138,25 @@ export class DeviceCurrentSession implements TypedCallProvider {
 
         if (isExpectedResponse(payload, expectedType)) {
             return payload;
-        } else {
-            // handle possible race condition - Bridge may have some unread message in buffer, read it
-            // TODO could be possible to remove
-            await scheduleAction(
-                abort =>
-                    this.transport.receive({
-                        session: this.session,
-                        protocol: this.device.protocol,
-                        thpState: this.device.getThpState(),
-                        signal: abort,
-                    }),
-                { timeout: 500 },
-            ).catch(() => {});
-
-            throw ERRORS.TypedError(
-                'Runtime',
-                `assertType: Response of unexpected type: ${receivedType}. Should be ${expectedType}`,
-            );
         }
+
+        // handle possible race condition - Bridge may have some unread message in buffer, read it
+        // TODO could be possible to remove
+        await scheduleAction(
+            abort =>
+                this.transport.receive({
+                    session: this.session,
+                    protocol: this.device.protocol,
+                    thpState: this.device.getThpState(),
+                    signal: abort,
+                }),
+            { timeout: 500 },
+        ).catch(() => {});
+
+        throw ERRORS.TypedError(
+            'Runtime',
+            `assertType: Response of unexpected type: ${receivedType}. Should be ${expectedType}`,
+        );
     }
 
     private async callLoop<T extends Messages.MessageKey>(

--- a/packages/connect/src/utils/firmwareUtils.ts
+++ b/packages/connect/src/utils/firmwareUtils.ts
@@ -22,7 +22,7 @@ export const findBestCompatibleRelease = (
     currentVesion: CurrentVersion,
     checkProperty: VersionCheckProperty,
 ): FirmwareRelease | undefined => {
-    if (!availableFirmwares || availableFirmwares.length === 0) {
+    if (!availableFirmwares?.length) {
         return;
     }
 

--- a/packages/connect/src/utils/formatUtils.ts
+++ b/packages/connect/src/utils/formatUtils.ts
@@ -27,9 +27,9 @@ export const messageToBuffer = (message: string) => {
         }
 
         return Buffer.from(clean, 'hex');
-    } else {
-        return Buffer.from(message, 'utf8');
     }
+
+    return Buffer.from(message, 'utf8');
 };
 
 export const messageToHex = (message: string) => messageToBuffer(message).toString('hex');

--- a/packages/device-authenticity/src/verifyAuthenticityProof.ts
+++ b/packages/device-authenticity/src/verifyAuthenticityProof.ts
@@ -122,7 +122,7 @@ const verifyDeviceAndCACertificates = async ({
     }
 
     const caCertValidityFrom = caCert.tbsCertificate.validity.from.getTime();
-    if (caCertValidityFrom > new Date().getTime()) {
+    if (caCertValidityFrom > Date.now()) {
         throw new Error(`CA validity from ${caCertValidityFrom} can't be in the future!`);
     }
     const modelFromSubject = parseModelFromDeviceCertSubject(deviceCert);

--- a/packages/e2e-utils/src/githubReporter/annotationBase.ts
+++ b/packages/e2e-utils/src/githubReporter/annotationBase.ts
@@ -106,12 +106,12 @@ export abstract class TestReportProviderBase {
     get testRun(): string {
         if (this.isManual) {
             return 'Manual';
-        } else {
-            // Capitalize first letter of testProject
-            const project = this.testProject;
-
-            return capitalizeFirstLetter(project);
         }
+
+        // Capitalize first letter of testProject
+        const project = this.testProject;
+
+        return capitalizeFirstLetter(project);
     }
 
     get osMatrix(): string[] {

--- a/packages/e2e-utils/src/llmTestAnalyzer/index.ts
+++ b/packages/e2e-utils/src/llmTestAnalyzer/index.ts
@@ -404,32 +404,27 @@ const main = async () => {
         log(`Cache written: ${cacheFile}`);
         reportUsageTotals(apiKey);
         if (failed > 0) process.exit(1);
+    } else if (testFiles.length === 1) {
+        const analysis = await analyzeTestFile(testFiles[0], apiKey);
+        output(JSON.stringify(analysis, null, 2));
     } else {
-        if (testFiles.length === 1) {
-            const analysis = await analyzeTestFile(testFiles[0], apiKey);
-            output(JSON.stringify(analysis, null, 2));
-        } else {
-            const results: Record<string, TestAnalysis> = {};
-            const gitRoot = getGitRoot(path.dirname(testFiles[0]));
-            let failed = 0;
-            for (const testFile of testFiles) {
-                try {
-                    results[path.relative(gitRoot, testFile)] = await analyzeTestFile(
-                        testFile,
-                        apiKey,
-                    );
-                } catch (err) {
-                    error(
-                        `Failed to analyze ${testFile}:`,
-                        err instanceof Error ? err.message : err,
-                    );
-                    failed++;
-                }
+        const results: Record<string, TestAnalysis> = {};
+        const gitRoot = getGitRoot(path.dirname(testFiles[0]));
+        let failed = 0;
+        for (const testFile of testFiles) {
+            try {
+                results[path.relative(gitRoot, testFile)] = await analyzeTestFile(
+                    testFile,
+                    apiKey,
+                );
+            } catch (err) {
+                error(`Failed to analyze ${testFile}:`, err instanceof Error ? err.message : err);
+                failed++;
             }
-            output(JSON.stringify(results, null, 2));
-            reportUsageTotals(apiKey);
-            if (failed > 0) process.exit(1);
         }
+        output(JSON.stringify(results, null, 2));
+        reportUsageTotals(apiKey);
+        if (failed > 0) process.exit(1);
     }
 };
 

--- a/packages/node-utils/src/findProcessFromIncomingPort.ts
+++ b/packages/node-utils/src/findProcessFromIncomingPort.ts
@@ -57,18 +57,18 @@ export async function findProcessFromIncomingPort(
                         const appName = appPathMatch[2];
 
                         return { name: appName, pid, fullPath: appPathMatch[0] };
-                    } else {
-                        // Binary in unusual location, show warning
-                        return { name, pid, fullPath, warning: true };
                     }
-                } else {
-                    const fullPathCommand = `cat /proc/${pid}/cmdline`;
-                    const fullPathRaw = await spawnAndCollectStdout(fullPathCommand);
-                    const fullPath = fullPathRaw.split('\0')[0].trim();
-                    // Binaries can be all over the place on Linux, so we don't check the path
 
-                    return { name, pid, fullPath };
+                    // Binary in unusual location, show warning
+                    return { name, pid, fullPath, warning: true };
                 }
+
+                const fullPathCommand = `cat /proc/${pid}/cmdline`;
+                const fullPathRaw = await spawnAndCollectStdout(fullPathCommand);
+                const fullPath = fullPathRaw.split('\0')[0].trim();
+
+                // Binaries can be all over the place on Linux, so we don't check the path
+                return { name, pid, fullPath };
             }
 
             return undefined;
@@ -98,10 +98,10 @@ export async function findProcessFromIncomingPort(
                 const appPathMatch = fullPath.match(appPathRegex);
                 if (appPathMatch) {
                     return { name: appName, pid: record.pid, fullPath };
-                } else {
-                    // Binary in unusual location, show warning
-                    return { name: appName, pid: record.pid, fullPath, warning: true };
                 }
+
+                // Binary in unusual location, show warning
+                return { name: appName, pid: record.pid, fullPath, warning: true };
             }
 
             return undefined;

--- a/packages/product-components/src/components/ConfirmOnDevice/ConfirmOnDevicePillContent.tsx
+++ b/packages/product-components/src/components/ConfirmOnDevice/ConfirmOnDevicePillContent.tsx
@@ -78,7 +78,7 @@ export const ConfirmOnDevicePillContent = ({
 
                 {hasSteps && activeStep <= steps && (
                     <Row gap={spacings.xxs} width={70} margin={{ top: spacings.xs }}>
-                        {Array.from(Array(steps).keys()).map((step, index) => (
+                        {[...Array(steps).keys()].map((step, index) => (
                             <Step
                                 key={step}
                                 $isActive={isStepActive(index, activeStep)}

--- a/packages/product-components/src/components/EditableText/ActionsContainer.tsx
+++ b/packages/product-components/src/components/EditableText/ActionsContainer.tsx
@@ -124,46 +124,43 @@ export const ActionsContainer = ({
                     />
                 </>
             );
-        } else {
-            return (
-                <>
+        }
+
+        return (
+            <>
+                <IconButton
+                    data-testid="@metadata/edit"
+                    intent="neutral"
+                    icon="pencilSimple"
+                    onClick={onEdit}
+                    tooltip={{
+                        content: (
+                            <FormattedMessage id="TR_LABELING_EDIT_LABEL" defaultMessage="Edit" />
+                        ),
+                        delayShow: 1000,
+                    }}
+                    {...commonProps}
+                />
+                {isDeleteButtonVisible && (
                     <IconButton
-                        data-testid="@metadata/edit"
-                        intent="neutral"
-                        icon="pencilSimple"
-                        onClick={onEdit}
+                        data-testid="@metadata/delete"
+                        intent="critical"
+                        icon="trash"
+                        onClick={onDelete}
                         tooltip={{
                             content: (
                                 <FormattedMessage
-                                    id="TR_LABELING_EDIT_LABEL"
-                                    defaultMessage="Edit"
+                                    id="TR_LABELING_REMOVE_LABEL"
+                                    defaultMessage="Remove"
                                 />
                             ),
                             delayShow: 1000,
                         }}
                         {...commonProps}
                     />
-                    {isDeleteButtonVisible && (
-                        <IconButton
-                            data-testid="@metadata/delete"
-                            intent="critical"
-                            icon="trash"
-                            onClick={onDelete}
-                            tooltip={{
-                                content: (
-                                    <FormattedMessage
-                                        id="TR_LABELING_REMOVE_LABEL"
-                                        defaultMessage="Remove"
-                                    />
-                                ),
-                                delayShow: 1000,
-                            }}
-                            {...commonProps}
-                        />
-                    )}
-                </>
-            );
-        }
+                )}
+            </>
+        );
     };
 
     return (

--- a/packages/protobuf/src/manager.ts
+++ b/packages/protobuf/src/manager.ts
@@ -189,7 +189,7 @@ export const ProtobufManager = () => {
         const wireTypeExtension = extensions['wire_type'];
         const wireTypeOption = unknownOptions.find(o => o.no === wireTypeExtension?.number);
 
-        return wireTypeOption ? wireTypeOption.data[0] : undefined;
+        return wireTypeOption?.data[0];
     };
 
     const findEnum = (enumName: string) => enums[enumName];

--- a/packages/request-manager/src/interceptor/interceptTlsConnect.ts
+++ b/packages/request-manager/src/interceptor/interceptTlsConnect.ts
@@ -20,14 +20,12 @@ export const interceptTlsConnect: Interceptor = ({ context, validateRequest }) =
             optionsOrPort.rejectUnauthorized =
                 optionsOrPort.rejectUnauthorized ??
                 !isWhitelistedHost(optionsOrPort.host, context.notRequiredTorDomainsList);
+        } else if (typeof optionsOrHost === 'object') {
+            // case: connect(port: number, options?: ConnectionOptions, secureConnectListener?: () => void): TLSSocket;
+            hostname = optionsOrHost.host ?? '';
         } else {
-            if (typeof optionsOrHost === 'object') {
-                // case: connect(port: number, options?: ConnectionOptions, secureConnectListener?: () => void): TLSSocket;
-                hostname = optionsOrHost.host ?? '';
-            } else {
-                // case: connect(port: number, host?: string, options?: ConnectionOptions, secureConnectListener?: () => void): TLSSocket;
-                hostname = typeof optionsOrHost === 'string' ? optionsOrHost : 'unknown';
-            }
+            // case: connect(port: number, host?: string, options?: ConnectionOptions, secureConnectListener?: () => void): TLSSocket;
+            hostname = typeof optionsOrHost === 'string' ? optionsOrHost : 'unknown';
         }
 
         context.handler({

--- a/packages/requirements/src/runRequirements.ts
+++ b/packages/requirements/src/runRequirements.ts
@@ -33,10 +33,8 @@ const executeRequirement = <T extends RequirementScope>({
     context,
     mode,
 }: ExecuteRequirementProps<T>): Promise<ReadonlyArray<string>> => {
-    if (mode === 'fix') {
-        if (requirement.fix !== undefined) {
-            return requirement.fix(context);
-        }
+    if (mode === 'fix' && requirement.fix !== undefined) {
+        return requirement.fix(context);
     }
 
     return requirement.verify(context);

--- a/packages/schema-utils/src/utils.ts
+++ b/packages/schema-utils/src/utils.ts
@@ -23,9 +23,9 @@ export function setDeepValue(obj: any, [prop, ...path]: string[], value: any) {
 export function getDeepValue(obj: any, [prop, ...path]: (string | number)[]): any {
     if (!path.length) {
         return obj[prop];
-    } else {
-        if (!(prop in obj)) return undefined;
-
-        return getDeepValue(obj[prop], path);
     }
+
+    if (!(prop in obj)) return undefined;
+
+    return getDeepValue(obj[prop], path);
 }

--- a/packages/suite-desktop-core/src/libs/user-data.ts
+++ b/packages/suite-desktop-core/src/libs/user-data.ts
@@ -82,12 +82,8 @@ export const save: {
     }
     const { dir, file } = resolvedPathResult.payload;
 
-    let data: string | Buffer;
-    if (encoding === 'binary') {
-        data = Buffer.from(content as ArrayBuffer);
-    } else {
-        data = content as string;
-    }
+    const data: string | Buffer =
+        encoding === 'binary' ? Buffer.from(content as ArrayBuffer) : (content as string);
 
     try {
         try {

--- a/packages/suite-desktop-core/src/modules/auto-start.ts
+++ b/packages/suite-desktop-core/src/modules/auto-start.ts
@@ -45,14 +45,15 @@ Terminal=false
 export const isAutoStartEnabled = () => {
     if (process.platform === 'linux') {
         return fs.existsSync(path.join(os.homedir(), LINUX_AUTOSTART_DIR, LINUX_AUTOSTART_FILE));
-    } else if (process.platform === 'win32') {
+    }
+    if (process.platform === 'win32') {
         return (
             app.getLoginItemSettings().openAtLogin ||
             app.getLoginItemSettings().executableWillLaunchAtLogin
         );
-    } else {
-        return app.getLoginItemSettings().openAtLogin;
     }
+
+    return app.getLoginItemSettings().openAtLogin;
 };
 
 const linuxAutoStart = (enabled: boolean) => {

--- a/packages/suite-desktop-core/src/modules/auto-start.ts
+++ b/packages/suite-desktop-core/src/modules/auto-start.ts
@@ -64,10 +64,8 @@ const linuxAutoStart = (enabled: boolean) => {
             LINUX_DESKTOP,
         );
         fs.chmodSync(path.join(os.homedir(), LINUX_AUTOSTART_DIR, LINUX_AUTOSTART_FILE), 0o755);
-    } else {
-        if (isAutoStartEnabled()) {
-            fs.unlinkSync(path.join(os.homedir(), LINUX_AUTOSTART_DIR, LINUX_AUTOSTART_FILE));
-        }
+    } else if (isAutoStartEnabled()) {
+        fs.unlinkSync(path.join(os.homedir(), LINUX_AUTOSTART_DIR, LINUX_AUTOSTART_FILE));
     }
 };
 

--- a/packages/suite-desktop-core/src/modules/event-logging/contents.ts
+++ b/packages/suite-desktop-core/src/modules/event-logging/contents.ts
@@ -29,7 +29,7 @@ export const init: ModuleInit = ({ mainWindowProxy }) => {
 
         let unresponsiveStart = 0;
         mainWindow.webContents.on('unresponsive', () => {
-            unresponsiveStart = +new Date();
+            unresponsiveStart = Date.now();
             logger.warn(SERVICE_NAME, 'Unresponsive');
         });
 
@@ -37,7 +37,7 @@ export const init: ModuleInit = ({ mainWindowProxy }) => {
             if (unresponsiveStart !== 0) {
                 logger.warn(
                     SERVICE_NAME,
-                    `Responsive again after ${(+new Date() - unresponsiveStart / 1000).toFixed(1)}s`,
+                    `Responsive again after ${(Date.now() - unresponsiveStart / 1000).toFixed(1)}s`,
                 );
                 unresponsiveStart = 0;
             }

--- a/packages/suite-desktop-core/src/modules/trezor-connect.ts
+++ b/packages/suite-desktop-core/src/modules/trezor-connect.ts
@@ -56,7 +56,7 @@ const getTransportsParam = (
     const bluetooth = bluetoothModuleState.getTransport();
     if (!bluetooth) return transports;
 
-    if (transports && transports.length > 0) {
+    if (transports?.length) {
         return [...transports, bluetooth];
     }
 

--- a/packages/suite/src/actions/firmware/__tests__/firmwareActions.test.ts
+++ b/packages/suite/src/actions/firmware/__tests__/firmwareActions.test.ts
@@ -22,9 +22,9 @@ interface InitialState {
 }
 
 const getInitialState = (override?: InitialState): any => {
-    const suite = override ? override.suite : undefined;
-    const suiteSettings = override ? override.suiteSettings : undefined;
-    const device = override ? override.device : undefined;
+    const suite = override?.suite;
+    const suiteSettings = override?.suiteSettings;
+    const device = override?.device;
 
     return {
         suite: {

--- a/packages/suite/src/actions/onboarding/__tests__/onboardingActions.test.ts
+++ b/packages/suite/src/actions/onboarding/__tests__/onboardingActions.test.ts
@@ -20,9 +20,9 @@ import fixtures from '../__fixtures__/onboardingActions';
 // }
 
 const getInitialState = (custom?: any) => {
-    const suite = custom ? custom.suite : undefined;
-    const onboarding = custom ? custom.onboarding : undefined;
-    const device = custom ? custom.device : undefined;
+    const suite = custom?.suite;
+    const onboarding = custom?.onboarding;
+    const device = custom?.device;
 
     return {
         onboarding: {

--- a/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
@@ -112,27 +112,15 @@ type PartialState = Pick<
 };
 
 const getInitialState = (prevState?: Partial<PartialState>, action?: any) => ({
-    suite: suiteReducer(
-        prevState ? prevState.suite : undefined,
-        action || ({ type: 'foo' } as any),
-    ),
+    suite: suiteReducer(prevState?.suite, action || ({ type: 'foo' } as any)),
     suiteSettings: prevState?.suiteSettings ?? suiteSettingsInitialState,
-    flags: flagsReducer(
-        prevState ? prevState.flags : undefined,
-        action || ({ type: 'foo' } as any),
-    ),
-    suiteSync: suiteSyncReducer(
-        prevState ? prevState.suiteSync : undefined,
-        action || ({ type: 'foo' } as any),
-    ),
+    flags: flagsReducer(prevState?.flags, action || ({ type: 'foo' } as any)),
+    suiteSync: suiteSyncReducer(prevState?.suiteSync, action || ({ type: 'foo' } as any)),
     suiteSyncQuotaManager: quotaManagerSliceReducer(
-        prevState ? prevState.suiteSyncQuotaManager : undefined,
+        prevState?.suiteSyncQuotaManager,
         action || ({ type: 'foo' } as any),
     ),
-    device: deviceReducer(
-        prevState ? prevState.device : undefined,
-        action || ({ type: 'foo' } as any),
-    ),
+    device: deviceReducer(prevState?.device, action || ({ type: 'foo' } as any)),
     wallet: {
         accounts: accountsReducer(prevState?.wallet?.accounts, action || ({ type: 'foo' } as any)),
         coinjoin: coinjoinReducer(prevState?.wallet?.coinjoin, action || ({ type: 'foo' } as any)),

--- a/packages/suite/src/actions/suite/__tests__/suiteActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/suiteActions.test.ts
@@ -46,7 +46,7 @@ const setTrezorConnectFixtures = (fixture: any) => {
                 success: true,
                 payload: {
                     state: {
-                        staticSessionId: `state@device-id:${device ? device.instance : undefined}`,
+                        staticSessionId: `state@device-id:${device?.instance}`,
                     },
                 },
             },

--- a/packages/suite/src/actions/suite/bioAuthThunks.ts
+++ b/packages/suite/src/actions/suite/bioAuthThunks.ts
@@ -79,9 +79,9 @@ export const requestBioAuthChangeThunk = createThunk(
         });
         if (!result.success) {
             return handleError(result.message, dispatch, messageError);
-        } else {
-            await desktopApi.setBioAuthSettings({ enabled: payload });
         }
+
+        await desktopApi.setBioAuthSettings({ enabled: payload });
     },
 );
 

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -464,7 +464,7 @@ const saveMetadata = async (metadata: Partial<Pick<MetadataState, MetadataPersis
 
     // remove undefined in metadata arg
     typedObjectKeys(metadata).forEach(key => {
-        if (typeof metadata[key] === 'undefined') {
+        if (metadata[key] === undefined) {
             delete metadata[key];
         }
     });

--- a/packages/suite/src/actions/wallet/__tests__/blockchainActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/blockchainActions.test.ts
@@ -141,7 +141,7 @@ describe('Blockchain Actions', () => {
             expect(actions).toMatchObject(f.actions);
             if (actions.length) {
                 // wait for reconnection timeout
-                const timeout = actions[0].payload.time - new Date().getTime() + 500;
+                const timeout = actions[0].payload.time - Date.now() + 500;
                 jest.setTimeout(10000);
                 await new Promise(resolve => setTimeout(resolve, timeout));
                 expect(TrezorConnect.blockchainUnsubscribeFiatRates).toHaveBeenCalledTimes(1);

--- a/packages/suite/src/actions/wallet/send/sendFormThunks.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormThunks.ts
@@ -150,7 +150,7 @@ const applySendFormMetadataLabelsThunk = createThunk<
                 // final ordering of outputs differs from order in send form
                 // outputsPermutation contains mapping from @trezor/utxo-lib outputs to send form outputs
                 // mapping goes like this: Array<@trezor/utxo-lib index : send form index>
-                const outputIndex = outputsPermutation.findIndex(p => p === index);
+                const outputIndex = outputsPermutation.indexOf(index);
                 const outputMetadata: Extract<MetadataAddPayload, { type: 'outputLabel' }> = {
                     type: 'outputLabel',
                     entityKey: selectedAccount.key,

--- a/packages/suite/src/components/connection/thp/ThpGlobalModalManager.tsx
+++ b/packages/suite/src/components/connection/thp/ThpGlobalModalManager.tsx
@@ -27,7 +27,6 @@ export const ThpGlobalModalManager = () => {
             case 'BeforeConnectionInfo':
                 return null;
             case 'ConfirmConnectionBeforePairing':
-                return <ThpConnectionModal device={device} />;
             case 'ConfirmOnlyConnection':
                 return <ThpConnectionModal device={device} />;
             case 'CodeEntry':

--- a/packages/suite/src/components/guide/GuideViewWrapper.tsx
+++ b/packages/suite/src/components/guide/GuideViewWrapper.tsx
@@ -25,11 +25,7 @@ export const GuideViewWrapper = ({ children }: GuideViewWrapperProps) => {
     const [isScrolled, setIsScrolled] = useState<boolean>(false);
 
     const onScroll: UIEventHandler<HTMLDivElement> = useCallback(e => {
-        if (e?.currentTarget?.scrollTop) {
-            setIsScrolled(true);
-        } else {
-            setIsScrolled(false);
-        }
+        setIsScrolled(!!e?.currentTarget?.scrollTop);
     }, []);
 
     return (

--- a/packages/suite/src/components/guide/HeaderBreadcrumb.tsx
+++ b/packages/suite/src/components/guide/HeaderBreadcrumb.tsx
@@ -69,13 +69,11 @@ export const HeaderBreadcrumb = () => {
     return (
         <Row gap={4} maxWidth="calc(100% - 36px - 8px)" flexWrap="wrap">
             <TextButton
-                onClick={() => {
-                    if (grandParentNode) {
-                        navigateToCategory(grandParentNode);
-                    } else {
-                        navigateToGuideDashboard();
-                    }
-                }}
+                onClick={() =>
+                    grandParentNode
+                        ? navigateToCategory(grandParentNode)
+                        : navigateToGuideDashboard()
+                }
                 size="small"
                 isUnderlined
                 intent="neutral"

--- a/packages/suite/src/components/onboarding/OnboardingProgressBar.tsx
+++ b/packages/suite/src/components/onboarding/OnboardingProgressBar.tsx
@@ -41,8 +41,7 @@ const useOnboardingStepCategoriesInPath = () => {
 
 const getState = (index: number, indexOfActiveStep: number): BulletListItemState => {
     // When active category is not in the visible list (e.g. final step), all visible steps are done.
-    if (indexOfActiveStep === -1) return 'done';
-    if (index < indexOfActiveStep) return 'done';
+    if (indexOfActiveStep === -1 || index < indexOfActiveStep) return 'done';
     if (index === indexOfActiveStep) return 'default';
 
     return 'pending';

--- a/packages/suite/src/components/suite/FindBar/useFindInPage.ts
+++ b/packages/suite/src/components/suite/FindBar/useFindInPage.ts
@@ -97,7 +97,7 @@ export const useFindInPage = () => {
         if (!el) return;
 
         const old = el.querySelector(MARK_HIGHLIGHT_PULSE_SELECTOR);
-        if (old) old.remove();
+        old?.remove();
 
         const pulse = document.createElement('span');
         pulse.className = MARK_HIGHLIGHT_PULSE_CLASSNAME;

--- a/packages/suite/src/components/suite/HiddenPlaceholder.tsx
+++ b/packages/suite/src/components/suite/HiddenPlaceholder.tsx
@@ -123,7 +123,7 @@ export const HiddenPlaceholder = ({
             onMouseLeave={onMouseLeave}
             onMouseMove={onMouseMove}
             $discreetMode={discreetMode}
-            $intensity={enforceIntensity !== undefined ? enforceIntensity : automaticIntensity}
+            $intensity={enforceIntensity ?? automaticIntensity}
             $minWidth={shouldEnforceMinWidth ? wrapperMinWidth : undefined}
             className={className}
             ref={ref}

--- a/packages/suite/src/components/suite/StoreBadge.tsx
+++ b/packages/suite/src/components/suite/StoreBadge.tsx
@@ -29,7 +29,7 @@ export const StoreBadge = ({ url, image, isHighlighted, onClick }: StoreBadgePro
     const onMouseLeave = () => {
         setIsHovered(false);
     };
-    const highlighted = isHighlighted !== undefined ? isHighlighted : isHovered;
+    const highlighted = isHighlighted ?? isHovered;
 
     return (
         <TrezorLink href={url} onClick={onClick}>

--- a/packages/suite/src/components/suite/graph/TransactionsGraph/TransactionsGraph.tsx
+++ b/packages/suite/src/components/suite/graph/TransactionsGraph/TransactionsGraph.tsx
@@ -72,9 +72,7 @@ const useTransactionGraphUpdater = ({
     const newestTransactions = allTransactions
         .slice(0, 3)
         .flat()
-        .filter((tx): tx is WalletAccountTransaction =>
-            Boolean(Boolean(tx) && tx && !isPending(tx)),
-        );
+        .filter((tx): tx is WalletAccountTransaction => Boolean(tx && !isPending(tx)));
 
     const promiseId = newestTransactions.map(tx => tx.txid).join('-');
 

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Navigation.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Navigation.tsx
@@ -76,7 +76,7 @@ export const Navigation = ({ children }: NavigationProps) => {
         <Column alignItems={isSidebarCollapsed ? 'center' : 'stretch'} gap={4} margin={8} as="nav">
             {children ?? null}
             {navItems.map(item => {
-                const Component = item.CustomComponent ? item.CustomComponent : NavigationItem;
+                const Component = item.CustomComponent || NavigationItem;
 
                 return <Component key={item.nameId} {...item} />;
             })}

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/DeviceContextModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/DeviceContextModal.tsx
@@ -72,9 +72,9 @@ export const DeviceContextModal = ({
             // See https://github.com/trezor/trezor-firmware/issues/5120
             if (selectedAccount?.networkType === 'stellar') {
                 return <TransactionReviewModal type="sign-transaction" />;
-            } else {
-                return <ConfirmActionModal device={device} />;
             }
+
+            return <ConfirmActionModal device={device} />;
         }
         case 'ButtonRequest_Address':
             return data?.type === 'address' ? (

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
@@ -43,7 +43,6 @@ import {
 const getFeeLabel = (networkType: NetworkType) => {
     switch (networkType) {
         case 'ethereum':
-            return 'MAX_FEE';
         case 'stellar':
             return 'MAX_FEE';
         case 'solana':

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewTotalOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewTotalOutput.tsx
@@ -54,7 +54,6 @@ const getLines = ({
     const feeLabelId = ((network: NetworkType) => {
         switch (network) {
             case 'ethereum':
-                return 'MAX_FEE';
             case 'stellar':
                 return 'MAX_FEE';
             case 'solana':

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/AffectedTransactions/DecreasedOutputs.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/AffectedTransactions/DecreasedOutputs.tsx
@@ -96,9 +96,9 @@ export const DecreasedOutputs = () => {
         if (account.accountType === 'coinjoin') {
             if (coinjoinRegisteredUtxos.length > 0) {
                 return 'TR_UTXO_REGISTERED_IN_COINJOIN_RBF_WARNING';
-            } else {
-                return 'TR_NOT_ENOUGH_ANONYMIZED_FUNDS_RBF_WARNING';
             }
+
+            return 'TR_NOT_ENOUGH_ANONYMIZED_FUNDS_RBF_WARNING';
         }
 
         return 'TR_DECREASE_TX';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IODetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IODetails.tsx
@@ -79,17 +79,17 @@ export const IODetails = ({ tx }: IODetailsProps) => {
                     />
                 </>
             );
-        } else {
-            return (
-                <IOGroup
-                    tx={tx}
-                    inputs={tx.details.vin}
-                    outputs={tx.details.vout}
-                    isUtxoBased
-                    isPhishingTransaction={isPhishingTransaction}
-                />
-            );
         }
+
+        return (
+            <IOGroup
+                tx={tx}
+                inputs={tx.details.vin}
+                outputs={tx.details.vout}
+                isUtxoBased
+                isPhishingTransaction={isPhishingTransaction}
+            />
+        );
     };
 
     return (

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
@@ -103,7 +103,6 @@ export const UserContextModal = ({ payload }: ReduxModalProps<typeof MODAL_CONTE
         case 'transaction-detail':
             return <TxDetailModal {...payload} onCancel={onCancel} />;
         case 'review-transaction':
-            return <TransactionReviewModal {...payload} />;
         case 'review-transaction-rbf-previous-transaction-mined-error':
             return <TransactionReviewModal {...payload} />;
         case 'import-transaction':

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/hooks/useFetchFees.ts
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/hooks/useFetchFees.ts
@@ -11,19 +11,12 @@ function useIsRefetchDisabled() {
     const modal = useSelector(state => state.modal);
     const setMaxOutputId = useWatch<FormState, 'setMaxOutputId'>({ name: 'setMaxOutputId' });
 
-    if (setMaxOutputId !== undefined) {
-        return true;
-    }
-
-    if (
-        modal.context === MODAL_CONTEXT_DEVICE &&
-        modal.windowType !== undefined &&
-        REFETCH_FEES_EXCLUDED_MODAL_WINDOW_TYPES.includes(modal.windowType)
-    ) {
-        return true;
-    }
-
-    return false;
+    return (
+        setMaxOutputId !== undefined ||
+        (modal.context === MODAL_CONTEXT_DEVICE &&
+            modal.windowType !== undefined &&
+            REFETCH_FEES_EXCLUDED_MODAL_WINDOW_TYPES.includes(modal.windowType))
+    );
 }
 
 interface UseFetchFeesProps {

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTypeIcon.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTypeIcon.tsx
@@ -16,11 +16,12 @@ const getIconIntent = (
 ) => {
     if (isPending) {
         return 'warning';
-    } else if (isPhishingTransaction || type === 'failed') {
-        return 'critical';
-    } else {
-        return 'neutral';
     }
+    if (isPhishingTransaction || type === 'failed') {
+        return 'critical';
+    }
+
+    return 'neutral';
 };
 
 export const TransactionTypeIcon = ({

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/TaprootBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/TaprootBanner.tsx
@@ -24,7 +24,7 @@ export const TaprootBanner = ({ account }: TaprootBannerProps) => {
     const dispatch = useDispatch();
 
     const isVisible =
-        !taprootBannerClosed && account && account.empty && getBip43Type(account.path) === 'bip86';
+        !taprootBannerClosed && account?.empty && getBip43Type(account.path) === 'bip86';
 
     if (!isVisible) {
         return null;

--- a/packages/suite/src/config/suite/features.ts
+++ b/packages/suite/src/config/suite/features.ts
@@ -1,2 +1,0 @@
-// TODO: remove this reexport and pass path directly in suite-build
-export * from '@suite-common/suite-config';

--- a/packages/suite/src/hooks/settings/backends/useBackendReconnection.ts
+++ b/packages/suite/src/hooks/settings/backends/useBackendReconnection.ts
@@ -18,7 +18,7 @@ export const useBackendReconnection = (
     useEffect(() => {
         if (!resolveTime) return;
         const interval = setInterval(() => {
-            const secToResolve = Math.round((resolveTime - new Date().getTime()) / 1000);
+            const secToResolve = Math.round((resolveTime - Date.now()) / 1000);
             setTime(secToResolve);
         }, 500);
 

--- a/packages/suite/src/hooks/settings/backends/useBackendsForm.ts
+++ b/packages/suite/src/hooks/settings/backends/useBackendsForm.ts
@@ -24,19 +24,14 @@ type BackendsFormData = {
 const validateUrl = (type: BackendOption, value: string) => {
     switch (type) {
         case 'blockbook':
-            return isUrlWithQuery(value);
         case 'blockfrost':
+        case 'solana':
+        case 'ripple':
+        case 'stellar':
+        case 'evm-rpc':
             return isUrlWithQuery(value);
         case 'electrum':
             return isElectrumUrl(value);
-        case 'solana':
-            return isUrlWithQuery(value);
-        case 'ripple':
-            return isUrlWithQuery(value);
-        case 'stellar':
-            return isUrlWithQuery(value);
-        case 'evm-rpc':
-            return isUrlWithQuery(value);
         default:
             return false;
     }

--- a/packages/suite/src/middlewares/suite/suiteMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/suiteMiddleware.ts
@@ -37,8 +37,11 @@ const isActionDeviceRelated = (action: AnyAction): boolean => {
         return true;
     }
 
-    if (action.type === METADATA.SET_DEVICE_METADATA) return true;
-    if (action.type === METADATA.SET_DEVICE_METADATA_PASSWORDS) return true;
+    if (
+        action.type === METADATA.SET_DEVICE_METADATA ||
+        action.type === METADATA.SET_DEVICE_METADATA_PASSWORDS
+    )
+        return true;
 
     if (isAnyDeviceEventAction(action)) return true;
 

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -201,7 +201,7 @@ const updateSession = (
     const { roundPhase } = account.session;
     const { phase, phaseDeadline } = round;
 
-    if (typeof roundPhase !== 'undefined' && roundPhase !== phase) {
+    if (roundPhase !== undefined && roundPhase !== phase) {
         account.session.sessionPhaseQueue = [];
     }
 

--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -477,7 +477,7 @@ export const runLegacyMigrations: OnUpgradeFunc<SuiteDBSchema> = async (
     if (oldVersion < 33) {
         await updateAll(transaction, 'messageSystem', messageSystem => {
             Object.values(messageSystem.dismissedMessages).forEach(dismissedMessage => {
-                if (typeof dismissedMessage.feature === 'undefined') {
+                if (dismissedMessage.feature === undefined) {
                     dismissedMessage.feature = false;
                 }
             });

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -313,9 +313,9 @@ export const extraDependencies: ExtraDependenciesStatic = {
                         ...device,
                         thp: persistentDeviceData.thp,
                     };
-                } else {
-                    return device;
                 }
+
+                return device;
             });
 
             state.persistentDeviceData = payload.persistentDeviceData ?? [];

--- a/packages/suite/src/utils/wallet/coinjoinUtils.ts
+++ b/packages/suite/src/utils/wallet/coinjoinUtils.ts
@@ -359,7 +359,7 @@ export const fixLoadedCoinjoinAccount = ({
 // Clean AnonymityGains from old records.
 export const cleanAnonymityGains = (anonymityGainsHistory: AnonymityGainPerRound[]) => {
     const oldestRelevantTimestamp =
-        new Date().getTime() - ANONYMITY_GAINS_HINDSIGHT_DAYS * 24 * 60 * 60 * 1000;
+        Date.now() - ANONYMITY_GAINS_HINDSIGHT_DAYS * 24 * 60 * 60 * 1000;
 
     return anonymityGainsHistory
         .filter(level => level.timestamp > oldestRelevantTimestamp)

--- a/packages/suite/src/utils/wallet/graph/utils.ts
+++ b/packages/suite/src/utils/wallet/graph/utils.ts
@@ -216,7 +216,7 @@ export const calcXDomain = (
 ): [number, number] => {
     const start = ticks[0];
     const lastTick = ticks[ticks.length - 1];
-    const lastData = data[data.length - 1];
+    const lastData = data.at(-1);
     // if the last data point is after last tick/label use datapoint's timestamp to mark the end of the interval
     const end = lastData && lastTick < lastData.time ? lastData.time : lastTick;
 
@@ -254,10 +254,10 @@ export const calcFakeGraphDataForTimestamps = (
 ) => {
     const balanceData: CommonAggregatedHistory[] = [];
     const firstDataPoint = data[0];
-    const lastDataPoint = data[data.length - 1];
+    const lastDataPoint = data.at(-1);
 
     const firstTimestamp = timestamps[0];
-    const lastTimestamp = timestamps[timestamps.length - 1];
+    const lastTimestamp = timestamps.at(-1);
 
     if (data.length === 0) {
         timestamps.forEach(ts => {

--- a/packages/suite/src/utils/wallet/graph/utils.ts
+++ b/packages/suite/src/utils/wallet/graph/utils.ts
@@ -124,7 +124,7 @@ export const getMinMaxValueFromData = <TType extends TypeName, TValue extends Bi
     extractReceivedValue: (sourceData: GraphDataPoint<TType>) => TValue | undefined,
     extractBalanceValue: (sourceData: GraphDataPoint<TType>) => TValue | undefined,
 ): [TValue, TValue] => {
-    if (!data || data.length === 0) {
+    if (!data?.length) {
         return [new BigNumber(0) as TValue, new BigNumber(0) as TValue];
     }
     let maxSent = new BigNumber(extractSentValue(data[0]) || 0);

--- a/packages/suite/src/utils/wallet/tokenUtils.ts
+++ b/packages/suite/src/utils/wallet/tokenUtils.ts
@@ -71,7 +71,7 @@ export const hasVisibleTokens = (
     tokenDefinitions: Partial<TokenDefinitionsState>,
     isNft: boolean = false,
 ): boolean => {
-    if (!tokens || tokens.length === 0) return false;
+    if (!tokens?.length) return false;
 
     const coinDefinitions = tokenDefinitions?.[symbol]?.coin;
     if (!coinDefinitions) return false;

--- a/packages/suite/src/utils/wallet/trading/buyUtils.ts
+++ b/packages/suite/src/utils/wallet/trading/buyUtils.ts
@@ -8,13 +8,9 @@ import { type Account } from 'src/types/wallet';
 export const createQuoteLink = async (request: BuyTradeQuoteRequest, account: Account) => {
     const assetPrefix = process.env.ASSET_PREFIX || '';
     const locationOrigin = getLocationOrigin();
-    let hash: string;
-
-    if (request.wantCrypto) {
-        hash = `qc/${request.country}/${request.fiatCurrency}/${request.cryptoStringAmount}/${request.receiveCurrency}/${request.paymentMethod}`;
-    } else {
-        hash = `qf/${request.country}/${request.fiatCurrency}/${request.fiatStringAmount}/${request.receiveCurrency}/${request.paymentMethod}`;
-    }
+    const hash = request.wantCrypto
+        ? `qc/${request.country}/${request.fiatCurrency}/${request.cryptoStringAmount}/${request.receiveCurrency}/${request.paymentMethod}`
+        : `qf/${request.country}/${request.fiatCurrency}/${request.fiatStringAmount}/${request.receiveCurrency}/${request.paymentMethod}`;
 
     const params = `offers/${account.symbol}/${account.accountType}/${account.index}/${hash}`;
 

--- a/packages/suite/src/utils/wallet/trading/sellUtils.ts
+++ b/packages/suite/src/utils/wallet/trading/sellUtils.ts
@@ -14,13 +14,9 @@ export const createQuoteLink = async (
 ) => {
     const assetPrefix = process.env.ASSET_PREFIX || '';
     const locationOrigin = getLocationOrigin();
-    let hash: string;
-
-    if (request.amountInCrypto) {
-        hash = `qc/${request.country}/${request.fiatCurrency}/${request.cryptoStringAmount}/${request.cryptoCurrency}/${request.paymentMethod}`;
-    } else {
-        hash = `qf/${request.country}/${request.fiatCurrency}/${request.fiatStringAmount}/${request.cryptoCurrency}/${request.paymentMethod}`;
-    }
+    let hash = request.amountInCrypto
+        ? `qc/${request.country}/${request.fiatCurrency}/${request.cryptoStringAmount}/${request.cryptoCurrency}/${request.paymentMethod}`
+        : `qf/${request.country}/${request.fiatCurrency}/${request.fiatStringAmount}/${request.cryptoCurrency}/${request.paymentMethod}`;
     if (orderId) {
         hash = `p-${hash}/${orderId}`;
     }

--- a/packages/suite/src/utils/wallet/utxoSortingUtils.ts
+++ b/packages/suite/src/utils/wallet/utxoSortingUtils.ts
@@ -38,18 +38,16 @@ const sortFromNewestToOldest: UtxoSortingFunctionWithContext =
     (a, b) => {
         if (a.blockHeight > 0 && b.blockHeight > 0) {
             return b.blockHeight - a.blockHeight;
-        } else {
-            // Pending transactions do not have blockHeight, so we must use blockTime of the transaction instead.
-            const getBlockTime = (txid: string) => {
-                const transaction = accountTransactions.find(
-                    transaction => transaction.txid === txid,
-                );
-
-                return transaction?.blockTime ?? 0;
-            };
-
-            return getBlockTime(b.txid) - getBlockTime(a.txid);
         }
+
+        // Pending transactions do not have blockHeight, so we must use blockTime of the transaction instead.
+        const getBlockTime = (txid: string) => {
+            const transaction = accountTransactions.find(transaction => transaction.txid === txid);
+
+            return transaction?.blockTime ?? 0;
+        };
+
+        return getBlockTime(b.txid) - getBlockTime(a.txid);
     };
 
 const utxoSortMap: Record<UtxoSorting, UtxoSortingFunctionWithContext> = {

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardException.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardException.tsx
@@ -48,7 +48,7 @@ const Container = ({ title, description, cta, dataTestBase, image }: ContainerPr
 
     return (
         <Column gap={spacings.xxs} data-testid={`@exception/${dataTestBase}`} alignItems="center">
-            {image ? image : <IconCircle name="warning" size={96} intent="warning" />}
+            {image || <IconCircle name="warning" size={96} intent="warning" />}
             <H3 data-testid={`@exception/${dataTestBase}/header`} margin={{ top: spacings.md }}>
                 <Translation id={title} />
             </H3>

--- a/packages/suite/src/views/dashboard/PortfolioCard/UnsupportedAssetsMessage.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/UnsupportedAssetsMessage.tsx
@@ -53,16 +53,17 @@ const Message = ({ affectedNetworks, hasTokens }: MessageProps) => {
                 values={{ networks: networksString }}
             />
         );
-    } else if (hasNetworks) {
+    }
+    if (hasNetworks) {
         return (
             <Translation
                 id="TR_GRAPH_MISSING_DATA_NETWORKS"
                 values={{ networks: networksString }}
             />
         );
-    } else {
-        return <Translation id="TR_GRAPH_MISSING_DATA_TOKENS" />;
     }
+
+    return <Translation id="TR_GRAPH_MISSING_DATA_TOKENS" />;
 };
 
 type UnsupportedAssetsMessageProps = {

--- a/packages/suite/src/views/firmware/Steps/StepDone.tsx
+++ b/packages/suite/src/views/firmware/Steps/StepDone.tsx
@@ -18,7 +18,7 @@ export const StepDone = ({
     isCustomFirmwareUploaded,
     install,
 }: StepDoneProps) => {
-    const isCustomFirmware = typeof isCustomFirmwareUploaded !== 'undefined';
+    const isCustomFirmware = isCustomFirmwareUploaded !== undefined;
 
     return (
         <Modal.ModalBase

--- a/packages/suite/src/views/firmware/Steps/StepInitial.tsx
+++ b/packages/suite/src/views/firmware/Steps/StepInitial.tsx
@@ -43,7 +43,7 @@ export const StepInitial = ({
         updateAnalytics({ firmware: 'install' });
     };
 
-    const isCustomFirmware = typeof isCustomFirmwareUploaded !== 'undefined';
+    const isCustomFirmware = isCustomFirmwareUploaded !== undefined;
 
     return (
         <Modal.ModalBase

--- a/packages/suite/src/views/firmware/Steps/StepStarted.tsx
+++ b/packages/suite/src/views/firmware/Steps/StepStarted.tsx
@@ -17,7 +17,7 @@ export const StepStarted = ({
     isCustomFirmwareUploaded,
     install,
 }: StepStartedProps) => {
-    const isCustomFirmware = typeof isCustomFirmwareUploaded !== 'undefined';
+    const isCustomFirmware = isCustomFirmwareUploaded !== undefined;
 
     return (
         <Modal.ModalBase

--- a/packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemConditionGroup.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemConditionGroup.tsx
@@ -11,7 +11,7 @@ type MessageSystemConditionGroupProps = {
 
 // TODO: Add rarely used conditions: duration, browser, transport, settings.
 export const MessageSystemConditionGroup = ({ conditions }: MessageSystemConditionGroupProps) => {
-    if (!conditions || conditions.length === 0) {
+    if (!conditions?.length) {
         return (
             <InfoItem label="Conditions" iconName="checkFat" intent="neutral" priority="primary">
                 -

--- a/packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemDevices.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemDevices.tsx
@@ -10,7 +10,7 @@ type MessageSystemDevicesProps = {
 export const MessageSystemDevices = ({ devices }: MessageSystemDevicesProps) => {
     const [expanded, setExpanded] = useState(false);
 
-    if (!devices || devices.length === 0) {
+    if (!devices?.length) {
         return (
             <InfoItem label="Devices" iconName="devices" intent="neutral" priority="primary">
                 -

--- a/packages/suite/src/views/suite/SwitchDevice/NeedsAttentionBanner.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/NeedsAttentionBanner.tsx
@@ -45,7 +45,6 @@ const getDeviceNeedsAttentionMessage = (
             return 'TR_NEEDS_ATTENTION_DEVICE_BUSY';
         case 'device-bootloader-locked':
         case 'device-hard-locked':
-            return 'TR_NEEDS_ATTENTION_DEVICE_LOCKED';
         case 'device-pin-locked':
             return 'TR_NEEDS_ATTENTION_DEVICE_LOCKED';
         case 'device-rebooting':

--- a/packages/suite/src/views/wallet/send/Options/TronOptions/TronNote.tsx
+++ b/packages/suite/src/views/wallet/send/Options/TronOptions/TronNote.tsx
@@ -31,7 +31,7 @@ export const TronNote = ({ close }: TronNoteProps) => {
     const asciiValue = watch(inputAsciiName);
     const hexValue = watch(inputHexName);
 
-    const isHexTooLong = !hexValue ? false : hexValue.length > formInputsMaxLength.tronNote;
+    const isHexTooLong = !!hexValue && hexValue.length > formInputsMaxLength.tronNote;
     const error = isHexTooLong ? translationString('TR_TRON_NOTE_TOO_LONG') : undefined;
 
     useEffect(() => {

--- a/packages/suite/src/views/wallet/send/Outputs/Address.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Address.tsx
@@ -85,7 +85,7 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
     // however if address is changed compose process may return `AMOUNT_IS_NOT_ENOUGH` which should appear under the amount filed.
     const amountInputName = `outputs.${outputId}.amount` as const;
     const outputError = errors.outputs ? errors.outputs[outputId] : undefined;
-    const addressError = outputError ? outputError.address : undefined;
+    const addressError = outputError?.address;
     const addressValue = getDefaultValue(inputName, output.address || '');
     const recipientId = outputId + 1;
     const label = watch(`outputs.${outputId}.label`, '');

--- a/packages/suite/src/views/wallet/send/Outputs/Amount/Amount.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/Amount.tsx
@@ -77,7 +77,7 @@ export const Amount = ({ output, outputId }: AmountProps) => {
     const maxOutputId = getDefaultValue('setMaxOutputId');
     const isSendMaxActive = maxOutputId === outputId;
     const outputError = errors.outputs ? errors.outputs[outputId] : undefined;
-    const error = outputError ? outputError.amount : undefined;
+    const error = outputError?.amount;
 
     const selectedBaseCurrency = watch(currencyInputName);
 

--- a/packages/suite/src/views/wallet/send/Outputs/Amount/BaseCurrencyInput.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/BaseCurrencyInput.tsx
@@ -76,7 +76,7 @@ export const BaseCurrencyInput = ({
     const tokenInputName = `outputs.${outputId}.token` as const;
 
     const outputError = errors.outputs ? errors.outputs[outputId] : undefined;
-    const error = outputError ? outputError.fiat : undefined;
+    const error = outputError?.fiat;
     const baseCurrencyValue = getDefaultValue(baseCurrencyInputName, output.fiat || '');
     const tokenContractAddress = getDefaultValue(tokenInputName, output.token);
 
@@ -134,7 +134,7 @@ export const BaseCurrencyInput = ({
     // Amount input has an error and Fiat has not (but it should)
     // usually this happens after Fiat > Amount recalculation (from here, onChange event)
     // or as a result on composeTransaction process
-    const amountError = outputError ? outputError.amount : undefined;
+    const amountError = outputError?.amount;
     const errorToDisplay = !error && baseCurrencyValue && amountError ? amountError : error;
 
     const isLowAnonymity = isLowAnonymityWarning(outputError);

--- a/packages/suite/src/views/wallet/send/Outputs/OpReturn.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/OpReturn.tsx
@@ -28,8 +28,8 @@ export const OpReturn = ({ outputId }: { outputId: number }) => {
     const hexValue = watch(inputHexName);
 
     const outputError = errors.outputs ? errors.outputs[outputId] : undefined;
-    const asciiError = outputError ? outputError.dataAscii : undefined;
-    const hexError = outputError ? outputError.dataHex : undefined;
+    const asciiError = outputError?.dataAscii;
+    const hexError = outputError?.dataHex;
 
     const { ref: asciiRef, ...asciiField } = register(inputAsciiName, {
         onChange: event => {

--- a/packages/suite/src/views/wallet/sign-verify/components/HiddenAddressRow.tsx
+++ b/packages/suite/src/views/wallet/sign-verify/components/HiddenAddressRow.tsx
@@ -27,7 +27,7 @@ export const HiddenAddressRow = ({
             cursor="pointer"
         >
             <Box minWidth={36}>
-                <Text isDisabled>/{pathParts[pathParts.length - 1]}</Text>
+                <Text isDisabled>/{pathParts.at(-1)}</Text>
             </Box>
             <Box position={{ type: 'relative' }} cursor="pointer" userSelect="none">
                 <GradientOverlay forcedElevation={currentElevation} hiddenFrom="160px" />

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
@@ -98,10 +98,9 @@ const TokenRowBasicActions = ({
     const tokenCryptoId = toTokenCryptoId(account.symbol, contractAddress);
     const tokenTradingOptions = coins?.[tokenCryptoId]?.services;
 
-    const canBuyToken = !!tokenTradingOptions && tokenTradingOptions.buy;
-    const canSwapToken =
-        (!!tokenTradingOptions && tokenTradingOptions.exchange) || token.balance === '0';
-    const canSellToken = !!tokenTradingOptions && tokenTradingOptions.sell;
+    const canBuyToken = !!tokenTradingOptions?.buy;
+    const canSwapToken = !!tokenTradingOptions?.exchange || token.balance === '0';
+    const canSellToken = !!tokenTradingOptions?.sell;
     const canReceiveToken = !isDeviceLocked && !isDeviceCompromised;
 
     const availableVault = yieldOpportunities?.find(

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputFiat.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputFiat.tsx
@@ -219,12 +219,12 @@ export const TradingFormInputFiat = ({
                                       ),
                                       currency: selectedCurrencyLabel,
                                   });
-                              } else {
-                                  return translationString('TR_BUY_VALIDATION_ERROR_MINIMUM_FIAT', {
-                                      minimum: context.amountLimits.minCrypto,
-                                      currency: selectedCurrencyLabel,
-                                  });
                               }
+
+                              return translationString('TR_BUY_VALIDATION_ERROR_MINIMUM_FIAT', {
+                                  minimum: context.amountLimits.minCrypto,
+                                  currency: selectedCurrencyLabel,
+                              });
                           }
                       },
                   },

--- a/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransaction/TradingTransactionStatus.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransaction/TradingTransactionStatus.tsx
@@ -12,11 +12,6 @@ const getBuyTradeData = (status: BuyTradeStatus) => {
     switch (message) {
         case 'TR_BUY_STATUS_PENDING':
         case 'TR_BUY_STATUS_ACTION_REQUIRED':
-            return {
-                icon: 'clock',
-                intent: 'warning',
-                statusMessageId: message,
-            } as const;
         case 'TR_BUY_STATUS_PENDING_GO_TO_GATEWAY':
             return {
                 icon: 'clock',

--- a/packages/suite/src/views/wallet/trading/common/TradingUtils/TradingUtilsProvider.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingUtils/TradingUtilsProvider.tsx
@@ -42,7 +42,7 @@ export const TradingUtilsProvider = ({
                     {providerName}
                 </>
             ) : (
-                <>{exchange ? exchange : <Translation id="TR_TRADING_UNKNOWN_PROVIDER" />}</>
+                <>{exchange || <Translation id="TR_TRADING_UNKNOWN_PROVIDER" />}</>
             )}
         </Wrapper>
     );

--- a/packages/suite/src/views/wallet/transactions/TransactionList/transaction-fetch-utils.ts
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/transaction-fetch-utils.ts
@@ -11,8 +11,11 @@ export function shouldAttemptToLoadNextPageForVisibleTransactions({
     currentNumberOfVisibleTransactions: number;
     numberOfPagesRequested: number;
 }): boolean {
-    if (totalNumberOfTransactions === 0) return false;
-    if (currentNumberOfTransactions === totalNumberOfTransactions) return false;
+    if (
+        totalNumberOfTransactions === 0 ||
+        currentNumberOfTransactions === totalNumberOfTransactions
+    )
+        return false;
 
     const requestedNumberOfVisibleItems = numberOfPagesRequested * perPage;
     if (requestedNumberOfVisibleItems > Math.ceil(totalNumberOfTransactions / perPage) * perPage)

--- a/packages/transport-bluetooth/src/client/bluetooth-api.ts
+++ b/packages/transport-bluetooth/src/client/bluetooth-api.ts
@@ -121,9 +121,8 @@ export class BluetoothApi extends AbstractApi {
             if (this.readSubscription[path]) {
                 // already subscribed to TX (read) characteristics
                 return Promise.resolve(success(undefined));
-            } else {
-                this.readSubscription[path] = true;
             }
+            this.readSubscription[path] = true;
         }
 
         return this.api

--- a/packages/transport-bluetooth/src/ui/app.tsx
+++ b/packages/transport-bluetooth/src/ui/app.tsx
@@ -66,7 +66,7 @@ export const App: React.FC = () => {
         document.head.appendChild(style);
 
         return () => {
-            if (style.parentNode) style.parentNode.removeChild(style);
+            style.parentNode?.removeChild(style);
         };
     }, []);
 

--- a/packages/transport-bridge/src/ui/components/Device.tsx
+++ b/packages/transport-bridge/src/ui/components/Device.tsx
@@ -27,10 +27,8 @@ export const Device = ({ device }: DeviceProps) => {
             {/* I am inclined not to translate model, path and session */}
             <div>model: {modelName}</div>
             <div>path: {device.path}</div>
-            <div>session: {device.session ? device.session : 'none'}</div>
-            {device.session && (
-                <div>session owner: {device.sessionOwner ? device.sessionOwner : 'unknown'}</div>
-            )}
+            <div>session: {device.session || 'none'}</div>
+            {device.session && <div>session owner: {device.sessionOwner || 'unknown'}</div>}
         </div>
     );
 };

--- a/packages/transport-common/src/api/abstract.ts
+++ b/packages/transport-common/src/api/abstract.ts
@@ -197,8 +197,8 @@ export abstract class AbstractApi extends TypedEmitter<{
             return this.unknownError(err);
         } finally {
             this.lock[path] = {
-                read: lock.read ? false : this.lock[path].read,
-                write: lock.write ? false : this.lock[path].write,
+                read: !lock.read && this.lock[path].read,
+                write: !lock.write && this.lock[path].write,
             };
         }
     };

--- a/packages/transport-common/src/api/usb.ts
+++ b/packages/transport-common/src/api/usb.ts
@@ -121,20 +121,16 @@ export class UsbApi extends AbstractApi {
     private matchDeviceType(device: UsbDeviceLike) {
         const isBootloader = device.productId === WEBUSB_BOOTLOADER_PRODUCT;
         if (device.deviceVersionMajor === 2) {
-            if (isBootloader) {
-                return DEVICE_TYPE.TypeT2Boot;
-            } else {
-                return DEVICE_TYPE.TypeT2;
-            }
-        } else {
-            if (isBootloader) {
-                return DEVICE_TYPE.TypeT1WebusbBoot;
-            } else if (device.vendorId === T1_HID_VENDOR && device.productId === T1_HID_PRODUCT) {
-                return DEVICE_TYPE.TypeT1Hid;
-            } else {
-                return DEVICE_TYPE.TypeT1Webusb;
-            }
+            return isBootloader ? DEVICE_TYPE.TypeT2Boot : DEVICE_TYPE.TypeT2;
         }
+        if (isBootloader) {
+            return DEVICE_TYPE.TypeT1WebusbBoot;
+        }
+        if (device.vendorId === T1_HID_VENDOR && device.productId === T1_HID_PRODUCT) {
+            return DEVICE_TYPE.TypeT1Hid;
+        }
+
+        return DEVICE_TYPE.TypeT1Webusb;
     }
 
     private devicesToDescriptors(): DescriptorApiLevel[] {

--- a/packages/transport/src/transports/bridge.ts
+++ b/packages/transport/src/transports/bridge.ts
@@ -466,7 +466,6 @@ export class BridgeTransport extends AbstractTransport {
             case '/listen':
                 return bridgeApiResult.devices(response.payload);
             case '/release':
-                return bridgeApiResult.empty(response.payload);
             case '/abort':
                 return bridgeApiResult.empty(response.payload);
             default:

--- a/packages/trezor-user-env-link/src/websocket-client.ts
+++ b/packages/trezor-user-env-link/src/websocket-client.ts
@@ -85,16 +85,14 @@ export class WebsocketClient extends WebsocketClientBase<WebsocketClientEvents> 
         super.onMessage(message, resp => {
             if (resp.type === 'client') {
                 this.emit('firmwares', resp.firmwares);
-            } else {
-                if (!resp.success) {
-                    const err = resp.error.message || resp.error;
+            } else if (!resp.success) {
+                const err = resp.error.message || resp.error;
 
-                    // this is sort of expected, we don't want this to kill entire test run.
-                    if (err.includes('ReadTimeout')) {
-                        console.log('=== ERROR === websocket_error_message: ReadTimeout');
-                    } else {
-                        throw new Error(`websocket_error_message: ${err}`);
-                    }
+                // this is sort of expected, we don't want this to kill entire test run.
+                if (err.includes('ReadTimeout')) {
+                    console.log('=== ERROR === websocket_error_message: ReadTimeout');
+                } else {
+                    throw new Error(`websocket_error_message: ${err}`);
                 }
             }
 

--- a/packages/utils/src/arrayToDictionary.ts
+++ b/packages/utils/src/arrayToDictionary.ts
@@ -15,13 +15,8 @@ type ArrayToDictionary = {
  * @returns Dictionary object with array items as values
  */
 
-const validateKey = (key: unknown): key is DictionaryKey => {
-    if (['string', 'number'].includes(typeof key)) {
-        return true;
-    }
-
-    return false;
-};
+const validateKey = (key: unknown): key is DictionaryKey =>
+    ['string', 'number'].includes(typeof key);
 
 export const arrayToDictionary: ArrayToDictionary = <T, Fn extends GetKey<T>>(
     array: T[],

--- a/packages/utils/src/comparison.ts
+++ b/packages/utils/src/comparison.ts
@@ -1,9 +1,7 @@
 export const deepEqual = (a: any, b: any): boolean => {
     if (a === b) return true;
 
-    if (typeof a !== typeof b) return false;
-    if (a === null || b === null) return false;
-    if (typeof a !== 'object') return false;
+    if (typeof a !== typeof b || a === null || b === null || typeof a !== 'object') return false;
 
     if (Array.isArray(a) !== Array.isArray(b)) return false;
 

--- a/packages/utils/src/extractUrlsFromText.ts
+++ b/packages/utils/src/extractUrlsFromText.ts
@@ -10,7 +10,7 @@ export const extractUrlsFromText = (text: string) => {
 
     matches.forEach(match => {
         const url = match[0];
-        const index = match.index !== undefined ? match.index : -1; // Ensure index is defined
+        const index = match.index ?? -1;
 
         // Capture text before the URL
         if (lastIndex < index) {

--- a/packages/utils/src/mergeDeepObject.ts
+++ b/packages/utils/src/mergeDeepObject.ts
@@ -60,7 +60,7 @@ const mergeValuesWithPath = (target: any, value: any, [key, ...rest]: string[]):
 const mergeValues = (target: any, value: any) => {
     if (Array.isArray(target) && Array.isArray(value)) {
         return mergeDeepObject.options.mergeArrays
-            ? Array.from(new Set((target as unknown[]).concat(value)))
+            ? [...new Set((target as unknown[]).concat(value))]
             : value;
     }
     if (isObject(target) && isObject(value)) {

--- a/packages/utils/src/mergeDeepObject.ts
+++ b/packages/utils/src/mergeDeepObject.ts
@@ -49,11 +49,12 @@ interface IObject {
 const mergeValuesWithPath = (target: any, value: any, [key, ...rest]: string[]): any => {
     if (key === undefined) {
         return mergeValues(target, value);
-    } else if (!isObject(target)) {
-        return { [key]: mergeValuesWithPath({}, value, rest) };
-    } else {
-        return { ...target, [key]: mergeValuesWithPath(target[key], value, rest) };
     }
+    if (!isObject(target)) {
+        return { [key]: mergeValuesWithPath({}, value, rest) };
+    }
+
+    return { ...target, [key]: mergeValuesWithPath(target[key], value, rest) };
 };
 
 const mergeValues = (target: any, value: any) => {
@@ -61,11 +62,12 @@ const mergeValues = (target: any, value: any) => {
         return mergeDeepObject.options.mergeArrays
             ? Array.from(new Set((target as unknown[]).concat(value)))
             : value;
-    } else if (isObject(target) && isObject(value)) {
-        return mergeDeepObject(target, value);
-    } else {
-        return value;
     }
+    if (isObject(target) && isObject(value)) {
+        return mergeDeepObject(target, value);
+    }
+
+    return value;
 };
 
 export const mergeDeepObject = <T extends IObject[]>(...objects: T): TMerged<T[number]> =>

--- a/packages/utils/src/objectPartition.ts
+++ b/packages/utils/src/objectPartition.ts
@@ -11,7 +11,7 @@ export const objectPartition = <T>(obj: Obj<T>, keys: string[]): [Obj<T>, Obj<T>
         ([included, excluded], key) => {
             const { [key]: value, ...rest } = excluded;
 
-            return typeof value !== 'undefined'
+            return value !== undefined
                 ? [{ ...included, [key]: value }, rest]
                 : [included, excluded];
         },

--- a/packages/utils/src/scheduleAction.ts
+++ b/packages/utils/src/scheduleAction.ts
@@ -72,8 +72,7 @@ const maybeRejectAfterMs = (ms: number | undefined, reason: Error, clear: AbortS
 const rejectWhenAborted = (signal: AbortSignal | undefined, clear: AbortSignal) =>
     new Promise<never>((_, reject) => {
         const errorSignal = new RejectWhenAbortedError();
-        if (clear.aborted) return reject(errorSignal);
-        if (signal?.aborted) return reject(errorSignal);
+        if (clear.aborted || signal?.aborted) return reject(errorSignal);
         const onAbort = () => reject(errorSignal);
         signal?.addEventListener('abort', onAbort);
         const onClear = () => {

--- a/packages/utxo-lib/src/bchUtils.ts
+++ b/packages/utxo-lib/src/bchUtils.ts
@@ -78,14 +78,14 @@ const decodeCashAddressWithPrefix = (address: string): DecodedAddress => {
 const decodeCashAddress = (address: string): DecodedAddress => {
     if (address.includes(':')) {
         return decodeCashAddressWithPrefix(address);
-    } else {
-        const prefixes = ['bitcoincash', 'bchtest', 'bchreg'];
-        for (const prefix of prefixes) {
-            try {
-                return decodeCashAddressWithPrefix(prefix + ':' + address);
-            } catch {
-                /* ignore */
-            }
+    }
+
+    const prefixes = ['bitcoincash', 'bchtest', 'bchreg'];
+    for (const prefix of prefixes) {
+        try {
+            return decodeCashAddressWithPrefix(prefix + ':' + address);
+        } catch {
+            /* ignore */
         }
     }
     throw new Error('Invalid cashaddr address');

--- a/packages/utxo-lib/src/bip32.ts
+++ b/packages/utxo-lib/src/bip32.ts
@@ -317,7 +317,7 @@ class BIP32 implements BIP32Interface {
 
         return splitPath.reduce((prevHd, indexStr) => {
             let index;
-            if (indexStr.slice(-1) === `'`) {
+            if (indexStr.endsWith(`'`)) {
                 index = parseInt(indexStr.slice(0, -1), 10);
 
                 return prevHd.deriveHardened(index);

--- a/packages/utxo-lib/src/derivation.ts
+++ b/packages/utxo-lib/src/derivation.ts
@@ -145,7 +145,7 @@ export const deriveAddresses = (
     const change = type === 'receive' ? 0 : 1;
     const changeNode = node.derive(change);
 
-    return Array.from(Array(count).keys())
+    return [...Array(count).keys()]
         .map(i => changeNode.derive(from + i).publicKey)
         .map(a => getAddress(a).address || throwError('Cannot convert pubkey to address'))
         .map((address, i) => ({

--- a/packages/utxo-lib/src/payments/embed.ts
+++ b/packages/utxo-lib/src/payments/embed.ts
@@ -47,15 +47,13 @@ export function p2data(a: Payment, opts?: PaymentOpts): Payment {
     });
 
     // extended validation
-    if (opts.validate) {
-        if (a.output) {
-            const chunks = bscript.decompile(a.output);
-            if (chunks![0] !== OPS.OP_RETURN) throw new TypeError('Output is invalid');
-            if (!chunks!.slice(1).every(v => isBuffer(v))) throw new TypeError('Output is invalid');
+    if (opts.validate && a.output) {
+        const chunks = bscript.decompile(a.output);
+        if (chunks![0] !== OPS.OP_RETURN) throw new TypeError('Output is invalid');
+        if (!chunks!.slice(1).every(v => isBuffer(v))) throw new TypeError('Output is invalid');
 
-            if (a.data && !stacksEqual(a.data, o.data as Buffer[]))
-                throw new TypeError('Data mismatch');
-        }
+        if (a.data && !stacksEqual(a.data, o.data as Buffer[]))
+            throw new TypeError('Data mismatch');
     }
 
     return Object.assign(o, a);

--- a/packages/utxo-lib/src/payments/p2tr.ts
+++ b/packages/utxo-lib/src/payments/p2tr.ts
@@ -38,12 +38,10 @@ function taggedHash(prefix: TaggedHashPrefix, data: Buffer): Buffer {
 }
 
 function tapTweakPubkey(pubkey: Buffer, tapTreeRoot?: Buffer) {
-    let tapTweak: Buffer;
-    if (tapTreeRoot) {
-        tapTweak = taggedHash('TapTweak', Buffer.concat([pubkey, tapTreeRoot]));
-    } else {
-        tapTweak = taggedHash('TapTweak', pubkey);
-    }
+    const tapTweak = taggedHash(
+        'TapTweak',
+        tapTreeRoot ? Buffer.concat([pubkey, tapTreeRoot]) : pubkey,
+    );
 
     const tweakedPubkey = ecc.pointAddScalar(
         Buffer.concat([EVEN_Y_COORD_PREFIX, pubkey]),

--- a/packages/utxo-lib/src/payments/p2wsh.ts
+++ b/packages/utxo-lib/src/payments/p2wsh.ts
@@ -21,11 +21,7 @@ function stacksEqual(a: Buffer[], b: Buffer[]): boolean {
 }
 
 function chunkHasUncompressedPubkey(chunk: StackElement): boolean {
-    if (Buffer.isBuffer(chunk) && chunk.length === 65 && chunk[0] === 0x04 && ecc.isPoint(chunk)) {
-        return true;
-    }
-
-    return false;
+    return Buffer.isBuffer(chunk) && chunk.length === 65 && chunk[0] === 0x04 && ecc.isPoint(chunk);
 }
 
 // input: <>

--- a/scripts/ci/pack-packages.ts
+++ b/scripts/ci/pack-packages.ts
@@ -81,7 +81,7 @@ const validatePackagePublishTargets = async (pkg: string) => {
         return !builtFilesRelative.some(file => matcher.test(file));
     });
 
-    return Array.from(new Set(missingTargets)).sort();
+    return [...new Set(missingTargets)].sort();
 };
 
 const validatePublishTargets = async (packages: string[]) => {

--- a/suite-common/bluetooth/src/bluetoothReducer.ts
+++ b/suite-common/bluetooth/src/bluetoothReducer.ts
@@ -112,12 +112,12 @@ export const prepareBluetoothReducerCreator = <T extends BluetoothDeviceCommon>(
                 state.scanStatus = status;
             })
             .addCase(deviceActions.deviceDisconnect, (state, { payload: { descriptor } }) => {
-                if (descriptor.apiType === 'bluetooth' && descriptor.id !== undefined) {
-                    if (state.nearbyDevices !== null) {
-                        state.nearbyDevices = state.nearbyDevices.filter(
-                            it => it.id !== descriptor.id,
-                        );
-                    }
+                if (
+                    descriptor.apiType === 'bluetooth' &&
+                    descriptor.id !== undefined &&
+                    state.nearbyDevices !== null
+                ) {
+                    state.nearbyDevices = state.nearbyDevices.filter(it => it.id !== descriptor.id);
                 }
             })
             .addCase(bluetoothActions.enableAutoConnect, (state, { payload }) => {

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -213,13 +213,8 @@ export const connectInitThunk = createThunk<void, ConnectInitHooks | void, void>
                 firmwareChannel: getEffectiveFirmwareChannel(getState()),
             });
         } catch (error) {
-            let formattedError: string;
-            if (typeof error === 'string') {
-                formattedError = error;
-            } else {
-                formattedError = error.code ? `${error.code}: ${error.message}` : error.message;
-            }
-            throw new Error(formattedError);
+            if (typeof error === 'string') throw new Error(error);
+            throw new Error(error.code ? `${error.code}: ${error.message}` : error.message);
         }
     },
 );

--- a/suite-common/connect-popup/src/methodHooks/addressConfirmation.ts
+++ b/suite-common/connect-popup/src/methodHooks/addressConfirmation.ts
@@ -34,12 +34,12 @@ const preCallHook = <M extends CallMethodKeys>({ method, payload }: PreCallHookP
                     showOnTrezor: false,
                 })),
             };
-        } else {
-            return {
-                ...payload,
-                showOnTrezor: false,
-            };
         }
+
+        return {
+            ...payload,
+            showOnTrezor: false,
+        };
     }
 
     return payload;

--- a/suite-common/device/src/deviceReducer.ts
+++ b/suite-common/device/src/deviceReducer.ts
@@ -120,7 +120,7 @@ const merge = (
  * @returns
  */
 const connectDevice = (draft: DeviceReducerState, { state, ...device }: Device) => {
-    const currentTime = new Date().getTime();
+    const currentTime = Date.now();
 
     const deviceCommonFields = {
         connected: true,
@@ -399,7 +399,7 @@ const updateTimestamp = (draft: DeviceReducerState, device?: TrezorDevice) => {
     const index = deviceUtils.findInstanceIndex(draft.devices, device);
     if (!draft.devices[index]) return;
     // update timestamp
-    const currentTime = new Date().getTime();
+    const currentTime = Date.now();
     draft.devices[index].ts = currentTime;
     draft.devices[index].firstConnectedTimestamp =
         draft.devices[index].firstConnectedTimestamp ?? currentTime;
@@ -418,7 +418,7 @@ const createInstance = (draft: DeviceReducerState, device: TrezorDevice) => {
 
     const isPortfolioTrackerDevice = device.id === PORTFOLIO_TRACKER_DEVICE_ID;
 
-    const currentTime = new Date().getTime();
+    const currentTime = Date.now();
     const newDevice: TrezorDevice = {
         ...device,
         remember: true,

--- a/suite-common/device/src/usePinHook.ts
+++ b/suite-common/device/src/usePinHook.ts
@@ -13,7 +13,7 @@ export const usePin = (buttonRequests: ButtonRequest[], requestId?: string) => {
     const [pin, setPin] = useState('');
     const [submitted, setSubmitted] = useState(false);
 
-    const pinRequestType = buttonRequests[buttonRequests.length - 1];
+    const pinRequestType = buttonRequests.at(-1);
     const isSettingNewWipeCode =
         pinRequestType?.code && NEW_WIPE_CODE_REQUEST_TYPES.includes(pinRequestType?.code);
     const isSettingNewPin =

--- a/suite-common/fiat-services/src/blockbook.ts
+++ b/suite-common/fiat-services/src/blockbook.ts
@@ -61,7 +61,7 @@ const getMultiTickers = async (
 
     return (
         rates && {
-            ts: new Date().getTime(),
+            ts: Date.now(),
             symbol: ticker,
             tickers: rates.map((rate, i) => ({ ...rate, ts: timestamps[i] })),
         }

--- a/suite-common/fiat-services/src/blockbook.ts
+++ b/suite-common/fiat-services/src/blockbook.ts
@@ -69,7 +69,7 @@ const getMultiTickers = async (
 };
 
 const getLastWeekTimestamps = () =>
-    Array.from(Array(7).keys()).map(i => {
+    [...Array(7).keys()].map(i => {
         const date = new Date();
         date.setDate(date.getDate() - 7 + i);
 

--- a/suite-common/fiat-services/src/coingecko.ts
+++ b/suite-common/fiat-services/src/coingecko.ts
@@ -125,7 +125,7 @@ export const fetchCurrentFiatRates = async (
 
         if (rates) {
             return {
-                ts: new Date().getTime() / 1000,
+                ts: Date.now() / 1000,
                 rates: rates.market_data?.current_price,
             };
         }
@@ -198,7 +198,7 @@ export const getFiatRatesForTimestamps = async (
             return {
                 symbol: ticker.symbol,
                 tickers,
-                ts: new Date().getTime(),
+                ts: Date.now(),
             };
         }
     }
@@ -238,7 +238,7 @@ export const fetchLastWeekRates = async (
                 return {
                     symbol,
                     tickers,
-                    ts: new Date().getTime(),
+                    ts: Date.now(),
                 };
             }
         }

--- a/suite-common/fiat-services/src/coingecko.ts
+++ b/suite-common/fiat-services/src/coingecko.ts
@@ -114,7 +114,7 @@ export const fetchCurrentFiatRates = async (
     options?: FetchCurrentFiatRatesOptions,
 ) => {
     const coinUrls = buildCoinUrls(ticker);
-    if (!coinUrls || coinUrls.length === 0) return null;
+    if (!coinUrls?.length) return null;
 
     const urlParams =
         'tickers=false&market_data=true&community_data=false&developer_data=false&sparkline=false&localization=false';
@@ -174,7 +174,7 @@ export const getFiatRatesForTimestamps = async (
 ): Promise<HistoricalResponse | null> => {
     const coinUrls = buildCoinUrls(ticker); // Assuming this now returns an array of URLs
     const urlEndpoint = `market_chart/range`;
-    if (!coinUrls || coinUrls.length === 0) return null;
+    if (!coinUrls?.length) return null;
 
     // sort timestamps chronologically to get the minimum and maximum values
     const sortedTimestampsInSeconds = [...timestamps].sort((ts1, ts2) => ts1 - ts2);
@@ -222,7 +222,7 @@ export const fetchLastWeekRates = async (
     const urlEndpoint = `market_chart`;
     const urlParams = `vs_currency=${fiatCurrencyCode}&days=7`;
     const coinUrls = buildCoinUrls(ticker);
-    if (!coinUrls || coinUrls.length === 0) return null;
+    if (!coinUrls?.length) return null;
 
     const { symbol } = ticker;
 

--- a/suite-common/fiat-services/src/coingecko.ts
+++ b/suite-common/fiat-services/src/coingecko.ts
@@ -25,12 +25,9 @@ const rateLimiter = new RateLimiter(1_000, 15_000);
 
 const fetchCoinGecko = async (url: string, skipCache?: boolean) => {
     try {
-        let res: Response;
-        if (skipCache) {
-            res = await fetchUrl(url, { headers: { 'X-Bypass-Cache': '1' } });
-        } else {
-            res = await rateLimiter.limit(signal => fetchUrl(url, { signal }));
-        }
+        const res = skipCache
+            ? await fetchUrl(url, { headers: { 'X-Bypass-Cache': '1' } })
+            : await rateLimiter.limit(signal => fetchUrl(url, { signal }));
         if (!res.ok) {
             console.warn(`Coingecko: Fiat rates failed to fetch: ${res.status}`);
 

--- a/suite-common/fiat-services/src/rates.ts
+++ b/suite-common/fiat-services/src/rates.ts
@@ -240,7 +240,7 @@ export const getFiatRatesForTimestamps = (
                     );
 
                     return {
-                        ts: new Date().getTime(),
+                        ts: Date.now(),
                         symbol: ticker.symbol,
                         tickers: validTickers,
                     };

--- a/suite-common/firmware/src/firmwareThunks.ts
+++ b/suite-common/firmware/src/firmwareThunks.ts
@@ -124,40 +124,34 @@ export const firmwareUpdate = createThunk<
                 error: firmwareUpdateResponse.error.message,
                 connectResponse: firmwareUpdateResponse,
             });
-        } else {
-            const {
-                versionCheck,
-                bootloaderVersion,
-                binaryVersion,
-                installedVersion,
-                releaseVersion,
-            } = firmwareUpdateResponse.payload;
+        }
+        const { versionCheck, bootloaderVersion, binaryVersion, installedVersion, releaseVersion } =
+            firmwareUpdateResponse.payload;
 
-            dispatch(firmwareActions.setStatus('done'));
+        dispatch(firmwareActions.setStatus('done'));
 
-            // TODO: Add to the if-else block above and add handle in UI.
-            if (!binary && !versionCheck) {
-                reportSecurityCheck({
-                    level: 'error',
-                    checkType: 'Firmware version',
-                    contextData: {
-                        model: device.features?.internal_model,
-                        revision: device.features?.revision,
-                        vendor: device.features?.fw_vendor,
-                        bootloaderVersion,
-                        binaryVersion,
-                        installedVersion,
-                        releaseVersion,
-                        error: 'Unexpected firmware version change during firmware update.',
-                    },
-                });
-            }
-
-            return fulfillWithValue({
-                device,
-                ...targetProperties,
-                connectResponse: firmwareUpdateResponse,
+        // TODO: Add to the if-else block above and add handle in UI.
+        if (!binary && !versionCheck) {
+            reportSecurityCheck({
+                level: 'error',
+                checkType: 'Firmware version',
+                contextData: {
+                    model: device.features?.internal_model,
+                    revision: device.features?.revision,
+                    vendor: device.features?.fw_vendor,
+                    bootloaderVersion,
+                    binaryVersion,
+                    installedVersion,
+                    releaseVersion,
+                    error: 'Unexpected firmware version change during firmware update.',
+                },
             });
         }
+
+        return fulfillWithValue({
+            device,
+            ...targetProperties,
+            connectResponse: firmwareUpdateResponse,
+        });
     },
 );

--- a/suite-common/icons/scripts/downloadCryptoIcons.ts
+++ b/suite-common/icons/scripts/downloadCryptoIcons.ts
@@ -136,7 +136,7 @@ async function ensureDirectoryExists(path: string) {
     const updatedIcons = (await getUpdatedIconsList()) ?? {};
 
     const coins = await getCoinList();
-    if (!coins || coins.length === 0) {
+    if (!coins?.length) {
         throw new Error('No coins found');
     }
 

--- a/suite-common/toast-notifications/src/notificationsActions.ts
+++ b/suite-common/toast-notifications/src/notificationsActions.ts
@@ -34,7 +34,7 @@ const remove = createAction(
 // Shared function to transform payload to NotificationEntry
 const toastPayloadTransform = (payload: ToastPayload): NotificationEntry => ({
     context: 'toast' as const,
-    id: new Date().getTime(),
+    id: Date.now(),
     seen: true,
     ...payload,
 });
@@ -64,7 +64,7 @@ export const addEvent = createAction(
     (payload: NotificationEventPayload): AddNotificationAction => ({
         payload: {
             context: 'event',
-            id: new Date().getTime(),
+            id: Date.now(),
             ...payload,
         },
     }),

--- a/suite-common/trading/src/thunks/common/__tests__/loadInitialDataThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/loadInitialDataThunk.test.ts
@@ -91,7 +91,7 @@ const testUpdatedInfoData = async (type: 'outdated' | 'account-changed') => {
     const getCurrentAccountDescriptorMock = jest.spyOn(invityAPI, 'getCurrentAccountDescriptor');
     const setInvityServersEnvironmentMock = jest.spyOn(invityAPI, 'setInvityServersEnvironment');
 
-    const mockedLastLoadedTimestamp = new Date().getTime();
+    const mockedLastLoadedTimestamp = Date.now();
     jest.spyOn(Date, 'now').mockImplementation(() => mockedLastLoadedTimestamp);
 
     const store = initStore({

--- a/suite-common/trading/src/utils.ts
+++ b/suite-common/trading/src/utils.ts
@@ -210,8 +210,7 @@ export const mapTestnetSymbol = (
     symbol: NetworkSymbol,
 ): Exclude<NetworkSymbol, 'test' | 'tsep' | 'thod' | 'txrp' | 'txlm'> => {
     if (symbol === 'test') return 'btc';
-    if (symbol === 'tsep') return 'eth';
-    if (symbol === 'thod') return 'eth';
+    if (symbol === 'tsep' || symbol === 'thod') return 'eth';
     if (symbol === 'txrp') return 'xrp';
     if (symbol === 'txlm') return 'xlm';
 

--- a/suite-common/wallet-core/src/accounts/accountsSelectors.ts
+++ b/suite-common/wallet-core/src/accounts/accountsSelectors.ts
@@ -345,8 +345,8 @@ export const selectAddressByNetworkAndPath = createMemoizedSelector(
                     .concat(account.addresses.change)
                     .find(a => a.path === path);
                 if (address) return address.address;
-            } else {
-                if (account.path === path) return account.descriptor;
+            } else if (account.path === path) {
+                return account.descriptor;
             }
         }
 

--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
@@ -199,9 +199,9 @@ export const unsubscribeBlockchainThunk = createThunk(
                     }));
 
                 return [...transformedRemovedAccounts, { symbol, blocks: true, accounts: [] }];
-            } else {
-                return [{ symbol, accounts: accountsToSubscribe, blocks: true }];
             }
+
+            return [{ symbol, accounts: accountsToSubscribe, blocks: true }];
         });
 
         return Promise.all(

--- a/suite-common/wallet-core/src/send/sendFormRippleStellarThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormRippleStellarThunks.ts
@@ -293,21 +293,18 @@ export const signRippleStellarSendFormTransactionThunk = createThunk<
                   }))(token.contract.split('-'))
                 : { type: StellarAssetType.NATIVE };
 
-            let operation: StellarOperation;
-            if (destinationActivated) {
-                operation = {
-                    type: 'payment',
-                    asset,
-                    amount: toStroops(formState.outputs[0].amount).toString(),
-                    destination: formState.outputs[0].address,
-                };
-            } else {
-                operation = {
-                    type: 'createAccount',
-                    startingBalance: toStroops(formState.outputs[0].amount).toString(),
-                    destination: formState.outputs[0].address,
-                };
-            }
+            const operation: StellarOperation = destinationActivated
+                ? {
+                      type: 'payment',
+                      asset,
+                      amount: toStroops(formState.outputs[0].amount).toString(),
+                      destination: formState.outputs[0].address,
+                  }
+                : {
+                      type: 'createAccount',
+                      startingBalance: toStroops(formState.outputs[0].amount).toString(),
+                      destination: formState.outputs[0].address,
+                  };
 
             const transaction = buildSendTransaction({
                 descriptor: selectedAccount.descriptor,

--- a/suite-common/wallet-core/src/send/sendFormSelectors.ts
+++ b/suite-common/wallet-core/src/send/sendFormSelectors.ts
@@ -96,5 +96,5 @@ export const selectSendFormReviewLastButtonCode = (
     const sendFormReviewRequest = selectSendFormButtonRequestCodes(state, symbol);
 
     // Return the last button request code from the filtered list
-    return sendFormReviewRequest[sendFormReviewRequest.length - 1] ?? null;
+    return sendFormReviewRequest.at(-1) ?? null;
 };

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -742,7 +742,7 @@ export const enhancePrecomposedTransactionThunk = createThunk<
                 formState: formValues,
                 precomposedTransaction: {
                     ...enhancedPrecomposedTransaction,
-                    createdTimestamp: new Date().getTime(),
+                    createdTimestamp: Date.now(),
                     isTokenKnown,
                 },
                 accountKey: selectedAccount.key,

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -498,18 +498,17 @@ export const pushSendFormRawTransactionThunk = createThunk(
             dispatch(syncAccountsWithBlockchainThunk(payload.symbol));
 
             return fulfillWithValue(true);
-        } else {
-            console.warn(sentTx.error.message);
-
-            dispatch(
-                notificationsActions.addToast({
-                    type: 'sign-tx-error',
-                    error: sentTx.error.message,
-                }),
-            );
-
-            return rejectWithValue(sentTx.error.message);
         }
+        console.warn(sentTx.error.message);
+
+        dispatch(
+            notificationsActions.addToast({
+                type: 'sign-tx-error',
+                error: sentTx.error.message,
+            }),
+        );
+
+        return rejectWithValue(sentTx.error.message);
     },
 );
 

--- a/suite-common/wallet-core/src/stake/stakeReducer.ts
+++ b/suite-common/wallet-core/src/stake/stakeReducer.ts
@@ -18,7 +18,7 @@ export const prepareStakeReducer = createReducerWithExtraDeps(stakeInitialState,
             if (action.payload) {
                 state.precomposedTx = {
                     ...action.payload.transactionInfo,
-                    createdTimestamp: new Date().getTime(),
+                    createdTimestamp: Date.now(),
                 };
                 // Deep-cloning to prevent buggy interaction between react-hook-form and immer, see https://github.com/orgs/react-hook-form/discussions/3715#discussioncomment-2151458
                 // Otherwise, whenever the outputs fieldArray is updated after the form draft or precomposedForm is saved, there is na error:

--- a/suite-common/wallet-core/src/token/stellarTokenThunks.ts
+++ b/suite-common/wallet-core/src/token/stellarTokenThunks.ts
@@ -116,30 +116,28 @@ const manageTrustline = async (
         },
     });
 
-    if (response.success) {
-        const signature = Buffer.from(response.payload.signature, 'hex').toString('base64');
-        transaction.addSignature(account.descriptor, signature);
-        const serializedTx = transaction.toEnvelope().toXDR('hex');
-
-        // Submit transaction to the network
-        const pushResponse = await TrezorConnect.pushTransaction({
-            tx: serializedTx,
-            coin: account.symbol,
-            identity: tryGetAccountIdentity(account),
-        });
-
-        if (pushResponse.success) {
-            return;
-        } else {
-            return rejectWithValue({
-                error: 'sign-transaction-failed',
-                message: pushResponse.error.message,
-            });
-        }
-    } else {
+    if (!response.success) {
         return rejectWithValue({
             error: 'sign-transaction-failed',
             message: response.error.message,
+        });
+    }
+
+    const signature = Buffer.from(response.payload.signature, 'hex').toString('base64');
+    transaction.addSignature(account.descriptor, signature);
+    const serializedTx = transaction.toEnvelope().toXDR('hex');
+
+    // Submit transaction to the network
+    const pushResponse = await TrezorConnect.pushTransaction({
+        tx: serializedTx,
+        coin: account.symbol,
+        identity: tryGetAccountIdentity(account),
+    });
+
+    if (!pushResponse.success) {
+        return rejectWithValue({
+            error: 'sign-transaction-failed',
+            message: pushResponse.error.message,
         });
     }
 };

--- a/suite-common/wallet-core/src/transactions/transactionsSelectors.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsSelectors.ts
@@ -327,7 +327,7 @@ export const selectAreAllAccountTransactionsLoadedFromNowUntilTimestamp = create
     ],
     (areAllTransactionsLoaded, transactions, timestamp) => {
         if (areAllTransactionsLoaded) return true;
-        const lastTransaction = transactions[transactions.length - 1];
+        const lastTransaction = transactions.at(-1);
 
         return lastTransaction?.blockTime && lastTransaction.blockTime < timestamp;
     },

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -100,7 +100,7 @@ export const replaceTransactionThunk = createThunk(
                     ...origTx.tx,
                     txid: newTxid,
                     fee: precomposedTransaction.fee,
-                    blockTime: Math.round(new Date().getTime() / 1000),
+                    blockTime: Math.round(Date.now() / 1000),
                     // TODO: details: {}, is it worth it?
                 };
 
@@ -413,7 +413,7 @@ export const addFakePendingCardanoTxThunk = createThunk(
         const fakeTx = {
             type: 'sent' as const,
             txid,
-            blockTime: Math.floor(new Date().getTime() / 1000),
+            blockTime: Math.floor(Date.now() / 1000),
             blockHash: undefined,
             // amounts (as most of props below) don't matter much since it is temp fake anyway
             amount: precomposedTransaction.totalSpent,

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -515,11 +515,10 @@ export const fetchTransactionsPageThunk = createThunk(
             dispatch(updateAction);
 
             return result.payload;
-        } else {
-            const error = result ? result.error.message : 'unknown error';
-
-            throw new Error(error);
         }
+        const error = result ? result.error.message : 'unknown error';
+
+        throw new Error(error);
     },
 );
 

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -1048,15 +1048,19 @@ export const isSameUtxo = (a: AccountUtxo, b: AccountUtxo) =>
  * Returns true if the network uses receive address instead of XPUB.
  */
 export const isAddressBasedNetwork = (networkType: NetworkType) => {
-    if (networkType === 'bitcoin') return false;
-    if (networkType === 'cardano') return false;
-    if (networkType === 'ethereum') return true;
-    if (networkType === 'tron') return true;
-    if (networkType === 'ripple') return true;
-    if (networkType === 'solana') return true;
-    if (networkType === 'stellar') return true;
-
-    return exhaustive(networkType);
+    switch (networkType) {
+        case 'bitcoin':
+        case 'cardano':
+            return false;
+        case 'ethereum':
+        case 'tron':
+        case 'ripple':
+        case 'solana':
+        case 'stellar':
+            return true;
+        default:
+            return exhaustive(networkType);
+    }
 };
 
 export const accountEqualTo = (a: Account) => (b: Account) =>

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -168,7 +168,6 @@ export const getAccountTypeName = ({ path, accountType, networkType }: getAccoun
             case 'legacy':
                 return 'TR_ACCOUNT_TYPE_LEGACY';
             case 'normal':
-                return 'TR_ACCOUNT_TYPE_DEFAULT';
             case 'placeholder':
                 return 'TR_ACCOUNT_TYPE_DEFAULT';
         }

--- a/suite-common/wallet-utils/src/cardanoStakingUtils.ts
+++ b/suite-common/wallet-utils/src/cardanoStakingUtils.ts
@@ -94,7 +94,7 @@ export const poolBech32ToHex = (poolId: string): string => {
 };
 
 export const selectBestCardanoPool = (pools?: AdaPools['pools']) => {
-    if (!pools || pools.length === 0) return CARDANO_EVERSTAKE_STAKING_POOL;
+    if (!pools?.length) return CARDANO_EVERSTAKE_STAKING_POOL;
 
     // find the one within the threshold
     const bestPool = pools.find(pool => pool.saturation < CARDANO_POOL_SATURATION_SAFE_THRESHOLD);

--- a/suite-common/wallet-utils/src/ethUtils.ts
+++ b/suite-common/wallet-utils/src/ethUtils.ts
@@ -21,14 +21,14 @@ export const hasEip1559MaxPriorityFee = (
 export const padLeftEven = (hex: string): string => (hex.length % 2 !== 0 ? `0${hex}` : hex);
 
 export const sanitizeHex = ($hex: string): string => {
-    const hex = $hex.toLowerCase().substring(0, 2) === '0x' ? $hex.substring(2) : $hex;
+    const hex = $hex.toLowerCase().startsWith('0x') ? $hex.substring(2) : $hex;
     if (hex === '') return '';
 
     return `0x${padLeftEven(hex)}`;
 };
 
 export const strip = (str: string): string => {
-    if (str.indexOf('0x') === 0) {
+    if (str.startsWith('0x')) {
         return padLeftEven(str.substring(2, str.length));
     }
 

--- a/suite-common/wallet-utils/src/ethereumStakingUtils.ts
+++ b/suite-common/wallet-utils/src/ethereumStakingUtils.ts
@@ -143,9 +143,5 @@ export const hasStakeInPendingDepositedState = (account: Account) => {
 
     const { pendingDepositedBalance, pendingBalance } = pool;
 
-    if (new BigNumber(pendingDepositedBalance).gt(0) && new BigNumber(pendingBalance).lte(0)) {
-        return true;
-    }
-
-    return false;
+    return new BigNumber(pendingDepositedBalance).gt(0) && new BigNumber(pendingBalance).lte(0);
 };

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.ts
@@ -235,13 +235,11 @@ const constructOldFlow = ({
 
     if (precomposedForm.tronDataAscii) {
         outputs.push({ type: 'note', value: precomposedForm.tronDataAscii });
-    } else {
-        if (
-            precomposedForm.transactionData &&
-            (!precomposedTx.token || precomposedForm.yieldMetadata)
-        ) {
-            outputs.push({ type: 'data', value: precomposedForm.transactionData });
-        }
+    } else if (
+        precomposedForm.transactionData &&
+        (!precomposedTx.token || precomposedForm.yieldMetadata)
+    ) {
+        outputs.push({ type: 'data', value: precomposedForm.transactionData });
     }
 
     // For bump fee we have to analyze tx data,
@@ -354,16 +352,14 @@ const constructNewFlow = ({
 
     if (precomposedForm.tronDataAscii) {
         outputs.push({ type: 'note', value: precomposedForm.tronDataAscii });
-    } else {
-        if (
-            (precomposedForm.transactionData && !precomposedTx.token && !isEvmApproval) ||
-            (precomposedForm.transactionData && isEvmApproval && !isApprovalFlowSupported) ||
-            (precomposedForm.transactionData &&
-                precomposedForm.yieldMetadata &&
-                !isUpdatedEthereumSendFlow)
-        ) {
-            outputs.push({ type: 'data', value: precomposedForm.transactionData });
-        }
+    } else if (
+        (precomposedForm.transactionData && !precomposedTx.token && !isEvmApproval) ||
+        (precomposedForm.transactionData && isEvmApproval && !isApprovalFlowSupported) ||
+        (precomposedForm.transactionData &&
+            precomposedForm.yieldMetadata &&
+            !isUpdatedEthereumSendFlow)
+    ) {
+        outputs.push({ type: 'data', value: precomposedForm.transactionData });
     }
 
     const isRbf = isRbfBumpFeeTransaction(precomposedTx);

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -857,7 +857,7 @@ const enhanceTokenTransfers = (
     tokenTransfers: AccountTransaction['tokens'],
     accountSymbol: Account['symbol'],
 ) => {
-    if (!tokenTransfers || tokenTransfers.length === 0) {
+    if (!tokenTransfers?.length) {
         return tokenTransfers;
     }
 

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -62,7 +62,7 @@ export const getAccountTransactions = (
 ) => transactions[accountKey] || [];
 
 export const isPending = (tx: WalletAccountTransaction | AccountTransaction) => {
-    if (tx && tx.solanaSpecific?.status === 'confirmed') {
+    if (tx?.solanaSpecific?.status === 'confirmed') {
         return false;
     }
 

--- a/suite-common/wallet-utils/src/validationUtils.ts
+++ b/suite-common/wallet-utils/src/validationUtils.ts
@@ -114,9 +114,5 @@ export const checkIsAddressNotUsedNotChecksummed = (
         return false;
     }
 
-    if (!hasHistory && address === address.toLowerCase()) {
-        return true;
-    }
-
-    return false;
+    return address === address.toLowerCase();
 };

--- a/suite-common/wallet-utils/src/validationUtils.ts
+++ b/suite-common/wallet-utils/src/validationUtils.ts
@@ -84,7 +84,7 @@ export const isInteger = (value: string) =>
 
 export const isHexValid = (value: string, prefix?: string) => {
     // ethereum data/signedTx may start with prefix
-    if (prefix && value.indexOf(prefix) === 0) {
+    if (prefix && value.startsWith(prefix)) {
         const hex = value.substring(prefix.length, value.length);
         // pad left even, is it necessary in ETH?
         // TODO: investigate

--- a/suite-native/app/src/devtools/InitRoseniteDevTools.tsx
+++ b/suite-native/app/src/devtools/InitRoseniteDevTools.tsx
@@ -25,7 +25,5 @@ export const InitRosenitePlugin = memo(() => {
         });
     }, [getMMKVStorage]);
 
-    return Boolean(mmkvStorage) && mmkvStorage ? (
-        <InitRosenitePluginInternal mmkvStorage={mmkvStorage} />
-    ) : null;
+    return mmkvStorage ? <InitRosenitePluginInternal mmkvStorage={mmkvStorage} /> : null;
 });

--- a/suite-native/assets/src/assetsSelectors.ts
+++ b/suite-native/assets/src/assetsSelectors.ts
@@ -142,8 +142,7 @@ const selectDeviceAssetsWithBalances = createMemoizedSelector(
             const fiatBalance = networkAccounts.reduce<BigNumber | null>((sum, { fiatValue }) => {
                 // If any account has null fiat data, set the network fiat to null.
                 // This prevents showing partial/incomplete values to users - we show loading state until all data is available.
-                if (sum === null) return null;
-                if (fiatValue == null) return null;
+                if (sum === null || fiatValue == null) return null;
 
                 return sum.plus(fiatValue);
             }, new BigNumber(0));

--- a/suite-native/atoms/src/Card/CompactCardWithIconLayout.tsx
+++ b/suite-native/atoms/src/Card/CompactCardWithIconLayout.tsx
@@ -88,7 +88,7 @@ export const CompactCardWithIconLayout = ({
                     borderColor={borderColor ?? undefined}
                     animatedStyle={animatedStyle}
                     // Android shadow does not work well with the Reanimated opacity animation.
-                    noShadow={Platform.OS === 'android' ? true : noShadow}
+                    noShadow={Platform.OS === 'android' || noShadow}
                     {...cardProps}
                 >
                     <HStack

--- a/suite-native/device/src/hooks/useWipeDevice.tsx
+++ b/suite-native/device/src/hooks/useWipeDevice.tsx
@@ -54,10 +54,8 @@ export const useWipeDevice = () => {
             navigation.navigate(DeviceSettingsStackRoutes.WipeDeviceStack, {
                 screen: WipeDeviceStackRoutes.WipeDeviceLoadingScreen,
             });
-        } else {
-            if (navigation.canGoBack()) {
-                navigation.goBack();
-            }
+        } else if (navigation.canGoBack()) {
+            navigation.goBack();
         }
     };
 

--- a/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
@@ -199,20 +199,18 @@ deviceConnectionMiddleware.startListening({
                 screen: DeviceOnboardingStackRoutes.DeviceDisconnected,
                 params: { wasDeviceConnectedViaBluetooth },
             });
-        } else {
-            if (!checkIsHomeStackFocused()) {
-                navigationContainerRef.reset({
-                    index: 0,
-                    routes: [
-                        {
-                            name: RootStackRoutes.AppTabs,
-                            params: {
-                                screen: HomeStackRoutes.Home,
-                            },
+        } else if (!checkIsHomeStackFocused()) {
+            navigationContainerRef.reset({
+                index: 0,
+                routes: [
+                    {
+                        name: RootStackRoutes.AppTabs,
+                        params: {
+                            screen: HomeStackRoutes.Home,
                         },
-                    ],
-                });
-            }
+                    },
+                ],
+            });
         }
     },
 });

--- a/suite-native/firmware/src/components/FirmwareVersionCard.tsx
+++ b/suite-native/firmware/src/components/FirmwareVersionCard.tsx
@@ -65,17 +65,18 @@ export const FirmwareVersionCard = ({ isUpdateRequired, children }: FirmwareVers
                 variant: 'critical',
                 children: <Translation id="firmware.versionCard.status.updateRequired" />,
             };
-        } else if (isFirmwareUpgradable) {
+        }
+        if (isFirmwareUpgradable) {
             return {
                 variant: 'info',
                 children: <Translation id="firmware.versionCard.status.updateAvailable" />,
             };
-        } else {
-            return {
-                variant: 'success',
-                children: <Translation id="firmware.versionCard.status.upToDate" />,
-            };
         }
+
+        return {
+            variant: 'success',
+            children: <Translation id="firmware.versionCard.status.upToDate" />,
+        };
     })();
     const firmwareType = isBtcOnly ? 'firmware.typeBitcoinOnly' : 'firmware.typeUniversal';
 

--- a/suite-native/graph/src/hooks.ts
+++ b/suite-native/graph/src/hooks.ts
@@ -218,7 +218,7 @@ export const useGraphAtoms = <TGraphPoint extends FiatGraphPoint>({
     const setSelectedPoint = useSetAtom(selectedPointAtom);
     const setReferencePoint = useSetAtom(referencePointAtom);
 
-    const lastPoint: TGraphPoint | undefined = graphPoints[graphPoints.length - 1];
+    const lastPoint: TGraphPoint | undefined = graphPoints.at(-1);
     const referencePoint: TGraphPoint | undefined = useMemo(
         () => graphPoints.find(point => point.value > 0) ?? graphPoints[0],
         [graphPoints],

--- a/suite-native/module-accounts-import/src/accountsImportThunks.ts
+++ b/suite-native/module-accounts-import/src/accountsImportThunks.ts
@@ -162,9 +162,9 @@ export const getAccountInfoThunk = createThunk<
                 );
 
                 return fetchedAccountInfo.payload;
-            } else {
-                return rejectWithValue(fetchedAccountInfo.error.message);
             }
+
+            return rejectWithValue(fetchedAccountInfo.error.message);
         } catch (error) {
             return rejectWithValue(error?.message);
         }

--- a/suite-native/module-earn/src/components/InstantlyAvailableRow.tsx
+++ b/suite-native/module-earn/src/components/InstantlyAvailableRow.tsx
@@ -24,9 +24,8 @@ export const InstantlyAvailableRow = ({
         selectAccountByKey(state, accountKey),
     );
 
-    if (!account) return null;
-    if (approximatedAmount === null) return null;
-    if (new BigNumber(approximatedAmount).lte(0)) return null;
+    if (!account || approximatedAmount === null || new BigNumber(approximatedAmount).lte(0))
+        return null;
 
     const showInfoAlert = () =>
         showAlert({

--- a/suite-native/module-trading/src/hooks/general/__tests__/useTransactionStateChangeAnalyticsReporting.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useTransactionStateChangeAnalyticsReporting.test.ts
@@ -45,7 +45,7 @@ describe('useTransactionStateChangeAnalyticsReporting', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
-        if (reportMock) reportMock.mockClear();
+        reportMock?.mockClear();
     });
 
     afterEach(() => {

--- a/suite-native/react-native-graph/src/AnimatedLineGraph.tsx
+++ b/suite-native/react-native-graph/src/AnimatedLineGraph.tsx
@@ -174,7 +174,7 @@ export function AnimatedLineGraph<TEventPayload extends object>({
     const drawingWidth = useMemo(() => width - 2 * horizontalPadding, [horizontalPadding, width]);
 
     const lineWidth = useMemo(() => {
-        const lastPoint = pointsInRange[pointsInRange.length - 1];
+        const lastPoint = pointsInRange.at(-1);
 
         if (lastPoint == null) return drawingWidth;
 
@@ -357,7 +357,7 @@ export function AnimatedLineGraph<TEventPayload extends object>({
         (fingerX: number) => {
             const fingerXInRange = Math.max(fingerX - horizontalPadding, 0);
 
-            const lastDate = pointsInRange[pointsInRange.length - 1]?.date;
+            const lastDate = pointsInRange.at(-1)?.date;
 
             if (!lastDate) return;
 

--- a/suite-native/react-native-graph/src/CreateGraphPath.ts
+++ b/suite-native/react-native-graph/src/CreateGraphPath.ts
@@ -46,7 +46,7 @@ type GraphPathConfigWithoutGradient = GraphPathConfig & {
 
 export function getGraphPathRange(points: GraphPoint[], range?: GraphRange): GraphPathRange {
     const minValueX = range?.x?.min ?? points[0]?.date ?? new Date();
-    const maxValueX = range?.x?.max ?? points[points.length - 1]?.date ?? new Date();
+    const maxValueX = range?.x?.max ?? points.at(-1)?.date ?? new Date();
 
     const minValueY =
         range?.y?.min ??

--- a/suite-native/toasts/src/toastsAtoms.ts
+++ b/suite-native/toasts/src/toastsAtoms.ts
@@ -22,7 +22,7 @@ export const addToastAtom = atom(null, (get, set, addedToast: ToastWithoutId) =>
     const toasts = get(toastsAtom);
 
     if (A.all(toasts, ({ message }) => message !== addedToast.message)) {
-        toasts.push({ ...addedToast, id: new Date().getTime() });
+        toasts.push({ ...addedToast, id: Date.now() });
     }
 
     set(toastsAtom, [...toasts]);

--- a/suite-native/trading-atoms/src/hooks/useSectionList.tsx
+++ b/suite-native/trading-atoms/src/hooks/useSectionList.tsx
@@ -118,7 +118,7 @@ const transformToInternalFlatListData = <T, U = undefined>({
                         isFirst: index === 0,
                         isLast: index === data.length - 1 && isLastItemRounded,
                         sectionData,
-                        isEnabled: item.isEnabled !== undefined ? item.isEnabled : true,
+                        isEnabled: item.isEnabled ?? true,
                     },
                 }),
             );

--- a/suite-native/trading-browser-auth/src/components/ProviderConfirmationStatusInfo.tsx
+++ b/suite-native/trading-browser-auth/src/components/ProviderConfirmationStatusInfo.tsx
@@ -42,12 +42,11 @@ export const ProviderConfirmationStatusInfo = () => {
             }, RESOLVE_ANIMATION_DURATION_MS);
 
             return () => clearTimeout(timeout);
-        } else {
-            setLoadingState('idle');
-            setDisplayStatus(status);
-
-            return () => {};
         }
+        setLoadingState('idle');
+        setDisplayStatus(status);
+
+        return () => {};
     }, [displayStatus, status]);
 
     if (NOT_VISIBLE_STATUSES.includes(displayStatus)) {

--- a/suite-native/transaction-management/src/addTransactionLabelingThunk.ts
+++ b/suite-native/transaction-management/src/addTransactionLabelingThunk.ts
@@ -53,7 +53,7 @@ export const addTransactionLabelingThunk = createThunk<
                     // final ordering of outputs differs from order in send form
                     // outputsPermutation contains mapping from @trezor/utxo-lib outputs to send form outputs
                     // mapping goes like this: Array<@trezor/utxo-lib index : send form index>
-                    const outputIndex = outputsPermutation.findIndex(p => p === index);
+                    const outputIndex = outputsPermutation.indexOf(index);
 
                     acc.push({
                         // Todo: this works only for bitcoin-like networks where txTargetId is the outputIndex (number)

--- a/suite-native/transaction-management/src/hooks/fees/useFeeSelection.ts
+++ b/suite-native/transaction-management/src/hooks/fees/useFeeSelection.ts
@@ -44,26 +44,24 @@ export const useFeeSelection = ({
                 payload: { value: feeLevel },
             });
 
-            let thunkParams: UpdateSelectedFeeLevelThunkParams;
-            if (feeLevel === 'custom') {
-                thunkParams = {
-                    accountKey,
-                    tokenContract,
-                    feeLevelLabel: 'custom',
-                    feePerUnit: customFeePerUnit!,
-                    feeLimit: customFeeLimit,
-                    maxFeePerGas: customMaxFeePerGas,
-                    maxPriorityFeePerGas: customMaxPriorityFeePerGas,
-                    formDraftKey,
-                };
-            } else {
-                thunkParams = {
-                    accountKey,
-                    tokenContract,
-                    feeLevelLabel: feeLevel,
-                    formDraftKey,
-                };
-            }
+            const thunkParams: UpdateSelectedFeeLevelThunkParams =
+                feeLevel === 'custom'
+                    ? {
+                          accountKey,
+                          tokenContract,
+                          feeLevelLabel: 'custom',
+                          feePerUnit: customFeePerUnit!,
+                          feeLimit: customFeeLimit,
+                          maxFeePerGas: customMaxFeePerGas,
+                          maxPriorityFeePerGas: customMaxPriorityFeePerGas,
+                          formDraftKey,
+                      }
+                    : {
+                          accountKey,
+                          tokenContract,
+                          feeLevelLabel: feeLevel,
+                          formDraftKey,
+                      };
 
             dispatch(updateThunk(thunkParams));
         },

--- a/suite/backup/src/backupReducer.ts
+++ b/suite/backup/src/backupReducer.ts
@@ -23,10 +23,7 @@ export const backupSlice = createSlice({
 
                 return;
             }
-            state.userConfirmed.splice(
-                state.userConfirmed.findIndex(r => r === payload),
-                1,
-            );
+            state.userConfirmed.splice(state.userConfirmed.indexOf(payload), 1);
         },
         setInProgress: (state, { payload }: PayloadAction<boolean>) => {
             state.inProgress = payload;

--- a/suite/device/src/useDevice.ts
+++ b/suite/device/src/useDevice.ts
@@ -15,12 +15,8 @@ export const useDevice = (): Result => {
     const isDeviceOrUiLocked = useSelector(selectIsDeviceOrUiLocked);
 
     const isLocked = useCallback(
-        (ignoreDisconnectedDevice = false) => {
-            if (!device?.connected && !ignoreDisconnectedDevice) return true;
-            if (isDeviceOrUiLocked) return true;
-
-            return false;
-        },
+        (ignoreDisconnectedDevice = false) =>
+            (!device?.connected && !ignoreDisconnectedDevice) || isDeviceOrUiLocked,
         [device, isDeviceOrUiLocked],
     );
 

--- a/suite/e2e/support/mocks/ada-endpoints.ts
+++ b/suite/e2e/support/mocks/ada-endpoints.ts
@@ -66,13 +66,9 @@ export const fixtures = [
     {
         method: 'GET_ACCOUNT_INFO',
         default: true,
-        response: ({ params }: any) => {
-            if (isFirstAccount(params.descriptor)) {
-                return { data: ADA_MOCKED_ACCOUNT };
-            } else {
-                return { data: ADA_MOCKED_EMPTY_ACCOUNT };
-            }
-        },
+        response: ({ params }: any) => ({
+            data: isFirstAccount(params.descriptor) ? ADA_MOCKED_ACCOUNT : ADA_MOCKED_EMPTY_ACCOUNT,
+        }),
     },
     {
         method: 'GET_ACCOUNT_UTXO',

--- a/suite/firmware-upgrade/src/firmwareUtils.ts
+++ b/suite/firmware-upgrade/src/firmwareUtils.ts
@@ -38,11 +38,11 @@ const FORMAT_MAP: { [format in FirmwareFormat]: DeviceModelInternal[] } = {
 
 export const parseFirmwareFormat = (fw: ArrayBuffer): FirmwareFormat | undefined => {
     const firmwareView = new Uint8Array(fw);
-    const header = String.fromCharCode(...Array.from(firmwareView.slice(0, 4)));
+    const header = String.fromCharCode(...firmwareView.slice(0, 4));
 
     switch (header) {
         case 'TRZR': {
-            const headerEmbedded = String.fromCharCode(...Array.from(firmwareView.slice(256, 260)));
+            const headerEmbedded = String.fromCharCode(...firmwareView.slice(256, 260));
 
             return headerEmbedded === 'TRZF' ? FirmwareFormat.T1_EMBEDDED_V2 : FirmwareFormat.T1;
         }

--- a/suite/firmware-upgrade/src/useFirmwareDesktopUpdate.ts
+++ b/suite/firmware-upgrade/src/useFirmwareDesktopUpdate.ts
@@ -32,7 +32,7 @@ export const useFirmwareDesktopUpdate = () => {
             firmware.uiEvent?.type === UI_REQUEST.FIRMWARE_PROGRESS &&
             firmware.uiEvent.payload.operation === 'start-flashing'
         ) {
-            setStartTime(new Date().getTime());
+            setStartTime(Date.now());
         }
     }, [firmware.uiEvent, startTime]);
 
@@ -42,7 +42,7 @@ export const useFirmwareDesktopUpdate = () => {
         }
 
         const interval = setInterval(() => {
-            const now = new Date().getTime();
+            const now = Date.now();
 
             if (now - startTime > TIME_THRESHOLD_SLOW_INSTALLATION_MS) {
                 if (

--- a/suite/labeling/src/Labeling.tsx
+++ b/suite/labeling/src/Labeling.tsx
@@ -106,23 +106,22 @@ export const Labeling = ({
                     }
 
                     return result.success;
-                } else {
-                    setShowEnableSuiteSyncModal(true);
-
-                    return new Promise<boolean>(resolve => {
-                        suiteSyncTurnOnEditResolveRef.current = resolve;
-                    });
                 }
-            } else {
-                return await dispatch(
-                    metadataLabelingActions.init(
-                        // Provide force=true argument (user wants to enable metadata).
-                        true,
-                        // If this is wallet(device) label, provide unique identifier entityKey which equals to device.state.
-                        deviceState,
-                    ),
-                );
+                setShowEnableSuiteSyncModal(true);
+
+                return new Promise<boolean>(resolve => {
+                    suiteSyncTurnOnEditResolveRef.current = resolve;
+                });
             }
+
+            return await dispatch(
+                metadataLabelingActions.init(
+                    // Provide force=true argument (user wants to enable metadata).
+                    true,
+                    // If this is wallet(device) label, provide unique identifier entityKey which equals to device.state.
+                    deviceState,
+                ),
+            );
         }
 
         return true;
@@ -167,11 +166,11 @@ export const Labeling = ({
                 }
 
                 return true;
-            } else {
-                return await dispatch(
-                    metadataLabelingActions.addMetadata({ ...payload, value: value || undefined }),
-                );
             }
+
+            return await dispatch(
+                metadataLabelingActions.addMetadata({ ...payload, value: value || undefined }),
+            );
         },
         [deviceStaticSessionId, dispatch, isSuiteSyncEnabled, payload],
     );

--- a/suite/metadata/src/__tests__/metadataActions.test.ts
+++ b/suite/metadata/src/__tests__/metadataActions.test.ts
@@ -53,7 +53,7 @@ interface InitialState {
 }
 
 const getInitialState = (state?: InitialState) => {
-    const metadata = state ? state.metadata : undefined;
+    const metadata = state?.metadata;
     const suite = state ? state.suite : {};
     const suiteSettings = state?.suiteSettings ?? {};
 

--- a/suite/metadata/src/metadataPasswordsActions.ts
+++ b/suite/metadata/src/metadataPasswordsActions.ts
@@ -218,26 +218,26 @@ export const addPasswordMetadata =
             cloneObject(provider.data[fileName]) ||
             METADATA_PASSWORDS.DEFAULT_PASSWORD_MANAGER_STATE;
 
-        if ('config' in metadata) {
-            metadata.entries[nextId] = payload;
-
-            dispatch(
-                metadataDataThunks.setMetadata({
-                    provider,
-                    fileName,
-                    data: metadata,
-                }),
-            );
-
-            metadataDataThunks.encryptAndSaveMetadata({
-                providerInstance,
-                fileName,
-                data: metadata,
-                aesKey,
-            });
-        } else {
+        if (!('config' in metadata)) {
             return Promise.resolve({ success: false, error: 'trying to edit wrong object' });
         }
+
+        metadata.entries[nextId] = payload;
+
+        dispatch(
+            metadataDataThunks.setMetadata({
+                provider,
+                fileName,
+                data: metadata,
+            }),
+        );
+
+        metadataDataThunks.encryptAndSaveMetadata({
+            providerInstance,
+            fileName,
+            data: metadata,
+            aesKey,
+        });
     };
 
 export const removePasswordMetadata =
@@ -259,24 +259,24 @@ export const removePasswordMetadata =
 
         const metadata = cloneObject(provider.data[fileName]);
 
-        if (metadata && 'config' in metadata) {
-            delete metadata.entries[index];
-
-            dispatch(
-                metadataDataThunks.setMetadata({
-                    provider,
-                    fileName,
-                    data: metadata,
-                }),
-            );
-
-            metadataDataThunks.encryptAndSaveMetadata({
-                providerInstance,
-                fileName,
-                data: metadata,
-                aesKey,
-            });
-        } else {
+        if (!metadata || !('config' in metadata)) {
             return Promise.resolve({ success: false, error: 'trying to edit wrong object' });
         }
+
+        delete metadata.entries[index];
+
+        dispatch(
+            metadataDataThunks.setMetadata({
+                provider,
+                fileName,
+                data: metadata,
+            }),
+        );
+
+        metadataDataThunks.encryptAndSaveMetadata({
+            providerInstance,
+            fileName,
+            data: metadata,
+            aesKey,
+        });
     };

--- a/suite/router/src/router.ts
+++ b/suite/router/src/router.ts
@@ -32,7 +32,7 @@ export type RouterPath = {
 export const getPrefixedURL = (url: string) => {
     // do not use object destructuring https://github.com/webpack/webpack/issues/5392
     const prefix = process.env.ASSET_PREFIX;
-    if (prefix && url.indexOf(prefix) !== 0) return prefix + url;
+    if (prefix && !url.startsWith(prefix)) return prefix + url;
 
     return url;
 };
@@ -40,7 +40,7 @@ export const getPrefixedURL = (url: string) => {
 export const stripPrefixedURL = (url: string) => {
     // do not use object destructuring https://github.com/webpack/webpack/issues/5392
     const prefix = process.env.ASSET_PREFIX;
-    if (typeof prefix === 'string' && url.indexOf(prefix) === 0) {
+    if (typeof prefix === 'string' && url.startsWith(prefix)) {
         url = url.slice(prefix.length);
     }
 

--- a/suite/router/src/router.ts
+++ b/suite/router/src/router.ts
@@ -143,7 +143,7 @@ const modalAppParamsDefaultValues: ModalAppParams = {
 
 const validateModalAppParams = (hash: HashString, params?: Route['params']): ModalAppParams => {
     const splitted = parseHash(hash);
-    if (!splitted || splitted.length === 0) return modalAppParamsDefaultValues;
+    if (!splitted?.length) return modalAppParamsDefaultValues;
 
     return {
         ...modalAppParamsDefaultValues,


### PR DESCRIPTION
## Summary

A series of small, behavior-preserving simplifications across `packages/`, `suite/`, `suite-common/` and `suite-native/`. Each commit targets one rewrite pattern so it can be reviewed in isolation.

Net diff: **286 files changed, 889 insertions(+), 1103 deletions(-)** — all dead/redundant code or noisier-than-needed expressions.

> **Reviewing this as a whole is heavy.** The strongest, lowest-risk patterns have been split out into standalone draft PRs for easier review.

### Split-out PRs

GitHub auto-renders the status icon (draft / open / merged / closed) next to each reference below — no manual updates needed.

Merged into `develop` (rebased away from this branch):

- [x] #27475
- [x] #27476
- [x] #27477
- [x] #27478
- [x] #27505
- [x] #27507
- [x] #27508
- [x] #27509

Closed without merge — patterns remain in this PR:

- [ ] #27504
- [ ] #27506

Open for review:

- [ ] #27950

### Linting possibility analysis

For each commit kept on this branch I noted whether the pattern is enforceable by an existing ESLint rule. Patterns that landed via split-out PRs above are not repeated here.

| Commit | ESLint enforceable? | Candidate rule / note | Bug-catching value |
|---|---|---|---|
| [`refactor: remove dead re-export and duplicate switch return`](https://github.com/trezor/trezor-suite/commit/88e141ac34a) | Mostly no | Better handled as dead-code/static-analysis cleanup, or a custom rule. | Low |
| [`refactor: shorten empty-array guards with optional chaining`](https://github.com/trezor/trezor-suite/commit/7f708b01786) | Yes | `@typescript-eslint/prefer-optional-chain` | Medium |
| [`refactor: reduce ternaries to logical operators`](https://github.com/trezor/trezor-suite/commit/ceb3e25dccd) | Partially | `no-unneeded-ternary` for the simpler cases. | Low |
| [`refactor: shorten null and undefined comparisons`](https://github.com/trezor/trezor-suite/commit/cee750992b1) | Mostly no | `x == null` / `x != null` preference would likely need a custom rule. | Low |
| [`refactor: replace redundant ternaries with logical OR`](https://github.com/trezor/trezor-suite/commit/b572b1f3c2d) | Partially | `no-unneeded-ternary` covers part of the change set. | Low |
| [`refactor: combine nested conditions`](https://github.com/trezor/trezor-suite/commit/caf3c20e925) | Mostly no | Collapsible nested `if` blocks are better suited to a custom rule. | Low |
| [`refactor: replace timestamp expressions with Date.now`](https://github.com/trezor/trezor-suite/commit/8bfe8b34df5) | Yes | `unicorn/prefer-date-now` | Low |
| [`refactor: use startsWith and endsWith helpers`](https://github.com/trezor/trezor-suite/commit/b20458aecfe) | Yes | `unicorn/prefer-string-starts-ends-with` | Medium |
| [`refactor: invert throw and return branches`](https://github.com/trezor/trezor-suite/commit/f7384dda1e3) | Mostly no | Better left as manual readability refactoring. | Low |
| [`refactor: replace equality callbacks with includes and indexOf`](https://github.com/trezor/trezor-suite/commit/e536fabae53) | Partially | `unicorn/prefer-includes` covers part of the change set. | Medium |
| [`refactor: replace boolean find checks with some`](https://github.com/trezor/trezor-suite/commit/a7038f8d3be) | Yes | `unicorn/prefer-array-some` | Medium |
| [`refactor: replace undefined ternaries with optional chaining`](https://github.com/trezor/trezor-suite/commit/e8a19e17d3d) | Yes | `@typescript-eslint/prefer-optional-chain` | Medium |
| [`refactor: use optional calls and Object.values`](https://github.com/trezor/trezor-suite/commit/739b2f2b992) | Partially | `@typescript-eslint/prefer-optional-chain` covers the optional-call part; `Object.entries -> Object.values` would be custom. | Medium |
| [`refactor: simplify timestamps and boolean filters`](https://github.com/trezor/trezor-suite/commit/e6b48fe868f) | Partially | `unicorn/prefer-date-now` covers the timestamp part; `.filter(Boolean)` would likely be custom. | Low |
| [`refactor: replace Array.from patterns with spread`](https://github.com/trezor/trezor-suite/commit/b43af2951c5) | Yes | `unicorn/prefer-spread` would cover most of these. | Low |
| [`refactor: use at for last-element access`](https://github.com/trezor/trezor-suite/commit/fa82b21d5aa) | Yes | `unicorn/prefer-at` | Medium |
| [`refactor: simplify optional field guards`](https://github.com/trezor/trezor-suite/commit/b9c11be1edf) | Yes | `@typescript-eslint/prefer-optional-chain` | Medium |
| [`refactor: simplify member access with optional chaining`](https://github.com/trezor/trezor-suite/commit/62580c759ac) | Yes | `@typescript-eslint/prefer-optional-chain` | Medium |

### Notes

- No behavior changes intended in any commit.
- Commits are kept granular (one pattern per commit) so review can happen pattern-by-pattern; reviewers can also skip directly to a category they care about.
- After a follow-up readability review, 13 commits with net-neutral or net-negative impact on readability were dropped from this branch — purely stylistic rewrites like `inline ternary arguments in calls`, `inline conditional/default assignments with ternaries`, `collapse guard returns into OR expressions`, `invert guard clauses to early returns`, `simplify string templates and slice calls`, `remove redundant boolean coercions in predicates`, `inline assign-then-return locals`, and similar.
- Earlier exploratory patterns also intentionally dropped as net-neutral or net-negative: `!arr || arr.length === 0` → `!arr?.length`, `cond ? false : X` → `!cond && X`, `X === null || X === undefined` → `X == null`, `x ? x : y` → `x || y`.

## Test plan

- [ ] CI: type-check, lint, unit tests
- [ ] Spot-check `suite-native` and `suite` runtime since several touched files are on the hot path

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/simplify-codebase/web/](https://dev.suite.sldev.cz/suite-web/mroz22/simplify-codebase/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/simplify-codebase&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

