### PR TITLE
chore(requirements): forbid connect-tier deps in foundational packages

### DIFF
--- a/packages/blockchain-link-types/forbiddenDeps.config.ts
+++ b/packages/blockchain-link-types/forbiddenDeps.config.ts
@@ -1,0 +1,14 @@
+import type { ForbiddenDepsConfig } from '@trezor/requirements';
+
+const CONNECT_TIER_FORBIDDEN_REASON =
+    'Foundational packages must not depend on connect-tier packages (would create a dependency cycle through @trezor/connect-common).';
+
+export const forbiddenDepsConfig: ForbiddenDepsConfig = {
+    'forbidden-deps': [
+        { packageName: '@trezor/connect-common', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect-web', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect-webextension', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect-mobile', reason: CONNECT_TIER_FORBIDDEN_REASON },
+    ],
+};

--- a/packages/blockchain-link/forbiddenDeps.config.ts
+++ b/packages/blockchain-link/forbiddenDeps.config.ts
@@ -1,0 +1,14 @@
+import type { ForbiddenDepsConfig } from '@trezor/requirements';
+
+const CONNECT_TIER_FORBIDDEN_REASON =
+    'Foundational packages must not depend on connect-tier packages (would create a dependency cycle through @trezor/connect-common).';
+
+export const forbiddenDepsConfig: ForbiddenDepsConfig = {
+    'forbidden-deps': [
+        { packageName: '@trezor/connect-common', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect-web', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect-webextension', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect-mobile', reason: CONNECT_TIER_FORBIDDEN_REASON },
+    ],
+};

--- a/packages/device-authenticity/forbiddenDeps.config.ts
+++ b/packages/device-authenticity/forbiddenDeps.config.ts
@@ -1,0 +1,14 @@
+import type { ForbiddenDepsConfig } from '@trezor/requirements';
+
+const CONNECT_TIER_FORBIDDEN_REASON =
+    'Foundational packages must not depend on connect-tier packages (would create a dependency cycle through @trezor/connect-common).';
+
+export const forbiddenDepsConfig: ForbiddenDepsConfig = {
+    'forbidden-deps': [
+        { packageName: '@trezor/connect-common', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect-web', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect-webextension', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect-mobile', reason: CONNECT_TIER_FORBIDDEN_REASON },
+    ],
+};

--- a/packages/device-utils/forbiddenDeps.config.ts
+++ b/packages/device-utils/forbiddenDeps.config.ts
@@ -1,0 +1,14 @@
+import type { ForbiddenDepsConfig } from '@trezor/requirements';
+
+const CONNECT_TIER_FORBIDDEN_REASON =
+    'Foundational packages must not depend on connect-tier packages (would create a dependency cycle through @trezor/connect-common).';
+
+export const forbiddenDepsConfig: ForbiddenDepsConfig = {
+    'forbidden-deps': [
+        { packageName: '@trezor/connect-common', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect-web', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect-webextension', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect-mobile', reason: CONNECT_TIER_FORBIDDEN_REASON },
+    ],
+};

--- a/packages/protobuf/forbiddenDeps.config.ts
+++ b/packages/protobuf/forbiddenDeps.config.ts
@@ -1,0 +1,14 @@
+import type { ForbiddenDepsConfig } from '@trezor/requirements';
+
+const CONNECT_TIER_FORBIDDEN_REASON =
+    'Foundational packages must not depend on connect-tier packages (would create a dependency cycle through @trezor/connect-common).';
+
+export const forbiddenDepsConfig: ForbiddenDepsConfig = {
+    'forbidden-deps': [
+        { packageName: '@trezor/connect-common', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect-web', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect-webextension', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect-mobile', reason: CONNECT_TIER_FORBIDDEN_REASON },
+    ],
+};

--- a/packages/protocol/forbiddenDeps.config.ts
+++ b/packages/protocol/forbiddenDeps.config.ts
@@ -1,0 +1,14 @@
+import type { ForbiddenDepsConfig } from '@trezor/requirements';
+
+const CONNECT_TIER_FORBIDDEN_REASON =
+    'Foundational packages must not depend on connect-tier packages (would create a dependency cycle through @trezor/connect-common).';
+
+export const forbiddenDepsConfig: ForbiddenDepsConfig = {
+    'forbidden-deps': [
+        { packageName: '@trezor/connect-common', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect-web', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect-webextension', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect-mobile', reason: CONNECT_TIER_FORBIDDEN_REASON },
+    ],
+};

--- a/packages/schema-utils/forbiddenDeps.config.ts
+++ b/packages/schema-utils/forbiddenDeps.config.ts
@@ -1,0 +1,14 @@
+import type { ForbiddenDepsConfig } from '@trezor/requirements';
+
+const CONNECT_TIER_FORBIDDEN_REASON =
+    'Foundational packages must not depend on connect-tier packages (would create a dependency cycle through @trezor/connect-common).';
+
+export const forbiddenDepsConfig: ForbiddenDepsConfig = {
+    'forbidden-deps': [
+        { packageName: '@trezor/connect-common', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect-web', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect-webextension', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect-mobile', reason: CONNECT_TIER_FORBIDDEN_REASON },
+    ],
+};

--- a/packages/transport/forbiddenDeps.config.ts
+++ b/packages/transport/forbiddenDeps.config.ts
@@ -1,0 +1,14 @@
+import type { ForbiddenDepsConfig } from '@trezor/requirements';
+
+const CONNECT_TIER_FORBIDDEN_REASON =
+    'Foundational packages must not depend on connect-tier packages (would create a dependency cycle through @trezor/connect-common).';
+
+export const forbiddenDepsConfig: ForbiddenDepsConfig = {
+    'forbidden-deps': [
+        { packageName: '@trezor/connect-common', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect-web', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect-webextension', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect-mobile', reason: CONNECT_TIER_FORBIDDEN_REASON },
+    ],
+};

--- a/packages/type-utils/forbiddenDeps.config.ts
+++ b/packages/type-utils/forbiddenDeps.config.ts
@@ -1,0 +1,14 @@
+import type { ForbiddenDepsConfig } from '@trezor/requirements';
+
+const CONNECT_TIER_FORBIDDEN_REASON =
+    'Foundational packages must not depend on connect-tier packages (would create a dependency cycle through @trezor/connect-common).';
+
+export const forbiddenDepsConfig: ForbiddenDepsConfig = {
+    'forbidden-deps': [
+        { packageName: '@trezor/connect-common', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect-web', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect-webextension', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect-mobile', reason: CONNECT_TIER_FORBIDDEN_REASON },
+    ],
+};

--- a/packages/utils/forbiddenDeps.config.ts
+++ b/packages/utils/forbiddenDeps.config.ts
@@ -1,0 +1,14 @@
+import type { ForbiddenDepsConfig } from '@trezor/requirements';
+
+const CONNECT_TIER_FORBIDDEN_REASON =
+    'Foundational packages must not depend on connect-tier packages (would create a dependency cycle through @trezor/connect-common).';
+
+export const forbiddenDepsConfig: ForbiddenDepsConfig = {
+    'forbidden-deps': [
+        { packageName: '@trezor/connect-common', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect-web', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect-webextension', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect-mobile', reason: CONNECT_TIER_FORBIDDEN_REASON },
+    ],
+};

--- a/packages/utxo-lib/forbiddenDeps.config.ts
+++ b/packages/utxo-lib/forbiddenDeps.config.ts
@@ -1,0 +1,14 @@
+import type { ForbiddenDepsConfig } from '@trezor/requirements';
+
+const CONNECT_TIER_FORBIDDEN_REASON =
+    'Foundational packages must not depend on connect-tier packages (would create a dependency cycle through @trezor/connect-common).';
+
+export const forbiddenDepsConfig: ForbiddenDepsConfig = {
+    'forbidden-deps': [
+        { packageName: '@trezor/connect-common', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect-web', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect-webextension', reason: CONNECT_TIER_FORBIDDEN_REASON },
+        { packageName: '@trezor/connect-mobile', reason: CONNECT_TIER_FORBIDDEN_REASON },
+    ],
+};


### PR DESCRIPTION
## Summary

Adds `forbiddenDeps.config.ts` to each foundational `@trezor/*` package that `@trezor/connect-common` depends on, so the existing `@trezor/requirements` verifier fails any future attempt to declare a connect-tier dependency on these packages. Structurally prevents the dependency cycle that surfaced during the audit when moving `pathUtils` / `firmwareUtils` into `@trezor/device-utils` was considered.

This is the package.json-level guardrail that complements the ESLint deep-import guardrail tracked in #27376: ESLint guards import paths in code; this one guards declared dependencies.

## Source issue

Resolves #27377

## Implementation notes

- Each new config follows the shape demonstrated in `suite-native/module-onboarding/forbiddenDeps.config.ts` (uses `import type { ForbiddenDepsConfig } from '@trezor/requirements'` plus a `forbiddenDepsConfig` named export). `@trezor/requirements` only ships types, so no runtime dependency on it is introduced.
- Each config forbids all five connect-tier packages (`@trezor/connect-common`, `@trezor/connect`, `@trezor/connect-web`, `@trezor/connect-webextension`, `@trezor/connect-mobile`). The reason string explains the cycle rationale, so when verification fails the developer immediately understands what's expected.
- Audited the list against `packages/connect-common/package.json`'s `dependencies` and `devDependencies`. Configs were added to the 7 packages explicitly listed in the issue **plus** the 4 additional packages found in `connect-common`'s `devDependencies` (`@trezor/blockchain-link`, `@trezor/blockchain-link-types`, `@trezor/device-authenticity`, `@trezor/transport`). All four sit at the same architectural tier as the explicit list and the same cycle reasoning applies; if a reviewer prefers to keep the strict scope narrower, the four extra files can be removed without affecting the rest.
- Configured packages (11 total): `utils`, `device-utils`, `protobuf`, `protocol`, `schema-utils`, `type-utils`, `utxo-lib`, `blockchain-link`, `blockchain-link-types`, `device-authenticity`, `transport`.
- No `package.json` changes required. Each foundational package's existing tsconfig and Yarn workspace symlinks make the type import resolve cleanly without adding `@trezor/requirements` as a devDependency, which would otherwise create a workspace-graph cycle (`@trezor/requirements` already depends on `@trezor/utils` at runtime).

### Alternative rejected

`allowed-only-in` on `packages/connect-common/forbiddenDeps.config.ts` was considered (single-file enumeration of every package allowed to consume connect-common). Rejected per the issue's analysis: the consumer list is large (suite, suite-native/*, suite-common/*, suite-desktop-core, …) and brittle. Forbidding the cycle direction at the foundational packages keeps each config small (5 entries) and stays close to the cycle root.

## Review guide

- 11 new files at `packages/<pkg>/forbiddenDeps.config.ts` — verify the list of foundational packages is appropriate. The 4 packages beyond the issue's explicit list (`blockchain-link`, `blockchain-link-types`, `device-authenticity`, `transport`) can be dropped if you want to mirror the issue exactly.
- Confirm the `@trezor/connect-mobile` entry in the forbidden list is correct. The issue's example only listed the four other connect-tier packages, but `connect-mobile` depends on `connect-common`, so the same cycle concern applies. Drop the line if you'd prefer to scope strictly to the issue.

## Validation

- `yarn install --immutable` clean (no manifest changes).
- `yarn build:libs` clean.
- `yarn workspace @trezor/requirements requirements:verify` clean (552 requirements pass).
- Type-check on each of the 11 configured packages — all clean (`yarn workspaces foreach -A --include … run type-check`).
- Lint on each of the 11 configured packages — all clean (`yarn workspaces foreach -A --include … run lint:js`).
- Local simulation per the issue's verification step:
  - Temporarily added `"@trezor/connect-common": "workspace:*"` to `packages/utils/package.json` `devDependencies`.
  - `yarn workspace @trezor/requirements requirements:verify` failed with: `✗ forbidden-deps [utils] — @trezor/utils: "@trezor/connect-common" is forbidden in devDependencies. Reason: Foundational packages must not depend on connect-tier packages (would create a dependency cycle through @trezor/connect-common).` ✓
  - Reverted before commit.

### Skipped

- Full repo-wide `yarn lint` / `yarn type-check` — the change is additive (new files only) and only the 11 configured packages can be affected by it. No `package.json` was modified, so no other workspace can have its dependency graph altered.

## Remaining work / open questions

- None — the verifier will now flag any future regression on these 11 packages.
- Independent of #27376 (Part 3 ESLint guardrail) — can land in either order.

---
_Generated by [Claude Code](https://claude.ai/code/session_014bY9Z74SAyCrD4a8Vp67Wf)_

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=issue/27377-foundational-forbidden-deps&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=issue/27377-foundational-forbidden-deps&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-07T19:43:24.794Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-07T19:41:44.914Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/issue/27377-foundational-forbidden-deps/web/](https://dev.suite.sldev.cz/suite-web/issue/27377-foundational-forbidden-deps/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->