### PR TITLE
refactor: adopt capitalizeFirstLetter from @trezor/utils

### DIFF
--- a/packages/coinjoin/src/utils/http.ts
+++ b/packages/coinjoin/src/utils/http.ts
@@ -1,6 +1,6 @@
 import fetch from 'cross-fetch';
 
-import { type ScheduleActionParams, getWeakRandomId } from '@trezor/utils';
+import { type ScheduleActionParams, capitalizeFirstLetter, getWeakRandomId } from '@trezor/utils';
 
 export interface RequestOptions extends ScheduleActionParams {
     method?: 'POST' | 'GET';
@@ -10,8 +10,6 @@ export interface RequestOptions extends ScheduleActionParams {
     userAgent?: string;
 }
 
-const camelCaseToPascalCase = (key: string) => key.charAt(0).toUpperCase() + key.slice(1);
-
 export const patchResponse = (obj: any) => {
     if (Array.isArray(obj)) {
         for (let i = 0; i < obj.length; i++) {
@@ -19,7 +17,7 @@ export const patchResponse = (obj: any) => {
         }
     } else if (obj && typeof obj === 'object') {
         Object.keys(obj).forEach(key => {
-            const newKey = camelCaseToPascalCase(key);
+            const newKey = capitalizeFirstLetter(key);
             obj[newKey] = obj[key];
             if (key !== newKey) {
                 delete obj[key];

--- a/packages/e2e-utils/src/githubReporter/annotationBase.ts
+++ b/packages/e2e-utils/src/githubReporter/annotationBase.ts
@@ -1,3 +1,5 @@
+import { capitalizeFirstLetter } from '@trezor/utils';
+
 import { type TestDetailsAnnotation, type TestMetadataInput } from './types';
 import {
     DeviceModel,
@@ -108,7 +110,7 @@ export abstract class TestReportProviderBase {
             // Capitalize first letter of testProject
             const project = this.testProject;
 
-            return project.charAt(0).toUpperCase() + project.slice(1);
+            return capitalizeFirstLetter(project);
         }
     }
 


### PR DESCRIPTION
## Summary
Replace locally-defined `capitalizeFirstLetter` string helpers across packages with the shared version from `@trezor/utils`.

## Utility
[`capitalizeFirstLetter`](https://github.com/trezor/trezor-suite/blob/develop/packages/utils/src/capitalizeFirstLetter.ts)

## Related PRs (series)
- #27591 — feat(utils): add noop helper and adopt across packages
- #27592 — feat(utils): add clamp helper and adopt across packages
- #27593 — refactor: adopt unique from @trezor/utils
- #27594 — refactor: adopt resolveAfter from @trezor/utils
- #27595 — refactor: adopt filter predicates (isNotNull, isNotNullOrUndefined, isNotUndefined) from @trezor/utils
- #27596 — refactor: adopt isArrayMember from @trezor/utils
- #27597 — refactor: adopt typed object helpers (typedObjectKeys, typedObjectEntries, isSafeObjectKey) from @trezor/utils
- #27598 — refactor(suite-native): use arrayShuffle and getWeakRandomInt for TrezorFacts
- #27599 — refactor(suite): use splitStringEveryNCharacters from @trezor/utils for homescreen
- #27600 — refactor: adopt getWeakRandomInt from @trezor/utils
- #27601 — refactor: adopt capitalizeFirstLetter from @trezor/utils
- #27602 — refactor(analytics-docs): use removeTrailingSlashes from @trezor/utils

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/utils-adopt-capitalize-first-letter&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/utils-adopt-capitalize-first-letter&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-11T19:46:44.474Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-11T19:45:21.147Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/utils-adopt-capitalize-first-letter/web/](https://dev.suite.sldev.cz/suite-web/mroz22/utils-adopt-capitalize-first-letter/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->
