### PR TITLE
chore(earn): apy format refactor

### DIFF
--- a/packages/suite/src/components/earn/dashboard/staking/EarnStakingAccountRow.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/EarnStakingAccountRow.tsx
@@ -23,11 +23,11 @@ import {
 import { Button, Column, Icon, Paragraph, Row, Table } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
 
+import { formatApyValue } from 'src/components/earn/utils/earnApyUtils';
 import { HiddenPlaceholder } from 'src/components/suite/HiddenPlaceholder';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useAnalytics } from 'src/support/useAnalytics';
 import { ApyValue } from 'src/views/wallet/staking/components/ApyValue';
-import { formatApyValue } from 'src/views/wallet/staking/utils/formatStakeValues';
 
 import { EarnAccountCell } from '../common/EarnAccountCell';
 import { EarnRewardsAmount } from '../common/EarnRewardsAmount';

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyTooltip.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyTooltip.tsx
@@ -1,3 +1,5 @@
+import { type ReactNode } from 'react';
+
 import styled from 'styled-components';
 
 import { type YieldDto } from '@suite-common/earn-stablecoin-api';
@@ -18,35 +20,27 @@ type EarnYieldApyTooltipProps = {
     vault: YieldDto;
     apyPercentage: number | null;
     networkSymbol: NetworkSymbol;
+    children?: ReactNode;
 };
 
 export const EarnYieldApyTooltip = ({
     vault,
     apyPercentage,
     networkSymbol,
-}: EarnYieldApyTooltipProps) => {
-    const { components: rewards } = vault.rewardRate;
-
-    if (!rewards?.length) {
-        return <ApyValue apy={apyPercentage} />;
-    }
-
-    return (
-        <Tooltip
-            content={
-                <EarnYieldApyBreakdown
-                    rewards={rewards}
-                    networkSymbol={networkSymbol}
-                    underlyingToken={vault.token}
-                />
-            }
-            maxWidth={600}
-            placement="top"
-            hasArrow
-        >
-            <Abbr>
-                <ApyValue apy={apyPercentage} />
-            </Abbr>
-        </Tooltip>
-    );
-};
+    children,
+}: EarnYieldApyTooltipProps) => (
+    <Tooltip
+        content={
+            <EarnYieldApyBreakdown
+                rewards={vault.rewardRate.components}
+                networkSymbol={networkSymbol}
+                underlyingToken={vault.token}
+            />
+        }
+        maxWidth={600}
+        placement="top"
+        hasArrow
+    >
+        <Abbr>{children ?? <ApyValue apy={apyPercentage} />}</Abbr>
+    </Tooltip>
+);

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/YieldEarnInANutshellModal.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/YieldEarnInANutshellModal.tsx
@@ -63,7 +63,9 @@ export const YieldEarnInANutshellModal = ({
         {
             heading: <Translation id="TR_EARN_SUPPLYING_PROCESS" />,
             badge: <Translation id="TR_TX_FEE" />,
-            content: <YieldSupplyingInfo apy={yieldApy} />,
+            content: (
+                <YieldSupplyingInfo apy={yieldApy} vault={vault} networkSymbol={account.symbol} />
+            ),
         },
         {
             heading: <Translation id="TR_EARN_WITHDRAWING_PROCESS" />,

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/components/EarnSupplyingInfo.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/components/EarnSupplyingInfo.tsx
@@ -13,8 +13,8 @@ import { selectEthValidatorsQueue, selectPoolStatsApy } from '@suite-common/wall
 import { type Account } from '@suite-common/wallet-types';
 import { BulletList } from '@trezor/components';
 
+import { formatApyValue } from 'src/components/earn/utils/earnApyUtils';
 import { useSelector } from 'src/hooks/suite';
-import { formatApyValue } from 'src/views/wallet/staking/utils/formatStakeValues';
 
 import { EarnInfoRow } from './EarnInfoRow';
 

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/components/UpdateEarnInANutshellHighlights.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/components/UpdateEarnInANutshellHighlights.tsx
@@ -6,7 +6,7 @@ import {
 } from '@suite-common/wallet-config';
 import { exhaustive } from '@trezor/type-utils';
 
-import { formatApyValue } from 'src/views/wallet/staking/utils/formatStakeValues';
+import { formatApyValue } from 'src/components/earn/utils/earnApyUtils';
 
 import {
     type EarnInANutshellHighlight,

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/components/YieldSupplyingInfo.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/components/YieldSupplyingInfo.tsx
@@ -1,15 +1,20 @@
 import { Translation } from '@suite/intl';
+import { type YieldDto } from '@suite-common/earn-stablecoin-api';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { BulletList } from '@trezor/components';
 
+import { EarnYieldApyTooltip } from 'src/components/earn/dashboard/yield/EarnYieldApyTooltip';
 import { formatApyValue } from 'src/components/earn/utils/earnApyUtils';
 
 import { EarnInfoRow } from './EarnInfoRow';
 
 interface YieldSupplyingInfoProps {
     apy: number | null;
+    vault: YieldDto | undefined;
+    networkSymbol: NetworkSymbol;
 }
 
-export const YieldSupplyingInfo = ({ apy }: YieldSupplyingInfoProps) => (
+export const YieldSupplyingInfo = ({ apy, vault, networkSymbol }: YieldSupplyingInfoProps) => (
     <BulletList bulletGap={12} gap={16} bulletSize="small" titleGap={2}>
         <EarnInfoRow
             heading={<Translation id="TR_EARN_YIELD_APPROVE_SPENDING_TRANSACTION" />}
@@ -19,15 +24,21 @@ export const YieldSupplyingInfo = ({ apy }: YieldSupplyingInfoProps) => (
             heading={<Translation id="TR_EARN_SIGN_SUPPLYING_TRANSACTION" />}
             content={{ text: <Translation id="TR_TRADING_NETWORK_FEE" />, isBadge: true }}
         />
-        {apy !== null && (
+        {apy !== null && vault && (
             <EarnInfoRow
                 heading={<Translation id="TR_EARN_YIELD_EARN_REWARDS_EACH_BLOCK" />}
                 content={{
                     text: (
-                        <Translation
-                            id="TR_EARN_APY_APPROX"
-                            values={{ apyPercent: formatApyValue(apy) }}
-                        />
+                        <EarnYieldApyTooltip
+                            vault={vault}
+                            apyPercentage={apy}
+                            networkSymbol={networkSymbol}
+                        >
+                            <Translation
+                                id="TR_EARN_APY_APPROX"
+                                values={{ apyPercent: formatApyValue(apy) }}
+                            />
+                        </EarnYieldApyTooltip>
                     ),
                 }}
             />

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/components/YieldSupplyingInfo.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/components/YieldSupplyingInfo.tsx
@@ -1,7 +1,7 @@
 import { Translation } from '@suite/intl';
 import { BulletList } from '@trezor/components';
 
-import { ApyValue } from 'src/views/wallet/staking/components/ApyValue';
+import { formatApyValue } from 'src/components/earn/utils/earnApyUtils';
 
 import { EarnInfoRow } from './EarnInfoRow';
 
@@ -22,7 +22,14 @@ export const YieldSupplyingInfo = ({ apy }: YieldSupplyingInfoProps) => (
         {apy !== null && (
             <EarnInfoRow
                 heading={<Translation id="TR_EARN_YIELD_EARN_REWARDS_EACH_BLOCK" />}
-                content={{ text: <ApyValue apy={apy} /> }}
+                content={{
+                    text: (
+                        <Translation
+                            id="TR_EARN_APY_APPROX"
+                            values={{ apyPercent: formatApyValue(apy) }}
+                        />
+                    ),
+                }}
             />
         )}
     </BulletList>

--- a/packages/suite/src/components/earn/utils/earnApyUtils.ts
+++ b/packages/suite/src/components/earn/utils/earnApyUtils.ts
@@ -1,2 +1,0 @@
-export const getApyRate = (apyRate: number): number =>
-    Number.isFinite(apyRate) ? apyRate : Number.NEGATIVE_INFINITY;

--- a/packages/suite/src/components/earn/utils/earnApyUtils.tsx
+++ b/packages/suite/src/components/earn/utils/earnApyUtils.tsx
@@ -1,0 +1,12 @@
+import { Translation } from '@suite/intl';
+
+export const getApyRate = (apyRate: number): number =>
+    Number.isFinite(apyRate) ? apyRate : Number.NEGATIVE_INFINITY;
+
+export const formatApyValue = (apy?: number | null) => {
+    if (apy == null) {
+        return <Translation id="TR_EARN_APY_N_A" />;
+    }
+
+    return `${apy}`;
+};

--- a/packages/suite/src/components/earn/yield/common/YieldFlowCompleteSupply.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldFlowCompleteSupply.tsx
@@ -1,8 +1,10 @@
 import { Translation } from '@suite/intl';
+import { type YieldDto } from '@suite-common/earn-stablecoin-api';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type YieldFlowCompleteValue } from '@suite-common/wallet-core';
 import { Divider, Row, Text } from '@trezor/components';
 
-import { ApyValue } from 'src/views/wallet/staking/components/ApyValue';
+import { EarnYieldApyTooltip } from 'src/components/earn/dashboard/yield/EarnYieldApyTooltip';
 
 import { YieldFlowComplete } from './YieldFlowComplete';
 import { YieldFlowTransferRow } from './YieldFlowTransferRow';
@@ -11,9 +13,17 @@ type YieldFlowCompleteSupplyProps = {
     input: YieldFlowCompleteValue;
     output: YieldFlowCompleteValue;
     apy?: number | null;
+    vault: YieldDto;
+    networkSymbol: NetworkSymbol;
 };
 
-export const YieldFlowCompleteSupply = ({ input, output, apy }: YieldFlowCompleteSupplyProps) => (
+export const YieldFlowCompleteSupply = ({
+    input,
+    output,
+    apy,
+    vault,
+    networkSymbol,
+}: YieldFlowCompleteSupplyProps) => (
     <YieldFlowComplete
         type="supply"
         heading={<Translation id="TR_EARN_YIELD_SUPPLY_COMPLETE" />}
@@ -29,7 +39,11 @@ export const YieldFlowCompleteSupply = ({ input, output, apy }: YieldFlowComplet
                 <Translation id="TR_EARN_DASHBOARD_TABLE_APY" />
             </Text>
             <Text typographyStyle="body-md-strong">
-                <ApyValue apy={apy} />
+                <EarnYieldApyTooltip
+                    vault={vault}
+                    apyPercentage={apy ?? null}
+                    networkSymbol={networkSymbol}
+                />
             </Text>
         </Row>
         <Divider color="borderNeutral" margin={0} />

--- a/packages/suite/src/components/earn/yield/supply/YieldSupplyForm.tsx
+++ b/packages/suite/src/components/earn/yield/supply/YieldSupplyForm.tsx
@@ -21,6 +21,7 @@ export const YieldSupplyForm = () => {
 
     const {
         account,
+        vault,
         token,
         receiptToken,
         apy,
@@ -155,6 +156,8 @@ export const YieldSupplyForm = () => {
                     {flow.currentStep === 'complete' ? (
                         <YieldFlowCompleteSupply
                             apy={apy}
+                            vault={vault}
+                            networkSymbol={account.symbol}
                             input={{
                                 token,
                                 amount: completedAmount,

--- a/packages/suite/src/components/suite/banners/SuiteBanners/CardanoOutdatedStakingBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/CardanoOutdatedStakingBanner.tsx
@@ -4,8 +4,8 @@ import { Feature, selectIsFeatureEnabled } from '@suite-common/message-system';
 import { selectPoolStatsApy } from '@suite-common/wallet-core';
 import { Banner } from '@trezor/components';
 
+import { formatApyValue } from 'src/components/earn/utils/earnApyUtils';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { formatApyValue } from 'src/views/wallet/staking/utils/formatStakeValues';
 
 export const CardanoOutdatedStakingBanner = () => {
     const dispatch = useDispatch();

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakingBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakingBanner.tsx
@@ -19,9 +19,9 @@ import { Banner } from '@trezor/components';
 import { exhaustive } from '@trezor/type-utils';
 import { BigNumber } from '@trezor/utils';
 
+import { formatApyValue } from 'src/components/earn/utils/earnApyUtils';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useAnalytics } from 'src/support/useAnalytics';
-import { formatApyValue } from 'src/views/wallet/staking/utils/formatStakeValues';
 
 type StakingBannerProps = {
     account: Account;

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EmptyStakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EmptyStakingCard.tsx
@@ -29,11 +29,11 @@ import { spacings } from '@trezor/theme';
 import { BigNumber } from '@trezor/utils';
 
 import { DashboardSection } from 'src/components/dashboard';
+import { formatApyValue } from 'src/components/earn/utils/earnApyUtils';
 import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
 import { useDispatch, useLayoutSize, useSelector } from 'src/hooks/suite';
 import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
-import { formatApyValue } from 'src/views/wallet/staking/utils/formatStakeValues';
 
 import { DiscoveryWarning } from './DiscoveryWarning';
 

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/NewProviderCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/NewProviderCard.tsx
@@ -8,9 +8,9 @@ import { isCardanoStakedWithFiveBinaries } from '@suite-common/wallet-utils';
 import { Button, Card, Column, H3, Icon, Paragraph, Row, Tooltip } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
+import { formatApyValue } from 'src/components/earn/utils/earnApyUtils';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
-import { formatApyValue } from 'src/views/wallet/staking/utils/formatStakeValues';
 
 interface NewProviderCardProps {
     account: Account;

--- a/packages/suite/src/views/wallet/staking/utils/formatStakeValues.tsx
+++ b/packages/suite/src/views/wallet/staking/utils/formatStakeValues.tsx
@@ -1,9 +1,0 @@
-import { Translation } from '@suite/intl';
-
-export const formatApyValue = (apy?: number | null) => {
-    if (apy == null) {
-        return <Translation id="TR_STAKE_N_A" />;
-    }
-
-    return `${apy}`;
-};

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10064,8 +10064,8 @@ export const messages = defineMessages({
         id: 'TR_EARN_NOT_AVAILABLE',
         defaultMessage: 'Not available',
     },
-    TR_STAKE_N_A: {
-        id: 'TR_STAKE_N_A',
+    TR_EARN_APY_N_A: {
+        id: 'TR_EARN_APY_N_A',
         defaultMessage: 'N/A',
     },
     TR_EARN_APY_REQUIRED: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- add APY text to nutshell modal
- rewards breakdown in nutshell modal and when deposit is complete

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #27462
Resolve #27326

## Screenshots:

<img width="677" height="860" alt="Screenshot 2026-05-07 at 16 04 36" src="https://github.com/user-attachments/assets/6cce86aa-1599-4c8f-ba91-6292c0fe143e" />
<img width="681" height="746" alt="Screenshot 2026-05-07 at 16 03 45" src="https://github.com/user-attachments/assets/c7fb3020-b461-4afb-ae89-8838ae9f17e1" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/apy-improvements&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-07T14:28:18.004Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->