### PR TITLE
fix(trading): preserve swap token selection for percentages

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/useTradingFormAccount.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingFormAccount.ts
@@ -95,15 +95,19 @@ export const useTradingFormAccount = (tradingType: TradingType) => {
         [isAccountEligibleForTrade],
     );
 
+    // Once prefilled.key is cleared the account is already determined; don't restrict eligibility
+    // to a token that may belong to a different network than what the user just selected.
+    const eligibilityCryptoId = prefilled.key ? prefilled.cryptoId : undefined;
+
     const account = useMemo(() => {
-        if (preferredAccount && isAccountEligibleForTrade(preferredAccount, prefilled.cryptoId)) {
+        if (preferredAccount && isAccountEligibleForTrade(preferredAccount, eligibilityCryptoId)) {
             return preferredAccount;
         }
 
         const sameSymbolAccount = visibileDeviceAccounts.find(
             acc =>
                 acc.symbol === preferredAccount?.symbol &&
-                isAccountEligibleForTrade(acc, prefilled.cryptoId),
+                isAccountEligibleForTrade(acc, eligibilityCryptoId),
         );
 
         if (sameSymbolAccount) {
@@ -116,7 +120,7 @@ export const useTradingFormAccount = (tradingType: TradingType) => {
         isAccountEligibleForTrade,
         pickFallbackAccount,
         preferredAccount,
-        prefilled.cryptoId,
+        eligibilityCryptoId,
     ]);
 
     const cryptoId = useMemo(() => {


### PR DESCRIPTION
## Description

- stop re-evaluating the selected trading account against a stale prefilled token `cryptoId` after `prefilled.key` is cleared
- keep the already selected swap account when the user switches from a prefilled token flow to another tradable asset on the same screen
- preserve percentage button behavior by preventing the amount state from falling back through an unrelated account selection path

## Notes for QA

- Open Swap from a token entry point, use the percentage buttons, switch the From asset to another tradable asset such as ARB, and verify the selected asset stays valid and the amount does not reset to `0`
- Repeat the same flow with a regular non-token asset switch and verify the percentage buttons still calculate from the currently selected asset balance

## Related Issue

Resolve #27405

## Screenshots:

N/A

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to `useTradingFormAccount.ts`, a hook in the trading form infrastructure that manages account context for buy/sell/swap flows. This is a focused change but with high impact potential since it affects all trading form variants (buy, sell, swap) across multiple cryptocurrency networks. The recommended strategy is to prioritize direct trading flow tests (buy, sell, swap for various coins/tokens) and also cover staking forms that share the trading form infrastructure. Non-trading tests (backup, onboarding, settings, etc.) that statically reference this file only do so through deep transitive imports and are omitted since they don't exercise trading form account selection.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/hooks/wallet/trading/form/useTradingFormAccount.ts`

</details>

**Recommended tests (20)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — This test exercises trading form navigation from multiple entry points (dashboard, account, global header) for Buy/Sell/Swap flows. The `useTradingFormAccount` hook directly manages account selection and form state for trading forms, making this test highly likely to exercise the changed code path when opening trading forms for different cryptocurrencies.
- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — This test covers the full buy flow including filling the buy form, selecting a receive address/account, viewing quotes, and confirming trades. The `useTradingFormAccount` hook manages the account context for trading forms, directly impacting account selection and form initialization in the buy flow.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — Tests buying Ethereum through the trading panel including asset selection, receive address addition, and quote confirmation. The changed hook manages which account is used in the trading form, directly affecting how the ETH buy form initializes and handles account context.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — Tests buying a Solana SPL token (Jupiter/JUP) with asset picker selection and Suite receive account selection. The `useTradingFormAccount` hook is central to managing which account/token is selected in the trading form, and token-specific flows are especially sensitive to account context changes.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — Tests the full sell flow for Bitcoin including form filling, quote display, trade confirmation, and device prompt verification. The trading form account hook manages the account context that determines which account's balance and address are used in the sell form.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Tests swapping SOL to BTC through the full swap flow including form filling, device confirmation, and transaction status tracking. The `useTradingFormAccount` hook manages send/receive account selection which is core to swap form functionality.

</details>

<details><summary>🟡 <b>Medium priority (12)</b></summary>

- `suite/e2e/tests/trading/buy-negative.test.ts` — Tests buy form validation (min/max amounts, no quotes). While primarily testing input validation, the form initialization and account context managed by `useTradingFormAccount` must work correctly for the validation to be exercised properly.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Tests Ethereum sell flow with custom gas fees. The trading form account hook provides the account context needed for the sell form, and Ethereum-specific fee handling depends on correct account initialization.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Tests selling an ERC-20 token (USDC) which requires token-specific account context. The `useTradingFormAccount` hook likely handles token account selection differently from native coin accounts, making this a meaningful test for the change.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Tests sell form input validation including percentage buttons and max calculation for both BTC and SOL. The balance values and account context used for percentage calculations originate from the trading form account hook.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Tests Solana sell flow including offer comparison and selecting alternative offers. Account context management by the changed hook affects which account and balance are presented in the sell form.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Tests cross-network swap (SOL to USDC on Ethereum) with receive address selection from Suite accounts. The trading form account hook manages both send and receive account contexts, which is critical for cross-network swaps.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Tests swapping a Solana token (USDT) to BTC. Token-to-coin swaps exercise the account hook's handling of token accounts as the send context.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Tests token-to-token swap (USDT to USDC on Solana). This exercises token account handling in the trading form account hook for both send and receive sides.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Tests BTC-to-ETH swap with custom fee settings. The account context from the trading form account hook determines which network's fee structure is used.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests ETH-to-BTC swap with custom Ethereum gas fee parameters. Account context from the changed hook determines gas fee applicability.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — Tests swap with a buy asset on a disabled network. The account hook may need to handle edge cases where the target network is not enabled, making this a relevant regression test.
- `suite/e2e/tests/staking/staking-form.test.ts` — The staking form shares trading form infrastructure and validates input amounts against account balances. The `useTradingFormAccount` hook likely provides the account context for staking forms as well, given the shared 'trading/form' path.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — Tests initiating a buy action from the Assets section which navigates to the trading page. The trading form account hook is involved when the trading page initializes after navigation from the dashboard buy button.
- `suite/e2e/tests/trading/swap-history.test.ts` — Tests swap transaction history display. While the history view may share some trading infrastructure, it primarily reads historical data rather than exercising the form account hook directly. However, navigation to the swap trading section still initializes the form context.

</details>

_Updated: 2026-05-07T14:12:29.023Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/27405-swap-percent-buttons&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/27405-swap-percent-buttons&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-07T14:16:55.821Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-07T14:15:17.866Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/27405-swap-percent-buttons/web/](https://dev.suite.sldev.cz/suite-web/fix/27405-swap-percent-buttons/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->