### PR TITLE
refactor: adopt typed object helpers (typedObjectKeys, typedObjectEntries, isSafeObjectKey) from @trezor/utils

### DIFF
--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -26,7 +26,7 @@ import {
     selectHistoricRatesByTransactions,
 } from '@suite-common/wallet-utils';
 import { type StaticSessionId } from '@trezor/connect';
-import { cloneObject } from '@trezor/utils';
+import { cloneObject, typedObjectKeys } from '@trezor/utils';
 
 import { selectCoinjoinAccountByKey } from 'src/reducers/wallet/coinjoinReducer';
 import { db } from 'src/storage';
@@ -463,13 +463,11 @@ const saveMetadata = async (metadata: Partial<Pick<MetadataState, MetadataPersis
     if (!db.isAccessible()) return;
 
     // remove undefined in metadata arg
-    (Object.keys as unknown as (args: any) => MetadataPersistentKeys[])(metadata).forEach(
-        (key: MetadataPersistentKeys) => {
-            if (typeof metadata[key] === 'undefined') {
-                delete metadata[key];
-            }
-        },
-    );
+    typedObjectKeys(metadata).forEach(key => {
+        if (typeof metadata[key] === 'undefined') {
+            delete metadata[key];
+        }
+    });
     const savedMetadata = await db.getItemByPK('metadata', 'state');
     const nextMetadata = { ...savedMetadata, ...metadata } as Pick<
         MetadataState,

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/ExplorerConfigForm.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/ExplorerConfigForm.tsx
@@ -5,6 +5,7 @@ import { Translation } from '@suite/intl';
 import { type Explorer } from '@suite-common/wallet-config';
 import { Button, Column, InfoItem, Input, Row, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
+import { typedObjectKeys } from '@trezor/utils';
 
 import { type useExplorerForm } from 'src/hooks/settings/useExplorerForm';
 
@@ -45,7 +46,7 @@ export const ExplorerConfigForm = ({ form }: ExplorerConfigProps) => {
     const { explorerConfig, setDefaultValues, usesDefaultExplorer, input, explorer } = form;
 
     const explorerKeys = useMemo(() => {
-        const keys = Object.keys(explorer) as (keyof Explorer)[];
+        const keys = typedObjectKeys(explorer);
 
         return keys.filter(key => key !== 'base' && input.fields[key].value !== undefined);
     }, [explorer, input]);

--- a/packages/suite/src/hooks/settings/useExplorerForm.ts
+++ b/packages/suite/src/hooks/settings/useExplorerForm.ts
@@ -4,7 +4,7 @@ import { useForm } from 'react-hook-form';
 import { useTranslation } from '@suite/intl';
 import { type Explorer, type NetworkSymbol } from '@suite-common/wallet-config';
 import { explorerActions } from '@suite-common/wallet-core';
-import { isUrl } from '@trezor/utils';
+import { isUrl, typedObjectKeys } from '@trezor/utils';
 
 import { useDispatch, useSelector } from '../suite';
 
@@ -129,7 +129,7 @@ export const useExplorerForm = (symbol: NetworkSymbol) => {
     const normalizeExplorer = (explorer: Explorer) => {
         const stripSlashes = (value: string): string => value.replace(/^\/+|\/+$/g, '');
 
-        (Object.keys(explorer) as (keyof Explorer)[]).forEach(key => {
+        typedObjectKeys(explorer).forEach(key => {
             if (!explorer[key]) return;
             explorer[key] = stripSlashes(explorer[key]).trim();
         });

--- a/packages/suite/src/support/suite/Resize.tsx
+++ b/packages/suite/src/support/suite/Resize.tsx
@@ -1,15 +1,14 @@
 import { useEffect } from 'react';
 
 import {
-    type Breakpoint,
     type BreakpointFlagName,
     type BreakpointFlags,
-    type BreakpointValue,
     aboveBreakpoint,
     belowBreakpoint,
     breakpoints,
     getBreakpointFlagNames,
 } from '@trezor/theme';
+import { typedObjectEntries } from '@trezor/utils';
 
 import { updateBreakpoints } from 'src/actions/suite/windowActions';
 import { useDispatch } from 'src/hooks/suite';
@@ -18,22 +17,21 @@ const Resize = () => {
     const dispatch = useDispatch();
 
     useEffect(() => {
-        const queryList: Array<{ mq: MediaQueryList; flag: BreakpointFlagName }> = (
-            Object.entries(breakpoints) as [Breakpoint, BreakpointValue][]
-        ).flatMap(([breakpoint, breakpointValue]) => {
-            const [belowFlag, aboveFlag] = getBreakpointFlagNames(breakpoint);
+        const queryList: Array<{ mq: MediaQueryList; flag: BreakpointFlagName }> =
+            typedObjectEntries(breakpoints).flatMap(([breakpoint, breakpointValue]) => {
+                const [belowFlag, aboveFlag] = getBreakpointFlagNames(breakpoint);
 
-            return [
-                {
-                    mq: window.matchMedia(belowBreakpoint(breakpointValue)),
-                    flag: belowFlag,
-                },
-                {
-                    mq: window.matchMedia(aboveBreakpoint(breakpointValue)),
-                    flag: aboveFlag,
-                },
-            ];
-        });
+                return [
+                    {
+                        mq: window.matchMedia(belowBreakpoint(breakpointValue)),
+                        flag: belowFlag,
+                    },
+                    {
+                        mq: window.matchMedia(aboveBreakpoint(breakpointValue)),
+                        flag: aboveFlag,
+                    },
+                ];
+            });
 
         const initialFlags = queryList.reduce<Partial<BreakpointFlags>>((acc, { mq, flag }) => {
             acc[flag] = mq.matches;

--- a/packages/suite/src/utils/suite/l10n.ts
+++ b/packages/suite/src/utils/suite/l10n.ts
@@ -1,5 +1,6 @@
 import { LANGUAGES, type Locale } from '@suite-common/suite-types';
 import { getPlatformLanguages } from '@trezor/env-utils';
+import { typedObjectKeys } from '@trezor/utils';
 
 const DEFAULT_LOCALE = 'en-US';
 
@@ -12,7 +13,7 @@ export const getOsLocale = (defaultLocale: Locale = DEFAULT_LOCALE): Locale => {
 
     const isLocale = (lang: string): lang is Locale => lang in LANGUAGES;
 
-    const suiteLanguageCodes = Object.keys(LANGUAGES) as Locale[];
+    const suiteLanguageCodes = typedObjectKeys(LANGUAGES);
     for (const platformLanguage of platformLanguages) {
         if (isLocale(platformLanguage)) {
             return platformLanguage;

--- a/packages/utils/src/enumUtils.ts
+++ b/packages/utils/src/enumUtils.ts
@@ -1,3 +1,5 @@
+import { typedObjectKeys } from './typedObject';
+
 type EnumValue = string | number;
 type EnumObject = Record<string, EnumValue>;
 
@@ -5,14 +7,14 @@ type EnumObject = Record<string, EnumValue>;
  * Find enum value and return corresponding key
  */
 export function getKeyByValue<E extends EnumObject>(obj: E, value: E[keyof E]) {
-    return obj && (Object.keys(obj) as (keyof E)[]).find(x => obj[x] === value);
+    return obj && typedObjectKeys(obj).find(x => obj[x] === value);
 }
 
 /**
  * Find enum key and return corresponding value
  */
 export function getValueByKey<E extends EnumObject>(obj: E, enumKey: keyof E) {
-    const key = obj && (Object.keys(obj) as (keyof E)[]).find(x => x === enumKey);
+    const key = obj && typedObjectKeys(obj).find(x => x === enumKey);
 
     return key && obj[key];
 }

--- a/packages/utils/src/mergeDeepObject.ts
+++ b/packages/utils/src/mergeDeepObject.ts
@@ -3,6 +3,8 @@
 
 import { type KeysOfUnion } from '@trezor/type-utils';
 
+import { isSafeObjectKey } from './isSafeObjectKey';
+
 type TIndexValue<T, K extends PropertyKey, D = never> = T extends any
     ? K extends keyof T
         ? T[K]
@@ -73,7 +75,7 @@ export const mergeDeepObject = <T extends IObject[]>(...objects: T): TMerged<T[n
         }
 
         Object.keys(current).forEach(key => {
-            if (['__proto__', 'constructor', 'prototype'].includes(key)) {
+            if (!isSafeObjectKey(key)) {
                 return;
             }
 

--- a/suite-common/token-definitions/src/tokenDefinitionsUtils.ts
+++ b/suite-common/token-definitions/src/tokenDefinitionsUtils.ts
@@ -6,6 +6,7 @@ import {
 import { getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils';
 import { type TokenInfo } from '@trezor/connect';
 import { isCodesignBuild } from '@trezor/env-utils';
+import { isSafeObjectKey } from '@trezor/utils';
 
 import {
     TOKEN_DEFINITIONS_PREFIX_URL,
@@ -59,11 +60,7 @@ type TokenDefinitionsParameters = [NetworkSymbol, DefinitionType, TokenManagemen
 const getSafeDefinitionParameters = (
     definitionKey: string,
 ): TokenDefinitionsParameters | undefined => {
-    const safeDefinitions = definitionKey
-        .split('-')
-        .filter(
-            definitionPart => !['__proto__', 'constructor', 'prototype'].includes(definitionPart),
-        );
+    const safeDefinitions = definitionKey.split('-').filter(isSafeObjectKey);
 
     if (safeDefinitions.length !== 3) return undefined;
 

--- a/suite-native/module-add-accounts/src/hooks/useAddCoinAccount.ts
+++ b/suite-native/module-add-accounts/src/hooks/useAddCoinAccount.ts
@@ -47,7 +47,7 @@ import {
     type StackToStackCompositeNavigationProps,
 } from '@suite-native/navigation';
 import { exhaustive } from '@trezor/type-utils';
-import { resolveAfter } from '@trezor/utils';
+import { resolveAfter, typedObjectKeys } from '@trezor/utils';
 
 import { useAddCoinAccountAlerts } from './useAddCoinAccountAlerts';
 
@@ -124,9 +124,9 @@ export const useAddCoinAccount = () => {
 
         networkSymbolCollection.forEach(symbol => {
             // for Cardano and Ethereum only allow latest account type and coinjoin and ledger are not supported
-            const types = Object.keys(networks[symbol].accountTypes).filter(
+            const types = typedObjectKeys(networks[symbol].accountTypes).filter(
                 t => !['coinjoin', 'imported', 'ledger'].includes(t),
-            ) as AccountType[];
+            );
 
             availableTypes.set(symbol, [
                 NORMAL_ACCOUNT_TYPE,


### PR DESCRIPTION
## Summary
Replace locally-defined typed object iteration helpers (`typedObjectKeys`, `typedObjectEntries`, `isSafeObjectKey`) across packages with the shared versions from `@trezor/utils`.

## Utility
- [`typedObjectKeys / typedObjectEntries`](https://github.com/trezor/trezor-suite/blob/develop/packages/utils/src/typedObject.ts)
- [`isSafeObjectKey`](https://github.com/trezor/trezor-suite/blob/develop/packages/utils/src/isSafeObjectKey.ts)

## Related PRs (series)
- #27591 — feat(utils): add noop helper and adopt across packages
- #27592 — feat(utils): add clamp helper and adopt across packages
- #27593 — refactor: adopt unique from @trezor/utils
- #27594 — refactor: adopt resolveAfter from @trezor/utils
- #27595 — refactor: adopt filter predicates (isNotNull, isNotNullOrUndefined, isNotUndefined) from @trezor/utils
- #27596 — refactor: adopt isArrayMember from @trezor/utils
- #27597 — refactor: adopt typed object helpers (typedObjectKeys, typedObjectEntries, isSafeObjectKey) from @trezor/utils
- #27598 — refactor(suite-native): use arrayShuffle and getWeakRandomInt for TrezorFacts
- #27599 — refactor(suite): use splitStringEveryNCharacters from @trezor/utils for homescreen
- #27600 — refactor: adopt getWeakRandomInt from @trezor/utils
- #27601 — refactor: adopt capitalizeFirstLetter from @trezor/utils
- #27602 — refactor(analytics-docs): use removeTrailingSlashes from @trezor/utils

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/utils-adopt-typed-object-helpers&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/utils-adopt-typed-object-helpers/web/](https://dev.suite.sldev.cz/suite-web/mroz22/utils-adopt-typed-object-helpers/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->