### PR TITLE
refactor: drop redundant ?? undefined no-ops

### DIFF
--- a/suite-common/wallet-core/src/send/sendFormCardanoThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormCardanoThunks.ts
@@ -157,7 +157,7 @@ export const signCardanoSendFormTransactionThunk = createThunk<
                 message: 'Account network type is not Cardano.',
             });
 
-        const payment_req = paymentRequests?.[0] ?? undefined;
+        const payment_req = paymentRequests?.[0];
 
         // todo: add chunkify once we allow it for Cardano
         const response = await TrezorConnect.cardanoSignTransaction({

--- a/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
@@ -409,7 +409,7 @@ export const signEthereumSendFormTransactionThunk = createThunk<
             maxPriorityFeePerGas: precomposedTransaction.maxPriorityFeePerGas,
             gasPrice: precomposedTransaction.feePerByte,
             nonce,
-            payment_req: paymentRequests?.[0] ?? undefined,
+            payment_req: paymentRequests?.[0],
         });
 
         const response = await TrezorConnect.ethereumSignTransaction({

--- a/suite-common/wallet-core/src/send/sendFormRippleStellarThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormRippleStellarThunks.ts
@@ -265,7 +265,7 @@ export const signRippleStellarSendFormTransactionThunk = createThunk<
                     sequence: selectedAccount.misc.sequence,
                     payment,
                 },
-                payment_req: paymentRequests?.[0] ?? undefined,
+                payment_req: paymentRequests?.[0],
                 chunkify: addressDisplayType === AddressDisplayOptions.CHUNKED,
             });
             if (response.success) {
@@ -345,7 +345,7 @@ export const signRippleStellarSendFormTransactionThunk = createThunk<
                     },
                     operations: [operation],
                 },
-                payment_req: paymentRequests?.[0] ?? undefined,
+                payment_req: paymentRequests?.[0],
                 chunkify: addressDisplayType === AddressDisplayOptions.CHUNKED,
             };
             response = await TrezorConnect.stellarSignTransaction(transformedTransaction);

--- a/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
@@ -387,7 +387,7 @@ export const signSolanaSendFormTransactionThunk = createThunk<
             });
         }
 
-        const payment_req = paymentRequests?.[0] ?? undefined;
+        const payment_req = paymentRequests?.[0];
 
         const response = await TrezorConnect.solanaSignTransaction({
             device: {


### PR DESCRIPTION
## Summary

Drop `X ?? undefined` where the LHS is already typed `T | undefined`. Pure no-op removal — when the LHS is already nullable, falling back to `undefined` is exactly what would have happened anyway.

Single-pattern slice of the larger simplification batch in #27472. Behavior-preserving; pattern is mechanical and applied consistently. Pulled out into its own PR for easier review.

## Stats
```
 4 files changed, 5 insertions(+), 5 deletions(-)
```

## Test plan

- [ ] CI: type-check, lint, unit tests

---
Part of https://github.com/trezor/trezor-suite/pull/27472 (the umbrella branch with all simplification commits).

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect send form thunks for four specific blockchain networks: Cardano, Ethereum, Ripple/Stellar, and Solana. These are core transaction composition modules that directly impact how transactions are built, validated, and signed for each network. High-priority tests are the direct send flow tests for each affected network (ETH, Base/EVM, SOL, ADA). Medium-priority tests cover staking and trading flows that compose transactions through these same thunks. The Ripple/Stellar thunk change has no direct E2E send test coverage, representing a gap.

<details><summary><b>Changed files (4)</b></summary>

- `suite-common/wallet-core/src/send/sendFormCardanoThunks.ts`
- `suite-common/wallet-core/src/send/sendFormEthereumThunks.ts`
- `suite-common/wallet-core/src/send/sendFormRippleStellarThunks.ts`
- `suite-common/wallet-core/src/send/sendFormSolanaThunks.ts`

</details>

**Recommended tests (23)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/wallet/send-eth.test.ts` — This test directly exercises the Ethereum send flow including custom gas fees and device confirmation. Changes to sendFormEthereumThunks.ts could break ETH transaction composition, fee calculation, or signing logic tested here.
- `suite/e2e/tests/wallet/send-base.test.ts` — Base is an EVM-compatible network that uses the same Ethereum send thunks. This test covers custom EVM fees, transaction signing, and broadcasting on Base, directly exercising sendFormEthereumThunks.ts logic.
- `suite/e2e/tests/wallet/send-sol.test.ts` — This test directly exercises the Solana send flow including Send Max calculation, fee handling, and device confirmation. Changes to sendFormSolanaThunks.ts could break SOL transaction composition or signing.
- `suite/e2e/tests/wallet/cardano.test.ts` — This test exercises the Cardano send form and receive flow. Changes to sendFormCardanoThunks.ts could break ADA transaction composition or the send form rendering for Cardano accounts.

</details>

<details><summary>🟡 <b>Medium priority (18)</b></summary>

- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts` — While primarily focused on passphrase and receive address verification for Cardano, this test interacts with ADA wallet functionality that depends on Cardano send/receive infrastructure potentially affected by sendFormCardanoThunks changes.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — ETH staking involves composing and sending Ethereum transactions through the send form infrastructure. Changes to sendFormEthereumThunks.ts could affect staking transaction composition and signing.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — SOL staking involves composing Solana transactions through the send infrastructure. Changes to sendFormSolanaThunks.ts could affect staking transaction creation, fee calculation, or device confirmation.
- `suite/e2e/tests/staking/ada/stake.test.ts` — ADA staking involves composing Cardano transactions. Changes to sendFormCardanoThunks.ts could affect stake delegation transaction composition and signing.
- `suite/e2e/tests/staking/ada/claim.test.ts` — Claiming ADA staking rewards involves composing a Cardano withdrawal transaction that likely flows through sendFormCardanoThunks.ts.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — ADA unstaking involves composing a Cardano stake deregistration transaction that likely uses sendFormCardanoThunks.ts.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Selling ETH involves composing and sending an Ethereum transaction with custom gas fees. The sell confirmation send step exercises sendFormEthereumThunks.ts logic.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Selling an ERC-20 token involves composing an Ethereum token transfer transaction that flows through sendFormEthereumThunks.ts.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Selling SOL involves composing and sending a Solana transaction, exercising sendFormSolanaThunks.ts for transaction creation and signing.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Swapping SOL to BTC involves sending a Solana transaction as part of the swap flow, which exercises sendFormSolanaThunks.ts.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — This test verifies custom Ethereum fee parameters during a swap, which are composed via sendFormEthereumThunks.ts transaction composition logic.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — While Bitcoin send uses different thunks, the sell flow shares send form infrastructure. Changes to sendFormRippleStellarThunks.ts are unlikely to affect this, but the shared send architecture warrants monitoring since all four thunk files changed simultaneously.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — ETH unstaking and claiming involve composing Ethereum transactions through the send form thunks. Changes to sendFormEthereumThunks.ts could affect the unstake/claim transaction flow.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — SOL unstaking and claiming involve composing Solana transactions. Changes to sendFormSolanaThunks.ts could affect the unstake/claim transaction flow.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Swapping SOL to USDC involves sending a Solana transaction, exercising sendFormSolanaThunks.ts for the swap send step.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Swapping a Solana token (USDT) to BTC involves sending a Solana SPL token transaction, which exercises sendFormSolanaThunks.ts.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Swapping Solana SPL tokens (USDT to USDC) involves composing a Solana token send transaction through sendFormSolanaThunks.ts.
- `suite/e2e/tests/staking/staking-form.test.ts` — The ETH staking form validates input amounts and calculates fees using the Ethereum send form infrastructure that depends on sendFormEthereumThunks.ts.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/trading/sell-inputs.test.ts` — Sell input validation for SOL involves fee calculation that may depend on sendFormSolanaThunks.ts for computing max amounts and fees.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/wallet-core/src/send/sendFormRippleStellarThunks.ts`

_Updated: 2026-05-08T05:56:12.353Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/drop-noop-nullish&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/drop-noop-nullish&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/drop-noop-nullish&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 8 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-08T06:00:50.247Z • 8 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-08T05:58:55.808Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/drop-noop-nullish/web/](https://dev.suite.sldev.cz/suite-web/mroz22/drop-noop-nullish/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->