### PR TITLE
fix(suite-native): fix unchunked short format

### DIFF
--- a/suite-common/formatters/src/formatters/AddressFormatter.ts
+++ b/suite-common/formatters/src/formatters/AddressFormatter.ts
@@ -25,7 +25,7 @@ export const AddressFormatter = makeFormatter<string, string, AddressFormatterDa
                 case 'long':
                     return [prefix, beginning, TRUNCATION_PLACEHOLDER, end];
                 case 'short':
-                    return [prefix, beginning?.split(' ')[0], TRUNCATION_PLACEHOLDER, end];
+                    return [prefix, beginning?.slice(0, 4), TRUNCATION_PLACEHOLDER, end];
             }
         })();
 

--- a/suite-common/formatters/src/formatters/tests/AddressFormatter.test.ts
+++ b/suite-common/formatters/src/formatters/tests/AddressFormatter.test.ts
@@ -80,10 +80,10 @@ describe('AddressFormatter', () => {
         );
 
         it.each([
-            ['EVM', EVM_ADDRESS, '0xde0B2956...cb697BAe'],
-            ['BTC', BTC_ADDRESS, 'bc1qar0s...wf5mdq'],
-            ['ADA', ADA_ADDRESS, 'addr1qyu...spd3k22'],
-            ['SOL', SOL_ADDRESS, '14CCvQzQ...cdfbZVBS'],
+            ['EVM', EVM_ADDRESS, '0xde0B...cb697BAe'],
+            ['BTC', BTC_ADDRESS, 'bc1q...wf5mdq'],
+            ['ADA', ADA_ADDRESS, 'addr...spd3k22'],
+            ['SOL', SOL_ADDRESS, '14CC...cdfbZVBS'],
         ])(
             'returns continuous string with truncation for %s when isChunked is false',
             (_label, address, expected) => {


### PR DESCRIPTION
## Description
The SHORT address format without chunking was displaying the extra fragment. This PR fixes that.

## Related Issue

Related to #23986 

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file `suite-common/formatters/src/formatters/AddressFormatter.ts` is a formatter utility for addresses. No static test coverage mapping exists for this file, and none of the E2E test analyses reference AddressFormatter directly in their source hints. While address formatting is used broadly across the application (receive flows, send flows, device prompt displays), the E2E tests interact with addresses at the UI level through page objects and device prompts rather than directly importing AddressFormatter. Without concrete evidence that any specific test's code path exercises AddressFormatter in a way that would surface a regression, recommending tests would be speculative. The risk is low-to-moderate since address formatting bugs would likely be visible in multiple flows, but no specific E2E test can be confidently linked to this change.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/formatters/src/formatters/AddressFormatter.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `suite-common/formatters/src/formatters/AddressFormatter.ts`

_Updated: 2026-05-11T07:50:58.242Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/address-chunking-bugs&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/address-chunking-bugs&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/address-chunking-bugs&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-11T07:56:23.218Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-11T07:53:43.267Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/native/address-chunking-bugs/web/](https://dev.suite.sldev.cz/suite-web/fix/native/address-chunking-bugs/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->