### PR TITLE
feat(suite-native): token account settings and tab-aware back navigation

### DIFF
--- a/suite-common/fiat-services/src/rates.ts
+++ b/suite-common/fiat-services/src/rates.ts
@@ -213,6 +213,7 @@ export const getFiatRatesForTimestamps = (
     timestamps: number[],
     baseCurrencyCode: BaseCurrencyCode,
     isElectrumBackend: boolean,
+    isCoingeckoForced: boolean = false,
 ): Promise<HistoricRates | null> =>
     parallelRequestsCache.cache(
         [
@@ -223,7 +224,7 @@ export const getFiatRatesForTimestamps = (
             ...timestamps,
         ],
         async () => {
-            if (isBlockbookBasedNetwork(ticker.symbol)) {
+            if (isBlockbookBasedNetwork(ticker.symbol) && !isCoingeckoForced) {
                 if (!isElectrumBackend) {
                     const result = await getConnectFiatRatesForTimestamp(
                         ticker,

--- a/suite-common/wallet-core/src/tokens/tokenSelectors.ts
+++ b/suite-common/wallet-core/src/tokens/tokenSelectors.ts
@@ -48,6 +48,35 @@ export const selectAccountHiddenTokens = createMemoizedSelector(
     },
 );
 
+export const selectAccountManuallyHiddenTokens = createMemoizedSelector(
+    [selectAccountTokens],
+    (tokenCategories): TokenInfoBranded[] => {
+        if (!tokenCategories) return [];
+
+        return [
+            ...tokenCategories.hiddenWithBalance,
+            ...tokenCategories.hiddenWithoutBalance,
+        ] as TokenInfoBranded[];
+    },
+);
+
+export const selectAccountUnrecognizedTokens = createMemoizedSelector(
+    [selectAccountTokens],
+    (tokenCategories): TokenInfoBranded[] => {
+        if (!tokenCategories) return [];
+
+        return [
+            ...tokenCategories.unverifiedWithBalance,
+            ...tokenCategories.unverifiedWithoutBalance,
+        ] as TokenInfoBranded[];
+    },
+);
+
+export const selectAccountManuallyHiddenTokensCount = createMemoizedSelector(
+    [selectAccountManuallyHiddenTokens],
+    (tokens): number => tokens.length,
+);
+
 export const selectAccountDefiTokens = createMemoizedSelector(
     [selectAccountTokens],
     (tokenCategories): TokenInfoBranded[] => {

--- a/suite-common/wallet-core/src/tokens/tokenSelectors.ts
+++ b/suite-common/wallet-core/src/tokens/tokenSelectors.ts
@@ -53,10 +53,12 @@ export const selectAccountManuallyHiddenTokens = createMemoizedSelector(
     (tokenCategories): TokenInfoBranded[] => {
         if (!tokenCategories) return [];
 
-        return [
-            ...tokenCategories.hiddenWithBalance,
-            ...tokenCategories.hiddenWithoutBalance,
-        ] as TokenInfoBranded[];
+        return (
+            [
+                ...tokenCategories.hiddenWithBalance,
+                ...tokenCategories.hiddenWithoutBalance,
+            ] as TokenInfoBranded[]
+        ).sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''));
     },
 );
 
@@ -65,10 +67,12 @@ export const selectAccountUnrecognizedTokens = createMemoizedSelector(
     (tokenCategories): TokenInfoBranded[] => {
         if (!tokenCategories) return [];
 
-        return [
-            ...tokenCategories.unverifiedWithBalance,
-            ...tokenCategories.unverifiedWithoutBalance,
-        ] as TokenInfoBranded[];
+        return (
+            [
+                ...tokenCategories.unverifiedWithBalance,
+                ...tokenCategories.unverifiedWithoutBalance,
+            ] as TokenInfoBranded[]
+        ).sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''));
     },
 );
 
@@ -82,7 +86,9 @@ export const selectAccountDefiTokens = createMemoizedSelector(
     (tokenCategories): TokenInfoBranded[] => {
         if (!tokenCategories) return [];
 
-        return tokenCategories.shownWithBalance.filter(isErc4626) as TokenInfoBranded[];
+        return (tokenCategories.shownWithBalance.filter(isErc4626) as TokenInfoBranded[]).sort(
+            (a, b) => (a.name ?? '').localeCompare(b.name ?? ''),
+        );
     },
 );
 

--- a/suite-native/accounts/src/components/AccountsList/AccountsListItem.tsx
+++ b/suite-native/accounts/src/components/AccountsList/AccountsListItem.tsx
@@ -14,15 +14,15 @@ import { CryptoIcon, CryptoIconWithNetwork } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 import { AccountLabel } from '@suite-native/labeling';
 import { type NativeStakingRootState, selectAccountHasStaking } from '@suite-native/staking';
-import {
-    type TokensRootState,
-    isNetworkWithTokens,
-    selectNumberOfAccountKnownTokensWithBalance,
-} from '@suite-native/tokens';
+import { isNetworkWithTokens } from '@suite-native/tokens';
 
 import { AccountsListItemBase } from './AccountsListItemBase';
 import { StakingBadge } from './StakingBadge';
-import { type NativeAccountsRootState, selectAccountFiatBalance } from '../../selectors';
+import {
+    type NativeAccountsRootState,
+    selectAccountFiatBalance,
+    selectActiveAndDefiTokensCount,
+} from '../../selectors';
 import { type OnSelectAccount } from '../../types';
 
 export type AccountListItemProps = {
@@ -45,8 +45,8 @@ const CRYPTO_PRIMARY_BALANCE_TEXT_PROPS = [
 ];
 
 const TokenBadge = React.memo(({ accountKey }: { accountKey: AccountKey }) => {
-    const numberOfTokens = useSelector((state: TokensRootState) =>
-        selectNumberOfAccountKnownTokensWithBalance(state, accountKey),
+    const numberOfTokens = useSelector((state: NativeAccountsRootState) =>
+        selectActiveAndDefiTokensCount(state, accountKey),
     );
 
     return (
@@ -74,8 +74,7 @@ export const AccountsListItem = ({
         selectFormattedAccountType(state, account.key),
     );
     const accountHasKnownTokensWithBalance = useSelector(
-        (state: TokensRootState) =>
-            selectNumberOfAccountKnownTokensWithBalance(state, account.key) > 0,
+        (state: NativeAccountsRootState) => selectActiveAndDefiTokensCount(state, account.key) > 0,
     );
 
     const accountHasStaking = useSelector((state: NativeStakingRootState) =>

--- a/suite-native/accounts/src/selectors.ts
+++ b/suite-native/accounts/src/selectors.ts
@@ -13,8 +13,8 @@ import {
 import {
     type SimpleTokenStructure,
     type TokenDefinitionsRootState,
-    filterKnownTokens,
     getSimpleCoinDefinitionsByNetwork,
+    isTokenDefinitionKnown,
     selectTokenDefinitions,
 } from '@suite-common/token-definitions';
 import {
@@ -147,6 +147,8 @@ export const getAccountListSections = (
     account: Account,
     tokenDefinitions: SimpleTokenStructure | undefined,
     groupZeroBalance = false,
+    hiddenContracts: string[] = [],
+    shownContracts: string[] = [],
 ) => {
     const sections: AccountSelectBottomSheetSection[] = [];
     const isNetworkSupportingTokens = isNetworkWithTokens(account.symbol);
@@ -156,10 +158,21 @@ export const getAccountListSections = (
     // For Stellar, show all tokens without filtering.
     // Unlike EVM chains where tokens can be airdropped as spam, Stellar tokens (trustlines)
     // require explicit user action to activate. See tokensSelectors.ts for details.
+    const hiddenSet = new Set(hiddenContracts.map(c => c.toLowerCase()));
+    const shownSet = new Set(shownContracts.map(c => c.toLowerCase()));
     const tokens =
         account.networkType === 'stellar'
             ? (account.tokens ?? [])
-            : filterKnownTokens(tokenDefinitions, account.symbol, account.tokens ?? []);
+            : (account.tokens ?? [])
+                  .filter(
+                      token =>
+                          isTokenDefinitionKnown(
+                              tokenDefinitions,
+                              account.symbol,
+                              token.contract,
+                          ) || shownSet.has(token.contract.toLowerCase()),
+                  )
+                  .filter(token => !hiddenSet.has(token.contract.toLowerCase()));
 
     const tokensWithBalance =
         account.networkType === 'stellar'
@@ -239,8 +252,15 @@ export const selectAccountListSections = createMemoizedSelector(
             tokenDefinitions,
             account.symbol,
         );
+        const coinDefs = tokenDefinitions[account.symbol]?.coin;
 
-        return getAccountListSections(account, networkTokenDefinitions);
+        return getAccountListSections(
+            account,
+            networkTokenDefinitions,
+            false,
+            coinDefs?.hide ?? [],
+            coinDefs?.show ?? [],
+        );
     },
 );
 
@@ -253,8 +273,15 @@ export const selectAccountListSectionsWithZeroBalanceGroup = createMemoizedSelec
             tokenDefinitions,
             account.symbol,
         );
+        const coinDefs = tokenDefinitions[account.symbol]?.coin;
 
-        return getAccountListSections(account, networkTokenDefinitions, true);
+        return getAccountListSections(
+            account,
+            networkTokenDefinitions,
+            true,
+            coinDefs?.hide ?? [],
+            coinDefs?.show ?? [],
+        );
     },
 );
 

--- a/suite-native/accounts/src/selectors.ts
+++ b/suite-native/accounts/src/selectors.ts
@@ -30,7 +30,13 @@ import {
     selectPendingAccountAddresses,
     selectVisibleDeviceAccounts,
 } from '@suite-common/wallet-core';
-import { type Account, type AccountKey, type TokenInfoBranded } from '@suite-common/wallet-types';
+import {
+    type Account,
+    type AccountKey,
+    type RatesByKey,
+    type TokenAddress,
+    type TokenInfoBranded,
+} from '@suite-common/wallet-types';
 import {
     BASE_CURRENCY_ZERO,
     getAccountFiatBalance,
@@ -150,6 +156,8 @@ export const getAccountListSections = (
     groupZeroBalance = false,
     hiddenContracts: string[] = [],
     shownContracts: string[] = [],
+    fiatRates?: RatesByKey,
+    localCurrency?: ReturnType<typeof selectBaseCurrency>,
 ) => {
     const sections: AccountSelectBottomSheetSection[] = [];
     const isNetworkSupportingTokens = isNetworkWithTokens(account.symbol);
@@ -211,7 +219,22 @@ export const getAccountListSections = (
     }
 
     if (hasAnyKnownTokens) {
-        const tokensToShow = tokensWithBalance.filter(token => !isErc4626(token));
+        const getTokenFiatValue = (token: { contract: string; balance?: string }): number => {
+            if (!fiatRates || !localCurrency) return 0;
+            const fiatRateKey = getFiatRateKey(
+                account.symbol,
+                localCurrency,
+                token.contract as TokenAddress,
+            );
+            const rate = fiatRates[fiatRateKey]?.rate;
+            if (!rate || !token.balance) return 0;
+
+            return toFiatCurrency({ amount: token.balance, rate })?.toNumber() ?? 0;
+        };
+
+        const tokensToShow = tokensWithBalance
+            .filter(token => !isErc4626(token))
+            .sort((a, b) => getTokenFiatValue(b) - getTokenFiatValue(a));
         tokensToShow.forEach((token, index) => {
             sections.push({
                 type: 'token',
@@ -225,7 +248,9 @@ export const getAccountListSections = (
             sections.push({
                 type: 'zeroBalance',
                 account,
-                tokens: zeroBalanceTokens,
+                tokens: [...zeroBalanceTokens].sort((a, b) =>
+                    (a.name ?? '').localeCompare(b.name ?? ''),
+                ),
             });
         }
     }
@@ -236,8 +261,8 @@ export const getAccountListSections = (
 const EMPTY_ARRAY: AccountSelectBottomSheetSection[] = [];
 
 export const selectAccountListSections = createMemoizedSelector(
-    [selectAccountByKey, selectTokenDefinitions],
-    (account, tokenDefinitions) => {
+    [selectAccountByKey, selectTokenDefinitions, selectCurrentFiatRates, selectBaseCurrency],
+    (account, tokenDefinitions, fiatRates, localCurrency) => {
         if (!account) return EMPTY_ARRAY;
 
         const networkTokenDefinitions = getSimpleCoinDefinitionsByNetwork(
@@ -252,13 +277,15 @@ export const selectAccountListSections = createMemoizedSelector(
             false,
             coinDefs?.hide ?? [],
             coinDefs?.show ?? [],
+            fiatRates,
+            localCurrency,
         );
     },
 );
 
 export const selectAccountListSectionsWithZeroBalanceGroup = createMemoizedSelector(
-    [selectAccountByKey, selectTokenDefinitions],
-    (account, tokenDefinitions) => {
+    [selectAccountByKey, selectTokenDefinitions, selectCurrentFiatRates, selectBaseCurrency],
+    (account, tokenDefinitions, fiatRates, localCurrency) => {
         if (!account) return EMPTY_ARRAY;
 
         const networkTokenDefinitions = getSimpleCoinDefinitionsByNetwork(
@@ -273,6 +300,8 @@ export const selectAccountListSectionsWithZeroBalanceGroup = createMemoizedSelec
             true,
             coinDefs?.hide ?? [],
             coinDefs?.show ?? [],
+            fiatRates,
+            localCurrency,
         );
     },
 );

--- a/suite-native/accounts/src/selectors.ts
+++ b/suite-native/accounts/src/selectors.ts
@@ -23,6 +23,7 @@ import {
     type TransactionsRootState,
     type WalletSettingsRootState,
     selectAccountByKey,
+    selectAccountDefiTokensCount,
     selectBaseCurrency,
     selectCurrentFiatRates,
     selectIsAccountUtxoBased,
@@ -153,16 +154,11 @@ export const getAccountListSections = (
     const sections: AccountSelectBottomSheetSection[] = [];
     const isNetworkSupportingTokens = isNetworkWithTokens(account.symbol);
 
-    // TODO: unify with desktop when token management is ready,
-    // unhide token during activation automatically
-    // For Stellar, show all tokens without filtering.
-    // Unlike EVM chains where tokens can be airdropped as spam, Stellar tokens (trustlines)
-    // require explicit user action to activate. See tokensSelectors.ts for details.
     const hiddenSet = new Set(hiddenContracts.map(c => c.toLowerCase()));
     const shownSet = new Set(shownContracts.map(c => c.toLowerCase()));
     const tokens =
         account.networkType === 'stellar'
-            ? (account.tokens ?? [])
+            ? (account.tokens ?? []).filter(token => !hiddenSet.has(token.contract.toLowerCase()))
             : (account.tokens ?? [])
                   .filter(
                       token =>
@@ -174,17 +170,13 @@ export const getAccountListSections = (
                   )
                   .filter(token => !hiddenSet.has(token.contract.toLowerCase()));
 
-    const tokensWithBalance =
-        account.networkType === 'stellar'
-            ? tokens
-            : tokens.filter(token => parseFloat(token?.balance ?? '0') > 0);
+    const tokensWithBalance = tokens.filter(token => parseFloat(token?.balance ?? '0') > 0);
 
-    const zeroBalanceTokens: TokenInfoBranded[] =
-        groupZeroBalance && account.networkType !== 'stellar'
-            ? (tokens
-                  .filter(token => parseFloat(token?.balance ?? '0') === 0)
-                  .filter(token => !isErc4626(token)) as TokenInfoBranded[])
-            : [];
+    const zeroBalanceTokens: TokenInfoBranded[] = groupZeroBalance
+        ? (tokens
+              .filter(token => parseFloat(token?.balance ?? '0') === 0)
+              .filter(token => !isErc4626(token)) as TokenInfoBranded[])
+        : [];
 
     const hasAnyKnownTokens =
         isNetworkSupportingTokens && !!(tokensWithBalance.length + zeroBalanceTokens.length);
@@ -283,6 +275,16 @@ export const selectAccountListSectionsWithZeroBalanceGroup = createMemoizedSelec
             coinDefs?.show ?? [],
         );
     },
+);
+
+export const selectActiveTokensTabSections = createMemoizedSelector(
+    [selectAccountListSectionsWithZeroBalanceGroup],
+    sections => sections.filter(item => item.type !== 'sectionTitle'),
+);
+
+export const selectActiveAndDefiTokensCount = createMemoizedSelector(
+    [selectActiveTokensTabSections, selectAccountDefiTokensCount],
+    (sections, defiCount) => sections.filter(item => item.type === 'token').length + defiCount,
 );
 
 export const selectFreshAccountAddress = createMemoizedSelector(

--- a/suite-native/atoms/src/TouchableSwitchRow.tsx
+++ b/suite-native/atoms/src/TouchableSwitchRow.tsx
@@ -70,9 +70,11 @@ export const TouchableSwitchRow = ({
                         <HStack justifyContent="space-between" flex={1}>
                             <VStack flex={1} spacing="sp2">
                                 <Text variant="body-md-strong">{text}</Text>
-                                <Text variant="body-sm" color="contentSecondary">
-                                    {description}
-                                </Text>
+                                {description && (
+                                    <Text variant="body-sm" color="contentSecondary">
+                                        {description}
+                                    </Text>
+                                )}
                             </VStack>
                             <Switch
                                 testID={testID}

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2002,7 +2002,7 @@ export const messages = {
             tab: {
                 tokens: 'Tokens{count, plural, =0 {} other { #}}',
                 defi: 'DeFi{count, plural, =0 {} other { #}}',
-                hidden: 'Hidden',
+                hidden: 'Hidden{count, plural, =0 {} other { #}}',
                 inactive: 'Inactive',
             },
             zeroBalanceSection: {
@@ -2013,6 +2013,15 @@ export const messages = {
                 warning: "We don't recognize this token. It may be unsafe—proceed with caution.",
                 emptyTitle: 'No hidden tokens',
             },
+            hiddenByUserSection: {
+                title: 'Hidden tokens',
+            },
+        },
+        tokenSettings: {
+            contractAddress: 'Contract address',
+            network: 'Network',
+            balance: 'Balance',
+            hideToken: 'Hide token',
         },
         accountSettingsScreen: {
             coin: 'Coin',

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2013,9 +2013,6 @@ export const messages = {
                 warning: "We don't recognize this token. It may be unsafe—proceed with caution.",
                 emptyTitle: 'No hidden tokens',
             },
-            hiddenByUserSection: {
-                title: 'Hidden tokens',
-            },
         },
         tokenSettings: {
             contractAddress: 'Contract address',

--- a/suite-native/module-accounts-management/package.json
+++ b/suite-native/module-accounts-management/package.json
@@ -16,6 +16,7 @@
         "@trezor/requirements": "workspace:*"
     },
     "dependencies": {
+        "@gorhom/bottom-sheet": "5.2.8",
         "@react-navigation/native": "7.1.28",
         "@react-navigation/native-stack": "7.12.0",
         "@reduxjs/toolkit": "2.11.2",

--- a/suite-native/module-accounts-management/package.json
+++ b/suite-native/module-accounts-management/package.json
@@ -20,6 +20,7 @@
         "@react-navigation/native": "7.1.28",
         "@react-navigation/native-stack": "7.12.0",
         "@reduxjs/toolkit": "2.11.2",
+        "@shopify/flash-list": "2.3.0",
         "@suite-common/bip329": "workspace:*",
         "@suite-common/device": "workspace:*",
         "@suite-common/earn-stablecoin-api": "workspace:*",

--- a/suite-native/module-accounts-management/src/components/AccountAssets/AccountAssetsScreenHeader.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountAssets/AccountAssetsScreenHeader.tsx
@@ -5,7 +5,7 @@ import { type AccountKey } from '@suite-common/wallet-types';
 import { type NativeAccountsRootState, selectAccountFiatBalance } from '@suite-native/accounts';
 import { HStack, Text, VStack } from '@suite-native/atoms';
 import { BaseCurrencyAmountFormatter } from '@suite-native/formatters';
-import { CryptoIconWithNetwork } from '@suite-native/icons';
+import { CryptoIcon } from '@suite-native/icons';
 import { AccountLabel } from '@suite-native/labeling';
 import { ScreenHeader } from '@suite-native/navigation';
 
@@ -15,6 +15,7 @@ const AccountAssetsScreenHeaderContent = ({ accountKey }: Props) => {
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
     );
+
     const fiatBalance = useSelector((state: NativeAccountsRootState) =>
         selectAccountFiatBalance(state, accountKey),
     );
@@ -23,7 +24,7 @@ const AccountAssetsScreenHeaderContent = ({ accountKey }: Props) => {
 
     return (
         <HStack alignItems="center" spacing="sp8">
-            <CryptoIconWithNetwork symbol={account.symbol} size="small" />
+            <CryptoIcon symbol={account.symbol} size="small" />
             <VStack spacing={0} alignItems="flex-start">
                 <Text variant="body-md-strong" adjustsFontSizeToFit numberOfLines={1}>
                     <AccountLabel account={account} />

--- a/suite-native/module-accounts-management/src/components/AccountAssets/AccountAssetsTabBar.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountAssets/AccountAssetsTabBar.tsx
@@ -31,6 +31,7 @@ type AccountAssetsTabBarProps = {
     activeTab: AccountAssetsTab;
     tokenCount: number;
     defiTokenCount: number;
+    hiddenTokenCount: number;
     showInactiveTab: boolean;
     onTabChange: (tab: AccountAssetsTab) => void;
 };
@@ -38,6 +39,7 @@ type AccountAssetsTabBarProps = {
 const getTabsConfig = (
     tokenCount: number,
     defiTokenCount: number,
+    hiddenTokenCount: number,
     showInactiveTab: boolean,
 ): TabItem[] => [
     {
@@ -58,6 +60,7 @@ const getTabsConfig = (
         tab: 'hidden',
         icon: 'eyeSlash',
         translationId: 'moduleAccountManagement.accountAssetsScreen.tab.hidden',
+        translationValues: { count: hiddenTokenCount },
         isVisible: true,
     },
     {
@@ -72,6 +75,7 @@ export const AccountAssetsTabBar = ({
     activeTab,
     tokenCount,
     defiTokenCount,
+    hiddenTokenCount,
     showInactiveTab,
     onTabChange,
 }: AccountAssetsTabBarProps) => {
@@ -90,7 +94,7 @@ export const AccountAssetsTabBar = ({
             scrollEventThrottle={16}
             onLayout={handleScrollViewLayout}
         >
-            {getTabsConfig(tokenCount, defiTokenCount, showInactiveTab)
+            {getTabsConfig(tokenCount, defiTokenCount, hiddenTokenCount, showInactiveTab)
                 .filter(({ isVisible }) => isVisible)
                 .map(({ tab, icon, translationId, translationValues }) => (
                     <View key={tab} onLayout={handleTabLayout(tab)}>

--- a/suite-native/module-accounts-management/src/components/AccountAssets/ActiveTokensTab.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountAssets/ActiveTokensTab.tsx
@@ -1,7 +1,8 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
+import { FlashList } from '@shopify/flash-list';
 
 import { type AccountKey } from '@suite-common/wallet-types';
 import {
@@ -10,9 +11,8 @@ import {
     AccountsListTokenItem,
     type NativeAccountsRootState,
     type OnSelectAccount,
-    selectAccountListSectionsWithZeroBalanceGroup,
+    selectActiveTokensTabSections,
 } from '@suite-native/accounts';
-import { Box } from '@suite-native/atoms';
 import { useStakingDetailNavigation } from '@suite-native/module-earn';
 import {
     type RootStackParamList,
@@ -26,13 +26,29 @@ type ActiveTokensTabProps = {
     accountKey: AccountKey;
 };
 
+type SectionItem = ReturnType<typeof selectActiveTokensTabSections>[number];
+type ActiveTokenListItem = SectionItem & { isLast: boolean };
+
+const getItemKey = (item: ActiveTokenListItem): string => {
+    switch (item.type) {
+        case 'account':
+            return item.account.key;
+        case 'staking':
+            return `${item.account.key}-staking`;
+        case 'token':
+            return item.token.contract;
+        case 'zeroBalance':
+            return 'zero-balance';
+    }
+};
+
 export const ActiveTokensTab = ({ accountKey }: ActiveTokensTabProps) => {
     const navigation =
         useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes.AccountAssets>>();
     const { navigateToStakingDetail } = useStakingDetailNavigation();
 
     const sections = useSelector((state: NativeAccountsRootState) =>
-        selectAccountListSectionsWithZeroBalanceGroup(state, accountKey),
+        selectActiveTokensTabSections(state, accountKey),
     );
 
     const handleSelectAccount: OnSelectAccount = useCallback(
@@ -51,71 +67,66 @@ export const ActiveTokensTab = ({ accountKey }: ActiveTokensTabProps) => {
         [navigation, navigateToStakingDetail],
     );
 
-    const items = sections.filter(item => item.type !== 'sectionTitle');
+    const listItems: ActiveTokenListItem[] = useMemo(
+        () => sections.map((item, index, arr) => ({ ...item, isLast: index === arr.length - 1 })),
+        [sections],
+    );
+
+    const renderItem = useCallback(
+        ({ item }: { item: ActiveTokenListItem }) => {
+            switch (item.type) {
+                case 'account':
+                    return (
+                        <AccountsListItem
+                            {...item}
+                            hasBackground
+                            showDivider
+                            isNativeCoinOnly
+                            onPress={handleSelectAccount}
+                        />
+                    );
+                case 'staking':
+                    return (
+                        <AccountsListStakingItem
+                            {...item}
+                            hasBackground
+                            onPress={() =>
+                                handleSelectAccount({
+                                    account: item.account,
+                                    isStaking: true,
+                                    hasAnyKnownTokens: false,
+                                })
+                            }
+                        />
+                    );
+                case 'token':
+                    return (
+                        <AccountsListTokenItem
+                            {...item}
+                            hasBackground
+                            onSelectAccount={() =>
+                                handleSelectAccount({
+                                    account: item.account,
+                                    tokenAddress: item.token.contract,
+                                    tokenSymbol: item.token.symbol,
+                                    hasAnyKnownTokens: true,
+                                })
+                            }
+                        />
+                    );
+                case 'zeroBalance':
+                    return <ZeroBalanceTokensSection tokens={item.tokens} account={item.account} />;
+            }
+        },
+        [handleSelectAccount],
+    );
 
     return (
-        <Box>
-            {items.map((item, index) => {
-                const isLast = index === items.length - 1;
-
-                switch (item.type) {
-                    case 'account':
-                        return (
-                            <AccountsListItem
-                                key={item.account.key}
-                                {...item}
-                                hasBackground
-                                showDivider
-                                isNativeCoinOnly
-                                isLast={isLast}
-                                onPress={handleSelectAccount}
-                            />
-                        );
-                    case 'staking':
-                        return (
-                            <AccountsListStakingItem
-                                key={`${item.account.key}-staking`}
-                                {...item}
-                                hasBackground
-                                isLast={isLast}
-                                onPress={() =>
-                                    handleSelectAccount({
-                                        account: item.account,
-                                        isStaking: true,
-                                        hasAnyKnownTokens: false,
-                                    })
-                                }
-                            />
-                        );
-                    case 'token':
-                        return (
-                            <AccountsListTokenItem
-                                key={item.token.contract}
-                                {...item}
-                                hasBackground
-                                isLast={isLast}
-                                onSelectAccount={() =>
-                                    handleSelectAccount({
-                                        account: item.account,
-                                        tokenAddress: item.token.contract,
-                                        tokenSymbol: item.token.symbol,
-                                        hasAnyKnownTokens: true,
-                                    })
-                                }
-                            />
-                        );
-                    case 'zeroBalance':
-                        return (
-                            <ZeroBalanceTokensSection
-                                key="zero-balance"
-                                tokens={item.tokens}
-                                account={item.account}
-                            />
-                        );
-                    default:
-                        return null;
-                }
-            })}
-        </Box>
+        <FlashList
+            data={listItems}
+            keyExtractor={getItemKey}
+            getItemType={item => item.type}
+            renderItem={renderItem}
+        />
     );
 };

--- a/suite-native/module-accounts-management/src/components/AccountAssets/ActiveTokensTab.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountAssets/ActiveTokensTab.tsx
@@ -81,7 +81,6 @@ export const ActiveTokensTab = ({ accountKey }: ActiveTokensTabProps) => {
                             {...item}
                             hasBackground
                             showDivider
-                            isNativeCoinOnly
                             onPress={handleSelectAccount}
                         />
                     );

--- a/suite-native/module-accounts-management/src/components/AccountAssets/DefiTokensTab.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountAssets/DefiTokensTab.tsx
@@ -1,6 +1,8 @@
+import { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
+import { FlashList } from '@shopify/flash-list';
 
 import {
     type AccountsRootState,
@@ -8,14 +10,21 @@ import {
     selectAccountByKey,
     selectAccountDefiTokens,
 } from '@suite-common/wallet-core';
-import { type AccountKey } from '@suite-common/wallet-types';
+import { type AccountKey, type TokenInfoBranded } from '@suite-common/wallet-types';
 import { AccountsListTokenItem } from '@suite-native/accounts';
-import { Box } from '@suite-native/atoms';
 import {
     type RootStackParamList,
     RootStackRoutes,
     type StackNavigationProps,
 } from '@suite-native/navigation';
+
+type DefiTokenListItem = {
+    type: 'token';
+    id: string;
+    token: TokenInfoBranded;
+    isFirst: boolean;
+    isLast: boolean;
+};
 
 type DefiTokensTabProps = {
     accountKey: AccountKey;
@@ -32,27 +41,39 @@ export const DefiTokensTab = ({ accountKey }: DefiTokensTabProps) => {
         selectAccountDefiTokens(state, accountKey),
     );
 
+    const listItems: DefiTokenListItem[] = useMemo(
+        () =>
+            defiTokens.map((token, index) => ({
+                type: 'token' as const,
+                id: token.contract,
+                token,
+                isFirst: index === 0,
+                isLast: index === defiTokens.length - 1,
+            })),
+        [defiTokens],
+    );
+
+    const renderItem = useCallback(
+        ({ item }: { item: DefiTokenListItem }) => (
+            <AccountsListTokenItem
+                token={item.token}
+                account={account!}
+                hasBackground
+                isFirst={item.isFirst}
+                isLast={item.isLast}
+                onSelectAccount={() =>
+                    navigation.navigate(RootStackRoutes.AccountDetail, {
+                        accountKey,
+                        tokenContract: item.token.contract,
+                        closeActionType: 'back',
+                    })
+                }
+            />
+        ),
+        [account, accountKey, navigation],
+    );
+
     if (!account) return null;
 
-    return (
-        <Box>
-            {defiTokens.map((token, index) => (
-                <AccountsListTokenItem
-                    key={token.contract}
-                    token={token}
-                    account={account}
-                    hasBackground
-                    isFirst={index === 0}
-                    isLast={index === defiTokens.length - 1}
-                    onSelectAccount={() =>
-                        navigation.navigate(RootStackRoutes.AccountDetail, {
-                            accountKey,
-                            tokenContract: token.contract,
-                            closeActionType: 'back',
-                        })
-                    }
-                />
-            ))}
-        </Box>
-    );
+    return <FlashList data={listItems} keyExtractor={item => item.id} renderItem={renderItem} />;
 };

--- a/suite-native/module-accounts-management/src/components/AccountAssets/HiddenTokensTab.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountAssets/HiddenTokensTab.tsx
@@ -6,7 +6,8 @@ import {
     type AccountsRootState,
     type TokensRootState,
     selectAccountByKey,
-    selectAccountHiddenTokens,
+    selectAccountManuallyHiddenTokens,
+    selectAccountUnrecognizedTokens,
 } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { AccountsListTokenItem } from '@suite-native/accounts';
@@ -29,11 +30,14 @@ export const HiddenTokensTab = ({ accountKey }: HiddenTokensTabProps) => {
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
     );
-    const hiddenTokens = useSelector((state: TokensRootState) =>
-        selectAccountHiddenTokens(state, accountKey),
+    const manuallyHiddenTokens = useSelector((state: TokensRootState) =>
+        selectAccountManuallyHiddenTokens(state, accountKey),
+    );
+    const unrecognizedTokens = useSelector((state: TokensRootState) =>
+        selectAccountUnrecognizedTokens(state, accountKey),
     );
 
-    if (hiddenTokens.length === 0) {
+    if (manuallyHiddenTokens.length === 0 && unrecognizedTokens.length === 0) {
         return (
             <Card>
                 <PictogramTitleHeader
@@ -51,35 +55,64 @@ export const HiddenTokensTab = ({ accountKey }: HiddenTokensTabProps) => {
 
     return (
         <VStack spacing="sp16">
-            <Text variant="headline-sm">
-                <Translation id="moduleAccountManagement.accountAssetsScreen.hiddenTokensSection.title" />
-            </Text>
-            <Card
-                noPadding
-                alertProps={{
-                    variant: 'warning',
-                    title: (
-                        <Translation id="moduleAccountManagement.accountAssetsScreen.hiddenTokensSection.warning" />
-                    ),
-                }}
-            >
-                {hiddenTokens.map((token, index) => (
-                    <AccountsListTokenItem
-                        key={token.contract}
-                        token={token}
-                        account={account}
-                        isLast={index === hiddenTokens.length - 1}
-                        showFiatValue={false}
-                        onSelectAccount={() =>
-                            navigation.navigate(RootStackRoutes.AccountDetail, {
-                                accountKey,
-                                tokenContract: token.contract,
-                                closeActionType: 'back',
-                            })
-                        }
-                    />
-                ))}
-            </Card>
+            {manuallyHiddenTokens.length > 0 && (
+                <>
+                    <Text variant="headline-sm">
+                        <Translation id="moduleAccountManagement.accountAssetsScreen.hiddenByUserSection.title" />
+                    </Text>
+                    <Card noPadding>
+                        {manuallyHiddenTokens.map((token, index) => (
+                            <AccountsListTokenItem
+                                key={token.contract}
+                                token={token}
+                                account={account}
+                                isLast={index === manuallyHiddenTokens.length - 1}
+                                showFiatValue={false}
+                                onSelectAccount={() =>
+                                    navigation.navigate(RootStackRoutes.AccountDetail, {
+                                        accountKey,
+                                        tokenContract: token.contract,
+                                        closeActionType: 'back',
+                                    })
+                                }
+                            />
+                        ))}
+                    </Card>
+                </>
+            )}
+            {unrecognizedTokens.length > 0 && (
+                <>
+                    <Text variant="headline-sm">
+                        <Translation id="moduleAccountManagement.accountAssetsScreen.hiddenTokensSection.title" />
+                    </Text>
+                    <Card
+                        noPadding
+                        alertProps={{
+                            variant: 'warning',
+                            title: (
+                                <Translation id="moduleAccountManagement.accountAssetsScreen.hiddenTokensSection.warning" />
+                            ),
+                        }}
+                    >
+                        {unrecognizedTokens.map((token, index) => (
+                            <AccountsListTokenItem
+                                key={token.contract}
+                                token={token}
+                                account={account}
+                                isLast={index === unrecognizedTokens.length - 1}
+                                showFiatValue={false}
+                                onSelectAccount={() =>
+                                    navigation.navigate(RootStackRoutes.AccountDetail, {
+                                        accountKey,
+                                        tokenContract: token.contract,
+                                        closeActionType: 'back',
+                                    })
+                                }
+                            />
+                        ))}
+                    </Card>
+                </>
+            )}
         </VStack>
     );
 };

--- a/suite-native/module-accounts-management/src/components/AccountAssets/HiddenTokensTab.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountAssets/HiddenTokensTab.tsx
@@ -1,6 +1,9 @@
+import { useCallback } from 'react';
+import { View } from 'react-native';
 import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
+import { FlashList } from '@shopify/flash-list';
 
 import {
     type AccountsRootState,
@@ -9,23 +12,88 @@ import {
     selectAccountManuallyHiddenTokens,
     selectAccountUnrecognizedTokens,
 } from '@suite-common/wallet-core';
-import { type AccountKey } from '@suite-common/wallet-types';
+import { type AccountKey, type TokenInfoBranded } from '@suite-common/wallet-types';
 import { AccountsListTokenItem } from '@suite-native/accounts';
-import { Card, PictogramTitleHeader, Text, VStack } from '@suite-native/atoms';
-import { Translation } from '@suite-native/intl';
+import { Card, InlineAlertBox, PictogramTitleHeader, Text } from '@suite-native/atoms';
+import { Translation, type TxKeyPath } from '@suite-native/intl';
 import {
     type RootStackParamList,
     RootStackRoutes,
     type StackNavigationProps,
 } from '@suite-native/navigation';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+
+type SectionHeaderListItem = { type: 'section-header'; id: string; translationId: TxKeyPath };
+type WarningListItem = { type: 'warning'; id: string };
+type TokenListItem = {
+    type: 'token';
+    id: string;
+    token: TokenInfoBranded;
+    isFirst: boolean;
+    isLast: boolean;
+};
+type HiddenListItem = SectionHeaderListItem | WarningListItem | TokenListItem;
 
 type HiddenTokensTabProps = {
     accountKey: AccountKey;
 };
 
+const sectionHeaderStyle = prepareNativeStyle(utils => ({
+    paddingBottom: utils.spacings.sp8,
+}));
+
+const warningWrapperStyle = prepareNativeStyle(utils => ({
+    backgroundColor: utils.colors.surfaceFillRaised,
+    borderTopLeftRadius: utils.borders.radii.r16,
+    borderTopRightRadius: utils.borders.radii.r16,
+    overflow: 'hidden',
+    paddingTop: utils.spacings.sp16,
+    paddingHorizontal: utils.spacings.sp16,
+}));
+
+const buildListItems = (
+    manuallyHiddenTokens: TokenInfoBranded[],
+    unrecognizedTokens: TokenInfoBranded[],
+): HiddenListItem[] => {
+    const listItems: HiddenListItem[] = [];
+
+    if (manuallyHiddenTokens.length > 0) {
+        manuallyHiddenTokens.forEach((token, index) => {
+            listItems.push({
+                type: 'token',
+                id: token.contract,
+                token,
+                isFirst: index === 0,
+                isLast: index === manuallyHiddenTokens.length - 1,
+            });
+        });
+    }
+
+    if (unrecognizedTokens.length > 0) {
+        listItems.push({
+            type: 'section-header',
+            id: 'header-unrecognized',
+            translationId: 'moduleAccountManagement.accountAssetsScreen.hiddenTokensSection.title',
+        });
+        listItems.push({ type: 'warning', id: 'warning-unrecognized' });
+        unrecognizedTokens.forEach((token, index) => {
+            listItems.push({
+                type: 'token',
+                id: `unrecognized-${token.contract}`,
+                token,
+                isFirst: false,
+                isLast: index === unrecognizedTokens.length - 1,
+            });
+        });
+    }
+
+    return listItems;
+};
+
 export const HiddenTokensTab = ({ accountKey }: HiddenTokensTabProps) => {
     const navigation =
         useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes.AccountAssets>>();
+    const { applyStyle } = useNativeStyles();
 
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
@@ -37,7 +105,54 @@ export const HiddenTokensTab = ({ accountKey }: HiddenTokensTabProps) => {
         selectAccountUnrecognizedTokens(state, accountKey),
     );
 
-    if (manuallyHiddenTokens.length === 0 && unrecognizedTokens.length === 0) {
+    const listItems = buildListItems(manuallyHiddenTokens, unrecognizedTokens);
+
+    const renderItem = useCallback(
+        ({ item }: { item: HiddenListItem }) => {
+            switch (item.type) {
+                case 'section-header':
+                    return (
+                        <View style={applyStyle(sectionHeaderStyle)}>
+                            <Text variant="headline-sm">
+                                <Translation id={item.translationId} />
+                            </Text>
+                        </View>
+                    );
+                case 'warning':
+                    return (
+                        <View style={applyStyle(warningWrapperStyle)}>
+                            <InlineAlertBox
+                                variant="warning"
+                                title={
+                                    <Translation id="moduleAccountManagement.accountAssetsScreen.hiddenTokensSection.warning" />
+                                }
+                            />
+                        </View>
+                    );
+                case 'token':
+                    return (
+                        <AccountsListTokenItem
+                            token={item.token}
+                            account={account!}
+                            hasBackground
+                            isFirst={item.isFirst}
+                            isLast={item.isLast}
+                            showFiatValue={false}
+                            onSelectAccount={() =>
+                                navigation.navigate(RootStackRoutes.AccountDetail, {
+                                    accountKey,
+                                    tokenContract: item.token.contract,
+                                    closeActionType: 'back',
+                                })
+                            }
+                        />
+                    );
+            }
+        },
+        [account, accountKey, applyStyle, navigation],
+    );
+
+    if (listItems.length === 0) {
         return (
             <Card>
                 <PictogramTitleHeader
@@ -54,65 +169,11 @@ export const HiddenTokensTab = ({ accountKey }: HiddenTokensTabProps) => {
     if (!account) return null;
 
     return (
-        <VStack spacing="sp16">
-            {manuallyHiddenTokens.length > 0 && (
-                <>
-                    <Text variant="headline-sm">
-                        <Translation id="moduleAccountManagement.accountAssetsScreen.hiddenByUserSection.title" />
-                    </Text>
-                    <Card noPadding>
-                        {manuallyHiddenTokens.map((token, index) => (
-                            <AccountsListTokenItem
-                                key={token.contract}
-                                token={token}
-                                account={account}
-                                isLast={index === manuallyHiddenTokens.length - 1}
-                                showFiatValue={false}
-                                onSelectAccount={() =>
-                                    navigation.navigate(RootStackRoutes.AccountDetail, {
-                                        accountKey,
-                                        tokenContract: token.contract,
-                                        closeActionType: 'back',
-                                    })
-                                }
-                            />
-                        ))}
-                    </Card>
-                </>
-            )}
-            {unrecognizedTokens.length > 0 && (
-                <>
-                    <Text variant="headline-sm">
-                        <Translation id="moduleAccountManagement.accountAssetsScreen.hiddenTokensSection.title" />
-                    </Text>
-                    <Card
-                        noPadding
-                        alertProps={{
-                            variant: 'warning',
-                            title: (
-                                <Translation id="moduleAccountManagement.accountAssetsScreen.hiddenTokensSection.warning" />
-                            ),
-                        }}
-                    >
-                        {unrecognizedTokens.map((token, index) => (
-                            <AccountsListTokenItem
-                                key={token.contract}
-                                token={token}
-                                account={account}
-                                isLast={index === unrecognizedTokens.length - 1}
-                                showFiatValue={false}
-                                onSelectAccount={() =>
-                                    navigation.navigate(RootStackRoutes.AccountDetail, {
-                                        accountKey,
-                                        tokenContract: token.contract,
-                                        closeActionType: 'back',
-                                    })
-                                }
-                            />
-                        ))}
-                    </Card>
-                </>
-            )}
-        </VStack>
+        <FlashList
+            data={listItems}
+            keyExtractor={item => item.id}
+            getItemType={item => item.type}
+            renderItem={renderItem}
+        />
     );
 };

--- a/suite-native/module-accounts-management/src/components/AccountAssets/InactiveTokensTab.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountAssets/InactiveTokensTab.tsx
@@ -1,8 +1,10 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
+import { View } from 'react-native';
 import { useDispatch } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 import { isFulfilled } from '@reduxjs/toolkit';
+import { FlashList } from '@shopify/flash-list';
 
 import {
     type AccountKey,
@@ -10,7 +12,7 @@ import {
     type TokenAddress,
 } from '@suite-common/wallet-types';
 import { useAlert } from '@suite-native/alerts';
-import { Box, Button, Card, Loader, SearchInput, Text, VStack } from '@suite-native/atoms';
+import { Box, Button, Loader, SearchInput, Text } from '@suite-native/atoms';
 import { Translation, useTranslate } from '@suite-native/intl';
 import {
     InactiveTokenListItem,
@@ -23,15 +25,33 @@ import {
     type StackNavigationProps,
     StellarManageTokenStackRoutes,
 } from '@suite-native/navigation';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+
 type InactiveTokensTabProps = {
     accountKey: AccountKey;
 };
+
+const tokenItemWrapperStyle = prepareNativeStyle<{ isFirst: boolean; isLast: boolean }>(
+    (utils, { isFirst, isLast }) => ({
+        backgroundColor: utils.colors.surfaceFillRaised,
+        borderTopLeftRadius: isFirst ? utils.borders.radii.r16 : 0,
+        borderTopRightRadius: isFirst ? utils.borders.radii.r16 : 0,
+        borderBottomLeftRadius: isLast ? utils.borders.radii.r16 : 0,
+        borderBottomRightRadius: isLast ? utils.borders.radii.r16 : 0,
+        overflow: 'hidden',
+    }),
+);
+
+const listFooterStyle = prepareNativeStyle(utils => ({
+    paddingTop: utils.spacings.sp16,
+}));
 
 export const InactiveTokensTab = ({ accountKey }: InactiveTokensTabProps) => {
     const navigation =
         useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes.AccountAssets>>();
     const { translate } = useTranslate();
     const { showAlert } = useAlert();
+    const { applyStyle } = useNativeStyles();
     const dispatch = useDispatch();
 
     const { inactiveTokens, isLoading } = useInactiveStellarTokens(accountKey);
@@ -89,46 +109,65 @@ export const InactiveTokensTab = ({ accountKey }: InactiveTokensTabProps) => {
         });
     }, [accountKey, navigation]);
 
-    return (
-        <VStack spacing="sp16">
-            <SearchInput
-                onChange={setSearchQuery}
-                placeholder={translate('moduleStellarToken.tokenSelection.searchPlaceholder')}
-            />
-
-            {isLoading ? (
-                <Box alignItems="center" justifyContent="center" paddingVertical="sp24">
-                    <Loader />
-                </Box>
-            ) : (
-                <Card noPadding>
-                    {filteredTokens.length === 0 ? (
-                        <Box padding="sp16" alignItems="center">
-                            <Text variant="body-md" color="contentSecondary">
-                                <Translation id="moduleStellarToken.tokenSelection.noResults" />
-                            </Text>
-                        </Box>
-                    ) : (
-                        filteredTokens.map((token: StellarTokenInfo) => (
-                            <InactiveTokenListItem
-                                key={token.contract}
-                                token={token}
-                                onPress={() => handleTokenPress(token.contract as TokenAddress)}
-                            />
-                        ))
-                    )}
-                </Card>
-            )}
-
-            <Button
-                intent="neutral"
-                priority="secondary"
-                iconLeft="plus"
-                onPress={handleManualActivate}
-                testID="@stellar-token/activate-manually-button"
+    const renderItem = useCallback(
+        ({ item, index }: { item: StellarTokenInfo; index: number }) => (
+            <View
+                style={applyStyle(tokenItemWrapperStyle, {
+                    isFirst: index === 0,
+                    isLast: index === filteredTokens.length - 1,
+                })}
             >
-                <Translation id="moduleStellarToken.tokenSelection.activateManually" />
-            </Button>
-        </VStack>
+                <InactiveTokenListItem
+                    token={item}
+                    onPress={() => handleTokenPress(item.contract as TokenAddress)}
+                />
+            </View>
+        ),
+        [applyStyle, filteredTokens.length, handleTokenPress],
+    );
+
+    return (
+        <FlashList
+            data={filteredTokens}
+            keyExtractor={item => item.contract}
+            renderItem={renderItem}
+            ListHeaderComponent={
+                <Box paddingBottom="sp16">
+                    <SearchInput
+                        onChange={setSearchQuery}
+                        placeholder={translate(
+                            'moduleStellarToken.tokenSelection.searchPlaceholder',
+                        )}
+                    />
+                    {isLoading && (
+                        <Box alignItems="center" justifyContent="center" paddingVertical="sp24">
+                            <Loader />
+                        </Box>
+                    )}
+                </Box>
+            }
+            ListEmptyComponent={
+                !isLoading ? (
+                    <Box padding="sp16" alignItems="center">
+                        <Text variant="body-md" color="contentSecondary">
+                            <Translation id="moduleStellarToken.tokenSelection.noResults" />
+                        </Text>
+                    </Box>
+                ) : null
+            }
+            ListFooterComponent={
+                <View style={applyStyle(listFooterStyle)}>
+                    <Button
+                        intent="neutral"
+                        priority="secondary"
+                        iconLeft="plus"
+                        onPress={handleManualActivate}
+                        testID="@stellar-token/activate-manually-button"
+                    >
+                        <Translation id="moduleStellarToken.tokenSelection.activateManually" />
+                    </Button>
+                </View>
+            }
+        />
     );
 };

--- a/suite-native/module-accounts-management/src/components/AccountAssets/types.ts
+++ b/suite-native/module-accounts-management/src/components/AccountAssets/types.ts
@@ -1,1 +1,1 @@
-export type AccountAssetsTab = 'tokens' | 'defi' | 'hidden' | 'inactive';
+export type { AccountAssetsTab } from '@suite-native/navigation';

--- a/suite-native/module-accounts-management/src/components/TokenAccountDetailScreenHeader.tsx
+++ b/suite-native/module-accounts-management/src/components/TokenAccountDetailScreenHeader.tsx
@@ -20,6 +20,8 @@ import {
 } from '@suite-native/navigation';
 import { type TokensRootState, selectAccountTokenInfo } from '@suite-native/tokens';
 
+import { TokenScreenHeaderSettings } from './TokenScreenHeaderSettings';
+
 type TokenAccountDetailScreenHeaderProps = {
     accountKey: AccountKey;
     tokenContract: TokenAddress;
@@ -89,6 +91,9 @@ export const TokenAccountDetailScreenHeader = ({
                         </VStack>
                     </HStack>
                 </Box>
+            }
+            rightIcon={
+                <TokenScreenHeaderSettings accountKey={accountKey} tokenContract={tokenContract} />
             }
             closeActionType={closeActionType}
         />

--- a/suite-native/module-accounts-management/src/components/TokenAccountDetailScreenHeader.tsx
+++ b/suite-native/module-accounts-management/src/components/TokenAccountDetailScreenHeader.tsx
@@ -1,6 +1,12 @@
+import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 
-import { type RouteProp, useRoute } from '@react-navigation/native';
+import {
+    type NavigationProp,
+    type RouteProp,
+    useNavigation,
+    useRoute,
+} from '@react-navigation/native';
 
 import { type SuiteSyncDataRootState, selectSuiteSyncAccountLabel } from '@suite-common/suite-sync';
 import {
@@ -13,13 +19,10 @@ import { type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
 import { parseAccountKey, parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
 import { Badge, Box, HStack, Text, VStack } from '@suite-native/atoms';
 import { CryptoIconWithNetwork } from '@suite-native/icons';
-import {
-    type RootStackParamList,
-    type RootStackRoutes,
-    ScreenHeader,
-} from '@suite-native/navigation';
+import { type RootStackParamList, RootStackRoutes, ScreenHeader } from '@suite-native/navigation';
 import { type TokensRootState, selectAccountTokenInfo } from '@suite-native/tokens';
 
+import { selectAssetTabOfAccountToken } from '../selectors';
 import { TokenScreenHeaderSettings } from './TokenScreenHeaderSettings';
 
 type TokenAccountDetailScreenHeaderProps = {
@@ -54,6 +57,19 @@ export const TokenAccountDetailScreenHeader = ({
     );
     const route = useRoute<RouteProp<RootStackParamList, RootStackRoutes.AccountDetail>>();
     const { closeActionType } = route.params;
+
+    const navigation = useNavigation<NavigationProp<RootStackParamList>>();
+
+    const tokenTab = useSelector((state: TokensRootState) =>
+        selectAssetTabOfAccountToken(state, accountKey, tokenContract),
+    );
+
+    const handleGoBack = useCallback(() => {
+        navigation.popTo(RootStackRoutes.AccountAssets, {
+            accountKey,
+            tab: tokenTab,
+        });
+    }, [navigation, accountKey, tokenTab]);
 
     if (!symbol) {
         return null;
@@ -96,6 +112,7 @@ export const TokenAccountDetailScreenHeader = ({
                 <TokenScreenHeaderSettings accountKey={accountKey} tokenContract={tokenContract} />
             }
             closeActionType={closeActionType}
+            closeAction={handleGoBack}
         />
     );
 };

--- a/suite-native/module-accounts-management/src/components/TokenAccountDetailScreenHeader.tsx
+++ b/suite-native/module-accounts-management/src/components/TokenAccountDetailScreenHeader.tsx
@@ -1,12 +1,8 @@
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 
-import {
-    type NavigationProp,
-    type RouteProp,
-    useNavigation,
-    useRoute,
-} from '@react-navigation/native';
+import { type RouteProp, useNavigation, useRoute } from '@react-navigation/native';
+import { type NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 import { type SuiteSyncDataRootState, selectSuiteSyncAccountLabel } from '@suite-common/suite-sync';
 import {
@@ -58,17 +54,25 @@ export const TokenAccountDetailScreenHeader = ({
     const route = useRoute<RouteProp<RootStackParamList, RootStackRoutes.AccountDetail>>();
     const { closeActionType } = route.params;
 
-    const navigation = useNavigation<NavigationProp<RootStackParamList>>();
+    const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
 
     const tokenTab = useSelector((state: TokensRootState) =>
         selectAssetTabOfAccountToken(state, accountKey, tokenContract),
     );
 
     const handleGoBack = useCallback(() => {
-        navigation.popTo(RootStackRoutes.AccountAssets, {
-            accountKey,
-            tab: tokenTab,
-        });
+        const isAccountAssetsInStack = navigation
+            .getState()
+            .routes.some(stackRoute => stackRoute.name === RootStackRoutes.AccountAssets);
+
+        if (isAccountAssetsInStack) {
+            navigation.popTo(RootStackRoutes.AccountAssets, {
+                accountKey,
+                tab: tokenTab,
+            });
+        } else {
+            navigation.goBack();
+        }
     }, [navigation, accountKey, tokenTab]);
 
     if (!symbol) {

--- a/suite-native/module-accounts-management/src/components/TokenScreenHeaderSettings.tsx
+++ b/suite-native/module-accounts-management/src/components/TokenScreenHeaderSettings.tsx
@@ -1,0 +1,33 @@
+import { type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
+import { Box, IconButton, useBottomSheetModal } from '@suite-native/atoms';
+
+import { TokenSettingsBottomSheet } from './TokenSettingsBottomSheet';
+
+type TokenScreenHeaderSettingsProps = {
+    accountKey: AccountKey;
+    tokenContract: TokenAddress;
+};
+
+export const TokenScreenHeaderSettings = ({
+    accountKey,
+    tokenContract,
+}: TokenScreenHeaderSettingsProps) => {
+    const { bottomSheetRef, openModal } = useBottomSheetModal();
+
+    return (
+        <Box>
+            <IconButton
+                intent="neutral"
+                priority="secondary"
+                iconName="gear"
+                onPress={openModal}
+                testID="@token-detail/settings-button"
+            />
+            <TokenSettingsBottomSheet
+                ref={bottomSheetRef}
+                accountKey={accountKey}
+                tokenContract={tokenContract}
+            />
+        </Box>
+    );
+};

--- a/suite-native/module-accounts-management/src/components/TokenSettingsBottomSheet.tsx
+++ b/suite-native/module-accounts-management/src/components/TokenSettingsBottomSheet.tsx
@@ -1,0 +1,187 @@
+import { type ReactNode, type Ref, forwardRef } from 'react';
+import { View } from 'react-native';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { type BottomSheetModalMethods } from '@gorhom/bottom-sheet/lib/typescript/types';
+
+import {
+    DefinitionType,
+    TokenManagementAction,
+    tokenDefinitionsActions,
+} from '@suite-common/token-definitions';
+import { getNetwork } from '@suite-common/wallet-config';
+import {
+    type AccountsRootState,
+    type TokensRootState,
+    selectAccountByKey,
+    selectAccountHiddenTokens,
+    selectAccountNetworkSymbol,
+} from '@suite-common/wallet-core';
+import { type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
+import {
+    BottomSheetModal,
+    Box,
+    Card,
+    CardDivider,
+    HStack,
+    Text,
+    TouchableSwitchRow,
+    VStack,
+} from '@suite-native/atoms';
+import {
+    AddressFormatter,
+    TokenAmountFormatter,
+    TokenToFiatAmountFormatter,
+} from '@suite-native/formatters';
+import { CryptoIcon } from '@suite-native/icons';
+import { Translation } from '@suite-native/intl';
+import {
+    type TokensRootState as NativeTokensRootState,
+    selectAccountTokenInfo,
+} from '@suite-native/tokens';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+
+const detailRowStyle = prepareNativeStyle(({ spacings }) => ({
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    height: spacings.sp40,
+}));
+
+const cardStyle = prepareNativeStyle(({ colors, borders, boxShadows, spacings }) => ({
+    paddingVertical: spacings.sp10,
+    backgroundColor: colors.legacyBackgroundTertiaryDefaultOnElevation1,
+    borderColor: colors.borderNeutral,
+    borderWidth: borders.widths.small,
+    ...boxShadows.none,
+}));
+
+type DetailRowProps = {
+    label: ReactNode;
+    children: ReactNode;
+};
+
+const DetailRow = ({ label, children }: DetailRowProps) => {
+    const { applyStyle } = useNativeStyles();
+
+    return (
+        <View style={applyStyle(detailRowStyle)}>
+            <Text variant="body-sm-strong">{label}</Text>
+            {children}
+        </View>
+    );
+};
+
+type TokenSettingsBottomSheetProps = {
+    accountKey: AccountKey;
+    tokenContract: TokenAddress;
+};
+
+export const TokenSettingsBottomSheet = forwardRef(
+    (
+        { accountKey, tokenContract }: TokenSettingsBottomSheetProps,
+        ref: Ref<BottomSheetModalMethods>,
+    ) => {
+        const { applyStyle } = useNativeStyles();
+        const dispatch = useDispatch();
+
+        const token = useSelector((state: NativeTokensRootState) =>
+            selectAccountTokenInfo(state, accountKey, tokenContract),
+        );
+        const account = useSelector((state: AccountsRootState) =>
+            selectAccountByKey(state, accountKey),
+        );
+        const symbol = useSelector((state: AccountsRootState) =>
+            selectAccountNetworkSymbol(state, accountKey),
+        );
+        const hiddenTokens = useSelector((state: TokensRootState) =>
+            selectAccountHiddenTokens(state, accountKey),
+        );
+
+        if (!token || !account || !symbol) return null;
+
+        const balance = token.balance ?? '0';
+        const networkName = getNetwork(symbol).name;
+        const isHidden = hiddenTokens.some(
+            t => t.contract.toLowerCase() === tokenContract.toLowerCase(),
+        );
+
+        const handleToggleHide = () => {
+            dispatch(
+                tokenDefinitionsActions.setTokenStatus({
+                    symbol,
+                    type: DefinitionType.COIN,
+                    status: isHidden ? TokenManagementAction.SHOW : TokenManagementAction.HIDE,
+                    contractAddress: tokenContract,
+                }),
+            );
+        };
+
+        return (
+            <BottomSheetModal ref={ref} title={token.name ?? tokenContract} isCloseDisplayed>
+                <VStack spacing="sp16" paddingBottom="sp16">
+                    <Card style={applyStyle(cardStyle)}>
+                        <VStack>
+                            <DetailRow
+                                label={
+                                    <Translation id="moduleAccountManagement.tokenSettings.contractAddress" />
+                                }
+                            >
+                                <Box flex={1} alignItems="flex-end" marginLeft="sp8">
+                                    <AddressFormatter
+                                        value={tokenContract}
+                                        variant="body-sm"
+                                        format="long"
+                                    />
+                                </Box>
+                            </DetailRow>
+                            <CardDivider />
+                            <DetailRow
+                                label={
+                                    <Translation id="moduleAccountManagement.tokenSettings.network" />
+                                }
+                            >
+                                <HStack alignItems="center" spacing="sp8">
+                                    <CryptoIcon symbol={symbol} size="tiny" />
+                                    <Text variant="body-sm">{networkName}</Text>
+                                </HStack>
+                            </DetailRow>
+                            <CardDivider />
+                            <DetailRow
+                                label={
+                                    <Translation id="moduleAccountManagement.tokenSettings.balance" />
+                                }
+                            >
+                                <VStack spacing={0} alignItems="flex-end">
+                                    <TokenAmountFormatter
+                                        value={balance}
+                                        tokenSymbol={token.symbol}
+                                        decimals={token.decimals}
+                                        variant="body-sm"
+                                        color="contentPrimary"
+                                    />
+                                    <TokenToFiatAmountFormatter
+                                        symbol={symbol}
+                                        value={balance}
+                                        contract={tokenContract}
+                                        decimals={token.decimals}
+                                        variant="body-sm"
+                                        color="contentSecondary"
+                                    />
+                                </VStack>
+                            </DetailRow>
+                        </VStack>
+                    </Card>
+                    <TouchableSwitchRow
+                        icon="eyeSlash"
+                        accessibilityLabel="Hide token"
+                        text={<Translation id="moduleAccountManagement.tokenSettings.hideToken" />}
+                        isChecked={isHidden}
+                        onChange={handleToggleHide}
+                        testID="@token-detail/hide-token-switch"
+                    />
+                </VStack>
+            </BottomSheetModal>
+        );
+    },
+);

--- a/suite-native/module-accounts-management/src/hooks/useDayCoinPriceChange.ts
+++ b/suite-native/module-accounts-management/src/hooks/useDayCoinPriceChange.ts
@@ -34,6 +34,9 @@ export const useDayCoinPriceChange = (
         selectIsElectrumBackendSelected(state, symbol ?? 'btc'),
     );
 
+    // Block book does not have historical data for tokens of other networks than ETH.
+    const isCoingeckoForce = tokenContract && symbol !== 'eth';
+
     useEffect(() => {
         const getPrices = async () => {
             if (!symbol) return;
@@ -45,13 +48,13 @@ export const useDayCoinPriceChange = (
                 [weekAgoTimestamp, currentTimestamp],
                 fiatCurrencyCode,
                 isElectrumBackend,
+                isCoingeckoForce,
             );
 
             if (!timestampedFiatRates) return;
 
             const [weekAgo, today] = timestampedFiatRates.tickers;
             setWeekAgoValue(weekAgo.rates[fiatCurrencyCode] ?? null);
-
             const currentRate = today.rates[fiatCurrencyCode];
             setCurrentValue(
                 currentRate !== undefined ? asBaseCurrencyAmount(new BigNumber(currentRate)) : null,
@@ -62,7 +65,7 @@ export const useDayCoinPriceChange = (
         const refreshInterval = setInterval(getPrices, REFRESH_INTERVAL);
 
         return () => clearInterval(refreshInterval);
-    }, [symbol, tokenContract, fiatCurrencyCode, isElectrumBackend]);
+    }, [symbol, tokenContract, fiatCurrencyCode, isElectrumBackend, isCoingeckoForce]);
 
     useEffect(() => {
         if (isNotNullOrUndefined(currentValue) && isNotNullOrUndefined(weekAgoValue)) {

--- a/suite-native/module-accounts-management/src/screens/AccountAssetsScreen.tsx
+++ b/suite-native/module-accounts-management/src/screens/AccountAssetsScreen.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import { type RouteProp, useRoute } from '@react-navigation/native';
@@ -24,9 +24,15 @@ import { type AccountAssetsTab } from '../components/AccountAssets/types';
 
 export const AccountAssetsScreen = () => {
     const { params } = useRoute<RouteProp<RootStackParamList, RootStackRoutes.AccountAssets>>();
-    const { accountKey } = params;
+    const { accountKey, tab } = params;
 
-    const [activeTab, setActiveTab] = useState<AccountAssetsTab>('tokens');
+    const [activeTab, setActiveTab] = useState<AccountAssetsTab>(tab ?? 'tokens');
+
+    useEffect(() => {
+        if (tab !== undefined) {
+            setActiveTab(tab);
+        }
+    }, [tab]);
 
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),

--- a/suite-native/module-accounts-management/src/screens/AccountAssetsScreen.tsx
+++ b/suite-native/module-accounts-management/src/screens/AccountAssetsScreen.tsx
@@ -8,6 +8,7 @@ import {
     type TokensRootState,
     selectAccountByKey,
     selectAccountDefiTokensCount,
+    selectAccountManuallyHiddenTokensCount,
 } from '@suite-common/wallet-core';
 import {
     type NativeAccountsRootState,
@@ -36,6 +37,9 @@ export const AccountAssetsScreen = () => {
     const defiTokenCount = useSelector((state: TokensRootState) =>
         selectAccountDefiTokensCount(state, accountKey),
     );
+    const manuallyHiddenTokens = useSelector((state: TokensRootState) =>
+        selectAccountManuallyHiddenTokensCount(state, accountKey),
+    );
 
     const tokenCount = sections.filter(item => item.type === 'token').length;
     const showInactiveTab = account?.networkType === 'stellar';
@@ -47,6 +51,7 @@ export const AccountAssetsScreen = () => {
                     activeTab={activeTab}
                     tokenCount={tokenCount}
                     defiTokenCount={defiTokenCount}
+                    hiddenTokenCount={manuallyHiddenTokens}
                     showInactiveTab={showInactiveTab ?? false}
                     onTabChange={setActiveTab}
                 />

--- a/suite-native/module-accounts-management/src/selectors.ts
+++ b/suite-native/module-accounts-management/src/selectors.ts
@@ -1,9 +1,35 @@
 import { type NetworkSymbol, getNetworkType } from '@suite-common/wallet-config';
 import {
+    selectAccountDefiTokens,
+    selectAccountManuallyHiddenTokens,
+    selectAccountUnrecognizedTokens,
+} from '@suite-common/wallet-core';
+import { type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
+import {
     FeatureFlag,
     type FeatureFlagsRootState,
     selectIsFeatureFlagEnabled,
 } from '@suite-native/feature-flags';
+import { type AccountAssetsTab } from '@suite-native/navigation';
+import { type TokensRootState } from '@suite-native/tokens';
+
+export const selectAssetTabOfAccountToken = (
+    state: TokensRootState,
+    accountKey: AccountKey,
+    tokenContract: TokenAddress,
+): AccountAssetsTab => {
+    const lcContract = tokenContract.toLowerCase();
+
+    const defiTokens = selectAccountDefiTokens(state, accountKey);
+    if (defiTokens.some(t => t.contract.toLowerCase() === lcContract)) return 'defi';
+
+    const hiddenTokens = selectAccountManuallyHiddenTokens(state, accountKey);
+    const unrecognizedTokens = selectAccountUnrecognizedTokens(state, accountKey);
+    if ([...hiddenTokens, ...unrecognizedTokens].some(t => t.contract.toLowerCase() === lcContract))
+        return 'hidden';
+
+    return 'tokens';
+};
 
 export const selectIsNetworkSendFlowEnabled = (
     state: FeatureFlagsRootState,

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -55,6 +55,7 @@ type AddCoinFlowParams = RequireAllOrNone<
 >;
 
 export type CloseActionType = 'back' | 'close';
+export type AccountAssetsTab = 'tokens' | 'defi' | 'hidden' | 'inactive';
 export type DeviceSuspicionCause =
     | 'deviceLooksDifferent'
     | 'firmwareAlreadyInstalled'
@@ -400,7 +401,7 @@ export type RootStackParamList = {
     [RootStackRoutes.AccountSettings]: { accountKey: AccountKey };
     [RootStackRoutes.TransactionDetailStack]: NavigatorScreenParams<TransactionDetailStackParamList>;
     [RootStackRoutes.DevUtils]: undefined;
-    [RootStackRoutes.AccountAssets]: { accountKey: AccountKey };
+    [RootStackRoutes.AccountAssets]: { accountKey: AccountKey; tab?: AccountAssetsTab };
     [RootStackRoutes.AccountDetail]: AccountDetailParams;
     [RootStackRoutes.StakingDetail]: { accountKey: AccountKey };
     [RootStackRoutes.StakingManagement]: { accountKey: AccountKey };

--- a/suite-native/state/src/reducers.ts
+++ b/suite-native/state/src/reducers.ts
@@ -65,6 +65,7 @@ import {
     migrateTransactionsBnbToBsc,
     migrateTransactionsDeprecateNetworks,
     preparePersistReducer,
+    tokenDefinitionsPersistTransform,
     walletPersistTransform,
     walletStopPersistTransform,
 } from '@suite-native/storage';
@@ -395,8 +396,12 @@ export const prepareRootReducers = (deps: PrepareRootReducersDeps) => {
         } as const),
         // 'wallet' and 'graph' need to be persisted at the top level to ensure device state
         // is accessible for transformation.
-        persistedKeys: ['wallet', 'graph'],
-        transforms: [walletPersistTransform, graphPersistTransform],
+        persistedKeys: ['wallet', 'graph', 'tokenDefinitions'],
+        transforms: [
+            walletPersistTransform,
+            graphPersistTransform,
+            tokenDefinitionsPersistTransform,
+        ],
         mergeLevel: 2,
         key: 'root',
         version: 4,

--- a/suite-native/storage/package.json
+++ b/suite-native/storage/package.json
@@ -21,6 +21,7 @@
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
         "@suite-common/suite-utils": "workspace:*",
+        "@suite-common/token-definitions": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",

--- a/suite-native/storage/src/index.ts
+++ b/suite-native/storage/src/index.ts
@@ -24,5 +24,6 @@ export * from './migrations/locale/v2';
 export * from './transforms/blockchainTransforms';
 export * from './transforms/bluetoothTransforms';
 export * from './transforms/deviceTransforms';
+export * from './transforms/tokenDefinitionsTransforms';
 export * from './transforms/walletTransforms';
 export * from './transforms/utils';

--- a/suite-native/storage/src/transforms/tokenDefinitionsTransforms.ts
+++ b/suite-native/storage/src/transforms/tokenDefinitionsTransforms.ts
@@ -1,0 +1,34 @@
+import { createTransform } from 'redux-persist';
+
+import { type TokenDefinitionsState } from '@suite-common/token-definitions';
+
+type PersistedTokenDefinitionsState = {
+    [symbol: string]: {
+        coin?: { hide: string[]; show: string[] };
+    };
+};
+
+export const tokenDefinitionsPersistTransform = createTransform<
+    TokenDefinitionsState,
+    PersistedTokenDefinitionsState
+>(
+    inboundState => {
+        const result: PersistedTokenDefinitionsState = {};
+
+        for (const [symbol, definitions] of Object.entries(inboundState)) {
+            if (!definitions) continue;
+            result[symbol] = {};
+
+            if (definitions.coin) {
+                result[symbol].coin = {
+                    hide: definitions.coin.hide ?? [],
+                    show: definitions.coin.show ?? [],
+                };
+            }
+        }
+
+        return result;
+    },
+    outboundState => outboundState as TokenDefinitionsState,
+    { whitelist: ['tokenDefinitions'] },
+);

--- a/suite-native/storage/tsconfig.json
+++ b/suite-native/storage/tsconfig.json
@@ -16,6 +16,9 @@
             "path": "../../suite-common/suite-utils"
         },
         {
+            "path": "../../suite-common/token-definitions"
+        },
+        {
             "path": "../../suite-common/wallet-config"
         },
         {

--- a/suite-native/tokens/src/tokensSelectors.ts
+++ b/suite-native/tokens/src/tokensSelectors.ts
@@ -4,8 +4,8 @@ import type { DeviceRootState } from '@suite-common/device';
 import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import {
     type TokenDefinitionsRootState,
-    filterKnownTokens,
     getSimpleCoinDefinitionsByNetwork,
+    isTokenDefinitionKnown,
     selectIsSpecificCoinDefinitionKnown,
     selectTokenDefinitions,
 } from '@suite-common/token-definitions';
@@ -196,10 +196,19 @@ export const selectAccountKnownTokens = createMemoizedSelector(
             account.symbol,
         );
 
-        const knownTokens = filterKnownTokens(
-            tokenDefinitionsForNetwork,
-            account.symbol,
-            account.tokens ?? [],
+        const coinDefs = tokenDefinitions[account.symbol]?.coin;
+        const hiddenSet = new Set((coinDefs?.hide ?? []).map(c => c.toLowerCase()));
+        const shownSet = new Set((coinDefs?.show ?? []).map(c => c.toLowerCase()));
+
+        const knownTokens = (account.tokens ?? []).filter(
+            token =>
+                (isTokenDefinitionKnown(
+                    tokenDefinitionsForNetwork,
+                    account.symbol,
+                    token.contract,
+                ) ||
+                    shownSet.has(token.contract.toLowerCase())) &&
+                !hiddenSet.has(token.contract.toLowerCase()),
         ) as TokenInfoBranded[];
 
         return returnStableArrayIfEmpty(knownTokens);

--- a/yarn.lock
+++ b/yarn.lock
@@ -12523,6 +12523,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-native/module-accounts-management@workspace:suite-native/module-accounts-management"
   dependencies:
+    "@gorhom/bottom-sheet": "npm:5.2.8"
     "@react-navigation/native": "npm:7.1.28"
     "@react-navigation/native-stack": "npm:7.12.0"
     "@reduxjs/toolkit": "npm:2.11.2"
@@ -13723,6 +13724,7 @@ __metadata:
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/suite-utils": "workspace:*"
+    "@suite-common/token-definitions": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12527,6 +12527,7 @@ __metadata:
     "@react-navigation/native": "npm:7.1.28"
     "@react-navigation/native-stack": "npm:7.12.0"
     "@reduxjs/toolkit": "npm:2.11.2"
+    "@shopify/flash-list": "npm:2.3.0"
     "@suite-common/bip329": "workspace:*"
     "@suite-common/device": "workspace:*"
     "@suite-common/earn-stablecoin-api": "workspace:*"


### PR DESCRIPTION
## Description

- Add token settings bottom sheet to token account detail header (hide/show token)
- Split hidden tokens section in `HiddenTokensTab` by source (manually hidden vs unrecognized)
- Show hidden token count badge in the hidden tab
- Add optional `tab` param to `AccountAssets` route so navigators can pre-select a tab
- Navigate back from token detail to the correct `AccountAssets` tab (defi/hidden/tokens) based on currently openeed token state

## Notes for QA

- Open an account with ERC-20 tokens; hide a token via the token detail header settings → verify it moves to the hidden tab
- From the hidden tab, open a hidden token detail → press back → verify landing on the hidden tab (not tokens)
- Same flow for a DeFi (ERC-4626) token → back should land on the defi tab
- Hiding a token while viewing its detail screen, then pressing back → should land on the hidden tab

## Related Issue

Resolve #27222

## Screenshots:

https://github.com/user-attachments/assets/c366895d-cb11-40cf-bbd5-fb3114eaa46e


<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/native/token-account-settings/web/](https://dev.suite.sldev.cz/suite-web/feat/native/token-account-settings/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/token-account-settings&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/token-account-settings&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/token-account-settings&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > call cancellation | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-12T17:30:21.772Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-11T14:30:41.000Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->