### PR TITLE
chore(ipc-proxy): remove unused unregistered array from cleanup

### DIFF
--- a/packages/ipc-proxy/src/proxy-handler.ts
+++ b/packages/ipc-proxy/src/proxy-handler.ts
@@ -149,11 +149,9 @@ export const createIpcProxyHandler = <Api extends EventEmitterApi>(
 
     return () => {
         // TODO: walk thru all instances, disable, remove listeners, remove references
-        const unregistered = [];
         ipcMain.eventNames().forEach(name => {
             if (typeof name === 'string' && name.startsWith(`${channel}/`)) {
                 ipcMain.removeAllListeners(name);
-                unregistered.push(name);
             }
         });
 


### PR DESCRIPTION
## Summary

- Remove dead `unregistered` array from cleanup function in `@trezor/ipc-proxy` — the array was populated but never read.

## Test plan

- [ ] `yarn workspace @trezor/ipc-proxy build` passes

## Related PRs

Part of a series removing dead code across packages:

- #27526 — `@trezor/blockchain-link`
- #27527 — `@trezor/ipc-proxy`
- #27528 — `@trezor/styles`
- #27529 — `@trezor/dom-utils`
- #27531 — `@trezor/coinjoin`
- #27532 — `suite-desktop-core`
- #27533 — `@trezor/suite-storage`
- #27534 — `@trezor/transport`

🤖 Generated with [Claude Code](https://claude.com/claude-code)