### PR TITLE
feat(suite-native): change button priority for all InlineAlertBox variants

### DIFF
--- a/suite-native/atoms/src/InlineAlertBox/presets.ts
+++ b/suite-native/atoms/src/InlineAlertBox/presets.ts
@@ -22,27 +22,27 @@ export const variantToColorMap = {
     info: {
         backgroundColor: 'legacyBackgroundAlertBlueSubtleOnElevation1',
         borderColor: 'legacyBackgroundAlertBlueSubtleOnElevationNegative',
-        buttonColorProps: { intent: 'info', priority: 'primary' },
+        buttonColorProps: { intent: 'info', priority: 'secondary' },
     },
     success: {
         backgroundColor: 'legacyBackgroundPrimarySubtleOnElevation1',
         borderColor: 'legacyBackgroundPrimarySubtleOnElevationNegative',
-        buttonColorProps: { intent: 'brand', priority: 'primary' },
+        buttonColorProps: { intent: 'brand', priority: 'secondary' },
     },
     warning: {
         backgroundColor: 'legacyBackgroundAlertYellowSubtleOnElevation1',
         borderColor: 'legacyBackgroundAlertYellowSubtleOnElevationNegative',
-        buttonColorProps: { intent: 'warning', priority: 'primary' },
+        buttonColorProps: { intent: 'warning', priority: 'secondary' },
     },
     neutral: {
         backgroundColor: 'legacyBackgroundTertiaryDefaultOnElevation1',
         borderColor: 'legacyBackgroundTertiaryDefaultOnElevation0',
-        buttonColorProps: { intent: 'neutral', priority: 'primary' },
+        buttonColorProps: { intent: 'neutral', priority: 'secondary' },
     },
     critical: {
         backgroundColor: 'legacyBackgroundAlertRedSubtleOnElevation1',
         borderColor: 'legacyBackgroundAlertRedSubtleOnElevationNegative',
-        buttonColorProps: { intent: 'critical', priority: 'primary' },
+        buttonColorProps: { intent: 'critical', priority: 'secondary' },
     },
 } as const satisfies Record<InlineAlertBoxVariant, InlineAlertBoxStyles>;
 


### PR DESCRIPTION
Based on David's request:

> With those buttons on neutral intent it is not so clear. A common pattern is that in neutral context we also use brand primary next to neutral secondary (e.g. eshop) and primary neutral is an alternative button next to brand if there are more primary actions on the page. But honestly, right now I would not complicate it and leave it as it is.
> 
> The only thing that would make sense from my point of view is that in case when only 1 icon button is used, then **priority secondary is always used** and not primary. Primary icon button looks too prominent for the fact that it practically has the only purpose as a closable button.

Related to #27339 where `neutral` is used.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/inline-alert-box-button-priority&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->