### PR TITLE
fix(connect): flush stale transport messages on fresh device session

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -497,7 +497,12 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
         if (acquireNeeded || !staticSessionId || (!deriveCardano && options.useCardanoDerivation)) {
             // update features
             try {
-                await handshakeCancel({ device: this, logger: _log, signal: abortSignal });
+                await handshakeCancel({
+                    device: this,
+                    logger: _log,
+                    signal: abortSignal,
+                    cancelNeeded: acquireNeeded && this.protocol.name !== 'v2',
+                });
 
                 if (this.protocol.name === 'v2') {
                     const withInteraction = !!fn;

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -501,7 +501,7 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
                     device: this,
                     logger: _log,
                     signal: abortSignal,
-                    cancelNeeded: acquireNeeded && this.protocol.name !== 'v2',
+                    cancelNeeded: acquireNeeded && this.protocol.name === 'v1',
                 });
 
                 if (this.protocol.name === 'v2') {

--- a/packages/connect/src/device/__tests__/handshakeWorkflow.test.ts
+++ b/packages/connect/src/device/__tests__/handshakeWorkflow.test.ts
@@ -150,7 +150,37 @@ describe('workflow/handshake', () => {
         expect(readMock).toHaveBeenCalledTimes(10);
     });
 
-    it('skipped. Device with features', async () => {
+    it('drains stale Failure_UnexpectedMessage before reading actual response', async () => {
+        // T1B1 firmware (v1.14.1+) can leave a spontaneous Failure_UnexpectedMessage in the
+        // transport buffer after some operations (e.g. resetDevice entropy check). That stale
+        // message must be drained so the actual Cancel response is not left for initialize().
+        //
+        // Protocol frame: ?## (3f 23 23) + type BE u16 (00 03 = Failure) + len BE u32 + protobuf
+        // Failure{code: UnexpectedMessage=1}: payload 08 01 → 3f23230003000000020801
+        // Failure{code: ActionCancelled=4}:   payload 08 04 → 3f23230003000000020804
+        const staleMessage = Buffer.from('3f23230003000000020801', 'hex');
+        const cancelResponse = Buffer.from('3f23230003000000020804', 'hex');
+
+        let readAttempt = 0;
+        const readMock = jest.fn(() => {
+            if (readAttempt === 0) {
+                readAttempt++;
+
+                return Promise.resolve({ success: true, payload: staleMessage });
+            }
+
+            return Promise.resolve({ success: true, payload: cancelResponse });
+        });
+
+        const { device, abortController, transport } = await getAcquiredDevice({ read: readMock });
+        const sendSpy = jest.spyOn(transport, 'send');
+        await handshakeCancel({ device, signal: abortController.signal, cancelNeeded: true });
+
+        expect(sendSpy).toHaveBeenCalledTimes(1); // Cancel was sent
+        expect(readMock).toHaveBeenCalledTimes(2); // stale drained, then actual response
+    });
+
+    it('skipped. Device with features on same ongoing session', async () => {
         const { device, abortController, transport } = await getAcquiredDevice();
         await device.getFeatures();
 
@@ -158,6 +188,19 @@ describe('workflow/handshake', () => {
         await handshakeCancel({ device, signal: abortController.signal });
 
         expect(sendSpy).toHaveBeenCalledTimes(0);
+    });
+
+    it('NOT skipped. Device with features but freshly acquired session', async () => {
+        // Simulates: previous call (e.g. resetDevice) left device.features set, then released
+        // the session. Next call acquires a new session — Cancel must run to flush residual
+        // transport state regardless of the cached features.
+        const { device, abortController, transport } = await getAcquiredDevice();
+        await device.getFeatures();
+
+        const sendSpy = jest.spyOn(transport, 'send');
+        await handshakeCancel({ device, signal: abortController.signal, cancelNeeded: true });
+
+        expect(sendSpy).toHaveBeenCalledTimes(1);
     });
 
     it('skipped. Device with protocol v2', async () => {

--- a/packages/connect/src/device/workflow/handshake.ts
+++ b/packages/connect/src/device/workflow/handshake.ts
@@ -13,6 +13,7 @@ type Context = {
     device: WorkflowContext['device'];
     signal: AbortSignal;
     logger?: Log;
+    cancelNeeded?: boolean;
 };
 
 const isLegacyBridge = (transport: Context['device']['transport']) =>
@@ -27,9 +28,11 @@ const isLegacyBridge = (transport: Context['device']['transport']) =>
 //         the 'use device here' button and here you go. Yet I didn't want to burden every TrezorConnect method call with this but we may reconsider this.
 // note 5: ad note 4. it is not so problematic anymore since cleanup on dispose has been improved in https://github.com/trezor/trezor-suite/pull/16930
 // note 6: T1 with older bootloader (1.8.0) doesn't respond to Cancel message, so we better ignore those
-export const handshakeCancel = async ({ device, logger, signal }: Context) => {
+// note 7: when a session is freshly acquired (param cancelNeeded), cached features belong to the prior session
+//         Cancel must run regardless to flush any residual transport state (e.g. T1B1 leaves a spontaneous Failure_UnexpectedMessage after resetDevice)
+export const handshakeCancel = async ({ device, logger, signal, cancelNeeded }: Context) => {
     // device handshake already done
-    if (device.features || device.getThpState()?.properties) {
+    if (!cancelNeeded && (device.features || device.getThpState()?.properties)) {
         return;
     }
 
@@ -91,6 +94,16 @@ export const handshakeCancel = async ({ device, logger, signal }: Context) => {
                 result.payload.message.code === 'Failure_Busy'
             ) {
                 throw TypedError(result.payload.message.code, result.payload.message.message);
+            }
+
+            // Stale residual from a prior session; only drain when cancelNeeded — otherwise it is a legitimate Cancel response.
+            if (
+                cancelNeeded &&
+                result.payload.type === 'Failure' &&
+                result.payload.message.code === 'Failure_UnexpectedMessage'
+            ) {
+                logger?.debug(`handshake Cancel drained stale Failure_UnexpectedMessage`);
+                continue;
             }
 
             return;

--- a/suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts
+++ b/suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts
@@ -75,7 +75,7 @@ test.describe('Onboarding - create wallet', { tag: ['@firmware-ready', '@T1B1'] 
             await test.step('Finish wallet creation', async () => {
                 await onboardingPage.finalButton.click();
                 await expect(onboardingPage.suiteLoadedIndicator).toBeVisible();
-                await expect(dashboardPage.walletReady).toBeVisible();
+                await expect(dashboardPage.discoveryEmptyHeader).toBeVisible();
             });
         },
     );


### PR DESCRIPTION
## Problem

T1B1 firmware 1.14.1 introduced an entropy check workflow in `resetDevice`. After that operation completes and the session is released, the firmware spontaneously writes a `Failure_UnexpectedMessage` into the UDP transport buffer. This stale message persists across session boundaries.

When the next TrezorConnect call (e.g. `changePin`) acquires a new session, `handshakeCancel` was skipping entirely because `device.features` was still cached from the previous session — never cleared on release. The stale message was then read by `initialize()`, which failed with:

`Error: Initialize failed: messages.c:257:Unknown message, code: Failure_UnexpectedMessage`



Bridge log showing the stale message appearing between `/release/2` and the next `/read/3`:
```
@trezor/transport-bridge Handling request for POST /release/2
...
@trezor/transport-bridge udp: globalOnMessage log: 3f23230003000000220801121e...messages.c:257:Unknown message
@trezor/transport-bridge Handling request for POST /read/3
@trezor/transport-bridge core: readUtil result: messageType: 3 byteLength: 34
```


`byteLength: 34` matches `Failure_UnexpectedMessage`, not the `Failure_ActionCancelled` (49 bytes) that would be the legitimate Cancel response.

## Fix

Two changes to `handshakeCancel`:

**1. `cancelNeeded` parameter** — when a new session is acquired on a v1 protocol device (`acquireNeeded && protocol.name !== 'v2'`), cached features belong to the prior session and cannot be trusted to prove the handshake was already done. `cancelNeeded: true` bypasses the early-return so Cancel always runs on fresh sessions.

**2. Drain `Failure_UnexpectedMessage`** — in the read loop, when `cancelNeeded` is set, `Failure_UnexpectedMessage` is treated as a stale residual and drained (loop continues) rather than returned on, leaving the actual `Failure_ActionCancelled` from our Cancel for the next read. When `cancelNeeded` is false, the same message is a legitimate device response and terminates the loop as before.

The `cancelNeeded` guard on the THP protocol (`=== 'v1'`) ensures Cancel is never sent to THP devices, which manage their own session state independently (note 2).

Vibed coded -> creating a draft PR to see what rest of the test will tell about the fix. I will consult this with @mroz22 before opening PR.

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes modify core device communication infrastructure (Device.ts and handshake.ts) along with a unit test for the handshake workflow and a T1B1 onboarding E2E test. Since Device.ts and handshake.ts are foundational files imported by 121 tests, the risk is broad but the most likely regressions will appear during device initialization and onboarding flows. The recommended strategy focuses on onboarding/wallet-creation tests across device models (T1B1, T2T1, T3T1, T3W1) as these most directly exercise the handshake workflow, with the directly-modified T1B1 test at highest priority.

<details><summary><b>Changed files (4)</b></summary>

- `packages/connect/src/device/Device.ts`
- `packages/connect/src/device/__tests__/handshakeWorkflow.test.ts`
- `packages/connect/src/device/workflow/handshake.ts`
- `suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts` — This test file was directly modified in the changeset. It tests the T1B1 wallet creation onboarding flow, which exercises the handshake workflow and device initialization paths that were also changed.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts` — Wallet creation during onboarding directly triggers the device handshake workflow. Changes to handshake.ts and Device.ts affect how the device is initialized and communicates during onboarding, making this a plausible regression target for a different device model.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts` — Another device model's wallet creation onboarding flow that exercises the handshake workflow. Testing across multiple device models ensures the handshake changes don't break model-specific paths.
- `suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts` — T3W1 onboarding with THP pairing flow exercises the handshake workflow including newer protocol paths. Changes to Device.ts and handshake.ts could affect THP-specific handshake behavior.
- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-success.test.ts` — Recovery on T1B1 involves device handshake after firmware setup. Since the T1B1 create-wallet test was modified alongside handshake changes, recovery on the same model is a plausible regression path.
- `suite/e2e/tests/suite/initial-run.test.ts` — The initial run test verifies device connection and onboarding persistence across reloads, which depends on the handshake workflow establishing a proper device session. Changes to handshake.ts could affect session establishment during initial connect.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-success.test.ts` — Recovery flow on T2T1 exercises device handshake during reconnection and firmware setup. While less directly affected than create-wallet flows, changes to the handshake could impact device communication during recovery.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — Wallet discovery involves ejecting and re-adding wallets which triggers device re-handshake. Changes to Device.ts and handshake.ts could affect device session management during wallet switching.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/connect/src/device/__tests__/handshakeWorkflow.test.ts`

_Updated: 2026-05-10T23:44:14.332Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-fixes-05&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-fixes-05&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test-fixes-05&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-11T02:51:04.305Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 10 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-11T02:49:26.316Z • 10 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test-fixes-05/web/](https://dev.suite.sldev.cz/suite-web/test-fixes-05/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->