### PR TITLE
chore(transport): remove unused version() bridge API response parser

### DIFF
--- a/packages/transport/src/utils/bridgeApiResult.ts
+++ b/packages/transport/src/utils/bridgeApiResult.ts
@@ -25,14 +25,6 @@ export function info(res: UnknownPayload) {
     return success({ version, configured, protocolMessages });
 }
 
-export function version(res: UnknownPayload) {
-    if (!isString(res)) {
-        return error({ code: ERRORS.WRONG_RESULT_TYPE });
-    }
-
-    return success(res.trim());
-}
-
 export function devices(res: UnknownPayload) {
     if (isString(res)) {
         return error({ code: ERRORS.WRONG_RESULT_TYPE });


### PR DESCRIPTION
## Summary

- Remove dead function `version()` from `packages/transport/src/utils/bridgeApiResult.ts` — internal bridge API response parser for the `/version` endpoint that does not exist in `BridgeTransport`.

related #23794

## Related PRs

Part of a series removing dead code across packages:

- #27526 — `@trezor/blockchain-link`
- #27527 — `@trezor/ipc-proxy`
- #27528 — `@trezor/styles`
- #27529 — `@trezor/dom-utils`
- #27531 — `@trezor/coinjoin`
- #27532 — `suite-desktop-core`
- #27533 — `@trezor/suite-storage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is to a single transport utility file (bridgeApiResult.ts) that processes bridge API responses. This is a broad, low-level dependency imported by 116 tests, so the risk is diffuse rather than concentrated. The highest-risk area is bridge communication and session management, where incorrect API result parsing would cause immediate failures. Most of the 116 mapped tests only transitively depend on this file through the transport layer and are unlikely to be affected unless the change fundamentally breaks bridge communication. A focused set of bridge-specific and transport-dependent tests should provide sufficient confidence.

<details><summary><b>Changed files (1)</b></summary>

- `packages/transport/src/utils/bridgeApiResult.ts`

</details>

**Recommended tests (4)**

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — This test directly exercises bridge transport functionality including bridge version endpoints and bridge lifecycle management. Changes to bridgeApiResult.ts could affect how bridge API responses are parsed, which would directly impact bridge spawning and reconnection behavior tested here.
- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — This test validates bridge daemon mode spawning and lifecycle. bridgeApiResult.ts is a transport utility that processes bridge API responses, and changes could affect how the bridge running/stopped status is determined via HTTP endpoint checks.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test exercises BridgeTransport session acquire/enumerate operations and session stealing behavior. bridgeApiResult.ts processes bridge API responses which are central to session management, so changes could affect session acquisition and status detection.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — This test explicitly asserts on TransportType event reporting 'BridgeTransport' with a valid version. Changes to bridgeApiResult.ts could affect how the bridge transport type and version are resolved, directly impacting the TransportType analytics event assertion.

</details>

_Updated: 2026-05-10T05:13:51.732Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/barcelona-transport-dead-code&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/barcelona-transport-dead-code&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-10T05:18:36.257Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-10T05:16:42.823Z • 13 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/barcelona-transport-dead-code/web/](https://dev.suite.sldev.cz/suite-web/mroz22/barcelona-transport-dead-code/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->