### PR TITLE
chore(utxo-lib): replace bip66 with @noble/curves DER utils

### DIFF
--- a/packages/utxo-lib/package.json
+++ b/packages/utxo-lib/package.json
@@ -53,7 +53,6 @@
         "@scure/base": "^2.0.0",
         "@sinclair/typebox": "^0.34.49",
         "@trezor/utils": "workspace:*",
-        "bip66": "^2.0.0",
         "bitcoin-ops": "^1.4.1",
         "bn.js": "5.2.3",
         "cashaddrjs": "0.4.4",

--- a/packages/utxo-lib/src/script/index.ts
+++ b/packages/utxo-lib/src/script/index.ts
@@ -2,7 +2,7 @@
 // differences:
 // - bitcoin-ops extended by decred codes.
 
-import * as bip66 from 'bip66';
+import { DER } from '@noble/curves/abstract/weierstrass.js';
 import pushdata from 'pushdata-bitcoin';
 
 import * as ecc from '../noble-compatibility';
@@ -205,7 +205,13 @@ export function isCanonicalScriptSignature(buffer: Buffer) {
     if (!isBuffer(buffer)) return false;
     if (!isDefinedHashType(buffer[buffer.length - 1])) return false;
 
-    return bip66.check(buffer.subarray(0, -1));
+    try {
+        DER.toSig(buffer.subarray(0, -1));
+
+        return true;
+    } catch {
+        return false;
+    }
 }
 
 export const number = scriptNumber;

--- a/packages/utxo-lib/src/script/scriptSignature.ts
+++ b/packages/utxo-lib/src/script/scriptSignature.ts
@@ -1,29 +1,9 @@
 // upstream: https://github.com/bitcoinjs/bitcoinjs-lib/blob/master/ts_src/script_signature.ts
 
-import * as bip66 from 'bip66';
+import { DER } from '@noble/curves/abstract/weierstrass.js';
+import { bytesToNumberBE, numberToBytesBE } from '@noble/curves/utils.js';
 
 import { BufferNSchema, Type, UInt8, assertType } from '../types/validation';
-
-const ZERO = Buffer.alloc(1, 0);
-
-export function toDER(x: Buffer) {
-    let i = 0;
-    while (x[i] === 0) ++i;
-    if (i === x.length) return ZERO;
-    x = x.subarray(i);
-    if (x[0] & 0x80) return Buffer.concat([ZERO, x], 1 + x.length);
-
-    return x;
-}
-
-export function fromDER(x: Buffer) {
-    if (x[0] === 0x00) x = x.subarray(1);
-    const buffer = Buffer.alloc(32, 0);
-    const bstart = Math.max(0, 32 - x.length);
-    x.copy(buffer, bstart);
-
-    return buffer;
-}
 
 // BIP62: 1 byte hashType flag (only 0x01, 0x02, 0x03, 0x81, 0x82 and 0x83 are allowed)
 export function decode(buffer: Buffer) {
@@ -31,10 +11,8 @@ export function decode(buffer: Buffer) {
     const hashTypeMod = hashType & ~0x80;
     if (hashTypeMod <= 0 || hashTypeMod >= 4) throw new Error(`Invalid hashType ${hashType}`);
 
-    const decoded = bip66.decode(buffer.subarray(0, -1));
-    const r = fromDER(decoded.r);
-    const s = fromDER(decoded.s);
-    const signature = Buffer.concat([r, s], 64);
+    const { r, s } = DER.toSig(buffer.subarray(0, -1));
+    const signature = Buffer.concat([numberToBytesBE(r, 32), numberToBytesBE(s, 32)], 64);
 
     return { signature, hashType };
 }
@@ -54,8 +32,8 @@ export function encode(signature: Buffer, hashType: number) {
     const hashTypeBuffer = Buffer.allocUnsafe(1);
     hashTypeBuffer.writeUInt8(hashType, 0);
 
-    const r = toDER(signature.subarray(0, 32));
-    const s = toDER(signature.subarray(32, 64));
+    const r = bytesToNumberBE(signature.subarray(0, 32));
+    const s = bytesToNumberBE(signature.subarray(32, 64));
 
-    return Buffer.concat([bip66.encode(r, s), hashTypeBuffer]);
+    return Buffer.concat([Buffer.from(DER.hexFromSig({ r, s }), 'hex'), hashTypeBuffer]);
 }

--- a/packages/utxo-lib/src/types/bip66.d.ts
+++ b/packages/utxo-lib/src/types/bip66.d.ts
@@ -1,5 +1,0 @@
-declare module 'bip66' {
-    function check(buffer: Buffer): boolean;
-    function decode(buffer: Buffer): { r: Buffer; s: Buffer };
-    function encode(r: Buffer, s: Buffer): Buffer;
-}

--- a/packages/utxo-lib/tests/__fixtures__/scriptSignature.ts
+++ b/packages/utxo-lib/tests/__fixtures__/scriptSignature.ts
@@ -59,63 +59,63 @@ export const fixtures = {
     ],
     invalid: [
         {
-            exception: 'DER sequence length is too short',
+            exception: 'tlv.decode: wrong tlv',
             hex: 'ffffffffffffff01',
         },
         {
-            exception: 'DER sequence length is too long',
+            exception: 'tlv.decode: wrong tlv',
             hex: 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff01',
         },
         {
-            exception: 'Expected DER sequence',
+            exception: 'tlv.decode: wrong tlv',
             hex: '00ffff0400ffffff020400ffffff01',
         },
         {
-            exception: 'DER sequence length is invalid',
+            exception: 'tlv.decode(long): byte length is too big',
             hex: '30ff020400ffffff020400ffffff01',
         },
         {
-            exception: 'DER sequence length is invalid',
+            exception: 'invalid signature: left bytes after parsing',
             hex: '300c030400ffffff030400ffffff000001',
         },
         {
-            exception: 'Expected DER integer',
+            exception: 'tlv.decode: wrong tlv',
             hex: '300cff0400ffffff020400ffffff01',
         },
         {
-            exception: 'Expected DER integer (2)',
+            exception: 'tlv.decode: wrong tlv',
             hex: '300c020200ffffff020400ffffff01',
         },
         {
-            exception: 'R length is zero',
+            exception: 'invalid signature integer: empty',
             hex: '30080200020400ffffff01',
         },
         {
-            exception: 'S length is zero',
+            exception: 'invalid signature integer: empty',
             hex: '3008020400ffffff020001',
         },
         {
-            exception: 'R length is too long',
+            exception: 'tlv.decode(long): byte length is too big',
             hex: '300c02dd00ffffff020400ffffff01',
         },
         {
-            exception: 'S length is invalid',
+            exception: 'tlv.decode(long): byte length is too big',
             hex: '300c020400ffffff02dd00ffffff01',
         },
         {
-            exception: 'R value is negative',
+            exception: 'invalid signature integer: negative',
             hex: '300c020480000000020400ffffff01',
         },
         {
-            exception: 'S value is negative',
+            exception: 'invalid signature integer: negative',
             hex: '300c020400ffffff02048000000001',
         },
         {
-            exception: 'R value excessively padded',
+            exception: 'invalid signature integer: unnecessary leading zero',
             hex: '300c02040000ffff020400ffffff01',
         },
         {
-            exception: 'S value excessively padded',
+            exception: 'invalid signature integer: unnecessary leading zero',
             hex: '300c020400ffffff02040000ffff01',
         },
         {

--- a/packages/utxo-lib/tests/scriptSignature.test.ts
+++ b/packages/utxo-lib/tests/scriptSignature.test.ts
@@ -55,11 +55,4 @@ describe('Script Signatures', () => {
             });
         });
     });
-
-    describe('toDER', () => {
-        it('returns the 1-byte 0x00 ZERO buffer when input is all zero bytes', () => {
-            const result = bscriptSig.toDER(Buffer.alloc(32, 0));
-            expect(result.equals(Buffer.from([0x00]))).toBe(true);
-        });
-    });
 });

--- a/scripts/list-outdated-dependencies/wallet-dependencies.txt
+++ b/scripts/list-outdated-dependencies/wallet-dependencies.txt
@@ -30,7 +30,6 @@
 abortcontroller-polyfill
 ajv
 bignumber.js
-bip66
 bitcoin-ops
 blake-hash
 bn.js

--- a/yarn.lock
+++ b/yarn.lock
@@ -16618,7 +16618,6 @@ __metadata:
     "@trezor/eslint": "workspace:*"
     "@trezor/utils": "workspace:*"
     "@types/bn.js": "npm:^5.2.0"
-    bip66: "npm:^2.0.0"
     bitcoin-ops: "npm:^1.4.1"
     bn.js: "npm:5.2.3"
     cashaddrjs: "npm:0.4.4"
@@ -20558,13 +20557,6 @@ __metadata:
   dependencies:
     file-uri-to-path: "npm:1.0.0"
   checksum: 10/593d5ae975ffba15fbbb4788fe5abd1e125afbab849ab967ab43691d27d6483751805d98cb92f7ac24a2439a8a8678cd0131c535d5d63de84e383b0ce2786133
-  languageName: node
-  linkType: hard
-
-"bip66@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "bip66@npm:2.0.0"
-  checksum: 10/919b25d3ed2b9d774eefe550ae6e825e29e1aa450fc1af12e7cef39115a8bc867018b5aa3d8e68b459ec198decabfc1ebe2bdbae9edfdca61c97e862d1db098d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Sixth slice of #27403 — modernize `@trezor/utxo-lib` and `@trezor/address-validator` dependencies.

## Why

[`@noble/curves`](https://github.com/paulmillr/noble-curves/tree/2.2.0) is already a dependency, and v2 ships DER signature parsing via [`DER.toSig`](https://github.com/paulmillr/noble-curves/blob/2.2.0/src/abstract/weierstrass.ts#L628) / [`DER.hexFromSig`](https://github.com/paulmillr/noble-curves/blob/2.2.0/src/abstract/weierstrass.ts#L639) that cover the same surface as [`bip66`](https://github.com/bitcoinjs/bip66/blob/v2.0.0/ts_src/index.ts). Switching to it lets us drop the `bip66` dep, remove its `declare module` shim, and simplify `scriptSignature.ts`.

## Summary

- `script/scriptSignature.ts`:
  - `bip66.decode(...)` → `DER.toSig(...)` (returns `{r: bigint, s: bigint}` directly).
  - `bip66.encode(r, s)` → `DER.hexFromSig({r, s})` + `Buffer.from(..., 'hex')`.
  - The local `toDER` / `fromDER` helpers are gone — `bip66` returned `r` / `s` as raw DER-padded buffers (so callers stripped a leading `0x00` and left-padded to 32 bytes); `DER.toSig` returns numeric bigints, and [`numberToBytesBE`](https://github.com/paulmillr/noble-curves/blob/2.2.0/src/utils.ts#L385)`(value, 32)` handles the zero-padded big-endian output cleanly.
- `script/index.ts`:
  - `bip66.check(...)` → small local try/catch around `DER.toSig(...)` for the `isCanonicalScriptSignature` predicate.
- `tests/__fixtures__/scriptSignature.ts`:
  - Invalid-input expectations updated to noble's DER parser error messages (e.g. `'tlv.decode: wrong tlv'`, `'invalid signature integer: negative'`). Both libraries agree on which inputs are valid vs invalid; only the wording differs.
- `package.json` — `bip66` removed.
- `src/global.ts` — `declare module 'bip66'` shim removed.
- `scripts/list-outdated-dependencies/wallet-dependencies.txt` — corresponding entry removed.
- `yarn.lock` deduped.

## Test status

**Direct coverage**
- [`packages/utxo-lib/tests/scriptSignature.test.ts`](https://github.com/trezor/trezor-suite/blob/mroz22/issue-27403-bip66/packages/utxo-lib/tests/scriptSignature.test.ts) — 4 `describe` blocks covering `encode` / `decode` round-trip on the valid fixtures and rejection on the invalid ones. Backing fixtures in [`__fixtures__/scriptSignature.ts`](https://github.com/trezor/trezor-suite/blob/mroz22/issue-27403-bip66/packages/utxo-lib/tests/__fixtures__/scriptSignature.ts) include valid signatures across multiple `hashType` variants and invalid-DER cases (sequence length, S length, negative integer). The invalid-input error-message strings are updated in this PR to noble's wording — both libraries agree on _which_ inputs are valid/invalid; only the message differs.

**Indirect coverage**
- [`packages/utxo-lib/tests/script.test.ts`](https://github.com/trezor/trezor-suite/blob/mroz22/issue-27403-bip66/packages/utxo-lib/tests/script.test.ts) and [`packages/utxo-lib/tests/transaction.test.ts`](https://github.com/trezor/trezor-suite/blob/mroz22/issue-27403-bip66/packages/utxo-lib/tests/transaction.test.ts) exercise `isCanonicalScriptSignature` via input-script parsing across the full transaction fixture set.
- Aggregate: utxo-lib `test:unit` = **2451 / 2451 passing** on this branch.

**Coverage assessment:** Strong. Encode/decode and the canonical-signature predicate are directly fixture-tested, with explicit invalid-input rejection cases.

**Change safety:** **Moderate–low risk.**
- The file touches Bitcoin script-signature encoding, which is consensus-adjacent — but the surface is small and the fixture set pins it precisely.
- `@noble/curves` is already a dependency; `DER.toSig` / `DER.hexFromSig` are the documented DER-parsing surface.
- `numberToBytesBE(value, 32)` replaces the hand-rolled "strip leading `0x00`, left-pad to 32 bytes" logic — a clear simplification with equivalent output.
- The `r` / `s` shape changes from raw DER-padded `Buffer` to `bigint` internally; all external API shapes (`encode(r: Buffer, s: Buffer)`, `decode(...) => {r: Buffer, s: Buffer}`) are preserved.

## Test plan

- [x] `yarn workspace @trezor/utxo-lib test:unit` — 2451/2451 pass (covers all `scriptSignature.encode` / `decode` fixtures, including the invalid-DER cases)
- [x] `yarn workspace @trezor/utxo-lib type-check`
- [x] `yarn workspace @trezor/utxo-lib lint:js`
- [x] `yarn workspace @trezor/utxo-lib depcheck`
- [x] `yarn workspace @trezor/blockchain-link type-check` (consumer)
- [x] `yarn workspace @trezor/connect` lib type-check (consumer; e2e directory has pre-existing submodule-related errors unrelated to this PR)
- [x] `yarn dedupe`

## Related PRs (issue #27403)

- #27536 — refactor: drop unused `format` parameter
- #27535 — chore: jssha → @noble/hashes
- #27537 — chore: inline bitcoin-ops + pushdata-bitcoin
- #27538 — chore: int64-buffer → native BigInt
- #27540 — chore: base-x → @scure/base
- #27543 — chore: browserify-bignum → native BigInt
- #PLACEHOLDER — chore: bip66 → @noble/curves DER (← this PR)

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are confined to `packages/utxo-lib` — specifically `scriptSignature.ts`, `script/index.ts`, `global.ts`, `package.json`, and a test fixture file. These are low-level UTXO library internals dealing with Bitcoin script signature encoding/decoding. While `script/index.ts` and `scriptSignature.ts` are transitively imported by 121 E2E tests, this is because they are deep infrastructure dependencies (utxo-lib → connect → suite). None of the E2E tests directly exercise script signature parsing or encoding logic; they interact with much higher-level UI flows. The real test coverage for these changes comes from the unit test fixture (`packages/utxo-lib/tests/__fixtures__/scriptSignature.ts`) and the unit tests in the utxo-lib package itself. No E2E tests need to be run for this change — the risk of an E2E-detectable regression is negligible, and running any would not provide meaningful additional confidence beyond unit tests.

<details><summary><b>Changed files (5)</b></summary>

- `packages/utxo-lib/package.json`
- `packages/utxo-lib/src/global.ts`
- `packages/utxo-lib/src/script/index.ts`
- `packages/utxo-lib/src/script/scriptSignature.ts`
- `packages/utxo-lib/tests/__fixtures__/scriptSignature.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (3)**
- `packages/utxo-lib/package.json`
- `packages/utxo-lib/src/global.ts`
- `packages/utxo-lib/tests/__fixtures__/scriptSignature.ts`

_Updated: 2026-05-10T18:57:20.750Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/issue-27403-bip66&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/issue-27403-bip66&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-10T19:01:43.239Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 10 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-10T19:00:09.925Z • 10 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/issue-27403-bip66/web/](https://dev.suite.sldev.cz/suite-web/mroz22/issue-27403-bip66/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

