### PR TITLE
refactor: drop redundant === true comparisons on booleans

### DIFF
--- a/packages/analytics-docs/src/utils/urlParams.ts
+++ b/packages/analytics-docs/src/utils/urlParams.ts
@@ -38,8 +38,8 @@ export const updateUrl = (
     if (query) params.set('q', query);
     if (platform !== 'all') params.set('platform', platform);
     if (sort !== 'az') params.set('sort', sort);
-    if (sidebarOpen === true) params.set('sidebar', 'true');
-    if (liveLogOpen === true) params.set('liveLog', 'true');
+    if (sidebarOpen) params.set('sidebar', 'true');
+    if (liveLogOpen) params.set('liveLog', 'true');
     const search = params.toString();
     const url = search ? `${window.location.pathname}?${search}` : window.location.pathname;
 

--- a/packages/components/src/components/Flex/Flex.tsx
+++ b/packages/components/src/components/Flex/Flex.tsx
@@ -107,7 +107,7 @@ const Container = styled.div<ContainerProps>`
     display: flex;
 
     flex-flow: ${({ $direction, $isReversed, $flexWrap }) =>
-        `${$direction}${$isReversed === true ? '-reverse' : ''} ${$flexWrap}`};
+        `${$direction}${$isReversed ? '-reverse' : ''} ${$flexWrap}`};
     flex: ${({ $flex }) => $flex};
     gap: ${({ $rowGap, $columnGap }) => `${$rowGap}px ${$columnGap}px`};
     justify-content: ${({ $justifyContent }) => $justifyContent};

--- a/packages/suite-desktop-core/src/config.ts
+++ b/packages/suite-desktop-core/src/config.ts
@@ -38,7 +38,7 @@ export const allowedDomains = [
     'xrplcluster.com', // XRP Ledger cluster, hosted by XRP Ledger Foundation
     'xrpl.ws', // XRP Ledger cluster, hosted by XRP Ledger Foundation
     's2.ripple.com', // XRP Ledger cluster, hosted by Ripple
-    ...(isDevEnv === true ? allowedDomainsDev : []),
+    ...(isDevEnv ? allowedDomainsDev : []),
 ];
 
 export const silentlyBlockedDomains = [

--- a/packages/suite-desktop-core/src/modules/auto-updater.ts
+++ b/packages/suite-desktop-core/src/modules/auto-updater.ts
@@ -77,7 +77,7 @@ export const init: ModuleInit = ({ mainWindowProxy, store }) => {
     // possibility to override the default behavior. This wraps the original function, bypassing it if `isManualCheck`
     const isUserWithinRolloutDefaultMethod = autoUpdater.isUserWithinRollout;
     autoUpdater.isUserWithinRollout = async updateInfo =>
-        isManualCheck === true
+        isManualCheck
             ? // do not force if it is set to exactly 0, so we can completely stop distributing a release in case of trouble
               updateInfo.stagingPercentage !== 0
             : await isUserWithinRolloutDefaultMethod(updateInfo);

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ImportTransactionModal/useExampleCSV.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ImportTransactionModal/useExampleCSV.tsx
@@ -27,7 +27,7 @@ export const useExampleCSV = (): string => {
     }`;
     const lines = [headerLine, example1];
 
-    if (network.testnet === true) return lines.join('\n');
+    if (network.testnet) return lines.join('\n');
 
     // Inserting fiat rate is only available for mainnet networks
     const example2 = `${addresses[1]},4.9,USD${

--- a/packages/suite/src/views/onboarding/steps/SelectBackupType/OptionWithContent.tsx
+++ b/packages/suite/src/views/onboarding/steps/SelectBackupType/OptionWithContent.tsx
@@ -44,7 +44,7 @@ export const OptionStyled = styled.div<{ $hasHoverInteraction?: boolean; $disabl
     color: ${({ $disabled, theme }) => ($disabled ? theme.contentSecondary : undefined)};
 
     ${({ $hasHoverInteraction }) =>
-        $hasHoverInteraction === true
+        $hasHoverInteraction
             ? css`
                   &:hover {
                       background-color: ${({ theme }) => theme.legacyBackgroundSurfaceElevation2};

--- a/suite-common/wallet-config/src/utils.ts
+++ b/suite-common/wallet-config/src/utils.ts
@@ -57,7 +57,7 @@ export const getTestnets = ({
 }: GetTestnetsProps) =>
     allNetworks.filter(
         n =>
-            n.testnet === true &&
+            n.testnet &&
             useTestnetNetworks &&
             (!n.isDebugOnlyNetwork || debug) &&
             (!n.isExperimentalOnlyNetwork || useExperimentalNetworks),

--- a/suite-common/wallet-core/src/fees/hooks/useRefetchFees.ts
+++ b/suite-common/wallet-core/src/fees/hooks/useRefetchFees.ts
@@ -12,7 +12,7 @@ export const useFetchFeesOnce = ({ networkSymbol, isDisabled }: UseRefetchFeesPr
     const dispatch = useDispatch();
 
     useEffect(() => {
-        if (isDisabled === true || networkSymbol === undefined) return;
+        if (isDisabled || networkSymbol === undefined) return;
         dispatch(updateFeeInfoThunk({ networkSymbol }));
     }, [dispatch, networkSymbol, isDisabled]);
 };
@@ -22,7 +22,7 @@ export const useRefetchFees = ({ networkSymbol, isDisabled }: UseRefetchFeesProp
     const dispatch = useDispatch();
 
     useEffect(() => {
-        if (isDisabled === true || !networkSymbol) return;
+        if (isDisabled || !networkSymbol) return;
 
         const intervalId = setInterval(() => {
             dispatch(


### PR DESCRIPTION
## Summary

Drop `val === true` where `val` is statically typed `boolean` (or `boolean | undefined`, where `if (val)` and `val === true` behave identically). Pure noise removal.

Single-pattern slice of the larger simplification batch in #27472. Behavior-preserving; pattern is mechanical and applied consistently. Pulled out into its own PR for easier review.

## Stats
```
 8 files changed, 10 insertions(+), 10 deletions(-)
```

## Test plan

- [ ] CI: type-check, lint, unit tests

---
Part of https://github.com/trezor/trezor-suite/pull/27472 (the umbrella branch with all 17 simplification commits).

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/drop-eq-true&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/drop-eq-true&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/drop-eq-true&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-07T12:35:45.647Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-07T12:33:42.464Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/drop-eq-true/web/](https://dev.suite.sldev.cz/suite-web/mroz22/drop-eq-true/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->