### PR TITLE
feat(components): add isFloating prop to Button and IconButton components

### DIFF
--- a/packages/components/src/components/buttons/Button/Button.stories.tsx
+++ b/packages/components/src/components/buttons/Button/Button.stories.tsx
@@ -23,6 +23,7 @@ export const Button: StoryObj<ButtonProps> = {
         isDisabled: false,
         isLoading: false,
         isInverse: false,
+        isFloating: false,
         shortcut: undefined,
         ...getFramePropsStory(allowedButtonFrameProps).args,
     },
@@ -55,6 +56,9 @@ export const Button: StoryObj<ButtonProps> = {
             type: 'boolean',
         },
         isInverse: {
+            type: 'boolean',
+        },
+        isFloating: {
             type: 'boolean',
         },
         iconLeft: {

--- a/packages/components/src/components/buttons/Button/Button.tsx
+++ b/packages/components/src/components/buttons/Button/Button.tsx
@@ -45,6 +45,7 @@ type ButtonContainerProps = TransientProps<AllowedButtonFrameProps> & {
     $priority: ButtonPriority;
     $intent: ButtonIntent;
     $isInverse: boolean;
+    $isFloating: boolean;
     disabled: boolean;
 };
 
@@ -53,8 +54,8 @@ const Container = styled.button<ButtonContainerProps>`
 
     border-radius: ${({ $size }) => mapSizeToBorderRadius($size)};
 
-    ${({ $intent, $priority, disabled, $isInverse, theme }) =>
-        mapPropsToCSS($intent, $priority, disabled, $isInverse, theme)}
+    ${({ $intent, $priority, disabled, $isInverse, $isFloating, theme }) =>
+        mapPropsToCSS($intent, $priority, disabled, $isInverse, theme, $isFloating)}
 
     ${withFrameProps}
 `;
@@ -76,6 +77,7 @@ export const Button = ({
     iconRight,
     shortcut,
     size = 'medium',
+    isFloating = false,
     ...props
 }: ButtonProps) => {
     const frameProps = pickAndPrepareFrameProps(props, allowedButtonFrameProps);
@@ -94,6 +96,7 @@ export const Button = ({
             $priority={priority}
             $isInverse={isInverse}
             $intent={intent}
+            $isFloating={isFloating}
             {...frameProps}
             {...buttonProps}
         >

--- a/packages/components/src/components/buttons/IconButton/IconButton.stories.tsx
+++ b/packages/components/src/components/buttons/IconButton/IconButton.stories.tsx
@@ -27,6 +27,7 @@ export const IconButton: StoryObj<IconButtonProps> = {
         isDisabled: false,
         isLoading: false,
         isInverse: false,
+        isFloating: false,
         ...getFramePropsStory(allowedIconButtonFrameProps).args,
     },
     argTypes: {
@@ -59,6 +60,9 @@ export const IconButton: StoryObj<IconButtonProps> = {
             type: 'boolean',
         },
         isInverse: {
+            type: 'boolean',
+        },
+        isFloating: {
             type: 'boolean',
         },
         ...getFramePropsStory(allowedIconButtonFrameProps).argTypes,

--- a/packages/components/src/components/buttons/IconButton/IconButton.tsx
+++ b/packages/components/src/components/buttons/IconButton/IconButton.tsx
@@ -37,6 +37,7 @@ type ButtonContainerProps = TransientProps<AllowedIconButtonFrameProps> & {
     $priority: ButtonPriority;
     $intent: ButtonIntent;
     $isInverse: boolean;
+    $isFloating: boolean;
     disabled: boolean;
 };
 
@@ -45,8 +46,8 @@ const Container = styled.button<ButtonContainerProps>`
 
     border-radius: ${({ $size }) => mapSizeToBorderRadius($size)};
 
-    ${({ $intent, $priority, disabled, $isInverse, theme }) =>
-        mapPropsToCSS($intent, $priority, disabled, $isInverse, theme)}
+    ${({ $intent, $priority, disabled, $isInverse, $isFloating, theme }) =>
+        mapPropsToCSS($intent, $priority, disabled, $isInverse, theme, $isFloating)}
 
     ${withFrameProps}
 `;
@@ -62,6 +63,7 @@ export const IconButton = ({
     'data-testid': dataTestId,
     icon,
     size = 'medium',
+    isFloating = false,
     ...props
 }: IconButtonProps) => {
     const frameProps = pickAndPrepareFrameProps(props, allowedIconButtonFrameProps);
@@ -80,6 +82,7 @@ export const IconButton = ({
             $priority={priority}
             $intent={intent}
             $isInverse={isInverse}
+            $isFloating={isFloating}
             {...buttonProps}
             {...frameProps}
         >

--- a/packages/components/src/components/buttons/types.ts
+++ b/packages/components/src/components/buttons/types.ts
@@ -21,6 +21,7 @@ export type ButtonPriority = Extract<UIPriority, (typeof buttonPriorities)[numbe
 export type CommonButtonProps = {
     intent?: ButtonIntent;
     priority?: ButtonPriority;
+    isFloating?: boolean;
     isLoading?: boolean;
     isDisabled?: boolean;
     isInverse?: boolean;

--- a/packages/components/src/components/buttons/utils.ts
+++ b/packages/components/src/components/buttons/utils.ts
@@ -297,24 +297,35 @@ export const mapPropsToCSS = (
     isDisabled: boolean,
     isInverse: boolean,
     theme: DefaultTheme,
+    isFloating: boolean,
 ): RuleSet<object> => {
     const inverseKey: InverseKey = isInverse ? 'inverse' : 'normal';
+    const getBackground = (backgroundColor: Color) =>
+        isFloating
+            ? css`
+                  background:
+                      linear-gradient(${theme[backgroundColor]}, ${theme[backgroundColor]}),
+                      ${theme['surfaceFillRaised']};
+              `
+            : css`
+                  background: ${theme[backgroundColor]};
+              `;
 
     if (isDisabled) {
         return css`
-            background: ${theme[backgroundMapDisabled[inverseKey][priority]]};
+            ${getBackground(backgroundMapDisabled[inverseKey][priority])}
         `;
     }
 
     return css`
-        background: ${theme[backgroundMapBase[inverseKey][priority][intent]]};
+        ${getBackground(backgroundMapBase[inverseKey][priority][intent])}
 
         &:hover {
-            background: ${theme[backgroundMapHovered[inverseKey][priority][intent]]};
+            ${getBackground(backgroundMapHovered[inverseKey][priority][intent])}
         }
 
         &:active {
-            background: ${theme[backgroundMapPressed[inverseKey][priority][intent]]};
+            ${getBackground(backgroundMapPressed[inverseKey][priority][intent])}
         }
     `;
 };

--- a/packages/suite/src/components/connection/ConnectDeviceGlobalModal.tsx
+++ b/packages/suite/src/components/connection/ConnectDeviceGlobalModal.tsx
@@ -47,12 +47,9 @@ type DontSeeTrezorPillProps = {
 };
 
 const DontSeeTrezorPill = ({ onClick }: DontSeeTrezorPillProps) => (
-    // A little hack so we can use the subtle variant of the button instead of creating a brand new variant for a single use case
-    <Box backgroundColor="surfaceFillRaised" borderRadius={10}>
-        <Button onClick={onClick} iconLeft="question" intent="info" priority="secondary">
-            <Translation id="TR_STILL_DONT_SEE_YOUR_TREZOR" />
-        </Button>
-    </Box>
+    <Button onClick={onClick} iconLeft="question" intent="info" priority="secondary" isFloating>
+        <Translation id="TR_STILL_DONT_SEE_YOUR_TREZOR" />
+    </Button>
 );
 
 type ConnectModalContentProps = {

--- a/packages/suite/src/views/suite/SwitchDevice/SwitchDevice.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/SwitchDevice.tsx
@@ -3,7 +3,7 @@ import { Translation } from '@suite/intl';
 import { bluetoothActions, selectAdapterStatus } from '@suite-common/bluetooth';
 import { selectDevices } from '@suite-common/device';
 import * as deviceUtils from '@suite-common/suite-utils';
-import { Box, Button, Column } from '@trezor/components';
+import { Button, Column } from '@trezor/components';
 
 import { setConnectionMode, toggleConnectionModal } from 'src/actions/device/deviceSlice';
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -53,18 +53,17 @@ export const SwitchDeviceContent = ({ cancelable, onCancel }: ForegroundAppProps
                     onCancel={cancelable ? onCancel : undefined}
                 />
             ))}
-            <Box backgroundColor="surfaceFillRaised" borderRadius={12}>
-                <Button
-                    intent="neutral"
-                    priority="secondary"
-                    iconLeft="trezorDevices"
-                    width="100%"
-                    size="large"
-                    onClick={openDeviceConnectionModal}
-                >
-                    <Translation id="TR_CONNECT_DEVICE" />
-                </Button>
-            </Box>
+            <Button
+                intent="neutral"
+                priority="secondary"
+                iconLeft="trezorDevices"
+                isFloating
+                width="100%"
+                size="large"
+                onClick={openDeviceConnectionModal}
+            >
+                <Translation id="TR_CONNECT_DEVICE" />
+            </Button>
         </Column>
     );
 };


### PR DESCRIPTION
## Notes for QA

Fix floating secondary priority buttons to not show wrapper background when clicked

## Screenshots:

### Before
<img width="395" height="315" alt="image" src="https://github.com/user-attachments/assets/f93749df-4ebb-46a3-a030-fa86cf2c5dea" />

### After
<img width="385" height="297" alt="image" src="https://github.com/user-attachments/assets/9c8db3f8-604f-4301-bde1-02517cf6637a" />



<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/floating-buttons/web/](https://dev.suite.sldev.cz/suite-web/fix/floating-buttons/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/floating-buttons&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/floating-buttons&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/floating-buttons&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-07T13:45:07.532Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-07T13:44:32.879Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->