### PR TITLE
refactor: collapse if (cb) { cb(args) } into cb?.(args)

### DIFF
--- a/packages/connect-web/src/bootstrap/bootstrap.ts
+++ b/packages/connect-web/src/bootstrap/bootstrap.ts
@@ -378,9 +378,7 @@ const bootstrapIframe = (): Promise<void> => {
 
                     // Restart forwarding messages between suite-web and 3rd party window (in case it was already started by a previous handshake attempt).
                     // This ensures that we are forwarding messages through the correct BroadcastChannel instance.
-                    if (stopForwarding) {
-                        stopForwarding();
-                    }
+                    stopForwarding?.();
                     stopForwarding = startForwarding(broadcast, window.parent, ownerOrigin);
 
                     window.parent.postMessage(getConfirmHandshake(event.data), ownerOrigin);

--- a/packages/suite/src/components/guide/GuideSearch.tsx
+++ b/packages/suite/src/components/guide/GuideSearch.tsx
@@ -56,9 +56,7 @@ export const GuideSearch = ({ pageRoot, setSearchActive }: GuideSearchProps) => 
     const { searchResult, loading } = useGuideSearch(query, pageRoot);
 
     useEffect(() => {
-        if (setSearchActive) {
-            setSearchActive(!!searchResult.length || !!query);
-        }
+        setSearchActive?.(!!searchResult.length || !!query);
     }, [query, searchResult, setSearchActive, loading]);
 
     return (

--- a/packages/suite/src/components/suite/HomescreenGallery.tsx
+++ b/packages/suite/src/components/suite/HomescreenGallery.tsx
@@ -66,9 +66,7 @@ export const HomescreenGallery = ({ onConfirm }: HomescreenGalleryProps) => {
             dispatch(applySettings({ homescreen: hex }));
         }
 
-        if (onConfirm) {
-            onConfirm();
-        }
+        onConfirm?.();
     };
 
     const homescreens = getHomescreens(isBitcoinOnlyFirmware); // Get the homescreens based on the firmware type

--- a/packages/suite/src/components/suite/graph/GraphRangeSelector.tsx
+++ b/packages/suite/src/components/suite/graph/GraphRangeSelector.tsx
@@ -83,9 +83,7 @@ export const GraphRangeSelector = ({
 
                     setSelectedRange(range);
 
-                    if (onSelectedRange) {
-                        onSelectedRange(range);
-                    }
+                    onSelectedRange?.(range);
                 }}
             />
             {isLoading && <Spinner size={32} isDisabled={true} />}

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/CustomFee/CustomFeeEthereum.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/CustomFee/CustomFeeEthereum.tsx
@@ -38,15 +38,11 @@ export const CustomFeeEthereum = ({
     const customMaxPriorityFeePerGas = getValues('maxPriorityFeePerGas');
 
     useEffect(() => {
-        if (trigger) {
-            trigger(MAX_PRIORITY_FEE_PER_GAS);
-        }
+        trigger?.(MAX_PRIORITY_FEE_PER_GAS);
     }, [customMaxFeePerGas, trigger]);
 
     useEffect(() => {
-        if (trigger) {
-            trigger(MAX_FEE_PER_GAS);
-        }
+        trigger?.(MAX_FEE_PER_GAS);
     }, [customMaxPriorityFeePerGas, trigger]);
 
     const recommendedMaxFeePerGas = levels.find(level => level.label === 'normal')?.maxFeePerGas;

--- a/packages/suite/src/hooks/wallet/form/useFees.ts
+++ b/packages/suite/src/hooks/wallet/form/useFees.ts
@@ -187,7 +187,7 @@ export const useFees = <TFieldValues extends FeesFormValues>({
         }
 
         // on change callback
-        if (onChange) onChange(selectedFeeRef.current, level);
+        onChange?.(selectedFeeRef.current, level);
 
         selectedFeeRef.current = selectedFee;
     };

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingCurrencySwitcher.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingCurrencySwitcher.ts
@@ -59,9 +59,7 @@ export const useTradingCurrencySwitcher = <T extends TradingAllFormProps>({
         setValue('amountInCrypto', !amountInCrypto);
 
         // should be allowed only in sell/exchange
-        if (composeRequest) {
-            composeRequest(TRADING_FORM_OUTPUT_AMOUNT);
-        }
+        composeRequest?.(TRADING_FORM_OUTPUT_AMOUNT);
     };
 
     useDidUpdate(() => {

--- a/packages/suite/src/hooks/wallet/useSendFormImport.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormImport.ts
@@ -181,9 +181,7 @@ export const useSendFormImport = ({
     // wait for data population (rerender) and trigger form validation
     const [trigger, setTriggerFn] = useState<(() => Promise<void>) | undefined>(undefined);
     useEffect(() => {
-        if (trigger) {
-            trigger();
-        }
+        trigger?.();
     }, [trigger]);
 
     const validateImportedTransaction = (triggerFn: () => Promise<void>) => {

--- a/packages/suite/src/support/tests/hooksHelper.tsx
+++ b/packages/suite/src/support/tests/hooksHelper.tsx
@@ -122,6 +122,6 @@ export const actionSequence = async <A extends UserAction[]>(
         }
 
         // action complete. run test
-        if (callback) callback(action);
+        callback?.(action);
     }
 };

--- a/suite-native/atoms/src/Button/AsyncButton.tsx
+++ b/suite-native/atoms/src/Button/AsyncButton.tsx
@@ -15,9 +15,7 @@ export const AsyncButton = ({ onPress, onReject, ...props }: AsyncButtonProps) =
         try {
             await onPress();
         } catch (error) {
-            if (onReject) {
-                onReject(error);
-            }
+            onReject?.(error);
         }
         setIsLoading(false);
     };

--- a/suite-native/forms/src/fields/TextInputField.tsx
+++ b/suite-native/forms/src/fields/TextInputField.tsx
@@ -48,16 +48,12 @@ export const TextInputField = forwardRef<InputType, FieldProps>(
 
         const handleOnBlur = () => {
             hookFormOnBlur();
-            if (onBlur) {
-                onBlur();
-            }
+            onBlur?.();
         };
 
         const handleOnChange = (text: string) => {
             onChange(text);
-            if (onChangeText) {
-                onChangeText(text);
-            }
+            onChangeText?.(text);
         };
 
         return (

--- a/suite-native/module-device-onboarding/src/hooks/useExitAlert.ts
+++ b/suite-native/module-device-onboarding/src/hooks/useExitAlert.ts
@@ -61,9 +61,7 @@ export const useExitAlert = (handleContinueButtonPress?: () => void) => {
                 }
             },
             onPressSecondaryButton: () => {
-                if (handleContinueButtonPress) {
-                    handleContinueButtonPress();
-                }
+                handleContinueButtonPress?.();
             },
         });
     }, [


### PR DESCRIPTION
## Summary

Replace the `if (cb) { cb(args); }` truthy-then-call pattern with the optional-chain call form `cb?.(args)`. Modern JS syntax, single line, identical runtime behavior.

Single-pattern slice of the larger simplification batch in #27472. Behavior-preserving; pattern is mechanical and applied consistently. Pulled out into its own PR for easier review.

## Stats
```
 12 files changed, 14 insertions(+), 38 deletions(-)
```

## Test plan

- [ ] CI: type-check, lint, unit tests

---
Part of https://github.com/trezor/trezor-suite/pull/27472 (the umbrella branch with all simplification commits).

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/optional-callback-call&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/optional-callback-call&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/optional-callback-call&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 8 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-08T06:02:21.587Z • 8 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-08T06:00:19.064Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/optional-callback-call/web/](https://dev.suite.sldev.cz/suite-web/mroz22/optional-callback-call/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->