### PR TITLE
fix(suite-data): add dark mode support to unsupported browser page

### DIFF
--- a/packages/suite-data/src/browser-detection/styles.css
+++ b/packages/suite-data/src/browser-detection/styles.css
@@ -129,6 +129,53 @@ body {
     list-style-type: none;
 }
 
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #0d0d0d;
+    }
+
+    .title {
+        color: #ffffff;
+    }
+
+    .subtitle {
+        color: #ffffff;
+    }
+
+    .buttonSecondary {
+        background: #1c1c1c;
+        color: #4caf93;
+        border: 1px solid #333333;
+    }
+
+    .browser {
+        border: 1px solid #333333;
+    }
+
+    .browser:hover {
+        border: 1px solid #555555;
+        box-shadow:
+            0px 2px 2px #1a1a1a,
+            0px 4px 28px #1a1a1a;
+    }
+
+    .name {
+        color: #ffffff;
+    }
+
+    .hr {
+        border-top: 1px solid #333333;
+    }
+
+    .continueInfo {
+        color: #ffffff;
+    }
+
+    .continueButton {
+        color: #ffffff;
+    }
+}
+
 @media (max-width: 900px) {
     .title {
         font-size: 40px;


### PR DESCRIPTION
## Description

The "Your browser is not supported" page had no dark mode support, it would look broken in Safari 

## Notes for QA

Open the unsupported browser page (e.g., in Safari) with the OS set to dark mode and verify text is legible

## Screenshots:

Before

<img width="1024" height="849" alt="Screenshot 2026-05-07 at 15 41 22" src="https://github.com/user-attachments/assets/21403d61-7773-4647-9aa1-7eba2c20a8da" />

After

<img width="1024" height="849" alt="Screenshot 2026-05-07 at 15 39 51" src="https://github.com/user-attachments/assets/05fa6428-47b4-40f2-b65a-dcd3ba6c2adf" />

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to `packages/suite-data/src/browser-detection/styles.css`, which styles the browser/platform detection UI shown to users on unsupported browsers or platforms. The primary risk is visual breakage of the unsupported-browser warning pages (Safari, iOS) and potentially affecting supported-browser detection (Firefox). The three browser-specific E2E tests directly exercise this functionality and should be prioritized. No other tests are meaningfully impacted since this CSS file is scoped to browser detection only.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite-data/src/browser-detection/styles.css`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `../../suite/e2e/tests/browser/safari.test.ts` — The changed file is `packages/suite-data/src/browser-detection/styles.css`, which directly relates to browser detection styling. The Safari test verifies the unsupported browser warning page UI, which is rendered using browser-detection styles. A CSS change here could break the layout or visibility of the warning page, download links, and 'Continue at my own risk' button.
- `../../suite/e2e/tests/browser/ios.test.ts` — The iOS test validates the unsupported platform blocking page, which is part of the browser/device detection UI. The changed `browser-detection/styles.css` directly styles this detection component. Changes could affect the heading, informational paragraph, and supported alternatives list visibility.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `../../suite/e2e/tests/browser/firefox.test.ts` — The Firefox test checks that the browser detection component correctly identifies Firefox as supported (no warning shown). While the test primarily asserts absence of the warning, a CSS change in browser-detection styles could inadvertently affect the detection page rendering or the visibility of the 'Continue at my own risk' element.

</details>

_Updated: 2026-05-07T13:42:45.230Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-unsupported-browser-dark-mode&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-unsupported-browser-dark-mode&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-07T13:47:27.908Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-07T13:46:16.927Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-unsupported-browser-dark-mode/web/](https://dev.suite.sldev.cz/suite-web/fix-unsupported-browser-dark-mode/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->