### PR TITLE
refactor: collapse if/return boolean-coercion into direct return

### DIFF
--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/hooks/useProgressLabelsData.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/hooks/useProgressLabelsData.tsx
@@ -246,9 +246,7 @@ const shouldHideProgressBar = ({
 
             // Hide progress not staking with us,
             // but show it when pending tx as it can be update provider
-            if (!isStakedWithEverstake && hasNoPendingTx) return true;
-
-            return false;
+            return !isStakedWithEverstake && hasNoPendingTx;
         }
 
         case 'ethereum': {

--- a/packages/suite/src/views/wallet/transactions/TransactionList/transaction-fetch-utils.ts
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/transaction-fetch-utils.ts
@@ -24,7 +24,5 @@ export function shouldAttemptToLoadNextPageForVisibleTransactions({
 
     const pagesByVisibleTransactions = Math.ceil(currentNumberOfVisibleTransactions / perPage);
 
-    if (pagesByVisibleTransactions === 0 && totalNumberOfTransactions > 0) return true;
-
-    return false;
+    return pagesByVisibleTransactions === 0 && totalNumberOfTransactions > 0;
 }

--- a/suite-common/suite-utils/src/device.ts
+++ b/suite-common/suite-utils/src/device.ts
@@ -262,11 +262,7 @@ export const getSelectedDevice = (
         }
 
         // special case we need to use after wipe device (which changes device_id)
-        if (d.instance === instance && d.path.length > 0 && d.path === device.path) {
-            return true;
-        }
-
-        return false;
+        return d.instance === instance && d.path.length > 0 && d.path === device.path;
     });
 };
 

--- a/suite-native/accounts/src/utils.ts
+++ b/suite-native/accounts/src/utils.ts
@@ -54,9 +54,7 @@ export const isFilterValueMatchingAccount = (
         account.tokens?.some(token => token.name?.toLowerCase().includes(lowerCaseFilterValue)) ??
         false;
 
-    if (isMatchingTokenName) return true;
-
-    return false;
+    return isMatchingTokenName;
 };
 
 /**

--- a/suite-native/module-accounts-management/src/selectors.ts
+++ b/suite-native/module-accounts-management/src/selectors.ts
@@ -17,7 +17,5 @@ export const selectIsNetworkSendFlowEnabled = (
         FeatureFlag.IsCardanoSendEnabled,
     );
 
-    if (networkType !== 'cardano' || isCardanoSendEnabled) return true;
-
-    return false;
+    return networkType !== 'cardano' || isCardanoSendEnabled;
 };

--- a/suite/recovery/src/isRecoveryInProgress.ts
+++ b/suite/recovery/src/isRecoveryInProgress.ts
@@ -16,12 +16,5 @@ export const isRecoveryInProgress = (features: PROTO.Features) => {
         return true;
     }
 
-    const isShamirAdditionalBackupRecovery =
-        recovery_status === 'Backup' && backup_availability === 'NotAvailable';
-
-    if (isShamirAdditionalBackupRecovery) {
-        return true;
-    }
-
-    return false;
+    return recovery_status === 'Backup' && backup_availability === 'NotAvailable';
 };


### PR DESCRIPTION
## Summary

Collapse the `if (cond) return true; return false;` pattern into `return cond;` where `cond` is statically typed `boolean`. Classic anti-pattern, the rewrite is mechanical and the static types make it safe (no truthy non-boolean values).

Single-pattern slice of the larger simplification batch in #27472. Behavior-preserving; pattern is mechanical and applied consistently. Pulled out into its own PR for easier review.

## Stats
```
 6 files changed, 6 insertions(+), 25 deletions(-)
```

## Test plan

- [ ] CI: type-check, lint, unit tests

---
Part of https://github.com/trezor/trezor-suite/pull/27472 (the umbrella branch with all 17 simplification commits).

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set touches a staking dashboard hook (useProgressLabelsData), a transaction fetch utility, a broad device utility (121 tests), two suite-native mobile files, and a recovery utility. The highest-risk change is useProgressLabelsData.tsx which directly powers staking progress indicators — the ETH and SOL staking tests that assert on progress phases should be run. The device.ts change maps to 121 tests indicating it's a broad utility; without evidence of behavioral changes affecting specific test flows, those tests are omitted. The transaction-fetch-utils, suite-native files, and recovery utility have no E2E test coverage.

<details><summary><b>Changed files (6)</b></summary>

- `packages/suite/src/views/wallet/staking/components/StakingDashboard/hooks/useProgressLabelsData.tsx`
- `packages/suite/src/views/wallet/transactions/TransactionList/transaction-fetch-utils.ts`
- `suite-common/suite-utils/src/device.ts`
- `suite-native/accounts/src/utils.ts`
- `suite-native/module-accounts-management/src/selectors.ts`
- `suite/recovery/src/isRecoveryInProgress.ts`

</details>

**Recommended tests (7)**

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — useProgressLabelsData.tsx is directly used in the staking dashboard to render progress indicators (pendingTransaction, addingToPool, receivingRewards phases). This test explicitly asserts on progress indicator phases via expectProgressIndicatorsToMatchPhase, making it sensitive to changes in that hook.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — This test verifies progress indicator phases (pendingTransaction, addingToPool, receivingRewards) on the staking dashboard after staking more ETH. Changes to useProgressLabelsData.tsx directly affect the labels and phases rendered in these progress indicators.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — The ETH unstake test exercises the staking dashboard which renders progress indicators powered by useProgressLabelsData. The test checks staking amounts and dashboard state transitions that depend on this hook's output.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — This test explicitly asserts progress indicators match specific phases (addingToPool, receivingRewards) after SOL staking. useProgressLabelsData.tsx controls these progress label computations.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — Tests progress indicator phases (addingToPool) after staking more SOL, which directly depends on the progress labels computed by useProgressLabelsData.tsx.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — The SOL unstake flow exercises the staking dashboard including claim card visibility and staking amount transitions that rely on the staking dashboard components using useProgressLabelsData.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/staking/staking-form.test.ts` — While this test is mapped to useProgressLabelsData.tsx, it primarily tests staking form input validation (min/max amounts, decimal precision, percentage buttons) rather than progress indicators. A regression from the hook change is possible but unlikely to surface here.

</details>

⚠️ **Changes with no test coverage (5)**
- `packages/suite/src/views/wallet/transactions/TransactionList/transaction-fetch-utils.ts`
- `suite-common/suite-utils/src/device.ts`
- `suite-native/accounts/src/utils.ts`
- `suite-native/module-accounts-management/src/selectors.ts`
- `suite/recovery/src/isRecoveryInProgress.ts`

_Updated: 2026-05-07T12:30:08.177Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/boolean-coercion-return&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/boolean-coercion-return&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/boolean-coercion-return&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-07T12:34:48.254Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-07T12:33:28.585Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/boolean-coercion-return/web/](https://dev.suite.sldev.cz/suite-web/mroz22/boolean-coercion-return/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->