### PR TITLE
refactor: adopt resolveAfter from @trezor/utils

### DIFF
--- a/packages/connect/src/device/thp/pairing.ts
+++ b/packages/connect/src/device/thp/pairing.ts
@@ -4,7 +4,7 @@ import type { UiResponseThpPairingTag } from '@trezor/connect-common';
 import { DEVICE } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { ThpPairingMethod, thp as protocolThp } from '@trezor/protocol';
-import { createDeferred } from '@trezor/utils';
+import { createDeferred, resolveAfter } from '@trezor/utils';
 
 import { abortThpWorkflow, thpCall } from './thpCall';
 import * as settingsStore from '../../data/settingsStore';
@@ -207,7 +207,7 @@ const waitForPairingTag = async (device: IDevice) => {
     }
 
     // node-bridge + usb: abort received on client side of http request resolves faster than server. result with "device call in progress"
-    await new Promise(resolve => setTimeout(resolve, 500));
+    await resolveAfter(500);
 
     return processThpPairingResponse(device, pairingResponse).catch(e => {
         // catch pairing tag mismatch

--- a/packages/e2e-utils/src/githubReporter/gitHubReporterBase.ts
+++ b/packages/e2e-utils/src/githubReporter/gitHubReporterBase.ts
@@ -1,6 +1,6 @@
 import type { Octokit } from '@octokit/rest';
 
-import { scheduleAction } from '@trezor/utils';
+import { resolveAfter, scheduleAction } from '@trezor/utils';
 
 import { type TestReportProviderBase } from './annotationBase';
 import { GitHubProject } from './gitHubProject';
@@ -381,7 +381,7 @@ abstract class GitHubReporterBase implements LoggingFunctions {
                 // Random delay between 1-5 seconds to distribute load on GitHub API
                 // Without it we often hit "Your attempt to move this item created a temporary conflict. Please try again"
                 const randomDelay = Math.floor(Math.random() * 4000) + 1000; // 1000-5000ms
-                await new Promise(resolve => setTimeout(resolve, randomDelay));
+                await resolveAfter(randomDelay);
                 this.log(
                     `Creating GitHub draft issue for test "(OS ${operationSystem}) ${report.testTitle}"...`,
                 );

--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -392,7 +392,7 @@ const init = async () => {
         mainWindow?.removeAllListeners();
         logger.exit();
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await resolveAfter(1000);
 
         readyToQuit = true;
         app.quit();

--- a/packages/trezor-user-env-link/src/api.ts
+++ b/packages/trezor-user-env-link/src/api.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 
-import { TypedEmitter } from '@trezor/utils';
+import { TypedEmitter, resolveAfter } from '@trezor/utils';
 
 import { type Firmwares, Model } from './types';
 import { WebsocketClient, type WebsocketClientEvents } from './websocket-client';
@@ -257,49 +257,49 @@ export class TrezorUserEnvLinkClass extends TypedEmitter<WebsocketClientEvents> 
         return null;
     }
     async pressYes() {
-        await new Promise(resolve => setTimeout(resolve, EMU_RACE_CONDITION_WORKAROUND_DELAY));
+        await resolveAfter(EMU_RACE_CONDITION_WORKAROUND_DELAY);
         await this.client.send({ type: 'emulator-press-yes' });
 
         return null;
     }
     async pressNo() {
-        await new Promise(resolve => setTimeout(resolve, EMU_RACE_CONDITION_WORKAROUND_DELAY));
+        await resolveAfter(EMU_RACE_CONDITION_WORKAROUND_DELAY);
         await this.client.send({ type: 'emulator-press-no' });
 
         return null;
     }
     async swipeEmu(direction: 'up' | 'down' | 'left' | 'right') {
-        await new Promise(resolve => setTimeout(resolve, EMU_RACE_CONDITION_WORKAROUND_DELAY));
+        await resolveAfter(EMU_RACE_CONDITION_WORKAROUND_DELAY);
         await this.client.send({ type: 'emulator-swipe', direction });
 
         return null;
     }
     async inputEmu(value: string) {
-        await new Promise(resolve => setTimeout(resolve, EMU_RACE_CONDITION_WORKAROUND_DELAY));
+        await resolveAfter(EMU_RACE_CONDITION_WORKAROUND_DELAY);
         await this.client.send({ type: 'emulator-input', value });
 
         return null;
     }
     async clickEmu(options: ClickEmu) {
-        await new Promise(resolve => setTimeout(resolve, EMU_RACE_CONDITION_WORKAROUND_DELAY));
+        await resolveAfter(EMU_RACE_CONDITION_WORKAROUND_DELAY);
         await this.client.send({ type: 'emulator-click', ...options });
 
         return null;
     }
     async resetDevice(options: any) {
-        await new Promise(resolve => setTimeout(resolve, EMU_RACE_CONDITION_WORKAROUND_DELAY));
+        await resolveAfter(EMU_RACE_CONDITION_WORKAROUND_DELAY);
         await this.client.send({ type: 'emulator-reset-device', ...options });
 
         return null;
     }
     async readAndConfirmMnemonicEmu() {
-        await new Promise(resolve => setTimeout(resolve, EMU_RACE_CONDITION_WORKAROUND_DELAY));
+        await resolveAfter(EMU_RACE_CONDITION_WORKAROUND_DELAY);
         await this.client.send({ type: 'emulator-read-and-confirm-mnemonic' });
 
         return null;
     }
     async readAndConfirmShamirMnemonicEmu(options: ReadAndConfirmShamirMnemonicEmu) {
-        await new Promise(resolve => setTimeout(resolve, EMU_RACE_CONDITION_WORKAROUND_DELAY));
+        await resolveAfter(EMU_RACE_CONDITION_WORKAROUND_DELAY);
         await this.client.send({
             type: 'emulator-read-and-confirm-shamir-mnemonic',
             ...options,
@@ -308,7 +308,7 @@ export class TrezorUserEnvLinkClass extends TypedEmitter<WebsocketClientEvents> 
         return null;
     }
     async readAndConfirmAtomicShamirMnemonicEmu(options: ReadAndConfirmAtomicShamirMnemonicEmu) {
-        await new Promise(resolve => setTimeout(resolve, EMU_RACE_CONDITION_WORKAROUND_DELAY));
+        await resolveAfter(EMU_RACE_CONDITION_WORKAROUND_DELAY);
         await this.client.send({
             type: 'emulator-read-and-confirm-atomic-shamir-mnemonic',
             ...options,
@@ -336,7 +336,7 @@ export class TrezorUserEnvLinkClass extends TypedEmitter<WebsocketClientEvents> 
         return null;
     }
     async selectNumOfWordsEmu(num: number) {
-        await new Promise(resolve => setTimeout(resolve, EMU_RACE_CONDITION_WORKAROUND_DELAY * 2));
+        await resolveAfter(EMU_RACE_CONDITION_WORKAROUND_DELAY * 2);
         await this.client.send({ type: 'emulator-select-num-of-words', num });
 
         return null;
@@ -349,7 +349,7 @@ export class TrezorUserEnvLinkClass extends TypedEmitter<WebsocketClientEvents> 
     }
 
     async getDebugState() {
-        await new Promise(resolve => setTimeout(resolve, EMU_RACE_CONDITION_WORKAROUND_DELAY));
+        await resolveAfter(EMU_RACE_CONDITION_WORKAROUND_DELAY);
         const { response } = await this.client.send({ type: 'emulator-get-debug-state' });
 
         return response;

--- a/packages/trezor-user-env-link/src/websocket-client.ts
+++ b/packages/trezor-user-env-link/src/websocket-client.ts
@@ -2,6 +2,7 @@
 
 import fetch from 'cross-fetch';
 
+import { resolveAfter } from '@trezor/utils';
 import {
     WebsocketClient as WebsocketClientBase,
     type WebsocketResponse as WebsocketResponseData,
@@ -21,8 +22,6 @@ const USER_ENV_URL = {
     WEBSOCKET: `ws://127.0.0.1:9001/`,
     DASHBOARD: `http://127.0.0.1:9002`,
 };
-
-const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 export type WebsocketClientEvents = {
     firmwares: Firmwares;
@@ -115,7 +114,7 @@ export class WebsocketClient extends WebsocketClientBase<WebsocketClientEvents> 
             if (i === limit - 1) {
                 console.log(`cant connect to trezor-user-env: ${error}\n`);
             }
-            await delay(1000);
+            await resolveAfter(1000);
 
             try {
                 const res = await fetch(USER_ENV_URL.DASHBOARD);

--- a/suite-common/fiat-services/src/limiter.ts
+++ b/suite-common/fiat-services/src/limiter.ts
@@ -1,4 +1,4 @@
-import { scheduleAction } from '@trezor/utils';
+import { resolveAfter, scheduleAction } from '@trezor/utils';
 
 // Poor man's rate limiter that slows down requests so there is a `delayMs` gap between them.
 export class RateLimiter {
@@ -19,7 +19,7 @@ export class RateLimiter {
 
         this.queue = resultPromise
             .catch(error => console.error(error)) // ensure errors don't stop the queue
-            .then(() => new Promise(res => setTimeout(res, this.delayMs)));
+            .then(() => resolveAfter(this.delayMs));
 
         return resultPromise;
     }

--- a/suite-common/wallet-core/src/fees/feesThunks.ts
+++ b/suite-common/wallet-core/src/fees/feesThunks.ts
@@ -3,6 +3,7 @@ import { createThunk } from '@suite-common/redux-utils';
 import { type NetworkSymbol, getNetwork, networksCollection } from '@suite-common/wallet-config';
 import { type FeeInfo, type FeesState } from '@suite-common/wallet-types';
 import TrezorConnect from '@trezor/connect';
+import { resolveAfter } from '@trezor/utils';
 
 import { FEES_MODULE_PREFIX, feesActions } from './feesActions';
 import { getNewFeeInfo, sortLevels } from './feesUtils';
@@ -69,9 +70,7 @@ type UpdateFeeInfoThunkProps = {
 };
 
 const getArtificialDelayPromise = (artificialDelay?: number): Promise<void> =>
-    artificialDelay === undefined
-        ? Promise.resolve()
-        : new Promise(resolve => setTimeout(resolve, artificialDelay));
+    artificialDelay === undefined ? Promise.resolve() : resolveAfter(artificialDelay);
 
 /**
  * Fetches feeInfo for a given network from backend.

--- a/suite-native/module-accounts-import/src/screens/AccountImportLoadingScreen.tsx
+++ b/suite-native/module-accounts-import/src/screens/AccountImportLoadingScreen.tsx
@@ -12,12 +12,11 @@ import {
     useInterceptNativeNavigation,
 } from '@suite-native/navigation';
 import { type AccountInfo } from '@trezor/connect';
+import { resolveAfter } from '@trezor/utils';
 
 import { getAccountInfoThunk } from '../accountsImportThunks';
 import { AccountImportLoader } from '../components/AccountImportLoader';
 import { useShowImportError } from '../useShowImportError';
-
-const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 export const AccountImportLoadingScreen = ({
     navigation,
@@ -58,7 +57,7 @@ export const AccountImportLoadingScreen = ({
         async (onRetry?: () => Promise<void>) => {
             // Delay displaying the error message to avoid freezing the app on iOS. If an error occurs too quickly during the
             // transition from ScanQRCodeModalScreen, the error modal won't appear, resulting in a frozen app.
-            await sleep(1000);
+            await resolveAfter(1000);
             showImportError(error, () => {
                 if (!onRetry) return;
                 onRetry();

--- a/suite-native/module-add-accounts/src/hooks/useAddCoinAccount.ts
+++ b/suite-native/module-add-accounts/src/hooks/useAddCoinAccount.ts
@@ -47,6 +47,7 @@ import {
     type StackToStackCompositeNavigationProps,
 } from '@suite-native/navigation';
 import { exhaustive } from '@trezor/type-utils';
+import { resolveAfter } from '@trezor/utils';
 
 import { useAddCoinAccountAlerts } from './useAddCoinAccountAlerts';
 
@@ -512,7 +513,7 @@ export const useAddCoinAccount = () => {
         if (networkSymbolWithTypeToBeAdded) {
             clearNetworkWithTypeToBeAdded();
             // TODO why timeout?
-            await new Promise(resolve => setTimeout(resolve, 100));
+            await resolveAfter(100);
             await addCoinAccount({
                 symbol: networkSymbolWithTypeToBeAdded[0],
                 accountType: networkSymbolWithTypeToBeAdded[1],

--- a/suite-native/module-earn/src/screens/StakingDetailScreen.tsx
+++ b/suite-native/module-earn/src/screens/StakingDetailScreen.tsx
@@ -10,11 +10,10 @@ import { isStakingSymbol, parseAccountKey } from '@suite-common/wallet-utils';
 import { ContextMessage } from '@suite-native/message-system';
 import { type RootStackParamList, type RootStackRoutes, Screen } from '@suite-native/navigation';
 import { useNativeStyles } from '@trezor/styles-native';
+import { resolveAfter } from '@trezor/utils';
 
 import { StakingDetailScreenHeader } from '../components/StakingDetailScreenHeader';
 import { StakingInfo } from '../components/StakingInfo';
-
-const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 export const StakingDetailScreen = () => {
     const route = useRoute<RouteProp<RootStackParamList, RootStackRoutes.StakingDetail>>();
@@ -33,7 +32,7 @@ export const StakingDetailScreen = () => {
         setIsRefreshing(true);
         await dispatch(initStakeDataThunk());
         // sleep little bit because it's too fast
-        await sleep(1000);
+        await resolveAfter(1000);
         setIsRefreshing(false);
     }, [dispatch]);
 


### PR DESCRIPTION
## Summary
Replace all locally-defined `resolveAfter` / `sleep`-style promise delay helpers across packages with the shared `resolveAfter` from `@trezor/utils`.

## Utility
[`resolveAfter`](https://github.com/trezor/trezor-suite/blob/develop/packages/utils/src/resolveAfter.ts)

## Related PRs (series)
- #27591 — feat(utils): add noop helper and adopt across packages
- #27592 — feat(utils): add clamp helper and adopt across packages
- #27593 — refactor: adopt unique from @trezor/utils
- #27594 — refactor: adopt resolveAfter from @trezor/utils
- #27595 — refactor: adopt filter predicates (isNotNull, isNotNullOrUndefined, isNotUndefined) from @trezor/utils
- #27596 — refactor: adopt isArrayMember from @trezor/utils
- #27597 — refactor: adopt typed object helpers (typedObjectKeys, typedObjectEntries, isSafeObjectKey) from @trezor/utils
- #27598 — refactor(suite-native): use arrayShuffle and getWeakRandomInt for TrezorFacts
- #27599 — refactor(suite): use splitStringEveryNCharacters from @trezor/utils for homescreen
- #27600 — refactor: adopt getWeakRandomInt from @trezor/utils
- #27601 — refactor: adopt capitalizeFirstLetter from @trezor/utils
- #27602 — refactor(analytics-docs): use removeTrailingSlashes from @trezor/utils

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/utils-adopt-resolve-after&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/utils-adopt-resolve-after&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/utils-adopt-resolve-after&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/utils-adopt-resolve-after/web/](https://dev.suite.sldev.cz/suite-web/mroz22/utils-adopt-resolve-after/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > TrezorConnect.getAddress | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-13T07:35:39.978Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Send form for bitcoin > add and remove output in send form, toggle form options, input data | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-13T07:34:10.721Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->