### PR TITLE
refactor: replace indexOf comparisons with Array.includes

### DIFF
--- a/packages/blockchain-link-utils/src/blockbook.ts
+++ b/packages/blockchain-link-utils/src/blockbook.ts
@@ -60,16 +60,16 @@ export const filterTokenTransfers = (
         .filter(transfer => {
             if (transfer && typeof transfer === 'object') {
                 return (
-                    (transfer.from && all.indexOf(transfer.from) >= 0) ||
-                    (transfer.to && all.indexOf(transfer.to) >= 0)
+                    (transfer.from && all.includes(transfer.from)) ||
+                    (transfer.to && all.includes(transfer.to))
                 );
             }
 
             return false;
         })
         .map(transfer => {
-            const isIncoming = transfer.from && all.indexOf(transfer.from) >= 0;
-            const isOutgoing = transfer.to && all.indexOf(transfer.to) >= 0;
+            const isIncoming = transfer.from && all.includes(transfer.from);
+            const isOutgoing = transfer.to && all.includes(transfer.to);
 
             let type: TokenTransfer['type'];
             if (isIncoming && isOutgoing) {
@@ -208,7 +208,7 @@ export const transformTransaction = (
     const myInternalTransfers = filterEthereumInternalTransfers(descriptor, tx.ethereumSpecific);
 
     const isNonChangeOutput = (o: VinVout) =>
-        addresses ? filterTargets(addresses.change, tx.vout).indexOf(o) < 0 : true;
+        addresses ? !filterTargets(addresses.change, tx.vout).includes(o) : true;
 
     const isNonZero = (o: VinVout) => o.value && o.value !== '0';
 
@@ -365,7 +365,7 @@ export const transformAddresses = (
 
     if (addresses.length < 1) return undefined;
     const internal = addresses.filter(a => a.path.split('/')[4] === '1');
-    const external = addresses.filter(a => internal.indexOf(a) < 0);
+    const external = addresses.filter(a => !internal.includes(a));
 
     return {
         change: internal,

--- a/packages/blockchain-link-utils/src/blockfrost.ts
+++ b/packages/blockchain-link-utils/src/blockfrost.ts
@@ -268,7 +268,7 @@ export const transformTransaction = (
     ) {
         // all inputs and outputs are mine
         type = 'self';
-        targets = outputs.filter(o => internal.indexOf(o) < 0);
+        targets = outputs.filter(o => !internal.includes(o));
         // recalculate amount, amount spent is just a fee
         amount = blockfrostTxData.txData.fees;
 
@@ -298,7 +298,7 @@ export const transformTransaction = (
         }
     } else {
         type = 'sent';
-        targets = outputs.filter(o => internal.indexOf(o) < 0);
+        targets = outputs.filter(o => !internal.includes(o));
         // regular targets
         if (voutLength) {
             // bitcoin-like transaction

--- a/packages/blockchain-link/src/workers/ripple/index.ts
+++ b/packages/blockchain-link/src/workers/ripple/index.ts
@@ -301,7 +301,7 @@ const subscribeAccounts = async (ctx: Context, accounts: SubscriptionAccountInfo
     const { state } = ctx;
     const prevAddresses = state.getAddresses();
     state.addAccounts(accounts);
-    const uniqueAddresses = state.getAddresses().filter(a => prevAddresses.indexOf(a) < 0);
+    const uniqueAddresses = state.getAddresses().filter(a => !prevAddresses.includes(a));
     if (uniqueAddresses.length > 0) {
         if (!state.getSubscription('notification')) {
             api.on('transaction', ev => onTransaction(ctx, ev));
@@ -399,7 +399,7 @@ const unsubscribeAccounts = async (ctx: Context, accounts?: SubscriptionAccountI
     const prevAddresses = state.getAddresses();
     state.removeAccounts(accounts || state.getAccounts());
     const addresses = state.getAddresses();
-    const uniqueAddresses = prevAddresses.filter(a => addresses.indexOf(a) < 0);
+    const uniqueAddresses = prevAddresses.filter(a => !addresses.includes(a));
     await unsubscribeAddresses(ctx, uniqueAddresses);
 };
 

--- a/packages/blockchain-link/src/workers/state.ts
+++ b/packages/blockchain-link/src/workers/state.ts
@@ -22,7 +22,7 @@ export class WorkerState {
 
         return addr.filter(a => {
             if (typeof a !== 'string') return false;
-            if (seen.indexOf(a) >= 0) return false;
+            if (seen.includes(a)) return false;
             seen.push(a);
 
             return true;
@@ -30,7 +30,7 @@ export class WorkerState {
     }
 
     addAddresses(addr: string[]) {
-        const unique = this.validateAddresses(addr).filter(a => this.addresses.indexOf(a) < 0);
+        const unique = this.validateAddresses(addr).filter(a => !this.addresses.includes(a));
         this.addresses = this.addresses.concat(unique);
 
         return unique;
@@ -42,7 +42,7 @@ export class WorkerState {
 
     removeAddresses(addr: string[]) {
         const unique = this.validateAddresses(addr);
-        this.addresses = this.addresses.filter(a => unique.indexOf(a) < 0);
+        this.addresses = this.addresses.filter(a => !unique.includes(a));
 
         return this.addresses;
     }
@@ -53,7 +53,7 @@ export class WorkerState {
 
         return acc.filter(a => {
             if (a && typeof a === 'object' && typeof a.descriptor === 'string') {
-                if (seen.indexOf(a.descriptor) >= 0) return false;
+                if (seen.includes(a.descriptor)) return false;
                 seen.push(a.descriptor);
 
                 return true;
@@ -113,7 +113,7 @@ export class WorkerState {
             (addr, acc) => addr.concat(this.getAccountAddresses(acc)),
             [] as string[],
         );
-        this.accounts = this.accounts.filter(a => accountsToRemove.indexOf(a) < 0);
+        this.accounts = this.accounts.filter(a => !accountsToRemove.includes(a));
         this.removeAddresses(addressesToRemove);
 
         return this.accounts;

--- a/packages/connect-explorer/src/data/methods/bitcoin/signTransaction.p2sh.ts
+++ b/packages/connect-explorer/src/data/methods/bitcoin/signTransaction.p2sh.ts
@@ -55,7 +55,7 @@ export default [
                 value: 'test',
                 affect: ['inputs', 'outputs'],
                 data: select
-                    .filter(c => c.affectedValue.indexOf('m/49') >= 0)
+                    .filter(c => c.affectedValue.includes('m/49'))
                     .map(v => {
                         const example = examples[v.value as keyof typeof examples];
 

--- a/packages/suite/src/utils/wallet/exportTransactionsUtils.ts
+++ b/packages/suite/src/utils/wallet/exportTransactionsUtils.ts
@@ -317,7 +317,7 @@ const prepareContent = (
 };
 
 export const sanitizeCsvValue = (value: string) => {
-    if (value.indexOf(CSV_SEPARATOR) !== -1) {
+    if (value.includes(CSV_SEPARATOR)) {
         return `"${value.replace(/"/g, '""')}"`;
     }
 

--- a/packages/suite/src/views/suite/udev/index.tsx
+++ b/packages/suite/src/views/suite/udev/index.tsx
@@ -74,7 +74,7 @@ export const UdevRules = ({ onCancel }: ForegroundAppProps) => {
     const installers: Installer[] = udev.packages.map(p => ({
         label: p.name,
         value: DATA_URL + p.url.substring(1),
-        preferred: platform ? p.platform.indexOf(platform) >= 0 : false,
+        preferred: platform ? p.platform.includes(platform) : false,
     }));
     const [selectedTarget, setSelectedTarget] = useState<Installer | null>(null);
     const preferredTarget = installers.find(i => i.preferred);

--- a/packages/utils/src/comparison.ts
+++ b/packages/utils/src/comparison.ts
@@ -55,7 +55,7 @@ export const isChanged = (prev?: any, current?: any, filter?: { [k: string]: str
         if (prevKeys.length !== currentKeys.length) return true;
 
         // 6. "prev" has keys which "current" doesn't have
-        const prevDifference = prevKeys.find(k => currentKeys.indexOf(k) < 0);
+        const prevDifference = prevKeys.find(k => !currentKeys.includes(k));
         if (prevDifference) return true;
 
         // 8. observe every key recursive

--- a/packages/utxo-lib/src/bchUtils.ts
+++ b/packages/utxo-lib/src/bchUtils.ts
@@ -76,7 +76,7 @@ const decodeCashAddressWithPrefix = (address: string): DecodedAddress => {
 };
 
 const decodeCashAddress = (address: string): DecodedAddress => {
-    if (address.indexOf(':') !== -1) {
+    if (address.includes(':')) {
         return decodeCashAddressWithPrefix(address);
     } else {
         const prefixes = ['bitcoincash', 'bchtest', 'bchreg'];

--- a/suite-common/device/src/deviceReducer.ts
+++ b/suite-common/device/src/deviceReducer.ts
@@ -180,7 +180,7 @@ const connectDevice = (draft: DeviceReducerState, { state, ...device }: Device) 
     // get not affected devices
     // and exclude unacquired devices with current "device_id" (they will become acquired)
     const otherDevices: TrezorDevice[] = draft.devices.filter(
-        d => affectedDevices.indexOf(d as AcquiredDevice) < 0 && unacquiredDevices.indexOf(d) < 0,
+        d => !affectedDevices.includes(d as AcquiredDevice) && !unacquiredDevices.includes(d),
     );
 
     // clear draft
@@ -268,9 +268,7 @@ const changeDevice = (
                 (d.mode === 'bootloader' && d.remember && d.id === device.id)),
     ) as AcquiredDevice[];
 
-    const otherDevices = draft.devices.filter(
-        d => affectedDevices.indexOf(d as AcquiredDevice) === -1,
-    );
+    const otherDevices = draft.devices.filter(d => !affectedDevices.includes(d as AcquiredDevice));
     // clear draft
     draft.devices.splice(0, draft.devices.length);
     // fill draft with not affected devices

--- a/suite-common/transaction-search/src/simpleSearchTransactions.ts
+++ b/suite-common/transaction-search/src/simpleSearchTransactions.ts
@@ -21,7 +21,7 @@ const groupTransactionIdsByAddress = (transactions: WalletAccountTransaction[]) 
                 addresses[address] = [];
             }
 
-            if (addresses[address].indexOf(txid) === -1) {
+            if (!addresses[address].includes(txid)) {
                 addresses[address].push(txid);
             }
         });

--- a/suite-common/wallet-utils/src/csvParserUtils.ts
+++ b/suite-common/wallet-utils/src/csvParserUtils.ts
@@ -6,7 +6,7 @@ type Result = { [key: string]: string };
 const occurrences = (text: string, delimiter: string) => {
     // special chars needs to be escaped in RegExp
     const specialChars = '!@#$^&%*()+=-[]/{}|:<>?,.';
-    const escaped = specialChars.indexOf(delimiter) >= 0 ? '\\' : '';
+    const escaped = specialChars.includes(delimiter) ? '\\' : '';
     const regExp = new RegExp(escaped + delimiter, 'g');
 
     return (text.match(regExp) || []).length;


### PR DESCRIPTION
## Summary

Replace `arr.indexOf(x) {!=,===,>=,<} {-1,0}` patterns with `arr.includes(x)` / `!arr.includes(x)` across packages, suite, and suite-common. Modern idiom, easier to read at a glance, no semantic difference for the values used here (no NaN, no surrogate-pair string corner cases).

Single-pattern slice of the larger simplification batch in #27472. Behavior-preserving; pattern is mechanical and applied consistently. Pulled out into its own PR for easier review.

## Stats
```
 12 files changed, 24 insertions(+), 26 deletions(-)
```

## Test plan

- [ ] CI: type-check, lint, unit tests

---
Part of https://github.com/trezor/trezor-suite/pull/27472 (the umbrella branch with all 17 simplification commits).

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/indexof-to-includes&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/indexof-to-includes&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/indexof-to-includes&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-07T12:34:35.329Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-07T12:32:53.500Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/indexof-to-includes/web/](https://dev.suite.sldev.cz/suite-web/mroz22/indexof-to-includes/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->