### PR TITLE
chore(styles): remove deprecated dark_theme from mediaQueries

### DIFF
--- a/packages/styles/src/mediaQueries.ts
+++ b/packages/styles/src/mediaQueries.ts
@@ -6,9 +6,4 @@ export const mediaQueries = {
             : '@media print',
     touch: '@media (hover: none)',
     hover: '@media (hover: hover)',
-
-    /**
-     * @deprecated remove this query as it shall be done via the Theme, this is not working properly (if changing theme in settings)
-     */
-    dark_theme: '@media (prefers-color-scheme: dark)',
 };


### PR DESCRIPTION
## Summary

- Remove deprecated `dark_theme` property from `mediaQueries` object in `@trezor/styles` — explicitly marked `@deprecated` with removal instruction and no usages found across the repo.

## Test plan

- [ ] `yarn workspace @trezor/styles build` passes
- [ ] No TypeScript errors referencing `mediaQueries.dark_theme`

## Related PRs

Part of a series removing dead code across packages:

- #27526 — `@trezor/blockchain-link`
- #27527 — `@trezor/ipc-proxy`
- #27528 — `@trezor/styles`
- #27529 — `@trezor/dom-utils`
- #27531 — `@trezor/coinjoin`
- #27532 — `suite-desktop-core`
- #27533 — `@trezor/suite-storage`
- #27534 — `@trezor/transport`

🤖 Generated with [Claude Code](https://claude.com/claude-code)