### PR TITLE
Bump beta version to 26.6.0

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/suite",
-    "suiteVersion": "26.5.0",
+    "suiteVersion": "26.6.0",
     "version": "1.0.0",
     "private": true,
     "scripts": {


### PR DESCRIPTION
Automatically generated PR to bump beta Suite version

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is packages/suite/package.json, which is a package manifest file. Changes to package.json typically involve dependency version bumps, adding/removing dependencies, or updating scripts. There is no static test coverage mapping for this file, and none of the E2E tests directly exercise package.json behavior. Since package.json changes affect the build/dependency resolution layer rather than any specific application feature, the risk is best mitigated through build verification and unit tests rather than E2E tests. No specific E2E tests can be concretely linked to this change — any regression from a dependency change would be broad and unpredictable, making targeted E2E test selection impractical.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/package.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/suite/package.json`

_Updated: 2026-05-07T17:18:24.076Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/bump-suite-version-26.6.0&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/bump-suite-version-26.6.0&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-07T17:23:33.787Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-07T17:21:47.758Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/bump-suite-version-26.6.0/web/](https://dev.suite.sldev.cz/suite-web/chore/bump-suite-version-26.6.0/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->