### PR TITLE
refactor(suite): collapse duplicate switch returns into fall-through cases

### DIFF
--- a/packages/suite/src/constants/suite/homescreens.ts
+++ b/packages/suite/src/constants/suite/homescreens.ts
@@ -100,7 +100,6 @@ export const getDefaultHomeScreenImage = ({
         case DeviceModelInternal.T2T1:
             return 'original_t2t1';
         case DeviceModelInternal.T2B1:
-            return 'original_t3b1';
         case DeviceModelInternal.T3B1:
             return 'original_t3b1';
         case DeviceModelInternal.T3T1:

--- a/packages/suite/src/utils/suite/notification.ts
+++ b/packages/suite/src/utils/suite/notification.ts
@@ -10,7 +10,6 @@ export const getNotificationIcon = (variant: ToastNotificationVariant) => {
         case 'info':
             return 'info';
         case 'warning':
-            return 'warning';
         case 'error':
             return 'warning';
         case 'success':

--- a/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetTableExtraRowsSection.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetTableExtraRowsSection.tsx
@@ -9,7 +9,6 @@ const mapPositionToTop = (position: DashedLinePosition) => {
         case 'middleToBottom':
             return '50%';
         case 'topToBottom':
-            return borders.widths.large;
         case 'topToMiddle':
             return borders.widths.large;
     }
@@ -18,7 +17,6 @@ const mapPositionToTop = (position: DashedLinePosition) => {
 const mapPositionToBottom = (position: DashedLinePosition) => {
     switch (position) {
         case 'middleToBottom':
-            return '0';
         case 'topToBottom':
             return '0';
         case 'topToMiddle':

--- a/packages/suite/src/views/suite/SwitchDevice/NeedsAttentionBanner.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/NeedsAttentionBanner.tsx
@@ -44,7 +44,6 @@ const getDeviceNeedsAttentionMessage = (
         case 'device-busy':
             return 'TR_NEEDS_ATTENTION_DEVICE_BUSY';
         case 'device-bootloader-locked':
-            return 'TR_NEEDS_ATTENTION_DEVICE_LOCKED';
         case 'device-hard-locked':
             return 'TR_NEEDS_ATTENTION_DEVICE_LOCKED';
         case 'device-pin-locked':


### PR DESCRIPTION
## Summary

Collapse five duplicate consecutive `switch` returns into fall-through cases across four suite files. Eliminates the trap where two duplicate-return cases look like they could legitimately diverge in the future, and tightens intent.

Single-pattern slice of the larger simplification batch in #27472. Behavior-preserving; pattern is mechanical and applied consistently. Pulled out into its own PR for easier review.

## Stats
```
 4 files changed, 5 deletions(-)
```

## Test plan

- [ ] CI: type-check, lint, unit tests

---
Part of https://github.com/trezor/trezor-suite/pull/27472 (the umbrella branch with all simplification commits).

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set touches four files: a dashboard asset table component (AssetTableExtraRowsSection), a device switch-device banner (NeedsAttentionBanner), homescreen constants, and a notification utility. The highest-risk change is to AssetTableExtraRowsSection which directly affects the dashboard assets view. The homescreen constants change could affect device settings tests that change backgrounds. The NeedsAttentionBanner change is relevant to multi-session/device-switching scenarios. The notification utility is broadly imported but unlikely to cause regressions unless its interface changed significantly. A targeted set of dashboard, device settings, and session-management tests provides good coverage.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite/src/constants/suite/homescreens.ts`
- `packages/suite/src/utils/suite/notification.ts`
- `packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetTableExtraRowsSection.tsx`
- `packages/suite/src/views/suite/SwitchDevice/NeedsAttentionBanner.tsx`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — AssetTableExtraRowsSection.tsx is a component rendered within the dashboard assets view. This test directly exercises the Assets section in both table and grid views, including enabling new coins and verifying asset contents, which would surface regressions in the extra rows section.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — This test interacts with the dashboard assets section in both card and table views, verifying fiat amounts for asset rows. Changes to AssetTableExtraRowsSection.tsx could affect table row rendering and balance display in the assets table.
- `suite/e2e/tests/settings/t1b1-device-settings.test.ts` — This test changes the homescreen background image on a T1B1 device, directly exercising homescreen constants. Changes to homescreens.ts could affect available homescreen options or their data format.
- `suite/e2e/tests/settings/t2t1-device-settings.test.ts` — This test explicitly changes the homescreen background to 'original_t2t1', which directly relies on homescreen constants. Changes to homescreens.ts could break homescreen selection or application for T2T1 devices.
- `suite/e2e/tests/settings/t3b1-device-settings.test.ts` — This test changes the device background image (circleweb option), which exercises homescreen constants. Changes to homescreens.ts could affect available background options for T3B1.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — NeedsAttentionBanner.tsx is part of the SwitchDevice view shown when device sessions need attention (e.g., 'Use Here' state). This test directly exercises the device switcher panel with session conflicts and 'Solve Issues' button, which is the exact scenario where NeedsAttentionBanner would render.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/backup/t2t1-fail.test.ts` — This test shows a 'backup-failed' toast notification after a device disconnect during backup. Changes to notification.ts utility could affect how toast notifications are formatted or displayed in this failure scenario.
- `suite/e2e/tests/analytics/staking-events.test.ts` — This test navigates to staking from the dashboard assets section, which could render AssetTableExtraRowsSection (staking-related extra rows). A change in extra row rendering could affect the dashboard stake button interaction.

</details>

_Updated: 2026-05-08T05:57:50.327Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/switch-fallthrough&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/switch-fallthrough&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/switch-fallthrough/web/](https://dev.suite.sldev.cz/suite-web/mroz22/switch-fallthrough/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 8 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-08T06:02:40.990Z • 8 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-08T06:00:50.019Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->