### PR TITLE
chore(connect-cli): remove unreachable stdio abort field

### DIFF
--- a/packages/connect-cli/src/stdio.ts
+++ b/packages/connect-cli/src/stdio.ts
@@ -24,7 +24,6 @@ export const stdioManager = () => {
                     });
                 }, 10);
             }),
-            abort: () => rl.close(),
         };
     };
 };


### PR DESCRIPTION
## Summary

Remove the unreachable `abort: () => rl.close()` field from `stdioManager` in `@trezor/connect-cli`. Both call sites only destructure `.promise`, so the abort closure was never called.

Part of a 3-PR split — see related PRs below.

**Scope**: 1 commit, 1 file, −1 line. No behavior change.

### Safety verification

`packages/connect-cli/src/index.ts` is the only consumer of `stdioManager()`; both `await waitForStdio(...).promise` call sites confirmed.

## Related PRs (split of original cleanup)

- trezor/trezor-suite#27519 — `@trezor/connect`
- trezor/trezor-suite#27521 — `@trezor/connect-explorer`
- trezor/trezor-suite#27522 — this PR (`@trezor/connect-cli`)

## Test plan

- [ ] `yarn workspace @trezor/connect-cli type-check`
- [ ] CI green

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/review-remove-only-safe-int-cli/web/](https://dev.suite.sldev.cz/suite-web/mroz22/review-remove-only-safe-int-cli/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/review-remove-only-safe-int-cli&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-09T08:03:36.942Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->