### PR TITLE
fix(suite): fix condition for Add label button in send form

### DIFF
--- a/packages/suite/src/views/wallet/send/Outputs/Address.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Address.tsx
@@ -35,6 +35,7 @@ import {
 } from '@trezor/urls';
 import { capitalizeFirstLetter } from '@trezor/utils';
 
+import { selectDesktopSuiteSyncInteraction } from 'src/actions/suiteSync/suiteSyncSlice';
 import { AddressLabeling, Labeling } from 'src/components/suite';
 import { InputError } from 'src/components/wallet';
 import { type InputErrorProps } from 'src/components/wallet/InputError';
@@ -68,7 +69,6 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
         getDefaultValue,
         formState: { errors },
         setValue,
-        metadataEnabled,
         watch,
         setDraftSaveRequest,
         trigger,
@@ -93,6 +93,11 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
     const broadcastEnabled = options.includes('broadcast');
     const isOnline = useSelector(state => state.suite.online);
     const isDebug = useSelector(selectIsDebugModeActive);
+    const suiteSyncInteraction = useSelector(state =>
+        account ? selectDesktopSuiteSyncInteraction(state, account.deviceState) : null,
+    );
+
+    const shouldShowLabelAction = suiteSyncInteraction === null || !!device?.connected;
 
     const [isExternalAddressCheckWarningDismissed, setIsExternalAddressCheckWarningDismissed] =
         useState(false);
@@ -499,7 +504,7 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
             labelRight={
                 <Row gap={spacings.md}>
                     {isDebug && <DevSelfAddress outputId={outputId} account={account} />}
-                    {metadataEnabled && broadcastEnabled && (
+                    {shouldShowLabelAction && broadcastEnabled && (
                         <Text typographyStyle="body-sm" as="div">
                             <Labeling
                                 deviceStaticSessionId={device.state.staticSessionId}

--- a/suite/e2e/tests/wallet/send-form-regtest.test.ts
+++ b/suite/e2e/tests/wallet/send-form-regtest.test.ts
@@ -15,7 +15,6 @@ test.describe('Send form for bitcoin', { tag: ['@T3W1', '@T3T1'] }, () => {
             await settingsPage.toggleTestnetNetworks();
             await settingsPage.navigateTo('coins');
             await settingsPage.coinsTab.enableNetwork('regtest');
-
             await trezorUserEnv.sendToAddressAndMineBlock({
                 address: ADDRESS_INDEX_1,
                 btc_amount: 1,
@@ -48,6 +47,7 @@ test.describe('Send form for bitcoin', { tag: ['@T3W1', '@T3T1'] }, () => {
         await page.getByTestId('@send/header-dropdown/locktime').click();
         await page.getByTestId('locktime-option/input').click();
         await page.getByTestId('locktime-option/option/block').click();
+        await expect(page.getByTestId('locktime-blockheight-input')).toBeVisible();
         await page.getByTestId('locktime-blockheight-input').fill('1000');
 
         await tradingPage.sendButton.click();


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

It should be visible if you can add the label or you have the device connected so you can enable Suite Sync. But not if you have older FW, unsupported device, disconnected device and keys missing.

<!--- Describe your changes in detail -->

## Notes for QA

Test the send form in all possible states and check if you can Add label only in cases where it's supposed to work.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27054

## Screenshots
<img width="785" height="330" alt="image" src="https://github.com/user-attachments/assets/0786f670-fcac-4606-bd01-dd04a22f2202" />


<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to the Address.tsx component within the send form's Outputs section, which handles recipient address input across all cryptocurrency networks. This is a focused UI component change affecting the send flow directly. The highest risk is in tests that fill in and validate address fields in send forms across different networks (BTC, ETH, DOGE, SOL, LTC). The file maps to 9 tests, all of which are relevant since they exercise the send form address functionality for various coin types.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/views/wallet/send/Outputs/Address.tsx`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test directly exercises the Bitcoin send form with multiple outputs, including address input fields. The Address.tsx component is a core part of the send form's output rendering, so any changes to address handling, validation, or display would be caught here.
- `suite/e2e/tests/wallet/send-eth.test.ts` — This test fills in a send form with a recipient address for Ethereum and verifies address display on both the app UI and hardware device. Address.tsx is the component responsible for the address input field in the send form outputs, making this a direct test of the changed component.
- `suite/e2e/tests/wallet/send-doge.test.ts` — This test opens the DOGE send form and fills in a recipient address, directly exercising the Address.tsx output component. It also verifies the address is correctly displayed in the device prompt modal.
- `suite/e2e/tests/wallet/send-sol.test.ts` — This test fills in a recipient address in the Solana send form and verifies address formatting in both the app and on the device display. The Address.tsx component handles the address input for all send form outputs.
- `suite/e2e/tests/wallet/import-btc-csv.test.ts` — This test imports a CSV file that auto-populates recipient addresses into the send form outputs. It directly asserts on outputs.0.address and outputs.1.address fields, which are rendered by Address.tsx.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — This test opens the LTC send form and fills in a recipient address for a MimbleWimble peg-out transaction. The address input is handled by the Address.tsx component being changed.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/wallet/cardano.test.ts` — This test opens the Cardano send form and verifies it displays Cardano-specific content. While it doesn't deeply test address input, it does exercise the send form which includes the Address.tsx component for Cardano's address format.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test exercises the global send flow where a user selects an account and sees the send form with correct labeling. The send form includes the Address.tsx component, though the test focuses more on account selection than address input.
- `suite/e2e/tests/wallet/without-device.test.ts` — This test navigates to the send form and fills in a send address input while the device is disconnected. It exercises the Address.tsx component in a disconnected-device scenario, testing that the address field works without device connectivity.

</details>

_Updated: 2026-05-07T15:42:51.388Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/send-form-add-label&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/send-form-add-label&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > call cancellation | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-12T14:21:38.886Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-12T14:20:58.920Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/send-form-add-label/web/](https://dev.suite.sldev.cz/suite-web/fix/send-form-add-label/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->