### PR TITLE
feat(suite-native): add localization component for Payment method

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2799,6 +2799,17 @@ export const messages = {
         },
     },
     moduleTrading: {
+        paymentMethods: {
+            bankTransfer: 'Bank Transfer',
+            creditCard: 'Credit/Debit Card',
+            sepa: 'SEPA',
+            ach: 'Automated Clearing House',
+            skrill: 'Skrill',
+            neteller: 'Neteller',
+            payid: 'PayID',
+            dcinterac: 'Interac',
+            fasterPayment: 'Faster Payment System',
+        },
         providerSheet: {
             title: 'Providers',
             fixed: {
@@ -2994,17 +3005,6 @@ export const messages = {
             title: 'Sell',
             fromAccount: 'From',
             toFiat: 'To',
-            paymentMethods: {
-                bankTransfer: 'Bank Transfer',
-                creditCard: 'Credit/Debit Card',
-                sepa: 'SEPA',
-                ach: 'Automated Clearing House',
-                skrill: 'Skrill',
-                neteller: 'Neteller',
-                payid: 'PayID',
-                dcinterac: 'Interac',
-                fasterPayment: 'Faster Payment System',
-            },
             bankAccount: 'Bank account',
             verified: 'Verified',
             notVerified: 'Not verified',

--- a/suite-native/module-trading/src/components/buy/BuyPaymentMethodPicker.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyPaymentMethodPicker.tsx
@@ -13,6 +13,7 @@ import { selectBuyBestQuotesForAvailablePaymentMethods } from '@suite-native/tra
 import { useBuyFormContext } from '../../hooks/buy/useBuyFormContext';
 import { useSheetControls } from '../../hooks/general/useSheetControls';
 import { PaymentMethodSheet } from '../general/PaymentMethodSheet/PaymentMethodSheet';
+import { PaymentMethodTranslation } from '../general/PaymentMethodTranslation';
 
 const PAYMENT_METHOD_PICKER_TEST_ID = '@trading/buy/payment-method-picker';
 
@@ -39,7 +40,10 @@ const BuyPaymentMethodPickerRight = ({
                 accessibilityLabel={translate('moduleTrading.tradingScreen.selectedPaymentMethod')}
                 testID={PAYMENT_METHOD_PICKER_TEST_ID + '/value'}
             >
-                {selectedValue.paymentMethodName}
+                <PaymentMethodTranslation
+                    paymentMethod={selectedValue.paymentMethod}
+                    paymentMethodName={selectedValue.paymentMethodName}
+                />
             </Text>
         );
     }

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyPaymentMethodPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyPaymentMethodPicker.test.tsx
@@ -5,7 +5,7 @@ import { tradingBuyActions } from '@suite-common/trading';
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
 import { events } from '@suite-native/analytics';
 import { Form } from '@suite-native/forms';
-import { localeInitialState } from '@suite-native/intl';
+import { getTranslation, localeInitialState } from '@suite-native/intl';
 import { useAnalytics } from '@suite-native/services';
 import {
     type PreloadedStatePartial,
@@ -31,6 +31,9 @@ import { useBuyForm } from '../../../hooks/buy/useBuyForm';
 import { BuyPaymentMethodPicker } from '../BuyPaymentMethodPicker';
 
 const reportMock = jest.fn();
+const creditCardPaymentMethodTranslation = getTranslation(
+    'moduleTrading.paymentMethods.creditCard',
+);
 
 jest.mock('@suite-native/services', () => {
     const original = jest.requireActual('@suite-native/services');
@@ -126,9 +129,11 @@ describe('BuyPaymentMethodPicker', () => {
             const { getByText, getByLabelText } = renderPaymentMethodPicker(withQuotes);
 
             fireEvent.press(getByText('Payment method'));
-            fireEvent.press(getByText('Credit Card'));
+            fireEvent.press(getByText(creditCardPaymentMethodTranslation));
 
-            expect(getByLabelText('Selected payment method')).toHaveTextContent('Credit Card');
+            expect(getByLabelText('Selected payment method')).toHaveTextContent(
+                creditCardPaymentMethodTranslation,
+            );
         });
 
         it('should display loader while quotes are fetched', () => {
@@ -158,7 +163,7 @@ describe('BuyPaymentMethodPicker', () => {
                 store.dispatch(tradingBuyActions.setIsLoading(true));
             });
 
-            expect(getByText('Credit Card')).toBeOnTheScreen();
+            expect(getByText(creditCardPaymentMethodTranslation)).toBeOnTheScreen();
         });
 
         describe('analytics', () => {
@@ -170,7 +175,7 @@ describe('BuyPaymentMethodPicker', () => {
                 const { getByText } = renderPaymentMethodPicker(withQuotes);
 
                 fireEvent.press(getByText('Payment method'));
-                fireEvent.press(getByText('Credit Card'));
+                fireEvent.press(getByText(creditCardPaymentMethodTranslation));
 
                 expect(reportMock).toHaveBeenCalledWith({
                     type: events.tradingParameterChangedEvent.name,
@@ -202,7 +207,7 @@ describe('BuyPaymentMethodPicker', () => {
                 });
 
                 fireEvent.press(getByText('Payment method'));
-                fireEvent.press(getAllByText('Credit Card')[1]);
+                fireEvent.press(getAllByText(creditCardPaymentMethodTranslation)[1]);
 
                 expect(reportMock).toHaveBeenCalledTimes(0);
             });

--- a/suite-native/module-trading/src/components/general/PaymentMethodSheet/PaymentMethodListItem.tsx
+++ b/suite-native/module-trading/src/components/general/PaymentMethodSheet/PaymentMethodListItem.tsx
@@ -8,6 +8,7 @@ import { Translation } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 import { useChangeStringsExtractor } from '../../../hooks/history/useChangeStringsExtractor';
+import { PaymentMethodTranslation } from '../PaymentMethodTranslation';
 
 export type PaymentMethodListItemProps<T extends BuyTrade | SellFiatTrade> = {
     quote: T;
@@ -72,7 +73,10 @@ export const PaymentMethodListItem = <T extends BuyTrade | SellFiatTrade>({
                         numberOfLines={1}
                         ellipsizeMode="tail"
                     >
-                        {quote.paymentMethodName ?? ''}
+                        <PaymentMethodTranslation
+                            paymentMethod={quote.paymentMethod}
+                            paymentMethodName={quote.paymentMethodName}
+                        />
                     </Text>
                 </HStack>
                 {!!formattedRate && (

--- a/suite-native/module-trading/src/components/general/PaymentMethodTranslation.tsx
+++ b/suite-native/module-trading/src/components/general/PaymentMethodTranslation.tsx
@@ -1,0 +1,46 @@
+import type { BuyCryptoPaymentMethod } from 'invity-api';
+
+import { Translation, type TxKeyPath } from '@suite-native/intl';
+import type { ExtendedSellCryptoPaymentMethod } from '@suite-native/trading-types';
+
+type PaymentMethodTranslationMethod = BuyCryptoPaymentMethod | ExtendedSellCryptoPaymentMethod;
+
+export type PaymentMethodTranslationProps = {
+    paymentMethod?: PaymentMethodTranslationMethod | string;
+    paymentMethodName?: string;
+};
+
+const paymentMethodTranslationMap = {
+    bankTransfer: 'moduleTrading.paymentMethods.bankTransfer',
+    creditCard: 'moduleTrading.paymentMethods.creditCard',
+    sepa: 'moduleTrading.paymentMethods.sepa',
+    ach: 'moduleTrading.paymentMethods.ach',
+    skrill: 'moduleTrading.paymentMethods.skrill',
+    neteller: 'moduleTrading.paymentMethods.neteller',
+    payid: 'moduleTrading.paymentMethods.payid',
+    dcinterac: 'moduleTrading.paymentMethods.dcinterac',
+    fasterPayment: 'moduleTrading.paymentMethods.fasterPayment',
+} as const satisfies Partial<Record<PaymentMethodTranslationMethod, TxKeyPath>>;
+
+const getPaymentMethodTranslationId = (paymentMethod?: string): TxKeyPath | undefined => {
+    if (paymentMethod && paymentMethod in paymentMethodTranslationMap) {
+        return paymentMethodTranslationMap[
+            paymentMethod as keyof typeof paymentMethodTranslationMap
+        ];
+    }
+
+    return undefined;
+};
+
+export const PaymentMethodTranslation = ({
+    paymentMethod,
+    paymentMethodName,
+}: PaymentMethodTranslationProps) => {
+    const paymentMethodTranslationId = getPaymentMethodTranslationId(paymentMethod);
+
+    if (paymentMethodTranslationId) {
+        return <Translation id={paymentMethodTranslationId} />;
+    }
+
+    return paymentMethodName ?? paymentMethod ?? null;
+};

--- a/suite-native/module-trading/src/components/general/PaymentMethodTranslation.tsx
+++ b/suite-native/module-trading/src/components/general/PaymentMethodTranslation.tsx
@@ -42,5 +42,5 @@ export const PaymentMethodTranslation = ({
         return <Translation id={paymentMethodTranslationId} />;
     }
 
-    return paymentMethodName ?? paymentMethod ?? null;
+    return (paymentMethodName || paymentMethod) ?? '';
 };

--- a/suite-native/module-trading/src/components/general/TradeInfo/TradeFiatSideCard.tsx
+++ b/suite-native/module-trading/src/components/general/TradeInfo/TradeFiatSideCard.tsx
@@ -3,43 +3,17 @@ import { type ReactNode } from 'react';
 import { type FiatCurrencyCode } from 'invity-api';
 
 import { Card, HStack, Text, VStack } from '@suite-native/atoms';
-import { Translation } from '@suite-native/intl';
 import { TradeInfoHeader, TradeInfoRow } from '@suite-native/trading-atoms';
 import type { ExtendedSellCryptoPaymentMethod } from '@suite-native/trading-types';
 
 import { FiatCurrencyIcon } from '../FiatCurrencyIcon';
+import { PaymentMethodTranslation } from '../PaymentMethodTranslation';
 
 export type TradeFiatSideCardProps = {
     paymentMethod: ExtendedSellCryptoPaymentMethod;
     amount: ReactNode;
     title: ReactNode;
     fiatCurrency: FiatCurrencyCode;
-};
-const paymentMethodNamesMap: Record<ExtendedSellCryptoPaymentMethod, ReactNode> = {
-    bankTransfer: (
-        <Translation id="moduleTrading.tradingSellPreviewScreen.paymentMethods.bankTransfer" />
-    ),
-    creditCard: (
-        <Translation id="moduleTrading.tradingSellPreviewScreen.paymentMethods.creditCard" />
-    ),
-    sepa: <Translation id="moduleTrading.tradingSellPreviewScreen.paymentMethods.sepa" />,
-    ach: <Translation id="moduleTrading.tradingSellPreviewScreen.paymentMethods.ach" />,
-    skrill: <Translation id="moduleTrading.tradingSellPreviewScreen.paymentMethods.skrill" />,
-
-    neteller: <Translation id="moduleTrading.tradingSellPreviewScreen.paymentMethods.neteller" />,
-    payid: <Translation id="moduleTrading.tradingSellPreviewScreen.paymentMethods.payid" />,
-    dcinterac: <Translation id="moduleTrading.tradingSellPreviewScreen.paymentMethods.dcinterac" />,
-    fasterPayment: (
-        <Translation id="moduleTrading.tradingSellPreviewScreen.paymentMethods.fasterPayment" />
-    ),
-};
-
-const getPaymentMethodTranslation = (paymentMethod: ExtendedSellCryptoPaymentMethod | string) => {
-    if (paymentMethod in paymentMethodNamesMap) {
-        return paymentMethodNamesMap[paymentMethod as ExtendedSellCryptoPaymentMethod];
-    }
-
-    return paymentMethod;
 };
 
 export const TradeFiatSideCard = ({
@@ -52,7 +26,9 @@ export const TradeFiatSideCard = ({
         <TradeInfoHeader
             title={title}
             rightContent={
-                <Text variant="body-sm">{getPaymentMethodTranslation(paymentMethod)}</Text>
+                <Text variant="body-sm">
+                    <PaymentMethodTranslation paymentMethod={paymentMethod} />
+                </Text>
             }
         />
         <TradeInfoRow>

--- a/suite-native/module-trading/src/components/general/TradeInfo/TradeFiatSideCard.tsx
+++ b/suite-native/module-trading/src/components/general/TradeInfo/TradeFiatSideCard.tsx
@@ -11,6 +11,7 @@ import { PaymentMethodTranslation } from '../PaymentMethodTranslation';
 
 export type TradeFiatSideCardProps = {
     paymentMethod: ExtendedSellCryptoPaymentMethod;
+    paymentMethodName?: string;
     amount: ReactNode;
     title: ReactNode;
     fiatCurrency: FiatCurrencyCode;
@@ -21,13 +22,17 @@ export const TradeFiatSideCard = ({
     amount,
     title,
     fiatCurrency,
+    paymentMethodName,
 }: TradeFiatSideCardProps) => (
     <Card noPadding>
         <TradeInfoHeader
             title={title}
             rightContent={
                 <Text variant="body-sm">
-                    <PaymentMethodTranslation paymentMethod={paymentMethod} />
+                    <PaymentMethodTranslation
+                        paymentMethod={paymentMethod}
+                        paymentMethodName={paymentMethodName}
+                    />
                 </Text>
             }
         />

--- a/suite-native/module-trading/src/components/general/__tests__/PaymentMethodTranslation.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/PaymentMethodTranslation.test.tsx
@@ -1,0 +1,44 @@
+import { Text } from '@suite-native/atoms';
+import { getTranslation } from '@suite-native/intl';
+import { renderWithBasicProvider } from '@suite-native/test-utils';
+
+import {
+    PaymentMethodTranslation,
+    type PaymentMethodTranslationProps,
+} from '../PaymentMethodTranslation';
+
+describe('PaymentMethodTranslation', () => {
+    const renderPaymentMethodTranslation = (props: PaymentMethodTranslationProps) =>
+        renderWithBasicProvider(
+            <Text>
+                <PaymentMethodTranslation {...props} />
+            </Text>,
+        );
+
+    it('should render known payment method translation', () => {
+        const { getByText } = renderPaymentMethodTranslation({
+            paymentMethod: 'creditCard',
+        });
+
+        expect(
+            getByText(getTranslation('moduleTrading.paymentMethods.creditCard')),
+        ).toBeOnTheScreen();
+    });
+
+    it('should render payment method name when payment method is unknown', () => {
+        const { getByText } = renderPaymentMethodTranslation({
+            paymentMethod: 'customMethod',
+            paymentMethodName: 'Custom Method',
+        });
+
+        expect(getByText('Custom Method')).toBeOnTheScreen();
+    });
+
+    it('should render payment method when payment method name is missing', () => {
+        const { getByText } = renderPaymentMethodTranslation({
+            paymentMethod: 'customMethod',
+        });
+
+        expect(getByText('customMethod')).toBeOnTheScreen();
+    });
+});

--- a/suite-native/module-trading/src/components/general/__tests__/PaymentMethodTranslation.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/PaymentMethodTranslation.test.tsx
@@ -37,8 +37,15 @@ describe('PaymentMethodTranslation', () => {
     it('should render payment method when payment method name is missing', () => {
         const { getByText } = renderPaymentMethodTranslation({
             paymentMethod: 'customMethod',
+            paymentMethodName: '',
         });
 
         expect(getByText('customMethod')).toBeOnTheScreen();
+    });
+
+    it('should render empty string when no payment method or name is provided', () => {
+        const { getByText } = renderPaymentMethodTranslation({});
+
+        expect(getByText('')).toBeOnTheScreen();
     });
 });

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailInfo.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailInfo.tsx
@@ -11,6 +11,7 @@ import { Translation } from '@suite-native/intl';
 import { ProviderLogo } from '@suite-native/trading-atoms';
 
 import { TradeDetailInfoRow } from './TradeDetailInfoRow';
+import { PaymentMethodTranslation } from '../../general/PaymentMethodTranslation';
 
 type TradeDetailInfoProps = {
     orderId: string;
@@ -63,7 +64,14 @@ export const TradeDetailInfo = ({ orderId }: TradeDetailInfoProps) => {
                     />
                     <TradeDetailInfoRow
                         title={<Translation id="moduleTrading.tradeHistory.detail.method" />}
-                        content={trade.data.paymentMethodName}
+                        content={
+                            <Text variant="body-sm">
+                                <PaymentMethodTranslation
+                                    paymentMethod={trade.data.paymentMethod}
+                                    paymentMethodName={trade.data.paymentMethodName}
+                                />
+                            </Text>
+                        }
                     />
                 </>
             )}

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailInfo.test.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailInfo.test.tsx
@@ -1,4 +1,5 @@
 import { type TradingTransaction } from '@suite-common/trading';
+import { getTranslation } from '@suite-native/intl';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 import {
     getBuyTrade,
@@ -40,7 +41,7 @@ describe('TradeDetailInfo', () => {
         );
 
         expect(getByText('Mercuryo')).toBeTruthy();
-        expect(getByText('Credit Card')).toBeTruthy();
+        expect(getByText(getTranslation('moduleTrading.paymentMethods.creditCard'))).toBeTruthy();
 
         expect(getByText(/0[45]\/10\/2025/)).toBeTruthy();
         expect(getByText(/[0-9]{1,2}:21/)).toBeTruthy();

--- a/suite-native/module-trading/src/components/sell/SellPreview/SellToFiatTradePreviewCard.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/SellToFiatTradePreviewCard.tsx
@@ -21,6 +21,7 @@ export const SellToFiatTradePreviewCard = ({ quote }: SellToFiatTradePreviewCard
         <TradeFiatSideCard
             fiatCurrency={quote.fiatCurrency as FiatCurrencyCode}
             paymentMethod={quote.paymentMethod}
+            paymentMethodName={quote.paymentMethodName}
             amount={
                 !!toStringValue && (
                     <Text variant="body-sm" color="contentBrand">

--- a/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellPreviewView.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellPreviewView.test.tsx
@@ -72,11 +72,7 @@ describe('SellPreviewView', () => {
             getByText(getTranslation('moduleTrading.tradingSellPreviewScreen.toFiat')),
         ).toBeOnTheScreen();
         expect(
-            getByText(
-                getTranslation(
-                    'moduleTrading.tradingSellPreviewScreen.paymentMethods.bankTransfer',
-                ),
-            ),
+            getByText(getTranslation('moduleTrading.paymentMethods.bankTransfer')),
         ).toBeOnTheScreen();
     });
 
@@ -93,11 +89,7 @@ describe('SellPreviewView', () => {
             getByText(getTranslation('moduleTrading.tradingSellPreviewScreen.toFiat')),
         ).toBeOnTheScreen();
         expect(
-            getByText(
-                getTranslation(
-                    'moduleTrading.tradingSellPreviewScreen.paymentMethods.bankTransfer',
-                ),
-            ),
+            getByText(getTranslation('moduleTrading.paymentMethods.bankTransfer')),
         ).toBeOnTheScreen();
         expect(getByText('Transaction error occurred')).toBeOnTheScreen();
     });

--- a/suite-native/module-trading/src/components/sell/fiat/SellReceiveMethodPicker.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/SellReceiveMethodPicker.tsx
@@ -15,6 +15,7 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 import { useSheetControls } from '../../../hooks/general/useSheetControls';
 import { useSellFormContext } from '../../../hooks/sell/useSellFormContext';
 import { PaymentMethodSheet } from '../../general/PaymentMethodSheet/PaymentMethodSheet';
+import { PaymentMethodTranslation } from '../../general/PaymentMethodTranslation';
 
 const RECEIVE_METHOD_PICKER_TEST_ID = '@trading/sell/receive-method-picker';
 
@@ -46,7 +47,10 @@ const SellReceiveMethodPickerRight = ({
                 accessibilityLabel={translate('moduleTrading.tradingScreen.selectedReceiveMethod')}
                 testID={RECEIVE_METHOD_PICKER_TEST_ID + '/value'}
             >
-                {selectedValue.paymentMethodName}
+                <PaymentMethodTranslation
+                    paymentMethod={selectedValue.paymentMethod}
+                    paymentMethodName={selectedValue.paymentMethodName}
+                />
             </Text>
         );
     }

--- a/suite-native/module-trading/src/components/sell/fiat/__tests__/SellReceiveMethodPicker.test.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/__tests__/SellReceiveMethodPicker.test.tsx
@@ -1,5 +1,6 @@
 import { events } from '@suite-native/analytics';
 import { Form } from '@suite-native/forms';
+import { getTranslation } from '@suite-native/intl';
 import { useAnalytics } from '@suite-native/services';
 import {
     act,
@@ -20,6 +21,9 @@ import { useSellForm } from '../../../../hooks/sell/useSellForm';
 import { SellReceiveMethodPicker } from '../SellReceiveMethodPicker';
 
 const reportMock = jest.fn();
+const creditCardPaymentMethodTranslation = getTranslation(
+    'moduleTrading.paymentMethods.creditCard',
+);
 
 jest.mock('@suite-native/services', () => {
     const original = jest.requireActual('@suite-native/services');
@@ -109,9 +113,11 @@ describe('SellReceiveMethodPicker', () => {
             const { getByText, getByLabelText } = renderSellReceiveMethodPicker(withQuotes);
 
             fireEvent.press(getByText('Receive method'));
-            fireEvent.press(getByText('Credit Card'));
+            fireEvent.press(getByText(creditCardPaymentMethodTranslation));
 
-            expect(getByLabelText('Selected receive method')).toHaveTextContent('Credit Card');
+            expect(getByLabelText('Selected receive method')).toHaveTextContent(
+                creditCardPaymentMethodTranslation,
+            );
         });
 
         describe('analytics', () => {
@@ -123,7 +129,7 @@ describe('SellReceiveMethodPicker', () => {
                 const { getByText } = renderSellReceiveMethodPicker(withQuotes);
 
                 fireEvent.press(getByText('Receive method'));
-                fireEvent.press(getByText('Credit Card'));
+                fireEvent.press(getByText(creditCardPaymentMethodTranslation));
 
                 expect(reportMock).toHaveBeenCalledWith({
                     type: events.tradingParameterChangedEvent.name,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* Add `PaymentMethodTranslation` to unify localization for payment methods in trading

## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/24212

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/24212-mobile-trade-localize-paymentmethodname&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->