### PR TITLE
chore(coinjoin): remove unused findNearestDeadline function

### DIFF
--- a/packages/coinjoin/src/utils/roundUtils.ts
+++ b/packages/coinjoin/src/utils/roundUtils.ts
@@ -92,7 +92,7 @@ export const scheduleDelay = (
 };
 
 // NOTE: deadlines are not accurate. phase may change earlier
-// accept CoinjoinRound or modified coordinator Round (see estimatePhaseDeadline below)
+// accept CoinjoinRound or modified coordinator Round
 type PartialCoinjoinRound = {
     Phase: RoundPhase;
     InputRegistrationEnd: string;
@@ -151,18 +151,6 @@ export const getCoinjoinRoundDeadlines = (round: PartialCoinjoinRound) => {
                 roundDeadline: now,
             };
     }
-};
-
-export const estimatePhaseDeadline = (round: Round) => {
-    const roundParameters = getRoundParameters(round);
-    if (!roundParameters) return 0;
-
-    const { phaseDeadline } = getCoinjoinRoundDeadlines({
-        ...round,
-        RoundParameters: roundParameters,
-    });
-
-    return phaseDeadline;
 };
 
 // get relevant round data from the most recent round

--- a/packages/coinjoin/src/utils/roundUtils.ts
+++ b/packages/coinjoin/src/utils/roundUtils.ts
@@ -165,18 +165,6 @@ export const estimatePhaseDeadline = (round: Round) => {
     return phaseDeadline;
 };
 
-export const findNearestDeadline = (rounds: Round[]) => {
-    const now = Date.now();
-    const deadlines = rounds.map(r => {
-        const phaseDeadline = estimatePhaseDeadline(r);
-        const timeLeft = phaseDeadline ? new Date(phaseDeadline).getTime() - now : 0;
-
-        return timeLeft > 0 ? timeLeft : now;
-    });
-
-    return Math.min(...deadlines);
-};
-
 // get relevant round data from the most recent round
 const getDataFromRounds = (rounds: Round[]) => {
     const lastRound = rounds.at(-1);

--- a/packages/coinjoin/tests/utils/roundUtils.test.ts
+++ b/packages/coinjoin/tests/utils/roundUtils.test.ts
@@ -1,8 +1,6 @@
 import { getWeakRandomNumberInRange } from '@trezor/utils';
 
-import { ROUND_REGISTRATION_END_OFFSET } from '../../src/constants';
 import {
-    estimatePhaseDeadline,
     getAffiliateRequest,
     getCommitmentData,
     getRoundParams,
@@ -10,7 +8,7 @@ import {
     scheduleDelay,
     transformStatus,
 } from '../../src/utils/roundUtils';
-import { DEFAULT_ROUND, STATUS_EVENT, STATUS_TRANSFORMED } from '../fixtures/round.fixture';
+import { STATUS_EVENT, STATUS_TRANSFORMED } from '../fixtures/round.fixture';
 
 // mock random delay function
 jest.mock('@trezor/utils', () => {
@@ -36,66 +34,6 @@ describe('roundUtils', () => {
         expect(readTimeSpan('1d 2h 0m 0s')).toEqual(26 * 60 * 60000);
         expect(readTimeSpan('1d 2h 3m 30s')).toEqual(26 * 60 * 60000 + 3 * 60000 + 30000);
         expect(readTimeSpan('d h m s')).toEqual(0);
-    });
-
-    it('estimatePhaseDeadline', () => {
-        const round = {
-            ...DEFAULT_ROUND,
-            CoinjoinState: {
-                Events: [
-                    {
-                        Type: 'RoundCreated',
-                        RoundParameters: {
-                            ConnectionConfirmationTimeout: '0d 0h 1m 0s',
-                            OutputRegistrationTimeout: '0d 0h 2m 0s',
-                            TransactionSigningTimeout: '0d 0h 3m 0s',
-                        },
-                    },
-                ],
-            },
-        } as typeof DEFAULT_ROUND;
-
-        const base = new Date(round.InputRegistrationEnd).getTime() + ROUND_REGISTRATION_END_OFFSET;
-        expect(estimatePhaseDeadline(DEFAULT_ROUND)).toEqual(base);
-
-        // result may vary +-5 milliseconds
-        const expectInRange = (result: number, expected: number) => {
-            expect(result).toBeGreaterThanOrEqual(expected - 5);
-            expect(result).toBeLessThan(expected + 5);
-        };
-
-        const timeouts = 60000; // each phase timeout of DEFAULT_ROUND is set to 1 min.
-        expectInRange(
-            estimatePhaseDeadline({
-                ...round,
-                Phase: 1,
-            }),
-            Date.now() + timeouts,
-        );
-
-        expectInRange(
-            estimatePhaseDeadline({
-                ...round,
-                Phase: 2,
-            }),
-            Date.now() + timeouts * 2,
-        );
-
-        expectInRange(
-            estimatePhaseDeadline({
-                ...round,
-                Phase: 3,
-            }),
-            Date.now() + timeouts * 3,
-        );
-
-        expectInRange(
-            estimatePhaseDeadline({
-                ...round,
-                Phase: 4,
-            }),
-            Date.now() + timeouts * 3,
-        );
     });
 
     describe('transformStatus', () => {


### PR DESCRIPTION
## Summary

- Remove dead function `findNearestDeadline` from `@trezor/coinjoin` (`packages/coinjoin/src/utils/roundUtils.ts`) — function had no callers in the repository.
- Remove dead function `estimatePhaseDeadline` from `@trezor/coinjoin` (`packages/coinjoin/src/utils/roundUtils.ts`) — function was never called in production code, only referenced in tests.

## Test plan

- [ ] `yarn workspace @trezor/coinjoin build` passes

## Related PRs

Part of a series removing dead code across packages:

- #27526 — `@trezor/blockchain-link`
- #27527 — `@trezor/ipc-proxy`
- #27528 — `@trezor/styles`
- #27529 — `@trezor/dom-utils`
- #27531 — `@trezor/coinjoin`
- #27532 — `suite-desktop-core`
- #27533 — `@trezor/suite-storage`
- #27534 — `@trezor/transport`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/barcelona-coinjoin-dead-code/web/](https://dev.suite.sldev.cz/suite-web/mroz22/barcelona-coinjoin-dead-code/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->