### PR TITLE
feat(earn): rename supply route to deposit

### DIFF
--- a/packages/suite-desktop-ui/src/support/desktopComponents.ts
+++ b/packages/suite-desktop-ui/src/support/desktopComponents.ts
@@ -6,7 +6,7 @@ import { ConnectPopup } from 'src/views/connect-popup';
 import { Dashboard } from 'src/views/dashboard';
 import { Earn } from 'src/views/earn';
 import { EarnClaim } from 'src/views/earn/claim';
-import { EarnSupply } from 'src/views/earn/supply';
+import { EarnDeposit } from 'src/views/earn/deposit';
 import { EarnWithdraw } from 'src/views/earn/withdraw';
 import PasswordManagerView from 'src/views/password-manager';
 import { SettingsCoins } from 'src/views/settings/SettingsCoins/SettingsCoins';
@@ -40,7 +40,7 @@ import { Transactions } from 'src/views/wallet/transactions/Transactions';
 export const desktopComponents: Record<PageName, ComponentType> = {
     'suite-index': Dashboard,
     'suite-earn': Earn,
-    'earn-supply': EarnSupply,
+    'earn-deposit': EarnDeposit,
     'earn-withdraw': EarnWithdraw,
     'earn-claim': EarnClaim,
     'suite-connect-popup': ConnectPopup,

--- a/packages/suite-web/src/support/webComponents.ts
+++ b/packages/suite-web/src/support/webComponents.ts
@@ -13,10 +13,10 @@ export const webComponents: Record<PageName, LazyExoticComponent<ComponentType>>
             default: Earn,
         })),
     ),
-    'earn-supply': lazy(() =>
-        import(/* webpackChunkName: "earn" */ 'src/views/earn/supply/index').then(
-            ({ EarnSupply }) => ({
-                default: EarnSupply,
+    'earn-deposit': lazy(() =>
+        import(/* webpackChunkName: "earn" */ 'src/views/earn/deposit/index').then(
+            ({ EarnDeposit }) => ({
+                default: EarnDeposit,
             }),
         ),
     ),

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx
@@ -165,7 +165,7 @@ export const EarnYieldAccountOpportunity = ({ opportunity }: EarnYieldAccountOpp
 
         dispatch(
             goto({
-                routeName: 'earn-supply',
+                routeName: 'earn-deposit',
                 params: getEarnRouteParams({
                     account: opportunity.account,
                     yieldId: opportunity.vault.id,

--- a/packages/suite/src/components/earn/modals/EarnProviderConsent/hooks/useEarnProviderConsentActions.ts
+++ b/packages/suite/src/components/earn/modals/EarnProviderConsent/hooks/useEarnProviderConsentActions.ts
@@ -64,7 +64,7 @@ export const useEarnProviderConsentActions = ({
                 if (yieldContext) {
                     dispatch(
                         goto({
-                            routeName: 'earn-supply',
+                            routeName: 'earn-deposit',
                             params: getEarnRouteParams({
                                 account,
                                 yieldId: yieldContext.id,

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Navigation.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Navigation.tsx
@@ -46,7 +46,7 @@ export const Navigation = ({ children }: NavigationProps) => {
                               nameId: 'TR_EARN',
                               icon: 'piggyBank',
                               goToRoute: 'suite-earn',
-                              routes: ['suite-earn', 'earn-supply', 'earn-withdraw', 'earn-claim'],
+                              routes: ['suite-earn', 'earn-deposit', 'earn-withdraw', 'earn-claim'],
                           } as NavigationItemProps,
                       ]
                     : []),

--- a/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
@@ -14,7 +14,7 @@ const SIGN_TX_ROUTES = [
     'wallet-index',
     'wallet-trading-exchange-confirm',
     'wallet-trading-sell-confirm',
-    'earn-supply',
+    'earn-deposit',
     'earn-withdraw',
 ] as const;
 

--- a/packages/suite/src/utils/suite/transactionReview.ts
+++ b/packages/suite/src/utils/suite/transactionReview.ts
@@ -76,7 +76,7 @@ export const getTransactionReviewModalActionTranslation = ({
     }
 
     if (
-        (routeName === 'earn-supply' || routeName === 'earn-withdraw') &&
+        (routeName === 'earn-deposit' || routeName === 'earn-withdraw') &&
         (txSignature === 'approve' || txSignature === 'revoke')
     ) {
         return {
@@ -96,7 +96,7 @@ export const getTransactionReviewModalActionTranslation = ({
         return { id: 'TR_CONFIRMING_TX' };
     }
 
-    if (routeName === 'earn-supply') {
+    if (routeName === 'earn-deposit') {
         return { id: 'TR_EARN_YIELD_SUPPLY' };
     }
 

--- a/packages/suite/src/views/earn/deposit/index.tsx
+++ b/packages/suite/src/views/earn/deposit/index.tsx
@@ -2,7 +2,7 @@ import { YieldSupply } from 'src/components/earn';
 
 import { useEarnLayout } from '../useEarnLayout';
 
-export const EarnSupply = () => {
+export const EarnDeposit = () => {
     const { account, routeParams } = useEarnLayout({ analyticsStep: 'yield-supply' });
 
     if (!account || !routeParams) {

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
@@ -148,7 +148,7 @@ const TokenRowBasicActions = ({
 
         dispatch(
             goto({
-                routeName: 'earn-supply',
+                routeName: 'earn-deposit',
                 params: getEarnRouteParams({
                     account,
                     yieldId,

--- a/suite/router-config/src/routeConfig.ts
+++ b/suite/router-config/src/routeConfig.ts
@@ -36,8 +36,8 @@ export const routes = [
         app: 'earn',
     },
     {
-        name: 'earn-supply',
-        pattern: '/earn/supply',
+        name: 'earn-deposit',
+        pattern: '/earn/deposit',
         app: 'earn',
         params: earnParams,
     },

--- a/suite/router/src/__tests__/router.test.ts
+++ b/suite/router/src/__tests__/router.test.ts
@@ -44,14 +44,14 @@ describe('router', () => {
             expect(test('unknown-route')).toEqual('/');
             expect(test('wallet-index')).toEqual('/accounts');
             expect(
-                test('earn-supply', {
+                test('earn-deposit', {
                     symbol: 'eth',
                     accountIndex: 0,
                     accountType: 'normal',
                     yieldId: 'vault-1',
                     contractAddress: '0xabc',
                 }),
-            ).toEqual('/earn/supply#/eth/0/normal/vault-1/0xabc');
+            ).toEqual('/earn/deposit#/eth/0/normal/vault-1/0xabc');
             expect(
                 test('earn-withdraw', {
                     symbol: 'eth',
@@ -194,7 +194,7 @@ describe('router', () => {
 
             expect(
                 getAppWithParams({
-                    pathname: '/earn/supply',
+                    pathname: '/earn/deposit',
                     hash: '#/eth/0/normal/vault-1/0xabc',
                 }),
             ).toEqual({
@@ -206,7 +206,7 @@ describe('router', () => {
                     yieldId: 'vault-1',
                     contractAddress: '0xabc',
                 },
-                route: getRoute('earn-supply'),
+                route: getRoute('earn-deposit'),
             });
 
             expect(
@@ -228,13 +228,13 @@ describe('router', () => {
 
             expect(
                 getAppWithParams({
-                    pathname: '/earn/supply',
+                    pathname: '/earn/deposit',
                     hash: '#/eth/0/normal',
                 }),
             ).toEqual({
                 app: 'earn',
                 params: undefined,
-                route: getRoute('earn-supply'),
+                route: getRoute('earn-deposit'),
             });
 
             expect(


### PR DESCRIPTION
## Description

Renames the `/earn/supply` route to `/earn/deposit`.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27586

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/earn-change-route-supply-to-deposit&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/earn-change-route-supply-to-deposit&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-11T17:04:30.875Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-11T17:02:31.857Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/earn-change-route-supply-to-deposit/web/](https://dev.suite.sldev.cz/suite-web/feat/earn-change-route-supply-to-deposit/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->