### PR TITLE
refactor: replace .some(x => x === y) with .includes(y)

### DIFF
--- a/packages/blockchain-link-utils/src/solana.ts
+++ b/packages/blockchain-link-utils/src/solana.ts
@@ -32,7 +32,7 @@ import type {
     TokenProgramName,
 } from '@trezor/coins-solana/types';
 import { isCodesignBuild } from '@trezor/env-utils';
-import { arrayPartition } from '@trezor/utils';
+import { arrayPartition, isArrayMember } from '@trezor/utils';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 export type ApiTokenAccount = {
@@ -71,7 +71,7 @@ export const getTokenNameAndSymbol = (mint: string, tokenDetailByMint: TokenDeta
 };
 
 const isTokenProgramName = (programName: string): programName is TokenProgramName =>
-    tokenProgramNames.some(name => name === programName);
+    isArrayMember(programName, tokenProgramNames);
 
 export const tokenStandardToTokenProgramName = (standard: TokenStandard): TokenProgramName => {
     const tokenProgram = Object.entries(tokenProgramsInfo).find(

--- a/packages/connect/e2e/tests/device/methods.test.ts
+++ b/packages/connect/e2e/tests/device/methods.test.ts
@@ -35,7 +35,7 @@ const getFixtures = () => {
     let subset = Object.values(fixtures);
     if (includedMethods) {
         const methodsArr = includedMethods.split(',');
-        subset = subset.filter(f => methodsArr.some(includedM => includedM === f.method));
+        subset = subset.filter(f => methodsArr.includes(f.method));
     } else if (excludedMethods) {
         const methodsArr = excludedMethods.split(',');
         subset = subset.filter(f => !methodsArr.includes(f.method));

--- a/packages/suite-desktop-core/src/modules/http-receiver.ts
+++ b/packages/suite-desktop-core/src/modules/http-receiver.ts
@@ -3,6 +3,7 @@
  */
 import { isMacOs, isWindows } from '@trezor/env-utils';
 import { validateIpcMessage } from '@trezor/ipc-proxy';
+import { isArrayMember } from '@trezor/utils';
 
 import { restartApp } from '../libs/app-utils';
 import { initConnectPopupResponseHandler } from '../libs/connect-popup-messages';
@@ -70,10 +71,7 @@ export const initBackground: ModuleInitBackground = ({
             validateIpcMessage({ ipcEvent });
             try {
                 // Use deeplink URLs for trading redirects on macOS/Windows only
-                if (
-                    TRADING_REDIRECT_PATHS.some(path => path === pathname) &&
-                    (isMacOs() || isWindows())
-                ) {
+                if (isArrayMember(pathname, TRADING_REDIRECT_PATHS) && (isMacOs() || isWindows())) {
                     receiver.activateRoute(pathname);
 
                     return `trezorsuite:/${pathname}`;

--- a/packages/suite/src/reducers/store.ts
+++ b/packages/suite/src/reducers/store.ts
@@ -94,7 +94,7 @@ const getCustomMiddleware = (getExtra: () => ExtraDependencies | null) => {
             // https://redux-toolkit.js.org/api/createAsyncThunk#promise-lifecycle-actions
             !action?.meta?.requestId &&
             // explicitly excluded actions
-            !loggerExcludedActions.some(act => action.type === act);
+            !loggerExcludedActions.includes(action.type);
 
         const logger = createLogger({
             level: 'info',

--- a/packages/suite/src/utils/onboarding/steps.ts
+++ b/packages/suite/src/utils/onboarding/steps.ts
@@ -79,9 +79,7 @@ export const isStepUsed = (step: Step, props: IsStepUsedProps): boolean => {
         return true;
     }
 
-    return onboardingPath.every((pathMember: AnyPath) =>
-        step.path?.some((stepPathMember: AnyPath) => stepPathMember === pathMember),
-    );
+    return onboardingPath.every((pathMember: AnyPath) => step.path?.includes(pathMember));
 };
 
 export const isStepCategoryUsed = (stepCategory: StepCategory, props: IsStepUsedProps): boolean =>

--- a/packages/suite/src/views/backup/BackupStepDescription.tsx
+++ b/packages/suite/src/views/backup/BackupStepDescription.tsx
@@ -1,5 +1,6 @@
 import { selectBackupStatus } from '@suite/backup';
 import { Translation } from '@suite/intl';
+import { isArrayMember } from '@trezor/utils';
 
 import { useSelector } from 'src/hooks/suite';
 
@@ -7,7 +8,7 @@ const nonErrorBackupStatuses = ['initial', 'in-progress', 'finished'] as const;
 
 export const BackupStepDescription = () => {
     const backupStatus = useSelector(selectBackupStatus);
-    const currentProgressBarStep = nonErrorBackupStatuses.some(status => status === backupStatus)
+    const currentProgressBarStep = isArrayMember(backupStatus, nonErrorBackupStatuses)
         ? nonErrorBackupStatuses.findIndex(s => s === backupStatus) + 1
         : undefined;
 

--- a/packages/suite/src/views/dashboard/useNotificationForDisconnectedDevice.tsx
+++ b/packages/suite/src/views/dashboard/useNotificationForDisconnectedDevice.tsx
@@ -20,9 +20,8 @@ export const useNotificationForDisconnectedDevice = () => {
         const deviceId = selectedDevice?.id;
 
         if (deviceId) {
-            const isNotificationSeenOnThisDevice = seenDisconnectNotificationForDeviceIds
-                ? seenDisconnectNotificationForDeviceIds.some(id => id === selectedDevice?.id)
-                : false;
+            const isNotificationSeenOnThisDevice =
+                seenDisconnectNotificationForDeviceIds?.includes(deviceId) ?? false;
 
             const isNotificationVisible =
                 recentlyDisconnectedDevice === deviceId &&

--- a/suite-common/earn-stablecoin-api/src/verification/shared.ts
+++ b/suite-common/earn-stablecoin-api/src/verification/shared.ts
@@ -8,7 +8,7 @@ export const aggregateStatuses = (
     statuses: TransactionVerificationStatus[],
 ): VerificationStatus => {
     if (statuses.length === 0) return 'skipped';
-    if (statuses.some(s => s === 'failed')) return 'failure';
+    if (statuses.includes('failed')) return 'failure';
     if (statuses.every(s => s === 'verified')) return 'success';
 
     return 'skipped';

--- a/suite-native/module-accounts-import/src/screens/AccountImportSummaryScreen.tsx
+++ b/suite-native/module-accounts-import/src/screens/AccountImportSummaryScreen.tsx
@@ -39,9 +39,7 @@ export const AccountImportSummaryScreen = ({
     );
     const supportedNetworks = useSelector(selectDiscoveryNetworkSymbols);
 
-    const isAccountImportSupported = supportedNetworks.some(
-        supportedSymbol => supportedSymbol === networkSymbol,
-    );
+    const isAccountImportSupported = supportedNetworks.includes(networkSymbol);
 
     if (!isAccountImportSupported) {
         return (

--- a/suite-native/module-accounts-import/src/screens/XpubScanScreen.tsx
+++ b/suite-native/module-accounts-import/src/screens/XpubScanScreen.tsx
@@ -45,7 +45,7 @@ const isBtcTestnetXpub = (xpubAddress: string) => {
 
     const btcTestnetPrefixes = ['tpub', 'upub', 'vpub', 'Upub', 'Vpub'];
 
-    return btcTestnetPrefixes.some(prefix => prefix === xpub.slice(0, 4));
+    return btcTestnetPrefixes.includes(xpub.slice(0, 4));
 };
 
 export const XpubScanScreen = ({

--- a/suite/idb-migration-utils/src/parseIdbVersion.ts
+++ b/suite/idb-migration-utils/src/parseIdbVersion.ts
@@ -19,7 +19,7 @@ export const parseIdbVersion = (raw: string): VersionInfo => {
         .split('.')
         .map(part => part.trim());
 
-    if ((parts.length !== 3 && parts.length !== 4) || parts.some(part => part === '')) {
+    if ((parts.length !== 3 && parts.length !== 4) || parts.includes('')) {
         throw new Error(
             `Invalid IDB version: "${raw}". Expected "major.minor.patch" or "major.minor.patch.revision".`,
         );


### PR DESCRIPTION
## Summary

Replaces `.some(x => x === y)` patterns with `.includes(y)` across the monorepo. Pure refactor; no behavioural change.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mvarmuza/eslint-prefer-includes-cleanup&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mvarmuza/eslint-prefer-includes-cleanup&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mvarmuza/eslint-prefer-includes-cleanup&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-14T13:51:47.745Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-14T07:53:09.432Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mvarmuza/eslint-prefer-includes-cleanup/web/](https://dev.suite.sldev.cz/suite-web/mvarmuza/eslint-prefer-includes-cleanup/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->