### PR TITLE
Earn page discovery issues

### DIFF
--- a/packages/suite/src/components/earn/dashboard/common/EarnInactiveNetworkOpportunity.tsx
+++ b/packages/suite/src/components/earn/dashboard/common/EarnInactiveNetworkOpportunity.tsx
@@ -4,8 +4,8 @@ import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
 import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
-import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
-import { Button, Paragraph, Table } from '@trezor/components';
+import { selectEnabledNetworks, selectHasRunningDiscovery } from '@suite-common/wallet-core';
+import { Button, Paragraph, TOOLTIP_DELAY_NORMAL, Table, Tooltip } from '@trezor/components';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { ApyValue } from 'src/views/wallet/staking/components/ApyValue';
@@ -25,8 +25,16 @@ export const EarnInactiveNetworkOpportunity = ({
 }: EarnInactiveNetworkOpportunityProps) => {
     const dispatch = useDispatch();
     const { device } = useDevice();
+    const enabledNetworks = useSelector(selectEnabledNetworks);
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
+    const isDiscoveringThisNetwork = isDiscoveryRunning && enabledNetworks.includes(symbol);
     const { name } = getNetwork(symbol);
+
+    const isDeviceDisconnected = !device || !device.connected;
+    const isButtonDisabled = isDeviceDisconnected || isDiscoveryRunning;
+    const tooltipMessage = isDeviceDisconnected ? (
+        <Translation id="TR_TO_ADD_NEW_ACCOUNT_PLEASE_CONNECT" />
+    ) : undefined;
 
     const openAddAcountModal = () => {
         if (!device) {
@@ -64,12 +72,26 @@ export const EarnInactiveNetworkOpportunity = ({
             </Table.Cell>
 
             <Table.Cell align="end">
-                <Button size="small" onClick={openAddAcountModal} isDisabled={isDiscoveryRunning}>
-                    <Translation
-                        id="TR_EARN_STAKING_DASHBOARD_ACTIVATE"
-                        values={{ networkName: name }}
-                    />
-                </Button>
+                <Tooltip
+                    isActive={!!tooltipMessage}
+                    tooltipMaxWidth={200}
+                    content={tooltipMessage}
+                    placement="top"
+                    cursor="not-allowed"
+                    delayShow={TOOLTIP_DELAY_NORMAL}
+                >
+                    <Button
+                        size="small"
+                        onClick={openAddAcountModal}
+                        isDisabled={isButtonDisabled}
+                        isLoading={isDiscoveringThisNetwork}
+                    >
+                        <Translation
+                            id="TR_EARN_STAKING_DASHBOARD_ACTIVATE"
+                            values={{ networkName: name }}
+                        />
+                    </Button>
+                </Tooltip>
             </Table.Cell>
         </Table.Row>
     );

--- a/packages/suite/src/components/earn/dashboard/common/EarnInactiveNetworkOpportunity.tsx
+++ b/packages/suite/src/components/earn/dashboard/common/EarnInactiveNetworkOpportunity.tsx
@@ -4,7 +4,11 @@ import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
 import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
-import { selectEnabledNetworks, selectHasRunningDiscovery } from '@suite-common/wallet-core';
+import {
+    selectEnabledNetworks,
+    selectHasRunningDiscovery,
+    startOrRestartDiscoveryThunk,
+} from '@suite-common/wallet-core';
 import { Button, Paragraph, TOOLTIP_DELAY_NORMAL, Table, Tooltip } from '@trezor/components';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -27,7 +31,8 @@ export const EarnInactiveNetworkOpportunity = ({
     const { device } = useDevice();
     const enabledNetworks = useSelector(selectEnabledNetworks);
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
-    const isDiscoveringThisNetwork = isDiscoveryRunning && enabledNetworks.includes(symbol);
+    const isNetworkEnabled = enabledNetworks.includes(symbol);
+    const isDiscoveringThisNetwork = isDiscoveryRunning && isNetworkEnabled;
     const { name } = getNetwork(symbol);
 
     const isDeviceDisconnected = !device || !device.connected;
@@ -36,8 +41,14 @@ export const EarnInactiveNetworkOpportunity = ({
         <Translation id="TR_TO_ADD_NEW_ACCOUNT_PLEASE_CONNECT" />
     ) : undefined;
 
-    const openAddAcountModal = () => {
+    const handleActivate = () => {
         if (!device) {
+            return;
+        }
+
+        if (isNetworkEnabled) {
+            dispatch(startOrRestartDiscoveryThunk());
+
             return;
         }
 
@@ -82,7 +93,7 @@ export const EarnInactiveNetworkOpportunity = ({
                 >
                     <Button
                         size="small"
-                        onClick={openAddAcountModal}
+                        onClick={handleActivate}
                         isDisabled={isButtonDisabled}
                         isLoading={isDiscoveringThisNetwork}
                     >

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldInactiveVaultOpportunity.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldInactiveVaultOpportunity.tsx
@@ -2,7 +2,11 @@ import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
 import { getNetwork } from '@suite-common/wallet-config';
-import { selectEnabledNetworks, selectHasRunningDiscovery } from '@suite-common/wallet-core';
+import {
+    selectEnabledNetworks,
+    selectHasRunningDiscovery,
+    startOrRestartDiscoveryThunk,
+} from '@suite-common/wallet-core';
 import { Button, TOOLTIP_DELAY_NORMAL, Table, Tooltip } from '@trezor/components';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -22,8 +26,8 @@ export const EarnYieldInactiveVaultOpportunity = ({
     const { device } = useDevice();
     const enabledNetworks = useSelector(selectEnabledNetworks);
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
-    const isDiscoveringThisNetwork =
-        isDiscoveryRunning && enabledNetworks.includes(opportunity.networkSymbol);
+    const isNetworkEnabled = enabledNetworks.includes(opportunity.networkSymbol);
+    const isDiscoveringThisNetwork = isDiscoveryRunning && isNetworkEnabled;
     const { name } = getNetwork(opportunity.networkSymbol);
 
     const isDeviceDisconnected = !device || !device.connected;
@@ -32,8 +36,14 @@ export const EarnYieldInactiveVaultOpportunity = ({
         <Translation id="TR_TO_ADD_NEW_ACCOUNT_PLEASE_CONNECT" />
     ) : undefined;
 
-    const openAddAccountModal = () => {
+    const handleActivate = () => {
         if (!device) {
+            return;
+        }
+
+        if (isNetworkEnabled) {
+            dispatch(startOrRestartDiscoveryThunk());
+
             return;
         }
 
@@ -81,7 +91,7 @@ export const EarnYieldInactiveVaultOpportunity = ({
                 >
                     <Button
                         size="small"
-                        onClick={openAddAccountModal}
+                        onClick={handleActivate}
                         isDisabled={isButtonDisabled}
                         isLoading={isDiscoveringThisNetwork}
                     >

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldInactiveVaultOpportunity.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldInactiveVaultOpportunity.tsx
@@ -2,8 +2,8 @@ import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
 import { getNetwork } from '@suite-common/wallet-config';
-import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
-import { Button, Table } from '@trezor/components';
+import { selectEnabledNetworks, selectHasRunningDiscovery } from '@suite-common/wallet-core';
+import { Button, TOOLTIP_DELAY_NORMAL, Table, Tooltip } from '@trezor/components';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
@@ -20,8 +20,17 @@ export const EarnYieldInactiveVaultOpportunity = ({
 }: EarnYieldInactiveVaultOpportunityProps) => {
     const dispatch = useDispatch();
     const { device } = useDevice();
+    const enabledNetworks = useSelector(selectEnabledNetworks);
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
+    const isDiscoveringThisNetwork =
+        isDiscoveryRunning && enabledNetworks.includes(opportunity.networkSymbol);
     const { name } = getNetwork(opportunity.networkSymbol);
+
+    const isDeviceDisconnected = !device || !device.connected;
+    const isButtonDisabled = isDeviceDisconnected || isDiscoveryRunning;
+    const tooltipMessage = isDeviceDisconnected ? (
+        <Translation id="TR_TO_ADD_NEW_ACCOUNT_PLEASE_CONNECT" />
+    ) : undefined;
 
     const openAddAccountModal = () => {
         if (!device) {
@@ -62,12 +71,26 @@ export const EarnYieldInactiveVaultOpportunity = ({
             <Table.Cell colSpan={2} />
 
             <Table.Cell align="end">
-                <Button size="small" onClick={openAddAccountModal} isDisabled={isDiscoveryRunning}>
-                    <Translation
-                        id="TR_EARN_STAKING_DASHBOARD_ACTIVATE"
-                        values={{ networkName: name }}
-                    />
-                </Button>
+                <Tooltip
+                    isActive={!!tooltipMessage}
+                    tooltipMaxWidth={200}
+                    content={tooltipMessage}
+                    placement="top"
+                    cursor="not-allowed"
+                    delayShow={TOOLTIP_DELAY_NORMAL}
+                >
+                    <Button
+                        size="small"
+                        onClick={openAddAccountModal}
+                        isDisabled={isButtonDisabled}
+                        isLoading={isDiscoveringThisNetwork}
+                    >
+                        <Translation
+                            id="TR_EARN_STAKING_DASHBOARD_ACTIVATE"
+                            values={{ networkName: name }}
+                        />
+                    </Button>
+                </Tooltip>
             </Table.Cell>
         </Table.Row>
     );

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenuHeader.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenuHeader.tsx
@@ -3,12 +3,12 @@ import styled from 'styled-components';
 import { Translation } from '@suite/intl';
 import { selectIsCoinsFilterVisible, suiteSettingsActions } from '@suite/settings';
 import { selectSelectedDevice } from '@suite-common/device';
-import { selectAllAccountsToList } from '@suite-common/wallet-core';
+import { selectAllAccountsToList, selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { Box, Column, Divider, Icon, Row, SkeletonRectangle, Tooltip } from '@trezor/components';
 
 import { CollapsedSidebarOnly } from 'src/components/suite/layouts/SuiteLayout/Sidebar/CollapsedSidebarOnly';
 import { ExpandedSidebarOnly } from 'src/components/suite/layouts/SuiteLayout/Sidebar/ExpandedSidebarOnly';
-import { useAccountSearch, useDiscovery, useDispatch, useSelector } from 'src/hooks/suite';
+import { useAccountSearch, useDispatch, useSelector } from 'src/hooks/suite';
 
 import { AccountSearchBox } from './AccountSearchBox';
 import { AddAccountButton } from './AddAccountButton';
@@ -36,11 +36,10 @@ export const AccountsMenuHeader = () => {
 
     const device = useSelector(selectSelectedDevice);
     const accounts = useSelector(selectAllAccountsToList);
-    const { discovery } = useDiscovery();
 
     const isEmpty = accounts.length === 0;
 
-    const isDiscoveryRunning = discovery?.status === 'progress';
+    const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
     const isCoinsFilterVisible = useSelector(selectIsCoinsFilterVisible);
     const dispatch = useDispatch();
     const availableNetworksSymbols = useAvailableNetworkSymbols();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Done for both staking and stablecoin yield
- show skeleton in sidebar immediately when discovery starts
- disable activateing network if device disconnected
- show loading state in button when discovery starts for specific network (can be shown many times if same network)
- if discovery fails, activate network button starts discovery again (you can activate network in settings without device connected). If you connected device and closed passphrase, it showed discovery failed

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27445

## Screenshots:

<img width="634" height="226" alt="Screenshot 2026-05-11 at 16 57 22" src="https://github.com/user-attachments/assets/caf32f95-c42c-4469-ac35-32920e5f0621" />
<img width="1417" height="889" alt="Screenshot 2026-05-11 at 16 56 42" src="https://github.com/user-attachments/assets/de61eeb8-135a-4e2a-b762-27e06cb3566f" />
<img width="514" height="598" alt="Screenshot 2026-05-11 at 17 20 26" src="https://github.com/user-attachments/assets/189dab1c-aec9-4e58-aee9-fed9bdbe69fa" />

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect three UI components: two earn/staking dashboard components (EarnInactiveNetworkOpportunity, EarnYieldInactiveVaultOpportunity) and the AccountsMenuHeader in the wallet sidebar. All three files map to 121 tests each, indicating they are broadly imported shared components. The risk is relatively low since these appear to be presentational component changes. The most targeted tests are staking-related analytics events (for the earn components) and account search (for the menu header). Most of the 121 statically mapped tests have no direct behavioral connection to these specific components.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/components/earn/dashboard/common/EarnInactiveNetworkOpportunity.tsx`
- `packages/suite/src/components/earn/dashboard/yield/EarnYieldInactiveVaultOpportunity.tsx`
- `packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenuHeader.tsx`

</details>

**Recommended tests (3)**

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/analytics/staking-events.test.ts` — This test exercises staking navigation from both the account menu and dashboard for ETH and ADA. The EarnInactiveNetworkOpportunity and EarnYieldInactiveVaultOpportunity components are part of the earn/staking dashboard UI, and changes to inactive opportunity rendering could affect how staking navigation entry points appear or behave.
- `suite/e2e/tests/wallet/account-search.test.ts` — AccountsMenuHeader.tsx is the header of the accounts menu sidebar which contains the search functionality. Changes to this component could affect the account search input rendering or behavior, which this test directly exercises by searching and filtering accounts.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/metadata/legacy/account-metadata.test.ts` — This test exercises account search filtering by metadata labels via the accounts menu, which renders through AccountsMenuHeader. A regression in the header component could break the search/filter functionality tested here.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/components/earn/dashboard/common/EarnInactiveNetworkOpportunity.tsx`
- `packages/suite/src/components/earn/dashboard/yield/EarnYieldInactiveVaultOpportunity.tsx`

_Updated: 2026-05-11T15:24:16.312Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/stabels/web/](https://dev.suite.sldev.cz/suite-web/feat/stabels/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-11T15:30:17.454Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-11T15:27:51.809Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/stabels&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->