### PR TITLE
chore(address-validator): replace browserify-bignum with native BigInt

### DIFF
--- a/packages/address-validator/package.json
+++ b/packages/address-validator/package.json
@@ -38,7 +38,6 @@
     "dependencies": {
         "@scure/base": "^2.0.0",
         "base-x": "^5.0.1",
-        "browserify-bignum": "^1.3.0-2",
         "cbor": "^10.0.12",
         "crc": "^3.8.0",
         "groestl-hash-js": "1.0.0",

--- a/packages/address-validator/src/crypto/utils.ts
+++ b/packages/address-validator/src/crypto/utils.ts
@@ -1,4 +1,3 @@
-import BigNum from 'browserify-bignum';
 import groestl from 'groestl-hash-js';
 import jsSHA from 'jssha';
 
@@ -149,7 +148,19 @@ export function groestl512x2(hexString: string): string {
 }
 
 export function bigNumberToBuffer(bignumber: number | string, size?: number): Buffer {
-    return new BigNum(bignumber).toBuffer({ size, endian: 'big' });
+    const value = BigInt(bignumber);
+    if (value < 0n) {
+        throw new Error('converting negative numbers to Buffers not supported yet');
+    }
+
+    let hex = value.toString(16);
+    if (hex.length % 2) hex = '0' + hex;
+
+    const blockSize = size ?? 1;
+    const targetLength = Math.ceil(hex.length / (2 * blockSize)) * blockSize;
+    const padding = '0'.repeat(2 * targetLength - hex.length);
+
+    return Buffer.from(padding + hex, 'hex');
 }
 
 export const base58 = base58Decode;

--- a/packages/address-validator/src/types.d.ts
+++ b/packages/address-validator/src/types.d.ts
@@ -1,4 +1,3 @@
 declare module 'crc';
-declare module 'browserify-bignum';
 declare module 'groestl-hash-js';
 declare module 'jssha';

--- a/scripts/list-outdated-dependencies/connect-dependencies.txt
+++ b/scripts/list-outdated-dependencies/connect-dependencies.txt
@@ -31,7 +31,6 @@
 @walletconnect/types
 @walletconnect/utils
 base-x
-browserify-bignum
 buffer
 cbor
 clsx

--- a/yarn.lock
+++ b/yarn.lock
@@ -15048,7 +15048,6 @@ __metadata:
     "@scure/base": "npm:^2.0.0"
     "@trezor/eslint": "workspace:*"
     base-x: "npm:^5.0.1"
-    browserify-bignum: "npm:^1.3.0-2"
     cbor: "npm:^10.0.12"
     crc: "npm:^3.8.0"
     groestl-hash-js: "npm:1.0.0"
@@ -20599,13 +20598,6 @@ __metadata:
     inherits: "npm:^2.0.1"
     safe-buffer: "npm:^5.0.1"
   checksum: 10/2813058f74e083a00450b11ea9d5d1f072de7bf0133f5d122d4ff7b849bece56d52b9c51ad0db0fad21c0bc4e8272fd5196114bbe7b94a9b7feb0f9fbb33a3bf
-  languageName: node
-  linkType: hard
-
-"browserify-bignum@npm:^1.3.0-2":
-  version: 1.3.0
-  resolution: "browserify-bignum@npm:1.3.0"
-  checksum: 10/83b11623d06405396ba707ec1c34ead0ba91d1f408697e330c4a8410a1b63d65c5bff125183cff0d39c4000bd6241a72db2e665b15b00506b55accbda6a8f526
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fifth slice of #27403 — modernize `@trezor/address-validator` and `@trezor/utxo-lib` dependencies.

## Why

[`browserify-bignum`](https://github.com/innoying/browserify-bignum/blob/master/bignumber.js#L1755) is unmaintained (last release 2014). The single callsite, `bigNumberToBuffer` in `crypto/utils.ts`, only needs non-negative integer → bytes conversion, which native `BigInt` handles cleanly.

## Summary

- `crypto/utils.ts` — drop `browserify-bignum` import, reimplement `bigNumberToBuffer` on top of `BigInt` + hex string concatenation.
- The replacement preserves byte-for-byte behavior verified against the original [`BigNum.toBuffer({size, endian: 'big'})`](https://github.com/innoying/browserify-bignum/blob/master/bignumber.js#L1755):
  - value `0` → single zero byte (1-byte buffer)
  - `size` undefined → minimum number of bytes (default `size=1` → `ceil(hex/2)`)
  - `size = N` (block) → rounded up to nearest multiple of `N`
  - same negative-input error message preserved
- `package.json` — `browserify-bignum` removed.
- `types.d.ts` — `declare module 'browserify-bignum'` shim removed.
- `scripts/list-outdated-dependencies/connect-dependencies.txt` — corresponding entry removed.
- `yarn.lock` deduped.

## Test status

**Direct coverage**
- None — `bigNumberToBuffer` has no isolated unit test.

**Indirect coverage**
- [`packages/address-validator/tests/wallet_address_validator.test.ts`](https://github.com/trezor/trezor-suite/blob/mroz22/issue-27403-bignum/packages/address-validator/tests/wallet_address_validator.test.ts#L1050) — Lisk fixtures at [L1050–L1062](https://github.com/trezor/trezor-suite/blob/mroz22/issue-27403-bignum/packages/address-validator/tests/wallet_address_validator.test.ts#L1050): 6 valid `lsk` / `Lisk` addresses plus an address-type lookup. `lisk_validator` is the only consumer of `bigNumberToBuffer` — it parses the numeric `L`-suffix ID and feeds the resulting 8-byte BE buffer into a sha256 checksum comparison. Any regression in the new implementation would break all 6 cases.
- Aggregate: address-validator `test:unit` = **176 / 176 passing** on this branch.

**Coverage assessment:** Moderate. Fixture-based only, 6 cases. To compensate, the author additionally verified byte-for-byte parity against the original `BigNum.toBuffer({size, endian: 'big'})` across:
- value `0` → single zero byte (1-byte buffer)
- `size` undefined → minimum number of bytes
- explicit `size = N` → rounded up to nearest multiple of `N`
- negative inputs preserve the original error message

**Change safety:** **Low risk.**
- Native `BigInt` covers the full non-negative integer range used by Lisk IDs (which are bounded by Lisk's own protocol limits well under `2^64`).
- The replacement preserves all documented edge cases of the original API; only the implementation is new.
- `browserify-bignum` is dead upstream (last release 2014); native BigInt removes a stale supply-chain entry.

## Test plan

- [x] `yarn workspace @trezor/address-validator test:unit` — 176/176 pass (covers `lisk_validator` which is the consumer of `bigNumberToBuffer`)
- [x] `yarn workspace @trezor/address-validator type-check`
- [x] `yarn workspace @trezor/address-validator lint:js`
- [x] `yarn workspace @trezor/address-validator depcheck`
- [x] `yarn dedupe`
- [x] Compared `BigNum.toBuffer` outputs with new implementation across `0`, small numbers, and explicit `size` arguments (matches byte-for-byte)

## Related PRs (issue #27403)

- #27536 — refactor: drop unused `format` parameter
- #27535 — chore: jssha → @noble/hashes
- #27537 — chore: inline bitcoin-ops + pushdata-bitcoin
- #27538 — chore: int64-buffer → native BigInt
- #27540 — chore: base-x → @scure/base
- #PLACEHOLDER — chore: browserify-bignum → native BigInt (← this PR)

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are confined to the `packages/address-validator` package — specifically its `package.json`, a crypto utilities file (`src/crypto/utils.ts`), and type definitions (`src/types.d.ts`). None of the 80+ E2E tests analyzed have any static or inferred dependency on the `address-validator` package. The LLM analysis of every test's source hints, entry points, and behaviors shows no reference to `address-validator` or its crypto utilities. This is a low-risk, self-contained library change with no E2E test coverage available; unit/integration tests within the `address-validator` package itself would be the appropriate verification layer.

<details><summary><b>Changed files (3)</b></summary>

- `packages/address-validator/package.json`
- `packages/address-validator/src/crypto/utils.ts`
- `packages/address-validator/src/types.d.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (3)**
- `packages/address-validator/package.json`
- `packages/address-validator/src/crypto/utils.ts`
- `packages/address-validator/src/types.d.ts`

_Updated: 2026-05-10T18:40:25.393Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/issue-27403-bignum&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/issue-27403-bignum&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-10T18:45:00.082Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 10 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-10T18:43:30.595Z • 10 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/issue-27403-bignum/web/](https://dev.suite.sldev.cz/suite-web/mroz22/issue-27403-bignum/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

