### PR TITLE
feat(utils): add noop helper and adopt across packages

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingExchangeHandleChange.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingExchangeHandleChange.ts
@@ -8,6 +8,7 @@ import {
     useTradingRefetchScheduler,
 } from '@suite-common/trading';
 import { type Network } from '@suite-common/wallet-config';
+import { noop } from '@trezor/utils';
 
 import { useDispatch } from 'src/hooks/suite';
 import { useAnalytics } from 'src/support/useAnalytics';
@@ -24,8 +25,6 @@ type TradingExchangeUseHandleChangeProps = {
 type PromiseType = {
     abort: (message?: string) => void;
 } | null;
-
-const noop = () => {};
 
 /**
  * Wrapping the handleRequestThunk to have a better control

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -43,6 +43,7 @@ export * from './isWhitelistedHost';
 export * from './logs';
 export * from './logsManager';
 export * from './mergeDeepObject';
+export * from './noop';
 export * from './objectPartition';
 export * from './parseElectrumUrl';
 export * from './parseHostname';

--- a/packages/utils/src/noop.ts
+++ b/packages/utils/src/noop.ts
@@ -1,0 +1,1 @@
+export const noop = (..._args: unknown[]) => {};

--- a/packages/utils/tests/noop.test.ts
+++ b/packages/utils/tests/noop.test.ts
@@ -1,0 +1,16 @@
+import { noop } from '../src/noop';
+
+describe(noop.name, () => {
+    it('returns undefined', () => {
+        expect(noop()).toBeUndefined();
+    });
+
+    it('can be called with any arguments', () => {
+        expect(() => noop('a', 1, null, undefined, {})).not.toThrow();
+    });
+
+    it('is assignable as a no-op callback', () => {
+        const fn: (value: string) => void = noop;
+        expect(() => fn('test')).not.toThrow();
+    });
+});

--- a/suite-native/atoms/src/AnimatedDoubleView/AnimatedDoubleInput.tsx
+++ b/suite-native/atoms/src/AnimatedDoubleView/AnimatedDoubleInput.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode, type RefObject, useCallback, useRef, useState } from 'react';
 
 import { useUpdateEffect } from '@suite-native/helpers';
+import { noop } from '@trezor/utils';
 
 import {
     ANIMATED_DOUBLE_VIEW_SWITCH_ANIMATION_DURATION,
@@ -20,8 +21,6 @@ export type AnimatedDoubleInputProps = {
     onInputSwitch?: (activeView: ActiveView) => void;
     switchLabel?: string;
 };
-
-const noop = () => {};
 
 export const AnimatedDoubleInput = ({
     renderPrimary,

--- a/suite-native/atoms/src/AnimatedDoubleView/AnimatedDoubleView.tsx
+++ b/suite-native/atoms/src/AnimatedDoubleView/AnimatedDoubleView.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react';
 import Animated, { LinearTransition } from 'react-native-reanimated';
 
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+import { noop } from '@trezor/utils';
 
 import {
     ANIMATION_DURATION,
@@ -28,8 +29,6 @@ const viewsWrapperStyle = prepareNativeStyle(() => ({
     height: ANIMATED_DOUBLE_VIEW_WRAPPER_HEIGHT,
     justifyContent: 'space-between',
 }));
-
-const noop = () => {};
 
 export const AnimatedDoubleView = ({
     renderPrimary,

--- a/suite-native/atoms/src/Input/BottomSheetSearchInput.tsx
+++ b/suite-native/atoms/src/Input/BottomSheetSearchInput.tsx
@@ -5,6 +5,7 @@ import { type TextInput } from 'react-native-gesture-handler';
 import { BottomSheetTextInput } from '@gorhom/bottom-sheet';
 
 import { useNativeStyles } from '@trezor/styles-native';
+import { noop } from '@trezor/utils';
 
 import { Box } from '../Box';
 import { type SurfaceElevation } from '../types';
@@ -28,8 +29,6 @@ export type BottomSheetSearchInputProps = {
 
 export type BottomSheetSearchInputRef = TextInput | null;
 
-const noOp = () => {};
-
 export const BottomSheetSearchInput = forwardRef<
     BottomSheetSearchInputRef,
     BottomSheetSearchInputProps
@@ -41,8 +40,8 @@ export const BottomSheetSearchInput = forwardRef<
             maxLength,
             isDisabled = false,
             elevation = '0',
-            onFocus = noOp,
-            onBlur = noOp,
+            onFocus = noop,
+            onBlur = noop,
             value,
             autoCorrect,
             testId,

--- a/suite-native/module-trading/src/components/buy/BuyTradeableAssetPicker.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyTradeableAssetPicker.tsx
@@ -6,6 +6,7 @@ import { selectHasBitcoinOnlyFirmware } from '@suite-common/device';
 import { HStack } from '@suite-native/atoms';
 import { selectBuyTradeableAssets } from '@suite-native/trading-state';
 import { type TradeableAsset } from '@suite-native/trading-types';
+import { noop } from '@trezor/utils';
 
 import { BuyCryptoAmountInput } from './BuyCryptoAmountInput';
 import { BuyTradeableAssetsSheet } from './BuyTradeableAssetsSheet';
@@ -14,8 +15,6 @@ import { useSheetControls } from '../../hooks/general/useSheetControls';
 import { SelectTradeableAssetButton } from '../general/SelectTradeableAssetButton';
 
 const ASSET_PICKER_TEST_ID = '@trading/buy/asset-receive-button';
-
-const noop = () => {};
 
 export const BuyTradeableAssetPicker = () => {
     const inputRef = useRef<TextInput>(null);

--- a/suite-native/module-trading/src/components/exchange/receive/ExchangeReceiveAmountInput.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/ExchangeReceiveAmountInput.tsx
@@ -6,6 +6,7 @@ import { selectTradingExchangeIsLoading } from '@suite-common/trading';
 import { useAmountInputTransformers } from '@suite-native/helpers';
 import { useTranslate } from '@suite-native/intl';
 import { getSymbolFromTradeableAsset } from '@suite-native/trading-atoms';
+import { noop } from '@trezor/utils';
 
 import { useExchangeFormContext } from '../../../hooks/exchange/useExchangeFormContext';
 import { AmountInput } from '../../general/Input/AmountInput';
@@ -15,8 +16,6 @@ export type ExchangeReceiveAmountInputProps = {
 };
 
 const EXCHANGE_RECEIVE_INPUT_TEST_ID = '@trading/exchange/receive-amount-input';
-
-const noop = () => {};
 
 export const ExchangeReceiveAmountInput = forwardRef<TextInput, ExchangeReceiveAmountInputProps>(
     ({ showAssetsSheet }, ref) => {

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeQuotes.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeQuotes.ts
@@ -21,6 +21,7 @@ import { exchangeActions, selectExchangeQuotes } from '@suite-native/trading-sta
 import { type AbortablePromise, type ExchangeFormType } from '@suite-native/trading-types';
 import { type Analytics } from '@trezor/analytics-uploader';
 import { useDebounce } from '@trezor/react-utils';
+import { noop } from '@trezor/utils';
 
 import { tradingExchangeFormToTradingExchangeFormProps } from '../../utils/exchange/quotesUtils';
 import { useQuotesInvalidator } from '../general/useQuotesInvalidator';
@@ -31,8 +32,6 @@ type ShouldFetchExchangeQuotesRef = {
     sendCryptoAmount: string | undefined;
     accountDescriptor: string | undefined;
 };
-
-const noop = () => {};
 
 const defaultState = {
     sendAsset: undefined,

--- a/suite-native/module-trading/src/hooks/general/useTradingTransaction.ts
+++ b/suite-native/module-trading/src/hooks/general/useTradingTransaction.ts
@@ -40,6 +40,7 @@ import {
     usePrecomposedTransactionError,
 } from '@suite-native/transaction-management';
 import TrezorConnect from '@trezor/connect';
+import { noop } from '@trezor/utils';
 
 import { useConsent } from './useConsent';
 import { composeTradingTransactionThunk, signAndPushSendFormTransactionThunk } from '../../thunks';
@@ -289,9 +290,9 @@ export const useTradingTransaction = ({
                             shouldSendInSats,
                             isSlip24Active,
                             nextStep,
-                            processResponseData: processResponseData || (() => {}),
+                            processResponseData: processResponseData || noop,
                             triggerAnalyticsTradeConfirmation:
-                                triggerAnalyticsTradeConfirmation || (() => {}),
+                                triggerAnalyticsTradeConfirmation || noop,
                             signAndPushSendFormTransaction,
                         }),
                     ).unwrap();

--- a/suite-native/module-trading/src/hooks/sell/useSellQuotes.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellQuotes.ts
@@ -16,6 +16,7 @@ import { getSymbolFromTradeableAsset } from '@suite-native/trading-atoms';
 import { sellActions } from '@suite-native/trading-state';
 import { type AbortablePromise, type SellFormType } from '@suite-native/trading-types';
 import { useDebounce } from '@trezor/react-utils';
+import { noop } from '@trezor/utils';
 
 import { tradingSellFormToTradingSellFormProps } from '../../utils/sell/quotesUtils';
 import { useQuotesInvalidator } from '../general/useQuotesInvalidator';
@@ -44,8 +45,6 @@ const defaultState: ShouldFetchSellQuotesRef = {
     countrySubdivision: undefined,
     accountDescriptor: undefined,
 } as const;
-
-const noop = () => {};
 
 const useShouldFetchSellQuotes = ({ watch, control }: SellFormType): ShouldFetchSellQuotes => {
     const prevState = useRef<ShouldFetchSellQuotesRef>(defaultState);

--- a/suite-native/trading-browser-auth/src/hooks/useBrowserAuth.ts
+++ b/suite-native/trading-browser-auth/src/hooks/useBrowserAuth.ts
@@ -15,6 +15,7 @@ import { useTranslate } from '@suite-native/intl';
 import { captureSentryException } from '@suite-native/sentry';
 import { tradingActions } from '@suite-native/trading-state';
 import { exhaustive } from '@trezor/type-utils';
+import { noop } from '@trezor/utils';
 
 import type { BrowserAuthRet } from './useBrowserAuthTypes';
 import { useBrowserStateChangeCallbacks } from './useBrowserStateChangeCallbacks';
@@ -30,8 +31,6 @@ class BrowserAuthError extends Error {
         this.name = 'BrowserAuthError';
     }
 }
-
-const noop = () => {};
 
 const useLastErrorMessageDispatcher = (tradingType: TradingType | undefined) => {
     const dispatch = useDispatch();


### PR DESCRIPTION
## Summary
Add a `noop` helper function to `@trezor/utils` and replace all inline no-op arrow functions (`() => {}`) across packages with the shared utility.

## Utility
[`noop`](https://github.com/trezor/trezor-suite/blob/mroz22/utils-noop-helper/packages/utils/src/noop.ts)

## Related PRs (series)
- #27591 — feat(utils): add noop helper and adopt across packages
- #27592 — feat(utils): add clamp helper and adopt across packages
- #27593 — refactor: adopt unique from @trezor/utils
- #27594 — refactor: adopt resolveAfter from @trezor/utils
- #27595 — refactor: adopt filter predicates (isNotNull, isNotNullOrUndefined, isNotUndefined) from @trezor/utils
- #27596 — refactor: adopt isArrayMember from @trezor/utils
- #27597 — refactor: adopt typed object helpers (typedObjectKeys, typedObjectEntries, isSafeObjectKey) from @trezor/utils
- #27598 — refactor(suite-native): use arrayShuffle and getWeakRandomInt for TrezorFacts
- #27599 — refactor(suite): use splitStringEveryNCharacters from @trezor/utils for homescreen
- #27600 — refactor: adopt getWeakRandomInt from @trezor/utils
- #27601 — refactor: adopt capitalizeFirstLetter from @trezor/utils
- #27602 — refactor(analytics-docs): use removeTrailingSlashes from @trezor/utils

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/utils-noop-helper&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/utils-noop-helper/web/](https://dev.suite.sldev.cz/suite-web/mroz22/utils-noop-helper/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->