### PR TITLE
refactor: adopt getWeakRandomInt from @trezor/utils

### DIFF
--- a/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
+++ b/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
@@ -46,7 +46,7 @@ export class CoinjoinBackendClient implements CoinjoinBackendClientShape {
         this.logger = settings.logger;
         this.blockbookUrls = arrayShuffle(settings.blockbookUrls, { randomInt: getWeakRandomInt });
         this.onionDomains = settings.onionDomains ?? {};
-        this.blockbookRequestId = Math.floor(Math.random() * settings.blockbookUrls.length);
+        this.blockbookRequestId = getWeakRandomInt(0, settings.blockbookUrls.length);
         this.websockets = new CoinjoinWebsocketController(settings);
 
         // This allows to subscribe to mempool WS disconnecting in this.subscribeMempoolTxs(),

--- a/packages/coinjoin/src/client/Status.ts
+++ b/packages/coinjoin/src/client/Status.ts
@@ -1,5 +1,5 @@
 import type { TimerId } from '@trezor/type-utils';
-import { TypedEmitter } from '@trezor/utils';
+import { TypedEmitter, getWeakRandomInt } from '@trezor/utils';
 
 import * as coordinator from './coordinator';
 import { coordinatorRequest } from './coordinatorRequest';
@@ -214,7 +214,7 @@ export class Status extends TypedEmitter<StatusEvents> {
     async getStatus() {
         if (!this.enabled) return Promise.resolve();
 
-        const identity = this.identities[Math.floor(Math.random() * this.identities.length)];
+        const identity = this.identities[getWeakRandomInt(0, this.identities.length)];
         const status = await coordinator.getStatus({
             baseUrl: this.settings.coordinatorUrl,
             signal: this.abortController.signal,

--- a/packages/e2e-utils/src/githubReporter/gitHubReporterBase.ts
+++ b/packages/e2e-utils/src/githubReporter/gitHubReporterBase.ts
@@ -1,6 +1,6 @@
 import type { Octokit } from '@octokit/rest';
 
-import { resolveAfter, scheduleAction } from '@trezor/utils';
+import { getWeakRandomInt, resolveAfter, scheduleAction } from '@trezor/utils';
 
 import { type TestReportProviderBase } from './annotationBase';
 import { GitHubProject } from './gitHubProject';
@@ -378,9 +378,9 @@ abstract class GitHubReporterBase implements LoggingFunctions {
 
         for (const operationSystem of report.osMatrix) {
             const issueNodeId = await scheduleAction(async () => {
-                // Random delay between 1-5 seconds to distribute load on GitHub API
+                // Random delay between 1000–4999ms to distribute load on GitHub API
                 // Without it we often hit "Your attempt to move this item created a temporary conflict. Please try again"
-                const randomDelay = Math.floor(Math.random() * 4000) + 1000; // 1000-5000ms
+                const randomDelay = getWeakRandomInt(1000, 5000); // 1000-4999ms
                 await resolveAfter(randomDelay);
                 this.log(
                     `Creating GitHub draft issue for test "(OS ${operationSystem}) ${report.testTitle}"...`,

--- a/suite-common/fiat-services/src/blockbook.ts
+++ b/suite-common/fiat-services/src/blockbook.ts
@@ -1,4 +1,5 @@
 import type { HistoricRates, TimestampedRates } from '@suite-common/wallet-types';
+import { getWeakRandomInt } from '@trezor/utils';
 
 import { fetchUrl } from './fetch';
 import { RateLimiter } from './limiter';
@@ -11,7 +12,7 @@ const ENDPOINTS = {
 type Ticker = keyof typeof ENDPOINTS;
 
 const randomEndpoint = (ticker: Ticker) =>
-    ENDPOINTS[ticker][Math.floor(Math.random() * ENDPOINTS[ticker].length)];
+    ENDPOINTS[ticker][getWeakRandomInt(0, ENDPOINTS[ticker].length)];
 
 const getQuery = (query?: { currency?: string; timestamp?: number | string }) =>
     Object.entries(query || {})


### PR DESCRIPTION
## Summary
Replace all locally-defined `getWeakRandomInt` helpers across packages with the shared version from `@trezor/utils`.

## Utility
[`getWeakRandomInt`](https://github.com/trezor/trezor-suite/blob/develop/packages/utils/src/getWeakRandomInt.ts)

## Related PRs (series)
- #27591 — feat(utils): add noop helper and adopt across packages
- #27592 — feat(utils): add clamp helper and adopt across packages
- #27593 — refactor: adopt unique from @trezor/utils
- #27594 — refactor: adopt resolveAfter from @trezor/utils
- #27595 — refactor: adopt filter predicates (isNotNull, isNotNullOrUndefined, isNotUndefined) from @trezor/utils
- #27596 — refactor: adopt isArrayMember from @trezor/utils
- #27597 — refactor: adopt typed object helpers (typedObjectKeys, typedObjectEntries, isSafeObjectKey) from @trezor/utils
- #27598 — refactor(suite-native): use arrayShuffle and getWeakRandomInt for TrezorFacts
- #27599 — refactor(suite): use splitStringEveryNCharacters from @trezor/utils for homescreen
- #27600 — refactor: adopt getWeakRandomInt from @trezor/utils
- #27601 — refactor: adopt capitalizeFirstLetter from @trezor/utils
- #27602 — refactor(analytics-docs): use removeTrailingSlashes from @trezor/utils

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/utils-adopt-get-weak-random-int&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/utils-adopt-get-weak-random-int&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/utils-adopt-get-weak-random-int&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-12T07:14:13.490Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-11T19:43:54.953Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/utils-adopt-get-weak-random-int/web/](https://dev.suite.sldev.cz/suite-web/mroz22/utils-adopt-get-weak-random-int/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->
