### PR TITLE
refactor: adopt unique from @trezor/utils

### DIFF
--- a/packages/analytics-docs/scripts/buildData.ts
+++ b/packages/analytics-docs/scripts/buildData.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import type { EventDef } from '@suite-common/analytics';
+import { unique } from '@trezor/utils';
 
 import type { EventDoc } from '../src/types';
 import {
@@ -84,7 +85,7 @@ const getPackageRoots = (): string[] => {
         findPackageRoot(path.join(getPackageRoot(name), 'package.json')),
     ).filter((x): x is string => Boolean(x));
 
-    return [...new Set(roots)];
+    return unique(roots);
 };
 
 const getEventFileGlobs = (packageRoots: string[]): string[] =>

--- a/packages/analytics-docs/src/utils/extractAttributeTypes.ts
+++ b/packages/analytics-docs/src/utils/extractAttributeTypes.ts
@@ -11,6 +11,8 @@ import {
     ts,
 } from 'ts-morph';
 
+import { unique } from '@trezor/utils';
+
 /** Options for the attribute type extraction (tsconfig path and globs for event files). */
 type ExtractOptions = {
     tsConfigFilePath: string;
@@ -142,7 +144,7 @@ const formatTypeAsString = (t: Type, contextNode: Node): string => {
         const parts = t.getUnionTypes();
         if (parts.length > 80) return t.getText(contextNode, FORMAT_FLAGS);
         const rendered = parts.map(p => formatTypeAsString(p, contextNode));
-        const uniq = [...new Set(rendered)];
+        const uniq = unique(rendered);
 
         return uniq.join('\n| ');
     }

--- a/packages/connect/src/api/composeTransaction.ts
+++ b/packages/connect/src/api/composeTransaction.ts
@@ -19,6 +19,7 @@ import {
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { promiseAllSequence } from '@trezor/utils/src/promiseAllSequence';
 import { resolveAfter } from '@trezor/utils/src/resolveAfter';
+import { unique } from '@trezor/utils/src/unique';
 import type { ComposeOutput, TransactionInputOutputSortingStrategy } from '@trezor/utxo-lib';
 
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
@@ -262,7 +263,7 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
         context.sendCoreMessage(
             createUiMessage(UI_REQUEST.SELECT_ACCOUNT, {
                 type: 'complete',
-                accountTypes: [...new Set(accounts.map(a => a.type))],
+                accountTypes: unique(accounts.map(a => a.type)),
                 coinInfo,
                 accounts,
             }),

--- a/packages/connect/src/api/getAccountInfo.ts
+++ b/packages/connect/src/api/getAccountInfo.ts
@@ -12,6 +12,7 @@ import type {
 } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { resolveAfter } from '@trezor/utils/src/resolveAfter';
+import { unique } from '@trezor/utils/src/unique';
 
 import { type Blockchain, initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
 import type { MethodContext, MethodMessage, MethodReturnType } from '../core/AbstractMethod';
@@ -334,7 +335,7 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
         context.sendCoreMessage(
             createUiMessage(UI_REQUEST.SELECT_ACCOUNT, {
                 type: 'complete',
-                accountTypes: [...new Set(accounts.map(a => a.type))],
+                accountTypes: unique(accounts.map(a => a.type)),
                 defaultAccountType,
                 coinInfo,
                 accounts,

--- a/packages/e2e-utils/src/githubReporter/gitHubReporterBase.ts
+++ b/packages/e2e-utils/src/githubReporter/gitHubReporterBase.ts
@@ -1,6 +1,6 @@
 import type { Octokit } from '@octokit/rest';
 
-import { getWeakRandomInt, resolveAfter, scheduleAction } from '@trezor/utils';
+import { getWeakRandomInt, resolveAfter, scheduleAction, unique } from '@trezor/utils';
 
 import { type TestReportProviderBase } from './annotationBase';
 import { GitHubProject } from './gitHubProject';
@@ -94,7 +94,7 @@ abstract class GitHubReporterBase implements LoggingFunctions {
 
     protected logInstructionsForRerun(): void {
         const failedCount = this.failedTestFilenames.length;
-        const uniqueFailedFilenames = [...new Set(this.failedTestFilenames)];
+        const uniqueFailedFilenames = unique(this.failedTestFilenames);
 
         this.logError(LOG_VISUAL_SEPARATOR);
         this.logError(`GITHUB REPORTER SUMMARY: ~${failedCount} test(s) failed to report`);

--- a/packages/e2e-utils/src/llmTestSelector/index.ts
+++ b/packages/e2e-utils/src/llmTestSelector/index.ts
@@ -4,6 +4,8 @@ import { createHash } from 'node:crypto';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
+import { unique } from '@trezor/utils';
+
 import { error, log, output } from '../logger';
 import type { CoverageIndex } from '../testCoverage/types';
 
@@ -118,7 +120,7 @@ const getChangedFiles = (headRef = 'HEAD'): string[] => {
         .filter((l: string) => l.length > 0);
 
     // Deduplicate
-    return [...new Set(files)].filter(isAllowedFile);
+    return unique(files).filter(isAllowedFile);
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/e2e-utils/src/testCoverage/selectTestsByChangedFiles.ts
+++ b/packages/e2e-utils/src/testCoverage/selectTestsByChangedFiles.ts
@@ -3,6 +3,8 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as readline from 'node:readline';
 
+import { unique } from '@trezor/utils';
+
 import { error, log, output } from '../logger';
 import type { CoverageIndex } from './types';
 
@@ -159,7 +161,7 @@ const main = async () => {
     const index: CoverageIndex = JSON.parse(fs.readFileSync(coverageMapFile, 'utf8'));
 
     const stdinFiles = await readStdin();
-    const changedFiles = [...new Set([...stdinFiles, ...explicitFiles])];
+    const changedFiles = unique([...stdinFiles, ...explicitFiles]);
 
     if (changedFiles.length === 0) {
         error('No changed files provided. Pipe git diff output or use --files.');

--- a/packages/suite/src/hooks/wallet/useSendFormImport.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormImport.ts
@@ -19,6 +19,7 @@ import {
     toFiatCurrency,
 } from '@suite-common/wallet-utils';
 import { type BaseCurrencyCode, baseCurrencies } from '@trezor/blockchain-link-types';
+import { unique } from '@trezor/utils';
 
 import { useDispatch } from 'src/hooks/suite';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
@@ -56,7 +57,7 @@ export const useSendFormImport = ({
         }
 
         const currencies = result.map(it => it.currency.toLowerCase());
-        const uniqueCurrencies = [...new Set(currencies)];
+        const uniqueCurrencies = unique(currencies);
 
         for (const currency of uniqueCurrencies) {
             const fiatRateKey = getFiatRateKey(network.symbol, currency as BaseCurrencyCode);

--- a/packages/suite/src/views/firmware/Steps/StepInitial.tsx
+++ b/packages/suite/src/views/firmware/Steps/StepInitial.tsx
@@ -4,6 +4,7 @@ import { Translation } from '@suite/intl';
 import { selectDevices, selectSelectedDevice } from '@suite-common/device';
 import { type FirmwareStatus } from '@suite-common/suite-types';
 import { Modal, Tooltip } from '@trezor/components';
+import { unique } from '@trezor/utils';
 
 import { updateAnalytics } from 'src/actions/onboarding/onboardingActions';
 import { PrerequisitesGuide } from 'src/components/suite';
@@ -30,7 +31,7 @@ export const StepInitial = ({
 
     const devices = useSelector(selectDevices);
     const devicesConnected = devices.filter(device => device?.connected);
-    const multipleDevicesConnected = [...new Set(devicesConnected.map(d => d.path))].length > 1;
+    const multipleDevicesConnected = unique(devicesConnected.map(d => d.path)).length > 1;
     const shouldCheckSeed = device?.mode !== 'initialize';
 
     if (!device?.connected || !device?.features) {

--- a/packages/suite/src/views/onboarding/steps/FirmwareStep/FirmwareInitialStep.tsx
+++ b/packages/suite/src/views/onboarding/steps/FirmwareStep/FirmwareInitialStep.tsx
@@ -14,6 +14,7 @@ import { type AcquiredDevice } from '@suite-common/suite-types';
 import { type ButtonProps, Card, Column, Link, Note, Row, Tooltip } from '@trezor/components';
 import { FirmwareType } from '@trezor/connect';
 import { DeviceModelInternal, isBitcoinOnlyDevice } from '@trezor/device-utils';
+import { unique } from '@trezor/utils';
 
 import { FirmwareOffer } from 'src/components/firmware';
 import { FirmwareLowBatteryModal } from 'src/components/firmware/FirmwareLowBatteryModal';
@@ -118,7 +119,7 @@ export const FirmwareInitialStep = ({ onClose }: FirmwareInitialStepProps) => {
 
     // todo: move to utils device.ts
     const devicesConnected = devices.filter(device => device?.connected);
-    const multipleDevicesConnected = [...new Set(devicesConnected.map(d => d.path))].length > 1;
+    const multipleDevicesConnected = unique(devicesConnected.map(d => d.path)).length > 1;
 
     // The first condition is a defensive measure against https://github.com/trezor/trezor-suite/issues/17246, I could not reproduce the error.
     const shouldCheckSeed = !isOnboarding && device?.mode !== 'initialize';

--- a/suite-common/suite-utils/src/device.ts
+++ b/suite-common/suite-utils/src/device.ts
@@ -11,7 +11,7 @@ import {
 import { DeviceModelInternal, getNarrowedDeviceModelInternal } from '@trezor/device-utils';
 import { exhaustive } from '@trezor/type-utils';
 import * as URLS from '@trezor/urls';
-import { hasProp, isArrayMember } from '@trezor/utils';
+import { hasProp, isArrayMember, unique } from '@trezor/utils';
 
 export const deviceStatuses = [
     'acquired',
@@ -453,7 +453,7 @@ export const getFirstDeviceInstance = (
         .sort(options.sortingFn);
 
 export const getPhysicalDeviceUniqueIds = (devices: TrezorDevice[]) =>
-    [...new Set(devices.map(d => d.id))].filter(id => id) as string[];
+    unique(devices.map(d => d.id).filter((id): id is string => !!id));
 
 export const getPhysicalDeviceCount = (devices: TrezorDevice[]) =>
     getPhysicalDeviceUniqueIds(devices).length;

--- a/suite-common/token-definitions/scripts/utils/fetchNft.ts
+++ b/suite-common/token-definitions/scripts/utils/fetchNft.ts
@@ -1,4 +1,6 @@
 /* eslint-disable no-console */
+import { unique } from '@trezor/utils';
+
 import {
     AdvancedTokenStructure,
     SimpleTokenStructure,
@@ -57,5 +59,5 @@ export const fetchNftData = async (assetPlatformId: string, structure: TokenStru
         }, {});
     }
 
-    return [...new Set(allData.map(item => item.contract_address))] as SimpleTokenStructure;
+    return unique(allData.map(item => item.contract_address)) as SimpleTokenStructure;
 };

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -20,6 +20,7 @@ import {
 import { type Account, type SelectedAccountStatus } from '@suite-common/wallet-types';
 import { getCurrencies } from '@trezor/address-validator';
 import { exhaustive } from '@trezor/type-utils';
+import { unique } from '@trezor/utils';
 
 import {
     EMPTY_GROUPED_TRADING_EXCHANGE_QUOTES,
@@ -473,7 +474,7 @@ const getFilteredCryptoIds = (
 
     const supportedAddressValidatorSymbols = new Set(getCurrencies().map(c => c.symbol));
 
-    const uniqueSupportedCryptoIds = [...new Set(supportedCryptoIds).values()];
+    const uniqueSupportedCryptoIds = unique(supportedCryptoIds);
 
     return uniqueSupportedCryptoIds
         .filter(cryptoId => !!coins[cryptoId])

--- a/suite-common/trading/src/thunks/exchange/loadExchangeInfoThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/loadExchangeInfoThunk.ts
@@ -1,6 +1,7 @@
 import { type CryptoId, type ExchangeProviderInfo } from 'invity-api';
 
 import { createThunk } from '@suite-common/redux-utils';
+import { unique } from '@trezor/utils';
 
 import { TRADING_EXCHANGE_THUNK_PREFIX } from '../../constants';
 import { invityAPI } from '../../invityAPI';
@@ -33,8 +34,8 @@ export const loadExchangeInfoThunk = createThunk<ExchangeInfo>(
 
         return fulfillWithValue({
             providerInfos,
-            buyCryptoIds: [...new Set(buyCryptoIds)],
-            sellCryptoIds: [...new Set(sellCryptoIds)],
+            buyCryptoIds: unique(buyCryptoIds),
+            sellCryptoIds: unique(sellCryptoIds),
         });
     },
 );

--- a/suite-common/trading/src/thunks/sell/loadSellInfoThunk.ts
+++ b/suite-common/trading/src/thunks/sell/loadSellInfoThunk.ts
@@ -1,6 +1,7 @@
 import { type CryptoId, type FiatCurrencyCode, type SellProviderInfo } from 'invity-api';
 
 import { createThunk } from '@suite-common/redux-utils';
+import { unique } from '@trezor/utils';
 
 import { TRADING_SELL_THUNK_PREFIX } from '../../constants';
 import { invityAPI } from '../../invityAPI';
@@ -38,8 +39,8 @@ export const loadSellInfoThunk = createThunk<SellInfo>(
 
         return fulfillWithValue({
             providerInfos,
-            supportedFiatCurrencies: [...new Set(supportedFiatCurrencies)],
-            supportedCryptoCurrencies: [...new Set(supportedCryptoCurrencies)],
+            supportedFiatCurrencies: unique(supportedFiatCurrencies),
+            supportedCryptoCurrencies: unique(supportedCryptoCurrencies),
             country: toTradingCountryCode(sellList.country),
             countrySubdivision: sellList.subdivision,
         });

--- a/suite-common/transaction-search/src/simpleSearchTransactions.ts
+++ b/suite-common/transaction-search/src/simpleSearchTransactions.ts
@@ -1,6 +1,6 @@
 import { type WalletAccountTransaction } from '@suite-common/wallet-types';
 import { isTokenTransferMatchesSearch } from '@suite-common/wallet-utils';
-import { BigNumber, typedObjectKeys } from '@trezor/utils';
+import { BigNumber, typedObjectKeys, unique } from '@trezor/utils';
 
 import { getTargetAmounts } from './getTargetAmounts';
 import { numberSearchFilter } from './numberSearchFilter';
@@ -202,6 +202,6 @@ export const simpleSearchTransactions = (
 
     // Remove duplicate txIDs
     return transactions.filter(
-        t => [...new Set(txsToSearch)].includes(t.txid) || t.txid.includes(search),
+        t => unique(txsToSearch).includes(t.txid) || t.txid.includes(search),
     );
 };

--- a/suite-common/wallet-utils/src/fiatRatesUtils.ts
+++ b/suite-common/wallet-utils/src/fiatRatesUtils.ts
@@ -12,7 +12,7 @@ import {
     asTimestamp,
 } from '@suite-common/wallet-types';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
-import { typedObjectKeys } from '@trezor/utils';
+import { typedObjectKeys, unique } from '@trezor/utils';
 
 const ONE_HOUR_IN_SECONDS = 60 * 60;
 
@@ -134,7 +134,7 @@ export const fetchTransactionsRates = async (
     rates: TickerResult[],
 ) => {
     const roundedTimestamps = roundTimestampsToNearestPastHour(timestamps);
-    const uniqueTimestamps = [...new Set(roundedTimestamps)];
+    const uniqueTimestamps = unique(roundedTimestamps);
 
     try {
         const results = await getFiatRatesForTimestamps(

--- a/suite-native/intl/src/getTranslation.ts
+++ b/suite-native/intl/src/getTranslation.ts
@@ -1,5 +1,7 @@
 import { createIntl, createIntlCache } from 'react-intl';
 
+import { unique } from '@trezor/utils';
+
 import { messages } from './messages';
 import { type TxKeyPath } from './types';
 import { flatten } from './utils';
@@ -60,7 +62,7 @@ export const getTranslation = (
     // Throw an error if translation expects a value that was not provided.
     const placeholderRegex = /\{(\w+)(?:,\s*\w+[^}]*)?}/g;
     const matches = template.matchAll(placeholderRegex);
-    const placeholders = Array.from(new Set(Array.from(matches, m => m[1])));
+    const placeholders = unique(Array.from(matches, m => m[1]));
 
     if (placeholders.length > 0) {
         const providedKeys = values ? Object.keys(values) : [];

--- a/suite-native/trading-state/src/selectors/buySelectors.ts
+++ b/suite-native/trading-state/src/selectors/buySelectors.ts
@@ -23,6 +23,7 @@ import {
     getReceiveAccountFromAccountAndAddressString,
 } from '@suite-native/trading-atoms';
 import { type BuyFormValues, type FiatCurrencyItem } from '@suite-native/trading-types';
+import { unique } from '@trezor/utils';
 
 import { getAssetByEnabledNetworksFilter } from '../utils';
 import {
@@ -120,7 +121,7 @@ export const selectBuyFormDefaultValues = createMemoizedSelector(
 export const selectBuySupportedFiatCurrenciesList = createMemoizedSelector(
     [selectBuySupportedFiatCurrencies],
     (currencies): FiatCurrencyItem[] =>
-        [...new Set(currencies)].map(code => ({
+        unique(currencies).map(code => ({
             value: code,
             displayValue: code.toUpperCase(),
             label: getCurrencyLabel(code),

--- a/suite-native/trading-state/src/selectors/sellSelectors.ts
+++ b/suite-native/trading-state/src/selectors/sellSelectors.ts
@@ -14,6 +14,7 @@ import {
 } from '@suite-common/trading';
 import { selectAccountByKey } from '@suite-common/wallet-core';
 import { type FiatCurrencyItem, type SellFormValues } from '@suite-native/trading-types';
+import { unique } from '@trezor/utils';
 
 import {
     selectTradingResidenceCountry,
@@ -36,7 +37,7 @@ export const selectSellSupportedFiatCurrencies = (state: TradingRootState) =>
 export const selectSellSupportedFiatCurrenciesList = createMemoizedSelector(
     [selectSellSupportedFiatCurrencies],
     (currencies): FiatCurrencyItem[] =>
-        [...new Set(currencies)].map(code => ({
+        unique(currencies).map(code => ({
             value: code,
             displayValue: code.toUpperCase(),
             label: getCurrencyLabel(code),


### PR DESCRIPTION
## Summary
Replace all locally-defined `unique` array deduplication functions across packages with the shared `unique` helper from `@trezor/utils`.

## Utility
[`unique`](https://github.com/trezor/trezor-suite/blob/develop/packages/utils/src/unique.ts)

## Related PRs (series)
- #27591 — feat(utils): add noop helper and adopt across packages
- #27592 — feat(utils): add clamp helper and adopt across packages
- #27593 — refactor: adopt unique from @trezor/utils
- #27594 — refactor: adopt resolveAfter from @trezor/utils
- #27595 — refactor: adopt filter predicates (isNotNull, isNotNullOrUndefined, isNotUndefined) from @trezor/utils
- #27596 — refactor: adopt isArrayMember from @trezor/utils
- #27597 — refactor: adopt typed object helpers (typedObjectKeys, typedObjectEntries, isSafeObjectKey) from @trezor/utils
- #27598 — refactor(suite-native): use arrayShuffle and getWeakRandomInt for TrezorFacts
- #27599 — refactor(suite): use splitStringEveryNCharacters from @trezor/utils for homescreen
- #27600 — refactor: adopt getWeakRandomInt from @trezor/utils
- #27601 — refactor: adopt capitalizeFirstLetter from @trezor/utils
- #27602 — refactor(analytics-docs): use removeTrailingSlashes from @trezor/utils

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/utils-adopt-unique&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/utils-adopt-unique/web/](https://dev.suite.sldev.cz/suite-web/mroz22/utils-adopt-unique/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->