### PR TITLE
feat(suite-native-25746): mobile trade   trade detail statusurl and supporturl improvements

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -3426,16 +3426,8 @@ export const messages = {
                 buy: 'Buy',
                 exchange: 'Swap',
                 sell: 'Sell',
-                buttons: {
-                    providerSupport: 'Go to provider support',
-                    proceedToPay: 'Proceed to pay',
-                },
-                pendingAlert: {
-                    title: 'Transaction pending...',
-                    description:
-                        'Your sell transaction is being processed. Please wait for confirmation.',
-                    button: 'Go to provider support',
-                },
+                checkOrderStatus: 'Check order status on provider’s website',
+                providerSupport: 'Go to provider support',
             },
         },
         error: {

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailAlert.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailAlert.tsx
@@ -5,15 +5,11 @@ import {
     type TradingTransaction,
     type TradingTransactionBuy,
     type TradingTransactionSell,
-    type TradingType,
-    getStatusUrl,
-    selectTradingProviderByNameAndTradeType,
     selectTradingTradeByOrderId,
 } from '@suite-common/trading';
 import { FullAlertBox } from '@suite-native/atoms';
 import { type IconName } from '@suite-native/icons';
 import { type TxKeyPath, useTranslate } from '@suite-native/intl';
-import { useOpenLink } from '@suite-native/link';
 import { buildTradingUrl, useBrowserAuth } from '@suite-native/trading-browser-auth';
 import { exhaustive } from '@trezor/type-utils';
 
@@ -24,13 +20,11 @@ type AlertConfig = {
     variant: 'critical' | 'neutral' | 'success';
     titleKey: TxKeyPath;
     descriptionKey: TxKeyPath;
-    buttonKey: TxKeyPath;
+    buttonKey?: TxKeyPath;
 };
 
 type TradeDetailAlertProps = {
     alertType: TradeStatusStep;
-    provider?: string;
-    tradeType: TradingType;
     orderId?: string;
     onOpenedBrowser?: () => void;
 };
@@ -48,7 +42,6 @@ const getAlertConfig = (alertType: TradeStatusStep): AlertConfig | undefined => 
                 variant: 'critical',
                 titleKey: 'moduleTrading.tradeHistory.detail.errorAlert.title',
                 descriptionKey: 'moduleTrading.tradeHistory.detail.errorAlert.description',
-                buttonKey: 'moduleTrading.tradeHistory.detail.errorAlert.button',
             };
         case 'waiting':
             return {
@@ -64,7 +57,6 @@ const getAlertConfig = (alertType: TradeStatusStep): AlertConfig | undefined => 
                 variant: 'neutral',
                 titleKey: 'moduleTrading.tradeHistory.detail.convertingAlert.title',
                 descriptionKey: 'moduleTrading.tradeHistory.detail.convertingAlert.description',
-                buttonKey: 'moduleTrading.tradeHistory.detail.convertingAlert.button',
             };
         case 'kyc':
             return {
@@ -80,7 +72,6 @@ const getAlertConfig = (alertType: TradeStatusStep): AlertConfig | undefined => 
                 variant: 'neutral',
                 titleKey: 'moduleTrading.tradeHistory.detail.sendingAlert.title',
                 descriptionKey: 'moduleTrading.tradeHistory.detail.sendingAlert.description',
-                buttonKey: 'moduleTrading.tradeHistory.detail.sendingAlert.button',
             };
         // Success, pending, processing will be handled outside of this component
         case 'success':
@@ -96,61 +87,41 @@ const getAlertConfig = (alertType: TradeStatusStep): AlertConfig | undefined => 
 
 export const TradeDetailAlert = ({
     alertType,
-    provider,
-    tradeType,
     orderId,
     onOpenedBrowser,
 }: TradeDetailAlertProps) => {
-    const openLink = useOpenLink();
+    const { translate } = useTranslate();
 
-    const providerInfo = useSelector((state: TradingRootState) =>
-        selectTradingProviderByNameAndTradeType(state, provider, tradeType),
-    );
     const trade = useSelector((state: TradingRootState) =>
         orderId ? selectTradingTradeByOrderId(state, orderId) : undefined,
     );
-    const { translate } = useTranslate();
 
     const alertConfig = getAlertConfig(alertType);
 
     const { openBrowser } = useBrowserAuth(trade?.tradeType);
 
-    // If no config found for this alert type, return null
-    if (!alertConfig) {
+    if (!alertConfig || !trade) {
         return null;
     }
 
     const { iconName, variant, titleKey, descriptionKey, buttonKey } = alertConfig;
+    const { tradeType } = trade;
 
-    // todo: separate status url and support url just like on web and desktop
-    const supportUrl = providerInfo?.supportUrl;
-    const statusOrSupportUrl =
-        alertType === 'kyc' ? supportUrl : getStatusUrl(providerInfo, trade?.data) || supportUrl;
+    const hasPartnerData = isBuyOrSell(trade) && trade.data.partnerData;
+    const shouldShowPaymentButton = alertType === 'waiting' && orderId && hasPartnerData;
+    const buttonLabel = shouldShowPaymentButton && buttonKey ? translate(buttonKey) : undefined;
 
-    const navigateToBrowser = () => {
-        if (trade && isBuyOrSell(trade) && trade.data.partnerData) {
+    const handleButtonPress = () => {
+        if (shouldShowPaymentButton && trade.data.partnerData) {
             const callbackUrl = buildTradingUrl({
                 actionType: 'trade',
-                tradeType: trade.tradeType,
+                tradeType,
                 orderId,
             });
             onOpenedBrowser?.();
             openBrowser(trade.data.partnerData, callbackUrl, orderId);
         }
     };
-
-    // Special handling for different alert types
-    let handleButtonPress: (() => void) | undefined;
-
-    if ((['waiting', 'kyc'] as TradeStatusStep[]).includes(alertType) && orderId) {
-        handleButtonPress = () => navigateToBrowser();
-    }
-
-    if (statusOrSupportUrl) {
-        handleButtonPress = () => openLink(statusOrSupportUrl);
-    }
-
-    const buttonLabel = handleButtonPress ? translate(buttonKey) : undefined;
 
     return (
         <FullAlertBox

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailHeader.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailHeader.tsx
@@ -41,8 +41,6 @@ export const TradeDetailHeader = ({ orderId, onOpenedBrowser }: TradeDetailHeade
     return (
         <TradeDetailAlert
             alertType={statusStep}
-            provider={trade.data.exchange}
-            tradeType={trade.tradeType}
             orderId={orderId}
             onOpenedBrowser={onOpenedBrowser}
         />

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailInfoRow.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailInfoRow.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode } from 'react';
+import { Pressable } from 'react-native';
 
 import { HStack, Text } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
@@ -7,22 +8,32 @@ type TradeDetailInfoRowProps = {
     title: ReactNode;
     content: ReactNode;
     contentTestID?: string;
+    onPress?: () => void;
+    borderBottom?: boolean;
 };
 
 export const DETAIL_INFO_ROW_MIN_HEIGHT = 66;
 
-const wrapperStyle = prepareNativeStyle(utils => ({
+const wrapperStyle = prepareNativeStyle<{ borderBottom?: boolean }>((utils, { borderBottom }) => ({
     justifyContent: 'space-between',
     minHeight: DETAIL_INFO_ROW_MIN_HEIGHT,
     alignItems: 'center',
     paddingHorizontal: utils.spacings.sp16,
+    borderBottomWidth: borderBottom ? 1 : 0,
+    borderBottomColor: utils.colors.surfaceFillPage,
 }));
 
-export const TradeDetailInfoRow = ({ title, content, contentTestID }: TradeDetailInfoRowProps) => {
+export const TradeDetailInfoRow = ({
+    title,
+    content,
+    contentTestID,
+    onPress,
+    borderBottom = false,
+}: TradeDetailInfoRowProps) => {
     const { applyStyle } = useNativeStyles();
 
-    return (
-        <HStack style={applyStyle(wrapperStyle)}>
+    const row = (
+        <HStack style={applyStyle(wrapperStyle, { borderBottom })}>
             <Text variant="body-sm" color="contentSecondary">
                 {title}
             </Text>
@@ -35,4 +46,10 @@ export const TradeDetailInfoRow = ({ title, content, contentTestID }: TradeDetai
             )}
         </HStack>
     );
+
+    if (!onPress) {
+        return row;
+    }
+
+    return <Pressable onPress={onPress}>{row}</Pressable>;
 };

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailProviderCard.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailProviderCard.tsx
@@ -1,0 +1,115 @@
+import { useSelector } from 'react-redux';
+
+import {
+    type TradingRootState,
+    type TradingType,
+    selectTradingProviderByNameAndTradeType,
+    selectTradingTradeByOrderId,
+} from '@suite-common/trading';
+import { Card, HStack, Text } from '@suite-native/atoms';
+import { Icon } from '@suite-native/icons';
+import { Translation, useTranslate } from '@suite-native/intl';
+import { Link, useOpenLink } from '@suite-native/link';
+import { ProviderLogo } from '@suite-native/trading-atoms';
+
+import { TradeDetailInfoRow } from './TradeDetailInfoRow';
+
+type TradeProviderCardProps = {
+    orderId: string;
+};
+
+type ProviderCardContentProps = {
+    exchange: string;
+    tradeType: TradingType;
+    statusUrl?: string;
+};
+
+const ProviderCardContent = ({ exchange, tradeType, statusUrl }: ProviderCardContentProps) => {
+    const { translate } = useTranslate();
+    const openLink = useOpenLink();
+
+    const providerInfo = useSelector((state: TradingRootState) =>
+        selectTradingProviderByNameAndTradeType(state, exchange, tradeType),
+    );
+
+    const { logo, companyName, supportUrl } = providerInfo ?? {};
+
+    return (
+        <>
+            <TradeDetailInfoRow
+                borderBottom
+                title={translate('moduleTrading.tradingScreen.provider')}
+                content={
+                    <HStack>
+                        {logo && <ProviderLogo logo={logo} />}
+                        <Text
+                            color="contentSecondary"
+                            variant="body-sm"
+                            accessibilityLabel={translate(
+                                'moduleTrading.tradingScreen.selectedProvider',
+                            )}
+                        >
+                            {companyName ?? exchange.toUpperCase()}
+                        </Text>
+                    </HStack>
+                }
+            />
+            {statusUrl && (
+                <TradeDetailInfoRow
+                    borderBottom
+                    onPress={() => openLink(statusUrl)}
+                    title={
+                        <Link
+                            label={
+                                <Translation id="moduleTrading.tradeHistory.detail.checkOrderStatus" />
+                            }
+                            isUnderlined
+                            href={statusUrl}
+                        />
+                    }
+                    content={<Icon color="contentBrand" name="arrowSquareOut" />}
+                />
+            )}
+            {supportUrl && (
+                <TradeDetailInfoRow
+                    onPress={() => openLink(supportUrl)}
+                    title={
+                        <Link
+                            label={
+                                <Translation id="moduleTrading.tradeHistory.detail.providerSupport" />
+                            }
+                            isUnderlined
+                            href={supportUrl}
+                        />
+                    }
+                    content={<Icon color="contentBrand" name="arrowSquareOut" />}
+                />
+            )}
+        </>
+    );
+};
+
+export const TradeDetailProviderCard = ({ orderId }: TradeProviderCardProps) => {
+    const trade = useSelector((state: TradingRootState) =>
+        selectTradingTradeByOrderId(state, orderId),
+    );
+
+    if (!trade) {
+        return null;
+    }
+
+    const {
+        data: { statusUrl, exchange },
+        tradeType,
+    } = trade;
+
+    return (
+        <Card noPadding>
+            <ProviderCardContent
+                exchange={exchange ?? ''}
+                tradeType={tradeType}
+                statusUrl={statusUrl ?? ''}
+            />
+        </Card>
+    );
+};

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailSheet.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailSheet.tsx
@@ -9,6 +9,7 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 import { TradeDetailFooter } from './TradeDetailFooter';
 import { TradeDetailHeader } from './TradeDetailHeader';
 import { TradeDetailInfo } from './TradeDetailInfo';
+import { TradeDetailProviderCard } from './TradeDetailProviderCard';
 import { TradeDetailTransactionInfo } from './TradeDetailTransactionInfo';
 import { getTradeTitle } from '../../../utils/general/utils';
 import { Footer } from '../../general/Footer';
@@ -58,6 +59,7 @@ export const TradeDetailSheet = memo(({ orderId, isVisible, onDismiss }: TradeDe
             isCloseDisplayed
         >
             <TradeDetailHeader orderId={orderId} onOpenedBrowser={onOpenedBrowser} />
+            <TradeDetailProviderCard orderId={orderId} />
             <TradeDetailTransactionInfo orderId={orderId} />
             <TradeDetailInfo orderId={orderId} />
             <TradeDetailFooter orderId={orderId} />

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailAlert.test.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailAlert.test.tsx
@@ -1,435 +1,95 @@
-import type { BuyTradeStatus, ExchangeTradeStatus, SellTradeStatus } from 'invity-api';
-
 import { type TradingTransaction } from '@suite-common/trading';
-import { act, fireEvent, renderWithStoreProvider } from '@suite-native/test-utils-store';
-import {
-    buyMercuryo,
-    exchangeMercuryo,
-    getBuyTrade,
-    getExchangeTrade,
-    getInitializedTradingStateWithQuotes,
-    getSellTrade,
-    sellMercuryo,
-} from '@suite-native/trading-fixtures';
-import { mergeDeepObject } from '@trezor/utils';
+import { type TxKeyPath, getTranslation } from '@suite-native/intl';
+import { renderWithStoreProvider } from '@suite-native/test-utils-store';
+import { getBuyTrade, getInitializedTradingState } from '@suite-native/trading-fixtures';
 
-import {
-    type PreloadedStatePartial,
-    type TradingTestPreloadedState,
-} from '../../../../__tests__/tradingTestUtils';
-import { getTradeStatusStep } from '../../../../utils/general/utils';
+import { type TradeStatusStep } from '../../../../utils/general/utils';
 import { TradeDetailAlert } from '../TradeDetailAlert';
 
-// Note: this file uses `renderWithStoreProvider` (not `renderWithTradingProvider`) because several
-// cases assert on the *absence* of the test provider in `providerInfos`. The trading provider would
-// merge in a populated `providerInfos` from its base state, masking those fallback code paths.
+const mockOpenBrowser = jest.fn();
 
-const TEST_PROVIDER = 'mercuryo';
-const TEST_PROVIDER_STATUS_URL = 'https://checkout.mercuryo.io/trade-history';
-
-const mockOpenLink = jest.fn();
-const mockOnOpenedBrowser = jest.fn();
-const mockNavigation = {
-    navigate: jest.fn(),
-};
-
-jest.mock('@suite-native/link', () => ({
-    useOpenLink: () => mockOpenLink,
+jest.mock('@suite-native/trading-browser-auth', () => ({
+    ...jest.requireActual('@suite-native/trading-browser-auth'),
+    useBrowserAuth: () => ({
+        openBrowser: mockOpenBrowser,
+    }),
 }));
 
-jest.mock('@react-navigation/native', () => ({
-    ...jest.requireActual('@react-navigation/native'),
-    useNavigation: () => mockNavigation,
-}));
-
-const wrapAsPreloadedState = (
-    trading: Record<string, unknown>,
-): PreloadedStatePartial<TradingTestPreloadedState> => ({ wallet: { trading } });
-
-/**
- * @param statusUrl
- *   - `undefined` → leave the test provider with its base fixture `statusUrl`
- *   - `null` → include the test provider but with `statusUrl: undefined` (tests support-url fallback)
- *   - `string` → include the test provider with the supplied `statusUrl`
- */
-const preloadedStateWithTrades = (trades: TradingTransaction[], statusUrl?: string | null) => {
-    const base = { ...getInitializedTradingStateWithQuotes(), trades };
-
-    if (statusUrl === undefined) {
-        return wrapAsPreloadedState(base);
-    }
-
-    const resolvedStatusUrl = statusUrl ?? undefined;
-
-    return wrapAsPreloadedState(
-        mergeDeepObject(base, {
-            buy: {
-                buyInfo: {
-                    providerInfos: {
-                        [TEST_PROVIDER]: { ...buyMercuryo, statusUrl: resolvedStatusUrl },
-                    },
-                },
-            },
-            sell: {
-                sellInfo: {
-                    providerInfos: {
-                        [TEST_PROVIDER]: { ...sellMercuryo, statusUrl: resolvedStatusUrl },
-                    },
-                },
-            },
-            exchange: {
-                exchangeInfo: {
-                    providerInfos: {
-                        [TEST_PROVIDER]: { ...exchangeMercuryo, statusUrl: resolvedStatusUrl },
-                    },
-                },
-            },
-        }),
-    );
+type AlertLabelsCase = {
+    alertType: TradeStatusStep;
+    titleKey: TxKeyPath;
+    descriptionKey: TxKeyPath;
 };
 
-const preloadedStateWithoutTestProvider = (trades: TradingTransaction[]) => {
-    const base = getInitializedTradingStateWithQuotes();
-    const { [TEST_PROVIDER]: _omitted, ...buyProvidersWithoutTestProvider } =
-        base.buy.buyInfo?.providerInfos ?? {};
+const alertLabelsCases: AlertLabelsCase[] = [
+    {
+        alertType: 'error',
+        titleKey: 'moduleTrading.tradeHistory.detail.errorAlert.title',
+        descriptionKey: 'moduleTrading.tradeHistory.detail.errorAlert.description',
+    },
+    {
+        alertType: 'waiting',
+        titleKey: 'moduleTrading.tradeHistory.detail.waitingAlert.title',
+        descriptionKey: 'moduleTrading.tradeHistory.detail.waitingAlert.description',
+    },
+    {
+        alertType: 'converting',
+        titleKey: 'moduleTrading.tradeHistory.detail.convertingAlert.title',
+        descriptionKey: 'moduleTrading.tradeHistory.detail.convertingAlert.description',
+    },
+    {
+        alertType: 'kyc',
+        titleKey: 'moduleTrading.tradeHistory.detail.kycAlert.title',
+        descriptionKey: 'moduleTrading.tradeHistory.detail.kycAlert.description',
+    },
+    {
+        alertType: 'sending',
+        titleKey: 'moduleTrading.tradeHistory.detail.sendingAlert.title',
+        descriptionKey: 'moduleTrading.tradeHistory.detail.sendingAlert.description',
+    },
+];
 
-    // `providerInfos` must be *replaced* (not merged) to drop the test provider entry, so we rebuild
-    // `buy.buyInfo` manually instead of using `mergeDeepObject` which would merge the map back in.
-    return wrapAsPreloadedState({
-        ...base,
-        trades,
-        buy: {
-            ...base.buy,
-            buyInfo: { ...base.buy.buyInfo, providerInfos: buyProvidersWithoutTestProvider },
+const renderAlert = ({
+    alertType,
+    trade = getBuyTrade({ status: 'SUBMITTED' }),
+}: {
+    alertType: TradeStatusStep;
+    trade?: TradingTransaction;
+}) =>
+    renderWithStoreProvider(
+        <TradeDetailAlert alertType={alertType} orderId={trade.data.orderId} />,
+        {
+            preloadedState: {
+                wallet: {
+                    trading: {
+                        ...getInitializedTradingState(),
+                        trades: [trade],
+                    },
+                },
+            },
         },
-    });
-};
+    );
 
 describe('TradeDetailAlert', () => {
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
-    const renderAlert = (
-        tradeStatus: BuyTradeStatus | ExchangeTradeStatus | SellTradeStatus,
-        tradeType: 'buy' | 'exchange' | 'sell' = 'buy',
-        statusUrl?: string,
-        orderId?: string,
-    ) => {
-        let trade;
-        if (tradeType === 'exchange') {
-            trade = getExchangeTrade({ status: tradeStatus as ExchangeTradeStatus });
-        } else if (tradeType === 'sell') {
-            trade = getSellTrade({ status: tradeStatus as SellTradeStatus });
-        } else {
-            trade = getBuyTrade({ status: tradeStatus as BuyTradeStatus });
-        }
+    it.each(alertLabelsCases)(
+        'should render translated labels for $alertType alert',
+        ({ alertType, titleKey, descriptionKey }) => {
+            const { getByText } = renderAlert({ alertType });
 
-        const alertType = getTradeStatusStep(trade);
+            expect(getByText(getTranslation(titleKey))).toBeOnTheScreen();
+            expect(getByText(getTranslation(descriptionKey))).toBeOnTheScreen();
+        },
+    );
 
-        return renderWithStoreProvider(
-            <TradeDetailAlert
-                alertType={alertType}
-                provider={TEST_PROVIDER}
-                tradeType={tradeType}
-                orderId={orderId || trade.data.orderId}
-                onOpenedBrowser={mockOnOpenedBrowser}
-            />,
-            { preloadedState: preloadedStateWithTrades([trade], statusUrl) },
-        );
-    };
+    it('should render proceed payment button for waiting alert', () => {
+        const { getByText } = renderAlert({ alertType: 'waiting' });
 
-    describe('Error Alert', () => {
-        it('should render error alert with support button for buy trades', () => {
-            const { getByText } = renderAlert('ERROR', 'buy', TEST_PROVIDER_STATUS_URL);
-
-            expect(getByText('Transaction failed')).toBeTruthy();
-            expect(getByText('Go to provider support')).toBeTruthy();
-        });
-
-        it('should render error alert with support button for sell trades', () => {
-            const { getByText } = renderAlert('ERROR', 'sell', TEST_PROVIDER_STATUS_URL);
-
-            expect(getByText('Transaction failed')).toBeTruthy();
-            expect(getByText('Go to provider support')).toBeTruthy();
-        });
-    });
-
-    describe('Waiting Alert', () => {
-        it('should render waiting alert with payment button when orderId is provided', () => {
-            const { getByText } = renderAlert('SUBMITTED', 'buy', undefined, 'test-order-id');
-
-            expect(getByText('Waiting for your payment ...')).toBeTruthy();
-            expect(getByText('Proceed to pay')).toBeTruthy();
-        });
-
-        it('should render button but not navigate when trade is not found in store', () => {
-            const { getByText } = renderWithStoreProvider(
-                <TradeDetailAlert
-                    alertType="waiting"
-                    provider={TEST_PROVIDER}
-                    tradeType="buy"
-                    orderId="nonexistent-order-id"
-                    onOpenedBrowser={mockOnOpenedBrowser}
-                />,
-                { preloadedState: preloadedStateWithTrades([], undefined) },
-            );
-
-            expect(getByText('Proceed to pay')).toBeTruthy();
-
-            act(() => {
-                fireEvent.press(getByText('Proceed to pay'));
-            });
-
-            // Should not call onOpenedBrowser when trade is not found
-            expect(mockOnOpenedBrowser).not.toHaveBeenCalled();
-            expect(mockNavigation.navigate).not.toHaveBeenCalled();
-        });
-    });
-
-    describe('KYC Alert', () => {
-        it('should render kyc alert with support button when orderId is provided', () => {
-            const { getByText } = renderAlert('KYC', 'exchange', undefined, 'test-order-id');
-
-            expect(getByText('Identity verification required')).toBeTruthy();
-            expect(getByText('Go to provider support')).toBeTruthy();
-        });
-    });
-
-    describe('Converting Alert', () => {
-        it('should render converting alert with support button', () => {
-            const { getByText } = renderAlert('CONVERTING', 'exchange', TEST_PROVIDER_STATUS_URL);
-
-            expect(getByText('Converting your crypto...')).toBeTruthy();
-            expect(getByText('Go to provider support')).toBeTruthy();
-        });
-    });
-
-    describe('Sending Alert', () => {
-        it('should render sending alert with support button', () => {
-            const { getByText } = renderAlert('SENDING', 'exchange', TEST_PROVIDER_STATUS_URL);
-
-            expect(getByText('Sending your crypto...')).toBeTruthy();
-            expect(getByText('Go to provider support')).toBeTruthy();
-        });
-    });
-
-    describe('Sell Trade Alerts', () => {
-        it('should not render alert for sell trades with SUCCESS status', () => {
-            const { toJSON } = renderWithStoreProvider(
-                <TradeDetailAlert
-                    alertType="success"
-                    provider={TEST_PROVIDER}
-                    tradeType="sell"
-                    orderId="test-order-id"
-                    onOpenedBrowser={mockOnOpenedBrowser}
-                />,
-                { preloadedState: preloadedStateWithTrades([]) },
-            );
-
-            expect(toJSON()).toBeNull();
-        });
-
-        it('should not render alert for sell trades with SEND_CRYPTO status (pending)', () => {
-            const { toJSON } = renderAlert('SEND_CRYPTO', 'sell');
-
-            expect(toJSON()).toBeNull();
-        });
-    });
-
-    describe('Support Button Functionality', () => {
-        it.each([
-            ['ERROR', 'buy', TEST_PROVIDER_STATUS_URL],
-            ['ERROR', 'exchange', TEST_PROVIDER_STATUS_URL],
-            ['ERROR', 'sell', TEST_PROVIDER_STATUS_URL],
-            ['KYC', 'exchange', exchangeMercuryo.supportUrl],
-            ['CONVERTING', 'exchange', TEST_PROVIDER_STATUS_URL],
-            ['SENDING', 'exchange', TEST_PROVIDER_STATUS_URL],
-        ])(
-            'should call openLink with status URL when support button is pressed for %s %s trades',
-            (status, tradeType, expectedUrl) => {
-                const { getByText } = renderAlert(status as any, tradeType as any, expectedUrl);
-
-                act(() => {
-                    fireEvent.press(getByText('Go to provider support'));
-                });
-
-                expect(mockOpenLink).toHaveBeenCalledWith(expectedUrl);
-            },
-        );
-    });
-
-    describe('Edge Cases', () => {
-        it('should not render when alertType is undefined', () => {
-            const { toJSON } = renderWithStoreProvider(
-                <TradeDetailAlert
-                    alertType={undefined as any}
-                    provider={TEST_PROVIDER}
-                    tradeType="buy"
-                    orderId="test-order-id"
-                    onOpenedBrowser={mockOnOpenedBrowser}
-                />,
-                { preloadedState: preloadedStateWithTrades([]) },
-            );
-
-            expect(toJSON()).toBeNull();
-        });
-
-        it('should not render when alertType is success for non-exchange trades', () => {
-            const { toJSON } = renderWithStoreProvider(
-                <TradeDetailAlert
-                    alertType="success"
-                    provider={TEST_PROVIDER}
-                    tradeType="buy"
-                    orderId="test-order-id"
-                    onOpenedBrowser={mockOnOpenedBrowser}
-                />,
-                { preloadedState: preloadedStateWithTrades([]) },
-            );
-
-            expect(toJSON()).toBeNull();
-        });
-
-        it('should render error alert without button when trade and provider info is missing', () => {
-            const { getByText, queryByText } = renderWithStoreProvider(
-                <TradeDetailAlert
-                    alertType="error"
-                    provider={TEST_PROVIDER}
-                    tradeType="buy"
-                    orderId="test-order-id"
-                    onOpenedBrowser={mockOnOpenedBrowser}
-                />,
-                { preloadedState: preloadedStateWithoutTestProvider([]) },
-            );
-
-            expect(getByText('Transaction failed')).toBeTruthy();
-            expect(queryByText('Go to provider support')).toBeNull();
-        });
-
-        it('should render waiting alert with support fallback when statusUrl is missing', () => {
-            const { getByText } = renderWithStoreProvider(
-                <TradeDetailAlert
-                    alertType="waiting"
-                    provider={TEST_PROVIDER}
-                    tradeType="buy"
-                    orderId={undefined}
-                    onOpenedBrowser={mockOnOpenedBrowser}
-                />,
-                { preloadedState: preloadedStateWithTrades([], null) },
-            );
-
-            act(() => {
-                fireEvent.press(getByText('Proceed to pay'));
-            });
-
-            expect(mockOpenLink).toHaveBeenCalledWith(buyMercuryo.supportUrl);
-        });
-
-        it('should render button but not navigate when partnerData is missing for buy trades', () => {
-            const baseBuyTrade = getBuyTrade({ status: 'SUBMITTED' });
-            const { partnerData: _omitted, ...dataWithoutPartner } = baseBuyTrade.data;
-            const buyTrade = { ...baseBuyTrade, data: dataWithoutPartner };
-
-            const { getByText } = renderWithStoreProvider(
-                <TradeDetailAlert
-                    alertType="waiting"
-                    provider={TEST_PROVIDER}
-                    tradeType="buy"
-                    orderId={buyTrade.data.orderId!}
-                    onOpenedBrowser={mockOnOpenedBrowser}
-                />,
-                { preloadedState: preloadedStateWithTrades([buyTrade], undefined) }, // No support URL
-            );
-
-            act(() => {
-                fireEvent.press(getByText('Proceed to pay'));
-            });
-
-            // Should not navigate when partnerData is missing
-            expect(mockNavigation.navigate).not.toHaveBeenCalled();
-            expect(mockOnOpenedBrowser).not.toHaveBeenCalled();
-        });
-
-        it('should fall back to support URL when partnerData is missing for exchange trades', () => {
-            const exchangeTrade = getExchangeTrade({ status: 'KYC' });
-            // Exchange trades don't have partnerData, so they always fall back to support URL
-
-            const { getByText } = renderWithStoreProvider(
-                <TradeDetailAlert
-                    alertType="kyc"
-                    provider={TEST_PROVIDER}
-                    tradeType="exchange"
-                    orderId={exchangeTrade.data.orderId!}
-                    onOpenedBrowser={mockOnOpenedBrowser}
-                />,
-                {
-                    preloadedState: preloadedStateWithTrades(
-                        [exchangeTrade],
-                        TEST_PROVIDER_STATUS_URL,
-                    ),
-                },
-            );
-
-            act(() => {
-                fireEvent.press(getByText('Go to provider support'));
-            });
-
-            // Should fall back to support URL for exchange trades
-            expect(mockOpenLink).toHaveBeenCalledWith(exchangeMercuryo.supportUrl);
-            expect(mockNavigation.navigate).not.toHaveBeenCalled();
-        });
-
-        it('should render button but not navigate when neither URL for browser auth nor support URL is available', () => {
-            const baseBuyTrade = getBuyTrade({ status: 'SUBMITTED' });
-            const { partnerData: _omitted, ...dataWithoutPartner } = baseBuyTrade.data;
-            const buyTrade = { ...baseBuyTrade, data: dataWithoutPartner };
-
-            const { getByText } = renderWithStoreProvider(
-                <TradeDetailAlert
-                    alertType="waiting"
-                    provider={TEST_PROVIDER}
-                    tradeType="buy"
-                    orderId={buyTrade.data.orderId!}
-                    onOpenedBrowser={mockOnOpenedBrowser}
-                />,
-                { preloadedState: preloadedStateWithoutTestProvider([buyTrade]) },
-            );
-
-            act(() => {
-                fireEvent.press(getByText('Proceed to pay'));
-            });
-
-            // Should not navigate when neither partner authentication URL nor support URL is available
-            expect(mockNavigation.navigate).not.toHaveBeenCalled();
-            expect(mockOnOpenedBrowser).not.toHaveBeenCalled();
-            expect(mockOpenLink).not.toHaveBeenCalled();
-        });
-
-        it('should handle sell trades with browser navigation when partnerData is available', () => {
-            const baseSellTrade = getSellTrade({ status: 'ERROR' });
-            const sellTrade = {
-                ...baseSellTrade,
-                data: { ...baseSellTrade.data, partnerData: 'https://sell.mercuryo.io/test' },
-            };
-
-            const { getByText } = renderWithStoreProvider(
-                <TradeDetailAlert
-                    alertType="error"
-                    provider={TEST_PROVIDER}
-                    tradeType="sell"
-                    orderId={sellTrade.data.orderId!}
-                    onOpenedBrowser={mockOnOpenedBrowser}
-                />,
-                { preloadedState: preloadedStateWithTrades([sellTrade], TEST_PROVIDER_STATUS_URL) },
-            );
-
-            act(() => {
-                fireEvent.press(getByText('Go to provider support'));
-            });
-
-            // Should call status URL for sell trades (not browser auth navigation)
-            expect(mockOpenLink).toHaveBeenCalledWith(TEST_PROVIDER_STATUS_URL);
-            expect(mockNavigation.navigate).not.toHaveBeenCalled();
-        });
+        expect(
+            getByText(getTranslation('moduleTrading.tradeHistory.detail.waitingAlert.button')),
+        ).toBeOnTheScreen();
     });
 });

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailProviderCard.test.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailProviderCard.test.tsx
@@ -1,0 +1,87 @@
+import { Linking } from 'react-native';
+
+import { type TradingTransaction } from '@suite-common/trading';
+import { getTranslation } from '@suite-native/intl';
+import { renderWithStoreProvider, userEvent, waitFor } from '@suite-native/test-utils-store';
+import {
+    buyMercuryo,
+    getBuyTrade,
+    getInitializedTradingState,
+} from '@suite-native/trading-fixtures';
+
+import { TradeDetailProviderCard } from '../TradeDetailProviderCard';
+
+const statusUrl = 'https://checkout.mercuryo.io/trade-history';
+
+const getPreloadedState = (trades: TradingTransaction[]) => ({
+    wallet: {
+        trading: {
+            ...getInitializedTradingState(),
+            trades,
+        },
+    },
+});
+
+const getTrade = ({ shouldIncludeStatusUrl = false } = {}) => {
+    const trade = getBuyTrade({ status: 'SUBMITTED' });
+
+    return {
+        ...trade,
+        data: {
+            ...trade.data,
+            statusUrl: shouldIncludeStatusUrl ? statusUrl : undefined,
+        },
+    };
+};
+
+const renderProviderCard = (trade = getTrade()) =>
+    renderWithStoreProvider(<TradeDetailProviderCard orderId={trade.data.orderId!} />, {
+        preloadedState: getPreloadedState([trade]),
+    });
+
+describe('TradeDetailProviderCard', () => {
+    const mockOpenURL = jest.spyOn(Linking, 'openURL');
+
+    beforeEach(() => {
+        mockOpenURL.mockClear();
+    });
+
+    it('should show status url when it is defined and open it on press', async () => {
+        const { getByText } = renderProviderCard(getTrade({ shouldIncludeStatusUrl: true }));
+        const statusLink = getByText(
+            getTranslation('moduleTrading.tradeHistory.detail.checkOrderStatus'),
+        );
+
+        expect(statusLink).toBeOnTheScreen();
+
+        await userEvent.press(statusLink);
+
+        await waitFor(() => {
+            expect(mockOpenURL).toHaveBeenCalledWith(statusUrl);
+        });
+    });
+
+    it('should not show status url when it is not defined', () => {
+        const { queryByText } = renderProviderCard();
+
+        expect(
+            queryByText(getTranslation('moduleTrading.tradeHistory.detail.checkOrderStatus')),
+        ).not.toBeOnTheScreen();
+    });
+
+    it('should show support url when it is defined and open it on press', async () => {
+        const { getByText } = renderProviderCard();
+
+        const supportLink = getByText(
+            getTranslation('moduleTrading.tradeHistory.detail.providerSupport'),
+        );
+
+        expect(supportLink).toBeOnTheScreen();
+
+        await userEvent.press(supportLink);
+
+        await waitFor(() => {
+            expect(mockOpenURL).toHaveBeenCalledWith(buyMercuryo.supportUrl);
+        });
+    });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* Create provider info card 
* Show statusUrl and supportUrl when available
* Fix proceed to payment button 

 
<!--- Describe your changes in detail -->

## Notes for QA
Only CTA left in TradeDetail alert is proceed to payment button. Rest of the statuses should have statusUrl and supportUrl when available.

## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/25746

## Screenshots:
<img width="320" alt="simulator_screenshot_3D8B8923-7FA7-4E2B-AC7B-20C6BC390D87" src="https://github.com/user-attachments/assets/e97954a8-44be-4422-a3ec-963fdd4a151f" />
<img width="320"  alt="simulator_screenshot_31FFBCF8-3156-41BE-BB21-F6AB80DB5458" src="https://github.com/user-attachments/assets/88452f00-fef7-4b0f-80c8-9294f2dda20d" />
<img width="320"  alt="simulator_screenshot_694CF236-322B-4727-BF71-07618AC7B29D" src="https://github.com/user-attachments/assets/fa02ae4b-29ba-443c-8eaf-c2e8e835d890" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/25746-mobile-trade---trade-detail-statusurl-and-supporturl-improvements&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->