### PR TITLE
chore: use type imports

### DIFF
--- a/packages/blockchain-link/tests/integration/solana.test.ts
+++ b/packages/blockchain-link/tests/integration/solana.test.ts
@@ -1,4 +1,4 @@
-import { AccountInfoParams } from '@trezor/blockchain-link-types';
+import type { AccountInfoParams } from '@trezor/blockchain-link-types';
 
 import { BlockchainLink } from '../../src';
 import SolanaWorker, { SolanaAPI } from '../../src/workers/solana';

--- a/packages/coinjoin/tests/backend/CoinjoinMempoolController.test.ts
+++ b/packages/coinjoin/tests/backend/CoinjoinMempoolController.test.ts
@@ -1,7 +1,7 @@
 import { networks } from '@trezor/utxo-lib';
 
 import { CoinjoinMempoolController } from '../../src/backend/CoinjoinMempoolController';
-import { AccountAddress } from '../../src/types/backend';
+import type { AccountAddress } from '../../src/types/backend';
 import {
     BLOCK_TXS,
     SEGWIT_CHANGE_ADDRESSES,

--- a/packages/coinjoin/tests/client/selectRound.test.ts
+++ b/packages/coinjoin/tests/client/selectRound.test.ts
@@ -10,8 +10,8 @@ import {
 } from '../../src/client/round/selectRound';
 import { ROUND_SELECTION_MAX_OUTPUTS } from '../../src/constants';
 import { SessionPhase, WabiSabiProtocolErrorCode } from '../../src/enums';
-import { AliceGenerator } from '../../src/types/alice';
-import { CoinjoinRoundGenerator } from '../../src/types/round';
+import type { AliceGenerator } from '../../src/types/alice';
+import type { CoinjoinRoundGenerator } from '../../src/types/round';
 import {
     DEFAULT_ROUND,
     ROUND_CREATION_EVENT,

--- a/packages/coinjoin/tests/fixtures/filters.fixture.ts
+++ b/packages/coinjoin/tests/fixtures/filters.fixture.ts
@@ -1,4 +1,4 @@
-import { BlockFilter } from '../../src/types/backend';
+import type { BlockFilter } from '../../src/types/backend';
 
 export type MockBlockFilter = BlockFilter & {
     prevHash: string;

--- a/packages/coinjoin/tests/fixtures/round.fixture.ts
+++ b/packages/coinjoin/tests/fixtures/round.fixture.ts
@@ -1,7 +1,7 @@
 import { CoinjoinPrison } from '../../src/client/CoinjoinPrison';
 import { CoinjoinRound } from '../../src/client/CoinjoinRound';
 import { ROUND_SELECTION_REGISTRATION_OFFSET } from '../../src/constants';
-import { AllowedScriptTypes, Round } from '../../src/types/coordinator';
+import type { AllowedScriptTypes, Round } from '../../src/types/coordinator';
 
 export const ROUND_CREATION_EVENT = {
     Type: 'RoundCreated' as const,

--- a/packages/coinjoin/tests/mocks/server.ts
+++ b/packages/coinjoin/tests/mocks/server.ts
@@ -2,8 +2,8 @@ import * as http from 'http';
 
 import { getFreePort } from '@trezor/node-utils';
 
-import { CoinjoinClientEvents } from '../../src/types/client';
-import { Logger } from '../../src/types/logger';
+import type { CoinjoinClientEvents } from '../../src/types/client';
+import type { Logger } from '../../src/types/logger';
 import { AFFILIATE_INFO, DEFAULT_ROUND, FEE_RATE_MEDIANS } from '../fixtures/round.fixture';
 
 // Mock coordinator and middleware responses

--- a/packages/protobuf/tests/encode-decode-basic.test.ts
+++ b/packages/protobuf/tests/encode-decode-basic.test.ts
@@ -1,4 +1,4 @@
-import { AnyDesc } from '@bufbuild/protobuf';
+import type { AnyDesc } from '@bufbuild/protobuf';
 
 import { ProtobufManager } from '../src/manager';
 

--- a/packages/request-manager/e2e/interceptor.test.ts
+++ b/packages/request-manager/e2e/interceptor.test.ts
@@ -5,7 +5,7 @@ import WebSocket from 'ws';
 import { TorController, createInterceptor } from '../src';
 import { torRunner } from './torRunner';
 import { TorIdentities } from '../src/torIdentities';
-import { InterceptorOptions } from '../src/types';
+import type { InterceptorOptions } from '../src/types';
 
 const hostIp = '127.0.0.1';
 const port = 38835;

--- a/packages/request-manager/tests/interceptor-whitelist.test.ts
+++ b/packages/request-manager/tests/interceptor-whitelist.test.ts
@@ -4,7 +4,7 @@ import tls, { TLSSocket } from 'tls';
 import WebSocket from 'ws';
 
 import { createInterceptor } from '../src';
-import { InterceptorOptions } from '../src/types';
+import type { InterceptorOptions } from '../src/types';
 
 const WHITELISTED_DOMAIN = 'url-that-is-valid-and-white-listed-but-does-not-exists.com';
 const NOT_WHITELISTED_DOMAIN = 'not-white-listed-but-does-not-exists.com';

--- a/packages/schema-utils/tests/keyof-enum.test.ts
+++ b/packages/schema-utils/tests/keyof-enum.test.ts
@@ -1,4 +1,4 @@
-import { Static, Type, Validate } from '../src';
+import { type Static, Type, Validate } from '../src';
 
 describe('enum', () => {
     it('should work with keyof enum', () => {

--- a/packages/transport-bridge/tests/http.test.ts
+++ b/packages/transport-bridge/tests/http.test.ts
@@ -1,7 +1,7 @@
 import EventEmitter from 'events';
 
 import { getFreePort } from '@trezor/node-utils';
-import { AbstractApi } from '@trezor/transport/src/api/abstract';
+import type { AbstractApi } from '@trezor/transport/src/api/abstract';
 import { UdpApi } from '@trezor/transport/src/api/udp';
 import { bridgeApiCall } from '@trezor/transport/src/utils/bridgeApiCall';
 import { resolveAfter } from '@trezor/utils';

--- a/packages/transport-test/e2e/bridge/bridge-complex-cases.test.ts
+++ b/packages/transport-test/e2e/bridge/bridge-complex-cases.test.ts
@@ -1,4 +1,4 @@
-import { BridgeTransport, Descriptor, Session } from '@trezor/transport';
+import { BridgeTransport, type Descriptor, type Session } from '@trezor/transport';
 
 import { controller as TrezorUserEnvLink, env } from './controller';
 import { descriptor as expectedDescriptor } from './expect';

--- a/packages/transport-test/e2e/bridge/bridge.test.ts
+++ b/packages/transport-test/e2e/bridge/bridge.test.ts
@@ -1,4 +1,4 @@
-import { BridgeTransport, Descriptor } from '@trezor/transport';
+import { BridgeTransport, type Descriptor } from '@trezor/transport';
 import { Session } from '@trezor/transport/src/types';
 import { Model } from '@trezor/trezor-user-env-link';
 

--- a/packages/transport-test/e2e/bridge/multi-client.test.ts
+++ b/packages/transport-test/e2e/bridge/multi-client.test.ts
@@ -1,4 +1,4 @@
-import { BridgeTransport, Descriptor } from '@trezor/transport';
+import { BridgeTransport, type Descriptor } from '@trezor/transport';
 import { Session } from '@trezor/transport/src/types';
 import { Model } from '@trezor/trezor-user-env-link';
 

--- a/packages/transport/tests/bridgeProtocolMessage.test.ts
+++ b/packages/transport/tests/bridgeProtocolMessage.test.ts
@@ -1,4 +1,4 @@
-import { BridgeProtocolMessage } from '../src/types';
+import type { BridgeProtocolMessage } from '../src/types';
 import { validateProtocolMessage } from '../src/utils/bridgeProtocolMessage';
 
 type Fixture = {

--- a/packages/utxo-lib/tests/coinselect/accumulative.test.ts
+++ b/packages/utxo-lib/tests/coinselect/accumulative.test.ts
@@ -1,6 +1,6 @@
 import * as utils from './test.utils';
 import { accumulative } from '../../src/coinselect/inputs/accumulative';
-import { CoinSelectOptions } from '../../src/types';
+import type { CoinSelectOptions } from '../../src/types';
 import fixtures from '../__fixtures__/coinselect/accumulative';
 
 describe('coinselect: accumulative', () => {

--- a/packages/utxo-lib/tests/coinselect/branchAndBound.test.ts
+++ b/packages/utxo-lib/tests/coinselect/branchAndBound.test.ts
@@ -1,6 +1,6 @@
 import * as utils from './test.utils';
 import { branchAndBound } from '../../src/coinselect/inputs/branchAndBound';
-import { CoinSelectOptions } from '../../src/types';
+import type { CoinSelectOptions } from '../../src/types';
 import fixtures from '../__fixtures__/coinselect/bnb';
 
 describe('coinselect: branchAndBound (bnb)', () => {

--- a/packages/utxo-lib/tests/coinselect/split.test.ts
+++ b/packages/utxo-lib/tests/coinselect/split.test.ts
@@ -1,6 +1,6 @@
 import * as utils from './test.utils';
 import { split } from '../../src/coinselect/outputs/split';
-import { CoinSelectOptions } from '../../src/types';
+import type { CoinSelectOptions } from '../../src/types';
 import fixtures from '../__fixtures__/coinselect/split';
 
 describe('coinselect split', () => {

--- a/packages/utxo-lib/tests/compose.request.test.ts
+++ b/packages/utxo-lib/tests/compose.request.test.ts
@@ -1,4 +1,4 @@
-import { ComposeRequest } from '../src';
+import type { ComposeRequest } from '../src';
 import { validateAndParseRequest as validate } from '../src/compose/request';
 import * as NETWORKS from '../src/networks';
 

--- a/packages/websocket-client/tests/client.test.ts
+++ b/packages/websocket-client/tests/client.test.ts
@@ -1,4 +1,4 @@
-import { ServerOptions, WebSocket, WebSocketServer } from 'ws';
+import { type ServerOptions, type WebSocket, WebSocketServer } from 'ws';
 
 import { WebsocketClient } from '../src/client';
 

--- a/suite-common/bluetooth/tests/bluetoothReducer.test.ts
+++ b/suite-common/bluetooth/tests/bluetoothReducer.test.ts
@@ -1,14 +1,14 @@
 import { combineReducers } from '@reduxjs/toolkit';
 
 import { deviceActions } from '@suite-common/device';
-import { TrezorDevice } from '@suite-common/suite-types';
+import type { TrezorDevice } from '@suite-common/suite-types';
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
-import { Device, asBluetoothDeviceId } from '@trezor/connect';
+import { type Device, asBluetoothDeviceId } from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { bluetoothActions } from '../src/bluetoothActions';
 import { prepareBluetoothReducerCreator, prepareInitialState } from '../src/bluetoothReducer';
-import { BluetoothDeviceCommon, BluetoothManufacturerData } from '../src/types';
+import type { BluetoothDeviceCommon, BluetoothManufacturerData } from '../src/types';
 
 const manufacturerData: BluetoothManufacturerData = {
     deviceModel: DeviceModelInternal.T3W1,

--- a/suite-common/bluetooth/tests/bluetoothSelectors.test.ts
+++ b/suite-common/bluetooth/tests/bluetoothSelectors.test.ts
@@ -1,9 +1,9 @@
 import { asBluetoothDeviceId } from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
-import { BluetoothManufacturerData, prepareInitialState, prepareSelectAllDevices } from '../src';
-import { WithBluetoothState } from '../src/bluetoothSelectors';
-import { BluetoothDeviceCommon } from '../src/types';
+import { type BluetoothManufacturerData, prepareInitialState, prepareSelectAllDevices } from '../src';
+import type { WithBluetoothState } from '../src/bluetoothSelectors';
+import type { BluetoothDeviceCommon } from '../src/types';
 
 const manufacturerData: BluetoothManufacturerData = {
     deviceModel: DeviceModelInternal.T3W1,

--- a/suite-common/bluetooth/tests/bluetoothSelectors.test.ts
+++ b/suite-common/bluetooth/tests/bluetoothSelectors.test.ts
@@ -1,7 +1,11 @@
 import { asBluetoothDeviceId } from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
-import { type BluetoothManufacturerData, prepareInitialState, prepareSelectAllDevices } from '../src';
+import {
+    type BluetoothManufacturerData,
+    prepareInitialState,
+    prepareSelectAllDevices,
+} from '../src';
 import type { WithBluetoothState } from '../src/bluetoothSelectors';
 import type { BluetoothDeviceCommon } from '../src/types';
 

--- a/suite-common/bluetooth/tests/filterOutOldDuplicates.test.ts
+++ b/suite-common/bluetooth/tests/filterOutOldDuplicates.test.ts
@@ -3,7 +3,7 @@ import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { createBluetoothDeviceCommon } from '../mocks';
 import { filterOutOldDuplicates } from '../src/filterOutOldDuplicates';
-import { BluetoothDeviceCommon } from '../src/types';
+import type { BluetoothDeviceCommon } from '../src/types';
 import type { BluetoothManufacturerData } from '../src/types';
 
 const mockedManufacturerData: BluetoothManufacturerData = {

--- a/suite-common/bluetooth/tests/filterOutOldDuplicates.test.ts
+++ b/suite-common/bluetooth/tests/filterOutOldDuplicates.test.ts
@@ -3,8 +3,7 @@ import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { createBluetoothDeviceCommon } from '../mocks';
 import { filterOutOldDuplicates } from '../src/filterOutOldDuplicates';
-import type { BluetoothDeviceCommon } from '../src/types';
-import type { BluetoothManufacturerData } from '../src/types';
+import type { BluetoothDeviceCommon, BluetoothManufacturerData } from '../src/types';
 
 const mockedManufacturerData: BluetoothManufacturerData = {
     deviceModel: DeviceModelInternal.T3W1,

--- a/suite-common/device-authenticity/tests/deviceAuthenticityThunks.test.ts
+++ b/suite-common/device-authenticity/tests/deviceAuthenticityThunks.test.ts
@@ -1,9 +1,9 @@
 import { deviceActions } from '@suite-common/device';
 import { messageSystemInitialState } from '@suite-common/message-system';
-import { StoredAuthenticateDeviceResult, TrezorDevice } from '@suite-common/suite-types';
+import type { StoredAuthenticateDeviceResult, TrezorDevice } from '@suite-common/suite-types';
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { configureMockStore, testMocks } from '@suite-common/test-utils';
-import { ToastPayload, notificationsActions } from '@suite-common/toast-notifications';
+import { type ToastPayload, notificationsActions } from '@suite-common/toast-notifications';
 import type { AuthenticateDeviceResult, Response } from '@trezor/connect';
 import { Err, Ok } from '@trezor/type-utils';
 

--- a/suite-common/feedback/tests/getFeedbackUrl.test.ts
+++ b/suite-common/feedback/tests/getFeedbackUrl.test.ts
@@ -1,6 +1,6 @@
 import { isCodesignBuild } from '@trezor/env-utils';
 
-import { FeedbackType } from '../src';
+import type { FeedbackType } from '../src';
 import { FEEDBACK_ENDPOINT, getFeedbackUrl } from '../src/getFeedbackUrl';
 
 jest.mock('@trezor/env-utils', () => ({

--- a/suite-common/suite-sync-evolu/tests/createEvoluStorageFactory.test.ts
+++ b/suite-common/suite-sync-evolu/tests/createEvoluStorageFactory.test.ts
@@ -1,12 +1,12 @@
-import { Run, testCreateWebSocket } from '@evolu/common';
-import { EvoluPlatformDeps } from '@evolu/common/local-first';
+import { type Run, testCreateWebSocket } from '@evolu/common';
+import type { EvoluPlatformDeps } from '@evolu/common/local-first';
 
 import {
-    SuiteSyncAccount,
-    SuiteSyncAddress,
-    SuiteSyncOutput,
-    SuiteSyncOwner,
-    SuiteSyncWallet,
+    type SuiteSyncAccount,
+    type SuiteSyncAddress,
+    type SuiteSyncOutput,
+    type SuiteSyncOwner,
+    type SuiteSyncWallet,
     asSuiteSyncOwnerId,
     asSuiteSyncOwnerSecretHex,
 } from '@suite-common/suite-sync-storage';

--- a/suite-common/thp/tests/thpReducer.test.ts
+++ b/suite-common/thp/tests/thpReducer.test.ts
@@ -6,7 +6,7 @@ import { DEVICE, createDeviceMessage } from '@trezor/connect';
 
 import { createCredential, createDeviceThp } from '../mocks';
 import { thpActions } from '../src/thpActions';
-import { ThpState, prepareThpReducer } from '../src/thpReducer';
+import { type ThpState, prepareThpReducer } from '../src/thpReducer';
 import {
     selectThpAutoconnectStep,
     selectThpCredentials,

--- a/suite-common/wallet-core/tests/allowance/buildAllowanceTransaction.fixtures.ts
+++ b/suite-common/wallet-core/tests/allowance/buildAllowanceTransaction.fixtures.ts
@@ -1,5 +1,5 @@
-import { PrecomposedTransaction } from '@suite-common/wallet-types';
-import { FeeLevel, TokenInfo } from '@trezor/connect';
+import type { PrecomposedTransaction } from '@suite-common/wallet-types';
+import type { FeeLevel, TokenInfo } from '@trezor/connect';
 
 interface BuildAllowanceTransactionFixture {
     description: string;

--- a/suite-common/wallet-core/tests/send/composeCancelTransaction/chainedTransactions.fixture.ts
+++ b/suite-common/wallet-core/tests/send/composeCancelTransaction/chainedTransactions.fixture.ts
@@ -1,4 +1,4 @@
-import { ChainedTransactions, asAccountDescriptor } from '@suite-common/wallet-types';
+import { type ChainedTransactions, asAccountDescriptor } from '@suite-common/wallet-types';
 
 export const chainedTxsFixture: ChainedTransactions = {
     own: [

--- a/suite-common/wallet-core/tests/send/composeCancelTransaction/composeCancelTransactionThunk.test.ts
+++ b/suite-common/wallet-core/tests/send/composeCancelTransaction/composeCancelTransactionThunk.test.ts
@@ -1,6 +1,6 @@
 import { configureMockStore } from '@suite-common/test-utils';
-import { WalletAccountTransaction } from '@suite-common/wallet-types';
-import TrezorConnect, { PrecomposeResultFinal } from '@trezor/connect';
+import type { WalletAccountTransaction } from '@suite-common/wallet-types';
+import TrezorConnect, { type PrecomposeResultFinal } from '@trezor/connect';
 
 import { chainedTxsFixture } from './chainedTransactions.fixture';
 import {

--- a/suite-common/wallet-types/mocks/mockWalletAccount.ts
+++ b/suite-common/wallet-types/mocks/mockWalletAccount.ts
@@ -1,5 +1,5 @@
-import { NetworkSymbol } from '@suite-common/wallet-config';
-import { StaticSessionId } from '@trezor/connect';
+import type { NetworkSymbol } from '@suite-common/wallet-config';
+import type { StaticSessionId } from '@trezor/connect';
 
 import {
     Account,

--- a/suite-native/app/e2e/pageObjects/deviceOnboardingActions.ts
+++ b/suite-native/app/e2e/pageObjects/deviceOnboardingActions.ts
@@ -1,4 +1,4 @@
-import { BackupType } from '@suite-common/suite-types';
+import type { BackupType } from '@suite-common/suite-types';
 import { Model, TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
 import {

--- a/suite-native/app/e2e/pageObjects/settingsActions.ts
+++ b/suite-native/app/e2e/pageObjects/settingsActions.ts
@@ -1,6 +1,6 @@
-import { SupportedLocaleCode } from '@suite-native/intl';
+import type { SupportedLocaleCode } from '@suite-native/intl';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
-import { PROTO } from '@trezor/connect';
+import type { PROTO } from '@trezor/connect';
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
 import { onTabBar } from './tabBarActions';

--- a/suite-native/app/e2e/tests/entropyCheckFailT3T1.test.ts
+++ b/suite-native/app/e2e/tests/entropyCheckFailT3T1.test.ts
@@ -1,6 +1,6 @@
 import { expect as detoxExpect } from 'detox';
 
-import { DeviceReducerState, deviceReducerInitialState } from '@suite-common/device';
+import { type DeviceReducerState, deviceReducerInitialState } from '@suite-common/device';
 import { Model } from '@trezor/trezor-user-env-link';
 
 import { deviceChecksEnabledState } from '../fixtures/deviceChecksEnabledState';

--- a/suite/e2e/support/common.ts
+++ b/suite/e2e/support/common.ts
@@ -4,7 +4,7 @@ import { readdirSync } from 'node:fs';
 import path from 'node:path';
 
 import { validJws } from '@suite-common/message-system/src/__fixtures__/messageSystemActions';
-import { TradingCountryCode, regional } from '@suite-common/trading';
+import { type TradingCountryCode, regional } from '@suite-common/trading';
 import { getAccountDecimals, localizeNumber } from '@suite-common/wallet-utils';
 import { Model } from '@trezor/trezor-user-env-link';
 import { BigNumber, splitStringEveryNCharacters } from '@trezor/utils';

--- a/suite/e2e/support/networkAnalyzer.ts
+++ b/suite/e2e/support/networkAnalyzer.ts
@@ -1,6 +1,6 @@
 import { exec } from 'child_process';
 
-import { IntervalId } from '@trezor/type-utils';
+import type { IntervalId } from '@trezor/type-utils';
 
 export class NetworkAnalyzer {
     interval?: string | number | IntervalId;

--- a/suite/e2e/support/pageObjects/assetsSection.ts
+++ b/suite/e2e/support/pageObjects/assetsSection.ts
@@ -1,6 +1,6 @@
 import { Locator, Page, expect } from '@playwright/test';
 
-import { NetworkSymbol } from '@suite-common/wallet-config';
+import type { NetworkSymbol } from '@suite-common/wallet-config';
 
 import { step } from '../common';
 

--- a/suite/e2e/support/pageObjects/dashboardPage.ts
+++ b/suite/e2e/support/pageObjects/dashboardPage.ts
@@ -1,6 +1,6 @@
 import { Locator, Page } from '@playwright/test';
 
-import { NetworkSymbol } from '@suite-common/wallet-config';
+import type { NetworkSymbol } from '@suite-common/wallet-config';
 
 import { step } from '../common';
 import { DevicePrompt } from './devicePrompt';

--- a/suite/e2e/support/pageObjects/guidePanel.ts
+++ b/suite/e2e/support/pageObjects/guidePanel.ts
@@ -1,6 +1,6 @@
 import { Locator, Page, expect } from '@playwright/test';
 
-import { FeedbackCategory } from '@suite-common/feedback';
+import type { FeedbackCategory } from '@suite-common/feedback';
 import { capitalizeFirstLetter } from '@trezor/utils';
 
 import { step } from '../common';

--- a/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
+++ b/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
@@ -2,7 +2,7 @@ import { Locator, Page, expect } from '@playwright/test';
 
 import { setFlag } from '@suite/flags';
 import { suiteSettingsActions } from '@suite/settings';
-import { BackupType } from '@suite-common/suite-types';
+import type { BackupType } from '@suite-common/suite-types';
 import { Model } from '@trezor/trezor-user-env-link';
 
 import { step } from '../../common';

--- a/suite/e2e/support/pageObjects/settings/coinsTab.ts
+++ b/suite/e2e/support/pageObjects/settings/coinsTab.ts
@@ -1,6 +1,6 @@
 import { Locator, Page } from '@playwright/test';
 
-import { BackendType, NetworkSymbol } from '@suite-common/wallet-config';
+import type { BackendType, NetworkSymbol } from '@suite-common/wallet-config';
 
 import { step } from '../../common';
 import { expect } from '../../testExtends/customMatchers';

--- a/suite/e2e/support/pageObjects/settings/settingsPage.ts
+++ b/suite/e2e/support/pageObjects/settings/settingsPage.ts
@@ -1,8 +1,8 @@
 import { Locator, Page, test } from '@playwright/test';
 
-import { NetworkSymbol } from '@suite-common/wallet-config';
-import { BaseCurrencyCode } from '@trezor/blockchain-link-types';
-import { LabelingSelectValue } from '@trezor/suite/src/constants/suite/labeling';
+import type { NetworkSymbol } from '@suite-common/wallet-config';
+import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
+import type { LabelingSelectValue } from '@trezor/suite/src/constants/suite/labeling';
 import { capitalizeFirstLetter } from '@trezor/utils';
 
 import { CoinsTab } from './coinsTab';

--- a/suite/e2e/support/pageObjects/trading/assetsModal.ts
+++ b/suite/e2e/support/pageObjects/trading/assetsModal.ts
@@ -1,7 +1,7 @@
 import { Locator, Page } from '@playwright/test';
 import { CryptoId } from 'invity-api';
 
-import { NetworkSymbol } from '@suite-common/wallet-config';
+import type { NetworkSymbol } from '@suite-common/wallet-config';
 
 import { step } from '../../common';
 import { AssetPickerNetworkFilter, BuyAsset, SellAsset } from '../../types';

--- a/suite/e2e/support/pageObjects/trading/formInputs.ts
+++ b/suite/e2e/support/pageObjects/trading/formInputs.ts
@@ -1,6 +1,6 @@
 import { Locator, Page } from '@playwright/test';
 
-import { TradingCountryCode } from '@suite-common/trading';
+import type { TradingCountryCode } from '@suite-common/trading';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 
 import { calculatePercentageOfBalance, step } from '../../common';

--- a/suite/e2e/support/pageObjects/trading/receiveAccount.ts
+++ b/suite/e2e/support/pageObjects/trading/receiveAccount.ts
@@ -1,6 +1,6 @@
 import { Locator, Page, expect } from '@playwright/test';
 
-import { NetworkSymbol } from '@suite-common/wallet-config';
+import type { NetworkSymbol } from '@suite-common/wallet-config';
 
 import { step } from '../../common';
 

--- a/suite/e2e/support/pageObjects/trading/tradingPage.ts
+++ b/suite/e2e/support/pageObjects/trading/tradingPage.ts
@@ -1,7 +1,7 @@
 import { Locator, Page } from '@playwright/test';
 
 import { messages } from '@suite/intl';
-import { TradingCountryCode } from '@suite-common/trading';
+import type { TradingCountryCode } from '@suite-common/trading';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 
 import { TradingAssetPicker } from './assetsModal';

--- a/suite/e2e/support/pageObjects/walletPage.ts
+++ b/suite/e2e/support/pageObjects/walletPage.ts
@@ -1,6 +1,6 @@
 import { Locator, Page, expect } from '@playwright/test';
 
-import { NetworkSymbol } from '@suite-common/wallet-config';
+import type { NetworkSymbol } from '@suite-common/wallet-config';
 import { isTestnet } from '@suite-common/wallet-utils';
 
 import { step } from '../common';

--- a/suite/e2e/support/types/index.ts
+++ b/suite/e2e/support/types/index.ts
@@ -2,8 +2,8 @@ import { CryptoId } from 'invity-api';
 import { RequireExactlyOne } from 'type-fest';
 
 import { AnalyticsDesktopEvents } from '@suite/analytics';
-import { NetworkConfigWithoutTestnets, NetworkSymbol } from '@suite-common/wallet-config';
-import { TrezorUserEnvLinkClass } from '@trezor/trezor-user-env-link';
+import type { NetworkConfigWithoutTestnets, NetworkSymbol } from '@suite-common/wallet-config';
+import type { TrezorUserEnvLinkClass } from '@trezor/trezor-user-env-link';
 
 import { LaunchSuiteParams } from '../electron';
 

--- a/suite/e2e/tests/analytics/staking-events.test.ts
+++ b/suite/e2e/tests/analytics/staking-events.test.ts
@@ -1,5 +1,5 @@
 import { EventType } from '@suite/analytics/src/constants';
-import { NetworkSymbol } from '@suite-common/wallet-config';
+import type { NetworkSymbol } from '@suite-common/wallet-config';
 import { TestCategory, TestPriority, TestStream, createTestAnnotation } from '@trezor/e2e-utils';
 
 import { expect, test } from '../../support/fixtures';

--- a/suite/e2e/tests/settings/coins-custom-backend.test.ts
+++ b/suite/e2e/tests/settings/coins-custom-backend.test.ts
@@ -1,4 +1,4 @@
-import { BackendType, NetworkSymbol } from '@suite-common/wallet-config';
+import type { BackendType, NetworkSymbol } from '@suite-common/wallet-config';
 import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
 
 import { expect, test } from '../../support/fixtures';

--- a/suite/e2e/tests/settings/coins.test.ts
+++ b/suite/e2e/tests/settings/coins.test.ts
@@ -1,4 +1,4 @@
-import { NetworkSymbol } from '@suite-common/wallet-config';
+import type { NetworkSymbol } from '@suite-common/wallet-config';
 import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
 
 import { expect, test } from '../../support/fixtures';

--- a/suite/e2e/tests/settings/forget-device.test.ts
+++ b/suite/e2e/tests/settings/forget-device.test.ts
@@ -1,4 +1,4 @@
-import { NetworkSymbol } from '@suite-common/wallet-config';
+import type { NetworkSymbol } from '@suite-common/wallet-config';
 import { TestCategory, TestPriority, TestStream, createTestAnnotation } from '@trezor/e2e-utils';
 
 import { expect, test } from '../../support/fixtures';

--- a/suite/e2e/tests/staking/eth/stake-more.test.ts
+++ b/suite/e2e/tests/staking/eth/stake-more.test.ts
@@ -1,4 +1,4 @@
-import { EthValidatorsQueue, StakingBatch } from '@suite-common/earn-staking-api';
+import type { EthValidatorsQueue, StakingBatch } from '@suite-common/earn-staking-api';
 import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
 
 import ETH_BASE_TX from '../../../fixtures/staking/eth-base-tx.json';

--- a/suite/e2e/tests/suite/bug-report-form.test.ts
+++ b/suite/e2e/tests/suite/bug-report-form.test.ts
@@ -1,4 +1,4 @@
-import { FeedbackCategory } from '@suite-common/feedback';
+import type { FeedbackCategory } from '@suite-common/feedback';
 import { TestCategory, TestPriority } from '@trezor/e2e-utils';
 
 import { expect, test } from '../../support/fixtures';

--- a/suite/e2e/tests/wallet/add-account-types.test.ts
+++ b/suite/e2e/tests/wallet/add-account-types.test.ts
@@ -1,5 +1,5 @@
 import { events } from '@suite/analytics';
-import { NetworkSymbol } from '@suite-common/wallet-config';
+import type { NetworkSymbol } from '@suite-common/wallet-config';
 import { TestCategory, TestPriority } from '@trezor/e2e-utils';
 
 import { expect, test } from '../../support/fixtures';

--- a/suite/e2e/tests/wallet/discovery.test.ts
+++ b/suite/e2e/tests/wallet/discovery.test.ts
@@ -1,4 +1,4 @@
-import { NetworkSymbol } from '@suite-common/wallet-config';
+import type { NetworkSymbol } from '@suite-common/wallet-config';
 import { getRandomInt } from '@trezor/utils';
 
 import { expect, test } from '../../support/fixtures';

--- a/suite/e2e/tests/wallet/export-transactions.test.ts
+++ b/suite/e2e/tests/wallet/export-transactions.test.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 
-import { NetworkSymbol } from '@suite-common/wallet-config';
+import type { NetworkSymbol } from '@suite-common/wallet-config';
 import { TestCategory, TestPriority } from '@trezor/e2e-utils';
 
 import { expect, test } from '../../support/fixtures';

--- a/suite/e2e/tests/wallet/public-keys.test.ts
+++ b/suite/e2e/tests/wallet/public-keys.test.ts
@@ -1,4 +1,4 @@
-import { NetworkSymbol } from '@suite-common/wallet-config';
+import type { NetworkSymbol } from '@suite-common/wallet-config';
 
 import { expect, test } from '../../support/fixtures';
 

--- a/suite/e2e/tests/wallet/receive.test.ts
+++ b/suite/e2e/tests/wallet/receive.test.ts
@@ -1,4 +1,4 @@
-import { NetworkSymbol } from '@suite-common/wallet-config';
+import type { NetworkSymbol } from '@suite-common/wallet-config';
 import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
 
 import { expect, test } from '../../support/fixtures';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=gnhf/clean-up-typescript-a3b998&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=gnhf/clean-up-typescript-a3b998&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=gnhf/clean-up-typescript-a3b998&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-10T18:33:43.221Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 10 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-10T18:32:09.161Z • 10 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/gnhf/clean-up-typescript-a3b998/web/](https://dev.suite.sldev.cz/suite-web/gnhf/clean-up-typescript-a3b998/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->