### PR TITLE
chore(address-validator): consolidate base-x onto @scure/base

### DIFF
--- a/packages/address-validator/package.json
+++ b/packages/address-validator/package.json
@@ -29,7 +29,6 @@
     },
     "dependencies": {
         "@scure/base": "^2.0.0",
-        "base-x": "^5.0.1",
         "cbor": "^10.0.12",
         "crc": "^3.8.0",
         "groestl-hash-js": "1.0.0",

--- a/packages/address-validator/src/ripple_validator.ts
+++ b/packages/address-validator/src/ripple_validator.ts
@@ -1,4 +1,4 @@
-import baseX from 'base-x';
+import { base58xrp } from '@scure/base';
 
 import * as cryptoUtils from './crypto/utils';
 import { addressType } from './crypto/utils';
@@ -6,11 +6,10 @@ import type { Currency } from './currency-types';
 
 const ALLOWED_CHARS = 'rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz';
 
-const codec = baseX(ALLOWED_CHARS);
 const regexp = new RegExp('^r[' + ALLOWED_CHARS + ']{27,35}$');
 
 function verifyChecksum(address: string): boolean {
-    const bytes = codec.decode(address);
+    const bytes = base58xrp.decode(address);
     const computedChecksum = cryptoUtils.sha256Checksum(cryptoUtils.toHex(bytes.slice(0, -4)));
     const checksum = cryptoUtils.toHex(bytes.slice(-4));
 

--- a/packages/address-validator/src/stellar_validator.ts
+++ b/packages/address-validator/src/stellar_validator.ts
@@ -1,4 +1,4 @@
-import baseX from 'base-x';
+import { utils } from '@scure/base';
 import crc from 'crc';
 
 import * as cryptoUtils from './crypto/utils';
@@ -7,7 +7,7 @@ import type { Currency } from './currency-types';
 
 const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
 
-const base32 = baseX(ALPHABET);
+const base32 = utils.chain(utils.radix(32), utils.alphabet(ALPHABET), utils.join(''));
 const regexp = new RegExp('^[' + ALPHABET + ']{56}$');
 const ed25519PublicKeyVersionByte = 6 << 3;
 

--- a/scripts/list-outdated-dependencies/connect-dependencies.txt
+++ b/scripts/list-outdated-dependencies/connect-dependencies.txt
@@ -30,7 +30,6 @@
 @walletconnect/react-native-compat
 @walletconnect/types
 @walletconnect/utils
-base-x
 buffer
 cbor
 clsx

--- a/yarn.lock
+++ b/yarn.lock
@@ -15014,7 +15014,6 @@ __metadata:
   dependencies:
     "@scure/base": "npm:^2.0.0"
     "@trezor/eslint": "workspace:*"
-    base-x: "npm:^5.0.1"
     cbor: "npm:^10.0.12"
     crc: "npm:^3.8.0"
     groestl-hash-js: "npm:1.0.0"
@@ -20235,7 +20234,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base-x@npm:^5.0.0, base-x@npm:^5.0.1":
+"base-x@npm:^5.0.0":
   version: 5.0.1
   resolution: "base-x@npm:5.0.1"
   checksum: 10/6e4f847ef842e0a71c6b6020a6ec482a2a5e727f5a98534dbfd5d5a4e8afbc0d1bdf1fd57174b3f0455d107f10a932c3c7710bec07e2878f80178607f8f605c8


### PR DESCRIPTION
Fifth slice of #27403 — modernize `@trezor/address-validator` and `@trezor/utxo-lib` dependencies.

## Why

`@scure/base` is already a dependency of this package (used in bech32, ada validators) and v2 ships the same [arbitrary-base coder building blocks](https://github.com/paulmillr/scure-base/blob/2.0.0/index.ts#L343-L344) (`utils.chain(utils.radix(N), utils.alphabet(...), utils.join(''))`) plus prebuilt variants — including [`base58xrp`](https://github.com/paulmillr/scure-base/blob/2.0.0/index.ts#L568) with the exact alphabet that [`ripple_validator`](https://github.com/trezor/trezor-suite/blob/develop/packages/address-validator/src/ripple_validator.ts) was constructing manually.

## Summary

Two callsites:
- `stellar_validator.ts`: `baseX(32-char alphabet)` → `utils.chain(utils.radix(32), ...)` from `@scure/base`
- `ripple_validator.ts`:  `baseX(XRP alphabet)`    → `base58xrp` from `@scure/base` (alphabet matches exactly)

Behavior is byte-for-byte preserved: [`@scure/base`'s `convertRadix`](https://github.com/paulmillr/scure-base/blob/2.0.0/index.ts#L177) preserves leading zeros the same way [`base-x`](https://github.com/cryptocoinjs/base-x/blob/v5.0.1/ts_src/index.ts) does (each leading `LEADER`/zero digit ↔ leading zero byte).

- `package.json` — `base-x` removed.
- `scripts/list-outdated-dependencies/connect-dependencies.txt` — corresponding entry removed.
- `yarn.lock` deduped.

## Test status

**Direct coverage** in [`packages/address-validator/tests/wallet_address_validator.test.ts`](https://github.com/trezor/trezor-suite/blob/mroz22/issue-27403-base-x/packages/address-validator/tests/wallet_address_validator.test.ts):
- **Ripple / XRP** — valid + invalid blocks plus address-type lookups.
- **Stellar** — valid block (11 addresses) plus address-type lookups.

Aggregate: address-validator `test:unit` = **45 / 45 passing** on this branch.

**Coverage assessment:** Strong. Each of the two changed validators has dedicated valid + invalid fixtures — a regression in the radix conversion would fail checksum verification on the first address.

**Change safety:** **Low risk.**
- `@scure/base` is already a dependency of this package (bech32, ada validators).
- `base58xrp` ships with the exact XRP alphabet that `ripple_validator` was constructing manually — no opportunity for alphabet drift.
- `@scure/base`'s `convertRadix` preserves leading zeros identically to `base-x` (each leading leader/zero digit ↔ leading zero byte). Behavior is byte-for-byte preserved.

## Test plan

- [x] `yarn workspace @trezor/address-validator test:unit` — 45/45 pass
- [x] `yarn workspace @trezor/address-validator type-check`
- [x] `yarn workspace @trezor/address-validator lint:js`
- [x] `yarn workspace @trezor/address-validator depcheck`
- [x] `yarn dedupe`

## Related PRs (issue #27403)

- #27536 — refactor: drop unused `format` parameter
- #27535 — chore: jssha → @noble/hashes
- #27537 — chore: inline bitcoin-ops + pushdata-bitcoin
- #27538 — chore: int64-buffer → native BigInt
- #27540 — chore: base-x → @scure/base (← this PR)

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/issue-27403-base-x/web/](https://dev.suite.sldev.cz/suite-web/mroz22/issue-27403-base-x/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->