### PR TITLE
refactor: collapse cond ? false : true into !cond and short if/else into ternaries

### DIFF
--- a/packages/connect-common/src/data/thpSettings.ts
+++ b/packages/connect-common/src/data/thpSettings.ts
@@ -2,14 +2,8 @@ import type { ConnectSettings, ThpSettings } from '../types/settings';
 
 export const parseThpSettings = ({ manifest, thp }: Partial<ConnectSettings>): ThpSettings => {
     const settings: ThpSettings = {
-        pairingMethods: [],
+        pairingMethods: Array.isArray(thp?.pairingMethods) ? thp.pairingMethods : ['CodeEntry'],
     };
-
-    if (Array.isArray(thp?.pairingMethods)) {
-        settings.pairingMethods = thp.pairingMethods;
-    } else {
-        settings.pairingMethods = ['CodeEntry'];
-    }
 
     if (typeof thp?.hostName === 'string') {
         settings.hostName = thp.hostName;

--- a/packages/connect-examples/electron-main-process/src/renderer.js
+++ b/packages/connect-examples/electron-main-process/src/renderer.js
@@ -2,11 +2,7 @@
 const printLog = data => {
     const log = document.getElementById('log');
     const current = log.value;
-    if (current.length > 0) {
-        log.value = `${JSON.stringify(data)}\n\n${current}`;
-    } else {
-        log.value = JSON.stringify(data);
-    }
+    log.value = current.length > 0 ? `${JSON.stringify(data)}\n\n${current}` : JSON.stringify(data);
 };
 
 // click to get public key

--- a/packages/connect/src/api/bitcoin/enhanceSignTx.ts
+++ b/packages/connect/src/api/bitcoin/enhanceSignTx.ts
@@ -24,11 +24,7 @@ export const enhanceSignTx = (
         // use branch_id from backend or fallback to default
         if (typeof options.branch_id !== 'number') {
             const backend = findBackend(coinInfo.shortcut);
-            if (backend && backend.serverInfo?.consensusBranchId) {
-                options.branch_id = backend.serverInfo.consensusBranchId;
-            } else {
-                options.branch_id = 0xc2d6d0b4;
-            }
+            options.branch_id = backend?.serverInfo?.consensusBranchId || 0xc2d6d0b4;
         }
     }
 

--- a/packages/connect/src/core/__tests__/onCallFirmwareUpdate.test.ts
+++ b/packages/connect/src/core/__tests__/onCallFirmwareUpdate.test.ts
@@ -140,7 +140,7 @@ const buildProtobufMessage = (override: any = {}) => {
                   fw_major,
                   fw_minor,
                   fw_patch,
-                  firmware_present: override.data?.bootloader_mode ? false : true,
+                  firmware_present: !override.data?.bootloader_mode,
                   model,
                   internal_model,
                   revision: latest.firmware_revision, // used in calculateFirmwareHashMock

--- a/packages/product-components/src/components/EditableText/EditableText.stories.tsx
+++ b/packages/product-components/src/components/EditableText/EditableText.stories.tsx
@@ -74,7 +74,7 @@ export const EditableText: StoryObj<EditableTextProps> = {
         maxWidth: undefined,
         onSubmit: async (value: string) => {
             const result = await new Promise(resolve =>
-                setTimeout(() => resolve(value === 'error' ? false : true), 300),
+                setTimeout(() => resolve(value !== 'error'), 300),
             );
 
             action('onSubmit')(value);

--- a/packages/suite/src/reducers/wallet/graphReducer.ts
+++ b/packages/suite/src/reducers/wallet/graphReducer.ts
@@ -25,11 +25,7 @@ const initialState: State = {
 
 const updateError = (draft: State) => {
     const failedGraphData = draft.data.filter(d => d.error);
-    if (failedGraphData.length > 0) {
-        draft.error = failedGraphData.map(a => a.account);
-    } else {
-        draft.error = null;
-    }
+    draft.error = failedGraphData.length > 0 ? failedGraphData.map(a => a.account) : null;
 };
 
 const update = (draft: State, payload: GraphData) => {

--- a/packages/transport-test/e2e/bridge/expect.ts
+++ b/packages/transport-test/e2e/bridge/expect.ts
@@ -4,7 +4,7 @@ import { env } from './controller';
 
 const { USE_HW, USE_NODE_BRIDGE } = env;
 
-const debug = USE_NODE_BRIDGE ? undefined : USE_HW ? false : true;
+const debug = USE_NODE_BRIDGE ? undefined : !USE_HW;
 const debugSession = USE_NODE_BRIDGE ? undefined : null;
 
 const path = USE_NODE_BRIDGE ? expect.any(String) : '1';


### PR DESCRIPTION
## Summary

Two adjacent simplification patterns:

1. **`cond ? false : true` → `!cond`** (3 sites). Classic boolean-coercion anti-pattern; the negation form is the natural inverse and is shorter and clearer.
2. **`let x; if/else { x = … }` → ternary or default-value expression** (4 sites). Only applied where the new form is unambiguously clearer:
   - inlines the assignment into an object literal (`pairingMethods`)
   - collapses to a default-value expression (`branch_id || 0xc2d6d0b4`)
   - short, single-line conditions that fit comfortably on one line (`log.value`, `draft.error`)

Sites where the if/else → ternary collapse hurt readability (long multi-operand conditions, multi-line ternaries, or assignments that benefit from staying named) were intentionally **left out** of this PR.

Single-pattern slice of the larger simplification batch in #27472.

## Stats
```
 7 files changed, 7 insertions(+), 25 deletions(-)
```

## Test plan

- [ ] CI: type-check, lint, unit tests

---
Part of https://github.com/trezor/trezor-suite/pull/27472 (the umbrella branch with all simplification commits).

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/cond-false-true-to-not&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/cond-false-true-to-not&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/cond-false-true-to-not&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-08T06:24:36.865Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-08T06:22:14.144Z • 13 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/cond-false-true-to-not/web/](https://dev.suite.sldev.cz/suite-web/mroz22/cond-false-true-to-not/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->