### PR TITLE
refactor(suite-native): simplify selector selectHomeScreenState

### DIFF
--- a/suite-native/module-home/src/screens/HomeScreen/HomeScreen.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/HomeScreen.tsx
@@ -50,16 +50,16 @@ export const HomeScreen = () => {
 
     const renderContent = () => {
         switch (homeScreenState) {
-            case 'portfolioContent':
-                return <PortfolioContent ref={portfolioContentRef} />;
-            case 'uninitializedDevice':
-                return <UninitializedConnectedDeviceState />;
-            case 'noNetworkConfigured':
-                return <NoNetworksConfigured />;
             case 'emptyPortfolioCrossroads':
                 return <EmptyPortfolioCrossroads />;
             case 'emptyPortfolioTracker':
                 return <EmptyPortfolioTrackerState />;
+            case 'uninitializedDevice':
+                return <UninitializedConnectedDeviceState />;
+            case 'noNetworkConfigured':
+                return <NoNetworksConfigured />;
+            case 'portfolioContent':
+                return <PortfolioContent ref={portfolioContentRef} />;
             default:
                 return exhaustive(homeScreenState);
         }

--- a/suite-native/module-home/src/screens/HomeScreen/__tests__/selectHomeScreenState.test.ts
+++ b/suite-native/module-home/src/screens/HomeScreen/__tests__/selectHomeScreenState.test.ts
@@ -1,4 +1,4 @@
-import { PORTFOLIO_TRACKER_DEVICE_ID } from '@suite-common/device';
+import { PORTFOLIO_TRACKER_DEVICE_ID, PORTFOLIO_TRACKER_DEVICE_STATE } from '@suite-common/device';
 import { createStoreFromPreloadedState } from '@suite-native/test-utils-store';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
@@ -26,6 +26,43 @@ describe('selectHomeScreenState', () => {
                 wallet: {
                     settings: { enabledNetworks: ['btc'] },
                     accounts: [{ deviceState: TEST_SESSION_ID, visible: true }],
+                },
+            });
+
+            expect(selectHomeScreenState(state)).toBe('portfolioContent');
+        });
+
+        it('should return portfolioContent when device is disconnected, authorized and has accounts', () => {
+            const state = buildState({
+                device: {
+                    selectedDevice: {
+                        connected: false,
+                        state: { staticSessionId: TEST_SESSION_ID },
+                        features: { initialized: true },
+                    },
+                    devices: [{ id: 'device_id' }],
+                },
+                wallet: {
+                    settings: { enabledNetworks: ['btc'] },
+                    accounts: [{ deviceState: TEST_SESSION_ID, visible: true }],
+                },
+            });
+
+            expect(selectHomeScreenState(state)).toBe('portfolioContent');
+        });
+
+        it('should return portfolioContent when portfolio tracker with accounts is selected', () => {
+            const state = buildState({
+                device: {
+                    selectedDevice: {
+                        id: PORTFOLIO_TRACKER_DEVICE_ID,
+                        state: { staticSessionId: PORTFOLIO_TRACKER_DEVICE_STATE },
+                        features: { unlocked: true },
+                    },
+                    devices: [{ id: PORTFOLIO_TRACKER_DEVICE_ID }],
+                },
+                wallet: {
+                    accounts: [{ deviceState: PORTFOLIO_TRACKER_DEVICE_STATE, visible: true }],
                 },
             });
 
@@ -80,10 +117,8 @@ describe('selectHomeScreenState', () => {
                         reconnectRequested: true,
                         features: {
                             initialized: true,
+                            unlocked: true,
                             internal_model: DeviceModelInternal.T3B1,
-                            major_version: 2,
-                            minor_version: 6,
-                            patch_version: 3,
                         },
                         state: {},
                     },
@@ -172,12 +207,13 @@ describe('selectHomeScreenState', () => {
     });
 
     describe('noNetworkConfigured', () => {
-        it('should return noNetworkConfigured when device is connected, initialized and not authorized', () => {
+        it('should return noNetworkConfigured when device is connected, initialized, authorized, but no network is configured', () => {
             const state = buildState({
                 device: {
                     selectedDevice: {
                         connected: true,
                         features: { initialized: true },
+                        state: {},
                     },
                     devices: [{ id: 'device_id' }],
                 },
@@ -193,7 +229,6 @@ describe('selectHomeScreenState', () => {
                 device: {
                     selectedDevice: {
                         id: PORTFOLIO_TRACKER_DEVICE_ID,
-                        connected: false,
                         features: { initialized: true },
                         state: {},
                     },

--- a/suite-native/module-home/src/screens/HomeScreen/homescreenSelectors.ts
+++ b/suite-native/module-home/src/screens/HomeScreen/homescreenSelectors.ts
@@ -1,7 +1,6 @@
 import {
     type DeviceRootState,
     selectDeviceStaticSessionId,
-    selectHasOnlyPortfolioDevice,
     selectIsDeviceAuthorized,
     selectIsDeviceBackedUp,
     selectIsDeviceConnected,
@@ -84,52 +83,38 @@ export const selectShouldDisplaySuiteSyncFirmwareUpdateAlert = createMemoizedSel
 );
 
 export const selectHomeScreenState = (state: NativeDeviceRootState): HomeScreenState => {
-    const isAnyNetworkEnabled = selectIsAnyNetworkEnabled(state);
-    const hasOnlyPortfolioDevice = selectHasOnlyPortfolioDevice(state);
-    const isDiscoveredDeviceAccountless = selectIsDiscoveredDeviceAccountless(state);
-    const isDeviceAuthorized = selectIsDeviceAuthorized(state);
+    const isDeviceConnected = selectIsDeviceConnected(state);
     const isDeviceUnlocked = selectIsDeviceUnlocked(state);
+    const isDeviceAuthorized = selectIsDeviceAuthorized(state);
+    const isDeviceSetupSupported = selectIsDeviceSetupSupported(state);
     const isDeviceInitialized = selectIsDeviceInitialized(state);
     const isReconnectRequested = selectIsReconnectRequested(state);
-
-    // The reconnect requested flag is set only after the device is wiped. It indicates the old data
-    // is still in Redux but the physical device is already in initialize state and ready for setup.
-    const wasDeviceWiped = isReconnectRequested;
-
-    const isEmptyStateShown =
-        (isDiscoveredDeviceAccountless &&
-            (isDeviceAuthorized || // Initial state: empty portfolio device that is authorized.
-                !isDeviceUnlocked)) || // Device is locked (PIN not entered).
-        !isDeviceInitialized ||
-        (!isAnyNetworkEnabled && !hasOnlyPortfolioDevice) ||
-        wasDeviceWiped;
-
-    if (!isEmptyStateShown) {
-        return 'portfolioContent';
-    }
-
-    const isDeviceConnected = selectIsDeviceConnected(state);
-    const isDeviceSetupSupported = selectIsDeviceSetupSupported(state);
-
-    if (
-        isDeviceSetupSupported &&
-        isDeviceConnected &&
-        (wasDeviceWiped || (!isDeviceInitialized && isDeviceUnlocked))
-    ) {
-        return 'uninitializedDevice';
-    }
-
-    if (isDeviceConnected && isDeviceInitialized && !isAnyNetworkEnabled) {
-        return 'noNetworkConfigured';
-    }
-
+    const isAnyNetworkEnabled = selectIsAnyNetworkEnabled(state);
+    const isPortfolioTrackerDevice = selectIsPortfolioTrackerDevice(state);
     const hasOnlyEmptyPortfolioTracker = selectHasOnlyEmptyPortfolioTracker(state);
+    const isDiscoveredDeviceAccountless = selectIsDiscoveredDeviceAccountless(state);
 
-    // Crossroads is displayed when there is no real device connected and portfolio tracker has no
-    // accounts, or when a device is connected but not authorized (PIN enter cancelled).
-    if (hasOnlyEmptyPortfolioTracker || !isDeviceAuthorized) {
+    // Crossroads is displayed either when there is no real device connected and the portfolio tracker
+    // has no accounts, or when a device is connected but PIN entry or THP confirmation was canceled.
+    if (hasOnlyEmptyPortfolioTracker || (!isDeviceUnlocked && !isDeviceAuthorized)) {
         return 'emptyPortfolioCrossroads';
     }
 
-    return 'emptyPortfolioTracker';
+    if (isPortfolioTrackerDevice && isDiscoveredDeviceAccountless) {
+        return 'emptyPortfolioTracker';
+    }
+
+    if (isDeviceConnected) {
+        // The isReconnectRequested flag is set only after the device is wiped. It indicates that old data
+        // is still in Redux but the physical device is already in initialize state and ready for setup.
+        if (isDeviceSetupSupported && (!isDeviceInitialized || isReconnectRequested)) {
+            return 'uninitializedDevice';
+        }
+
+        if (isDeviceInitialized && !isAnyNetworkEnabled) {
+            return 'noNetworkConfigured';
+        }
+    }
+
+    return 'portfolioContent';
 };

--- a/suite-native/module-home/src/screens/HomeScreen/homescreenTypes.ts
+++ b/suite-native/module-home/src/screens/HomeScreen/homescreenTypes.ts
@@ -1,6 +1,6 @@
 export type HomeScreenState =
-    | 'portfolioContent'
+    | 'emptyPortfolioCrossroads'
+    | 'emptyPortfolioTracker'
     | 'uninitializedDevice'
     | 'noNetworkConfigured'
-    | 'emptyPortfolioCrossroads'
-    | 'emptyPortfolioTracker';
+    | 'portfolioContent';


### PR DESCRIPTION
The `selectHomeScreenState` selector simplified to be easier to understand and maintain.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/native/selectHomeScreenState&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->