### PR TITLE
feat(toasts): migrate Toast to new design system tokens

### DIFF
--- a/suite-native/accounts/src/components/AccountSelectBottomSheet.tsx
+++ b/suite-native/accounts/src/components/AccountSelectBottomSheet.tsx
@@ -59,7 +59,7 @@ export const AccountSelectBottomSheet = React.memo(
                                         });
                                     } else {
                                         showToast({
-                                            variant: 'warning',
+                                            intent: 'warning',
                                             message: (
                                                 <Translation id="accountList.stakingDisabled" />
                                             ),

--- a/suite-native/bluetooth/src/hooks/useBluetoothAdapter.ts
+++ b/suite-native/bluetooth/src/hooks/useBluetoothAdapter.ts
@@ -91,7 +91,7 @@ export const useBluetoothAdapter = () => {
                     } else if (event.connectionStatus.type === 'pairing-canceled') {
                         showToast({
                             message: translate('bluetooth.toasts.pairingCanceled'),
-                            variant: 'default',
+                            intent: 'neutral',
                         });
                     } else if (event.connectionStatus.type === 'pairing-error') {
                         showPairingFailedAlert();

--- a/suite-native/clipboard/src/hooks/useCopyToClipboard.ts
+++ b/suite-native/clipboard/src/hooks/useCopyToClipboard.ts
@@ -14,7 +14,7 @@ export function useCopyToClipboard() {
             await Clipboard.setStringAsync(value);
 
             showToast({
-                variant: 'default',
+                intent: 'neutral',
                 message: toastMessage ?? translate('moduleClipboard.copiedToClipboard'),
                 icon: 'copy',
             });

--- a/suite-native/coin-enabling/src/components/DiscoveryCoinsFilter.tsx
+++ b/suite-native/coin-enabling/src/components/DiscoveryCoinsFilter.tsx
@@ -40,7 +40,7 @@ export const DiscoveryCoinsFilter = ({
         if (!isDeviceConnected && isEnabled) {
             const { name } = getNetwork(symbol);
             showToast({
-                variant: 'default',
+                intent: 'neutral',
                 message: (
                     <Translation
                         id="moduleSettings.coinEnabling.toasts.coinEnabled"

--- a/suite-native/device-authorization/src/hooks/usePinAction.tsx
+++ b/suite-native/device-authorization/src/hooks/usePinAction.tsx
@@ -57,7 +57,7 @@ export const usePinAction = ({ type, onSuccess, onError }: PinActionProps) => {
         (messageKey: TxKeyPath) => {
             showToast({
                 icon: 'check',
-                variant: 'success',
+                intent: 'brand',
                 message: <Translation id={messageKey} />,
             });
         },

--- a/suite-native/device/src/hooks/useDeviceAuthenticityCheck.ts
+++ b/suite-native/device/src/hooks/useDeviceAuthenticityCheck.ts
@@ -106,7 +106,7 @@ export const useDeviceAuthenticityCheck = () => {
     const handleDeviceAccessError = useCallback(
         (error: string) => {
             showToast({
-                variant: 'error',
+                intent: 'critical',
                 message: translate('moduleDeviceSettings.authenticity.toast.failed', { error }),
             });
             reportCheckResult('failed', error);
@@ -120,7 +120,7 @@ export const useDeviceAuthenticityCheck = () => {
                 // Error code is Failure_ProcessError, but  Not all Failure_ProcessError codes mean the bootloader is unlocked,
                 // so this custom condition prevents false positives for that case.
                 showToast({
-                    variant: 'error',
+                    intent: 'critical',
                     message: translate('moduleDeviceSettings.authenticity.toast.error', {
                         error,
                     }),
@@ -135,7 +135,7 @@ export const useDeviceAuthenticityCheck = () => {
                 case 'Failure_PinCancelled': // PIN entry cancelled on T3T1
                     navigation.goBack();
                     showToast({
-                        variant: 'info',
+                        intent: 'info',
                         message: translate('moduleDeviceSettings.authenticity.toast.canceled'),
                     });
                     reportCheckResult('cancelled');
@@ -143,7 +143,7 @@ export const useDeviceAuthenticityCheck = () => {
                 default:
                     navigation.goBack();
                     showToast({
-                        variant: 'error',
+                        intent: 'critical',
                         message: translate('moduleDeviceSettings.authenticity.toast.error', {
                             error,
                         }),

--- a/suite-native/device/src/hooks/useDeviceCompromisedNotification.ts
+++ b/suite-native/device/src/hooks/useDeviceCompromisedNotification.ts
@@ -28,7 +28,7 @@ export const useDeviceCompromisedNotification = () => {
         if (revisionCheckError === null) return;
         if (getIsRevisionCheckErrorWithNotification(revisionCheckError)) {
             showToast({
-                variant: 'error',
+                intent: 'critical',
                 message: translate(revisionCheckNotifications[revisionCheckError]),
             });
         }

--- a/suite-native/firmware/src/hooks/useFirmwareLanguage.ts
+++ b/suite-native/firmware/src/hooks/useFirmwareLanguage.ts
@@ -41,7 +41,7 @@ export const useFirmwareLanguage = () => {
             const unwrappedResult = result.payload;
             if (unwrappedResult.success) {
                 showToast({
-                    variant: 'default',
+                    intent: 'neutral',
                     message: translate('firmware.changeLanguage.success', {
                         languageName: LANGUAGES[language].name,
                     }),

--- a/suite-native/labeling/src/hooks/useSuiteSyncLabelErrorHandler.ts
+++ b/suite-native/labeling/src/hooks/useSuiteSyncLabelErrorHandler.ts
@@ -22,7 +22,7 @@ export const useSuiteSyncErrorHandler = () => {
             case 'DeviceCancelled':
             case 'SuiteSyncUpdateError':
                 showToast({
-                    variant: 'error',
+                    intent: 'critical',
                     icon: 'warning',
                     message: translate(suiteSyncErrorMessageMap[type]),
                 });
@@ -33,7 +33,7 @@ export const useSuiteSyncErrorHandler = () => {
                 // enabled and will fetch keys the next time the device connects.
                 if (isDeviceConnected) {
                     showToast({
-                        variant: 'error',
+                        intent: 'critical',
                         icon: 'warning',
                         message: translate(suiteSyncErrorMessageMap[type]),
                     });

--- a/suite-native/labeling/src/hooks/useTurnOnSuiteSyncGuard.tsx
+++ b/suite-native/labeling/src/hooks/useTurnOnSuiteSyncGuard.tsx
@@ -79,7 +79,7 @@ export const useTurnOnSuiteSyncGuard = () => {
                 case 'DeviceCancelled':
                 case 'DeviceError':
                     showToast({
-                        variant: 'error',
+                        intent: 'critical',
                         icon: 'warning',
                         message: translate(suiteSyncErrorMessageMap[type]),
                     });

--- a/suite-native/link/src/useOpenLink.ts
+++ b/suite-native/link/src/useOpenLink.ts
@@ -12,7 +12,7 @@ export const useOpenLink = () => {
 
     const showErrorToast = useCallback(() => {
         showToast({
-            variant: 'error',
+            intent: 'critical',
             icon: 'warning',
             message: 'Unable to open the link',
         });

--- a/suite-native/module-accounts-management/src/components/AccountSettingsExportBip329Card.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountSettingsExportBip329Card.tsx
@@ -91,7 +91,7 @@ export const AccountSettingsExportBip329Card = ({
 
         if (result.success) {
             showToast({
-                variant: 'default',
+                intent: 'neutral',
                 message: (
                     <Translation id="moduleAccounts.accountSettingsExportBip329Button.exportSuccessfulToast" />
                 ),
@@ -104,7 +104,7 @@ export const AccountSettingsExportBip329Card = ({
         switch (result.reason) {
             case 'exportFailed':
                 showToast({
-                    variant: 'error',
+                    intent: 'critical',
                     message: (
                         <Translation id="moduleAccounts.accountSettingsExportBip329Button.exportFailedToast" />
                     ),
@@ -113,7 +113,7 @@ export const AccountSettingsExportBip329Card = ({
                 return;
             case 'fileSavingNotSupported':
                 showToast({
-                    variant: 'error',
+                    intent: 'critical',
                     message: (
                         <Translation id="moduleAccounts.accountSettingsExportBip329Button.fileSavingNotSupported" />
                     ),

--- a/suite-native/module-connect-popup/src/components/WalletConnectPairBottomSheet.tsx
+++ b/suite-native/module-connect-popup/src/components/WalletConnectPairBottomSheet.tsx
@@ -29,7 +29,7 @@ export const WalletConnectPairBottomSheet = ({
             .unwrap()
             .catch(error => {
                 showToast({
-                    variant: 'warning',
+                    intent: 'warning',
                     message: error.message,
                 });
             })

--- a/suite-native/module-dev-utils/src/components/AnalyticsLogging.tsx
+++ b/suite-native/module-dev-utils/src/components/AnalyticsLogging.tsx
@@ -48,7 +48,7 @@ export const AnalyticsLogging = () => {
         reset({ analyticsUrl: trimmedUrl });
         showToast({
             message: url ? 'Analytics URL updated' : 'Analytics URL reset to default',
-            variant: 'success',
+            intent: 'brand',
         });
     });
 
@@ -58,7 +58,7 @@ export const AnalyticsLogging = () => {
         analytics.setUrl(undefined);
         showToast({
             message: 'Analytics URL reset to default',
-            variant: 'success',
+            intent: 'brand',
         });
     };
 

--- a/suite-native/module-dev-utils/src/components/SuiteSyncQuotaManager.tsx
+++ b/suite-native/module-dev-utils/src/components/SuiteSyncQuotaManager.tsx
@@ -45,7 +45,7 @@ export const SuiteSyncQuotaManager = () => {
         dispatch(updateQuotaManagerBaseUrl({ baseUrl: values.suiteSyncQuotaManagerUrl }));
         showToast({
             message: 'Quota Manager URL updated',
-            variant: 'success',
+            intent: 'brand',
         });
     });
 

--- a/suite-native/module-dev-utils/src/components/SuiteSyncRelaySettings.tsx
+++ b/suite-native/module-dev-utils/src/components/SuiteSyncRelaySettings.tsx
@@ -34,7 +34,7 @@ export const SuiteSyncRelaySettings = () => {
         await suiteSync.changeRelayUrl({ relayUrl: values.suiteSyncRelayUrl });
         showToast({
             message: 'Suite Sync relay URL updated',
-            variant: 'success',
+            intent: 'brand',
         });
     });
 
@@ -51,7 +51,7 @@ export const SuiteSyncRelaySettings = () => {
         form.reset({ suiteSyncRelayUrl: DEFAULT_SUITE_SYNC_RELAY_URL });
         showToast({
             message: 'Suite Sync relay URL reset to default',
-            variant: 'success',
+            intent: 'brand',
         });
     };
 

--- a/suite-native/module-device-onboarding/src/screens/WalletCreationScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/WalletCreationScreen.tsx
@@ -69,7 +69,7 @@ export const WalletCreationScreen = () => {
             const isDefinitiveError = code && DEFINITIVE_ERRORS.includes(code);
             // inconclusive, so repeat the attempt
             if (!isDefinitiveError || getIsIgnoredEntropyCheckError(message)) {
-                showToast({ variant: 'error', message });
+                showToast({ intent: 'critical', message });
                 // This code is OK, but the eslint plugin crashes on recursive calls
                 // eslint-disable-next-line react-hooks/immutability
                 handleCreateAndBackupWallet();

--- a/suite-native/module-device-settings/src/components/DeviceFirmwareCard.tsx
+++ b/suite-native/module-device-settings/src/components/DeviceFirmwareCard.tsx
@@ -50,7 +50,7 @@ export const DeviceFirmwareCard = () => {
     const handleOnPress = () => {
         if (!isFirmwareUpdateEnabled) {
             showToast({
-                variant: 'warning',
+                intent: 'warning',
                 message: <Translation id="firmware.updateNotAvailable" />,
                 icon: 'warning',
             });

--- a/suite-native/module-device-settings/src/hooks/useDeviceAutoConnect.ts
+++ b/suite-native/module-device-settings/src/hooks/useDeviceAutoConnect.ts
@@ -42,12 +42,12 @@ export const useDeviceAutoConnect = () => {
         if (result && isRejected(result)) {
             TrezorConnect.cancel();
             showToast({
-                variant: 'error',
+                intent: 'critical',
                 message: translate('moduleDeviceSettings.autoConnect.errorToast'),
             });
         } else {
             showToast({
-                variant: 'success',
+                intent: 'brand',
                 message: translate('moduleDeviceSettings.autoConnect.successToast'),
             });
         }

--- a/suite-native/module-device-settings/src/hooks/useForgetDevice.ts
+++ b/suite-native/module-device-settings/src/hooks/useForgetDevice.ts
@@ -54,7 +54,7 @@ export const useForgetDevice = () => {
             });
             showToast({
                 icon: 'check',
-                variant: 'default',
+                intent: 'neutral',
                 message: translate('moduleDeviceSettings.forgetDevice.successToast'),
             });
         }

--- a/suite-native/module-device-settings/src/hooks/useTogglePassphrase.ts
+++ b/suite-native/module-device-settings/src/hooks/useTogglePassphrase.ts
@@ -28,7 +28,7 @@ export const useTogglePassphrase = () => {
 
         if (!response.success) {
             showToast({
-                variant: 'default',
+                intent: 'neutral',
                 message: response.error.message,
                 icon: 'check',
             });

--- a/suite-native/module-device-settings/src/screens/ForgetDeviceFinishScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/ForgetDeviceFinishScreen.tsx
@@ -20,7 +20,7 @@ export const ForgetDeviceFinishScreen = () => {
             navigation.addListener('beforeRemove', () => {
                 showToast({
                     icon: 'check',
-                    variant: 'default',
+                    intent: 'neutral',
                     message: <Translation id="moduleDeviceSettings.forgetDevice.successToast" />,
                 });
             }),

--- a/suite-native/module-home/src/screens/HomeScreen/useShowAutoEjectAlert.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/useShowAutoEjectAlert.tsx
@@ -80,7 +80,7 @@ export const useShowAutoEjectAlert = () => {
                             message: (
                                 <Translation id="moduleSettings.viewOnly.autoEject.alert.successToast" />
                             ),
-                            variant: 'default',
+                            intent: 'neutral',
                         });
                     },
                 });

--- a/suite-native/module-settings/src/components/EjectWallets/AutoEjectSwitch.tsx
+++ b/suite-native/module-settings/src/components/EjectWallets/AutoEjectSwitch.tsx
@@ -23,7 +23,7 @@ export const AutoEjectSwitch = () => {
     const onToggleAutoEject = () => {
         if (!isAutoEjectEnabled) {
             showToast({
-                variant: 'default',
+                intent: 'neutral',
                 message: isNoPhysicalDeviceConnected ? (
                     <Translation id="moduleSettings.viewOnly.autoEject.toast.walletsEjected" />
                 ) : (

--- a/suite-native/module-settings/src/components/EjectWallets/WalletRememberModeIconButton.tsx
+++ b/suite-native/module-settings/src/components/EjectWallets/WalletRememberModeIconButton.tsx
@@ -20,7 +20,7 @@ export const WalletRememberModeIconButton = ({ device }: { device: TrezorDevice 
             dispatch(deviceActions.setRememberDevice({ device, remember: !device.remember }));
             if (device.remember) {
                 showToast({
-                    variant: 'default',
+                    intent: 'neutral',
                     message: (
                         <Translation id="moduleSettings.viewOnly.autoEject.toast.walletsWillBeEjected" />
                     ),
@@ -29,7 +29,7 @@ export const WalletRememberModeIconButton = ({ device }: { device: TrezorDevice 
         } else {
             dispatch(deviceActions.forgetDevice({ device }));
             showToast({
-                variant: 'default',
+                intent: 'neutral',
                 message: <Translation id="moduleSettings.viewOnly.autoEject.toast.walletEjected" />,
             });
         }

--- a/suite-native/module-settings/src/components/ProductionDebug.tsx
+++ b/suite-native/module-settings/src/components/ProductionDebug.tsx
@@ -28,7 +28,7 @@ export const ProductionDebug = ({ children }: ProductionDebugProps) => {
         if (tapsCount === 7) {
             setIsDevButtonVisible(true);
             showToast({
-                variant: 'default',
+                intent: 'neutral',
                 message: 'Dev utils enabled.',
                 icon: 'check',
             });

--- a/suite-native/module-settings/src/components/TurnOffCheckCard.tsx
+++ b/suite-native/module-settings/src/components/TurnOffCheckCard.tsx
@@ -21,7 +21,7 @@ const TurnOnButton = ({ onTurnOn }: { onTurnOn: () => void }) => {
     const handleButtonPress = () => {
         onTurnOn();
         showToast({
-            variant: 'default',
+            intent: 'neutral',
             message: <Translation id="moduleSettings.advanced.authenticityChecks.toastOn" />,
             icon: 'check',
         });

--- a/suite-native/module-settings/src/components/TurnOffCheckScreenContent.tsx
+++ b/suite-native/module-settings/src/components/TurnOffCheckScreenContent.tsx
@@ -77,7 +77,7 @@ export const TurnOffCheckScreenContent = ({ title, onConfirm }: TurnOffCheckScre
             navigation.navigate(SettingsStackRoutes.SettingsAdvanced);
         }
         showToast({
-            variant: 'default',
+            intent: 'neutral',
             message: <Translation id="moduleSettings.advanced.authenticityChecks.toastOff" />,
             icon: 'check',
         });

--- a/suite-native/module-settings/src/hooks/useSuiteSyncRelayUrlForm.ts
+++ b/suite-native/module-settings/src/hooks/useSuiteSyncRelayUrlForm.ts
@@ -65,7 +65,7 @@ export const useSuiteSyncRelayUrlForm = () => {
 
             await suiteSync.changeRelayUrl({ relayUrl });
             showToast({
-                variant: 'success',
+                intent: 'brand',
                 message: translate('moduleSettings.items.features.suiteSync.relayUrl.saved'),
             });
             onSuccess?.();

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetListItem.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetListItem.tsx
@@ -38,7 +38,7 @@ export const MyAssetListItem = ({ account, asset, onPress }: MyAssetListItemProp
             onPress(tradeableAsset, account);
         } else {
             showToast({
-                variant: 'default',
+                intent: 'neutral',
                 message: <Translation id="moduleTrading.myAssetSheet.noPair.toast" />,
             });
         }

--- a/suite-native/qr-code/src/components/PickQRFromGalleryButton.tsx
+++ b/suite-native/qr-code/src/components/PickQRFromGalleryButton.tsx
@@ -28,7 +28,7 @@ export const PickQRFromGalleryButton = ({
         } catch {
             onError();
             showToast({
-                variant: 'error',
+                intent: 'critical',
                 icon: 'warning',
                 message: <Translation id="qrCode.pickImageError" />,
             });

--- a/suite-native/receive/src/hooks/useAccountReceiveAddress.tsx
+++ b/suite-native/receive/src/hooks/useAccountReceiveAddress.tsx
@@ -69,7 +69,7 @@ export const useAccountReceiveAddress = (accountKey: AccountKey) => {
             ) {
                 showToast({
                     icon: 'warningCircle',
-                    variant: 'default',
+                    intent: 'neutral',
                     message: <Translation id="moduleReceive.deviceCancelError" />,
                 });
                 if (navigation.canGoBack()) {

--- a/suite-native/toasts/src/components/Toast.tsx
+++ b/suite-native/toasts/src/components/Toast.tsx
@@ -6,7 +6,7 @@ import { Icon } from '@suite-native/icons';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 import { type Color } from '@trezor/theme';
 
-import { type Toast as ToastInterface, type ToastVariant } from '../toastsAtoms';
+import { type ToastIntent, type Toast as ToastInterface } from '../toastsAtoms';
 import { useToast } from '../useToast';
 
 type ToastProps = {
@@ -18,81 +18,82 @@ const TOAST_ANIMATION_DURATION = 500;
 
 type ToastStyle = {
     backgroundColor: Color;
+    borderColor: Color;
     iconBackgroundColor: Color;
-    textColor: Color;
-    iconColor: Color;
+    contentColor: Color;
 };
 
-const ToastContainerStyle = prepareNativeStyle<{ backgroundColor: Color; hasIcon: boolean }>(
-    (utils, { backgroundColor, hasIcon }) => ({
-        backgroundColor: utils.colors[backgroundColor],
-        paddingVertical: utils.spacings.sp4,
-        paddingLeft: utils.spacings.sp4,
-        paddingRight: utils.spacings.sp16,
-        borderRadius: utils.borders.radii.round,
-        extend: [
-            {
-                condition: !hasIcon,
-                style: {
-                    paddingLeft: utils.spacings.sp16,
-                    paddingVertical: 14,
-                },
+const ToastContainerStyle = prepareNativeStyle<{
+    backgroundColor: Color;
+    borderColor: Color;
+    hasIcon: boolean;
+}>((utils, { backgroundColor, borderColor, hasIcon }) => ({
+    backgroundColor: utils.colors[backgroundColor],
+    borderWidth: 1,
+    borderColor: utils.colors[borderColor],
+    paddingVertical: utils.spacings.sp4,
+    paddingLeft: utils.spacings.sp4,
+    paddingRight: utils.spacings.sp16,
+    borderRadius: utils.borders.radii.round,
+    ...utils.boxShadows.medium,
+    extend: [
+        {
+            condition: !hasIcon,
+            style: {
+                paddingLeft: utils.spacings.sp16,
+                paddingVertical: 14,
             },
-        ],
+        },
+    ],
+}));
+
+const IconContainerStyle = prepareNativeStyle<{ backgroundColor: Color }>(
+    (utils, { backgroundColor }) => ({
+        padding: utils.spacings.sp12,
+        borderRadius: utils.borders.radii.round,
+        backgroundColor: utils.colors[backgroundColor],
     }),
 );
 
-const IconContainerStyle = prepareNativeStyle<{
-    backgroundColor: Color;
-    isDefaultVariant: boolean;
-}>((utils, { backgroundColor, isDefaultVariant }) => ({
-    padding: utils.spacings.sp12,
-    borderRadius: utils.borders.radii.round,
-    backgroundColor: utils.transparentize(
-        isDefaultVariant ? 0.75 : 0,
-        utils.colors[backgroundColor],
-    ),
-}));
-
-const toastVariantToStyleMap = {
-    default: {
-        backgroundColor: 'legacyBackgroundNeutralBold',
-        iconBackgroundColor: 'contentSecondary',
-        textColor: 'contentButtonBrandPrimary',
-        iconColor: 'contentButtonBrandPrimary',
+const toastIntentToStyleMap = {
+    neutral: {
+        backgroundColor: 'surfaceFillModelessNeutralDark',
+        borderColor: 'surfaceBorderModelessNeutralDark',
+        iconBackgroundColor: 'elementFillOnDarkNeutralSoft',
+        contentColor: 'contentOnDarkPrimary',
     },
-    success: {
-        backgroundColor: 'legacyBackgroundPrimarySubtleOnElevation0',
-        iconBackgroundColor: 'legacyBackgroundPrimarySubtleOnElevation1',
-        textColor: 'contentBrand',
-        iconColor: 'contentBrand',
+    brand: {
+        backgroundColor: 'surfaceFillModelessBrand',
+        borderColor: 'surfaceBorderModelessBrand',
+        iconBackgroundColor: 'elementFillBrandSoft',
+        contentColor: 'contentBrand',
     },
     warning: {
-        backgroundColor: 'legacyBackgroundAlertYellowSubtleOnElevation0',
-        iconBackgroundColor: 'legacyBackgroundAlertYellowSubtleOnElevation1',
-        textColor: 'contentWarning',
-        iconColor: 'contentWarning',
+        backgroundColor: 'surfaceFillModelessWarning',
+        borderColor: 'surfaceBorderModelessWarning',
+        iconBackgroundColor: 'elementFillWarningSoft',
+        contentColor: 'contentWarning',
     },
-    error: {
-        backgroundColor: 'legacyBackgroundAlertRedSubtleOnElevation0',
-        iconBackgroundColor: 'legacyBackgroundAlertRedSubtleOnElevation1',
-        textColor: 'contentCritical',
-        iconColor: 'contentCritical',
+    critical: {
+        backgroundColor: 'surfaceFillModelessCritical',
+        borderColor: 'surfaceBorderModelessCritical',
+        iconBackgroundColor: 'elementFillCriticalSoft',
+        contentColor: 'contentCritical',
     },
     info: {
-        backgroundColor: 'legacyBackgroundAlertBlueSubtleOnElevation0',
-        iconBackgroundColor: 'legacyBackgroundAlertBlueSubtleOnElevation1',
-        textColor: 'contentInfo',
-        iconColor: 'contentInfo',
+        backgroundColor: 'surfaceFillModelessInfo',
+        borderColor: 'surfaceBorderModelessInfo',
+        iconBackgroundColor: 'elementFillInfoSoft',
+        contentColor: 'contentInfo',
     },
-} as const satisfies Record<ToastVariant, ToastStyle>;
+} as const satisfies Record<ToastIntent, ToastStyle>;
 
 export const Toast = ({ toast }: ToastProps) => {
     const { hideToast } = useToast();
     const { applyStyle } = useNativeStyles();
-    const { variant, icon, message } = toast;
-    const { backgroundColor, iconBackgroundColor, textColor, iconColor } =
-        toastVariantToStyleMap[variant];
+    const { intent, icon, message } = toast;
+    const { backgroundColor, borderColor, iconBackgroundColor, contentColor } =
+        toastIntentToStyleMap[intent];
 
     useEffect(() => {
         const timeout = setTimeout(() => hideToast(toast.id), TOAST_VISIBLE_DURATION);
@@ -104,20 +105,23 @@ export const Toast = ({ toast }: ToastProps) => {
         <Animated.View
             entering={FadeIn.duration(TOAST_ANIMATION_DURATION)}
             exiting={FadeOut.duration(TOAST_ANIMATION_DURATION)}
-            style={applyStyle(ToastContainerStyle, { backgroundColor, hasIcon: !!icon })}
+            style={applyStyle(ToastContainerStyle, {
+                backgroundColor,
+                borderColor,
+                hasIcon: !!icon,
+            })}
         >
             <HStack spacing="sp12" alignItems="center">
                 {icon && (
                     <Box
                         style={applyStyle(IconContainerStyle, {
                             backgroundColor: iconBackgroundColor,
-                            isDefaultVariant: variant === 'default',
                         })}
                     >
-                        <Icon name={icon} color={iconColor} size="medium" />
+                        <Icon name={icon} color={contentColor} size="medium" />
                     </Box>
                 )}
-                <Text color={textColor} variant="body-sm" testID="@toast">
+                <Text color={contentColor} variant="body-sm" testID="@toast">
                     {message}
                 </Text>
             </HStack>

--- a/suite-native/toasts/src/stories/Toast.stories.tsx
+++ b/suite-native/toasts/src/stories/Toast.stories.tsx
@@ -3,12 +3,12 @@ import type { Meta, StoryObj } from '@storybook/react-native';
 import { ICON_NAMES } from '@suite-native/icons';
 
 import { Toast as ToastComponent } from '../components/Toast';
-import { type ToastVariant } from '../toastsAtoms';
+import { type ToastIntent } from '../toastsAtoms';
 
-const TOAST_VARIANTS: ToastVariant[] = ['default', 'success', 'warning', 'error', 'info'];
+const TOAST_INTENTS: ToastIntent[] = ['neutral', 'brand', 'warning', 'critical', 'info'];
 
 type ToastArgs = {
-    variant: ToastVariant;
+    intent: ToastIntent;
     message: string;
     icon?: (typeof ICON_NAMES)[number];
 };
@@ -17,11 +17,11 @@ type ToastStory = StoryObj<ToastArgs>;
 
 const meta: Meta<ToastArgs> = {
     title: 'Toasts',
-    render: ({ variant, message, icon }) => (
+    render: ({ intent, message, icon }) => (
         <ToastComponent
             toast={{
                 id: 0,
-                variant,
+                intent,
                 message,
                 icon,
             }}
@@ -34,14 +34,14 @@ export default meta;
 export const Toast: ToastStory = {
     name: 'Toast',
     args: {
-        variant: 'default',
+        intent: 'neutral',
         message: 'This is a toast message.',
         icon: undefined,
     },
     argTypes: {
-        variant: {
+        intent: {
             control: { type: 'select' },
-            options: TOAST_VARIANTS,
+            options: TOAST_INTENTS,
         },
         message: {
             control: { type: 'text' },

--- a/suite-native/toasts/src/toastsAtoms.ts
+++ b/suite-native/toasts/src/toastsAtoms.ts
@@ -5,12 +5,12 @@ import { atom } from 'jotai';
 
 import { type IconName } from '@suite-native/icons';
 
-export type ToastVariant = 'default' | 'success' | 'warning' | 'error' | 'info';
+export type ToastIntent = 'neutral' | 'brand' | 'warning' | 'critical' | 'info';
 
 export type Toast = {
     id: number;
     icon?: IconName;
-    variant: ToastVariant;
+    intent: ToastIntent;
     message: ReactNode;
 };
 


### PR DESCRIPTION
## Description

- Rename `ToastVariant` → `ToastIntent` 
- Remap intent values: `default`→`neutral`, `success`→`brand`, `error`→`critical` (`warning` and `info` unchanged)
- Add 1px border using `surfaceBorderModeless*` tokens
- Add drop shadow via `utils.boxShadows.medium`
- Merge `textColor`/`iconColor` into a single `contentColor` field (they were always identical per intent)
- Update all 32 `showToast()` call sites across suite-native packages

## Notes for QA

- Verify all 5 toast intents visually: neutral (dark pill), brand (green), warning (yellow), critical (red), info (blue)

## Related Issue

Resolve #27548

## Screenshots:

https://github.com/user-attachments/assets/1fee1b6b-780e-4bad-a9a2-8efa0744bd71



<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/toast-ds-refresh&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->