### PR TITLE
docs(e2e): remove xhost & XQuartz E2E prerequisites

### DIFF
--- a/packages/connect-explorer/src/pages/guides/hardware-emulator.mdx
+++ b/packages/connect-explorer/src/pages/guides/hardware-emulator.mdx
@@ -20,8 +20,6 @@ The easiest way to run a Trezor hardware emulator is using [trezor-user-env](htt
 ### Prerequisites
 
 - Docker (on Linux, you need to be able to run it as non-root user, follow [those steps](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user))
-- xhost on Linux
-- [XQuartz](https://www.xquartz.org/) on macOS. Configure > Preferences > Security > Allow connections from network clients
 - Reboot (sign out/sign in might work)
 
 ### Steps

--- a/suite/e2e/docs/e2e-playwright-suite.md
+++ b/suite/e2e/docs/e2e-playwright-suite.md
@@ -6,25 +6,15 @@
 
 _Note: All paths below are relative to the root of trezor-suite repository, if not specified otherwise._
 
-### Common
+### Prerequisites
 
 - [Docker](https://docs.docker.com/desktop/mac/install/)
-- macOS only: [XQuartz](https://www.xquartz.org/) (to share your screen with Docker)
 - [Trezor user env](https://github.com/trezor/trezor-user-env)
 - No other instance of `Suite` or `trezord` service is running
 
-**Full steps:**<br />
-_(in case of Linux with X11 support, skip to step 6.)_
+### Common steps
 
-1. Run XQuartz. Wait till it is launched. Leave it running in the background.
-1. In XQuartz settings go to Preferences -> Security and enable "Allow connections from network clients".
-1. Open a new terminal window (not in XQuartz) and add yourself to the X access control list:
-    - `xhost +127.0.0.1`
-    - You will probably need to logout/login after XQuartz installation to have `xhost` command available.
-1. Run Docker and go to Preferences -> Resources -> Advanced and increase RAM to at least 4GB. Otherwise, the app during tests does not even load.
-1. In the terminal window, set two environment variables:
-    - ``export HOSTNAME=`hostname` ``
-    - `export DISPLAY=:0`
+1. _macOS only:_ Run Docker and go to Preferences -> Resources -> Advanced and increase RAM to at least 4GB. Otherwise, the app during tests does not even load.
 1. In terminal window, navigate to `trezor-user-env` repo root and run `./run.sh`.
 1. In another terminal window, run `yarn workspace @trezor/suite-e2e docker:suite-sync` to have local Relay server instance
 1. In workspace `@trezor/suite-e2e` create a `.env` file according to the `.example.env`


### PR DESCRIPTION
## Description

After https://github.com/trezor/trezor-user-env/pull/348 it is not needed to install XQuartz on macOS, and native xhost not needed on Linux.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/docs/remove-xhost-documentation-for-user-env/web/](https://dev.suite.sldev.cz/suite-web/docs/remove-xhost-documentation-for-user-env/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=docs/remove-xhost-documentation-for-user-env&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-11T11:38:27.010Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->