### PR TITLE
fix(e2e-suite): complete onboarding in recovery persistance test

### DIFF
--- a/suite/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts
+++ b/suite/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts
@@ -103,9 +103,11 @@ test.describe('Onboarding - T2T1 in recovery mode', { tag: ['@webOnly', '@T2T1']
         page,
         device,
         devicePrompt,
+        onboardingPage,
+        dashboardPage,
     }) => {
         await test.step('Start recovery', async () => {
-            await page.getByTestId('@onboarding/recovery/start-button').click();
+            await onboardingPage.startRecoveryButton.click();
             await devicePrompt.confirmOnDevicePromptIsShown();
             await device.pressYes();
             await devicePrompt.confirmOnDevicePromptIsShown();
@@ -141,8 +143,11 @@ test.describe('Onboarding - T2T1 in recovery mode', { tag: ['@webOnly', '@T2T1']
         });
 
         await test.step('Finish onboarding', async () => {
-            await page.getByTestId('@onboarding/recovery/continue-button').click();
-            await page.getByTestId('@onboarding/skip-button').click();
+            await onboardingPage.continueRecoveryButton.click();
+            await onboardingPage.pin.skip();
+            await onboardingPage.finalButton.click();
+
+            await dashboardPage.verifyDiscoveryEmpty();
         });
     });
 });


### PR DESCRIPTION
## Description

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is the t2t1-recovery-persistence E2E test itself. This is a low-risk change since no production source code was modified — only a test file. The primary concern is ensuring the modified test still passes. Secondary concern is whether the change reflects updates to shared test infrastructure (page objects, fixtures) that could affect sibling T2T1 recovery tests.

<details><summary><b>Changed files (1)</b></summary>

- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts` — The changed file IS this test file itself. Any modifications to t2t1-recovery-persistence.test.ts must be validated by running this test to confirm it passes correctly.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-success.test.ts` — This test covers the closely related T2T1 recovery success flow, sharing the same device model, recovery page objects, and onboarding infrastructure. Changes to the persistence test may reflect modifications to shared recovery flow components or page objects that could affect this test.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-fail.test.ts` — This test covers T2T1 recovery failure with device disconnection, which directly overlaps with the persistence test's behavior of handling disconnection and reconnection during Shamir recovery. They share the same device model, recovery flow entry points, and devicePrompt interactions.

</details>

_Updated: 2026-05-08T10:52:34.418Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/fix-t2t1-recovery-onboarding/web/](https://dev.suite.sldev.cz/suite-web/test/fix-t2t1-recovery-onboarding/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-08T10:57:31.152Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-08T10:56:30.086Z • 13 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/fix-t2t1-recovery-onboarding&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->