### PR TITLE
chore(earn): rename supply flow to deposit flow

### DIFF
--- a/packages/suite/src/actions/wallet/stablecoinYieldSigningThunks.ts
+++ b/packages/suite/src/actions/wallet/stablecoinYieldSigningThunks.ts
@@ -417,7 +417,7 @@ export const submitYieldActionThunk = createThunk(
             }
 
             const actionTransaction =
-                flowType === 'supply'
+                flowType === 'deposit'
                     ? getYieldSupplyTransaction(transactions)
                     : getYieldWithdrawTransaction(transactions);
 
@@ -478,7 +478,7 @@ export const submitYieldActionThunk = createThunk(
 
             dispatch(
                 notificationsActions.addToast({
-                    type: flowType === 'supply' ? 'tx-yield-supply' : 'tx-yield-withdraw',
+                    type: flowType === 'deposit' ? 'tx-yield-supply' : 'tx-yield-withdraw',
                     descriptor: flowData.account.descriptor,
                     symbol: flowData.account.symbol,
                     txid: result.txid,
@@ -486,7 +486,7 @@ export const submitYieldActionThunk = createThunk(
             );
 
             const receiptAmount =
-                flowType === 'supply'
+                flowType === 'deposit'
                     ? (getWithdrawRequestAmount({
                           networkSymbol: flowData.account.symbol,
                           amount,

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx
@@ -120,7 +120,7 @@ export const EarnYieldAccountOpportunity = ({ opportunity }: EarnYieldAccountOpp
             payload: {
                 action: 'continue',
                 from: 'earn-dashboard',
-                to: 'supply-in-a-nutshell-modal',
+                to: 'deposit-in-a-nutshell-modal',
                 networkSymbol: opportunity.account.symbol,
                 contractAddress: opportunity.vault.token.address,
             },
@@ -157,7 +157,7 @@ export const EarnYieldAccountOpportunity = ({ opportunity }: EarnYieldAccountOpp
             payload: {
                 action: 'continue',
                 from: 'earn-dashboard',
-                to: 'supply-form',
+                to: 'deposit-form',
                 networkSymbol: opportunity.account.symbol,
                 contractAddress: opportunity.vault.token.address,
             },

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/YieldEarnInANutshellModal.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/YieldEarnInANutshellModal.tsx
@@ -77,8 +77,8 @@ export const YieldEarnInANutshellModal = ({
             type: events.yieldNavigateEvent.name,
             payload: {
                 action: 'continue',
-                from: 'supply-in-a-nutshell-modal',
-                to: 'supply-morpho-modal',
+                from: 'deposit-in-a-nutshell-modal',
+                to: 'deposit-morpho-modal',
                 networkSymbol: account.symbol,
                 contractAddress: vault?.token.address,
             },
@@ -92,8 +92,8 @@ export const YieldEarnInANutshellModal = ({
             type: events.yieldNavigateEvent.name,
             payload: {
                 action: 'cancel',
-                from: 'supply-in-a-nutshell-modal',
-                to: 'supply-in-a-nutshell-modal',
+                from: 'deposit-in-a-nutshell-modal',
+                to: 'deposit-in-a-nutshell-modal',
                 networkSymbol: account.symbol,
                 contractAddress: vault?.token.address,
             },

--- a/packages/suite/src/components/earn/modals/EarnProviderConsent/YieldEarnProviderConsentModal.tsx
+++ b/packages/suite/src/components/earn/modals/EarnProviderConsent/YieldEarnProviderConsentModal.tsx
@@ -72,8 +72,8 @@ export const YieldEarnProviderConsentModal = ({
             type: events.yieldNavigateEvent.name,
             payload: {
                 action: 'continue',
-                from: 'supply-morpho-modal',
-                to: 'supply-form',
+                from: 'deposit-morpho-modal',
+                to: 'deposit-form',
                 networkSymbol: account.symbol,
                 contractAddress: yieldContext?.tokenContractAddress,
             },
@@ -87,8 +87,8 @@ export const YieldEarnProviderConsentModal = ({
             type: events.yieldNavigateEvent.name,
             payload: {
                 action: 'cancel',
-                from: 'supply-morpho-modal',
-                to: 'supply-morpho-modal',
+                from: 'deposit-morpho-modal',
+                to: 'deposit-morpho-modal',
                 networkSymbol: account.symbol,
                 contractAddress: yieldContext?.tokenContractAddress,
             },

--- a/packages/suite/src/components/earn/yield/common/YieldActionStep.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldActionStep.tsx
@@ -12,7 +12,7 @@ import { YieldAmountCard } from './YieldAmountCard';
 import { YieldPendingTransaction } from './YieldPendingTransaction';
 
 const actionStepTranslationMap = {
-    supply: {
+    deposit: {
         amountLabelTranslationId: 'TR_EARN_YIELD_AMOUNT_TO_SUPPLY',
         submitTranslationId: 'TR_EARN_YIELD_SUPPLY',
         balanceLabelTranslationId: 'TR_BALANCE',

--- a/packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx
@@ -14,7 +14,7 @@ import { YieldPendingTransaction } from './YieldPendingTransaction';
 import type { YieldApprovalAction } from '../yieldFlowUtils';
 
 const approveStepTranslationMap = {
-    supply: {
+    deposit: {
         amountLabelTranslationId: 'TR_EARN_YIELD_AMOUNT_TO_SUPPLY',
         balanceLabelTranslationId: 'TR_BALANCE',
     },

--- a/packages/suite/src/components/earn/yield/common/YieldDisabledBanner.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldDisabledBanner.tsx
@@ -10,7 +10,7 @@ type YieldDisabledBannerProps = {
 };
 
 const yieldDisabledMessageMap = {
-    supply: 'TR_EARN_YIELD_SUPPLY_DISABLED',
+    deposit: 'TR_EARN_YIELD_SUPPLY_DISABLED',
     withdraw: 'TR_EARN_YIELD_WITHDRAW_DISABLED',
     claim: 'TR_EARN_YIELD_CLAIM_DISABLED',
 } as const;

--- a/packages/suite/src/components/earn/yield/common/YieldFlowComplete.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldFlowComplete.tsx
@@ -11,7 +11,7 @@ import { useDispatch } from 'src/hooks/suite';
 import { useAnalytics } from 'src/support/useAnalytics';
 
 type YieldFlowCompleteProps = {
-    type: 'supply' | 'withdraw' | 'claim';
+    type: 'deposit' | 'withdraw' | 'claim';
     heading: ReactNode;
     description: ReactNode;
     showFeedback?: boolean;

--- a/packages/suite/src/components/earn/yield/common/YieldFlowCompleteSupply.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldFlowCompleteSupply.tsx
@@ -15,7 +15,7 @@ type YieldFlowCompleteSupplyProps = {
 
 export const YieldFlowCompleteSupply = ({ input, output, apy }: YieldFlowCompleteSupplyProps) => (
     <YieldFlowComplete
-        type="supply"
+        type="deposit"
         heading={<Translation id="TR_EARN_YIELD_SUPPLY_COMPLETE" />}
         description={<Translation id="TR_EARN_YIELD_SUPPLY_COMPLETE_DESCRIPTION" />}
         showFeedback

--- a/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
@@ -42,7 +42,7 @@ export const YieldPageHeader = ({ analyticsStep, account, routeParams }: YieldPa
                 from: (() => {
                     switch (analyticsStep) {
                         case 'yield-supply':
-                            return 'supply-form';
+                            return 'deposit-form';
                         case 'yield-withdraw':
                             return 'withdraw-form';
                     }

--- a/packages/suite/src/components/earn/yield/common/YieldPendingTransaction.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldPendingTransaction.tsx
@@ -17,7 +17,7 @@ const getPendingTransactionLabel = (kind: YieldPendingTransactionState['type']):
         case 'revoke':
         case 'revoke-only':
             return 'TR_EXCHANGE_APPROVAL_FORM_REVOKING_APPROVAL';
-        case 'supply':
+        case 'deposit':
             return 'TR_EARN_YIELD_PENDING_SUPPLY';
         case 'withdraw':
             return 'TR_EARN_YIELD_PENDING_WITHDRAW';

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -139,7 +139,7 @@ export const useYieldFlow = ({
 
     const session = useSelector(state => selectStablecoinYieldSession(state, flowType, flowKey));
 
-    const maxAmount = flowType === 'supply' ? (token?.balance ?? '') : suppliedAmount;
+    const maxAmount = flowType === 'deposit' ? (token?.balance ?? '') : suppliedAmount;
 
     useEffect(() => {
         if (!flowKey) {
@@ -171,7 +171,7 @@ export const useYieldFlow = ({
     );
 
     useEffect(() => {
-        if (flowType !== 'supply' || allowanceStatus !== 'idle') {
+        if (flowType !== 'deposit' || allowanceStatus !== 'idle') {
             return;
         }
 
@@ -495,7 +495,7 @@ export const useYieldFlow = ({
         });
 
         return {
-            approvalNetworkFeeWarning: flowType === 'supply' ? warning : null,
+            approvalNetworkFeeWarning: flowType === 'deposit' ? warning : null,
             actionNetworkFeeWarning: warning,
         };
     }, [account.availableBalance, account.networkType, account.symbol, feeInfo, flowType]);

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -466,6 +466,7 @@ export const useYieldFlow = ({
     const isAmountTooHigh = isAmountGreaterThan({ amount: liveAmount, threshold: maxAmount });
     const isApprovalInsufficient =
         !session.approval.isModifyMode &&
+        session.approval.allowanceStatus === 'loaded' &&
         isAmountGreaterThan({
             amount: liveAmount,
             threshold: session.approval.allowanceAmount ?? undefined,

--- a/packages/suite/src/components/earn/yield/supply/YieldSupply.tsx
+++ b/packages/suite/src/components/earn/yield/supply/YieldSupply.tsx
@@ -21,7 +21,7 @@ type YieldSupplyProps = {
 };
 
 export const YieldSupply = ({ account, routeParams }: YieldSupplyProps) => {
-    const { isDisabled, content } = useMessageSystemYield('supply');
+    const { isDisabled, content } = useMessageSystemYield('deposit');
     const allowanceContextValue = useAllowance({ account });
     const yieldSupplyContextValues = useYieldSupply({ account, routeParams });
 
@@ -32,9 +32,9 @@ export const YieldSupply = ({ account, routeParams }: YieldSupplyProps) => {
     return (
         <AllowanceContext.Provider value={allowanceContextValue}>
             <Column gap={24}>
-                <ContextMessage context={Context.getEarnYield('supply')} />
+                <ContextMessage context={Context.getEarnYield('deposit')} />
                 {isDisabled ? (
-                    <YieldDisabledBanner type="supply" content={content} />
+                    <YieldDisabledBanner type="deposit" content={content} />
                 ) : (
                     <YieldSupplyContext.Provider value={yieldSupplyContextValues}>
                         <FormProvider {...yieldSupplyContextValues.methods}>

--- a/packages/suite/src/components/earn/yield/supply/YieldSupplyForm.tsx
+++ b/packages/suite/src/components/earn/yield/supply/YieldSupplyForm.tsx
@@ -59,7 +59,7 @@ export const YieldSupplyForm = () => {
     } = flow.stepStates;
 
     const { approvalPendingTransaction, actionPendingTransaction: supplyPendingTransaction } =
-        splitYieldPendingTransaction(pendingTransaction, 'supply');
+        splitYieldPendingTransaction(pendingTransaction, 'deposit');
 
     // trigger success analytics event
     useEffect(() => {
@@ -201,7 +201,7 @@ export const YieldSupplyForm = () => {
                                     }
                                 >
                                     <YieldApproveStep
-                                        flowType="supply"
+                                        flowType="deposit"
                                         token={token}
                                         variant={approveStepState === 'done' ? 'done' : 'active'}
                                         summaryValue={
@@ -248,7 +248,7 @@ export const YieldSupplyForm = () => {
                                 >
                                     {actionStepState === 'active' && (
                                         <YieldActionStep
-                                            flowType="supply"
+                                            flowType="deposit"
                                             token={token}
                                             summaryValue={
                                                 <FormattedCryptoAmount

--- a/packages/suite/src/components/earn/yield/supply/useYieldSupply.ts
+++ b/packages/suite/src/components/earn/yield/supply/useYieldSupply.ts
@@ -12,7 +12,7 @@ export const useYieldSupply = ({
     account,
     routeParams,
 }: UseYieldSupplyProps): YieldFlowContextValues | null => {
-    const flowResult = useYieldFlow({ account, routeParams, flowType: 'supply' });
+    const flowResult = useYieldFlow({ account, routeParams, flowType: 'deposit' });
     const { vault, token, receiptToken } = flowResult;
 
     if (!token || !receiptToken || !vault) {

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
@@ -112,8 +112,8 @@ const getTranslationValues = (
         return getStakeTranslations(stakeType, networkType);
     }
 
-    if (evmTxType === 'supply' || evmTxType === 'withdraw') {
-        const isSupply = evmTxType === 'supply';
+    if (evmTxType === 'deposit' || evmTxType === 'withdraw') {
+        const isSupply = evmTxType === 'deposit';
 
         return {
             label: isSupply
@@ -172,7 +172,7 @@ const getOutputTitle = (
             return <Translation id={contractTitle} />;
         case 'address':
         case 'regular_legacy':
-            if (evmTxType === 'supply') {
+            if (evmTxType === 'deposit') {
                 return <Translation id="TR_EARN_YIELD_DEPOSIT_TO" />;
             }
             if (evmTxType === 'withdraw') {
@@ -182,7 +182,7 @@ const getOutputTitle = (
             return <Translation id={translation ? translation.label : 'TR_RECIPIENT_ADDRESS'} />;
 
         case 'amount':
-            if (evmTxType === 'supply' || evmTxType === 'withdraw') {
+            if (evmTxType === 'deposit' || evmTxType === 'withdraw') {
                 return <Translation id="AMOUNT" />;
             }
 
@@ -320,7 +320,7 @@ const getOutputLines = ({
                 device,
             );
 
-            if (evmTxType === 'supply' || evmTxType === 'withdraw') {
+            if (evmTxType === 'deposit' || evmTxType === 'withdraw') {
                 if (type === 'data' && translationValues) {
                     return [
                         {
@@ -397,14 +397,14 @@ const getOutputLines = ({
                 },
             ];
         case 'amount': {
-            if (evmTxType === 'supply' || evmTxType === 'withdraw') {
+            if (evmTxType === 'deposit' || evmTxType === 'withdraw') {
                 return [
                     {
                         id: 'amount',
                         label: (
                             <Translation
                                 id={
-                                    evmTxType === 'supply'
+                                    evmTxType === 'deposit'
                                         ? 'TR_EARN_YIELD_REVIEW_SUPPLY_AMOUNT'
                                         : 'TR_EARN_YIELD_REVIEW_WITHDRAW_AMOUNT'
                                 }

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
@@ -140,7 +140,7 @@ const TokenRowBasicActions = ({
             payload: {
                 action: 'continue',
                 from: 'account-defi-tokens',
-                to: 'supply-form',
+                to: 'deposit-form',
                 networkSymbol: account.symbol,
                 contractAddress,
             },

--- a/suite-common/earn-stablecoin/src/tx-simulation/txSimulationAction.ts
+++ b/suite-common/earn-stablecoin/src/tx-simulation/txSimulationAction.ts
@@ -20,7 +20,7 @@ const partialAccount = z.object({
 
 const stablecoinYieldTxSimulationParams = z.discriminatedUnion('flow', [
     z.strictObject({
-        flow: z.union([z.literal('supply'), z.literal('withdraw')]),
+        flow: z.union([z.literal('deposit'), z.literal('withdraw')]),
         account: partialAccount,
         unsignedTx: z.string(),
     }),
@@ -45,7 +45,7 @@ function composeUnsignedEvmTx(
     params: StablecoinYieldTxSimulationParams,
 ): EthereumSignTransaction['transaction'] {
     switch (params.flow) {
-        case 'supply':
+        case 'deposit':
         case 'withdraw': {
             const {
                 to,

--- a/suite-common/message-system/schema/config.schema.v1.json
+++ b/suite-common/message-system/schema/config.schema.v1.json
@@ -789,7 +789,7 @@
         },
         "yieldFlowType": {
             "type": "string",
-            "enum": ["supply", "withdraw", "claim"]
+            "enum": ["deposit", "withdraw", "claim"]
         }
     }
 }

--- a/suite-common/message-system/src/__tests__/messageSystemTypes.test.ts
+++ b/suite-common/message-system/src/__tests__/messageSystemTypes.test.ts
@@ -69,7 +69,7 @@ describe('Message system types', () => {
 
         describe('getEarnYield', () => {
             it.each([
-                ['supply', 'earn.yield.supply'],
+                ['deposit', 'earn.yield.deposit'],
                 ['withdraw', 'earn.yield.withdraw'],
                 ['claim', 'earn.yield.claim'],
             ] as const)('getEarnYield(%s) → %s', (type, expected) => {

--- a/suite-common/message-system/src/messageSystemTypes.ts
+++ b/suite-common/message-system/src/messageSystemTypes.ts
@@ -98,7 +98,7 @@ export const Feature = {
             yield: 'earn.dashboard.yield',
         } as const satisfies Record<EarnDashboardType, string>,
         yield: {
-            supply: 'earn.yield.supply',
+            deposit: 'earn.yield.deposit',
             withdraw: 'earn.yield.withdraw',
             claim: 'earn.yield.claim',
         } as const satisfies Record<YieldFlowType, string>,
@@ -157,7 +157,7 @@ const getLegalContext = (key: LegalContextKey) => `legal.${key}` as const;
  * - `getStaking('eth')` → 'accounts.eth.staking'
  * - `getTrading('buy')` → 'trading.buy'
  * - `getEarnDashboard('yield')` → 'earn.dashboard.yield'
- * - `getEarnYield('supply')` → 'earn.yield.supply'
+ * - `getEarnYield('deposit')` → 'earn.yield.deposit'
  * - `getEarnYield('claim')` → 'earn.yield.claim'
  * - `getSettings('device')` → 'settings.device'
 

--- a/suite-common/suite-types/src/messageSystem.ts
+++ b/suite-common/suite-types/src/messageSystem.ts
@@ -307,7 +307,7 @@ export type TradingType = 'buy' | 'sell' | 'exchange';
  * This interface was referenced by `MessageSystem`'s JSON-Schema
  * via the `definition` "yieldFlowType".
  */
-export type YieldFlowType = 'supply' | 'withdraw' | 'claim';
+export type YieldFlowType = 'deposit' | 'withdraw' | 'claim';
 
 /**
  * JSON schema of the Trezor Suite messaging system.

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.ts
@@ -42,7 +42,7 @@ export type YieldSessionDataAmountPayload = YieldSessionDataPayload & {
 };
 
 type InitYieldAllowancePayload = YieldSessionDataPayload & {
-    flowType: 'supply';
+    flowType: 'deposit';
 };
 
 type SetYieldGenericErrorParams = YieldSessionPayload & {
@@ -99,7 +99,7 @@ export const getApprovalContractAddress = ({
     flowType,
     flowData,
 }: GetApprovalContractAddressParams) =>
-    flowType === 'supply'
+    flowType === 'deposit'
         ? (flowData.token.contractAddress ?? undefined)
         : (flowData.receiptToken.contractAddress ?? undefined);
 
@@ -108,7 +108,7 @@ export const getApprovalRequestAmount = ({
     amount,
     flowData,
 }: GetApprovalRequestAmountParams) => {
-    if (flowType === 'supply') {
+    if (flowType === 'deposit') {
         return amount;
     }
 
@@ -234,7 +234,7 @@ export const submitYieldOpportunity = async ({
     amount,
 }: SubmitYieldOpportunityParams) => {
     switch (flowType) {
-        case 'supply': {
+        case 'deposit': {
             const response = await enterYield({
                 yieldId: flowData.vault.id,
                 address: flowData.account.descriptor,

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
@@ -113,7 +113,7 @@ export const initialStablecoinYieldTxReviewState: StablecoinYieldTxReviewState =
 };
 
 export const initialStablecoinYieldState: StablecoinYieldState = {
-    supply: Object.create(null),
+    deposit: Object.create(null),
     withdraw: Object.create(null),
     claim: Object.create(null),
     txReview: initialStablecoinYieldTxReviewState,

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldTypes.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldTypes.ts
@@ -2,7 +2,7 @@ import type { YieldDto } from '@suite-common/earn-stablecoin-api';
 import type { NetworkSymbol } from '@suite-common/wallet-config';
 import type { Account } from '@suite-common/wallet-types';
 
-export const YIELD_FLOW_TYPES = ['supply', 'withdraw', 'claim'] as const;
+export const YIELD_FLOW_TYPES = ['deposit', 'withdraw', 'claim'] as const;
 export const YIELD_FLOW_STEPS = ['approve', 'action', 'complete'] as const;
 
 export type YieldFlowType = (typeof YIELD_FLOW_TYPES)[number];
@@ -46,7 +46,7 @@ export type YieldApproveModalState = {
 };
 
 export type YieldPendingTransactionState = {
-    type: 'approve' | 'revoke' | 'revoke-only' | 'supply' | 'withdraw' | 'claim';
+    type: 'approve' | 'revoke' | 'revoke-only' | 'deposit' | 'withdraw' | 'claim';
     txid: string;
     amount: string;
 };

--- a/suite-common/wallet-types/src/sendForm.ts
+++ b/suite-common/wallet-types/src/sendForm.ts
@@ -95,6 +95,6 @@ export interface FormState {
 }
 
 export type YieldFormMetadata = {
-    type: 'supply' | 'withdraw';
+    type: 'deposit' | 'withdraw';
     vaultName: string;
 };

--- a/suite-common/wallet-types/src/transaction.ts
+++ b/suite-common/wallet-types/src/transaction.ts
@@ -250,9 +250,9 @@ export type EvmTransactionPurpose =
     | 'approve'
     | 'revoke'
     | 'unknown'
-    | ''
-    | 'supply'
-    | 'withdraw';
+    | 'deposit'
+    | 'withdraw'
+    | '';
 
 export interface RbfTransactionParamsEthereum {
     type: 'ethereum';

--- a/suite-native/module-accounts-management/src/components/StablecoinYieldTokenOverview.tsx
+++ b/suite-native/module-accounts-management/src/components/StablecoinYieldTokenOverview.tsx
@@ -213,7 +213,7 @@ export const StablecoinYieldTokenOverview = ({
                                     intent="brand"
                                     priority="secondary"
                                     size="medium"
-                                    testID="@account-detail/stablecoin-yield/supply-more-button"
+                                    testID="@account-detail/stablecoin-yield/deposit-more-button"
                                 >
                                     <Translation id="moduleAccounts.accountDetail.stablecoinYield.supplyMore" />
                                 </Button>

--- a/suite-native/module-earn/src/hooks/useYieldApprovalFees.ts
+++ b/suite-native/module-earn/src/hooks/useYieldApprovalFees.ts
@@ -122,7 +122,7 @@ export const useYieldApprovalFees = ({
                 formDraftKey: approvalFormDraftKey,
             } = composeApprovalFeeParams;
             const approvalContractAddress = getApprovalContractAddress({
-                flowType: 'supply',
+                flowType: 'deposit',
                 flowData: approvalFlowData,
             });
 

--- a/suite-native/module-earn/src/hooks/useYieldApprovalReview.ts
+++ b/suite-native/module-earn/src/hooks/useYieldApprovalReview.ts
@@ -90,7 +90,7 @@ export const useYieldApprovalReview = ({
     const isMevProtectionEnabled = useSelector(selectIsMevProtectionEnabled);
     const isMevProtectionFeatureEnabled = useSelector(selectIsMevProtectionFeatureEnabled);
     const session = useSelector((state: StablecoinYieldRootState) =>
-        selectStablecoinYieldSession(state, 'supply', flowKey),
+        selectStablecoinYieldSession(state, 'deposit', flowKey),
     );
     const { approval } = session;
 
@@ -109,7 +109,7 @@ export const useYieldApprovalReview = ({
     });
 
     useEffect(() => {
-        dispatch(stablecoinYieldActions.initSession({ flowType: 'supply', flowKey }));
+        dispatch(stablecoinYieldActions.initSession({ flowType: 'deposit', flowKey }));
     }, [dispatch, flowKey]);
 
     const handleSubmitApprovalReview = useCallback(async () => {
@@ -203,7 +203,7 @@ export const useYieldApprovalReview = ({
 
         const { txid } = pushResponse.payload.payload;
 
-        await dispatch(handleYieldApproveSuccessTxidThunk({ flowType: 'supply', flowKey, txid }));
+        await dispatch(handleYieldApproveSuccessTxidThunk({ flowType: 'deposit', flowKey, txid }));
         dispatch(formDraftActions.removeDraft({ key: formDraftKey }));
         setIsSendingApproval(false);
 

--- a/suite-native/module-earn/src/hooks/useYieldApprovalReviewNavigation.ts
+++ b/suite-native/module-earn/src/hooks/useYieldApprovalReviewNavigation.ts
@@ -28,7 +28,7 @@ export const useYieldApprovalReviewNavigation = ({
 
     const cleanupApprovalReview = useCallback(() => {
         dispatch(cancelSignSendFormTransactionThunk());
-        dispatch(handleYieldApproveCancelThunk({ flowType: 'supply', flowKey }));
+        dispatch(handleYieldApproveCancelThunk({ flowType: 'deposit', flowKey }));
     }, [dispatch, flowKey]);
 
     useEffect(() => {

--- a/suite-native/module-earn/src/hooks/useYieldSupplyApprovalSubmit.ts
+++ b/suite-native/module-earn/src/hooks/useYieldSupplyApprovalSubmit.ts
@@ -47,7 +47,7 @@ export const useYieldSupplyApprovalSubmit = ({
                 return;
             }
 
-            const sessionParams = { flowType: 'supply' as const, flowKey };
+            const sessionParams = { flowType: 'deposit' as const, flowKey };
             const showSupplyWorkInProgress = (title?: string) => {
                 // TODO: Replace with correct handling flow once deposit is implemented.
                 showWorkInProgressAlert(title);
@@ -73,7 +73,7 @@ export const useYieldSupplyApprovalSubmit = ({
                     return;
                 }
 
-                const session = selectStablecoinYieldSession(store.getState(), 'supply', flowKey);
+                const session = selectStablecoinYieldSession(store.getState(), 'deposit', flowKey);
 
                 if (session.error) {
                     // TODO: Show a dedicated approval error

--- a/suite-native/module-earn/src/yieldApprovalThunks.ts
+++ b/suite-native/module-earn/src/yieldApprovalThunks.ts
@@ -51,7 +51,7 @@ export const prepareYieldApprovalReviewTransactionThunk = createThunk(
         const formDraft = selectDeepCopyOfFormDraft(getState(), formDraftKey) as
             | FormState
             | undefined;
-        const { approval } = selectStablecoinYieldSession(getState(), 'supply', flowKey);
+        const { approval } = selectStablecoinYieldSession(getState(), 'deposit', flowKey);
 
         if (!approval.modalState) {
             return rejectWithValue('Approval review transaction is not ready.');

--- a/suite/analytics/src/events/yieldNavigateEvent.ts
+++ b/suite/analytics/src/events/yieldNavigateEvent.ts
@@ -8,20 +8,20 @@ type Attributes = {
     from: AttributeDef<
         | 'earn-dashboard'
         | 'account-defi-tokens'
-        | 'supply-in-a-nutshell-modal'
-        | 'supply-morpho-modal'
+        | 'deposit-in-a-nutshell-modal'
+        | 'deposit-morpho-modal'
         | 'claim-select-account-modal'
-        | 'supply-form'
+        | 'deposit-form'
         | 'withdraw-form'
         | 'claim-form'
     >;
     to: AttributeDef<
         | 'earn-dashboard'
-        | 'supply-form'
+        | 'deposit-form'
         | 'withdraw-form'
         | 'claim-form'
-        | 'supply-in-a-nutshell-modal'
-        | 'supply-morpho-modal'
+        | 'deposit-in-a-nutshell-modal'
+        | 'deposit-morpho-modal'
         | 'claim-select-account-modal'
     >;
     networkSymbol?: AttributeDef<string>;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- rename supply to deposit in analytics and message system to avoid migration and non-backwards compatible troubles
- fix flashing of approve banner after approval

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #27338
## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/message-system-yield&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/message-system-yield&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/message-system-yield&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-07T15:23:06.867Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-07T15:21:14.942Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/message-system-yield/web/](https://dev.suite.sldev.cz/suite-web/feat/message-system-yield/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->