### PR TITLE
feat(suite-native): tweak My assets empty state content

### DIFF
--- a/suite-native/accounts/src/components/AccountsList/AccountsListEmptyPlaceholder.tsx
+++ b/suite-native/accounts/src/components/AccountsList/AccountsListEmptyPlaceholder.tsx
@@ -1,5 +1,8 @@
+import { useSelector } from 'react-redux';
+
 import { useRoute } from '@react-navigation/native';
 
+import { selectIsDeviceConnected } from '@suite-common/device';
 import { Box, PictogramTitleHeader } from '@suite-native/atoms';
 import { type IconName } from '@suite-native/icons';
 import { Translation, type TxKeyPath } from '@suite-native/intl';
@@ -28,25 +31,28 @@ export const AccountsListEmptyPlaceholder = ({
         route.name === ReceiveStackRoutes.ReceiveAccounts ||
         route.name === ReceiveStackRoutes.ReceiveAccount;
 
+    const isDeviceConnected = useSelector(selectIsDeviceConnected);
+
     const getIcon = (): IconName => {
         if (!isFilterEmpty) {
             return 'magnifyingGlass';
         }
-
         if (isReceiveRoute) {
             return 'arrowLineDown';
         }
 
-        return 'discover';
+        return 'coins';
     };
 
     const getSubtitle = (): TxKeyPath => {
         if (!isFilterEmpty) {
             return 'moduleAccounts.emptyState.searchAgain';
         }
-
         if (isReceiveRoute) {
             return 'moduleAccounts.emptyState.receiveSubtitle';
+        }
+        if (isDeviceConnected) {
+            return 'moduleAccounts.emptyState.addSubtitle';
         }
 
         return 'moduleAccounts.emptyState.subtitle';

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -1852,6 +1852,7 @@ export const messages = {
         emptyState: {
             title: 'No assets',
             subtitle: 'Connect your Trezor or sync coins to view and track assets.',
+            addSubtitle: 'Start adding coins you want to use.',
             receiveSubtitle: 'Connect your Trezor or sync coins to view and receive assets.',
             searchAgain: 'Search again',
         },


### PR DESCRIPTION
- `coins` icon used
- different subtitle for connected Trezor

## Related issue

Required for #27339

## Screenshots:

| No Trezor | Connected Trezor |
| --- | --- |
| <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/d1f78dd9-5c32-4c64-af6a-54fed6988556" /> | <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/33d218db-1d26-4dc1-8914-1e26541aaab5" /> |

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/assets-empty-state&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->