### PR TITLE
chore: staging — shared utility adoption candidates (gnhf batch)

### DIFF
--- a/packages/analytics-docs/scripts/buildData.ts
+++ b/packages/analytics-docs/scripts/buildData.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import type { EventDef } from '@suite-common/analytics';
+import { unique } from '@trezor/utils';
 
 import type { EventDoc } from '../src/types';
 import {
@@ -84,7 +85,7 @@ const getPackageRoots = (): string[] => {
         findPackageRoot(path.join(getPackageRoot(name), 'package.json')),
     ).filter((x): x is string => Boolean(x));
 
-    return [...new Set(roots)];
+    return unique(roots);
 };
 
 const getEventFileGlobs = (packageRoots: string[]): string[] =>

--- a/packages/analytics-docs/src/components/LiveLogSidebar.tsx
+++ b/packages/analytics-docs/src/components/LiveLogSidebar.tsx
@@ -24,6 +24,7 @@ import {
     variables,
 } from '@trezor/components';
 import { zIndices } from '@trezor/theme';
+import { removeTrailingSlashes } from '@trezor/utils';
 
 import type { LiveLogEvent } from '../types';
 import { fuzzyMatch, getEventId } from '../utils/filterUtils';
@@ -313,7 +314,7 @@ export const LiveLogSidebar = ({ onEventClick, filterQuery }: LiveLogSidebarProp
                         <Text typographyStyle="body-xs" intent="neutral" priority="secondary">
                             In Suite, set Custom Analytics URL (Settings → Debug) to{' '}
                             <Text isMonospaced typographyStyle="inherit">
-                                {`${logServerBaseUrl.replace(/\/+$/, '')}/log`}
+                                {`${removeTrailingSlashes(logServerBaseUrl)}/log`}
                             </Text>
                         </Text>
                     </Box>
@@ -427,7 +428,7 @@ export const LiveLogSidebar = ({ onEventClick, filterQuery }: LiveLogSidebarProp
                                 This controls where analytics-docs connects for live events (SSE)
                                 and where Suite should send events to{' '}
                                 <Text isMonospaced typographyStyle="inherit">
-                                    {`${(logServerInput.trim() || getDefaultLogServerBaseUrl()).replace(/\/+$/, '')}/log`}
+                                    {`${removeTrailingSlashes(logServerInput.trim() || getDefaultLogServerBaseUrl())}/log`}
                                 </Text>
                                 .
                             </Text>

--- a/packages/analytics-docs/src/utils/extractAttributeTypes.ts
+++ b/packages/analytics-docs/src/utils/extractAttributeTypes.ts
@@ -11,6 +11,8 @@ import {
     ts,
 } from 'ts-morph';
 
+import { unique } from '@trezor/utils';
+
 /** Options for the attribute type extraction (tsconfig path and globs for event files). */
 type ExtractOptions = {
     tsConfigFilePath: string;
@@ -142,7 +144,7 @@ const formatTypeAsString = (t: Type, contextNode: Node): string => {
         const parts = t.getUnionTypes();
         if (parts.length > 80) return t.getText(contextNode, FORMAT_FLAGS);
         const rendered = parts.map(p => formatTypeAsString(p, contextNode));
-        const uniq = [...new Set(rendered)];
+        const uniq = unique(rendered);
 
         return uniq.join('\n| ');
     }

--- a/packages/analytics-docs/src/utils/logServerUrl.ts
+++ b/packages/analytics-docs/src/utils/logServerUrl.ts
@@ -1,11 +1,9 @@
+import { removeTrailingSlashes } from '@trezor/utils';
+
 const STORAGE_KEY = 'analytics-docs-log-server-base-url';
 const URL_PARAM = 'logServer';
 
-const normalizeBaseUrl = (input: string): string => {
-    const trimmed = input.trim().replace(/\/+$/, '');
-
-    return trimmed;
-};
+const normalizeBaseUrl = (input: string): string => removeTrailingSlashes(input.trim());
 
 export const getDefaultLogServerBaseUrl = (): string =>
     typeof window !== 'undefined'

--- a/packages/analytics-docs/src/utils/useLiveLogEvents.ts
+++ b/packages/analytics-docs/src/utils/useLiveLogEvents.ts
@@ -1,11 +1,13 @@
 import { useCallback, useEffect, useState } from 'react';
 
+import { removeTrailingSlashes } from '@trezor/utils';
+
 import type { LiveLogEvent } from '../types';
 
 const STREAM_PATH = '/api/analytics-events/stream';
 const CLEAR_PATH = '/api/analytics-events/clear';
 
-const joinUrl = (baseUrl: string, path: string) => `${baseUrl.replace(/\/+$/, '')}${path}`;
+const joinUrl = (baseUrl: string, path: string) => `${removeTrailingSlashes(baseUrl)}${path}`;
 
 export const useLiveLogEvents = (baseUrl: string) => {
     const [events, setEvents] = useState<LiveLogEvent[]>([]);

--- a/packages/blockchain-link-utils/src/blockfrost.ts
+++ b/packages/blockchain-link-utils/src/blockfrost.ts
@@ -13,6 +13,7 @@ import type {
     Utxo,
     VinVout,
 } from '@trezor/blockchain-link-types';
+import { isNotNullOrUndefined } from '@trezor/utils';
 import { BigNumber, type BigNumberValue } from '@trezor/utils/src/bigNumber';
 
 import { enhanceVinVout, filterTargets, sumVinVout, transformTarget } from './utils';
@@ -209,7 +210,7 @@ export const filterTokenTransfers = (
             });
     });
 
-    return transfers.filter(t => !!t) as TokenTransfer[];
+    return transfers.filter(isNotNullOrUndefined);
 };
 
 export const transformTransaction = (

--- a/packages/blockchain-link-utils/src/solana.ts
+++ b/packages/blockchain-link-utils/src/solana.ts
@@ -9,7 +9,7 @@ import {
     type Transaction,
 } from '@trezor/blockchain-link-types/src';
 import { isCodesignBuild } from '@trezor/env-utils';
-import { arrayPartition } from '@trezor/utils';
+import { arrayPartition, isNotNullOrUndefined } from '@trezor/utils';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import type {
@@ -279,7 +279,7 @@ export function getNativeEffects(transaction: ParsedTransactionWithMeta): Transa
                 amount: balanceDiff.postBalance.minus(balanceDiff.preBalance),
             };
         })
-        .filter((effect): effect is TransactionEffect => !!effect)
+        .filter(isNotNullOrUndefined)
         .filter(({ amount }) => !amount.isZero()); // filter out zero effects
 }
 

--- a/packages/blockchain-link/src/workers/evm-rpc/handlers/getAccountInfo.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/handlers/getAccountInfo.ts
@@ -3,6 +3,7 @@ import type {
     ResponseTypes as Responses,
     TokenInfo,
 } from '@trezor/blockchain-link-types';
+import { isNotNull } from '@trezor/utils';
 
 import { mapGetAccountInfoResponse } from '../mappers/accountInfo';
 import { getStakingPoolData } from '../staking/poolData';
@@ -29,7 +30,7 @@ export const getAccountInfo = async (
     if (payload.details === 'tokenBalances' && payload.contractFilter) {
         const contractAddress = toHex(payload.contractFilter);
         const tokenInfo = await getTokenInfo(client, address, contractAddress, true);
-        tokens = [tokenInfo].filter((token): token is TokenInfo => token !== null);
+        tokens = [tokenInfo].filter(isNotNull);
     }
 
     return mapGetAccountInfoResponse({

--- a/packages/blockchain-link/src/workers/evm-rpc/tokens/tokenDiscovery.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/tokens/tokenDiscovery.ts
@@ -1,6 +1,7 @@
 import { type Log, type PublicClient, parseAbiItem } from 'viem';
 
 import type { TokenInfo } from '@trezor/blockchain-link-types';
+import { unique } from '@trezor/utils';
 
 import { getTokenInfo } from './tokenInfo';
 import { TOKEN_DISCOVERY } from '../constants';
@@ -80,7 +81,7 @@ export const discoverTokens = async (
     }
 
     const allLogs = [...incomingLogs, ...outgoingLogs];
-    const contractAddresses = [...new Set(allLogs.map(log => log.address.toLowerCase()))];
+    const contractAddresses = unique(allLogs.map(log => log.address.toLowerCase()));
 
     if (contractAddresses.length === 0) {
         return [];

--- a/packages/blockchain-link/src/workers/evm-rpc/tokens/tokenDiscovery.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/tokens/tokenDiscovery.ts
@@ -1,7 +1,7 @@
 import { type Log, type PublicClient, parseAbiItem } from 'viem';
 
 import type { TokenInfo } from '@trezor/blockchain-link-types';
-import { unique } from '@trezor/utils';
+import { isNotNull, unique } from '@trezor/utils';
 
 import { getTokenInfo } from './tokenInfo';
 import { TOKEN_DISCOVERY } from '../constants';
@@ -93,5 +93,5 @@ export const discoverTokens = async (
 
     const tokens = await Promise.all(tokenPromises);
 
-    return tokens.filter((token): token is TokenInfo => token !== null);
+    return tokens.filter(isNotNull);
 };

--- a/packages/blockchain-link/src/workers/evm-rpc/utils/block.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/utils/block.ts
@@ -1,5 +1,7 @@
 import { type PublicClient } from 'viem';
 
+import { isNotNullOrUndefined } from '@trezor/utils';
+
 export const calculateBlockTime = async (client: PublicClient): Promise<number | null> => {
     try {
         const latestBlock = await client.getBlock({ blockTag: 'latest' });
@@ -26,7 +28,7 @@ export const averageRewards = (rewards: bigint[][], percentileIndex: number): bi
 
     for (const blockRewards of rewards) {
         const reward = blockRewards[percentileIndex];
-        if (reward !== null && reward !== undefined) {
+        if (isNotNullOrUndefined(reward)) {
             sum += reward;
             count++;
         }

--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -60,7 +60,7 @@ import type {
 } from '@trezor/blockchain-link-utils/src/solana-types';
 import { getSuiteVersion } from '@trezor/env-utils';
 import { type IntervalId } from '@trezor/type-utils';
-import { BigNumber, createDeferred, createLazy } from '@trezor/utils';
+import { BigNumber, createDeferred, createLazy, isNotNullOrUndefined } from '@trezor/utils';
 
 import { BaseWorker, CONTEXT, type ContextType } from '../baseWorker';
 import { getBaseFee, getPriorityFee } from './utils/fee';
@@ -91,10 +91,6 @@ type SignatureWithSlot = {
     signature: Signature;
     slot: Slot;
 };
-
-function nonNullable<T>(value: T): value is NonNullable<T> {
-    return value !== null && value !== undefined;
-}
 
 const getAllSignatures = async (
     api: SolanaAPI,
@@ -142,7 +138,7 @@ const fetchTransactionPage = async (
                     .send(),
             ),
         )
-    ).filter(nonNullable);
+    ).filter(isNotNullOrUndefined);
 
 const isValidTransaction = (tx: ParsedTransactionWithMeta): tx is SolanaValidParsedTxWithMeta =>
     !!(tx && tx.meta && tx.transaction && tx.blockTime);
@@ -380,7 +376,7 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
                     tokenMetadata,
                 ),
             )
-            .filter((tx): tx is Transaction => !!tx);
+            .filter(isNotNullOrUndefined);
 
         const transactions: Transaction[] = await Promise.all(
             page.map(async tx => {

--- a/packages/blockchain-link/src/workers/solana/utils/stakingAccounts.ts
+++ b/packages/blockchain-link/src/workers/solana/utils/stakingAccounts.ts
@@ -14,6 +14,7 @@ import {
 
 import { type SolanaStakingAccount } from '@trezor/blockchain-link-types';
 import { StakeState } from '@trezor/blockchain-link-types';
+import { isNotUndefined } from '@trezor/utils';
 
 export const STAKE_ACCOUNT_V2_SIZE = 200;
 export const FILTER_DATA_SIZE = 200n;
@@ -123,5 +124,5 @@ export const getSolanaStakingData = async (
                 };
             }
         })
-        .filter(account => account !== undefined);
+        .filter(isNotUndefined);
 };

--- a/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
+++ b/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
@@ -46,7 +46,7 @@ export class CoinjoinBackendClient implements CoinjoinBackendClientShape {
         this.logger = settings.logger;
         this.blockbookUrls = arrayShuffle(settings.blockbookUrls, { randomInt: getWeakRandomInt });
         this.onionDomains = settings.onionDomains ?? {};
-        this.blockbookRequestId = Math.floor(Math.random() * settings.blockbookUrls.length);
+        this.blockbookRequestId = getWeakRandomInt(0, settings.blockbookUrls.length);
         this.websockets = new CoinjoinWebsocketController(settings);
 
         // This allows to subscribe to mempool WS disconnecting in this.subscribeMempoolTxs(),

--- a/packages/coinjoin/src/client/Status.ts
+++ b/packages/coinjoin/src/client/Status.ts
@@ -1,5 +1,5 @@
 import type { TimerId } from '@trezor/type-utils';
-import { TypedEmitter } from '@trezor/utils';
+import { TypedEmitter, getWeakRandomInt } from '@trezor/utils';
 
 import * as coordinator from './coordinator';
 import { coordinatorRequest } from './coordinatorRequest';
@@ -214,7 +214,7 @@ export class Status extends TypedEmitter<StatusEvents> {
     async getStatus() {
         if (!this.enabled) return Promise.resolve();
 
-        const identity = this.identities[Math.floor(Math.random() * this.identities.length)];
+        const identity = this.identities[getWeakRandomInt(0, this.identities.length)];
         const status = await coordinator.getStatus({
             baseUrl: this.settings.coordinatorUrl,
             signal: this.abortController.signal,

--- a/packages/coinjoin/src/utils/http.ts
+++ b/packages/coinjoin/src/utils/http.ts
@@ -1,6 +1,6 @@
 import fetch from 'cross-fetch';
 
-import { type ScheduleActionParams, getWeakRandomId } from '@trezor/utils';
+import { type ScheduleActionParams, capitalizeFirstLetter, getWeakRandomId } from '@trezor/utils';
 
 export interface RequestOptions extends ScheduleActionParams {
     method?: 'POST' | 'GET';
@@ -10,8 +10,6 @@ export interface RequestOptions extends ScheduleActionParams {
     userAgent?: string;
 }
 
-const camelCaseToPascalCase = (key: string) => key.charAt(0).toUpperCase() + key.slice(1);
-
 export const patchResponse = (obj: any) => {
     if (Array.isArray(obj)) {
         for (let i = 0; i < obj.length; i++) {
@@ -19,7 +17,7 @@ export const patchResponse = (obj: any) => {
         }
     } else if (obj && typeof obj === 'object') {
         Object.keys(obj).forEach(key => {
-            const newKey = camelCaseToPascalCase(key);
+            const newKey = capitalizeFirstLetter(key);
             obj[newKey] = obj[key];
             if (key !== newKey) {
                 delete obj[key];

--- a/packages/coinjoin/src/utils/roundUtils.ts
+++ b/packages/coinjoin/src/utils/roundUtils.ts
@@ -1,4 +1,4 @@
-import { getWeakRandomNumberInRange } from '@trezor/utils';
+import { clamp, getWeakRandomNumberInRange } from '@trezor/utils';
 import { type Network, Transaction, bufferutils } from '@trezor/utxo-lib';
 
 import {
@@ -69,9 +69,6 @@ export const readTimeSpan = (ts: string) => {
 
     return date.getTime() - now;
 };
-
-const clamp = (value: number, min = Number.NEGATIVE_INFINITY, max = Number.POSITIVE_INFINITY) =>
-    Math.min(Math.max(value, min), max);
 
 export const scheduleDelay = (
     deadline: number,

--- a/packages/components/src/utils/utils.ts
+++ b/packages/components/src/utils/utils.ts
@@ -1,6 +1,7 @@
 import { css } from 'styled-components';
 
 import { type CSSColor } from '@trezor/theme';
+import { clamp } from '@trezor/utils';
 
 export const focusStyleTransition = 'box-shadow 0.1s ease-out, border-color 0.1s ease-out';
 
@@ -18,7 +19,7 @@ export const commonFocusStyles = css`
 
 export const addAlphaToHex = (hex: CSSColor, percent: number): CSSColor => {
     const cleanHex = hex.replace(/^#/, '');
-    const clampedPercent = Math.min(1, Math.max(0, percent));
+    const clampedPercent = clamp(percent, 0, 1);
 
     const normalizedHex =
         cleanHex.length === 3 || cleanHex.length === 4

--- a/packages/connect/src/api/composeTransaction.ts
+++ b/packages/connect/src/api/composeTransaction.ts
@@ -19,6 +19,7 @@ import {
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { promiseAllSequence } from '@trezor/utils/src/promiseAllSequence';
 import { resolveAfter } from '@trezor/utils/src/resolveAfter';
+import { unique } from '@trezor/utils/src/unique';
 import type { ComposeOutput, TransactionInputOutputSortingStrategy } from '@trezor/utxo-lib';
 
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
@@ -262,7 +263,7 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
         context.sendCoreMessage(
             createUiMessage(UI_REQUEST.SELECT_ACCOUNT, {
                 type: 'complete',
-                accountTypes: [...new Set(accounts.map(a => a.type))],
+                accountTypes: unique(accounts.map(a => a.type)),
                 coinInfo,
                 accounts,
             }),

--- a/packages/connect/src/api/getAccountInfo.ts
+++ b/packages/connect/src/api/getAccountInfo.ts
@@ -12,6 +12,7 @@ import type {
 } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { resolveAfter } from '@trezor/utils/src/resolveAfter';
+import { unique } from '@trezor/utils/src/unique';
 
 import { type Blockchain, initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
 import type { MethodContext, MethodMessage, MethodReturnType } from '../core/AbstractMethod';
@@ -334,7 +335,7 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
         context.sendCoreMessage(
             createUiMessage(UI_REQUEST.SELECT_ACCOUNT, {
                 type: 'complete',
-                accountTypes: [...new Set(accounts.map(a => a.type))],
+                accountTypes: unique(accounts.map(a => a.type)),
                 defaultAccountType,
                 coinInfo,
                 accounts,

--- a/packages/connect/src/backend/fees/BitcoinFeeLevels.ts
+++ b/packages/connect/src/backend/fees/BitcoinFeeLevels.ts
@@ -2,6 +2,7 @@
 
 import type { BitcoinNetworkInfo } from '@trezor/connect-common';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
+import { clamp } from '@trezor/utils/src/number';
 
 import type { Blockchain } from '../Blockchain';
 import { MiscFeeLevels } from './MiscFeeLevels';
@@ -33,7 +34,7 @@ export class BitcoinFeeLevels extends MiscFeeLevels {
                 // in case of invalid blockbook response, keep the previous or default data
                 if (isNaN(feePerB) || feePerB < 0) return;
 
-                const trimmedFeePerUnit = Math.min(maxFee, Math.max(minFee, feePerB));
+                const trimmedFeePerUnit = clamp(feePerB, minFee, maxFee);
                 this.levels[index].feePerUnit = trimmedFeePerUnit.toString();
             });
             this.wasFetchedSuccessfully = true;

--- a/packages/connect/src/backend/fees/EthereumFeeLevels.ts
+++ b/packages/connect/src/backend/fees/EthereumFeeLevels.ts
@@ -1,5 +1,6 @@
 import type { EthereumNetworkInfo, FeeLevel } from '@trezor/connect-common';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
+import { clamp } from '@trezor/utils/src/number';
 
 import type { Blockchain } from '../Blockchain';
 import { MiscFeeLevels } from './MiscFeeLevels';
@@ -25,9 +26,7 @@ export class EthereumFeeLevels extends MiscFeeLevels {
             const feeInWei = new BigNumber(response.feePerUnit).toNumber();
 
             // validate gas price from backend; clamp and round to integer wei (backend may return decimal)
-            const feePerUnit = new BigNumber(
-                Math.min(maxFeeInWei, Math.max(minFeeInWei, feeInWei)),
-            ).toFixed(0);
+            const feePerUnit = new BigNumber(clamp(feeInWei, minFeeInWei, maxFeeInWei)).toFixed(0);
 
             if (eip1559?.baseFeePerGas) {
                 const minMaxPriorityFeePerGas = new BigNumber(this.coinInfo.minPriorityFee)

--- a/packages/connect/src/data/firmwareInfo.ts
+++ b/packages/connect/src/data/firmwareInfo.ts
@@ -18,7 +18,12 @@ import {
     getFirmwareOrBootloaderVersionArray,
     getFirmwareVersionArray,
 } from '@trezor/device-utils';
-import { getIntegerInRangeFromString, removeTrailingSlashes, versionUtils } from '@trezor/utils';
+import {
+    getIntegerInRangeFromString,
+    isNotNull,
+    removeTrailingSlashes,
+    versionUtils,
+} from '@trezor/utils';
 import type { VersionArray } from '@trezor/utils/src/versionUtils';
 
 import * as firmwareReleaseStore from './firmwareReleaseStore';
@@ -228,7 +233,7 @@ export const createLocalFirmwareConfig = (baseConfig: FirmwareReleaseConfig) => 
 
             return [modelKey, releases];
         })
-        .filter(entry => entry !== null);
+        .filter(isNotNull);
 
     return Object.fromEntries(releaseEntries);
 };
@@ -263,7 +268,7 @@ export const createRemoteFirmwareConfig = async (config: FirmwareReleaseConfig) 
         },
     );
 
-    const validEntries = (await Promise.all(releaseEntryPromises)).filter(entry => entry !== null);
+    const validEntries = (await Promise.all(releaseEntryPromises)).filter(isNotNull);
 
     return Object.fromEntries(validEntries);
 };

--- a/packages/connect/src/device/resolveDescriptorForTaproot.ts
+++ b/packages/connect/src/device/resolveDescriptorForTaproot.ts
@@ -1,6 +1,6 @@
 import type { HDNodeResponse } from '@trezor/connect-common/src/types/api/getPublicKey';
 import type { MessagesSchema as Messages } from '@trezor/protobuf';
-import { convertTaprootXpub } from '@trezor/utils';
+import { convertTaprootXpub, isNotNull, isNotNullOrUndefined } from '@trezor/utils';
 
 interface ResolveDescriptorForTaprootParams {
     response: HDNodeResponse;
@@ -11,14 +11,14 @@ export const resolveDescriptorForTaproot = ({
     response,
     publicKey,
 }: ResolveDescriptorForTaprootParams) => {
-    if (publicKey.descriptor !== null && publicKey.descriptor !== undefined) {
+    if (isNotNullOrUndefined(publicKey.descriptor)) {
         const [xpub, checksum] = publicKey.descriptor.split('#');
 
         // This is here to keep backwards compatibility, suite and block-books
         // are still using `'` over `h`.
         const correctedXpub = convertTaprootXpub({ xpub, direction: 'h-to-apostrophe' });
 
-        if (correctedXpub !== null) {
+        if (isNotNull(correctedXpub)) {
             return { xpub: correctedXpub, checksum };
         }
     }

--- a/packages/connect/src/device/thp/pairing.ts
+++ b/packages/connect/src/device/thp/pairing.ts
@@ -4,7 +4,7 @@ import type { UiResponseThpPairingTag } from '@trezor/connect-common';
 import { DEVICE } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { ThpPairingMethod, thp as protocolThp } from '@trezor/protocol';
-import { createDeferred } from '@trezor/utils';
+import { createDeferred, resolveAfter } from '@trezor/utils';
 
 import { abortThpWorkflow, thpCall } from './thpCall';
 import * as settingsStore from '../../data/settingsStore';
@@ -207,7 +207,7 @@ const waitForPairingTag = async (device: IDevice) => {
     }
 
     // node-bridge + usb: abort received on client side of http request resolves faster than server. result with "device call in progress"
-    await new Promise(resolve => setTimeout(resolve, 500));
+    await resolveAfter(500);
 
     return processThpPairingResponse(device, pairingResponse).catch(e => {
         // catch pairing tag mismatch

--- a/packages/device-authenticity/src/validateSerialNumbers.ts
+++ b/packages/device-authenticity/src/validateSerialNumbers.ts
@@ -1,3 +1,5 @@
+import { isNotNull } from '@trezor/utils';
+
 import { type ResultsToValidate } from './types';
 
 const failAllResults = ({
@@ -29,7 +31,7 @@ const failAllResults = ({
 export const validateSerialNumbers = (resultsToValidate: ResultsToValidate): ResultsToValidate => {
     const { optigaResult, tropicResult, mcuResult } = resultsToValidate;
 
-    const availableResults = [optigaResult, tropicResult, mcuResult].filter(r => r !== null);
+    const availableResults = [optigaResult, tropicResult, mcuResult].filter(isNotNull);
     // Cannot happen, see authenticateDevice, there'll always be at least failed optigaResult (it's always required).
     if (availableResults.length === 0) return resultsToValidate;
 

--- a/packages/e2e-utils/src/currentsApi/api.ts
+++ b/packages/e2e-utils/src/currentsApi/api.ts
@@ -1,3 +1,5 @@
+import { resolveAfter } from '@trezor/utils';
+
 import { CURRENTS_API_BASE, DEVELOP_BRANCH, TEST_RESULTS_PAGE_SIZE } from './config';
 import { SpecFetchMode } from './types';
 import type {
@@ -45,7 +47,7 @@ export async function currentsRequest<T>(
         warn(
             `  [rate-limit] 429 received for ${url}. Waiting ${waitMs}ms before retry (${retries} left)…`,
         );
-        await new Promise(resolve => setTimeout(resolve, waitMs));
+        await resolveAfter(waitMs);
 
         return currentsRequest<T>(path, options, retries - 1);
     }

--- a/packages/e2e-utils/src/githubReporter/annotationBase.ts
+++ b/packages/e2e-utils/src/githubReporter/annotationBase.ts
@@ -1,3 +1,5 @@
+import { capitalizeFirstLetter } from '@trezor/utils';
+
 import { type TestDetailsAnnotation, type TestMetadataInput } from './types';
 import {
     DeviceModel,
@@ -108,7 +110,7 @@ export abstract class TestReportProviderBase {
             // Capitalize first letter of testProject
             const project = this.testProject;
 
-            return project.charAt(0).toUpperCase() + project.slice(1);
+            return capitalizeFirstLetter(project);
         }
     }
 

--- a/packages/e2e-utils/src/githubReporter/gitHubReporterBase.ts
+++ b/packages/e2e-utils/src/githubReporter/gitHubReporterBase.ts
@@ -1,6 +1,6 @@
 import type { Octokit } from '@octokit/rest';
 
-import { scheduleAction, unique } from '@trezor/utils';
+import { resolveAfter, scheduleAction, unique } from '@trezor/utils';
 
 import { type TestReportProviderBase } from './annotationBase';
 import { GitHubProject } from './gitHubProject';
@@ -381,7 +381,7 @@ abstract class GitHubReporterBase implements LoggingFunctions {
                 // Random delay between 1-5 seconds to distribute load on GitHub API
                 // Without it we often hit "Your attempt to move this item created a temporary conflict. Please try again"
                 const randomDelay = Math.floor(Math.random() * 4000) + 1000; // 1000-5000ms
-                await new Promise(resolve => setTimeout(resolve, randomDelay));
+                await resolveAfter(randomDelay);
                 this.log(
                     `Creating GitHub draft issue for test "(OS ${operationSystem}) ${report.testTitle}"...`,
                 );

--- a/packages/e2e-utils/src/githubReporter/gitHubReporterBase.ts
+++ b/packages/e2e-utils/src/githubReporter/gitHubReporterBase.ts
@@ -1,6 +1,6 @@
 import type { Octokit } from '@octokit/rest';
 
-import { scheduleAction } from '@trezor/utils';
+import { scheduleAction, unique } from '@trezor/utils';
 
 import { type TestReportProviderBase } from './annotationBase';
 import { GitHubProject } from './gitHubProject';
@@ -94,7 +94,7 @@ abstract class GitHubReporterBase implements LoggingFunctions {
 
     protected logInstructionsForRerun(): void {
         const failedCount = this.failedTestFilenames.length;
-        const uniqueFailedFilenames = [...new Set(this.failedTestFilenames)];
+        const uniqueFailedFilenames = unique(this.failedTestFilenames);
 
         this.logError(LOG_VISUAL_SEPARATOR);
         this.logError(`GITHUB REPORTER SUMMARY: ~${failedCount} test(s) failed to report`);

--- a/packages/e2e-utils/src/githubReporter/gitHubReporterBase.ts
+++ b/packages/e2e-utils/src/githubReporter/gitHubReporterBase.ts
@@ -1,6 +1,6 @@
 import type { Octokit } from '@octokit/rest';
 
-import { resolveAfter, scheduleAction, unique } from '@trezor/utils';
+import { getWeakRandomInt, resolveAfter, scheduleAction, unique } from '@trezor/utils';
 
 import { type TestReportProviderBase } from './annotationBase';
 import { GitHubProject } from './gitHubProject';
@@ -380,7 +380,7 @@ abstract class GitHubReporterBase implements LoggingFunctions {
             const issueNodeId = await scheduleAction(async () => {
                 // Random delay between 1-5 seconds to distribute load on GitHub API
                 // Without it we often hit "Your attempt to move this item created a temporary conflict. Please try again"
-                const randomDelay = Math.floor(Math.random() * 4000) + 1000; // 1000-5000ms
+                const randomDelay = getWeakRandomInt(1000, 5000); // 1000-4999ms
                 await resolveAfter(randomDelay);
                 this.log(
                     `Creating GitHub draft issue for test "(OS ${operationSystem}) ${report.testTitle}"...`,

--- a/packages/e2e-utils/src/llmTestSelector/index.ts
+++ b/packages/e2e-utils/src/llmTestSelector/index.ts
@@ -4,6 +4,8 @@ import { createHash } from 'node:crypto';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
+import { unique } from '@trezor/utils';
+
 import { error, log, output } from '../logger';
 import type { CoverageIndex } from '../testCoverage/types';
 
@@ -118,7 +120,7 @@ const getChangedFiles = (headRef = 'HEAD'): string[] => {
         .filter((l: string) => l.length > 0);
 
     // Deduplicate
-    return [...new Set(files)].filter(isAllowedFile);
+    return unique(files).filter(isAllowedFile);
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/e2e-utils/src/quarantineBot/manualQuarantine.ts
+++ b/packages/e2e-utils/src/quarantineBot/manualQuarantine.ts
@@ -1,5 +1,7 @@
 import * as readline from 'readline';
 
+import { isNotUndefined } from '@trezor/utils';
+
 import { extractKeyFromAction } from './actions';
 import { createManualQuarantineAction } from './api';
 import { PROJECTS } from './config';
@@ -76,7 +78,7 @@ export async function quarantineFromRun(
     // if the same test failed in multiple specs within the same run.
     const existingActions = await getAllQuarantineActions(projectId);
     const existingTitleKeys = new Set(
-        existingActions.map(a => extractKeyFromAction(a)).filter(Boolean),
+        existingActions.map(a => extractKeyFromAction(a)).filter(isNotUndefined),
     );
     debug(`existing quarantine actions for project: ${existingActions.length}`);
 

--- a/packages/e2e-utils/src/quarantineBot/quarantine.ts
+++ b/packages/e2e-utils/src/quarantineBot/quarantine.ts
@@ -1,3 +1,5 @@
+import { isNotUndefined } from '@trezor/utils';
+
 import { computeStats, extractKeyFromAction, getTestKey, normalizeTitlePath } from './actions';
 import { createQuarantineAction } from './api';
 import {
@@ -27,7 +29,7 @@ export async function quarantineFailingTests(
     log(`\n── [${projectLabel}] Checking for failing tests to quarantine ──`);
 
     const alreadyQuarantinedKeys = new Set(
-        existingActions.map(a => extractKeyFromAction(a)).filter(Boolean) as string[],
+        existingActions.map(a => extractKeyFromAction(a)).filter(isNotUndefined),
     );
     debug(`  already quarantined keys: ${alreadyQuarantinedKeys.size}`);
 

--- a/packages/e2e-utils/src/testCoverage/selectTestsByChangedFiles.ts
+++ b/packages/e2e-utils/src/testCoverage/selectTestsByChangedFiles.ts
@@ -3,6 +3,8 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as readline from 'node:readline';
 
+import { unique } from '@trezor/utils';
+
 import { error, log, output } from '../logger';
 import type { CoverageIndex } from './types';
 
@@ -159,7 +161,7 @@ const main = async () => {
     const index: CoverageIndex = JSON.parse(fs.readFileSync(coverageMapFile, 'utf8'));
 
     const stdinFiles = await readStdin();
-    const changedFiles = [...new Set([...stdinFiles, ...explicitFiles])];
+    const changedFiles = unique([...stdinFiles, ...explicitFiles]);
 
     if (changedFiles.length === 0) {
         error('No changed files provided. Pipe git diff output or use --files.');

--- a/packages/product-components/src/components/SelectAssetModal/hooks/useNetworkSelect.ts
+++ b/packages/product-components/src/components/SelectAssetModal/hooks/useNetworkSelect.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 
 import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { isNotNull } from '@trezor/utils';
 
 export interface SearchAssetSelectConfig {
     networks: NetworkSymbol[];
@@ -20,7 +21,7 @@ export const useNetworkSelect = (config?: SearchAssetSelectConfig) => {
 
                 return network ? { label: network.name, value: network.symbol } : null;
             })
-            .filter(option => !!option);
+            .filter(isNotNull);
 
         return includeAllOption
             ? [{ label: allLabel ?? 'All networks', value: undefined }, ...networkOptions]

--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -392,7 +392,7 @@ const init = async () => {
         mainWindow?.removeAllListeners();
         logger.exit();
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await resolveAfter(1000);
 
         readyToQuit = true;
         app.quit();

--- a/packages/suite-desktop-core/src/libs/app-utils.ts
+++ b/packages/suite-desktop-core/src/libs/app-utils.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
-import { mergeDeepObject } from '@trezor/utils';
+import { isNotNull, mergeDeepObject } from '@trezor/utils';
 
 import { app } from '../typed-electron';
 
@@ -48,7 +48,7 @@ export const processStatePatch = (): ProcessStatePatchResult =>
     // not using getSwitchValue because this is a very customized way to parse process switches
     process.argv
         .map(arg => arg.match(STATE_ASSIGNMENT_REGEX))
-        .filter(match => match !== null)
+        .filter(isNotNull)
         .map((assignment: RegExpMatchArray) => {
             const [_, key, value] = assignment;
 

--- a/packages/suite-desktop-core/src/libs/logger.ts
+++ b/packages/suite-desktop-core/src/libs/logger.ts
@@ -7,6 +7,7 @@ import path from 'path';
 import { isDevEnv } from '@suite-common/suite-utils';
 import { ensureDirectoryExists } from '@trezor/node-utils';
 import { type TimerId } from '@trezor/type-utils';
+import { isArrayMember } from '@trezor/utils';
 
 import { getBuildInfo, getComputerInfo } from './info';
 import { getSwitchValue, hasSwitch } from './process-switches';
@@ -14,8 +15,7 @@ import { getSwitchValue, hasSwitch } from './process-switches';
 const logLevels = ['mute', 'error', 'warn', 'info', 'debug'] as const;
 
 export type LogLevel = (typeof logLevels)[number];
-const isLogLevel = (level: string): level is LogLevel =>
-    !!level && logLevels.includes(level as LogLevel);
+const isLogLevel = (level: string): level is LogLevel => isArrayMember(level, logLevels);
 
 export type Options = {
     colors: boolean; // Console output has colors

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -26,7 +26,7 @@ import {
     selectHistoricRatesByTransactions,
 } from '@suite-common/wallet-utils';
 import { type StaticSessionId } from '@trezor/connect';
-import { cloneObject } from '@trezor/utils';
+import { cloneObject, isNotNullOrUndefined } from '@trezor/utils';
 
 import { selectCoinjoinAccountByKey } from 'src/reducers/wallet/coinjoinReducer';
 import { db } from 'src/storage';
@@ -295,7 +295,7 @@ export const saveAccountHistoricRates =
     (_dispatch: Dispatch, getState: GetState) => {
         if (!db.isAccessible()) return Promise.resolve();
         const allTxs = getState().wallet.transactions.transactions;
-        const accTxs = (allTxs[accountKey] || []).filter(tx => !!tx);
+        const accTxs = (allTxs[accountKey] || []).filter(isNotNullOrUndefined);
 
         const accHistoricRates = selectHistoricRatesByTransactions(historicRates, accTxs);
 

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -26,7 +26,7 @@ import {
     selectHistoricRatesByTransactions,
 } from '@suite-common/wallet-utils';
 import { type StaticSessionId } from '@trezor/connect';
-import { cloneObject, isNotNullOrUndefined } from '@trezor/utils';
+import { cloneObject, isNotNullOrUndefined, typedObjectKeys } from '@trezor/utils';
 
 import { selectCoinjoinAccountByKey } from 'src/reducers/wallet/coinjoinReducer';
 import { db } from 'src/storage';
@@ -463,13 +463,11 @@ const saveMetadata = async (metadata: Partial<Pick<MetadataState, MetadataPersis
     if (!db.isAccessible()) return;
 
     // remove undefined in metadata arg
-    (Object.keys as unknown as (args: any) => MetadataPersistentKeys[])(metadata).forEach(
-        (key: MetadataPersistentKeys) => {
-            if (typeof metadata[key] === 'undefined') {
-                delete metadata[key];
-            }
-        },
-    );
+    typedObjectKeys(metadata).forEach(key => {
+        if (typeof metadata[key] === 'undefined') {
+            delete metadata[key];
+        }
+    });
     const savedMetadata = await db.getItemByPK('metadata', 'state');
     const nextMetadata = { ...savedMetadata, ...metadata } as Pick<
         MetadataState,

--- a/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldAccountsVisibility.ts
+++ b/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldAccountsVisibility.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 
-import { type Account } from '@suite-common/wallet-types';
 import { sortByCoin } from '@suite-common/wallet-utils';
+import { isNotUndefined } from '@trezor/utils';
 
 import { type YieldAccountOpportunity } from '../types';
 
@@ -39,7 +39,7 @@ export const useYieldAccountsVisibility = ({
             );
             const vaultAccounts = vaultOpportunities
                 .map(opportunity => opportunity.account)
-                .filter((account): account is Account => account !== undefined);
+                .filter(isNotUndefined);
             const [firstAccountByCoinOrder] = sortByCoin([...vaultAccounts]);
 
             const fallbackOpportunity = firstAccountByCoinOrder

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/ExplorerConfigForm.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/ExplorerConfigForm.tsx
@@ -5,6 +5,7 @@ import { Translation } from '@suite/intl';
 import { type Explorer } from '@suite-common/wallet-config';
 import { Button, Column, InfoItem, Input, Row, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
+import { typedObjectKeys } from '@trezor/utils';
 
 import { type useExplorerForm } from 'src/hooks/settings/useExplorerForm';
 
@@ -45,7 +46,7 @@ export const ExplorerConfigForm = ({ form }: ExplorerConfigProps) => {
     const { explorerConfig, setDefaultValues, usesDefaultExplorer, input, explorer } = form;
 
     const explorerKeys = useMemo(() => {
-        const keys = Object.keys(explorer) as (keyof Explorer)[];
+        const keys = typedObjectKeys(explorer);
 
         return keys.filter(key => key !== 'base' && input.fields[key].value !== undefined);
     }, [explorer, input]);

--- a/packages/suite/src/hooks/settings/useExplorerForm.ts
+++ b/packages/suite/src/hooks/settings/useExplorerForm.ts
@@ -4,7 +4,7 @@ import { useForm } from 'react-hook-form';
 import { useTranslation } from '@suite/intl';
 import { type Explorer, type NetworkSymbol } from '@suite-common/wallet-config';
 import { explorerActions } from '@suite-common/wallet-core';
-import { isUrl } from '@trezor/utils';
+import { isUrl, typedObjectKeys } from '@trezor/utils';
 
 import { useDispatch, useSelector } from '../suite';
 
@@ -129,7 +129,7 @@ export const useExplorerForm = (symbol: NetworkSymbol) => {
     const normalizeExplorer = (explorer: Explorer) => {
         const stripSlashes = (value: string): string => value.replace(/^\/+|\/+$/g, '');
 
-        (Object.keys(explorer) as (keyof Explorer)[]).forEach(key => {
+        typedObjectKeys(explorer).forEach(key => {
             if (!explorer[key]) return;
             explorer[key] = stripSlashes(explorer[key]).trim();
         });

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingExchangeHandleChange.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingExchangeHandleChange.ts
@@ -8,6 +8,7 @@ import {
     useTradingRefetchScheduler,
 } from '@suite-common/trading';
 import { type Network } from '@suite-common/wallet-config';
+import { noop } from '@trezor/utils';
 
 import { useDispatch } from 'src/hooks/suite';
 import { useAnalytics } from 'src/support/useAnalytics';
@@ -24,8 +25,6 @@ type TradingExchangeUseHandleChangeProps = {
 type PromiseType = {
     abort: (message?: string) => void;
 } | null;
-
-const noop = () => {};
 
 /**
  * Wrapping the handleRequestThunk to have a better control

--- a/packages/suite/src/hooks/wallet/useSendFormImport.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormImport.ts
@@ -19,6 +19,7 @@ import {
     toFiatCurrency,
 } from '@suite-common/wallet-utils';
 import { type BaseCurrencyCode, baseCurrencies } from '@trezor/blockchain-link-types';
+import { unique } from '@trezor/utils';
 
 import { useDispatch } from 'src/hooks/suite';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
@@ -56,7 +57,7 @@ export const useSendFormImport = ({
         }
 
         const currencies = result.map(it => it.currency.toLowerCase());
-        const uniqueCurrencies = [...new Set(currencies)];
+        const uniqueCurrencies = unique(currencies);
 
         for (const currency of uniqueCurrencies) {
             const fiatRateKey = getFiatRateKey(network.symbol, currency as BaseCurrencyCode);

--- a/packages/suite/src/storage/migrations/legacyVersions/migrateToV56.ts
+++ b/packages/suite/src/storage/migrations/legacyVersions/migrateToV56.ts
@@ -10,6 +10,7 @@ import {
     getContractAddressForNetworkSymbol,
 } from '@suite-common/wallet-utils';
 import { type OnUpgradeFunc } from '@trezor/suite-storage';
+import { isNotUndefined } from '@trezor/utils';
 
 import { type SuiteDBSchema } from 'src/storage/definitions';
 import { type DBWalletAccountTransactionCompatible } from 'src/storage/migrations';
@@ -62,7 +63,7 @@ const findAccountForTrade = (
                 ),
             ) ?? []),
             getNetwork(account.symbol).tradeCryptoId,
-        ].filter(Boolean) as CryptoId[];
+        ].filter(isNotUndefined);
 
         return account.descriptor === address && cryptoIds.includes(cryptoId);
     });

--- a/packages/suite/src/support/suite/Resize.tsx
+++ b/packages/suite/src/support/suite/Resize.tsx
@@ -1,15 +1,14 @@
 import { useEffect } from 'react';
 
 import {
-    type Breakpoint,
     type BreakpointFlagName,
     type BreakpointFlags,
-    type BreakpointValue,
     aboveBreakpoint,
     belowBreakpoint,
     breakpoints,
     getBreakpointFlagNames,
 } from '@trezor/theme';
+import { typedObjectEntries } from '@trezor/utils';
 
 import { updateBreakpoints } from 'src/actions/suite/windowActions';
 import { useDispatch } from 'src/hooks/suite';
@@ -18,22 +17,21 @@ const Resize = () => {
     const dispatch = useDispatch();
 
     useEffect(() => {
-        const queryList: Array<{ mq: MediaQueryList; flag: BreakpointFlagName }> = (
-            Object.entries(breakpoints) as [Breakpoint, BreakpointValue][]
-        ).flatMap(([breakpoint, breakpointValue]) => {
-            const [belowFlag, aboveFlag] = getBreakpointFlagNames(breakpoint);
+        const queryList: Array<{ mq: MediaQueryList; flag: BreakpointFlagName }> =
+            typedObjectEntries(breakpoints).flatMap(([breakpoint, breakpointValue]) => {
+                const [belowFlag, aboveFlag] = getBreakpointFlagNames(breakpoint);
 
-            return [
-                {
-                    mq: window.matchMedia(belowBreakpoint(breakpointValue)),
-                    flag: belowFlag,
-                },
-                {
-                    mq: window.matchMedia(aboveBreakpoint(breakpointValue)),
-                    flag: aboveFlag,
-                },
-            ];
-        });
+                return [
+                    {
+                        mq: window.matchMedia(belowBreakpoint(breakpointValue)),
+                        flag: belowFlag,
+                    },
+                    {
+                        mq: window.matchMedia(aboveBreakpoint(breakpointValue)),
+                        flag: aboveFlag,
+                    },
+                ];
+            });
 
         const initialFlags = queryList.reduce<Partial<BreakpointFlags>>((acc, { mq, flag }) => {
             acc[flag] = mq.matches;

--- a/packages/suite/src/utils/suite/homescreen.ts
+++ b/packages/suite/src/utils/suite/homescreen.ts
@@ -1,6 +1,7 @@
 import { deflateRaw } from 'pako';
 
 import { DeviceModelInternal } from '@trezor/device-utils';
+import { splitStringEveryNCharacters } from '@trezor/utils';
 
 import { HAS_MONOCHROME_SCREEN } from 'src/constants/suite/device';
 import { type TrezorDevice } from 'src/types/suite/index';
@@ -159,14 +160,6 @@ const evenPad = (val: string) => {
     return `0${val}`;
 };
 
-const chunkString = (size: number, str: string) => {
-    const re = new RegExp(`.{1,${size}}`, 'g');
-    const result = str.match(re);
-    if (!result) return [];
-
-    return result;
-};
-
 // Convert RGB to grayscale using the formula grayscale = 0.299 * R + 0.587 * G + 0.114 * B
 const toGrayscale = (red: number, green: number, blue: number): number =>
     Math.round(0.299 * red + 0.587 * green + 0.114 * blue);
@@ -212,7 +205,7 @@ const toig = (imageData: ImageData, deviceModelInternal: DeviceModelInternal) =>
     if (length.length % 2 > 0) {
         length = evenPad(length);
     }
-    length = chunkString(2, length).reverse().join('');
+    length = splitStringEveryNCharacters(length, 2).reverse().join('');
     header += rightPad(8, length);
 
     return header + byteArrayToHexString(packed);

--- a/packages/suite/src/utils/suite/l10n.ts
+++ b/packages/suite/src/utils/suite/l10n.ts
@@ -1,5 +1,6 @@
 import { LANGUAGES, type Locale } from '@suite-common/suite-types';
 import { getPlatformLanguages } from '@trezor/env-utils';
+import { typedObjectKeys } from '@trezor/utils';
 
 const DEFAULT_LOCALE = 'en-US';
 
@@ -12,7 +13,7 @@ export const getOsLocale = (defaultLocale: Locale = DEFAULT_LOCALE): Locale => {
 
     const isLocale = (lang: string): lang is Locale => lang in LANGUAGES;
 
-    const suiteLanguageCodes = Object.keys(LANGUAGES) as Locale[];
+    const suiteLanguageCodes = typedObjectKeys(LANGUAGES);
     for (const platformLanguage of platformLanguages) {
         if (isLocale(platformLanguage)) {
             return platformLanguage;

--- a/packages/suite/src/utils/wallet/exportTransactionsUtils.ts
+++ b/packages/suite/src/utils/wallet/exportTransactionsUtils.ts
@@ -25,7 +25,7 @@ import {
 } from '@suite-common/wallet-utils';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 import { type TransactionTarget } from '@trezor/connect';
-import { BigNumber } from '@trezor/utils';
+import { BigNumber, isNotNull } from '@trezor/utils';
 
 type AccountTransactionForExports = Omit<WalletAccountTransaction, 'targets'> & {
     targets: (TransactionTarget & { metadataLabel?: string })[];
@@ -313,7 +313,7 @@ const prepareContent = (
 
             return [...targets, ...tokens, ...internalTransfers, ...cardanoStaking];
         })
-        .filter(record => record !== null) as Fields[];
+        .filter(isNotNull) as Fields[];
 };
 
 export const sanitizeCsvValue = (value: string) => {

--- a/packages/suite/src/utils/wallet/graph/utils.ts
+++ b/packages/suite/src/utils/wallet/graph/utils.ts
@@ -12,7 +12,7 @@ import { type Account } from '@suite-common/wallet-types';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 import type { BlockchainAccountBalanceHistory, StaticSessionId } from '@trezor/connect';
-import { BigNumber } from '@trezor/utils';
+import { BigNumber, isNotUndefined } from '@trezor/utils';
 
 import { type AppState } from 'src/reducers/store';
 import { type State as GraphState } from 'src/reducers/wallet/graphReducer';
@@ -169,8 +169,8 @@ export const getMinMaxValueFromData = <TType extends TypeName, TValue extends Bi
     const maxValue = BigNumber.max(maxSent, maxReceived, maxBalance);
 
     const minsToCompare = [minSent, minReceived, minBalance]
-        .filter(m => !!m)
-        .map(m => m!.toNumber());
+        .filter(isNotUndefined)
+        .map(m => m.toNumber());
     const minValue = BigNumber.min(...minsToCompare);
 
     return [minValue as TValue, maxValue as TValue];

--- a/packages/suite/src/views/firmware/Steps/StepInitial.tsx
+++ b/packages/suite/src/views/firmware/Steps/StepInitial.tsx
@@ -4,6 +4,7 @@ import { Translation } from '@suite/intl';
 import { selectDevices, selectSelectedDevice } from '@suite-common/device';
 import { type FirmwareStatus } from '@suite-common/suite-types';
 import { Modal, Tooltip } from '@trezor/components';
+import { unique } from '@trezor/utils';
 
 import { updateAnalytics } from 'src/actions/onboarding/onboardingActions';
 import { PrerequisitesGuide } from 'src/components/suite';
@@ -30,7 +31,7 @@ export const StepInitial = ({
 
     const devices = useSelector(selectDevices);
     const devicesConnected = devices.filter(device => device?.connected);
-    const multipleDevicesConnected = [...new Set(devicesConnected.map(d => d.path))].length > 1;
+    const multipleDevicesConnected = unique(devicesConnected.map(d => d.path)).length > 1;
     const shouldCheckSeed = device?.mode !== 'initialize';
 
     if (!device?.connected || !device?.features) {

--- a/packages/suite/src/views/onboarding/steps/FirmwareStep/FirmwareInitialStep.tsx
+++ b/packages/suite/src/views/onboarding/steps/FirmwareStep/FirmwareInitialStep.tsx
@@ -14,6 +14,7 @@ import { type AcquiredDevice } from '@suite-common/suite-types';
 import { type ButtonProps, Card, Column, Link, Note, Row, Tooltip } from '@trezor/components';
 import { FirmwareType } from '@trezor/connect';
 import { DeviceModelInternal, isBitcoinOnlyDevice } from '@trezor/device-utils';
+import { unique } from '@trezor/utils';
 
 import { FirmwareOffer } from 'src/components/firmware';
 import { FirmwareLowBatteryModal } from 'src/components/firmware/FirmwareLowBatteryModal';
@@ -118,7 +119,7 @@ export const FirmwareInitialStep = ({ onClose }: FirmwareInitialStepProps) => {
 
     // todo: move to utils device.ts
     const devicesConnected = devices.filter(device => device?.connected);
-    const multipleDevicesConnected = [...new Set(devicesConnected.map(d => d.path))].length > 1;
+    const multipleDevicesConnected = unique(devicesConnected.map(d => d.path)).length > 1;
 
     // The first condition is a defensive measure against https://github.com/trezor/trezor-suite/issues/17246, I could not reproduce the error.
     const shouldCheckSeed = !isOnboarding && device?.mode !== 'initialize';

--- a/packages/transport/src/errors-groups.ts
+++ b/packages/transport/src/errors-groups.ts
@@ -1,3 +1,5 @@
+import { isArrayMember } from '@trezor/utils';
+
 import * as ERRORS from './errors';
 
 /**
@@ -17,4 +19,4 @@ const ERRORS_WITHOUT_DEVICE_INTERACTION = [
 export const isErrorWithoutDeviceInteraction = (
     error: string,
 ): error is (typeof ERRORS_WITHOUT_DEVICE_INTERACTION)[number] =>
-    ERRORS_WITHOUT_DEVICE_INTERACTION.includes(error as any);
+    isArrayMember(error, ERRORS_WITHOUT_DEVICE_INTERACTION);

--- a/packages/trezor-user-env-link/src/api.ts
+++ b/packages/trezor-user-env-link/src/api.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 
-import { TypedEmitter } from '@trezor/utils';
+import { TypedEmitter, resolveAfter } from '@trezor/utils';
 
 import { type Firmwares, Model } from './types';
 import { WebsocketClient, type WebsocketClientEvents } from './websocket-client';
@@ -257,49 +257,49 @@ export class TrezorUserEnvLinkClass extends TypedEmitter<WebsocketClientEvents> 
         return null;
     }
     async pressYes() {
-        await new Promise(resolve => setTimeout(resolve, EMU_RACE_CONDITION_WORKAROUND_DELAY));
+        await resolveAfter(EMU_RACE_CONDITION_WORKAROUND_DELAY);
         await this.client.send({ type: 'emulator-press-yes' });
 
         return null;
     }
     async pressNo() {
-        await new Promise(resolve => setTimeout(resolve, EMU_RACE_CONDITION_WORKAROUND_DELAY));
+        await resolveAfter(EMU_RACE_CONDITION_WORKAROUND_DELAY);
         await this.client.send({ type: 'emulator-press-no' });
 
         return null;
     }
     async swipeEmu(direction: 'up' | 'down' | 'left' | 'right') {
-        await new Promise(resolve => setTimeout(resolve, EMU_RACE_CONDITION_WORKAROUND_DELAY));
+        await resolveAfter(EMU_RACE_CONDITION_WORKAROUND_DELAY);
         await this.client.send({ type: 'emulator-swipe', direction });
 
         return null;
     }
     async inputEmu(value: string) {
-        await new Promise(resolve => setTimeout(resolve, EMU_RACE_CONDITION_WORKAROUND_DELAY));
+        await resolveAfter(EMU_RACE_CONDITION_WORKAROUND_DELAY);
         await this.client.send({ type: 'emulator-input', value });
 
         return null;
     }
     async clickEmu(options: ClickEmu) {
-        await new Promise(resolve => setTimeout(resolve, EMU_RACE_CONDITION_WORKAROUND_DELAY));
+        await resolveAfter(EMU_RACE_CONDITION_WORKAROUND_DELAY);
         await this.client.send({ type: 'emulator-click', ...options });
 
         return null;
     }
     async resetDevice(options: any) {
-        await new Promise(resolve => setTimeout(resolve, EMU_RACE_CONDITION_WORKAROUND_DELAY));
+        await resolveAfter(EMU_RACE_CONDITION_WORKAROUND_DELAY);
         await this.client.send({ type: 'emulator-reset-device', ...options });
 
         return null;
     }
     async readAndConfirmMnemonicEmu() {
-        await new Promise(resolve => setTimeout(resolve, EMU_RACE_CONDITION_WORKAROUND_DELAY));
+        await resolveAfter(EMU_RACE_CONDITION_WORKAROUND_DELAY);
         await this.client.send({ type: 'emulator-read-and-confirm-mnemonic' });
 
         return null;
     }
     async readAndConfirmShamirMnemonicEmu(options: ReadAndConfirmShamirMnemonicEmu) {
-        await new Promise(resolve => setTimeout(resolve, EMU_RACE_CONDITION_WORKAROUND_DELAY));
+        await resolveAfter(EMU_RACE_CONDITION_WORKAROUND_DELAY);
         await this.client.send({
             type: 'emulator-read-and-confirm-shamir-mnemonic',
             ...options,
@@ -308,7 +308,7 @@ export class TrezorUserEnvLinkClass extends TypedEmitter<WebsocketClientEvents> 
         return null;
     }
     async readAndConfirmAtomicShamirMnemonicEmu(options: ReadAndConfirmAtomicShamirMnemonicEmu) {
-        await new Promise(resolve => setTimeout(resolve, EMU_RACE_CONDITION_WORKAROUND_DELAY));
+        await resolveAfter(EMU_RACE_CONDITION_WORKAROUND_DELAY);
         await this.client.send({
             type: 'emulator-read-and-confirm-atomic-shamir-mnemonic',
             ...options,
@@ -336,7 +336,7 @@ export class TrezorUserEnvLinkClass extends TypedEmitter<WebsocketClientEvents> 
         return null;
     }
     async selectNumOfWordsEmu(num: number) {
-        await new Promise(resolve => setTimeout(resolve, EMU_RACE_CONDITION_WORKAROUND_DELAY * 2));
+        await resolveAfter(EMU_RACE_CONDITION_WORKAROUND_DELAY * 2);
         await this.client.send({ type: 'emulator-select-num-of-words', num });
 
         return null;
@@ -349,7 +349,7 @@ export class TrezorUserEnvLinkClass extends TypedEmitter<WebsocketClientEvents> 
     }
 
     async getDebugState() {
-        await new Promise(resolve => setTimeout(resolve, EMU_RACE_CONDITION_WORKAROUND_DELAY));
+        await resolveAfter(EMU_RACE_CONDITION_WORKAROUND_DELAY);
         const { response } = await this.client.send({ type: 'emulator-get-debug-state' });
 
         return response;

--- a/packages/trezor-user-env-link/src/websocket-client.ts
+++ b/packages/trezor-user-env-link/src/websocket-client.ts
@@ -2,6 +2,7 @@
 
 import fetch from 'cross-fetch';
 
+import { resolveAfter } from '@trezor/utils';
 import {
     WebsocketClient as WebsocketClientBase,
     type WebsocketResponse as WebsocketResponseData,
@@ -21,8 +22,6 @@ const USER_ENV_URL = {
     WEBSOCKET: `ws://127.0.0.1:9001/`,
     DASHBOARD: `http://127.0.0.1:9002`,
 };
-
-const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 export type WebsocketClientEvents = {
     firmwares: Firmwares;
@@ -115,7 +114,7 @@ export class WebsocketClient extends WebsocketClientBase<WebsocketClientEvents> 
             if (i === limit - 1) {
                 console.log(`cant connect to trezor-user-env: ${error}\n`);
             }
-            await delay(1000);
+            await resolveAfter(1000);
 
             try {
                 const res = await fetch(USER_ENV_URL.DASHBOARD);

--- a/packages/utils/src/enumUtils.ts
+++ b/packages/utils/src/enumUtils.ts
@@ -1,3 +1,5 @@
+import { typedObjectKeys } from './typedObject';
+
 type EnumValue = string | number;
 type EnumObject = Record<string, EnumValue>;
 
@@ -5,14 +7,14 @@ type EnumObject = Record<string, EnumValue>;
  * Find enum value and return corresponding key
  */
 export function getKeyByValue<E extends EnumObject>(obj: E, value: E[keyof E]) {
-    return obj && (Object.keys(obj) as (keyof E)[]).find(x => obj[x] === value);
+    return obj && typedObjectKeys(obj).find(x => obj[x] === value);
 }
 
 /**
  * Find enum key and return corresponding value
  */
 export function getValueByKey<E extends EnumObject>(obj: E, enumKey: keyof E) {
-    const key = obj && (Object.keys(obj) as (keyof E)[]).find(x => x === enumKey);
+    const key = obj && typedObjectKeys(obj).find(x => x === enumKey);
 
     return key && obj[key];
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -43,6 +43,7 @@ export * from './isWhitelistedHost';
 export * from './logs';
 export * from './logsManager';
 export * from './mergeDeepObject';
+export * from './noop';
 export * from './objectPartition';
 export * from './parseElectrumUrl';
 export * from './parseHostname';

--- a/packages/utils/src/mergeDeepObject.ts
+++ b/packages/utils/src/mergeDeepObject.ts
@@ -3,6 +3,8 @@
 
 import { type KeysOfUnion } from '@trezor/type-utils';
 
+import { isSafeObjectKey } from './isSafeObjectKey';
+
 type TIndexValue<T, K extends PropertyKey, D = never> = T extends any
     ? K extends keyof T
         ? T[K]
@@ -73,7 +75,7 @@ export const mergeDeepObject = <T extends IObject[]>(...objects: T): TMerged<T[n
         }
 
         Object.keys(current).forEach(key => {
-            if (['__proto__', 'constructor', 'prototype'].includes(key)) {
+            if (!isSafeObjectKey(key)) {
                 return;
             }
 

--- a/packages/utils/src/noop.ts
+++ b/packages/utils/src/noop.ts
@@ -1,0 +1,1 @@
+export const noop = () => {};

--- a/packages/utils/src/number.ts
+++ b/packages/utils/src/number.ts
@@ -3,3 +3,9 @@ export function roundTo(value: number, precision = 2) {
 
     return Math.round(value * x) / x;
 }
+
+export const clamp = (
+    value: number,
+    min = Number.NEGATIVE_INFINITY,
+    max = Number.POSITIVE_INFINITY,
+) => Math.min(Math.max(value, min), max);

--- a/packages/utils/tests/noop.test.ts
+++ b/packages/utils/tests/noop.test.ts
@@ -1,0 +1,16 @@
+import { noop } from '../src/noop';
+
+describe(noop.name, () => {
+    it('returns undefined', () => {
+        expect(noop()).toBeUndefined();
+    });
+
+    it('can be called with any arguments', () => {
+        expect(() => noop()).not.toThrow();
+    });
+
+    it('is assignable as a no-op callback', () => {
+        const fn: (value: string) => void = noop;
+        expect(() => fn('test')).not.toThrow();
+    });
+});

--- a/packages/utils/tests/number.test.ts
+++ b/packages/utils/tests/number.test.ts
@@ -1,0 +1,41 @@
+import { clamp, roundTo } from '../src/number';
+
+describe('clamp', () => {
+    it('value within bounds', () => {
+        expect(clamp(5, 0, 10)).toBe(5);
+    });
+
+    it('value below min', () => {
+        expect(clamp(-5, 0, 10)).toBe(0);
+    });
+
+    it('value above max', () => {
+        expect(clamp(15, 0, 10)).toBe(10);
+    });
+
+    it('default bounds', () => {
+        expect(clamp(0)).toBe(0);
+        expect(clamp(-100)).toBe(-100);
+        expect(clamp(100)).toBe(100);
+    });
+
+    it('value below custom min', () => {
+        expect(clamp(5, 10, 20)).toBe(10);
+    });
+
+    it('value above custom max', () => {
+        expect(clamp(25, 10, 20)).toBe(20);
+    });
+});
+
+describe('roundTo', () => {
+    it('rounds to 2 decimal places by default', () => {
+        expect(roundTo(1.235)).toBe(1.24);
+        expect(roundTo(1.234)).toBe(1.23);
+    });
+
+    it('rounds to specified precision', () => {
+        expect(roundTo(1.2345, 3)).toBe(1.235);
+        expect(roundTo(123.456, 0)).toBe(123);
+    });
+});

--- a/suite-common/calldata/src/validation/createArrayValidator.ts
+++ b/suite-common/calldata/src/validation/createArrayValidator.ts
@@ -1,6 +1,8 @@
+import { isNotNull } from '@trezor/utils';
+
 import { type ValidationResult } from '../types/validation';
 
-const allValid = <T>(values: (T | null)[]): values is T[] => values.every(v => v !== null);
+const allValid = <T>(values: (T | null)[]): values is T[] => values.every(isNotNull);
 
 export const createArrayValidator =
     <Input, Output, Context = Record<string, unknown>>(

--- a/suite-common/calldata/src/validation/createValidator.ts
+++ b/suite-common/calldata/src/validation/createValidator.ts
@@ -1,3 +1,5 @@
+import { isNotNull } from '@trezor/utils';
+
 import { type IssueCode, type ValidationResult } from '../types/validation';
 
 export type ValidateFn<Input> = (input: Input) => IssueCode | null;
@@ -19,7 +21,7 @@ export const createValidator =
     (input: Input, path: string, context?: Context): ValidationResult<Output> => {
         for (const validateFn of config.validate) {
             const code = validateFn(input);
-            if (code !== null) {
+            if (isNotNull(code)) {
                 return { value: null, issues: [{ code, path }] };
             }
         }
@@ -28,7 +30,7 @@ export const createValidator =
 
         const inspectIssues = (config.inspect ?? [])
             .map(inspectFn => inspectFn(normalizedValue, context))
-            .filter((code): code is IssueCode => code !== null)
+            .filter(isNotNull)
             .map(code => ({ code, path }));
 
         return { value: normalizedValue, issues: inspectIssues };

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -26,10 +26,10 @@ import TrezorConnect, {
 } from '@trezor/connect';
 import { isDesktop, isWeb } from '@trezor/env-utils';
 import { DATA_URL } from '@trezor/urls';
-import { capitalizeFirstLetter, getSynchronize } from '@trezor/utils';
+import { capitalizeFirstLetter, getSynchronize, isArrayMember } from '@trezor/utils';
 
 import { blacklist } from './blacklist';
-import { type ConnectKey, type ConnectWebKey } from './types';
+import { type ConnectKey } from './types';
 
 const CONNECT_INIT_MODULE = '@common/connect-init';
 
@@ -149,7 +149,7 @@ export const connectInitThunk = createThunk<void, ConnectInitHooks | void, void>
         const synchronize = getSynchronize();
 
         Object.keys(TrezorConnect)
-            .filter(k => !blacklist.includes(k as ConnectWebKey))
+            .filter(k => !isArrayMember(k, blacklist))
             .forEach(key => {
                 // typescript complains about params and return type, need to be "any"
                 const original: any = TrezorConnect[key as ConnectKey];

--- a/suite-common/fiat-services/src/blockbook.ts
+++ b/suite-common/fiat-services/src/blockbook.ts
@@ -1,4 +1,5 @@
 import type { HistoricRates, TimestampedRates } from '@suite-common/wallet-types';
+import { getWeakRandomInt } from '@trezor/utils';
 
 import { fetchUrl } from './fetch';
 import { RateLimiter } from './limiter';
@@ -11,7 +12,7 @@ const ENDPOINTS = {
 type Ticker = keyof typeof ENDPOINTS;
 
 const randomEndpoint = (ticker: Ticker) =>
-    ENDPOINTS[ticker][Math.floor(Math.random() * ENDPOINTS[ticker].length)];
+    ENDPOINTS[ticker][getWeakRandomInt(0, ENDPOINTS[ticker].length)];
 
 const getQuery = (query?: { currency?: string; timestamp?: number | string }) =>
     Object.entries(query || {})

--- a/suite-common/fiat-services/src/limiter.ts
+++ b/suite-common/fiat-services/src/limiter.ts
@@ -1,4 +1,4 @@
-import { scheduleAction } from '@trezor/utils';
+import { resolveAfter, scheduleAction } from '@trezor/utils';
 
 // Poor man's rate limiter that slows down requests so there is a `delayMs` gap between them.
 export class RateLimiter {
@@ -19,7 +19,7 @@ export class RateLimiter {
 
         this.queue = resultPromise
             .catch(error => console.error(error)) // ensure errors don't stop the queue
-            .then(() => new Promise(res => setTimeout(res, this.delayMs)));
+            .then(() => resolveAfter(this.delayMs));
 
         return resultPromise;
     }

--- a/suite-common/suite-sync/src/owner/createEnsureSuiteSyncOwner.ts
+++ b/suite-common/suite-sync/src/owner/createEnsureSuiteSyncOwner.ts
@@ -1,5 +1,6 @@
 import { type EnsureSuiteSyncOwner } from '@suite-common/suite-sync-types';
 import { ok } from '@trezor/type-utils';
+import { isNotNull } from '@trezor/utils';
 
 import { type LoadSuiteSyncOwnerFromStateDep } from './createLoadSuiteSyncOwnerFromState';
 import { type RetrieveSuiteSyncOwnerKeysDep } from './createRetrieveSuiteSyncOwner';
@@ -21,7 +22,7 @@ export const createEnsureSuiteSyncOwner =
             deviceStaticId: device.state.staticSessionId,
         });
 
-        if (currentSuiteSyncOwner !== null) {
+        if (isNotNull(currentSuiteSyncOwner)) {
             return ok(currentSuiteSyncOwner);
         }
 

--- a/suite-common/suite-sync/src/relay/createChangeRelayUrl.ts
+++ b/suite-common/suite-sync/src/relay/createChangeRelayUrl.ts
@@ -5,6 +5,7 @@ import {
     type SuiteSyncStorageRepositoryDep,
 } from '@suite-common/suite-sync-types';
 import { type StaticSessionId } from '@trezor/connect';
+import { isNotNull } from '@trezor/utils';
 
 import { setSuiteSyncRelayUrl } from '../suiteSyncSlice';
 import { DEFAULT_SUITE_SYNC_RELAY_URL } from './relayUrl';
@@ -30,7 +31,7 @@ export const createChangeRelayUrl =
             const storageId = createStorageIdFromDeviceStaticSessionId(deviceStaticSessionId);
             const storage = deps.suiteSyncStorageRepository.get(storageId);
 
-            if (storage !== null) {
+            if (isNotNull(storage)) {
                 await storage.updateRelayUrl(normalizedUrl);
             }
         }

--- a/suite-common/suite-utils/src/device.ts
+++ b/suite-common/suite-utils/src/device.ts
@@ -11,7 +11,7 @@ import {
 import { DeviceModelInternal, getNarrowedDeviceModelInternal } from '@trezor/device-utils';
 import { exhaustive } from '@trezor/type-utils';
 import * as URLS from '@trezor/urls';
-import { hasProp, isArrayMember, unique } from '@trezor/utils';
+import { hasProp, isArrayMember, isNotNullOrUndefined, unique } from '@trezor/utils';
 
 export const deviceStatuses = [
     'acquired',
@@ -453,7 +453,7 @@ export const getFirstDeviceInstance = (
         .sort(options.sortingFn);
 
 export const getPhysicalDeviceUniqueIds = (devices: TrezorDevice[]) =>
-    unique(devices.map(d => d.id).filter(id => id)) as string[];
+    unique(devices.map(d => d.id).filter(isNotNullOrUndefined));
 
 export const getPhysicalDeviceCount = (devices: TrezorDevice[]) =>
     getPhysicalDeviceUniqueIds(devices).length;

--- a/suite-common/suite-utils/src/device.ts
+++ b/suite-common/suite-utils/src/device.ts
@@ -11,7 +11,7 @@ import {
 import { DeviceModelInternal, getNarrowedDeviceModelInternal } from '@trezor/device-utils';
 import { exhaustive } from '@trezor/type-utils';
 import * as URLS from '@trezor/urls';
-import { hasProp, isArrayMember } from '@trezor/utils';
+import { hasProp, isArrayMember, unique } from '@trezor/utils';
 
 export const deviceStatuses = [
     'acquired',
@@ -453,7 +453,7 @@ export const getFirstDeviceInstance = (
         .sort(options.sortingFn);
 
 export const getPhysicalDeviceUniqueIds = (devices: TrezorDevice[]) =>
-    [...new Set(devices.map(d => d.id))].filter(id => id) as string[];
+    unique(devices.map(d => d.id).filter(id => id)) as string[];
 
 export const getPhysicalDeviceCount = (devices: TrezorDevice[]) =>
     getPhysicalDeviceUniqueIds(devices).length;

--- a/suite-common/token-definitions/scripts/utils/fetchNft.ts
+++ b/suite-common/token-definitions/scripts/utils/fetchNft.ts
@@ -1,4 +1,6 @@
 /* eslint-disable no-console */
+import { unique } from '@trezor/utils';
+
 import {
     AdvancedTokenStructure,
     SimpleTokenStructure,
@@ -57,5 +59,5 @@ export const fetchNftData = async (assetPlatformId: string, structure: TokenStru
         }, {});
     }
 
-    return [...new Set(allData.map(item => item.contract_address))] as SimpleTokenStructure;
+    return unique(allData.map(item => item.contract_address)) as SimpleTokenStructure;
 };

--- a/suite-common/token-definitions/src/tokenDefinitionsUtils.ts
+++ b/suite-common/token-definitions/src/tokenDefinitionsUtils.ts
@@ -6,6 +6,7 @@ import {
 import { getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils';
 import { type TokenInfo } from '@trezor/connect';
 import { isCodesignBuild } from '@trezor/env-utils';
+import { isSafeObjectKey } from '@trezor/utils';
 
 import {
     TOKEN_DEFINITIONS_PREFIX_URL,
@@ -59,11 +60,7 @@ type TokenDefinitionsParameters = [NetworkSymbol, DefinitionType, TokenManagemen
 const getSafeDefinitionParameters = (
     definitionKey: string,
 ): TokenDefinitionsParameters | undefined => {
-    const safeDefinitions = definitionKey
-        .split('-')
-        .filter(
-            definitionPart => !['__proto__', 'constructor', 'prototype'].includes(definitionPart),
-        );
+    const safeDefinitions = definitionKey.split('-').filter(isSafeObjectKey);
 
     if (safeDefinitions.length !== 3) return undefined;
 

--- a/suite-common/trading/src/hooks/useTradingAssets.ts
+++ b/suite-common/trading/src/hooks/useTradingAssets.ts
@@ -19,6 +19,7 @@ import {
 } from '@suite-common/wallet-config';
 import { getCurrencies } from '@trezor/address-validator';
 import { type TokenInfo } from '@trezor/connect';
+import { isNotNull } from '@trezor/utils';
 
 import { TRADING_DEFAULT_CRYPTO_CURRENCY } from '../constants';
 import {
@@ -239,7 +240,7 @@ export function useTradingAssets() {
                         platformInfo: getTradingPlatformsInfoByCryptoId(platforms, cryptoId),
                     }),
                 )
-                .filter(asset => asset !== null);
+                .filter(isNotNull);
 
             const networks = assets.filter(asset => asset.isNativeToken).map(asset => asset.symbol);
 

--- a/suite-common/trading/src/hooks/useTradingRefetchScheduler.ts
+++ b/suite-common/trading/src/hooks/useTradingRefetchScheduler.ts
@@ -1,11 +1,12 @@
 import { useEffect, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 
+import { clamp } from '@trezor/utils';
+
 import { INVITY_API_RELOAD_QUOTES_AFTER_SECONDS } from '../constants';
 import { useSelector } from './useSelector';
 import { tradingActions } from '../reducers/tradingCommonReducer';
 import { selectTradingQuoteRefetchingState } from '../selectors/tradingSelectors';
-import { clamp } from '../utils/numberUtils';
 
 type UseTradingRefetchSchedulerProps = {
     onRefetch: () => void;

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -20,6 +20,7 @@ import {
 import { type Account, type SelectedAccountStatus } from '@suite-common/wallet-types';
 import { getCurrencies } from '@trezor/address-validator';
 import { exhaustive } from '@trezor/type-utils';
+import { unique } from '@trezor/utils';
 
 import { groupTradingExchangeQuotesProjection } from './utils/groupTradingExchangeQuotesProjection';
 import { bestQuotePerPaymentMethodProjection } from './utils/quotePerPaymentMethodProjection';
@@ -467,7 +468,7 @@ const getFilteredCryptoIds = (
 
     const supportedAddressValidatorSymbols = new Set(getCurrencies().map(c => c.symbol));
 
-    const uniqueSupportedCryptoIds = [...new Set(supportedCryptoIds).values()];
+    const uniqueSupportedCryptoIds = unique(supportedCryptoIds);
 
     return uniqueSupportedCryptoIds
         .filter(cryptoId => !!coins[cryptoId])

--- a/suite-common/trading/src/thunks/exchange/loadExchangeInfoThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/loadExchangeInfoThunk.ts
@@ -1,6 +1,7 @@
 import { type CryptoId, type ExchangeProviderInfo } from 'invity-api';
 
 import { createThunk } from '@suite-common/redux-utils';
+import { unique } from '@trezor/utils';
 
 import { TRADING_EXCHANGE_THUNK_PREFIX } from '../../constants';
 import { invityAPI } from '../../invityAPI';
@@ -33,8 +34,8 @@ export const loadExchangeInfoThunk = createThunk<ExchangeInfo>(
 
         return fulfillWithValue({
             providerInfos,
-            buyCryptoIds: [...new Set(buyCryptoIds)],
-            sellCryptoIds: [...new Set(sellCryptoIds)],
+            buyCryptoIds: unique(buyCryptoIds),
+            sellCryptoIds: unique(sellCryptoIds),
         });
     },
 );

--- a/suite-common/trading/src/thunks/sell/loadSellInfoThunk.ts
+++ b/suite-common/trading/src/thunks/sell/loadSellInfoThunk.ts
@@ -1,6 +1,7 @@
 import { type CryptoId, type FiatCurrencyCode, type SellProviderInfo } from 'invity-api';
 
 import { createThunk } from '@suite-common/redux-utils';
+import { unique } from '@trezor/utils';
 
 import { TRADING_SELL_THUNK_PREFIX } from '../../constants';
 import { invityAPI } from '../../invityAPI';
@@ -38,8 +39,8 @@ export const loadSellInfoThunk = createThunk<SellInfo>(
 
         return fulfillWithValue({
             providerInfos,
-            supportedFiatCurrencies: [...new Set(supportedFiatCurrencies)],
-            supportedCryptoCurrencies: [...new Set(supportedCryptoCurrencies)],
+            supportedFiatCurrencies: unique(supportedFiatCurrencies),
+            supportedCryptoCurrencies: unique(supportedCryptoCurrencies),
             country: toTradingCountryCode(sellList.country),
             countrySubdivision: sellList.subdivision,
         });

--- a/suite-common/trading/src/utils/__tests__/numberUtils.test.ts
+++ b/suite-common/trading/src/utils/__tests__/numberUtils.test.ts
@@ -1,34 +1,6 @@
 import { BigNumber } from '@trezor/utils';
 
-import { clamp, formatExchangeRate } from '../numberUtils';
-
-describe('numberUtils', () => {
-    it('clamp - value within bounds', () => {
-        expect(clamp(5, 0, 10)).toBe(5);
-    });
-
-    it('clamp - value below min', () => {
-        expect(clamp(-5, 0, 10)).toBe(0);
-    });
-
-    it('clamp - value above max', () => {
-        expect(clamp(15, 0, 10)).toBe(10);
-    });
-
-    it('clamp - default bounds', () => {
-        expect(clamp(0)).toBe(0);
-        expect(clamp(-100)).toBe(-100);
-        expect(clamp(100)).toBe(100);
-    });
-
-    it('clamp - value below custom min', () => {
-        expect(clamp(5, 10, 20)).toBe(10);
-    });
-
-    it('clamp - value above custom max', () => {
-        expect(clamp(25, 10, 20)).toBe(20);
-    });
-});
+import { formatExchangeRate } from '../numberUtils';
 
 describe('formatExchangeRate', () => {
     it('rate >= 1 uses 3 decimal places', () => {

--- a/suite-common/trading/src/utils/numberUtils.ts
+++ b/suite-common/trading/src/utils/numberUtils.ts
@@ -1,11 +1,5 @@
 import { type BigNumber } from '@trezor/utils';
 
-export const clamp = (
-    value: number,
-    min = Number.NEGATIVE_INFINITY,
-    max = Number.POSITIVE_INFINITY,
-) => Math.min(Math.max(value, min), max);
-
 export const formatExchangeRate = (rate: BigNumber): string => {
     if (rate.isGreaterThanOrEqualTo(1)) {
         return rate.toFixed(3);

--- a/suite-common/transaction-search/src/simpleSearchTransactions.ts
+++ b/suite-common/transaction-search/src/simpleSearchTransactions.ts
@@ -1,6 +1,6 @@
 import { type WalletAccountTransaction } from '@suite-common/wallet-types';
 import { isTokenTransferMatchesSearch } from '@suite-common/wallet-utils';
-import { BigNumber, typedObjectKeys } from '@trezor/utils';
+import { BigNumber, typedObjectKeys, unique } from '@trezor/utils';
 
 import { getTargetAmounts } from './getTargetAmounts';
 import { numberSearchFilter } from './numberSearchFilter';
@@ -202,6 +202,6 @@ export const simpleSearchTransactions = (
 
     // Remove duplicate txIDs
     return transactions.filter(
-        t => [...new Set(txsToSearch)].includes(t.txid) || t.txid.includes(search),
+        t => unique(txsToSearch).includes(t.txid) || t.txid.includes(search),
     );
 };

--- a/suite-common/wallet-config/src/utils.ts
+++ b/suite-common/wallet-config/src/utils.ts
@@ -1,4 +1,5 @@
 import { type NetworkDtoId } from '@suite-common/earn-stablecoin-api';
+import { isArrayMember } from '@trezor/utils';
 
 import { PROD_STAKING_SYMBOLS, type ProdStakingNetworkSymbol, networks } from './networksConfig';
 import {
@@ -171,5 +172,4 @@ export const getNetworkByYieldXyzId = (yieldXyzId: NetworkDtoId) =>
 
 export const isProdStakingNetworkSymbol = (
     symbol: NetworkSymbol,
-): symbol is ProdStakingNetworkSymbol =>
-    PROD_STAKING_SYMBOLS.includes(symbol as ProdStakingNetworkSymbol);
+): symbol is ProdStakingNetworkSymbol => isArrayMember(symbol, PROD_STAKING_SYMBOLS);

--- a/suite-common/wallet-core/src/fees/feesThunks.ts
+++ b/suite-common/wallet-core/src/fees/feesThunks.ts
@@ -3,6 +3,7 @@ import { createThunk } from '@suite-common/redux-utils';
 import { type NetworkSymbol, getNetwork, networksCollection } from '@suite-common/wallet-config';
 import { type FeeInfo, type FeesState } from '@suite-common/wallet-types';
 import TrezorConnect from '@trezor/connect';
+import { resolveAfter } from '@trezor/utils';
 
 import { FEES_MODULE_PREFIX, feesActions } from './feesActions';
 import { getNewFeeInfo, sortLevels } from './feesUtils';
@@ -69,9 +70,7 @@ type UpdateFeeInfoThunkProps = {
 };
 
 const getArtificialDelayPromise = (artificialDelay?: number): Promise<void> =>
-    artificialDelay === undefined
-        ? Promise.resolve()
-        : new Promise(resolve => setTimeout(resolve, artificialDelay));
+    artificialDelay === undefined ? Promise.resolve() : resolveAfter(artificialDelay);
 
 /**
  * Fetches feeInfo for a given network from backend.

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
@@ -26,7 +26,7 @@ import {
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 import TrezorConnect from '@trezor/connect';
 import { type TimerId, exhaustive } from '@trezor/type-utils';
-import { BigNumber, typedObjectKeys } from '@trezor/utils';
+import { BigNumber, isNotUndefined, typedObjectKeys } from '@trezor/utils';
 
 import { FIAT_RATES_MODULE_PREFIX, REFETCH_INTERVAL } from './fiatRatesConstants';
 import { selectTickersToBeUpdated } from './fiatRatesSelectors';
@@ -136,7 +136,7 @@ export const updateTxsFiatRatesThunk = createThunk(
 
         const timestamps = txs
             .map(tx => (tx.blockTime !== undefined ? asTimestamp(tx.blockTime) : undefined))
-            .filter(it => it !== undefined);
+            .filter(isNotUndefined);
 
         await fetchTransactionsRates(
             { symbol: account.symbol },
@@ -167,7 +167,7 @@ export const updateTxsFiatRatesThunk = createThunk(
 
             const tokenTimestamps = groupedTokensTxs[token]
                 .map(tx => (tx.blockTime !== undefined ? asTimestamp(tx.blockTime) : undefined))
-                .filter(it => it !== undefined);
+                .filter(isNotUndefined);
 
             await fetchTransactionsRates(
                 {

--- a/suite-common/wallet-core/src/send/sendFormBitcoinThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormBitcoinThunks.ts
@@ -1,9 +1,6 @@
 import { selectSelectedDevice } from '@suite-common/device';
 import { createThunk } from '@suite-common/redux-utils';
-import {
-    BITCOIN_ONLY_SYMBOLS,
-    type BitcoinOnlySymbolsItemType,
-} from '@suite-common/suite-constants';
+import { BITCOIN_ONLY_SYMBOLS } from '@suite-common/suite-constants';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { BTC_LOCKTIME_SEQUENCE, BTC_RBF_SEQUENCE } from '@suite-common/wallet-constants';
 import {
@@ -29,7 +26,7 @@ import TrezorConnect, {
     type SignTransaction,
     type SignedTransaction,
 } from '@trezor/connect';
-import { BigNumber } from '@trezor/utils';
+import { BigNumber, isArrayMember } from '@trezor/utils';
 
 import { SEND_MODULE_PREFIX } from './sendFormConstants';
 import {
@@ -325,7 +322,7 @@ export const signBitcoinSendFormTransactionThunk = createThunk<
             signEnhancement.unlockPath = selectedAccount.unlockPath;
         }
 
-        if (BITCOIN_ONLY_SYMBOLS.includes(selectedAccount.symbol as BitcoinOnlySymbolsItemType)) {
+        if (isArrayMember(selectedAccount.symbol, BITCOIN_ONLY_SYMBOLS)) {
             // nVersion, use 2 as it enables BIP68 + seems to be the most commonly used (= harder to fingerprint the Trezor)
             signEnhancement.version = 2;
         }

--- a/suite-common/wallet-core/src/transactions/transactionsSelectors.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsSelectors.ts
@@ -28,7 +28,7 @@ import {
     roundTimestampToNearestPastHour,
 } from '@suite-common/wallet-utils';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
-import { typedObjectKeys } from '@trezor/utils';
+import { isNotNullOrUndefined, typedObjectKeys } from '@trezor/utils';
 
 import type { TransactionsRootState } from './transactionsReducerTypes';
 import type { AccountsRootState } from '../accounts/accountsReducer';
@@ -83,7 +83,7 @@ export const selectAccountTransactionsWithNulls = (
 
 export const selectAccountTransactions = createMemoizedSelector(
     [selectAccountTransactionsWithNulls],
-    transactions => returnStableArrayIfEmpty(transactions.filter(t => !!t)),
+    transactions => returnStableArrayIfEmpty(transactions.filter(isNotNullOrUndefined)),
 );
 
 export const selectPendingAccountAddresses = createMemoizedSelector(

--- a/suite-common/wallet-utils/src/fiatRatesUtils.ts
+++ b/suite-common/wallet-utils/src/fiatRatesUtils.ts
@@ -12,7 +12,7 @@ import {
     asTimestamp,
 } from '@suite-common/wallet-types';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
-import { typedObjectKeys } from '@trezor/utils';
+import { typedObjectKeys, unique } from '@trezor/utils';
 
 const ONE_HOUR_IN_SECONDS = 60 * 60;
 
@@ -134,7 +134,7 @@ export const fetchTransactionsRates = async (
     rates: TickerResult[],
 ) => {
     const roundedTimestamps = roundTimestampsToNearestPastHour(timestamps);
-    const uniqueTimestamps = [...new Set(roundedTimestamps)];
+    const uniqueTimestamps = unique(roundedTimestamps);
 
     try {
         const results = await getFiatRatesForTimestamps(

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -28,7 +28,7 @@ import {
     type TokenTransfer,
 } from '@trezor/connect';
 import { type Branded } from '@trezor/type-utils';
-import { BigNumber, arrayPartition, typedObjectKeys } from '@trezor/utils';
+import { BigNumber, arrayPartition, isNotNullOrUndefined, typedObjectKeys } from '@trezor/utils';
 
 import { convertAmountSubunitsToUnits, formatNetworkAmount } from './amountUtils';
 import { isCardanoStakingTx } from './cardanoStakingUtils';
@@ -459,7 +459,7 @@ export const analyzeTransactions = (
     }
 
     // make sure the known transactions are sorted properly
-    const knownSorted = knownRest.filter(tx => tx != null).sort(sortByBlockHeight);
+    const knownSorted = knownRest.filter(isNotNullOrUndefined).sort(sortByBlockHeight);
     // run thru all fresh txs
     fresh.forEach((tx, i) => {
         const height = tx.blockHeight;

--- a/suite-native/atoms/src/AnimatedDoubleView/AnimatedDoubleInput.tsx
+++ b/suite-native/atoms/src/AnimatedDoubleView/AnimatedDoubleInput.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode, type RefObject, useCallback, useRef, useState } from 'react';
 
 import { useUpdateEffect } from '@suite-native/helpers';
+import { noop } from '@trezor/utils';
 
 import {
     ANIMATED_DOUBLE_VIEW_SWITCH_ANIMATION_DURATION,
@@ -20,8 +21,6 @@ export type AnimatedDoubleInputProps = {
     onInputSwitch?: (activeView: ActiveView) => void;
     switchLabel?: string;
 };
-
-const noop = () => {};
 
 export const AnimatedDoubleInput = ({
     renderPrimary,

--- a/suite-native/atoms/src/AnimatedDoubleView/AnimatedDoubleView.tsx
+++ b/suite-native/atoms/src/AnimatedDoubleView/AnimatedDoubleView.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react';
 import Animated, { LinearTransition } from 'react-native-reanimated';
 
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+import { noop } from '@trezor/utils';
 
 import {
     ANIMATION_DURATION,
@@ -28,8 +29,6 @@ const viewsWrapperStyle = prepareNativeStyle(() => ({
     height: ANIMATED_DOUBLE_VIEW_WRAPPER_HEIGHT,
     justifyContent: 'space-between',
 }));
-
-const noop = () => {};
 
 export const AnimatedDoubleView = ({
     renderPrimary,

--- a/suite-native/atoms/src/Input/BottomSheetSearchInput.tsx
+++ b/suite-native/atoms/src/Input/BottomSheetSearchInput.tsx
@@ -5,6 +5,7 @@ import { type TextInput } from 'react-native-gesture-handler';
 import { BottomSheetTextInput } from '@gorhom/bottom-sheet';
 
 import { useNativeStyles } from '@trezor/styles-native';
+import { noop } from '@trezor/utils';
 
 import { Box } from '../Box';
 import { type SurfaceElevation } from '../types';
@@ -28,8 +29,6 @@ export type BottomSheetSearchInputProps = {
 
 export type BottomSheetSearchInputRef = TextInput | null;
 
-const noOp = () => {};
-
 export const BottomSheetSearchInput = forwardRef<
     BottomSheetSearchInputRef,
     BottomSheetSearchInputProps
@@ -41,8 +40,8 @@ export const BottomSheetSearchInput = forwardRef<
             maxLength,
             isDisabled = false,
             elevation = '0',
-            onFocus = noOp,
-            onBlur = noOp,
+            onFocus = noop,
+            onBlur = noop,
             value,
             autoCorrect,
             testId,

--- a/suite-native/atoms/src/ProgressBar.tsx
+++ b/suite-native/atoms/src/ProgressBar.tsx
@@ -1,6 +1,7 @@
 import { View } from 'react-native';
 
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+import { clamp } from '@trezor/utils';
 
 export type ProgressBarProps = {
     value: number;
@@ -16,7 +17,7 @@ const trackStyle = prepareNativeStyle(utils => ({
 
 const fillStyle = prepareNativeStyle((utils, { ratio }: { ratio: number }) => ({
     height: '100%',
-    width: `${Math.max(0, Math.min(100, ratio * 100)).toFixed(0)}%` as `${number}%`,
+    width: `${clamp(ratio * 100, 0, 100).toFixed(0)}%` as `${number}%`,
     backgroundColor: utils.colors.contentBrand,
     borderRadius: utils.borders.radii.r4,
 }));

--- a/suite-native/firmware/src/components/TrezorFacts.tsx
+++ b/suite-native/firmware/src/components/TrezorFacts.tsx
@@ -4,6 +4,7 @@ import Animated, { FadeIn, FadeInUp, FadeOut, FadeOutDown } from 'react-native-r
 import { Text, VStack } from '@suite-native/atoms';
 import { Translation, type TxKeyPath } from '@suite-native/intl';
 import { useNativeStyles } from '@trezor/styles-native';
+import { arrayShuffle, getWeakRandomInt } from '@trezor/utils';
 
 import { firmwareTitlesWrapperStyle } from './FirmwareInstallationProgressTitles';
 
@@ -25,7 +26,9 @@ const FACTS_TRANSLATION_KEYS: TxKeyPath[] = [
 const FACTS_COUNT = FACTS_TRANSLATION_KEYS.length;
 
 // Randomly shuffle facts, so it do not always start with the same fact
-const SHUFFLED_FACTS_TRANSLATION_KEYS = FACTS_TRANSLATION_KEYS.sort(() => Math.random() - 0.5);
+const SHUFFLED_FACTS_TRANSLATION_KEYS = arrayShuffle(FACTS_TRANSLATION_KEYS, {
+    randomInt: getWeakRandomInt,
+});
 
 export const TrezorFacts = () => {
     const { applyStyle } = useNativeStyles();

--- a/suite-native/intl/src/getTranslation.ts
+++ b/suite-native/intl/src/getTranslation.ts
@@ -1,5 +1,7 @@
 import { createIntl, createIntlCache } from 'react-intl';
 
+import { unique } from '@trezor/utils';
+
 import { messages } from './messages';
 import { type TxKeyPath } from './types';
 import { flatten } from './utils';
@@ -60,7 +62,7 @@ export const getTranslation = (
     // Throw an error if translation expects a value that was not provided.
     const placeholderRegex = /\{(\w+)(?:,\s*\w+[^}]*)?}/g;
     const matches = template.matchAll(placeholderRegex);
-    const placeholders = Array.from(new Set(Array.from(matches, m => m[1])));
+    const placeholders = unique(Array.from(matches, m => m[1]));
 
     if (placeholders.length > 0) {
         const providedKeys = values ? Object.keys(values) : [];

--- a/suite-native/module-accounts-import/src/screens/AccountImportLoadingScreen.tsx
+++ b/suite-native/module-accounts-import/src/screens/AccountImportLoadingScreen.tsx
@@ -12,12 +12,11 @@ import {
     useInterceptNativeNavigation,
 } from '@suite-native/navigation';
 import { type AccountInfo } from '@trezor/connect';
+import { resolveAfter } from '@trezor/utils';
 
 import { getAccountInfoThunk } from '../accountsImportThunks';
 import { AccountImportLoader } from '../components/AccountImportLoader';
 import { useShowImportError } from '../useShowImportError';
-
-const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 export const AccountImportLoadingScreen = ({
     navigation,
@@ -58,7 +57,7 @@ export const AccountImportLoadingScreen = ({
         async (onRetry?: () => Promise<void>) => {
             // Delay displaying the error message to avoid freezing the app on iOS. If an error occurs too quickly during the
             // transition from ScanQRCodeModalScreen, the error modal won't appear, resulting in a frozen app.
-            await sleep(1000);
+            await resolveAfter(1000);
             showImportError(error, () => {
                 if (!onRetry) return;
                 onRetry();

--- a/suite-native/module-add-accounts/src/hooks/useAddCoinAccount.ts
+++ b/suite-native/module-add-accounts/src/hooks/useAddCoinAccount.ts
@@ -47,6 +47,7 @@ import {
     type StackToStackCompositeNavigationProps,
 } from '@suite-native/navigation';
 import { exhaustive } from '@trezor/type-utils';
+import { resolveAfter } from '@trezor/utils';
 
 import { useAddCoinAccountAlerts } from './useAddCoinAccountAlerts';
 
@@ -512,7 +513,7 @@ export const useAddCoinAccount = () => {
         if (networkSymbolWithTypeToBeAdded) {
             clearNetworkWithTypeToBeAdded();
             // TODO why timeout?
-            await new Promise(resolve => setTimeout(resolve, 100));
+            await resolveAfter(100);
             await addCoinAccount({
                 symbol: networkSymbolWithTypeToBeAdded[0],
                 accountType: networkSymbolWithTypeToBeAdded[1],

--- a/suite-native/module-add-accounts/src/hooks/useAddCoinAccount.ts
+++ b/suite-native/module-add-accounts/src/hooks/useAddCoinAccount.ts
@@ -47,7 +47,7 @@ import {
     type StackToStackCompositeNavigationProps,
 } from '@suite-native/navigation';
 import { exhaustive } from '@trezor/type-utils';
-import { resolveAfter } from '@trezor/utils';
+import { resolveAfter, typedObjectKeys } from '@trezor/utils';
 
 import { useAddCoinAccountAlerts } from './useAddCoinAccountAlerts';
 
@@ -124,9 +124,9 @@ export const useAddCoinAccount = () => {
 
         networkSymbolCollection.forEach(symbol => {
             // for Cardano and Ethereum only allow latest account type and coinjoin and ledger are not supported
-            const types = Object.keys(networks[symbol].accountTypes).filter(
+            const types = typedObjectKeys(networks[symbol].accountTypes).filter(
                 t => !['coinjoin', 'imported', 'ledger'].includes(t),
-            ) as AccountType[];
+            );
 
             availableTypes.set(symbol, [
                 NORMAL_ACCOUNT_TYPE,

--- a/suite-native/module-earn/src/screens/StakingDetailScreen.tsx
+++ b/suite-native/module-earn/src/screens/StakingDetailScreen.tsx
@@ -10,11 +10,10 @@ import { isStakingSymbol, parseAccountKey } from '@suite-common/wallet-utils';
 import { ContextMessage } from '@suite-native/message-system';
 import { type RootStackParamList, type RootStackRoutes, Screen } from '@suite-native/navigation';
 import { useNativeStyles } from '@trezor/styles-native';
+import { resolveAfter } from '@trezor/utils';
 
 import { StakingDetailScreenHeader } from '../components/StakingDetailScreenHeader';
 import { StakingInfo } from '../components/StakingInfo';
-
-const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 export const StakingDetailScreen = () => {
     const route = useRoute<RouteProp<RootStackParamList, RootStackRoutes.StakingDetail>>();
@@ -33,7 +32,7 @@ export const StakingDetailScreen = () => {
         setIsRefreshing(true);
         await dispatch(initStakeDataThunk());
         // sleep little bit because it's too fast
-        await sleep(1000);
+        await resolveAfter(1000);
         setIsRefreshing(false);
     }, [dispatch]);
 

--- a/suite-native/module-trading/src/components/buy/BuyTradeableAssetPicker.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyTradeableAssetPicker.tsx
@@ -6,6 +6,7 @@ import { selectHasBitcoinOnlyFirmware } from '@suite-common/device';
 import { HStack } from '@suite-native/atoms';
 import { selectBuyTradeableAssets } from '@suite-native/trading-state';
 import { type TradeableAsset } from '@suite-native/trading-types';
+import { noop } from '@trezor/utils';
 
 import { BuyCryptoAmountInput } from './BuyCryptoAmountInput';
 import { BuyTradeableAssetsSheet } from './BuyTradeableAssetsSheet';
@@ -14,8 +15,6 @@ import { useSheetControls } from '../../hooks/general/useSheetControls';
 import { SelectTradeableAssetButton } from '../general/SelectTradeableAssetButton';
 
 const ASSET_PICKER_TEST_ID = '@trading/buy/asset-receive-button';
-
-const noop = () => {};
 
 export const BuyTradeableAssetPicker = () => {
     const inputRef = useRef<TextInput>(null);

--- a/suite-native/module-trading/src/components/exchange/receive/ExchangeReceiveAmountInput.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/ExchangeReceiveAmountInput.tsx
@@ -6,6 +6,7 @@ import { selectTradingExchangeIsLoading } from '@suite-common/trading';
 import { useAmountInputTransformers } from '@suite-native/helpers';
 import { useTranslate } from '@suite-native/intl';
 import { getSymbolFromTradeableAsset } from '@suite-native/trading-atoms';
+import { noop } from '@trezor/utils';
 
 import { useExchangeFormContext } from '../../../hooks/exchange/useExchangeFormContext';
 import { AmountInput } from '../../general/Input/AmountInput';
@@ -15,8 +16,6 @@ export type ExchangeReceiveAmountInputProps = {
 };
 
 const EXCHANGE_RECEIVE_INPUT_TEST_ID = '@trading/exchange/receive-amount-input';
-
-const noop = () => {};
 
 export const ExchangeReceiveAmountInput = forwardRef<TextInput, ExchangeReceiveAmountInputProps>(
     ({ showAssetsSheet }, ref) => {

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeQuotes.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeQuotes.ts
@@ -21,6 +21,7 @@ import { exchangeActions, selectExchangeQuotes } from '@suite-native/trading-sta
 import { type AbortablePromise, type ExchangeFormType } from '@suite-native/trading-types';
 import { type Analytics } from '@trezor/analytics-uploader';
 import { useDebounce } from '@trezor/react-utils';
+import { noop } from '@trezor/utils';
 
 import { tradingExchangeFormToTradingExchangeFormProps } from '../../utils/exchange/quotesUtils';
 import { useQuotesInvalidator } from '../general/useQuotesInvalidator';
@@ -31,8 +32,6 @@ type ShouldFetchExchangeQuotesRef = {
     sendCryptoAmount: string | undefined;
     accountDescriptor: string | undefined;
 };
-
-const noop = () => {};
 
 const defaultState = {
     sendAsset: undefined,

--- a/suite-native/module-trading/src/hooks/general/useTradingTransaction.ts
+++ b/suite-native/module-trading/src/hooks/general/useTradingTransaction.ts
@@ -40,6 +40,7 @@ import {
     usePrecomposedTransactionError,
 } from '@suite-native/transaction-management';
 import TrezorConnect from '@trezor/connect';
+import { noop } from '@trezor/utils';
 
 import { useConsent } from './useConsent';
 import { composeTradingTransactionThunk, signAndPushSendFormTransactionThunk } from '../../thunks';
@@ -289,9 +290,9 @@ export const useTradingTransaction = ({
                             shouldSendInSats,
                             isSlip24Active,
                             nextStep,
-                            processResponseData: processResponseData || (() => {}),
+                            processResponseData: processResponseData || noop,
                             triggerAnalyticsTradeConfirmation:
-                                triggerAnalyticsTradeConfirmation || (() => {}),
+                                triggerAnalyticsTradeConfirmation || noop,
                             signAndPushSendFormTransaction,
                         }),
                     ).unwrap();

--- a/suite-native/module-trading/src/hooks/sell/useSellQuotes.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellQuotes.ts
@@ -16,6 +16,7 @@ import { getSymbolFromTradeableAsset } from '@suite-native/trading-atoms';
 import { sellActions } from '@suite-native/trading-state';
 import { type AbortablePromise, type SellFormType } from '@suite-native/trading-types';
 import { useDebounce } from '@trezor/react-utils';
+import { noop } from '@trezor/utils';
 
 import { tradingSellFormToTradingSellFormProps } from '../../utils/sell/quotesUtils';
 import { useQuotesInvalidator } from '../general/useQuotesInvalidator';
@@ -44,8 +45,6 @@ const defaultState: ShouldFetchSellQuotesRef = {
     countrySubdivision: undefined,
     accountDescriptor: undefined,
 } as const;
-
-const noop = () => {};
 
 const useShouldFetchSellQuotes = ({ watch, control }: SellFormType): ShouldFetchSellQuotes => {
     const prevState = useRef<ShouldFetchSellQuotesRef>(defaultState);

--- a/suite-native/react-native-graph/src/AnimatedLineGraph.tsx
+++ b/suite-native/react-native-graph/src/AnimatedLineGraph.tsx
@@ -30,7 +30,7 @@ import {
     vec,
 } from '@shopify/react-native-skia';
 
-import { hexToRgba } from '@trezor/utils';
+import { clamp, hexToRgba } from '@trezor/utils';
 
 import { BlurOverlay } from './BlurOverlay';
 import {
@@ -361,7 +361,7 @@ export function AnimatedLineGraph<TEventPayload extends object>({
                 (fingerXInRange / getXInRange(drawingWidth, lastDate, pathRange.x)) *
                     (pointsInRange.length - 1),
             );
-            const pointIndex = Math.min(Math.max(index, 0), pointsInRange.length - 1);
+            const pointIndex = clamp(index, 0, pointsInRange.length - 1);
 
             if (pointSelectedIndex.current !== pointIndex) {
                 const dataPoint = pointsInRange[pointIndex];

--- a/suite-native/send/src/sendFormThunks.ts
+++ b/suite-native/send/src/sendFormThunks.ts
@@ -32,7 +32,7 @@ import {
 } from '@suite-native/transaction-management';
 import { type BlockbookTransaction } from '@trezor/blockchain-link-types';
 import { type Ok } from '@trezor/type-utils';
-import { isNotNullOrUndefined, typedObjectKeys } from '@trezor/utils';
+import { isNotNull, isNotNullOrUndefined, typedObjectKeys } from '@trezor/utils';
 
 import { SEND_MODULE_PREFIX } from './constants';
 
@@ -205,7 +205,7 @@ export const sendTransactionThunk = createThunk<
 
         const formValues = selectSendFormDraftByKey(getState(), selectedAccount.key, tokenContract);
 
-        if (formValues !== null) {
+        if (isNotNull(formValues)) {
             await dispatch(
                 addTransactionLabelingThunk({
                     txId: sendResponse.payload.payload.txid,

--- a/suite-native/trading-browser-auth/src/hooks/useBrowserAuth.ts
+++ b/suite-native/trading-browser-auth/src/hooks/useBrowserAuth.ts
@@ -15,6 +15,7 @@ import { useTranslate } from '@suite-native/intl';
 import { captureSentryException } from '@suite-native/sentry';
 import { tradingActions } from '@suite-native/trading-state';
 import { exhaustive } from '@trezor/type-utils';
+import { noop } from '@trezor/utils';
 
 import type { BrowserAuthRet } from './useBrowserAuthTypes';
 import { useBrowserStateChangeCallbacks } from './useBrowserStateChangeCallbacks';
@@ -30,8 +31,6 @@ class BrowserAuthError extends Error {
         this.name = 'BrowserAuthError';
     }
 }
-
-const noop = () => {};
 
 const useLastErrorMessageDispatcher = (tradingType: TradingType | undefined) => {
     const dispatch = useDispatch();

--- a/suite-native/trading-state/src/selectors/buySelectors.ts
+++ b/suite-native/trading-state/src/selectors/buySelectors.ts
@@ -23,6 +23,7 @@ import {
     getReceiveAccountFromAccountAndAddressString,
 } from '@suite-native/trading-atoms';
 import { type BuyFormValues, type FiatCurrencyItem } from '@suite-native/trading-types';
+import { unique } from '@trezor/utils';
 
 import { getAssetByEnabledNetworksFilter } from '../utils';
 import {
@@ -120,7 +121,7 @@ export const selectBuyFormDefaultValues = createMemoizedSelector(
 export const selectBuySupportedFiatCurrenciesList = createMemoizedSelector(
     [selectBuySupportedFiatCurrencies],
     (currencies): FiatCurrencyItem[] =>
-        [...new Set(currencies)].map(code => ({
+        unique(currencies).map(code => ({
             value: code,
             displayValue: code.toUpperCase(),
             label: getCurrencyLabel(code),

--- a/suite-native/trading-state/src/selectors/sellSelectors.ts
+++ b/suite-native/trading-state/src/selectors/sellSelectors.ts
@@ -14,6 +14,7 @@ import {
 } from '@suite-common/trading';
 import { selectAccountByKey } from '@suite-common/wallet-core';
 import { type FiatCurrencyItem, type SellFormValues } from '@suite-native/trading-types';
+import { unique } from '@trezor/utils';
 
 import {
     selectTradingResidenceCountry,
@@ -36,7 +37,7 @@ export const selectSellSupportedFiatCurrencies = (state: TradingRootState) =>
 export const selectSellSupportedFiatCurrenciesList = createMemoizedSelector(
     [selectSellSupportedFiatCurrencies],
     (currencies): FiatCurrencyItem[] =>
-        [...new Set(currencies)].map(code => ({
+        unique(currencies).map(code => ({
             value: code,
             displayValue: code.toUpperCase(),
             label: getCurrencyLabel(code),

--- a/suite-native/transaction-management/src/hooks/usePrecomposedTransactionError.tsx
+++ b/suite-native/transaction-management/src/hooks/usePrecomposedTransactionError.tsx
@@ -3,6 +3,7 @@ import { type ReactNode, useMemo } from 'react';
 import { type NetworkSymbol, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { type PrecomposedTransactionError } from '@suite-common/wallet-types';
 import { Translation } from '@suite-native/intl';
+import { isArrayMember } from '@trezor/utils';
 
 export type UsePrecomposedTransactionErrorProps = {
     error: string | null | undefined;
@@ -25,8 +26,7 @@ const VALID_PRECOMPOSED_ERRORS: PrecomposedTransactionError['error'][] = [
  */
 export const isPrecomposedTransactionError = (
     error: string,
-): error is PrecomposedTransactionError['error'] =>
-    VALID_PRECOMPOSED_ERRORS.includes(error as PrecomposedTransactionError['error']);
+): error is PrecomposedTransactionError['error'] => isArrayMember(error, VALID_PRECOMPOSED_ERRORS);
 
 /**
  * Hook to get precomposed transaction error translation with proper values

--- a/suite-native/transaction-management/src/utils.ts
+++ b/suite-native/transaction-management/src/utils.ts
@@ -1,5 +1,5 @@
 import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
-import { BigNumber } from '@trezor/utils';
+import { BigNumber, isNotNull } from '@trezor/utils';
 
 export const getFeeDecimals = ({ symbol }: { symbol: NetworkSymbol }) => {
     const network = getNetwork(symbol);
@@ -31,7 +31,7 @@ export const getFeeValue = ({
 
     const decimals = getFeeDecimals({ symbol });
 
-    if (decimals !== null) {
+    if (isNotNull(decimals)) {
         return new BigNumber(feeRate).decimalPlaces(decimals, 1 /*ROUND_DOWN*/).toFixed();
     }
 


### PR DESCRIPTION
## Summary

Staging PR consolidating **37 small-duplicate cleanups** from the `gnhf/find-small-duplicate-46eb11` exploration branch, with each commit rewritten to Conventional Commits in English.

**This PR is not intended to be merged as-is.** It is a review surface so we can decide which individual commits to cherry-pick into focused per-package PRs (in the staging style of #27551 / #27529).

Each commit replaces a locally-duplicated inline pattern with a shared utility from `@trezor/utils` (`unique`, `clamp`, `resolveAfter`, `noop`, `isNotNull`, `isNotUndefined`, `isNotNullOrUndefined`, `getWeakRandomInt`, `arrayShuffle`, `splitStringEveryNCharacters`, `typedObjectKeys`, `typedObjectEntries`, `isSafeObjectKey`, `isArrayMember`, `capitalizeFirstLetter`, `removeTrailingSlashes`). Two commits also **add a new shared utility** to `@trezor/utils` and adopt it at the original duplication sites (`clamp`, `noop`).

## How to use this PR

1. Review individual commits in the file changes / commits tab.
2. For each commit we want to land: open a small per-package or per-utility PR cherry-picking just that commit (or a tight group), targeting `develop` directly.
3. Close this PR once all desired commits have been promoted (or keep open as a tracker).

## Commits (chronological, oldest first)

- 994a94ef1b refactor: use unique() from @trezor/utils in send-form helpers
- 1cdf227b07 feat(utils): add clamp helper and adopt in coinjoin and trading
- ce718818da refactor: use resolveAfter from @trezor/utils instead of inline sleep
- eb30bef2cf refactor(blockchain-link): use isNotNullOrUndefined from @trezor/utils
- 6554d6f591 refactor: use capitalizeFirstLetter from @trezor/utils
- 61167cb679 feat(utils): add noop helper and replace local duplicates
- 03b776df8c refactor: adopt isNotNull/isNotUndefined/noop from @trezor/utils in blockchain-link and atoms
- 946fb8e1de refactor: use isNotNull/isNotUndefined from @trezor/utils in filter callbacks
- 69fd9c5840 refactor: adopt shared unique and clamp from @trezor/utils
- 4e9c7b7ac7 refactor: use unique and isNotNull from @trezor/utils
- bf0f288589 refactor(e2e-utils): use unique() from @trezor/utils
- ee65993c25 refactor: use unique and clamp from @trezor/utils
- caf1ec56a1 refactor: use unique and resolveAfter from @trezor/utils
- 88501c3b32 refactor: use resolveAfter from @trezor/utils in test helpers
- bac5486281 refactor: adopt shared utils across desktop, connect and analytics
- 004e2b4a37 refactor: use resolveAfter and unique from @trezor/utils
- 3e303fad37 refactor: adopt shared utils (unique, resolveAfter, isNotNull, isNotNullOrUndefined) from @trezor/utils
- 762fc567ac refactor: use unique and isNotNullOrUndefined from @trezor/utils
- 2e9fb7183a refactor: use shared filter predicates from @trezor/utils
- 5819ef7c66 refactor: adopt shared utils (isNotNull, getWeakRandomInt, isNotNullOrUndefined)
- be475769cb refactor(blockchain-link): use isNotNullOrUndefined in worker filters
- 2c8bd53851 refactor: use getWeakRandomInt from @trezor/utils
- 7fde77561c refactor(suite): use splitStringEveryNCharacters from @trezor/utils for homescreen
- d2f76a6719 refactor(suite-native): use arrayShuffle from @trezor/utils for TrezorFacts
- e2242474c7 refactor: use isSafeObjectKey from @trezor/utils
- 9443e59946 refactor(suite): use typedObjectKeys from @trezor/utils
- 8d3e08d87a refactor: use typedObjectKeys from @trezor/utils in transport-bluetooth
- 4cdf303440 refactor: use typedObjectKeys from @trezor/utils
- d5fa72bcef refactor: use typedObjectKeys and unique from @trezor/utils
- fe5bae6593 refactor(suite): use typed object iteration helpers from @trezor/utils
- bd9a76b406 refactor(analytics-docs): use removeTrailingSlashes from @trezor/utils
- 80ffa339dd refactor: use isNotNullOrUndefined and isNotNull from @trezor/utils
- b8cfa4c095 refactor: use isNotNull from @trezor/utils for null guards
- 594bd95462 refactor: use noop and isArrayMember from @trezor/utils in trading
- 2575c0d8d1 refactor: use isArrayMember from @trezor/utils for safe includes
- 4627599b5f refactor: use isArrayMember from @trezor/utils for safe includes
- b6d1652b41 refactor: use isNotUndefined from @trezor/utils for filter(Boolean) patterns


## Notes

- Commit order matches the source branch chronology. Some commits depend on earlier ones (e.g. the `clamp` and `noop` adoption commits depend on the corresponding `feat(utils):` commits that introduce the utility) — keep those pairs grouped if cherry-picking.
- No automated checks have been run on the combined branch; per-package PRs will exercise their own typecheck/tests. Individual source commits had local `lint`/`type-check`/unit tests reported green by the author.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/staging-find-small-duplicate&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/staging-find-small-duplicate&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/staging-find-small-duplicate&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/staging-find-small-duplicate/web/](https://dev.suite.sldev.cz/suite-web/mroz22/staging-find-small-duplicate/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->