### PR TITLE
refactor: adopt isArrayMember from @trezor/utils

### DIFF
--- a/packages/suite-desktop-core/src/libs/logger.ts
+++ b/packages/suite-desktop-core/src/libs/logger.ts
@@ -7,6 +7,7 @@ import path from 'path';
 import { isDevEnv } from '@suite-common/suite-utils';
 import { ensureDirectoryExists } from '@trezor/node-utils';
 import { type TimerId } from '@trezor/type-utils';
+import { isArrayMember } from '@trezor/utils';
 
 import { getBuildInfo, getComputerInfo } from './info';
 import { getSwitchValue, hasSwitch } from './process-switches';
@@ -14,8 +15,7 @@ import { getSwitchValue, hasSwitch } from './process-switches';
 const logLevels = ['mute', 'error', 'warn', 'info', 'debug'] as const;
 
 export type LogLevel = (typeof logLevels)[number];
-const isLogLevel = (level: string): level is LogLevel =>
-    !!level && logLevels.includes(level as LogLevel);
+const isLogLevel = (level: string): level is LogLevel => isArrayMember(level, logLevels);
 
 export type Options = {
     colors: boolean; // Console output has colors

--- a/packages/transport/src/errors-groups.ts
+++ b/packages/transport/src/errors-groups.ts
@@ -1,3 +1,5 @@
+import { isArrayMember } from '@trezor/utils';
+
 import * as ERRORS from './errors';
 
 /**
@@ -17,4 +19,4 @@ const ERRORS_WITHOUT_DEVICE_INTERACTION = [
 export const isErrorWithoutDeviceInteraction = (
     error: string,
 ): error is (typeof ERRORS_WITHOUT_DEVICE_INTERACTION)[number] =>
-    ERRORS_WITHOUT_DEVICE_INTERACTION.includes(error as any);
+    isArrayMember(error, ERRORS_WITHOUT_DEVICE_INTERACTION);

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -26,10 +26,10 @@ import TrezorConnect, {
 } from '@trezor/connect';
 import { isDesktop, isWeb } from '@trezor/env-utils';
 import { DATA_URL } from '@trezor/urls';
-import { capitalizeFirstLetter, getSynchronize } from '@trezor/utils';
+import { capitalizeFirstLetter, getSynchronize, isArrayMember } from '@trezor/utils';
 
 import { blacklist } from './blacklist';
-import { type ConnectKey, type ConnectWebKey } from './types';
+import { type ConnectKey } from './types';
 
 const CONNECT_INIT_MODULE = '@common/connect-init';
 
@@ -149,7 +149,7 @@ export const connectInitThunk = createThunk<void, ConnectInitHooks | void, void>
         const synchronize = getSynchronize();
 
         Object.keys(TrezorConnect)
-            .filter(k => !blacklist.includes(k as ConnectWebKey))
+            .filter(k => !isArrayMember(k, blacklist))
             .forEach(key => {
                 // typescript complains about params and return type, need to be "any"
                 const original: any = TrezorConnect[key as ConnectKey];

--- a/suite-common/wallet-config/src/utils.ts
+++ b/suite-common/wallet-config/src/utils.ts
@@ -1,4 +1,5 @@
 import { type NetworkDtoId } from '@suite-common/earn-stablecoin-api';
+import { isArrayMember } from '@trezor/utils';
 
 import { PROD_STAKING_SYMBOLS, type ProdStakingNetworkSymbol, networks } from './networksConfig';
 import {
@@ -171,5 +172,4 @@ export const getNetworkByYieldXyzId = (yieldXyzId: NetworkDtoId) =>
 
 export const isProdStakingNetworkSymbol = (
     symbol: NetworkSymbol,
-): symbol is ProdStakingNetworkSymbol =>
-    PROD_STAKING_SYMBOLS.includes(symbol as ProdStakingNetworkSymbol);
+): symbol is ProdStakingNetworkSymbol => isArrayMember(symbol, PROD_STAKING_SYMBOLS);

--- a/suite-common/wallet-core/src/send/sendFormBitcoinThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormBitcoinThunks.ts
@@ -1,9 +1,6 @@
 import { selectSelectedDevice } from '@suite-common/device';
 import { createThunk } from '@suite-common/redux-utils';
-import {
-    BITCOIN_ONLY_SYMBOLS,
-    type BitcoinOnlySymbolsItemType,
-} from '@suite-common/suite-constants';
+import { BITCOIN_ONLY_SYMBOLS } from '@suite-common/suite-constants';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { BTC_LOCKTIME_SEQUENCE, BTC_RBF_SEQUENCE } from '@suite-common/wallet-constants';
 import {
@@ -29,7 +26,7 @@ import TrezorConnect, {
     type SignTransaction,
     type SignedTransaction,
 } from '@trezor/connect';
-import { BigNumber } from '@trezor/utils';
+import { BigNumber, isArrayMember } from '@trezor/utils';
 
 import { SEND_MODULE_PREFIX } from './sendFormConstants';
 import {
@@ -325,7 +322,7 @@ export const signBitcoinSendFormTransactionThunk = createThunk<
             signEnhancement.unlockPath = selectedAccount.unlockPath;
         }
 
-        if (BITCOIN_ONLY_SYMBOLS.includes(selectedAccount.symbol as BitcoinOnlySymbolsItemType)) {
+        if (isArrayMember(selectedAccount.symbol, BITCOIN_ONLY_SYMBOLS)) {
             // nVersion, use 2 as it enables BIP68 + seems to be the most commonly used (= harder to fingerprint the Trezor)
             signEnhancement.version = 2;
         }

--- a/suite-native/transaction-management/src/hooks/usePrecomposedTransactionError.tsx
+++ b/suite-native/transaction-management/src/hooks/usePrecomposedTransactionError.tsx
@@ -3,6 +3,7 @@ import { type ReactNode, useMemo } from 'react';
 import { type NetworkSymbol, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { type PrecomposedTransactionError } from '@suite-common/wallet-types';
 import { Translation } from '@suite-native/intl';
+import { isArrayMember } from '@trezor/utils';
 
 export type UsePrecomposedTransactionErrorProps = {
     error: string | null | undefined;
@@ -25,8 +26,7 @@ const VALID_PRECOMPOSED_ERRORS: PrecomposedTransactionError['error'][] = [
  */
 export const isPrecomposedTransactionError = (
     error: string,
-): error is PrecomposedTransactionError['error'] =>
-    VALID_PRECOMPOSED_ERRORS.includes(error as PrecomposedTransactionError['error']);
+): error is PrecomposedTransactionError['error'] => isArrayMember(error, VALID_PRECOMPOSED_ERRORS);
 
 /**
  * Hook to get precomposed transaction error translation with proper values


### PR DESCRIPTION
## Summary
Replace locally-defined `isArrayMember` type-guard helpers across packages with the shared `isArrayMember` from `@trezor/utils`.

## Utility
[`isArrayMember`](https://github.com/trezor/trezor-suite/blob/develop/packages/utils/src/isArrayMember.ts)

## Related PRs (series)
- #27591 — feat(utils): add noop helper and adopt across packages
- #27592 — feat(utils): add clamp helper and adopt across packages
- #27593 — refactor: adopt unique from @trezor/utils
- #27594 — refactor: adopt resolveAfter from @trezor/utils
- #27595 — refactor: adopt filter predicates (isNotNull, isNotNullOrUndefined, isNotUndefined) from @trezor/utils
- #27596 — refactor: adopt isArrayMember from @trezor/utils
- #27597 — refactor: adopt typed object helpers (typedObjectKeys, typedObjectEntries, isSafeObjectKey) from @trezor/utils
- #27598 — refactor(suite-native): use arrayShuffle and getWeakRandomInt for TrezorFacts
- #27599 — refactor(suite): use splitStringEveryNCharacters from @trezor/utils for homescreen
- #27600 — refactor: adopt getWeakRandomInt from @trezor/utils
- #27601 — refactor: adopt capitalizeFirstLetter from @trezor/utils
- #27602 — refactor(analytics-docs): use removeTrailingSlashes from @trezor/utils

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/utils-adopt-is-array-member&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->
