### PR TITLE
feat(eslint): add deep-import guardrail for connect-tier packages

### DIFF
--- a/packages/connect-webextension/src/index.ts
+++ b/packages/connect-webextension/src/index.ts
@@ -6,7 +6,9 @@ import { type ConnectDynamicSettings } from '@trezor/connect-common/src/impl/dyn
 import { TrezorConnectDynamic } from '@trezor/connect-common/src/impl/dynamic';
 // Import as src not lib due to webpack issues with inlining content script later
 import { ServiceWorkerWindowChannel } from '@trezor/connect-common/src/messageChannel/serviceworker-window';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports -- intra-tier wiring: connect-webextension composes implementations from connect-web (see #27376)
 import { CoreInSuiteDesktop } from '@trezor/connect-web/src/impl/core-in-suite-desktop';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports -- intra-tier wiring: connect-webextension composes implementations from connect-web (see #27376)
 import { CoreInSuiteWeb } from '@trezor/connect-web/src/impl/core-in-suite-web';
 
 const impl = new TrezorConnectDynamic({

--- a/packages/eslint/src/typescriptConfig.mjs
+++ b/packages/eslint/src/typescriptConfig.mjs
@@ -1,5 +1,52 @@
 import tseslint from 'typescript-eslint';
 
+// Deny importing from build artifact directories — consumers should resolve
+// through the package root, not from `lib/`, `libDev/`, or `libESM/`.
+const buildArtifactPatterns = {
+    group: [
+        '@trezor/*/lib',
+        '@trezor/*/lib/**',
+        '@trezor/*/libDev',
+        '@trezor/*/libDev/**',
+        '@trezor/*/libESM',
+        '@trezor/*/libESM/**',
+    ],
+    message:
+        'Import from the package root instead. Deep paths into "lib/", "libDev/" or "libESM/" target build artifacts that may not exist or may diverge from the workspace source.',
+};
+
+// Deep-path imports that bypass the public barrels of the connect-tier packages.
+// Tracked in https://github.com/trezor/trezor-suite/issues/27376.
+// External consumers must import from the package root (e.g. `@trezor/connect`).
+// A handful of legitimate cross-package wiring imports inside the connect-tier
+// (e.g. connect-webextension re-using connect-web impls) and a few deferred
+// refactors carry an inline `// eslint-disable-next-line` exception with a
+// pointer back to this issue.
+const connectDeepImportPatterns = [
+    {
+        group: ['@trezor/connect/src/**'],
+        message:
+            'Import from "@trezor/connect" instead. Deep paths into "@trezor/connect/src/**" bypass the public barrel.',
+    },
+    {
+        group: ['@trezor/connect-web/src/**'],
+        message:
+            'Import from "@trezor/connect-web" instead. Deep paths into "@trezor/connect-web/src/**" bypass the public barrel.',
+    },
+    {
+        group: ['@trezor/connect-webextension/src/**'],
+        message:
+            'Import from "@trezor/connect-webextension" instead. Deep paths into "@trezor/connect-webextension/src/**" bypass the public barrel.',
+    },
+];
+
+// Deny importing internal suite packages from outside the suite app itself.
+const suiteInternalPatterns = {
+    group: ['@suite-common/**', '@suite-native/**'],
+    message:
+        '@suite-common/* and @suite-native/* packages are private to the suite apps and must not be imported by other workspace packages.',
+};
+
 /** @type {import('typescript-eslint').ConfigArray} */
 export const typescriptConfig = [
     ...tseslint.configs.recommended,
@@ -18,14 +65,7 @@ export const typescriptConfig = [
                 'error',
                 {
                     paths: [{ name: '.' }, { name: '..' }, { name: '../..' }],
-                    patterns: [
-                        '@trezor/*/lib',
-                        '@trezor/*/lib/**',
-                        '@trezor/*/libDev',
-                        '@trezor/*/libDev/**',
-                        '@trezor/*/libESM',
-                        '@trezor/*/libESM/**',
-                    ],
+                    patterns: [buildArtifactPatterns, ...connectDeepImportPatterns],
                 },
             ],
 
@@ -62,12 +102,9 @@ export const typescriptConfig = [
                 {
                     paths: [{ name: '.' }, { name: '..' }, { name: '../..' }],
                     patterns: [
-                        '@trezor/*/lib',
-                        '@trezor/*/lib/**',
-                        '@trezor/*/libDev',
-                        '@trezor/*/libDev/**',
-                        '@suite-common/**',
-                        '@suite-native/**',
+                        buildArtifactPatterns,
+                        suiteInternalPatterns,
+                        ...connectDeepImportPatterns,
                     ],
                 },
             ],

--- a/packages/suite-desktop-core/src/modules/firmware.ts
+++ b/packages/suite-desktop-core/src/modules/firmware.ts
@@ -1,4 +1,5 @@
 import { FirmwareType } from '@trezor/connect';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports -- TODO: extract firmwareUtils to a shared location and remove this exception (see #27376 deferred work)
 import {
     buildLocalFirmwareFileName,
     buildLocalReleaseName,

--- a/packages/suite/src/actions/wallet/signVerifyActions.ts
+++ b/packages/suite/src/actions/wallet/signVerifyActions.ts
@@ -10,6 +10,7 @@ import {
     getStakingPath,
 } from '@suite-common/wallet-utils';
 import TrezorConnect, { PROTO } from '@trezor/connect';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports -- TODO: extract pathUtils to a shared location and remove this exception (see #27376 deferred work)
 import { getSerializedPath } from '@trezor/connect/src/utils/pathUtils';
 import { type SerializedError } from '@trezor/connect-common/src/constants/errors';
 import { type Result } from '@trezor/type-utils';

--- a/packages/suite/src/components/firmware/FirmwareInstallation.tsx
+++ b/packages/suite/src/components/firmware/FirmwareInstallation.tsx
@@ -2,6 +2,7 @@ import { FirmwareProgressBar, useFirmwareDesktopUpdate } from '@suite/firmware-u
 import { Translation } from '@suite/intl';
 import { Banner, Card, Column } from '@trezor/components';
 import TrezorConnect from '@trezor/connect';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports -- TODO: expose the browser-specific TrezorConnect type via the @trezor/connect barrel and remove this exception (see #27376)
 import type TrezorConnectBrowser from '@trezor/connect/src/index.browser';
 
 import { FirmwareOffer, ReconnectDevicePrompt, RotatingPhrases } from 'src/components/firmware';

--- a/packages/suite/src/components/suite/WebUsbButton.tsx
+++ b/packages/suite/src/components/suite/WebUsbButton.tsx
@@ -1,6 +1,7 @@
 import { Translation } from '@suite/intl';
 import { Button, type ButtonProps } from '@trezor/components';
 import TrezorConnect from '@trezor/connect';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports -- TODO: expose the browser-specific TrezorConnect type via the @trezor/connect barrel and remove this exception (see #27376)
 import type TrezorConnectBrowser from '@trezor/connect/src/index.browser';
 
 const handleClick = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {

--- a/packages/suite/src/hooks/suite/useOpenSuiteDesktop.ts
+++ b/packages/suite/src/hooks/suite/useOpenSuiteDesktop.ts
@@ -1,4 +1,5 @@
 import TrezorConnect from '@trezor/connect';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports -- TODO: expose the browser-specific TrezorConnect type via the @trezor/connect barrel and remove this exception (see #27376)
 import type TrezorConnectBrowser from '@trezor/connect/src/index.browser';
 import { useWindowFocus } from '@trezor/react-utils';
 import { SUITE_BRIDGE_DEEPLINK, SUITE_URL } from '@trezor/urls';

--- a/suite-common/connect-popup/src/methodHooks/bitcoinSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/bitcoinSignTransaction.ts
@@ -6,6 +6,7 @@ import {
 } from '@suite-common/wallet-core';
 import { type Account, type FormOptions } from '@suite-common/wallet-types';
 import type { CallMethodKeys, SignTransaction } from '@trezor/connect';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports -- TODO: extract pathUtils to a shared location and remove this exception (see #27376 deferred work)
 import { getSerializedPath } from '@trezor/connect/src/utils/pathUtils';
 
 import { connectPopupActions } from '../connectPopupActions';

--- a/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
@@ -13,6 +13,7 @@ import type {
     EthereumSignTypedData,
     MethodInfo,
 } from '@trezor/connect';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports -- TODO: extract pathUtils to a shared location and remove this exception (see #27376 deferred work)
 import { getSerializedPath, validatePath } from '@trezor/connect/src/utils/pathUtils';
 
 import { connectPopupActions } from '../connectPopupActions';

--- a/suite-common/connect-popup/src/methodHooks/solanaSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/solanaSignTransaction.ts
@@ -6,6 +6,7 @@ import {
 } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import type { CallMethodKeys, SolanaSignTransaction } from '@trezor/connect';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports -- TODO: extract pathUtils to a shared location and remove this exception (see #27376 deferred work)
 import { getSerializedPath, validatePath } from '@trezor/connect/src/utils/pathUtils';
 
 import { connectPopupActions } from '../connectPopupActions';

--- a/suite-common/trading/src/thunks/common/__tests__/createPaymentRequestsThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/createPaymentRequestsThunk.test.ts
@@ -5,6 +5,7 @@ import { createThunk } from '@suite-common/redux-utils';
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
 import { type Account, type GeneralPrecomposedTransaction } from '@suite-common/wallet-types';
 import TrezorConnect, { type Address, type PROTO } from '@trezor/connect';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports -- TODO: extract pathUtils to a shared location and remove this exception (see #27376 deferred work)
 import { validatePath } from '@trezor/connect/src/utils/pathUtils';
 
 import { invityAPI } from '../../../invityAPI';

--- a/suite-common/trading/src/thunks/common/createPaymentRequestsThunk.ts
+++ b/suite-common/trading/src/thunks/common/createPaymentRequestsThunk.ts
@@ -9,6 +9,7 @@ import { createThunk } from '@suite-common/redux-utils';
 import { selectAccountByKey } from '@suite-common/wallet-core';
 import { type Account, type GeneralPrecomposedTransaction } from '@suite-common/wallet-types';
 import { type PROTO } from '@trezor/connect';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports -- TODO: extract pathUtils to a shared location and remove this exception (see #27376 deferred work)
 import { getSlip44ByPath, validatePath } from '@trezor/connect/src/utils/pathUtils';
 import { exhaustive } from '@trezor/type-utils';
 

--- a/suite-common/trading/src/thunks/common/getPaymentRequestOutputs.ts
+++ b/suite-common/trading/src/thunks/common/getPaymentRequestOutputs.ts
@@ -4,6 +4,7 @@ import { createThunk } from '@suite-common/redux-utils';
 import type { Network } from '@suite-common/wallet-config';
 import { type GeneralPrecomposedTransactionFinal } from '@suite-common/wallet-types';
 import TrezorConnect from '@trezor/connect';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports -- TODO: blocked on blockchain plugin modularisation; remove this exception once Solana helpers are exposed via a public API (see #27376 deferred work)
 import { getAssociatedTokenAccountAddress } from '@trezor/connect/src/api/solana/solanaUtils';
 
 import { TRADING_THUNK_PREFIX } from '../../constants';

--- a/suite-common/trading/src/utils/signature/signatureUtils.ts
+++ b/suite-common/trading/src/utils/signature/signatureUtils.ts
@@ -8,6 +8,7 @@ import {
 import type { Network } from '@suite-common/wallet-config';
 import { asAmountUnit, unitsToSubunits } from '@suite-common/wallet-utils';
 import { type PROTO } from '@trezor/connect';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports -- TODO: extract pathUtils to a shared location and remove this exception (see #27376 deferred work)
 import { validatePath } from '@trezor/connect/src/utils/pathUtils';
 import { BigNumber, formatBigUintToLE } from '@trezor/utils';
 

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -36,6 +36,7 @@ import {
 } from '@suite-common/wallet-utils';
 import { type BlockbookTransaction } from '@trezor/blockchain-link-types';
 import TrezorConnect, { type PROTO } from '@trezor/connect';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports -- TODO: blocked on blockchain plugin modularisation; remove this exception once Solana helpers are exposed via a public API (see #27376 deferred work)
 import { getSolanaTokenDefinition } from '@trezor/connect/src/api/solana/solanaDefinitions';
 import { type Ok, exhaustive } from '@trezor/type-utils';
 import { BigNumber, cloneObject, typedObjectEntries } from '@trezor/utils';


### PR DESCRIPTION
## Summary

Adds an ESLint guardrail (`@typescript-eslint/no-restricted-imports`) that prevents future deep-path imports past the public barrels of the connect-tier packages. The rule fires on any import matching `@trezor/connect/src/**`, `@trezor/connect-web/src/**`, or `@trezor/connect-webextension/src/**`. Existing legitimate or deferred deep imports are annotated with inline `// eslint-disable-next-line` exceptions that point back to this issue.

## Source issue

Resolves #27376

## Implementation notes

- `packages/eslint/src/typescriptConfig.mjs`: extracted the existing string-form patterns into named object-form constants (`buildArtifactPatterns`, `suiteInternalPatterns`) so the new connect-tier patterns can co-exist with per-pattern messages. The `@typescript-eslint/no-restricted-imports` schema requires patterns to be either all-string or all-object — mixing the two forms is what required the refactor of the existing entries. Behavior of the existing build-artifact (`@trezor/*/lib`, `…/libDev`, `…/libESM`) and `@suite-common/**` / `@suite-native/**` rules is unchanged.
- The new `connectDeepImportPatterns` carry actionable messages that name the public barrel to import from instead.
- Each of the deferred deep imports identified in the issue gets an inline `eslint-disable-next-line` comment with a TODO and the issue number:
  - `pathUtils` (6 files): `packages/suite/src/actions/wallet/signVerifyActions.ts`, `suite-common/connect-popup/src/methodHooks/{bitcoin,ethereum,solana}SignTransaction.ts`, `suite-common/trading/src/thunks/common/createPaymentRequestsThunk.ts` (+ test), `suite-common/trading/src/utils/signature/signatureUtils.ts`.
  - `firmwareUtils` (1 file): `packages/suite-desktop-core/src/modules/firmware.ts`.
  - Solana helpers (2 files): `suite-common/wallet-core/src/send/sendFormThunks.ts`, `suite-common/trading/src/thunks/common/getPaymentRequestOutputs.ts`.
- Three additional type-only `@trezor/connect/src/index.browser` imports in `packages/suite` (`WebUsbButton.tsx`, `FirmwareInstallation.tsx`, `useOpenSuiteDesktop.ts`) are similarly annotated; the cleanup is to expose the browser-specific `TrezorConnect` type via the package barrel.
- Two intra-tier wiring deep imports (`packages/connect-webextension/src/index.ts` reaching into `@trezor/connect-web/src/impl/...`) keep the same inline annotation tagged as “intra-tier wiring”.

### Why no `files`-scoped connect-tier override

A first attempt added a third config block to `typescriptConfig.mjs` with `files: ['packages/connect*/**']` and a relaxed rule, but it does not take effect: the repo uses **per-package `eslint.config.mjs` files**, and ESLint resolves `files` globs against the directory of the config file in use. Inside `packages/connect-webextension/`, the base path becomes `packages/connect-webextension/`, so a glob like `packages/connect*/**` cannot match. (The same caveat applies to the pre-existing `packages/**`-scoped block — it only fires when linted from the repo root.) Inline `eslint-disable-next-line` exceptions are the simpler and more robust mechanism here, and only two intra-tier sites need them.

### Out of scope (intentional deviation from the issue)

The issue's pattern list also includes `@trezor/connect-common/src/**`, but enabling that would flag well over a hundred existing deep imports across `suite-*`, `suite-common/*`, `suite-native/*`, `connect-explorer`, and the connect-tier itself (e.g. `@trezor/connect-common/src/constants`, `…/src/types/...`). Cleaning those up requires either a broad refactor or extending the public surface of `@trezor/connect-common` — both clearly larger than this guardrail PR. Recommended follow-up: open a separate issue tracking the `@trezor/connect-common/src/**` migration before adding it to the rule.

## Review guide

- `packages/eslint/src/typescriptConfig.mjs` — verify that the rule definitions remain logically equivalent to the existing string-form patterns, plus the three new connect-tier object patterns.
- The 14 inline `eslint-disable-next-line` comments — verify the rationales are accurate and that each refers back to the issue.
- `packages/connect-webextension/src/index.ts` — sanity-check that the two intra-tier exceptions are still needed.

## Remaining work / open questions

- `@trezor/connect-common/src/**` is intentionally not in the rule yet (see "Out of scope"). Suggest opening a follow-up issue to track the connect-common deep-import migration.
- The deferred refactors (pathUtils, firmwareUtils, Solana helpers) are tracked in the issue's "Deferred work" section — each `eslint-disable-next-line` comment points back to this PR's issue number so they're easy to find later.
- Exposing the browser-specific `TrezorConnect` type via the `@trezor/connect` barrel (instead of `@trezor/connect/src/index.browser`) is a small follow-up worth doing alongside the deferred refactors.

---
_Generated by [Claude Code](https://claude.ai/code/session_014bY9Z74SAyCrD4a8Vp67Wf)_

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=issue/27376-eslint-deep-import-guardrail&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=issue/27376-eslint-deep-import-guardrail&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=issue/27376-eslint-deep-import-guardrail&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-07T19:35:28.613Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-07T19:33:12.542Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/issue/27376-eslint-deep-import-guardrail/web/](https://dev.suite.sldev.cz/suite-web/issue/27376-eslint-deep-import-guardrail/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->