### PR TITLE
chore(suite-storage): remove unused methods from CommonDB

### DIFF
--- a/packages/suite-storage/src/index.ts
+++ b/packages/suite-storage/src/index.ts
@@ -182,45 +182,6 @@ class CommonDB<TDBStructure> {
         return item;
     };
 
-    getItemByIndex = async <
-        TStoreName extends StoreNames<TDBStructure>,
-        TIndexName extends IndexNames<TDBStructure, TStoreName>,
-        TKey extends IndexKey<TDBStructure, TStoreName, TIndexName>,
-    >(
-        store: TStoreName,
-        indexName: TIndexName,
-        key: TKey,
-    ) => {
-        // returns the tx with txID
-        const db = await this.getDB();
-        const tx = db.transaction(store);
-        const index = tx.store.index(indexName);
-        const item = await index.get(IDBKeyRange.only(key));
-
-        return item;
-    };
-
-    updateItemByIndex = async <
-        TStoreName extends StoreNames<TDBStructure>,
-        TIndexName extends IndexNames<TDBStructure, TStoreName>,
-        TKey extends IndexKey<TDBStructure, TStoreName, TIndexName>,
-    >(
-        store: TStoreName,
-        indexName: TIndexName,
-        key: TKey,
-        updateObject: { [key: string]: any },
-    ) => {
-        const db = await this.getDB();
-        const tx = db.transaction(store, 'readwrite');
-        const index = tx.store.index(indexName);
-        const result = await index.get(key);
-        if (result) {
-            Object.assign(result, updateObject);
-
-            return tx.store.put(result);
-        }
-    };
-
     removeItemByPK = async <
         TStoreName extends StoreNames<TDBStructure>,
         TKey extends StoreKey<TDBStructure, TStoreName>,

--- a/packages/suite-storage/src/index.ts
+++ b/packages/suite-storage/src/index.ts
@@ -309,35 +309,6 @@ class CommonDB<TDBStructure> {
         return resp;
     };
 
-    clearStores = async <TStoreName extends StoreNames<TDBStructure>>(
-        storeNames?: TStoreName[],
-    ) => {
-        const db = await this.getDB();
-
-        const extractStoreNames = () => {
-            const names: StoreNames<TDBStructure>[] = [];
-            const list = db.objectStoreNames;
-            const { length } = list;
-            for (let i = 0; i < length; i++) {
-                const storeName = list.item(i);
-                if (storeName) {
-                    names.push(storeName);
-                }
-            }
-
-            return names;
-        };
-
-        const list = storeNames ?? extractStoreNames();
-        const promises = list.map(storeName => {
-            const transaction = db.transaction(storeName, 'readwrite');
-            const objectStore = transaction.objectStore(storeName);
-
-            return objectStore.clear();
-        });
-        await Promise.all(promises);
-    };
-
     removeDatabase = () => {
         this.lazyDb.dispose();
 


### PR DESCRIPTION
## Summary

- Remove dead methods `getItemByIndex` and `updateItemByIndex` from `CommonDB` class in `@trezor/suite-storage` — neither had any callers in the repository.
- Remove dead method `clearStores` from `CommonDB` class in `@trezor/suite-storage` — cleared IndexedDB object stores but was never called anywhere in the repository.

## Related PRs

Part of a series removing dead code across packages:

- #27526 — `@trezor/blockchain-link`
- #27527 — `@trezor/ipc-proxy`
- #27528 — `@trezor/styles`
- #27529 — `@trezor/dom-utils`
- #27531 — `@trezor/coinjoin`
- #27532 — `suite-desktop-core`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is to packages/suite-storage/src/index.ts, which is a foundational storage abstraction layer used transitively by 121 tests. Since this is a broad global utility, most tests only depend on it indirectly. The highest-risk scenarios are those that explicitly test data persistence across page reloads, database migrations, and state recovery — these are the tests most likely to break if the storage layer changes. The recommended strategy is to focus on the handful of tests that directly exercise persistence and migration behavior rather than running the full 121-test suite.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite-storage/src/index.ts`

</details>

**Recommended tests (6)**

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/suite/db-migration.test.ts` — This test explicitly exercises database migration across Suite versions, including IndexedDB persistence. Since suite-storage/src/index.ts is the core storage abstraction layer, changes here could directly affect how data is persisted, migrated, and read back — which is exactly what this test validates (theme persistence, send form drafts, transaction history, passphrase wallet remembering across DB migration).
- `suite/e2e/tests/suite/db-locale-migration.test.ts` — This test validates that user settings (language preference) persist across database migrations between Suite versions. The suite-storage index is the foundation for IndexedDB-backed persistence, so changes could break settings migration.
- `suite/e2e/tests/suite/initial-run.test.ts` — This test validates that onboarding/initial-run state persists across page reloads — a behavior directly dependent on the storage layer. The source hints mention 'Suite initial run / onboarding state persistence logic' which relies on suite-storage for persisting the initialRun flag.
- `suite/e2e/tests/analytics/toggle.test.ts` — This test verifies that analytics preference is persisted after reload and that instance_id remains the same across reloads while session_id changes. The source hints explicitly mention 'Suite storage layer (persisting initialRun flag and analytics preference)', directly tying this test to suite-storage functionality.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/wallet/discovery.test.ts` — This test involves a page reload interruption during discovery and validates that discovery recovers and completes — behavior that depends on state persistence through the storage layer. A storage regression could cause discovery state to be lost on reload.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts` — This test explicitly validates persisting recovery state across device disconnection, IndexedDB reset, and page reload. It directly exercises IndexedDB utilities and relies on the storage layer to maintain recovery progress across reloads.

</details>

_Updated: 2026-05-10T05:09:15.445Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/barcelona-suite-storage-dead-code&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/barcelona-suite-storage-dead-code&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-10T05:14:01.312Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-10T05:12:12.164Z • 13 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/barcelona-suite-storage-dead-code/web/](https://dev.suite.sldev.cz/suite-web/mroz22/barcelona-suite-storage-dead-code/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->