### PR TITLE
chore(eslint): forbid indexOf comparisons in favor of includes

### DIFF
--- a/packages/address-validator/src/loki_validator.ts
+++ b/packages/address-validator/src/loki_validator.ts
@@ -29,11 +29,11 @@ function validateNetwork(
 
     switch (networkType) {
         case 'prod':
-            return network.prod.indexOf(at) >= 0;
+            return network.prod.includes(at);
         case 'testnet':
-            return network.testnet.indexOf(at) >= 0;
+            return network.testnet.includes(at);
         case 'both':
-            return network.prod.indexOf(at) >= 0 || network.testnet.indexOf(at) >= 0;
+            return network.prod.includes(at) || network.testnet.includes(at);
         default:
             return false;
     }

--- a/packages/address-validator/src/monero_validator.ts
+++ b/packages/address-validator/src/monero_validator.ts
@@ -34,11 +34,11 @@ function validateNetwork(
 
     switch (networkType) {
         case 'prod':
-            return network.prod.indexOf(at) >= 0;
+            return network.prod.includes(at);
         case 'testnet':
-            return network.testnet.indexOf(at) >= 0;
+            return network.testnet.includes(at);
         case 'both':
-            return network.prod.indexOf(at) >= 0 || network.testnet.indexOf(at) >= 0;
+            return network.prod.includes(at) || network.testnet.includes(at);
         default:
             return false;
     }

--- a/packages/components/scripts/test-img-paths-exist.ts
+++ b/packages/components/scripts/test-img-paths-exist.ts
@@ -16,7 +16,7 @@ function fileExistsWithCaseSync(filepath: string) {
         return true;
     }
     const filenames = fs.readdirSync(dir);
-    if (filenames.indexOf(path.basename(filepath)) === -1) {
+    if (!filenames.includes(path.basename(filepath))) {
         return false;
     }
 

--- a/packages/eslint/src/javascriptConfig.mjs
+++ b/packages/eslint/src/javascriptConfig.mjs
@@ -56,6 +56,12 @@ export const javascriptConfig = [
                     selector:
                         "CallExpression[callee.name='useSelector'] MemberExpression[object.name='state']:matches([property.type='Identifier'])",
                 },
+                {
+                    message:
+                        'Use Array/String .includes() instead of .indexOf() comparison (e.g. `arr.indexOf(x) >= 0` → `arr.includes(x)`, `arr.indexOf(x) === -1` → `!arr.includes(x)`).',
+                    selector:
+                        "BinaryExpression[left.type='CallExpression'][left.callee.type='MemberExpression'][left.callee.property.name='indexOf']:matches([operator='>='][right.value=0], [operator='<'][right.value=0], [operator='>'][right.type='UnaryExpression'][right.operator='-'][right.argument.value=1], [operator='==='][right.type='UnaryExpression'][right.operator='-'][right.argument.value=1], [operator='!=='][right.type='UnaryExpression'][right.operator='-'][right.argument.value=1], [operator='=='][right.type='UnaryExpression'][right.operator='-'][right.argument.value=1], [operator='!='][right.type='UnaryExpression'][right.operator='-'][right.argument.value=1])",
+                },
             ],
             'object-shorthand': [
                 'error',


### PR DESCRIPTION
## Summary

Adds a `no-restricted-syntax` selector to `@trezor/eslint` that flags `indexOf` comparison patterns and points at `Array.prototype.includes` / `String.prototype.includes` instead.

Caught patterns:
- `arr.indexOf(x) >= 0` / `< 0`
- `arr.indexOf(x) > -1`
- `arr.indexOf(x) === -1` / `!== -1` (and loose `==` / `!=` variants)

Index-style usage (`const i = arr.indexOf(x)`, `arr.indexOf(x) === 5`, etc.) is unaffected.

Also fixes the remaining occurrences in `monero_validator.ts` and `loki_validator.ts` so the rule passes monorepo-wide.

Stacked on top of #27475 — that PR does the bulk refactor, this PR locks the convention in via lint. Once #27475 lands, GitHub will rebase this onto `develop` automatically.

## Test plan

- [x] `yarn workspace @trezor/address-validator lint:js` — rule fires on the unfixed cases, then passes after the fix
- [x] Lint passes on every package touched by #27475 (blockchain-link, blockchain-link-utils, connect-explorer, suite, utils, utxo-lib, suite-common/{device,transaction-search,wallet-utils})
- [ ] CI green

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mvarmuza/eslint-prefer-includes/web/](https://dev.suite.sldev.cz/suite-web/mvarmuza/eslint-prefer-includes/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mvarmuza/eslint-prefer-includes&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mvarmuza/eslint-prefer-includes&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mvarmuza/eslint-prefer-includes&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-09T09:31:01.470Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-09T09:29:28.338Z • 13 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->