### PR TITLE
chore(address-validator): replace jssha with @noble/hashes

### DIFF
--- a/packages/address-validator/jest.config.cjs
+++ b/packages/address-validator/jest.config.cjs
@@ -3,5 +3,5 @@ const baseConfig = require('../../jest.config.base.swc');
 module.exports = {
     ...baseConfig,
     testEnvironment: '../../JestCustomEnv.js',
-    transformIgnorePatterns: ['/node_modules/(?!@scure/base/)'],
+    transformIgnorePatterns: ['/node_modules/(?!(@scure/base|@noble/hashes)/)'],
 };

--- a/packages/address-validator/package.json
+++ b/packages/address-validator/package.json
@@ -28,10 +28,10 @@
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
     },
     "dependencies": {
+        "@noble/hashes": "^2.0.1",
         "@scure/base": "^2.0.0",
         "cbor": "^10.0.12",
-        "crc": "^3.8.0",
-        "jssha": "2.3.1"
+        "crc": "^3.8.0"
     },
     "devDependencies": {
         "@trezor/eslint": "workspace:*"

--- a/packages/address-validator/src/crypto/utils.ts
+++ b/packages/address-validator/src/crypto/utils.ts
@@ -1,4 +1,5 @@
-import jsSHA from 'jssha';
+import { sha256 as nobleSha256 } from '@noble/hashes/sha2.js';
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 
 import * as base32Module from './base32';
 import { decode as base58Decode } from './base58';
@@ -99,19 +100,16 @@ export function toHex(arrayOfBytes: ArrayLike<number>): string {
     return hex;
 }
 
-export function sha256(payload: string): string {
-    const sha = new jsSHA('SHA-256', 'HEX');
-    sha.update(payload);
-
-    return sha.getHash('HEX');
+export function sha256(hexPayload: string): string {
+    return bytesToHex(nobleSha256(hexToBytes(hexPayload)));
 }
 
-export function sha256x2(buffer: string): string {
-    return sha256(sha256(buffer));
+export function sha256x2(hexPayload: string): string {
+    return sha256(sha256(hexPayload));
 }
 
-export function sha256Checksum(payload: string): string {
-    return sha256(sha256(payload)).substr(0, 8);
+export function sha256Checksum(hexPayload: string): string {
+    return sha256(sha256(hexPayload)).substr(0, 8);
 }
 
 export function blake256(hexString: string): string {

--- a/packages/address-validator/src/types.d.ts
+++ b/packages/address-validator/src/types.d.ts
@@ -1,2 +1,1 @@
 declare module 'crc';
-declare module 'jssha';

--- a/packages/address-validator/tests/crypto_utils.test.ts
+++ b/packages/address-validator/tests/crypto_utils.test.ts
@@ -1,0 +1,46 @@
+import { sha256, sha256Checksum, sha256x2 } from '../src/crypto/utils';
+
+// These functions were re-implemented on top of @noble/hashes (issue #27403,
+// replacing the unmaintained jssha dependency). The behaviour must stay
+// byte-identical, so we pin it against published known-answer vectors.
+//
+// Inputs and outputs are hex strings; "abc" is the byte sequence 0x61 0x62 0x63.
+describe('crypto/utils sha256 helpers', () => {
+    describe('sha256', () => {
+        // NIST "SHA-256 Examples" — one-block message "abc", page 1
+        // ("Message Digest is BA7816BF 8F01CFEA ... F20015AD"):
+        // https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-and-Guidelines/documents/examples/SHA256.pdf
+        it('matches the NIST "abc" example vector', () => {
+            expect(sha256('616263')).toEqual(
+                'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad',
+            );
+        });
+
+        // NIST CAVP byte-oriented test vectors, SHA256ShortMsg.rsp entry "Len = 0":
+        // https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/shs/shabytetestvectors.zip
+        it('matches the NIST CAVP empty-message vector', () => {
+            expect(sha256('')).toEqual(
+                'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+            );
+        });
+    });
+
+    describe('sha256x2', () => {
+        // Double SHA-256 (Bitcoin "hash256") of the same FIPS "abc" input:
+        // SHA-256(SHA-256(0x616263)). Cross-checked against Node's crypto module.
+        it('is SHA-256 applied twice', () => {
+            expect(sha256x2('616263')).toEqual(
+                '4f8b42c22dd3729b519ba6f68d2da7cc5b2d606d05daed5ad5128cc03e6c6358',
+            );
+            expect(sha256x2('616263')).toEqual(sha256(sha256('616263')));
+        });
+    });
+
+    describe('sha256Checksum', () => {
+        // base58check checksum = first 4 bytes (8 hex chars) of the double SHA-256.
+        it('is the first 4 bytes of sha256x2', () => {
+            expect(sha256Checksum('616263')).toEqual('4f8b42c2');
+            expect(sha256Checksum('616263')).toEqual(sha256x2('616263').slice(0, 8));
+        });
+    });
+});

--- a/scripts/list-outdated-dependencies/connect-dependencies.txt
+++ b/scripts/list-outdated-dependencies/connect-dependencies.txt
@@ -48,7 +48,6 @@ html-inline-script-webpack-plugin
 http-server
 intersection-observer
 json5
-jssha
 lodash
 match-sorter
 next

--- a/yarn.lock
+++ b/yarn.lock
@@ -15248,11 +15248,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/address-validator@workspace:packages/address-validator"
   dependencies:
+    "@noble/hashes": "npm:^2.0.1"
     "@scure/base": "npm:^2.0.0"
     "@trezor/eslint": "workspace:*"
     cbor: "npm:^10.0.12"
     crc: "npm:^3.8.0"
-    jssha: "npm:2.3.1"
   peerDependencies:
     tslib: ^2.6.2
   languageName: unknown
@@ -32401,13 +32401,6 @@ __metadata:
   version: 5.0.1
   resolution: "jsonpointer@npm:5.0.1"
   checksum: 10/0b40f712900ad0c846681ea2db23b6684b9d5eedf55807b4708c656f5894b63507d0e28ae10aa1bddbea551241035afe62b6df0800fc94c2e2806a7f3adecd7c
-  languageName: node
-  linkType: hard
-
-"jssha@npm:2.3.1":
-  version: 2.3.1
-  resolution: "jssha@npm:2.3.1"
-  checksum: 10/6b2e033c7e38056ddb5756353b10a45e45316d6b1f54307ec3bbbc85dd96d2bc1cc20871ed8e439d1d07f3a1f2705895d613152dac13f1a97dfd50c76c1dbc94
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
First slice of #27403 — modernize `@trezor/address-validator` and `@trezor/utxo-lib` dependencies.

## Summary

- `crypto/utils.ts`: drop [`jssha`](https://github.com/Caligatio/jsSHA/blob/v2.3.1/src/sha256.js) (2.x, unmaintained since 2017) and reimplement `sha256`/`sha256x2`/`sha256Checksum` on top of [`@noble/hashes`](https://github.com/paulmillr/noble-hashes/blob/2.2.0/src/sha2.ts), which is already used across the monorepo (`utxo-lib`, `connect`, `blockchain-link-utils`).
- Drop the unused `format: 'HEX' | 'TEXT'` parameter — every in-tree caller passes hex strings, and `'TEXT'` was never a valid jssha output format anyway.
- `jest.config.js`: extend `transformIgnorePatterns` to also transform `@noble/hashes` (ESM-only, same treatment as `@scure/base`).
- `types.d.ts`: drop the obsolete `declare module 'jssha';` shim.
- `yarn.lock` deduped.

## Test status

**Direct coverage**
- [`packages/address-validator/tests/crypto_utils.test.ts`](https://github.com/trezor/trezor-suite/blob/mroz22/issue-27403/packages/address-validator/tests/crypto_utils.test.ts) — known-answer tests pinning `sha256` / `sha256x2` / `sha256Checksum` against the NIST "abc" example and CAVP empty-message vectors.

  > _Note for the reviewer:_ this maybe wasn't necessary to add — it almost feels like testing that "a `switch` in JavaScript is not broken". The functions are thin wrappers and the swap (jssha → `@noble/hashes`) is already covered indirectly by every base58check address test (below). There is prior art for this kind of trivial input → expected-output mapping test in the repo, e.g. [`getStatusMessage` in sellUtils](https://github.com/trezor/trezor-suite/blob/7396e8c871eba4272820483533646b677a33c27b/suite-common/trading/src/utils/sell/__tests__/sellUtils.test.ts#L81-L94), which just feeds each status into a `switch` and asserts the returned label. Happy to drop it if you would rather not carry it.

**Indirect coverage**
- [`packages/address-validator/tests/wallet_address_validator.test.ts`](https://github.com/trezor/trezor-suite/blob/develop/packages/address-validator/tests/wallet_address_validator.test.ts) — 175 jest cases × hundreds of `valid()` / `invalid()` address fixtures across ~60 currencies. BTC / BCH / BSV / Ripple / Tezos validators all flow through the modified `sha256` / `sha256x2` / `sha256Checksum`. A regression in noble's sha256 output would fail address-checksum verification across the suite.
- [`packages/address-validator/tests/wallet_address_get_currencies.test.ts`](https://github.com/trezor/trezor-suite/blob/develop/packages/address-validator/tests/wallet_address_get_currencies.test.ts) — 1 currency-lookup case.
- Aggregate: address-validator `test:unit` = **176 / 176 passing** on this branch.

**Coverage assessment:** Strong via fixtures. The crypto helpers are not unit-tested in isolation, but they are exercised by every BTC / BCH / Ripple / Tezos validator test — and the fixtures pin both valid and invalid addresses across many currency variants.

**Change safety:** **Low risk.**
- Drop-in replacement: same hex-string input → same hex-string output. `@noble/hashes` is already a transitive dep via `@scure/base` — no new top-level dependency.
- `jssha` has been unmaintained since 2017.
- The dropped `format: 'TEXT' | 'HEX'` parameter was unused in-tree (and `'TEXT'` was never a valid jssha output format anyway).

## Test plan

- [x] `yarn workspace @trezor/address-validator test:unit` — 176/176 pass
- [x] `yarn workspace @trezor/address-validator type-check`
- [x] `yarn workspace @trezor/address-validator lint:js`
- [x] `yarn workspace @trezor/address-validator depcheck`
- [x] `yarn dedupe`

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are limited to the `packages/address-validator` package — specifically its `package.json`, a crypto utility file (`crypto/utils.ts`), and type definitions (`types.d.ts`). This is a standalone validation library package. None of the E2E tests in the suite have any static mapping to these files, and after reviewing all 90+ test descriptions, none of them reference `address-validator` functionality, crypto validation utilities, or address validation logic from this package in their source hints, entry points, or behaviors. The address-validator package appears to be consumed by other packages or services that are not exercised by any of the existing E2E tests. The risk of user-facing regression from these changes is low from an E2E perspective, though unit/integration tests within the address-validator package itself (not listed here) would be the appropriate coverage.

<details><summary><b>Changed files (3)</b></summary>

- `packages/address-validator/package.json`
- `packages/address-validator/src/crypto/utils.ts`
- `packages/address-validator/src/types.d.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (3)**
- `packages/address-validator/package.json`
- `packages/address-validator/src/crypto/utils.ts`
- `packages/address-validator/src/types.d.ts`

_Updated: 2026-05-10T05:51:40.473Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/issue-27403&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/issue-27403&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-10T05:56:44.938Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-10T05:54:43.617Z • 13 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/issue-27403/web/](https://dev.suite.sldev.cz/suite-web/mroz22/issue-27403/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

