### PR TITLE
refactor(suite-native): use arrayShuffle and getWeakRandomInt for TrezorFacts

### DIFF
--- a/suite-native/firmware/src/components/TrezorFacts.tsx
+++ b/suite-native/firmware/src/components/TrezorFacts.tsx
@@ -4,6 +4,7 @@ import Animated, { FadeIn, FadeInUp, FadeOut, FadeOutDown } from 'react-native-r
 import { Text, VStack } from '@suite-native/atoms';
 import { Translation, type TxKeyPath } from '@suite-native/intl';
 import { useNativeStyles } from '@trezor/styles-native';
+import { arrayShuffle, getWeakRandomInt } from '@trezor/utils';
 
 import { firmwareTitlesWrapperStyle } from './FirmwareInstallationProgressTitles';
 
@@ -25,7 +26,9 @@ const FACTS_TRANSLATION_KEYS: TxKeyPath[] = [
 const FACTS_COUNT = FACTS_TRANSLATION_KEYS.length;
 
 // Randomly shuffle facts, so it do not always start with the same fact
-const SHUFFLED_FACTS_TRANSLATION_KEYS = FACTS_TRANSLATION_KEYS.sort(() => Math.random() - 0.5);
+const SHUFFLED_FACTS_TRANSLATION_KEYS = arrayShuffle(FACTS_TRANSLATION_KEYS, {
+    randomInt: getWeakRandomInt,
+});
 
 export const TrezorFacts = () => {
     const { applyStyle } = useNativeStyles();


### PR DESCRIPTION
## Summary
Use `arrayShuffle` and `getWeakRandomInt` from `@trezor/utils` in the suite-native TrezorFacts component, removing the inline implementations.

## Utility
- [`arrayShuffle`](https://github.com/trezor/trezor-suite/blob/develop/packages/utils/src/arrayShuffle.ts)
- [`getWeakRandomInt`](https://github.com/trezor/trezor-suite/blob/develop/packages/utils/src/getWeakRandomInt.ts)

## Related PRs (series)
- #27591 — feat(utils): add noop helper and adopt across packages
- #27592 — feat(utils): add clamp helper and adopt across packages
- #27593 — refactor: adopt unique from @trezor/utils
- #27594 — refactor: adopt resolveAfter from @trezor/utils
- #27595 — refactor: adopt filter predicates (isNotNull, isNotNullOrUndefined, isNotUndefined) from @trezor/utils
- #27596 — refactor: adopt isArrayMember from @trezor/utils
- #27597 — refactor: adopt typed object helpers (typedObjectKeys, typedObjectEntries, isSafeObjectKey) from @trezor/utils
- #27598 — refactor(suite-native): use arrayShuffle and getWeakRandomInt for TrezorFacts
- #27599 — refactor(suite): use splitStringEveryNCharacters from @trezor/utils for homescreen
- #27600 — refactor: adopt getWeakRandomInt from @trezor/utils
- #27601 — refactor: adopt capitalizeFirstLetter from @trezor/utils
- #27602 — refactor(analytics-docs): use removeTrailingSlashes from @trezor/utils

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/suite-native-adopt-array-shuffle-random-int&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->
