### PR TITLE
chore(connect-common): remove unused CONTENT_SCRIPT_LOADED event

### DIFF
--- a/packages/connect-common/src/events/popup.ts
+++ b/packages/connect-common/src/events/popup.ts
@@ -16,8 +16,6 @@ export const POPUP = {
     CLOSED: 'popup-closed',
     // Message called from inline element in popup.html (window.closeWindow), this is used only with webextensions to properly handle popup close event
     CLOSE_WINDOW: 'window.close',
-    // not used anymore, will removed in https://github.com/trezor/trezor-suite/pull/24471
-    CONTENT_SCRIPT_LOADED: 'popup-content-script-loaded',
 } as const;
 
 export interface PopupInit {
@@ -45,11 +43,6 @@ export interface PopupClosedMessage {
     payload: { error: any } | null;
 }
 
-export interface PopupContentScriptLoaded {
-    type: typeof POPUP.CONTENT_SCRIPT_LOADED;
-    payload: { id: string; contentScriptVersion: number };
-}
-
 export interface PopupCloseWindow {
     type: typeof POPUP.CLOSE_WINDOW;
     payload: typeof undefined;
@@ -62,7 +55,6 @@ export type PopupEvent =
       }
     | PopupInit
     | PopupHandshake
-    | PopupContentScriptLoaded
     | PopupCloseWindow
     | PopupClosedMessage;
 


### PR DESCRIPTION
## Summary

- Removes dead code `CONTENT_SCRIPT_LOADED` and `PopupContentScriptLoaded` from `@trezor/connect-common` that was explicitly marked as unused via inline comment.

## Test plan

- [ ] CI passes
- [ ] No references to `CONTENT_SCRIPT_LOADED` / `PopupContentScriptLoaded` remain in the codebase

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/pr-from-commit/web/](https://dev.suite.sldev.cz/suite-web/mroz22/pr-from-commit/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/pr-from-commit&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-09T12:11:21.438Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->