### PR TITLE
chore(utxo-lib): inline bitcoin-ops and pushdata-bitcoin

### DIFF
--- a/packages/utxo-lib/package.json
+++ b/packages/utxo-lib/package.json
@@ -53,11 +53,9 @@
         "@scure/base": "^2.0.0",
         "@sinclair/typebox": "^0.34.49",
         "@trezor/utils": "workspace:*",
-        "bitcoin-ops": "^1.4.1",
         "bn.js": "5.2.3",
         "cashaddrjs": "0.4.4",
         "int64-buffer": "^1.1.0",
-        "pushdata-bitcoin": "^1.0.1",
         "varuint-bitcoin": "2.0.0",
         "wif": "^5.0.0"
     },

--- a/packages/utxo-lib/src/bufferutils.ts
+++ b/packages/utxo-lib/src/bufferutils.ts
@@ -7,11 +7,11 @@
 
 import BN from 'bn.js';
 import { Int64LE } from 'int64-buffer';
-import pushdata from 'pushdata-bitcoin';
 import * as varuint from 'varuint-bitcoin';
 
 import { bufferUtils } from '@trezor/utils';
 
+import * as pushdata from './script/pushdata';
 import { BufferSchema, Type, UInt32, assertType } from './types/validation';
 
 const OUT_OF_RANGE_ERROR = 'value out of range';
@@ -109,22 +109,11 @@ export function cloneBuffer(buffer: Buffer): Buffer {
     return clone;
 }
 
-type PushDataSize = (len: number) => number;
-type ReadPushDataInt = (
-    buffer: Buffer,
-    offset: number,
-) => {
-    opcode: number;
-    number: number;
-    size: number;
-};
-type WritePushDataInt = (buffer: Buffer, number: number, offset: number) => number;
-
-export const pushDataSize: PushDataSize = pushdata.encodingLength;
-export const readPushDataInt: ReadPushDataInt = pushdata.decode;
+export const pushDataSize = pushdata.encodingLength;
+export const readPushDataInt = pushdata.decode;
 // export const varIntBuffer = varuint.encode; // TODO: not-used
 export const varIntSize = varuint.encodingLength;
-export const writePushDataInt: WritePushDataInt = pushdata.encode;
+export const writePushDataInt = pushdata.encode;
 export const { reverseBuffer, getChunkSize } = bufferUtils;
 
 /**

--- a/packages/utxo-lib/src/script/index.ts
+++ b/packages/utxo-lib/src/script/index.ts
@@ -1,12 +1,12 @@
 // upstream: https://github.com/bitcoinjs/bitcoinjs-lib/blob/master/ts_src/script.ts
 // differences:
-// - bitcoin-ops extended by decred codes.
+// - OP codes table extended by decred codes.
 
 import { DER } from '@noble/curves/abstract/weierstrass.js';
-import pushdata from 'pushdata-bitcoin';
 
 import * as ecc from '../noble-compatibility';
 import { OPS, REVERSE_OPS } from './ops';
+import * as pushdata from './pushdata';
 import * as scriptNumber from './scriptNumber';
 import * as scriptSignature from './scriptSignature';
 import type { Stack, StackElement } from '../types';

--- a/packages/utxo-lib/src/script/ops.ts
+++ b/packages/utxo-lib/src/script/ops.ts
@@ -1,8 +1,162 @@
-import * as ops from 'bitcoin-ops';
+// Inlined from bitcoin-ops (https://github.com/bitcoinjs/bitcoin-ops),
+// unmaintained since 2017. Extended with Decred OP codes.
+//
+// The MIT License (MIT)
+//
+// Copyright (c) 2016 Daniel Cousens
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 
-// extend with Decred OP codes
 const OPS: Record<string, number> = {
-    ...ops,
+    OP_FALSE: 0,
+    OP_0: 0,
+    OP_PUSHDATA1: 76,
+    OP_PUSHDATA2: 77,
+    OP_PUSHDATA4: 78,
+    OP_1NEGATE: 79,
+    OP_RESERVED: 80,
+    OP_TRUE: 81,
+    OP_1: 81,
+    OP_2: 82,
+    OP_3: 83,
+    OP_4: 84,
+    OP_5: 85,
+    OP_6: 86,
+    OP_7: 87,
+    OP_8: 88,
+    OP_9: 89,
+    OP_10: 90,
+    OP_11: 91,
+    OP_12: 92,
+    OP_13: 93,
+    OP_14: 94,
+    OP_15: 95,
+    OP_16: 96,
+
+    OP_NOP: 97,
+    OP_VER: 98,
+    OP_IF: 99,
+    OP_NOTIF: 100,
+    OP_VERIF: 101,
+    OP_VERNOTIF: 102,
+    OP_ELSE: 103,
+    OP_ENDIF: 104,
+    OP_VERIFY: 105,
+    OP_RETURN: 106,
+
+    OP_TOALTSTACK: 107,
+    OP_FROMALTSTACK: 108,
+    OP_2DROP: 109,
+    OP_2DUP: 110,
+    OP_3DUP: 111,
+    OP_2OVER: 112,
+    OP_2ROT: 113,
+    OP_2SWAP: 114,
+    OP_IFDUP: 115,
+    OP_DEPTH: 116,
+    OP_DROP: 117,
+    OP_DUP: 118,
+    OP_NIP: 119,
+    OP_OVER: 120,
+    OP_PICK: 121,
+    OP_ROLL: 122,
+    OP_ROT: 123,
+    OP_SWAP: 124,
+    OP_TUCK: 125,
+
+    OP_CAT: 126,
+    OP_SUBSTR: 127,
+    OP_LEFT: 128,
+    OP_RIGHT: 129,
+    OP_SIZE: 130,
+
+    OP_INVERT: 131,
+    OP_AND: 132,
+    OP_OR: 133,
+    OP_XOR: 134,
+    OP_EQUAL: 135,
+    OP_EQUALVERIFY: 136,
+    OP_RESERVED1: 137,
+    OP_RESERVED2: 138,
+
+    OP_1ADD: 139,
+    OP_1SUB: 140,
+    OP_2MUL: 141,
+    OP_2DIV: 142,
+    OP_NEGATE: 143,
+    OP_ABS: 144,
+    OP_NOT: 145,
+    OP_0NOTEQUAL: 146,
+    OP_ADD: 147,
+    OP_SUB: 148,
+    OP_MUL: 149,
+    OP_DIV: 150,
+    OP_MOD: 151,
+    OP_LSHIFT: 152,
+    OP_RSHIFT: 153,
+
+    OP_BOOLAND: 154,
+    OP_BOOLOR: 155,
+    OP_NUMEQUAL: 156,
+    OP_NUMEQUALVERIFY: 157,
+    OP_NUMNOTEQUAL: 158,
+    OP_LESSTHAN: 159,
+    OP_GREATERTHAN: 160,
+    OP_LESSTHANOREQUAL: 161,
+    OP_GREATERTHANOREQUAL: 162,
+    OP_MIN: 163,
+    OP_MAX: 164,
+
+    OP_WITHIN: 165,
+
+    OP_RIPEMD160: 166,
+    OP_SHA1: 167,
+    OP_SHA256: 168,
+    OP_HASH160: 169,
+    OP_HASH256: 170,
+    OP_CODESEPARATOR: 171,
+    OP_CHECKSIG: 172,
+    OP_CHECKSIGVERIFY: 173,
+    OP_CHECKMULTISIG: 174,
+    OP_CHECKMULTISIGVERIFY: 175,
+
+    OP_NOP1: 176,
+
+    OP_NOP2: 177,
+    OP_CHECKLOCKTIMEVERIFY: 177,
+
+    OP_NOP3: 178,
+    OP_CHECKSEQUENCEVERIFY: 178,
+
+    OP_NOP4: 179,
+    OP_NOP5: 180,
+    OP_NOP6: 181,
+    OP_NOP7: 182,
+    OP_NOP8: 183,
+    OP_NOP9: 184,
+    OP_NOP10: 185,
+
+    OP_PUBKEYHASH: 253,
+    OP_PUBKEY: 254,
+    OP_INVALIDOPCODE: 255,
+
+    // Decred-specific opcodes
     OP_SSTX: 0xba,
     OP_SSTXCHANGE: 0xbd,
     OP_SSGEN: 0xbb,

--- a/packages/utxo-lib/src/script/pushdata.ts
+++ b/packages/utxo-lib/src/script/pushdata.ts
@@ -1,0 +1,97 @@
+// Inlined from pushdata-bitcoin (https://github.com/bitcoinjs/pushdata-bitcoin),
+// unmaintained since 2017.
+//
+// The MIT License (MIT)
+//
+// Copyright (c) 2016 Daniel Cousens
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import { OPS } from './ops';
+
+export function encodingLength(i: number): number {
+    if (i < OPS.OP_PUSHDATA1) return 1;
+    if (i <= 0xff) return 2;
+    if (i <= 0xffff) return 3;
+
+    return 5;
+}
+
+export function encode(buffer: Buffer, number: number, offset: number): number {
+    const size = encodingLength(number);
+
+    // ~6 bit
+    if (size === 1) {
+        buffer.writeUInt8(number, offset);
+
+        // 8 bit
+    } else if (size === 2) {
+        buffer.writeUInt8(OPS.OP_PUSHDATA1, offset);
+        buffer.writeUInt8(number, offset + 1);
+
+        // 16 bit
+    } else if (size === 3) {
+        buffer.writeUInt8(OPS.OP_PUSHDATA2, offset);
+        buffer.writeUInt16LE(number, offset + 1);
+
+        // 32 bit
+    } else {
+        buffer.writeUInt8(OPS.OP_PUSHDATA4, offset);
+        buffer.writeUInt32LE(number, offset + 1);
+    }
+
+    return size;
+}
+
+export function decode(
+    buffer: Buffer,
+    offset: number,
+): { opcode: number; number: number; size: number } | null {
+    const opcode = buffer.readUInt8(offset);
+    let number: number;
+    let size: number;
+
+    // ~6 bit
+    if (opcode < OPS.OP_PUSHDATA1) {
+        number = opcode;
+        size = 1;
+
+        // 8 bit
+    } else if (opcode === OPS.OP_PUSHDATA1) {
+        if (offset + 2 > buffer.length) return null;
+        number = buffer.readUInt8(offset + 1);
+        size = 2;
+
+        // 16 bit
+    } else if (opcode === OPS.OP_PUSHDATA2) {
+        if (offset + 3 > buffer.length) return null;
+        number = buffer.readUInt16LE(offset + 1);
+        size = 3;
+
+        // 32 bit
+    } else {
+        if (offset + 5 > buffer.length) return null;
+        if (opcode !== OPS.OP_PUSHDATA4) throw new Error('Unexpected opcode');
+
+        number = buffer.readUInt32LE(offset + 1);
+        size = 5;
+    }
+
+    return { opcode, number, size };
+}

--- a/packages/utxo-lib/src/types/bitcoin-ops.d.ts
+++ b/packages/utxo-lib/src/types/bitcoin-ops.d.ts
@@ -1,1 +1,0 @@
-declare module 'bitcoin-ops';

--- a/packages/utxo-lib/src/types/pushdata-bitcoin.d.ts
+++ b/packages/utxo-lib/src/types/pushdata-bitcoin.d.ts
@@ -1,8 +1,0 @@
-declare module 'pushdata-bitcoin' {
-    function encodingLength(len: number): number;
-    function encode(buffer: Buffer, number: number, offset: number): number;
-    function decode(
-        buffer: Buffer,
-        offset: number,
-    ): { opcode: number; number: number; size: number };
-}

--- a/packages/utxo-lib/tests/bufferutils.test.ts
+++ b/packages/utxo-lib/tests/bufferutils.test.ts
@@ -23,6 +23,7 @@ describe('bufferutils', () => {
                 const d = bufferutils.readPushDataInt(buffer, 0);
                 const fopcode = parseInt(f.hexPD.substring(0, 2), 16);
 
+                if (d === null) throw new Error('expected non-null');
                 expect(d.opcode).toEqual(fopcode);
                 expect(d.number).toEqual(f.dec);
                 expect(d.size).toEqual(buffer.length);

--- a/scripts/list-outdated-dependencies/connect-dependencies.txt
+++ b/scripts/list-outdated-dependencies/connect-dependencies.txt
@@ -62,7 +62,6 @@ postcss
 postcss-cli
 postcss-import
 postcss-lightningcss
-pushdata-bitcoin
 react-inspector
 remark-gemoji
 remark-gfm

--- a/scripts/list-outdated-dependencies/wallet-dependencies.txt
+++ b/scripts/list-outdated-dependencies/wallet-dependencies.txt
@@ -29,7 +29,6 @@
 abortcontroller-polyfill
 ajv
 bignumber.js
-bitcoin-ops
 bn.js
 cashaddrjs
 event-target-shim

--- a/scripts/publish/babel-plugin-add-js-extension.js
+++ b/scripts/publish/babel-plugin-add-js-extension.js
@@ -14,7 +14,7 @@ const isTrezorLibESMImport = src => trezorLibESMPattern.test(src);
 const externalCjsSubpaths = [];
 const isExternalCjsSubpath = src => externalCjsSubpaths.includes(src);
 
-const externalJsonImports = ['bitcoin-ops'];
+const externalJsonImports = [];
 
 /**
  * Babel plugin to rewrite import/export statements to their runtime ESM extensions.

--- a/yarn.lock
+++ b/yarn.lock
@@ -16690,12 +16690,10 @@ __metadata:
     "@trezor/eslint": "workspace:*"
     "@trezor/utils": "workspace:*"
     "@types/bn.js": "npm:^5.2.0"
-    bitcoin-ops: "npm:^1.4.1"
     bn.js: "npm:5.2.3"
     cashaddrjs: "npm:0.4.4"
     int64-buffer: "npm:^1.1.0"
     minimaldata: "npm:^1.0.2"
-    pushdata-bitcoin: "npm:^1.0.1"
     varuint-bitcoin: "npm:2.0.0"
     wif: "npm:^5.0.0"
   peerDependencies:
@@ -20632,7 +20630,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bitcoin-ops@npm:^1.3.0, bitcoin-ops@npm:^1.4.1":
+"bitcoin-ops@npm:^1.3.0":
   version: 1.4.1
   resolution: "bitcoin-ops@npm:1.4.1"
   checksum: 10/3daa3303d6af49c0727041b5d7801a20c5806d00f1cc1afa2d53099974e30a7b1e7e9e578723dd25f5e120903f2725c595c0205d5d99a6578ad65213d74d806d


### PR DESCRIPTION
Second slice of #27403 — modernize `@trezor/utxo-lib` and `@trezor/address-validator` dependencies.

> **Land plan:** #28052 adds direct tests for the `pushdata.decode → null` branch and other `script` edge cases against today's `develop`. Merge #28052 first, then rebase this PR on top so the same tests guard the inlined `src/script/pushdata.ts`.

## Why

Both `bitcoin-ops` and `pushdata-bitcoin` are ~40 LOC each, unmaintained since 2017, and pulled in only by this workspace. Inlining drops two stale deps and lets us type them properly.

## Summary

- New `src/script/pushdata.ts` — TypeScript port of [`pushdata-bitcoin`](https://github.com/bitcoinjs/pushdata-bitcoin/blob/master/index.js) (3 functions: `encodingLength`, `encode`, `decode`). The return type of `decode` now correctly includes `| null` for truncated PUSHDATA payloads — the previous `declare module` signature omitted that branch even though the JS implementation always returned it.
- `src/script/ops.ts` — [`bitcoin-ops`](https://github.com/bitcoinjs/bitcoin-ops/blob/master/index.json) OPS table inlined directly, Decred extension co-located in the same file. Drops the `import * as ops from 'bitcoin-ops'` and the `declare module 'bitcoin-ops';` shim.
- `src/bufferutils.ts` — drops the local `PushDataSize` / `ReadPushDataInt` / `WritePushDataInt` aliases that only existed to compensate for missing `pushdata-bitcoin` types.
- `bufferutils.test.ts` — narrows nullability for the new `decode` return type.
- `package.json` — `bitcoin-ops` and `pushdata-bitcoin` removed.
- `scripts/list-outdated-dependencies/{connect,wallet}-dependencies.txt` — corresponding entries removed.
- `scripts/publish/babel-plugin-add-js-extension.js` — drops `bitcoin-ops` from `externalJsonImports` (only existed because the package shipped its OP table as JSON).
- `yarn.lock` deduped.

## Test status

**Direct coverage**
- [`packages/utxo-lib/tests/bufferutils.test.ts`](https://github.com/trezor/trezor-suite/blob/mroz22/issue-27403-inline-bitcoin-ops/packages/utxo-lib/tests/bufferutils.test.ts) — 14 `it` cases covering `pushDataSize` / `readPushDataInt` / `writePushDataInt` against the full fixture set (valid + invalid truncated inputs). This PR also narrows the nullability for the new `decode` return type here.
- [`packages/utxo-lib/tests/script.test.ts`](https://github.com/trezor/trezor-suite/blob/mroz22/issue-27403-inline-bitcoin-ops/packages/utxo-lib/tests/script.test.ts) — 12 `it` cases for `script.compile` / `script.decompile`, exercising the inlined OPS table and PUSHDATA decoding. Truncated-PUSHDATA cases for `OP_PUSHDATA1` / `OP_PUSHDATA2` / `OP_PUSHDATA4` are in [`__fixtures__/script.ts#L169-L177`](https://github.com/trezor/trezor-suite/blob/mroz22/issue-27403-inline-bitcoin-ops/packages/utxo-lib/tests/__fixtures__/script.ts#L169).

**Indirect coverage**
- [`packages/utxo-lib/tests/transaction.test.ts`](https://github.com/trezor/trezor-suite/blob/mroz22/issue-27403-inline-bitcoin-ops/packages/utxo-lib/tests/transaction.test.ts) — 25 cases of transaction parsing exercise OPS lookups and PUSHDATA encoding/decoding.
- [`packages/utxo-lib/tests/payments.test.ts`](https://github.com/trezor/trezor-suite/blob/mroz22/issue-27403-inline-bitcoin-ops/packages/utxo-lib/tests/payments.test.ts) — exercises script templates built on top of the OPS table.
- Aggregate: utxo-lib `test:unit` = **2451 / 2451 passing** on this branch.

**Coverage assessment:** Strong. OPS table and pushdata helpers are exercised directly by unit tests and transitively by every script-level / transaction test.

**Change safety:** **Low risk.**
- Pure TypeScript port of ~40 LOC each; logic preserved.
- Only behavioral change: `decode` return type is now correctly `… | null` for truncated payloads — the previous `declare module` signature omitted that branch even though the JS implementation always returned it.
- No new dependencies; two stale 2017-era deps dropped.

## Test plan

- [x] `yarn workspace @trezor/utxo-lib test:unit` — 2451/2451 pass
- [x] `yarn workspace @trezor/utxo-lib type-check`
- [x] `yarn workspace @trezor/utxo-lib lint:js`
- [x] `yarn workspace @trezor/utxo-lib depcheck`
- [x] `yarn workspace @trezor/connect type-check` (consumer)
- [x] `yarn workspace @trezor/blockchain-link type-check` (consumer)
- [x] `yarn dedupe`

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/issue-27403-inline-bitcoin-ops&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/issue-27403-inline-bitcoin-ops&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-26T16:10:20.612Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-26T16:07:49.459Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/issue-27403-inline-bitcoin-ops/web/](https://dev.suite.sldev.cz/suite-web/mroz22/issue-27403-inline-bitcoin-ops/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->


