### PR TITLE
Fix tests for useTradingOutputsReviewErrorAlert

### DIFF
--- a/suite-native/module-trading/src/hooks/exchange/Approval/__tests__/useEvmApprovalFees.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/Approval/__tests__/useEvmApprovalFees.test.ts
@@ -1,6 +1,7 @@
 import { tradingActions } from '@suite-common/trading';
 import { type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
 import { getFormDraftKey } from '@suite-common/wallet-utils';
+import { getTranslation } from '@suite-native/intl';
 import {
     type TestStore,
     renderHookWithStoreProvider,
@@ -139,7 +140,7 @@ describe('useEvmApprovalFees', () => {
 
         await waitFor(() => {
             expect(result.current.error).toBe(
-                'Failed to estimate approval fees. Please try again.',
+                getTranslation('moduleTrading.composeAllowanceError'),
             );
         });
 

--- a/suite-native/module-trading/src/hooks/reviewOutputs/__tests__/useTradingOutputsReviewErrorAlert.test.ts
+++ b/suite-native/module-trading/src/hooks/reviewOutputs/__tests__/useTradingOutputsReviewErrorAlert.test.ts
@@ -1,4 +1,5 @@
 import { type AccountKey } from '@suite-common/wallet-types';
+import { getTranslation } from '@suite-native/intl';
 import { type TestStore, act } from '@suite-native/test-utils-store';
 
 import {
@@ -42,13 +43,12 @@ describe('useTradingOutputsReviewErrorAlert', () => {
         expect(mockShowAlert).toHaveBeenCalledTimes(1);
         expect(mockShowAlert).toHaveBeenCalledWith({
             icon: 'warningCircle',
-            title: 'Transaction failed',
-            description:
-                'There has been an unexpected error, please try sending your transaction again.',
-            primaryButtonTitle: 'Try again',
+            title: getTranslation('moduleSend.review.outputs.errorAlert.generic.title'),
+            description: getTranslation('moduleSend.review.outputs.errorAlert.generic.description'),
+            primaryButtonTitle: getTranslation('generic.buttons.tryAgain'),
             primaryButtonColorProps: { intent: 'critical', priority: 'primary' },
             onPressPrimaryButton: mockOnRetry,
-            secondaryButtonTitle: 'Cancel',
+            secondaryButtonTitle: getTranslation('generic.buttons.cancel'),
             secondaryButtonColorProps: { intent: 'critical', priority: 'secondary' },
             onPressSecondaryButton: mockOnCancel,
         });
@@ -68,8 +68,10 @@ describe('useTradingOutputsReviewErrorAlert', () => {
         expect(mockShowAlert).toHaveBeenCalledTimes(1);
         expect(mockShowAlert).toHaveBeenCalledWith(
             expect.objectContaining({
-                title: 'Transaction failed due to timeout',
-                description: 'Make sure you send the transaction within 1 minute from signing.',
+                title: getTranslation('moduleSend.review.outputs.errorAlert.solana.title'),
+                description: getTranslation(
+                    'moduleSend.review.outputs.errorAlert.solana.description',
+                ),
             }),
         );
     });


### PR DESCRIPTION
Fixes failing tests for `useTradingOutputsReviewErrorAlert`.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=trezor-ci/crowdin-sync-mobile-1778486733-jirka&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->