### PR TITLE
refactor: adopt filter predicates (isNotNull, isNotNullOrUndefined, isNotUndefined) from @trezor/utils

### DIFF
--- a/packages/blockchain-link-utils/src/blockfrost.ts
+++ b/packages/blockchain-link-utils/src/blockfrost.ts
@@ -13,6 +13,7 @@ import type {
     Utxo,
     VinVout,
 } from '@trezor/blockchain-link-types';
+import { isNotNullOrUndefined } from '@trezor/utils';
 import { BigNumber, type BigNumberValue } from '@trezor/utils/src/bigNumber';
 
 import { enhanceVinVout, filterTargets, sumVinVout, transformTarget } from './utils';
@@ -209,7 +210,7 @@ export const filterTokenTransfers = (
             });
     });
 
-    return transfers.filter(t => !!t) as TokenTransfer[];
+    return transfers.filter(isNotNullOrUndefined);
 };
 
 export const transformTransaction = (

--- a/packages/blockchain-link-utils/src/solana.ts
+++ b/packages/blockchain-link-utils/src/solana.ts
@@ -32,7 +32,7 @@ import type {
     TokenProgramName,
 } from '@trezor/coins-solana/types';
 import { isCodesignBuild } from '@trezor/env-utils';
-import { arrayPartition, isArrayMember } from '@trezor/utils';
+import { arrayPartition, isArrayMember, isNotNullOrUndefined } from '@trezor/utils';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 export type ApiTokenAccount = {
@@ -258,7 +258,7 @@ export function getNativeEffects(transaction: ParsedTransactionWithMeta): Transa
                 amount: balanceDiff.postBalance.minus(balanceDiff.preBalance),
             };
         })
-        .filter((effect): effect is TransactionEffect => !!effect)
+        .filter(isNotNullOrUndefined)
         .filter(({ amount }) => !amount.isZero()); // filter out zero effects
 }
 

--- a/packages/blockchain-link/src/workers/evm-rpc/handlers/getAccountInfo.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/handlers/getAccountInfo.ts
@@ -3,6 +3,7 @@ import type {
     ResponseTypes as Responses,
     TokenInfo,
 } from '@trezor/blockchain-link-types';
+import { isNotNull } from '@trezor/utils';
 
 import { mapGetAccountInfoResponse } from '../mappers/accountInfo';
 import { getStakingPoolData } from '../staking/poolData';
@@ -29,7 +30,7 @@ export const getAccountInfo = async (
     if (payload.details === 'tokenBalances' && payload.contractFilter) {
         const contractAddress = toHex(payload.contractFilter);
         const tokenInfo = await getTokenInfo(client, address, contractAddress, true);
-        tokens = [tokenInfo].filter((token): token is TokenInfo => token !== null);
+        tokens = [tokenInfo].filter(isNotNull);
     }
 
     return mapGetAccountInfoResponse({

--- a/packages/blockchain-link/src/workers/evm-rpc/utils/block.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/utils/block.ts
@@ -1,5 +1,7 @@
 import { type PublicClient } from 'viem';
 
+import { isNotNullOrUndefined } from '@trezor/utils';
+
 export const calculateBlockTime = async (client: PublicClient): Promise<number | null> => {
     try {
         const latestBlock = await client.getBlock({ blockTag: 'latest' });
@@ -26,7 +28,7 @@ export const averageRewards = (rewards: bigint[][], percentileIndex: number): bi
 
     for (const blockRewards of rewards) {
         const reward = blockRewards[percentileIndex];
-        if (reward !== null && reward !== undefined) {
+        if (isNotNullOrUndefined(reward)) {
             sum += reward;
             count++;
         }

--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -24,7 +24,7 @@ import type {
 } from '@trezor/coins-solana/types';
 import { getSuiteVersion } from '@trezor/env-utils';
 import { type IntervalId } from '@trezor/type-utils';
-import { BigNumber, createDeferred, createLazy } from '@trezor/utils';
+import { BigNumber, createDeferred, createLazy, isNotNullOrUndefined } from '@trezor/utils';
 
 import { BaseWorker, CONTEXT, type ContextType } from '../baseWorker';
 
@@ -38,10 +38,6 @@ type SignatureWithSlot = {
     signature: Signature;
     slot: Slot;
 };
-
-function nonNullable<T>(value: T): value is NonNullable<T> {
-    return value !== null && value !== undefined;
-}
 
 const getAllSignatures = async (
     api: SolanaAPI,
@@ -90,7 +86,7 @@ const fetchTransactionPage = async (
                     .send(),
             ),
         )
-    ).filter(nonNullable);
+    ).filter(isNotNullOrUndefined);
 
 const isValidTransaction = (tx: ParsedTransactionWithMeta): tx is SolanaValidParsedTxWithMeta =>
     !!(tx?.meta && tx.transaction && tx.blockTime);
@@ -259,7 +255,7 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
                     tokenMetadata,
                 ),
             )
-            .filter((tx): tx is Transaction => !!tx);
+            .filter(isNotNullOrUndefined);
 
         const transactions: Transaction[] = await Promise.all(
             page.map(async tx => {

--- a/packages/blockchain-link/tests/unit/block.test.ts
+++ b/packages/blockchain-link/tests/unit/block.test.ts
@@ -1,0 +1,33 @@
+import { averageRewards } from '../../src/workers/evm-rpc/utils/block';
+
+describe(averageRewards.name, () => {
+    it('returns 0n for empty input', () => {
+        expect(averageRewards([], 0)).toBe(0n);
+    });
+
+    it('averages bigint rewards at the given percentile', () => {
+        const rewards = [
+            [10n, 100n],
+            [20n, 200n],
+            [30n, 300n],
+        ];
+        expect(averageRewards(rewards, 0)).toBe(20n);
+        expect(averageRewards(rewards, 1)).toBe(200n);
+    });
+
+    // Regression guard: filtering with a truthy predicate would drop legitimate 0n
+    // values and inflate the average. The filter must only skip null/undefined.
+    it('includes 0n as a legitimate reward', () => {
+        const rewards = [[0n], [0n], [6n]];
+        expect(averageRewards(rewards, 0)).toBe(2n);
+    });
+
+    it('skips entries where the percentile slot is missing', () => {
+        const rewards: bigint[][] = [[10n], [], [30n]];
+        expect(averageRewards(rewards, 0)).toBe(20n);
+    });
+
+    it('returns 0n when every percentile slot is missing', () => {
+        expect(averageRewards([[], [], []], 0)).toBe(0n);
+    });
+});

--- a/packages/connect/src/data/firmwareInfo.ts
+++ b/packages/connect/src/data/firmwareInfo.ts
@@ -18,7 +18,12 @@ import {
     getFirmwareOrBootloaderVersionArray,
     getFirmwareVersionArray,
 } from '@trezor/device-utils';
-import { getIntegerInRangeFromString, removeTrailingSlashes, versionUtils } from '@trezor/utils';
+import {
+    getIntegerInRangeFromString,
+    isNotNull,
+    removeTrailingSlashes,
+    versionUtils,
+} from '@trezor/utils';
 import type { VersionArray } from '@trezor/utils/src/versionUtils';
 
 import * as firmwareReleaseStore from './firmwareReleaseStore';
@@ -228,7 +233,7 @@ export const createLocalFirmwareConfig = (baseConfig: FirmwareReleaseConfig) => 
 
             return [modelKey, releases];
         })
-        .filter(entry => entry !== null);
+        .filter(isNotNull);
 
     return Object.fromEntries(releaseEntries);
 };
@@ -263,7 +268,7 @@ export const createRemoteFirmwareConfig = async (config: FirmwareReleaseConfig) 
         },
     );
 
-    const validEntries = (await Promise.all(releaseEntryPromises)).filter(entry => entry !== null);
+    const validEntries = (await Promise.all(releaseEntryPromises)).filter(isNotNull);
 
     return Object.fromEntries(validEntries);
 };

--- a/packages/connect/src/device/resolveDescriptorForTaproot.ts
+++ b/packages/connect/src/device/resolveDescriptorForTaproot.ts
@@ -1,6 +1,6 @@
 import type { HDNodeResponse } from '@trezor/connect-common/src/types/api/getPublicKey';
 import type { MessagesSchema as Messages } from '@trezor/protobuf';
-import { convertTaprootXpub } from '@trezor/utils';
+import { convertTaprootXpub, isNotNull, isNotNullOrUndefined } from '@trezor/utils';
 
 interface ResolveDescriptorForTaprootParams {
     response: HDNodeResponse;
@@ -11,14 +11,14 @@ export const resolveDescriptorForTaproot = ({
     response,
     publicKey,
 }: ResolveDescriptorForTaprootParams) => {
-    if (publicKey.descriptor !== null && publicKey.descriptor !== undefined) {
+    if (isNotNullOrUndefined(publicKey.descriptor)) {
         const [xpub, checksum] = publicKey.descriptor.split('#');
 
         // This is here to keep backwards compatibility, suite and block-books
         // are still using `'` over `h`.
         const correctedXpub = convertTaprootXpub({ xpub, direction: 'h-to-apostrophe' });
 
-        if (correctedXpub !== null) {
+        if (isNotNull(correctedXpub)) {
             return { xpub: correctedXpub, checksum };
         }
     }

--- a/packages/device-authenticity/src/validateSerialNumbers.ts
+++ b/packages/device-authenticity/src/validateSerialNumbers.ts
@@ -1,3 +1,5 @@
+import { isNotNull } from '@trezor/utils';
+
 import { type ResultsToValidate } from './types';
 
 const failAllResults = ({
@@ -29,7 +31,7 @@ const failAllResults = ({
 export const validateSerialNumbers = (resultsToValidate: ResultsToValidate): ResultsToValidate => {
     const { optigaResult, tropicResult, mcuResult } = resultsToValidate;
 
-    const availableResults = [optigaResult, tropicResult, mcuResult].filter(r => r !== null);
+    const availableResults = [optigaResult, tropicResult, mcuResult].filter(isNotNull);
     // Cannot happen, see authenticateDevice, there'll always be at least failed optigaResult (it's always required).
     if (availableResults.length === 0) return resultsToValidate;
 

--- a/packages/product-components/src/components/SelectAssetModal/hooks/useNetworkSelect.ts
+++ b/packages/product-components/src/components/SelectAssetModal/hooks/useNetworkSelect.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 
 import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { isNotNull } from '@trezor/utils';
 
 export interface SearchAssetSelectConfig {
     networks: NetworkSymbol[];
@@ -20,7 +21,7 @@ export const useNetworkSelect = (config?: SearchAssetSelectConfig) => {
 
                 return network ? { label: network.name, value: network.symbol } : null;
             })
-            .filter(option => !!option);
+            .filter(isNotNull);
 
         return includeAllOption
             ? [{ label: allLabel ?? 'All networks', value: undefined }, ...networkOptions]

--- a/packages/suite-desktop-core/src/libs/app-utils.ts
+++ b/packages/suite-desktop-core/src/libs/app-utils.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
-import { mergeDeepObject } from '@trezor/utils';
+import { isNotNull, mergeDeepObject } from '@trezor/utils';
 
 import { app } from '../typed-electron';
 
@@ -48,7 +48,7 @@ export const processStatePatch = (): ProcessStatePatchResult =>
     // not using getSwitchValue because this is a very customized way to parse process switches
     process.argv
         .map(arg => arg.match(STATE_ASSIGNMENT_REGEX))
-        .filter(match => match !== null)
+        .filter(isNotNull)
         .map((assignment: RegExpMatchArray) => {
             const [_, key, value] = assignment;
 

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -26,7 +26,7 @@ import {
     selectHistoricRatesByTransactions,
 } from '@suite-common/wallet-utils';
 import { type StaticSessionId } from '@trezor/connect';
-import { cloneObject, typedObjectKeys } from '@trezor/utils';
+import { cloneObject, isNotNullOrUndefined, typedObjectKeys } from '@trezor/utils';
 
 import { selectCoinjoinAccountByKey } from 'src/reducers/wallet/coinjoinReducer';
 import { db } from 'src/storage';
@@ -295,7 +295,7 @@ export const saveAccountHistoricRates =
     (_dispatch: Dispatch, getState: GetState) => {
         if (!db.isAccessible()) return Promise.resolve();
         const allTxs = getState().wallet.transactions.transactions;
-        const accTxs = (allTxs[accountKey] || []).filter(tx => !!tx);
+        const accTxs = (allTxs[accountKey] || []).filter(isNotNullOrUndefined);
 
         const accHistoricRates = selectHistoricRatesByTransactions(historicRates, accTxs);
 

--- a/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldAccountsVisibility.ts
+++ b/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldAccountsVisibility.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 
-import { type Account } from '@suite-common/wallet-types';
 import { sortByCoin } from '@suite-common/wallet-utils';
+import { isNotUndefined } from '@trezor/utils';
 
 import { type YieldAccountOpportunity } from '../types';
 
@@ -39,7 +39,7 @@ export const useYieldAccountsVisibility = ({
             );
             const vaultAccounts = vaultOpportunities
                 .map(opportunity => opportunity.account)
-                .filter((account): account is Account => account !== undefined);
+                .filter(isNotUndefined);
             const [firstAccountByCoinOrder] = sortByCoin([...vaultAccounts]);
 
             const fallbackOpportunity = firstAccountByCoinOrder

--- a/packages/suite/src/utils/wallet/exportTransactionsUtils.ts
+++ b/packages/suite/src/utils/wallet/exportTransactionsUtils.ts
@@ -25,7 +25,7 @@ import {
 } from '@suite-common/wallet-utils';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 import { type TransactionTarget } from '@trezor/connect';
-import { BigNumber } from '@trezor/utils';
+import { BigNumber, isNotNull } from '@trezor/utils';
 
 type AccountTransactionForExports = Omit<WalletAccountTransaction, 'targets'> & {
     targets: (TransactionTarget & { metadataLabel?: string })[];
@@ -313,7 +313,7 @@ const prepareContent = (
 
             return [...targets, ...tokens, ...internalTransfers, ...cardanoStaking];
         })
-        .filter(record => record !== null) as Fields[];
+        .filter(isNotNull) as Fields[];
 };
 
 export const sanitizeCsvValue = (value: string) => {

--- a/packages/suite/src/utils/wallet/graph/utils.ts
+++ b/packages/suite/src/utils/wallet/graph/utils.ts
@@ -169,8 +169,8 @@ export const getMinMaxValueFromData = <TType extends TypeName, TValue extends Bi
     const maxValue = BigNumber.max(maxSent, maxReceived, maxBalance);
 
     const minsToCompare = [minSent, minReceived, minBalance]
-        .filter(m => !!m)
-        .map(m => m!.toNumber());
+        .filter((m): m is TValue => !!m)
+        .map(m => m.toNumber());
     const minValue = BigNumber.min(...minsToCompare);
 
     return [minValue as TValue, maxValue as TValue];

--- a/suite-common/calldata/src/validation/createArrayValidator.ts
+++ b/suite-common/calldata/src/validation/createArrayValidator.ts
@@ -1,6 +1,8 @@
+import { isNotNull } from '@trezor/utils';
+
 import { type ValidationResult } from '../types/validation';
 
-const allValid = <T>(values: (T | null)[]): values is T[] => values.every(v => v !== null);
+const allValid = <T>(values: (T | null)[]): values is T[] => values.every(isNotNull);
 
 export const createArrayValidator =
     <Input, Output, Context = Record<string, unknown>>(

--- a/suite-common/calldata/src/validation/createValidator.ts
+++ b/suite-common/calldata/src/validation/createValidator.ts
@@ -1,3 +1,5 @@
+import { isNotNull } from '@trezor/utils';
+
 import { type IssueCode, type ValidationResult } from '../types/validation';
 
 export type ValidateFn<Input> = (input: Input) => IssueCode | null;
@@ -19,7 +21,7 @@ export const createValidator =
     (input: Input, path: string, context?: Context): ValidationResult<Output> => {
         for (const validateFn of config.validate) {
             const code = validateFn(input);
-            if (code !== null) {
+            if (isNotNull(code)) {
                 return { value: null, issues: [{ code, path }] };
             }
         }
@@ -28,7 +30,7 @@ export const createValidator =
 
         const inspectIssues = (config.inspect ?? [])
             .map(inspectFn => inspectFn(normalizedValue, context))
-            .filter((code): code is IssueCode => code !== null)
+            .filter(isNotNull)
             .map(code => ({ code, path }));
 
         return { value: normalizedValue, issues: inspectIssues };

--- a/suite-common/suite-sync/src/owner/createEnsureSuiteSyncOwner.ts
+++ b/suite-common/suite-sync/src/owner/createEnsureSuiteSyncOwner.ts
@@ -1,5 +1,6 @@
 import { type EnsureSuiteSyncOwner } from '@suite-common/suite-sync-types';
 import { ok } from '@trezor/type-utils';
+import { isNotNull } from '@trezor/utils';
 
 import { type LoadSuiteSyncOwnerFromStateDep } from './createLoadSuiteSyncOwnerFromState';
 import { type RetrieveSuiteSyncOwnerKeysDep } from './createRetrieveSuiteSyncOwner';
@@ -21,7 +22,7 @@ export const createEnsureSuiteSyncOwner =
             deviceStaticId: device.state.staticSessionId,
         });
 
-        if (currentSuiteSyncOwner !== null) {
+        if (isNotNull(currentSuiteSyncOwner)) {
             return ok(currentSuiteSyncOwner);
         }
 

--- a/suite-common/suite-sync/src/relay/createChangeRelayUrl.ts
+++ b/suite-common/suite-sync/src/relay/createChangeRelayUrl.ts
@@ -5,6 +5,7 @@ import {
     type SuiteSyncStorageRepositoryDep,
 } from '@suite-common/suite-sync-types';
 import { type StaticSessionId } from '@trezor/connect';
+import { isNotNull } from '@trezor/utils';
 
 import { setSuiteSyncRelayUrl } from '../suiteSyncSlice';
 import { DEFAULT_SUITE_SYNC_RELAY_URL } from './relayUrl';
@@ -30,7 +31,7 @@ export const createChangeRelayUrl =
             const storageId = createStorageIdFromDeviceStaticSessionId(deviceStaticSessionId);
             const storage = deps.suiteSyncStorageRepository.get(storageId);
 
-            if (storage !== null) {
+            if (isNotNull(storage)) {
                 await storage.updateRelayUrl(normalizedUrl);
             }
         }

--- a/suite-common/suite-utils/src/__tests__/device.test.ts
+++ b/suite-common/suite-utils/src/__tests__/device.test.ts
@@ -1,4 +1,5 @@
 import { type AcquiredDevice } from '@suite-common/suite-types';
+import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
 import fixtures from '../__fixtures__/device';
@@ -15,6 +16,8 @@ import {
     getNewInstanceNumber,
     getNewWalletNumber,
     getPackagingUrl,
+    getPhysicalDeviceCount,
+    getPhysicalDeviceUniqueIds,
     getSelectedDevice,
     getStatus,
     isDeviceWithButtonOnlyNoTouchscreen,
@@ -171,5 +174,56 @@ describe('device utils', () => {
     test(isDeviceWithButtonOnlyNoTouchscreen.name, () => {
         expect(isDeviceWithButtonOnlyNoTouchscreen(DeviceModelInternal.T3B1)).toBe(true);
         expect(isDeviceWithButtonOnlyNoTouchscreen(DeviceModelInternal.T3T1)).toBe(false);
+    });
+});
+
+describe(getPhysicalDeviceUniqueIds.name, () => {
+    it('returns empty array for no devices', () => {
+        expect(getPhysicalDeviceUniqueIds([])).toEqual([]);
+    });
+
+    it('returns single id for one device', () => {
+        const devices = [mockSuiteDevice(undefined, { device_id: 'a' })];
+        expect(getPhysicalDeviceUniqueIds(devices)).toEqual(['a']);
+    });
+
+    it('deduplicates ids across multiple instances of the same physical device', () => {
+        const devices = [
+            mockSuiteDevice({ instance: 1 }, { device_id: 'a' }),
+            mockSuiteDevice({ instance: 2 }, { device_id: 'a' }),
+            mockSuiteDevice(undefined, { device_id: 'b' }),
+        ];
+        expect(getPhysicalDeviceUniqueIds(devices)).toEqual(['a', 'b']);
+    });
+
+    // Regression guard: switching the filter to a pure null/undefined typeguard
+    // would let empty-string ids through and inflate the count (used in analytics).
+    it('filters out devices with an empty-string id', () => {
+        const devices = [
+            mockSuiteDevice(undefined, { device_id: '' }),
+            mockSuiteDevice(undefined, { device_id: 'a' }),
+        ];
+        expect(getPhysicalDeviceUniqueIds(devices)).toEqual(['a']);
+    });
+
+    it('filters out devices with a null id', () => {
+        const devices = [
+            mockSuiteDevice(undefined, { device_id: null }),
+            mockSuiteDevice(undefined, { device_id: 'a' }),
+        ];
+        expect(getPhysicalDeviceUniqueIds(devices)).toEqual(['a']);
+    });
+});
+
+describe(getPhysicalDeviceCount.name, () => {
+    it('counts unique physical devices, ignoring instances and falsy ids', () => {
+        const devices = [
+            mockSuiteDevice({ instance: 1 }, { device_id: 'a' }),
+            mockSuiteDevice({ instance: 2 }, { device_id: 'a' }),
+            mockSuiteDevice(undefined, { device_id: 'b' }),
+            mockSuiteDevice(undefined, { device_id: '' }),
+            mockSuiteDevice(undefined, { device_id: null }),
+        ];
+        expect(getPhysicalDeviceCount(devices)).toBe(2);
     });
 });

--- a/suite-common/trading/src/hooks/useTradingAssets.ts
+++ b/suite-common/trading/src/hooks/useTradingAssets.ts
@@ -19,6 +19,7 @@ import {
 } from '@suite-common/wallet-config';
 import { getCurrencies } from '@trezor/address-validator';
 import { type TokenInfo } from '@trezor/connect';
+import { isNotNull } from '@trezor/utils';
 
 import { TRADING_DEFAULT_CRYPTO_CURRENCY } from '../constants';
 import {
@@ -239,7 +240,7 @@ export function useTradingAssets() {
                         platformInfo: getTradingPlatformsInfoByCryptoId(platforms, cryptoId),
                     }),
                 )
-                .filter(asset => asset !== null);
+                .filter(isNotNull);
 
             const networks = assets.filter(asset => asset.isNativeToken).map(asset => asset.symbol);
 

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
@@ -26,7 +26,7 @@ import {
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 import TrezorConnect from '@trezor/connect';
 import { type TimerId, exhaustive } from '@trezor/type-utils';
-import { BigNumber, typedObjectKeys } from '@trezor/utils';
+import { BigNumber, isNotUndefined, typedObjectKeys } from '@trezor/utils';
 
 import { FIAT_RATES_MODULE_PREFIX, REFETCH_INTERVAL } from './fiatRatesConstants';
 import { selectTickersToBeUpdated } from './fiatRatesSelectors';
@@ -136,7 +136,7 @@ export const updateTxsFiatRatesThunk = createThunk(
 
         const timestamps = txs
             .map(tx => (tx.blockTime !== undefined ? asTimestamp(tx.blockTime) : undefined))
-            .filter(it => it !== undefined);
+            .filter(isNotUndefined);
 
         await fetchTransactionsRates(
             { symbol: account.symbol },
@@ -167,7 +167,7 @@ export const updateTxsFiatRatesThunk = createThunk(
 
             const tokenTimestamps = groupedTokensTxs[token]
                 .map(tx => (tx.blockTime !== undefined ? asTimestamp(tx.blockTime) : undefined))
-                .filter(it => it !== undefined);
+                .filter(isNotUndefined);
 
             await fetchTransactionsRates(
                 {

--- a/suite-common/wallet-core/src/transactions/transactionsSelectors.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsSelectors.ts
@@ -28,7 +28,7 @@ import {
     roundTimestampToNearestPastHour,
 } from '@suite-common/wallet-utils';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
-import { typedObjectKeys } from '@trezor/utils';
+import { isNotNullOrUndefined, typedObjectKeys } from '@trezor/utils';
 
 import type { TransactionsRootState } from './transactionsReducerTypes';
 import type { AccountsRootState } from '../accounts/accountsReducer';
@@ -83,7 +83,7 @@ export const selectAccountTransactionsWithNulls = (
 
 export const selectAccountTransactions = createMemoizedSelector(
     [selectAccountTransactionsWithNulls],
-    transactions => returnStableArrayIfEmpty(transactions.filter(t => !!t)),
+    transactions => returnStableArrayIfEmpty(transactions.filter(isNotNullOrUndefined)),
 );
 
 export const selectPendingAccountAddresses = createMemoizedSelector(

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -29,7 +29,7 @@ import {
     type TokenTransfer,
 } from '@trezor/connect';
 import { type Branded } from '@trezor/type-utils';
-import { BigNumber, arrayPartition, typedObjectKeys } from '@trezor/utils';
+import { BigNumber, arrayPartition, isNotNullOrUndefined, typedObjectKeys } from '@trezor/utils';
 
 import { convertAmountSubunitsToUnits, formatNetworkAmount } from './amountUtils';
 import { isCardanoStakingTx } from './cardanoStakingUtils';
@@ -460,7 +460,7 @@ export const analyzeTransactions = (
     }
 
     // make sure the known transactions are sorted properly
-    const knownSorted = knownRest.filter(tx => tx != null).sort(sortByBlockHeight);
+    const knownSorted = knownRest.filter(isNotNullOrUndefined).sort(sortByBlockHeight);
     // run thru all fresh txs
     fresh.forEach((tx, i) => {
         const height = tx.blockHeight;

--- a/suite-native/send/src/sendFormThunks.ts
+++ b/suite-native/send/src/sendFormThunks.ts
@@ -32,7 +32,7 @@ import {
 } from '@suite-native/transaction-management';
 import { type BlockbookTransaction } from '@trezor/blockchain-link-types';
 import { type Ok } from '@trezor/type-utils';
-import { isNotNullOrUndefined, typedObjectKeys } from '@trezor/utils';
+import { isNotNull, isNotNullOrUndefined, typedObjectKeys } from '@trezor/utils';
 
 import { SEND_MODULE_PREFIX } from './constants';
 
@@ -205,7 +205,7 @@ export const sendTransactionThunk = createThunk<
 
         const formValues = selectSendFormDraftByKey(getState(), selectedAccount.key, tokenContract);
 
-        if (formValues !== null) {
+        if (isNotNull(formValues)) {
             await dispatch(
                 addTransactionLabelingThunk({
                     txId: sendResponse.payload.payload.txid,

--- a/suite-native/transaction-management/src/utils.ts
+++ b/suite-native/transaction-management/src/utils.ts
@@ -1,5 +1,5 @@
 import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
-import { BigNumber } from '@trezor/utils';
+import { BigNumber, isNotNull } from '@trezor/utils';
 
 export const getFeeDecimals = ({ symbol }: { symbol: NetworkSymbol }) => {
     const network = getNetwork(symbol);
@@ -31,7 +31,7 @@ export const getFeeValue = ({
 
     const decimals = getFeeDecimals({ symbol });
 
-    if (decimals !== null) {
+    if (isNotNull(decimals)) {
         return new BigNumber(feeRate).decimalPlaces(decimals, 1 /*ROUND_DOWN*/).toFixed();
     }
 


### PR DESCRIPTION
## Summary
Replace locally-defined null/undefined filter predicates (`isNotNull`, `isNotNullOrUndefined`, `isNotUndefined`) across packages with the shared versions from `@trezor/utils`.

## Utility
- [`isNotNull`](https://github.com/trezor/trezor-suite/blob/develop/packages/utils/src/isNotNull.ts)
- [`isNotNullOrUndefined`](https://github.com/trezor/trezor-suite/blob/develop/packages/utils/src/isNotNullOrUndefined.ts)
- [`isNotUndefined`](https://github.com/trezor/trezor-suite/blob/develop/packages/utils/src/isNotUndefined.ts)

## Related PRs (series)
- #27591 — feat(utils): add noop helper and adopt across packages
- #27592 — feat(utils): add clamp helper and adopt across packages
- #27593 — refactor: adopt unique from @trezor/utils
- #27594 — refactor: adopt resolveAfter from @trezor/utils
- #27595 — refactor: adopt filter predicates (isNotNull, isNotNullOrUndefined, isNotUndefined) from @trezor/utils
- #27596 — refactor: adopt isArrayMember from @trezor/utils
- #27597 — refactor: adopt typed object helpers (typedObjectKeys, typedObjectEntries, isSafeObjectKey) from @trezor/utils
- #27598 — refactor(suite-native): use arrayShuffle and getWeakRandomInt for TrezorFacts
- #27599 — refactor(suite): use splitStringEveryNCharacters from @trezor/utils for homescreen
- #27600 — refactor: adopt getWeakRandomInt from @trezor/utils
- #27601 — refactor: adopt capitalizeFirstLetter from @trezor/utils
- #27602 — refactor(analytics-docs): use removeTrailingSlashes from @trezor/utils

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/utils-adopt-filter-predicates&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/utils-adopt-filter-predicates&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/utils-adopt-filter-predicates&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/utils-adopt-filter-predicates/web/](https://dev.suite.sldev.cz/suite-web/mroz22/utils-adopt-filter-predicates/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-13T09:24:14.196Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send form for bitcoin > add and remove output in send form, toggle form options, input data | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-13T09:22:19.858Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->