### PR TITLE
refactor(suite): drop dead-conditional branches with identical results

### DIFF
--- a/suite-common/device/src/deviceSelectors.ts
+++ b/suite-common/device/src/deviceSelectors.ts
@@ -590,11 +590,6 @@ export const selectDeviceUpdateFirmwareVersion = (state: DeviceRootState) => {
 
 export const selectFirmwareChangelog = (state: DeviceRootState) => {
     const device = selectSelectedDevice(state);
-    const isBitcoinOnlyFirmware = selectHasBitcoinOnlyFirmware(state);
-
-    if (isBitcoinOnlyFirmware) {
-        return device?.firmwareReleaseConfigInfo?.release.changelog;
-    }
 
     return device?.firmwareReleaseConfigInfo?.release.changelog;
 };

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputCard.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputCard.tsx
@@ -24,7 +24,6 @@ const cardStyle = prepareNativeStyle<{ isConfirmed: boolean }>((utils, { isConfi
         condition: isConfirmed,
         style: {
             backgroundColor: utils.colors.legacyBackgroundTertiaryDefaultOnElevation1,
-            borderColor: utils.colors.borderNeutral,
         },
     },
 }));
@@ -33,7 +32,6 @@ export const ReviewOutputCard = ({ children, title, outputState }: ReviewOutputC
     const { applyStyle } = useNativeStyles();
 
     const isConfirmed = outputState === 'success';
-    const dividerColor = isConfirmed ? 'borderNeutral' : 'borderNeutral';
 
     return (
         <Card style={applyStyle(cardStyle, { isConfirmed })}>
@@ -44,7 +42,7 @@ export const ReviewOutputCard = ({ children, title, outputState }: ReviewOutputC
                         {title}
                     </Text>
                 </HStack>
-                <CardDivider color={dividerColor} horizontalPadding="sp16" />
+                <CardDivider color="borderNeutral" horizontalPadding="sp16" />
                 <Box paddingLeft="sp24" testID={REVIEW_OUTPUT_CARD_TEST_ID + '/content'}>
                     {children}
                 </Box>


### PR DESCRIPTION
## Summary

Drop two dead-conditional patterns: a no-op `if/else` where both branches return the same selector expression, and a constant-valued ternary plus a redundant override-with-same-value style property. Genuinely dead code, removing it makes intent clearer.

Single-pattern slice of the larger simplification batch in #27472. Behavior-preserving; pattern is mechanical and applied consistently. Pulled out into its own PR for easier review.

## Stats
```
 2 files changed, 1 insertion(+), 8 deletions(-)
```

## Test plan

- [ ] CI: type-check, lint, unit tests

---
Part of https://github.com/trezor/trezor-suite/pull/27472 (the umbrella branch with all 17 simplification commits).

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set involves two files: `deviceSelectors.ts` (a broad shared utility mapped to 121 tests) and `ReviewOutputCard.tsx` (a suite-native component with no static test coverage). The `deviceSelectors.ts` file is a global dependency used pervasively across the Suite app — without knowing the specific nature of the selector change, none of the 121 mapped tests show direct evidence of being specifically impacted by selector logic changes in their described behaviors. The `ReviewOutputCard.tsx` is a React Native component for transaction review in the mobile app, which has no E2E test coverage in the Playwright suite (which targets web/desktop). No E2E tests are recommended to run since there is no concrete evidence any specific test's behavior would be affected, and running tests purely based on transitive imports of a 121-test utility would not be a targeted strategy.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/device/src/deviceSelectors.ts`
- `suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputCard.tsx`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputCard.tsx`

_Updated: 2026-05-07T12:30:46.684Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/drop-dead-conditionals&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/drop-dead-conditionals&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/drop-dead-conditionals&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-07T12:35:27.542Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-07T12:34:02.731Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/drop-dead-conditionals/web/](https://dev.suite.sldev.cz/suite-web/mroz22/drop-dead-conditionals/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->