### PR TITLE
refactor: replace .find/.some equality predicates with .includes

### DIFF
--- a/packages/product-components/src/components/AssetLogo/AssetLogoWithId.tsx
+++ b/packages/product-components/src/components/AssetLogo/AssetLogoWithId.tsx
@@ -167,7 +167,7 @@ export const AssetLogoWithId = ({
             address => !failedAddressesCache.has(makeAddressKey(coingeckoIdLogo, address)),
         );
 
-        const hasNative = filtered.some(addr => addr === ZERO_ADDRESS);
+        const hasNative = filtered.includes(ZERO_ADDRESS);
 
         for (const address of filtered) {
             const url1x = getAssetLogoUrl({

--- a/packages/product-components/src/components/AssetLogo/assetLogoUtils.ts
+++ b/packages/product-components/src/components/AssetLogo/assetLogoUtils.ts
@@ -44,7 +44,7 @@ export const getCoingeckoIdAndContractAddressIncludesNativeTokens = (
         .concat(contractAddress ?? [])
         .map(addr => addr ?? ZERO_ADDRESS);
 
-    const hasNative = addresses.some(addr => addr === ZERO_ADDRESS);
+    const hasNative = addresses.includes(ZERO_ADDRESS);
 
     const shouldUseTradeId = hasNative && !!mainNetworkSymbol && isNetworkSymbol(mainNetworkSymbol);
 

--- a/packages/suite/src/hooks/settings/backends/useBackendsForm.ts
+++ b/packages/suite/src/hooks/settings/backends/useBackendsForm.ts
@@ -80,7 +80,7 @@ const useBackendUrlInput = (symbol: NetworkSymbol, type: BackendOption, currentU
         }
 
         // Check if already exists
-        if (currentUrls.find(url => url === value)) {
+        if (currentUrls.includes(value)) {
             return translationString('TR_CUSTOM_BACKEND_BACKEND_ALREADY_ADDED');
         }
     };

--- a/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
+++ b/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
@@ -125,7 +125,7 @@ export const UsedAddresses = ({
     const revealed = unused.reduce(
         (result, addr) => {
             const r = addresses.find(u => u.path === addr.path);
-            const p = pendingAddresses.find(u => u === addr.address);
+            const p = pendingAddresses.includes(addr.address);
             const f = r || p;
 
             return f ? result.concat(addr) : result;

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -163,8 +163,7 @@ export const connectInitThunk = createThunk<void, ConnectInitHooks | void, void>
                         key === 'call'
                             ? params.method.startsWith('cardano')
                             : key.startsWith('cardano');
-                    const cardanoEnabled =
-                        !!enabledNetworks.find(a => a === 'ada') || isCardanoMethod;
+                    const cardanoEnabled = enabledNetworks.includes('ada') || isCardanoMethod;
 
                     const result = await synchronize(() =>
                         original({ ...params, useCardanoDerivation: cardanoEnabled }),

--- a/suite-common/wallet-core/src/settings/walletSettingsThunks.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsThunks.ts
@@ -19,7 +19,7 @@ export const changeCoinVisibility = createThunk<
     void
 >(WALLET_SETTINGS.CHANGE_COIN_VISIBILITY, ({ symbol, shouldBeVisible }, { dispatch, getState }) => {
     let enabledNetworks = selectEnabledNetworks(getState());
-    const isAlreadyHidden = enabledNetworks.find(enabledSymbol => enabledSymbol === symbol);
+    const isAlreadyHidden = enabledNetworks.includes(symbol);
     if (!shouldBeVisible) {
         enabledNetworks = enabledNetworks.filter(enabledSymbol => enabledSymbol !== symbol);
     } else if (!isAlreadyHidden) {

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -92,8 +92,7 @@ export const getFirstFreshAddress = (
 
     const unrevealed = unused.filter(
         a =>
-            !receiveAddresses.find(r => r.path === a.path) &&
-            !pendingAddresses.find(p => p === a.address),
+            !receiveAddresses.find(r => r.path === a.path) && !pendingAddresses.includes(a.address),
     );
 
     // const addressLabel = utxoBasedAccount ? 'RECEIVE_ADDRESS_FRESH' : 'RECEIVE_ADDRESS';
@@ -879,8 +878,7 @@ export const accountSearchFn = (
         token.symbol?.toLowerCase().includes(searchString) ||
         token.contract.toLowerCase().includes(searchString);
 
-    const tokenMatch =
-        tokensMatch && !!account.tokens && !!account.tokens.filter(filterTokens).length;
+    const tokenMatch = tokensMatch && !!account.tokens?.some(filterTokens);
 
     return (
         accountNumberMatch ||


### PR DESCRIPTION
## Summary

Replace `.find(x => x === y)` / `.some(x => x === y)` boolean-use predicates with `.includes(y)`, plus one `.filter(...).length` truthy check. When you only care about presence, `.includes` is the right method — shorter, more semantic, and skips the arrow function entirely.

Single-pattern slice of the larger simplification batch in #27472. Behavior-preserving; pattern is mechanical and applied consistently. Pulled out into its own PR for easier review.

## Stats
```
 7 files changed, 8 insertions(+), 11 deletions(-)
```

## Test plan

- [ ] CI: type-check, lint, unit tests

---
Part of https://github.com/trezor/trezor-suite/pull/27472 (the umbrella branch with all simplification commits).

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set spans receive address UI (UsedAddresses.tsx), backend configuration (useBackendsForm.ts), wallet settings thunks, connect initialization, account utilities, and asset logo components. The highest risk areas are the receive flow (UsedAddresses changes directly affect address display) and custom backend configuration (useBackendsForm changes affect coin settings). The broad utility files (connectInitThunks, walletSettingsThunks, accountUtils) map to 121+ tests each but only a few tests exercise their specific functionality. Testing should focus on receive address flows, custom backend configuration, and discovery to cover the most impactful code paths.

<details><summary><b>Changed files (7)</b></summary>

- `packages/product-components/src/components/AssetLogo/AssetLogoWithId.tsx`
- `packages/product-components/src/components/AssetLogo/assetLogoUtils.ts`
- `packages/suite/src/hooks/settings/backends/useBackendsForm.ts`
- `packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx`
- `suite-common/connect-init/src/connectInitThunks.ts`
- `suite-common/wallet-core/src/settings/walletSettingsThunks.ts`
- `suite-common/wallet-utils/src/accountUtils.ts`

</details>

**Recommended tests (15)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/wallet/receive.test.ts` — UsedAddresses.tsx is a component in the receive flow, and this test directly exercises the receive address reveal, copy, and display functionality across multiple coins. Changes to UsedAddresses could affect address display or interaction behavior.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test exercises the global receive flow including address reveal and verification. UsedAddresses.tsx is part of the receive view and could directly impact address display in this flow.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — useBackendsForm.ts is the hook powering custom backend configuration. This test directly validates configuring custom blockbook backends for coins, connecting to correct/incorrect URLs, and seeing the custom backend label — all functionality driven by that hook.

</details>

<details><summary>🟡 <b>Medium priority (10)</b></summary>

- `suite/e2e/tests/settings/coins.test.ts` — This test covers coin settings including setting a custom backend server for ETH and verifying the custom backend indicator. Changes to useBackendsForm.ts could affect the backend configuration workflow tested here.
- `suite/e2e/tests/settings/electrum.test.ts` — This test configures a custom Electrum backend for RegTest, which relies on the backends form hook. Changes to useBackendsForm.ts could break the Electrum backend configuration flow.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — This test exercises the receive address flow with used addresses being hidden/shown, which directly relates to UsedAddresses.tsx. It also tests passphrase re-confirmation during address reveal.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — This test verifies receive addresses and checks that used addresses are hidden before revealing new ones (usedAddress(0) is hidden), directly touching UsedAddresses component behavior.
- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts` — This test exercises the Cardano receive address flow including address reveal and copy, which involves the UsedAddresses component for displaying previously used addresses.
- `suite/e2e/tests/wallet/cardano.test.ts` — This test covers Cardano receive address reveal and confirmation, which exercises the receive view where UsedAddresses.tsx is rendered.
- `suite/e2e/tests/metadata/legacy/address-metadata.test.ts` — This test adds and edits labels on receive addresses, which directly involves the UsedAddresses component where address labels are displayed and edited.
- `suite/e2e/tests/analytics/events.test.ts` — This test specifically validates SuiteReady event properties including customBackends and enabledNetworks, which are directly affected by walletSettingsThunks.ts changes. It also exercises custom backend configuration in settings.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test configures custom Blockbook backends and verifies discovery completes. Changes to useBackendsForm.ts could affect backend URL submission and configuration logic.
- `suite/e2e/tests/wallet/discovery.test.ts` — accountUtils.ts contains core account discovery logic. This test validates multi-coin discovery completing successfully with correct balance display, making it sensitive to accountUtils changes.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts` — This test involves the receive screen for address label removal, which renders UsedAddresses.tsx. However the test focuses on label removal rather than address display itself.
- `suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — This test syncs address labels from the relay and displays them on the receive screen, which involves UsedAddresses.tsx, though the focus is on sync rather than address rendering.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/product-components/src/components/AssetLogo/AssetLogoWithId.tsx`
- `packages/product-components/src/components/AssetLogo/assetLogoUtils.ts`

_Updated: 2026-05-08T05:57:21.172Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/find-some-to-includes&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/find-some-to-includes&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/find-some-to-includes&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 8 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-08T06:01:22.717Z • 8 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-08T05:59:43.403Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/find-some-to-includes/web/](https://dev.suite.sldev.cz/suite-web/mroz22/find-some-to-includes/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->