### PR TITLE
feat(suite-native): show coin price card on token detail screens

### DIFF
--- a/suite-native/formatters/src/components/BaseCurrencyAmountFormatter.tsx
+++ b/suite-native/formatters/src/components/BaseCurrencyAmountFormatter.tsx
@@ -17,6 +17,7 @@ type FiatAmountFormatterProps = FormatterProps<BaseCurrencyAmount | null> &
         isDiscreetText?: boolean;
         isForcedDiscreetMode?: boolean;
         isLoading?: boolean;
+        maximumFractionDigits?: number;
     };
 
 export const BaseCurrencyAmountFormatter = React.memo(
@@ -27,6 +28,7 @@ export const BaseCurrencyAmountFormatter = React.memo(
         isDiscreetText = true,
         isLoading = false,
         isForcedDiscreetMode,
+        maximumFractionDigits,
         ...otherProps
     }: FiatAmountFormatterProps) => {
         const { BaseCurrencyAmountFormatter: formatter } = useFormatters();
@@ -39,7 +41,9 @@ export const BaseCurrencyAmountFormatter = React.memo(
         }
 
         // in case of isForceDiscreetMode the value is blurred, so the real value does not matter
-        const formattedValue = isForcedDiscreetMode ? '$0.00' : formatter.format(value!);
+        const formattedValue = isForcedDiscreetMode
+            ? '$0.00'
+            : formatter.format(value!, { maximumFractionDigits });
 
         return (
             <AmountText

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2038,7 +2038,7 @@ export const messages = {
         },
         accountDetailContentScreen: {
             coinPriceCard: {
-                changeIn24h: '24h change',
+                changeIn7d: '7d change',
                 coinPrice: '{coinName} price',
             },
         },

--- a/suite-native/module-accounts-management/src/components/CoinPriceCard.tsx
+++ b/suite-native/module-accounts-management/src/components/CoinPriceCard.tsx
@@ -2,17 +2,19 @@ import { useSelector } from 'react-redux';
 
 import { getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
 import { type AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
-import { type AccountKey } from '@suite-common/wallet-types';
+import { type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
 import { Box, Card, PriceChangeBadge, Text } from '@suite-native/atoms';
 import { BaseCurrencyAmountFormatter } from '@suite-native/formatters';
 import { CryptoIconWithNetwork } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
+import { type TokensRootState, selectAccountTokenInfo } from '@suite-native/tokens';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 import { useDayCoinPriceChange } from '../hooks/useDayCoinPriceChange';
 
 type CoinPriceCardProps = {
     accountKey: AccountKey;
+    tokenContract?: TokenAddress;
 };
 
 type PriceChangeIndicatorProps = {
@@ -48,36 +50,41 @@ const PriceChangeIndicator = ({ valuePercentageChange }: PriceChangeIndicatorPro
     return (
         <Box style={applyStyle(indicatorContainer)}>
             <Text variant="body-xs" color="contentSecondary">
-                <Translation id="moduleAccountManagement.accountDetailContentScreen.coinPriceCard.changeIn24h" />
+                <Translation id="moduleAccountManagement.accountDetailContentScreen.coinPriceCard.changeIn7d" />
             </Text>
             <PriceChangeBadge valuePercentageChange={valuePercentageChange} />
         </Box>
     );
 };
 
-export const CoinPriceCard = ({ accountKey }: CoinPriceCardProps) => {
+export const CoinPriceCard = ({ accountKey, tokenContract }: CoinPriceCardProps) => {
     const { applyStyle } = useNativeStyles();
 
     const symbol = useSelector((state: AccountsRootState) =>
         selectAccountNetworkSymbol(state, accountKey),
     );
-    const { currentValue, valuePercentageChange } = useDayCoinPriceChange(symbol);
+    const token = useSelector((state: TokensRootState) =>
+        selectAccountTokenInfo(state, accountKey, tokenContract),
+    );
+    const { currentValue, valuePercentageChange } = useDayCoinPriceChange(symbol, tokenContract);
 
     if (!symbol) return null;
 
-    const coinName = getNetworkDisplaySymbolName(symbol);
+    const tokenName = token?.name ?? token?.symbol;
+    const mainnetName = getNetworkDisplaySymbolName(symbol);
+    const assetName = tokenName ?? mainnetName;
 
     return (
         <Card style={applyStyle(cardStyle)}>
             <Box flexDirection="row" alignItems="center" flex={1}>
                 <Box marginRight="sp16">
-                    <CryptoIconWithNetwork symbol={symbol} />
+                    <CryptoIconWithNetwork symbol={symbol} contractAddress={tokenContract} />
                 </Box>
                 <Box style={applyStyle(cardContentStyle)}>
                     <Text variant="body-xs" color="contentSecondary">
                         <Translation
                             id="moduleAccountManagement.accountDetailContentScreen.coinPriceCard.coinPrice"
-                            values={{ coinName }}
+                            values={{ coinName: assetName }}
                         />
                     </Text>
                     <BaseCurrencyAmountFormatter
@@ -87,6 +94,7 @@ export const CoinPriceCard = ({ accountKey }: CoinPriceCardProps) => {
                         isDiscreetText={false}
                         numberOfLines={1}
                         adjustsFontSizeToFit
+                        maximumFractionDigits={tokenContract ? 8 : 2}
                     />
                 </Box>
             </Box>

--- a/suite-native/module-accounts-management/src/components/TransactionListHeader.tsx
+++ b/suite-native/module-accounts-management/src/components/TransactionListHeader.tsx
@@ -154,8 +154,7 @@ export const TransactionListHeader = memo(
             });
         };
 
-        const isTokenDetail = !!tokenContract;
-        const isPriceCardDisplayed = shallDisplayBaseCurrency && !isTokenDetail;
+        const isPriceCardDisplayed = shallDisplayBaseCurrency;
         const isStellarAccount = account.networkType === 'stellar';
 
         const isSendButtonDisplayed = isNetworkSendFlowEnabled && !isPortfolioTrackerDevice;
@@ -201,7 +200,9 @@ export const TransactionListHeader = memo(
                             )}
                         </HStack>
                     )}
-                    {isPriceCardDisplayed && <CoinPriceCard accountKey={accountKey} />}
+                    {isPriceCardDisplayed && (
+                        <CoinPriceCard accountKey={accountKey} tokenContract={tokenContract} />
+                    )}
                     {isStellarTokenActionsDisplayed && (
                         <StellarTokenActions
                             accountKey={accountKey}

--- a/suite-native/module-accounts-management/src/hooks/useDayCoinPriceChange.ts
+++ b/suite-native/module-accounts-management/src/hooks/useDayCoinPriceChange.ts
@@ -10,16 +10,23 @@ import {
     selectBaseCurrency,
     selectIsElectrumBackendSelected,
 } from '@suite-common/wallet-core';
-import { type BaseCurrencyAmount, asBaseCurrencyAmount } from '@suite-common/wallet-types';
+import {
+    type BaseCurrencyAmount,
+    type TokenAddress,
+    asBaseCurrencyAmount,
+} from '@suite-common/wallet-types';
 import { percentageDiff } from '@suite-native/graph';
 import { BigNumber, isNotNullOrUndefined } from '@trezor/utils';
 
 const UNIX_DAY = 24 * 60 * 60;
 const REFRESH_INTERVAL = 30_000;
 
-export const useDayCoinPriceChange = (symbol?: NetworkSymbol | null) => {
+export const useDayCoinPriceChange = (
+    symbol?: NetworkSymbol | null,
+    tokenContract?: TokenAddress,
+) => {
     const [currentValue, setCurrentValue] = useState<BaseCurrencyAmount | null>(null);
-    const [yesterdayValue, setYesterdayValue] = useState<number | null>(null);
+    const [weekAgoValue, setWeekAgoValue] = useState<number | null>(null);
     const [valuePercentageChange, setValuePercentageChange] = useState<number | null>(null);
 
     const fiatCurrencyCode = useSelector(selectBaseCurrency);
@@ -31,19 +38,19 @@ export const useDayCoinPriceChange = (symbol?: NetworkSymbol | null) => {
         const getPrices = async () => {
             if (!symbol) return;
             const currentTimestamp = getUnixTime(Date.now());
-            const yesterdayTimestamp = currentTimestamp - UNIX_DAY;
+            const weekAgoTimestamp = currentTimestamp - 7 * UNIX_DAY;
 
             const timestampedFiatRates = await getFiatRatesForTimestamps(
-                { symbol },
-                [yesterdayTimestamp, currentTimestamp],
+                { symbol, tokenAddress: tokenContract },
+                [weekAgoTimestamp, currentTimestamp],
                 fiatCurrencyCode,
                 isElectrumBackend,
             );
 
             if (!timestampedFiatRates) return;
 
-            const [yesterday, today] = timestampedFiatRates.tickers;
-            setYesterdayValue(yesterday.rates[fiatCurrencyCode] ?? null);
+            const [weekAgo, today] = timestampedFiatRates.tickers;
+            setWeekAgoValue(weekAgo.rates[fiatCurrencyCode] ?? null);
 
             const currentRate = today.rates[fiatCurrencyCode];
             setCurrentValue(
@@ -55,13 +62,13 @@ export const useDayCoinPriceChange = (symbol?: NetworkSymbol | null) => {
         const refreshInterval = setInterval(getPrices, REFRESH_INTERVAL);
 
         return () => clearInterval(refreshInterval);
-    }, [symbol, fiatCurrencyCode, isElectrumBackend]);
+    }, [symbol, tokenContract, fiatCurrencyCode, isElectrumBackend]);
 
     useEffect(() => {
-        if (isNotNullOrUndefined(currentValue) && isNotNullOrUndefined(yesterdayValue)) {
-            setValuePercentageChange(percentageDiff(yesterdayValue, currentValue.toNumber()));
+        if (isNotNullOrUndefined(currentValue) && isNotNullOrUndefined(weekAgoValue)) {
+            setValuePercentageChange(percentageDiff(weekAgoValue, currentValue.toNumber()));
         }
-    }, [currentValue, yesterdayValue]);
+    }, [currentValue, weekAgoValue]);
 
     return { currentValue, valuePercentageChange };
 };


### PR DESCRIPTION
## Description

- `CoinPriceCard` is now rendered also on token detail screens 
## Notes for QA

- Open any token account with tokens and tap into a token detail screen — the coin price card should appear showing the token's own price and 24h % change
- Verify mainnet account screens (BTC, ETH, etc.) still show the price card with 2 decimal places and no regression

## Related Issue

Resolve #27223

## Screenshots:
<img width="360" height="747" alt="Screenshot 2026-05-11 at 11 31 23" src="https://github.com/user-attachments/assets/b4e2df7c-304b-4edf-b7c0-c211cfe5a003" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/coin-price-card-token-detail&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/coin-price-card-token-detail&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/coin-price-card-token-detail&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-11T09:38:35.591Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-11T09:37:20.404Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/native/coin-price-card-token-detail/web/](https://dev.suite.sldev.cz/suite-web/feat/native/coin-price-card-token-detail/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->