### PR TITLE
fix(suite): Fix token icon set

### DIFF
--- a/packages/product-components/src/components/IconSet/IconSetBase.tsx
+++ b/packages/product-components/src/components/IconSet/IconSetBase.tsx
@@ -89,14 +89,18 @@ const CountContainer = styled.div<{ $size: AssetLogoSize }>`
     background: ${({ theme }) => theme.legacyBackgroundTertiaryDefaultOnElevationNegative};
 `;
 
-export type IconSetBaseProps = {
-    count: number;
+export type CommonIconSetProps = {
     size: AssetLogoSize;
     gap: SpacingValuesNew;
-    maxVisibleIcons?: number;
+    /** Maximum number of icons to show. When `null`, all icons are shown. @default 3 */
+    maxVisibleIcons?: number | null;
     isCountVisible?: boolean;
     isCentered?: boolean;
     isReversed?: boolean;
+};
+
+export type IconSetBaseProps = CommonIconSetProps & {
+    count: number;
     children: ReactNode;
 };
 
@@ -104,7 +108,7 @@ export const IconSetBase = ({
     count,
     size,
     gap,
-    maxVisibleIcons,
+    maxVisibleIcons = 3,
     isCountVisible = false,
     isCentered = false,
     isReversed = false,

--- a/packages/product-components/src/components/NetworkIconSet/NetworkIconSet.stories.tsx
+++ b/packages/product-components/src/components/NetworkIconSet/NetworkIconSet.stories.tsx
@@ -62,11 +62,12 @@ export const NetworkIconSet: StoryObj<NetworkIconSetProps> = {
             },
         },
         maxVisibleIcons: {
-            options: [undefined, 1, 2, 3, 4],
+            options: [null, undefined, 1, 2, 3, 4],
             control: {
                 type: 'select',
                 labels: {
-                    undefined: 'All',
+                    null: 'Unlimited (null)',
+                    undefined: 'Default (3)',
                     1: '1',
                     2: '2',
                     3: '3',

--- a/packages/product-components/src/components/NetworkIconSet/NetworkIconSet.tsx
+++ b/packages/product-components/src/components/NetworkIconSet/NetworkIconSet.tsx
@@ -1,32 +1,19 @@
 import { useMemo } from 'react';
 
 import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { type SpacingValuesNew } from '@trezor/theme';
 
-import { type AssetLogoSize } from '../AssetLogo/AssetLogoWithId';
 import { CoinLogo } from '../CoinLogo/CoinLogo';
-import { IconSetBase, IconWrapper } from '../IconSet/IconSetBase';
+import { type CommonIconSetProps, IconSetBase, IconWrapper } from '../IconSet/IconSetBase';
 
-export type NetworkIconSetProps = {
+export type NetworkIconSetProps = CommonIconSetProps & {
     networks: NetworkSymbol[];
-    size: AssetLogoSize;
-    gap: SpacingValuesNew;
-    /** Maximum number of icons to show. When `undefined`, all icons are shown. @default 3 */
-    maxVisibleIcons?: number;
-    isCountVisible?: boolean;
-    isCentered?: boolean;
-    /**
-     * If true, visible networks will be displayed from the last network to the first.
-     * This affects stacking order when icons overlap.
-     */
-    isReversed?: boolean;
 };
 
 export const NetworkIconSet = ({
     networks,
     size,
     gap,
-    maxVisibleIcons,
+    maxVisibleIcons = 3,
     isCountVisible = false,
     isCentered = false,
     isReversed = true,
@@ -35,7 +22,7 @@ export const NetworkIconSet = ({
 
     const visibleContent = useMemo(() => {
         const visibleNetworks =
-            maxVisibleIcons !== undefined ? networks.slice(0, maxVisibleIcons) : networks;
+            maxVisibleIcons !== null ? networks.slice(0, maxVisibleIcons) : networks;
 
         return visibleNetworks.map(network => (
             <IconWrapper key={network} $size={size} $gap={gap} $length={length}>

--- a/packages/product-components/src/components/TokenIconSet/TokenIconSet.stories.tsx
+++ b/packages/product-components/src/components/TokenIconSet/TokenIconSet.stories.tsx
@@ -63,6 +63,20 @@ export const TokenIconSet: StoryObj<TokenIconSetProps> = {
                 type: 'select',
             },
         },
+        maxVisibleIcons: {
+            options: [null, undefined, 1, 2, 3, 4],
+            control: {
+                type: 'select',
+                labels: {
+                    null: 'Unlimited (null)',
+                    undefined: 'Default (3)',
+                    1: '1',
+                    2: '2',
+                    3: '3',
+                    4: '4',
+                },
+            },
+        },
         isCountVisible: {
             control: 'boolean',
         },

--- a/packages/product-components/src/components/TokenIconSet/TokenIconSet.tsx
+++ b/packages/product-components/src/components/TokenIconSet/TokenIconSet.tsx
@@ -1,25 +1,13 @@
 import { useMemo } from 'react';
 
 import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { type SpacingValuesNew } from '@trezor/theme';
 
 import { AssetLogo } from '../AssetLogo/AssetLogo';
-import { type AssetLogoSize } from '../AssetLogo/AssetLogoWithId';
-import { IconSetBase, IconWrapper } from '../IconSet/IconSetBase';
+import { type CommonIconSetProps, IconSetBase, IconWrapper } from '../IconSet/IconSetBase';
 
-export type TokenIconSetProps = {
+export type TokenIconSetProps = CommonIconSetProps & {
     symbol: NetworkSymbol;
     tokens: { contract: string; symbol?: string }[]; // tokens represented by their contract addresses and symbols
-    size: AssetLogoSize;
-    gap: SpacingValuesNew;
-    /** Maximum number of icons to show. When `undefined`, all icons are shown. @default 3 */
-    maxVisibleIcons?: number;
-    isCountVisible?: boolean;
-    isCentered?: boolean;
-    /**
-     * If true, visible tokens will be displayed from the last token to the first.
-     */
-    isReversed?: boolean;
 };
 
 export const TokenIconSet = ({
@@ -27,7 +15,7 @@ export const TokenIconSet = ({
     tokens,
     size,
     gap,
-    maxVisibleIcons,
+    maxVisibleIcons = 3,
     isCountVisible = false,
     isCentered = false,
     isReversed = true,
@@ -35,8 +23,7 @@ export const TokenIconSet = ({
     const { length } = tokens;
 
     const visibleTokensContent = useMemo(() => {
-        const visibleTokens =
-            maxVisibleIcons !== undefined ? tokens.slice(0, maxVisibleIcons) : tokens;
+        const visibleTokens = maxVisibleIcons !== null ? tokens.slice(0, maxVisibleIcons) : tokens;
 
         return visibleTokens.map(token => (
             <IconWrapper key={token.contract} $size={size} $gap={gap} $length={length}>

--- a/packages/suite/src/views/dashboard/PortfolioCard/EmptyWallet.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/EmptyWallet.tsx
@@ -64,7 +64,7 @@ export const EmptyWallet = () => {
                                 networks={enabledNetworks}
                                 size={20}
                                 gap={16}
-                                maxVisibleIcons={undefined}
+                                maxVisibleIcons={null}
                             />
                         </Box>
                     </Row>

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
@@ -144,7 +144,9 @@ export const PortfolioCard = memo(() => {
     ) : null;
 
     const header =
-        (discovery && discoveryStatus?.status === 'exception') || isWalletEmpty ? null : (
+        (discovery && discoveryStatus?.status === 'exception') ||
+        isWalletEmpty ||
+        isDeviceEmpty ? null : (
             <PortfolioCardHeader
                 discovery={discovery}
                 fiatAmount={walletBalance}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

before

<img width="2012" height="614" alt="image" src="https://github.com/user-attachments/assets/760bf89b-dd5c-43f3-a244-44de4eb97ea7" />


after

<img width="1221" height="545" alt="image" src="https://github.com/user-attachments/assets/770f59e9-c1bf-4cb7-8c9e-fe59c6f4fd0c" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-token-icon-set&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-token-icon-set&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-11T18:05:45.055Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-11T18:03:18.533Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-token-icon-set/web/](https://dev.suite.sldev.cz/suite-web/fix-token-icon-set/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->