### PR TITLE
refactor: replace .filter(x => x) with .filter(Boolean)

### DIFF
--- a/packages/blockchain-link-utils/src/blockfrost.ts
+++ b/packages/blockchain-link-utils/src/blockfrost.ts
@@ -209,7 +209,7 @@ export const filterTokenTransfers = (
             });
     });
 
-    return transfers.filter(t => !!t) as TokenTransfer[];
+    return transfers.filter(Boolean) as TokenTransfer[];
 };
 
 export const transformTransaction = (

--- a/packages/blockchain-link/src/workers/electrum/client/json-rpc.ts
+++ b/packages/blockchain-link/src/workers/electrum/client/json-rpc.ts
@@ -104,7 +104,7 @@ export class JsonRpcClient {
     onReceive(chunk: string) {
         const msgs = (this.buffer + chunk).split('\n');
         this.buffer = msgs.pop() || '';
-        msgs.filter(msg => !!msg).forEach(this.onMessage, this);
+        msgs.filter(Boolean).forEach(this.onMessage, this);
     }
 
     onEnd(e: unknown) {

--- a/packages/connect-explorer/src/actions/methodActions.ts
+++ b/packages/connect-explorer/src/actions/methodActions.ts
@@ -125,7 +125,7 @@ export const onCodeChange = (value: string) => (dispatch: Dispatch, getState: Ge
         const { fields } = getState().method;
         const parsed = JSON5.parse(value);
         const processField = (field: Field<unknown>) => {
-            const valuePath = [...(field.path || []), ...field.name.split('.')].filter(f => !!f);
+            const valuePath = [...(field.path || []), ...field.name.split('.')].filter(Boolean);
             const value = getDeepValue(parsed, valuePath);
 
             if (field.type === 'array') {

--- a/packages/connect-explorer/src/reducers/methodInit.ts
+++ b/packages/connect-explorer/src/reducers/methodInit.ts
@@ -32,7 +32,7 @@ const schemaToFields = (schema: TSchema, name = ''): Field<any>[] => {
             return schemaToFields(field, key).map(field => {
                 const output = {
                     ...field,
-                    name: [key, field.name].filter(v => v).join('.'),
+                    name: [key, field.name].filter(Boolean).join('.'),
                     optional: field.optional || schema[OptionalKind] === 'Optional',
                 };
                 // If the array is optional, set the items to an empty array by default

--- a/packages/connect/src/backend/fees/EthereumFeeLevels.ts
+++ b/packages/connect/src/backend/fees/EthereumFeeLevels.ts
@@ -70,7 +70,7 @@ export class EthereumFeeLevels extends MiscFeeLevels {
                     };
                 });
 
-                this.levels = levels.filter(level => level) as FeeLevel[];
+                this.levels = levels.filter(Boolean) as FeeLevel[];
             } else {
                 this.levels[0] = {
                     ...this.levels[0],

--- a/packages/node-utils/src/http.ts
+++ b/packages/node-utils/src/http.ts
@@ -265,7 +265,7 @@ export class HttpServer<T extends EventMap> extends TypedEmitter<T & BaseEvents>
      */
     private splitSegments(pathname: string) {
         const [baseSegments, paramsSegments] = arrayPartition(
-            pathname.split('/').filter(segment => segment),
+            pathname.split('/').filter(Boolean),
             segment => !segment.includes(':'),
         );
 
@@ -353,14 +353,14 @@ export class HttpServer<T extends EventMap> extends TypedEmitter<T & BaseEvents>
      */
     private findBestMatchingRoute = (pathname: string, method = 'GET') => {
         // Split and filter to get only actual path segments (no empty strings from leading/trailing /)
-        const requestSegments = pathname.split('/').filter(s => s);
+        const requestSegments = pathname.split('/').filter(Boolean);
         const routes = this.routes.filter(r => r.method === method || r.method === '*');
 
         let bestMatch: { route: Route; specificity: number } | undefined;
 
         for (const route of routes) {
             // Split and filter to get only actual route segments
-            const routeSegments = route.pathname.split('/').filter(s => s);
+            const routeSegments = route.pathname.split('/').filter(Boolean);
             const expectedSegmentCount = routeSegments.length + route.params.length;
 
             // Request must have exactly the number of segments expected by this route
@@ -470,10 +470,7 @@ export class HttpServer<T extends EventMap> extends TypedEmitter<T & BaseEvents>
             return;
         }
 
-        const paramsSegments = pathname
-            .replace(route.pathname, '')
-            .split('/')
-            .filter(segment => segment);
+        const paramsSegments = pathname.replace(route.pathname, '').split('/').filter(Boolean);
 
         let isSegmentInvalid = false;
         const requestWithParams = request as RequestWithParams;

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -295,7 +295,7 @@ export const saveAccountHistoricRates =
     (_dispatch: Dispatch, getState: GetState) => {
         if (!db.isAccessible()) return Promise.resolve();
         const allTxs = getState().wallet.transactions.transactions;
-        const accTxs = (allTxs[accountKey] || []).filter(tx => !!tx);
+        const accTxs = (allTxs[accountKey] || []).filter(Boolean);
 
         const accHistoricRates = selectHistoricRatesByTransactions(historicRates, accTxs);
 

--- a/packages/suite/src/components/guide/GuideHint.tsx
+++ b/packages/suite/src/components/guide/GuideHint.tsx
@@ -26,7 +26,7 @@ export const GuideHint = ({ children }: BlockquoteHTMLAttributes<HTMLQuoteElemen
         }
 
         return false;
-    })?.filter(child => !!child);
+    })?.filter(Boolean);
     const intent = message?.[0]?.startsWith(WARNING_EMOJI) ? 'warning' : 'brand';
 
     let updatedMessage: string[] | undefined;

--- a/suite-common/suite-utils/src/device.ts
+++ b/suite-common/suite-utils/src/device.ts
@@ -453,7 +453,7 @@ export const getFirstDeviceInstance = (
         .sort(options.sortingFn);
 
 export const getPhysicalDeviceUniqueIds = (devices: TrezorDevice[]) =>
-    [...new Set(devices.map(d => d.id))].filter(id => id) as string[];
+    [...new Set(devices.map(d => d.id))].filter(Boolean) as string[];
 
 export const getPhysicalDeviceCount = (devices: TrezorDevice[]) =>
     getPhysicalDeviceUniqueIds(devices).length;

--- a/suite-common/wallet-core/src/transactions/transactionsSelectors.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsSelectors.ts
@@ -83,7 +83,7 @@ export const selectAccountTransactionsWithNulls = (
 
 export const selectAccountTransactions = createMemoizedSelector(
     [selectAccountTransactionsWithNulls],
-    transactions => returnStableArrayIfEmpty(transactions.filter(t => !!t)),
+    transactions => returnStableArrayIfEmpty(transactions.filter(Boolean)),
 );
 
 export const selectPendingAccountAddresses = createMemoizedSelector(

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -120,7 +120,7 @@ export const groupTransactionsByDate = (
     return (
         [...transactions]
             // There could be some undefined/null in array, not sure how it happens. Maybe related to pagination?
-            .filter(transaction => !!transaction)
+            .filter(Boolean)
             .sort(sortByBlockHeight)
             .reduce<GroupedTransactionsByDate>((r, item) => {
                 // pending txs are grouped as 'no-blocktime' only if blockTime is unavailable (otherwise sorted by blockTime)


### PR DESCRIPTION
## Summary

Replace verbose `.filter(x => x)` and `.filter(x => !!x)` predicates with the standard `.filter(Boolean)` idiom. Same semantics, more recognizable, and TS infers a better type for the resulting array.

Single-pattern slice of the larger simplification batch in #27472. Behavior-preserving; pattern is mechanical and applied consistently. Pulled out into its own PR for easier review.

## Stats
```
 11 files changed, 14 insertions(+), 17 deletions(-)
```

## Test plan

- [ ] CI: type-check, lint, unit tests

---
Part of https://github.com/trezor/trezor-suite/pull/27472 (the umbrella branch with all simplification commits).

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/filter-boolean&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/filter-boolean&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/filter-boolean&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 8 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-08T06:01:00.601Z • 8 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-08T05:59:13.928Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/filter-boolean/web/](https://dev.suite.sldev.cz/suite-web/mroz22/filter-boolean/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->