### PR TITLE
chore(utxo-lib): replace int64-buffer with native BigInt

### DIFF
--- a/packages/utxo-lib/package.json
+++ b/packages/utxo-lib/package.json
@@ -54,7 +54,6 @@
         "@sinclair/typebox": "^0.34.49",
         "@trezor/utils": "workspace:*",
         "cashaddrjs": "0.4.4",
-        "int64-buffer": "^1.1.0",
         "varuint-bitcoin": "2.0.0",
         "wif": "^5.0.0"
     },

--- a/packages/utxo-lib/src/bufferutils.ts
+++ b/packages/utxo-lib/src/bufferutils.ts
@@ -5,7 +5,6 @@
 // - added `BufferWritter` "writeInt64", "writeUInt16" methods.
 // - `BufferWritter.writeUInt64` is accepting string or number.
 
-import { Int64LE } from 'int64-buffer';
 import * as varuint from 'varuint-bitcoin';
 
 import { bufferUtils } from '@trezor/utils';
@@ -14,6 +13,17 @@ import * as pushdata from './script/pushdata';
 import { BufferSchema, Type, UInt32, assertType } from './types/validation';
 
 const OUT_OF_RANGE_ERROR = 'value out of range';
+
+const UINT64_MAX = 2n ** 64n - 1n;
+const INT64_MIN = -(2n ** 63n);
+const INT64_MAX = 2n ** 63n - 1n;
+
+// `DataView` is used over `Buffer.writeBigInt64LE` / `writeBigUInt64LE` on purpose: the
+// browser Buffer polyfill (buffer@5.x, pulled in via node-stdlib-browser) does not implement
+// those methods, so calling them throws at runtime in Suite Web. `DataView.setBig(U)int64` is
+// a native ECMAScript API available in every supported browser and in Node.
+const dataViewOf = (buffer: Buffer) =>
+    new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength);
 
 export function verifuint(value: number, max: number) {
     if (typeof value !== 'number') throw new Error('cannot write a non-number as a number');
@@ -67,20 +77,28 @@ export function writeUInt64LEasString(buffer: Buffer, value: string | number, of
     if (typeof value !== 'string') {
         return writeUInt64LE(buffer, value, offset);
     }
-    const v = new Int64LE(value);
-    v.toBuffer().copy(buffer, offset);
+
+    if (value.trim() === '') {
+        throw new Error('cannot write an empty string as a number');
+    }
+
+    const bigintValue = BigInt(value);
+    if (bigintValue < 0n || bigintValue > UINT64_MAX) {
+        throw new RangeError(OUT_OF_RANGE_ERROR);
+    }
+
+    dataViewOf(buffer).setBigUint64(offset, bigintValue, true);
 
     return offset + 8;
 }
 
 export function writeInt64LE(buffer: Buffer, value: number, offset: number) {
-    const v = new Int64LE(value);
-    const a = v.toArray();
-    for (let i = 0; i < 8; i++) {
-        // @ts-expect-error: indexing with noUncheckedIndexedAccess
-        const byte: number = a[i];
-        buffer.writeUInt8(byte, offset + i);
+    const bigintValue = BigInt(value);
+    if (bigintValue < INT64_MIN || bigintValue > INT64_MAX) {
+        throw new RangeError(OUT_OF_RANGE_ERROR);
     }
+
+    dataViewOf(buffer).setBigInt64(offset, bigintValue, true);
 
     return offset + 8;
 }

--- a/packages/utxo-lib/tests/bufferutils.test.ts
+++ b/packages/utxo-lib/tests/bufferutils.test.ts
@@ -216,28 +216,18 @@ describe('bufferutils', () => {
             });
         });
 
-        // int64-buffer silently coerces unparseable strings and overflows modulo 2^64
-        // without throwing. These snapshots pin that behavior so a future library swap
-        // (e.g. to viem / @noble) surfaces the change instead of corrupting silently.
-        // FIXME(bigint-migration): silent coercion is a latent bug — once int64-buffer
-        // is replaced, flip these expectations to `toThrow` for invalid inputs.
-        describe('invalid string input (regression guard)', () => {
+        describe('invalid string input', () => {
             [
-                { description: 'non-numeric string', input: 'abc', hex: '0000000000000000' },
-                { description: 'empty string', input: '', hex: '0000000000000000' },
-                {
-                    description: 'overflow > UINT64_MAX',
-                    input: '99999999999999999999',
-                    hex: 'ffff0f632d5ec76b',
-                },
+                { description: 'non-numeric string', input: 'abc' },
+                { description: 'empty string', input: '' },
+                { description: 'overflow > UINT64_MAX', input: '99999999999999999999' },
             ].forEach(f => {
-                it(`writes deterministic bytes for ${f.description}`, () => {
+                it(`throws for ${f.description}`, () => {
                     const buffer = Buffer.alloc(8, 0);
 
-                    const n = bufferutils.writeUInt64LEasString(buffer, f.input, 0);
-
-                    expect(buffer.toString('hex')).toEqual(f.hex);
-                    expect(n).toEqual(8);
+                    expect(() => {
+                        bufferutils.writeUInt64LEasString(buffer, f.input, 0);
+                    }).toThrow();
                 });
             });
         });
@@ -278,39 +268,27 @@ describe('bufferutils', () => {
                 });
             });
 
-        it('overflows for INT64_MIN due to JS number precision loss', () => {
-            // The JS Number literal -9223372036854775808 rounds to -9223372036854776000,
-            // which int64-buffer wraps modulo 2^64 to INT64_MAX. This regression test
-            // pins the current (buggy) behavior so future migrations of int64-buffer
-            // surface the change instead of silently corrupting amounts.
-            // FIXME(bigint-migration): once arithmetic moves to BigInt, expect either
-            // the correct INT64_MIN encoding (0000000000000080) or a thrown range error.
+        it('encodes INT64_MIN correctly', () => {
             const buffer = Buffer.alloc(8, 0);
 
-            bufferutils.writeInt64LE(buffer, -9223372036854775808, 0);
+            const n = bufferutils.writeInt64LE(buffer, -9223372036854775808, 0);
 
-            expect(buffer.toString('hex')).not.toEqual('0000000000000080');
-            expect(buffer.toString('hex')).toEqual('ffffffffffffff7f');
+            expect(buffer.toString('hex')).toEqual('0000000000000080');
+            expect(n).toEqual(8);
         });
 
-        // int64-buffer silently coerces NaN / Infinity to deterministic bytes
-        // without throwing. These snapshots pin that behavior so a future library swap
-        // surfaces the change instead of corrupting silently.
-        // FIXME(bigint-migration): silent coercion is a latent bug — once int64-buffer
-        // is replaced, flip these expectations to `toThrow` for invalid inputs.
-        describe('invalid number input (regression guard)', () => {
+        describe('invalid number input', () => {
             [
-                { description: 'NaN', input: NaN, hex: '0000000000000000' },
-                { description: 'Infinity', input: Infinity, hex: '0000000000000000' },
-                { description: '-Infinity', input: -Infinity, hex: 'ffffffffffffffff' },
+                { description: 'NaN', input: NaN },
+                { description: 'Infinity', input: Infinity },
+                { description: '-Infinity', input: -Infinity },
             ].forEach(f => {
-                it(`writes deterministic bytes for ${f.description}`, () => {
+                it(`throws for ${f.description}`, () => {
                     const buffer = Buffer.alloc(8, 0);
 
-                    const n = bufferutils.writeInt64LE(buffer, f.input, 0);
-
-                    expect(buffer.toString('hex')).toEqual(f.hex);
-                    expect(n).toEqual(8);
+                    expect(() => {
+                        bufferutils.writeInt64LE(buffer, f.input, 0);
+                    }).toThrow();
                 });
             });
         });

--- a/scripts/list-outdated-dependencies/wallet-dependencies.txt
+++ b/scripts/list-outdated-dependencies/wallet-dependencies.txt
@@ -32,7 +32,6 @@ cashaddrjs
 event-target-shim
 golomb
 immer
-int64-buffer
 json-schema-to-typescript
 jws
 minimaldata

--- a/yarn.lock
+++ b/yarn.lock
@@ -16723,7 +16723,6 @@ __metadata:
     "@trezor/eslint": "workspace:*"
     "@trezor/utils": "workspace:*"
     cashaddrjs: "npm:0.4.4"
-    int64-buffer: "npm:^1.1.0"
     minimaldata: "npm:^1.0.2"
     varuint-bitcoin: "npm:2.0.0"
     wif: "npm:^5.0.0"
@@ -30066,13 +30065,6 @@ __metadata:
     strip-ansi: "npm:^6.0.0"
     through: "npm:^2.3.6"
   checksum: 10/052c6fce2d467343ced6500080b4b70eaf2ca996933fc3b5c9b0dd1ea275dd9c2a1070880f5f163f42bd13acf25c1ab8ab384444c1a413050db34aab69112583
-  languageName: node
-  linkType: hard
-
-"int64-buffer@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "int64-buffer@npm:1.1.0"
-  checksum: 10/00619b84074ae49468b903dc1426c919e0eec38d33b1a85d73e62b1214ea91e66d0fb2785a8a30cde6d7c9326c2a32d2155fcc5c2e1dc09b22733b0d5c8c2078
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Third slice of #27403 — modernize `@trezor/utxo-lib` and `@trezor/address-validator` dependencies.

> **Alternative: #28219** — same goal (drop `int64-buffer`), opposite strategy: native `Buffer.writeBig(U)Int64LE` plus bumping the browser `buffer` polyfill to 6.x, instead of this PR's `DataView` approach which needs no dependency changes. Pick one, close the other.

> **Land plan:** #28053 adds direct unit coverage for `writeUInt64LEasString` (string path) and `writeInt64LE` against today's `develop`. Merge #28053 first, then rebase this PR on top so the same tests guard the `Int64LE` -> native BigInt swap.

## Why

[`int64-buffer`](https://github.com/kawanet/int64-buffer/blob/master/int64-buffer.js) is unmaintained. A native `BigInt` + [`DataView`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView) approach covers the same use case without the dependency. Two callsites, single file.

> ⚠️ `Buffer.writeBigInt64LE` / `writeBigUInt64LE` look like the obvious replacement, but the Suite Web browser bundle polyfills `Buffer` with `buffer@5.x` (via `node-stdlib-browser`), which does **not** implement those methods (added upstream in `buffer@6.0.0`). They work under Node — so unit tests pass — but throw `… is not a function` in the browser, which broke BTC transaction signing (caught only by the `trading/sell-bitcoin` + `trading/swap-fees-bitcoin` e2e tests). `DataView.setBigInt64` / `setBigUint64` is a native ECMAScript API present in every supported browser and in Node.

## Summary

- `bufferutils.ts`:
  - `writeUInt64LEasString` (string path) → `DataView.setBigUint64(offset, BigInt(value), true)`
  - `writeInt64LE` (number path) → `DataView.setBigInt64(offset, BigInt(value), true)`
  - both helpers range-check before writing (`DataView` wraps mod 2^64 rather than throwing, so the guard preserves throw-on-overflow / throw-on-invalid behaviour)
- The function names already implied UInt vs Int, but the previous code used `Int64LE` (signed) for both. The split restores that distinction — the unsigned helper now rejects negative inputs (which were always a caller bug under `writeUInt64`).
- `string | number` API on `BufferWriter.writeUInt64` / `writeInt64` is preserved.
- `package.json`: `int64-buffer` removed.
- `scripts/list-outdated-dependencies/wallet-dependencies.txt`: corresponding entry removed.
- `yarn.lock` deduped.

## Test status

**Direct coverage**
- [`packages/utxo-lib/tests/bufferutils.test.ts`](https://github.com/trezor/trezor-suite/blob/mroz22/issue-27403-int64-dataview/packages/utxo-lib/tests/bufferutils.test.ts) — dedicated `describe` blocks for `readInt64LE` / `readUInt64LE` / `writeInt64` / `writeUInt64` exercise both the signed (negative) and unsigned (positive) round-trip paths against the shared fixture file.

**Indirect coverage**
- [`packages/utxo-lib/tests/transaction.test.ts`](https://github.com/trezor/trezor-suite/blob/mroz22/issue-27403-int64-dataview/packages/utxo-lib/tests/transaction.test.ts) — 25 cases of transaction parse/serialize across Bitcoin / Zcash / Decred / Dash / Peercoin; both modified callsites (`writeUInt64LEasString`, `writeInt64LE`) are hit by every serialization fixture.
- [`packages/utxo-lib/tests/compose.test.ts`](https://github.com/trezor/trezor-suite/blob/mroz22/issue-27403-int64-dataview/packages/utxo-lib/tests/compose.test.ts) and the [`coinselect/`](https://github.com/trezor/trezor-suite/blob/mroz22/issue-27403-int64-dataview/packages/utxo-lib/tests/coinselect/) suite exercise value encoding paths.
- Aggregate: utxo-lib `test:unit` = **2451 / 2451 passing** on this branch.

**Coverage assessment:** Strong. The Int64 / UInt64 read/write paths are both unit-tested in isolation and exercised by every transaction serialization fixture.

**Change safety:** **Low risk + one tightened invariant.**
- `DataView.setBigInt64` / `setBigUint64` is a stable native ECMAScript API, available in every supported browser and in Node — unlike `Buffer.writeBig*64LE`, which is absent from the `buffer@5.x` polyfill the Suite Web bundle ships.
- The replacement also fixes a latent bug: the previous code used signed `Int64LE` for the `UInt64` path, silently accepting negative inputs that were always a caller bug. The new code rejects them, plus out-of-range / non-numeric / `NaN` / `Infinity` inputs, via explicit guards.
- `string | number` API on `BufferWriter.writeUInt64` / `writeInt64` is preserved.

## Test plan

- [x] `yarn workspace @trezor/utxo-lib test:unit` — 2451/2451 pass (transaction tests indirectly cover both callsites via Bitcoin/Zcash/Decred/Dash/Peercoin serialization)
- [x] `yarn workspace @trezor/utxo-lib type-check`
- [x] `yarn workspace @trezor/utxo-lib lint:js`
- [x] `yarn workspace @trezor/utxo-lib depcheck`
- [x] `yarn workspace @trezor/connect type-check` (consumer)
- [x] `yarn workspace @trezor/blockchain-link type-check` (consumer)
- [x] `yarn dedupe`

## Related PRs (issue #27403)

- #27536 — refactor: drop unused `format` parameter
- #27535 — chore: jssha → @noble/hashes
- #27537 — chore: inline bitcoin-ops + pushdata-bitcoin
- #27538 — chore: int64-buffer → native BigInt via `DataView` (← this PR)
- #28219 — chore: int64-buffer → native `Buffer` BigInt + bump `buffer` polyfill to 6.x (alternative)

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are to packages/utxo-lib/package.json and packages/utxo-lib/src/bufferutils.ts. bufferutils.ts is a low-level utility in the utxo-lib package used for buffer manipulation in UTXO-based cryptocurrency transaction serialization/deserialization. It maps to 121 E2E tests, making it a broad global dependency. None of the 121 tests in the LLM analysis directly exercise buffer utilities or transaction serialization logic at a level where changes to bufferutils.ts would plausibly cause a regression detectable by those E2E tests — they all operate at much higher abstraction levels (analytics, onboarding, trading, metadata, staking, settings UI, etc.). The package.json change is likely a version bump or dependency update. Given the extremely low-level nature of this utility and the high abstraction level of all mapped E2E tests, no specific E2E tests are recommended; unit tests within utxo-lib itself would provide far better coverage for these changes.

<details><summary><b>Changed files (2)</b></summary>

- `packages/utxo-lib/package.json`
- `packages/utxo-lib/src/bufferutils.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (2)**
- `packages/utxo-lib/package.json`
- `packages/utxo-lib/src/bufferutils.ts`

_Updated: 2026-05-10T09:50:56.444Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/issue-27403-int64-dataview/web/](https://dev.suite.sldev.cz/suite-web/mroz22/issue-27403-int64-dataview/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/issue-27403-int64-dataview&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/issue-27403-int64-dataview&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-01T08:12:44.573Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 10 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-10T09:54:28.037Z • 10 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->




