### PR TITLE
fix(ci): Testing configuration to find problematic test

### DIFF
--- a/.github/workflows/test-suite-native-e2e-android.yml
+++ b/.github/workflows/test-suite-native-e2e-android.yml
@@ -65,13 +65,142 @@ jobs:
 
   run_android_e2e_tests:
     if: github.repository == 'trezor/trezor-suite' && needs.check-previous-runs.outputs.skip_tests != 'true'
-    uses: ./.github/workflows/template-suite-native-e2e-android.yml
     needs: [prepare_android_test_app, check-previous-runs]
-    with:
-      publish_results_to_github: ${{ inputs.publish_results_to_github == true }}
-    secrets:
-      TREZOR_BOT_APP_ID: ${{ secrets.TREZOR_BOT_APP_ID }}
-      TREZOR_BOT_PRIVATE_KEY: ${{ secrets.TREZOR_BOT_PRIVATE_KEY }}
-      CURRENTS_RECORD_KEY: ${{ secrets.CURRENTS_RECORD_KEY }}
-      CURRENTS_API_KEY: ${{ secrets.CURRENTS_API_KEY }}
-      E2E_TEST_PASSPHRASE: ${{ secrets.E2E_TEST_PASSPHRASE }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - project: suite-sync
+          - project: entropy-check
+          - project: device-onboarding
+          - project: others-accounts-import
+          - project: app-settings
+
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: "true"
+
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
+        with:
+          dotnet: true
+          haskell: true
+          tool-cache: false
+          android: false
+          swap-storage: false
+          large-packages: false
+
+      - name: Install node and yarn
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: yarn
+
+      - name: Load node modules cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: node_modules
+          key: node_modules-${{ hashFiles('yarn.lock') }}
+          restore-keys: node_modules-
+
+      - name: Install Yarn dependencies
+        run: |
+          echo -e "\nenableScripts: false" >> .yarnrc.yml
+          echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
+          yarn install
+
+      - name: Sign message system config
+        working-directory: ./suite-common/message-system
+        run: yarn sign-config
+
+      - name: Generate GitHub App token
+        id: trezor-bot-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        with:
+          client-id: ${{ secrets.TREZOR_BOT_APP_ID }}
+          private-key: ${{ secrets.TREZOR_BOT_PRIVATE_KEY }}
+
+      - name: Extract Release Build
+        id: extract_branch
+        shell: bash
+        run: |
+          echo "release_build=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}-${GITHUB_SHA:0:7}" >> $GITHUB_ENV
+
+      - name: Get device name from detox config file
+        id: device
+        run: node -e "console.log('AVD_NAME=' + require('./suite-native/app/.detoxrc').devices.emulator.device.avdName)" >> $GITHUB_OUTPUT
+
+      - name: Run trezor-user-env
+        env:
+          COMPOSE_FILE: ./docker/docker-compose.suite-native-ci.yml
+        run: |
+          docker compose pull trezor-user-env-unix trezor-user-env-regtest quota-db suite-sync
+          docker compose up --detach trezor-user-env-unix trezor-user-env-regtest quota-db suite-sync
+
+      - name: Download Android build artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: android-test-build-${{ github.run_id }}
+          path: suite-native/app/android/app/build/
+
+      - name: Enable Android emulator KVM optimalization
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Run Detox E2E Android tests (${{ matrix.project }})
+        uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2
+        env:
+          RUNNER_TEMP: /tmp
+          GITHUB_TOKEN: ${{ steps.trezor-bot-token.outputs.token }}
+          RELEASE_BUILD: ${{ env.release_build }}
+          PUBLISH_RESULTS_TO_GITHUB: ${{ inputs.publish_results_to_github == true }}
+          TRADING_ACADEMIC_SEED_WALLET_PASSPHRASE: ${{ secrets.E2E_TEST_PASSPHRASE }}
+          GITHUB_ACTION: true
+          CURRENTS_PROJECT_ID: iUe1Y4
+          CURRENTS_RECORD_KEY: ${{ secrets.CURRENTS_RECORD_KEY }}
+          CURRENTS_API_KEY: ${{ secrets.CURRENTS_API_KEY }}
+          CURRENTS_CI_BUILD_ID: pr-run-${{ github.run_id }}-${{ github.run_attempt }}
+          COMMIT_INFO_BRANCH: ${{ github.head_ref }}
+        with:
+          api-level: 31
+          profile: pixel_3a
+          arch: x86_64
+          working-directory: suite-native/app
+          ram-size: 4096M
+          force-avd-creation: true
+          avd-name: ${{ steps.device.outputs.AVD_NAME }}
+          emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -grpc 8554
+          script: |
+            yarn test:e2e --config=e2e/trezorDetoxRunner/config/runner-android-release-pr.config.js --project=${{ matrix.project }} --headless --quarantine
+
+      - name: Post Currents link
+        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
+        uses: ./.github/actions/post-currents-link
+        with:
+          github_token: ${{ steps.trezor-bot-token.outputs.token }}
+          project: "native android"
+          currents-project-id: "iUe1Y4"
+
+      - name: Extract Trezor-user-env and Regtest logs
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          LOG_DIR="suite-native/app/artifacts"
+          docker cp trezor-user-env.unix:/trezor-user-env/logs/debugging.log "$LOG_DIR/trezor-user-env-debugging.log" || true
+          docker cp trezor-user-env.unix:/trezor-user-env/logs/emulator_bridge.log "$LOG_DIR/tenv-emulator-bridge-debugging.log" || true
+          docker cp trezor-user-env.unix:/trezor-user-env/docker/version.txt "$LOG_DIR/trezor-user-env-version.txt" || true
+          docker logs trezor-user-env-regtest > "$LOG_DIR/electrum-regtest.txt" || true
+
+      - name: "Store test artifacts"
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: android-tests-${{ matrix.project }}
+          path: suite-native/app/artifacts
+          retention-days: 14

--- a/suite-native/app/e2e/trezorDetoxRunner/config/runner-android-release-pr.config.js
+++ b/suite-native/app/e2e/trezorDetoxRunner/config/runner-android-release-pr.config.js
@@ -1,0 +1,47 @@
+const target = 'android.emu.release';
+
+/*
+ * Android Release PR config
+ * Temporary config — one project per spec so each CI worker runs exactly one test suite.
+ * Remove this file and revert the workflow change when no longer needed.
+ */
+/** @type {import('../types').RunnerConfig} */
+module.exports = {
+    projects: [
+        {
+            projectName: 'suite-sync',
+            target,
+            model: 'T3T1',
+            firmwareVersion: '2-latest',
+            grep: '^Suite Sync - Labelling',
+        },
+        {
+            projectName: 'entropy-check',
+            target,
+            model: 'T3T1',
+            firmwareVersion: '2-latest',
+            grep: '^Simulated entropy check failure on T3T1',
+        },
+        {
+            projectName: 'device-onboarding',
+            target,
+            model: 'T3T1',
+            firmwareVersion: '2-latest',
+            grep: '^Device onboarding',
+        },
+        {
+            projectName: 'others-accounts-import',
+            target,
+            model: undefined,
+            firmwareVersion: undefined,
+            grep: '^Import accounts of other networks',
+        },
+        {
+            projectName: 'app-settings',
+            target,
+            model: undefined,
+            firmwareVersion: undefined,
+            grep: '^App Settings - without device interactions',
+        },
+    ],
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** No relevant source file changes detected against origin/develop.

_No test recommendations found._

_Updated: 2026-05-11T08:25:55.184Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-android-test-freeze&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-android-test-freeze&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-e2e-android-test-freeze&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-11T08:31:17.257Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-11T08:29:36.841Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-e2e-android-test-freeze/web/](https://dev.suite.sldev.cz/suite-web/fix-e2e-android-test-freeze/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->