### PR TITLE
refactor(analytics-docs): use removeTrailingSlashes from @trezor/utils

### DIFF
--- a/packages/analytics-docs/src/components/LiveLogSidebar.tsx
+++ b/packages/analytics-docs/src/components/LiveLogSidebar.tsx
@@ -24,6 +24,7 @@ import {
     variables,
 } from '@trezor/components';
 import { zIndices } from '@trezor/theme';
+import { removeTrailingSlashes } from '@trezor/utils';
 
 import type { LiveLogEvent } from '../types';
 import { fuzzyMatch, getEventId } from '../utils/filterUtils';
@@ -313,7 +314,7 @@ export const LiveLogSidebar = ({ onEventClick, filterQuery }: LiveLogSidebarProp
                         <Text typographyStyle="body-xs" intent="neutral" priority="secondary">
                             In Suite, set Custom Analytics URL (Settings → Debug) to{' '}
                             <Text isMonospaced typographyStyle="inherit">
-                                {`${logServerBaseUrl.replace(/\/+$/, '')}/log`}
+                                {`${removeTrailingSlashes(logServerBaseUrl)}/log`}
                             </Text>
                         </Text>
                     </Box>
@@ -427,7 +428,7 @@ export const LiveLogSidebar = ({ onEventClick, filterQuery }: LiveLogSidebarProp
                                 This controls where analytics-docs connects for live events (SSE)
                                 and where Suite should send events to{' '}
                                 <Text isMonospaced typographyStyle="inherit">
-                                    {`${(logServerInput.trim() || getDefaultLogServerBaseUrl()).replace(/\/+$/, '')}/log`}
+                                    {`${removeTrailingSlashes(logServerInput.trim() || getDefaultLogServerBaseUrl())}/log`}
                                 </Text>
                                 .
                             </Text>

--- a/packages/analytics-docs/src/utils/logServerUrl.ts
+++ b/packages/analytics-docs/src/utils/logServerUrl.ts
@@ -1,11 +1,9 @@
+import { removeTrailingSlashes } from '@trezor/utils';
+
 const STORAGE_KEY = 'analytics-docs-log-server-base-url';
 const URL_PARAM = 'logServer';
 
-const normalizeBaseUrl = (input: string): string => {
-    const trimmed = input.trim().replace(/\/+$/, '');
-
-    return trimmed;
-};
+const normalizeBaseUrl = (input: string): string => removeTrailingSlashes(input.trim());
 
 export const getDefaultLogServerBaseUrl = (): string =>
     typeof window !== 'undefined'

--- a/packages/analytics-docs/src/utils/useLiveLogEvents.ts
+++ b/packages/analytics-docs/src/utils/useLiveLogEvents.ts
@@ -1,11 +1,13 @@
 import { useCallback, useEffect, useState } from 'react';
 
+import { removeTrailingSlashes } from '@trezor/utils';
+
 import type { LiveLogEvent } from '../types';
 
 const STREAM_PATH = '/api/analytics-events/stream';
 const CLEAR_PATH = '/api/analytics-events/clear';
 
-const joinUrl = (baseUrl: string, path: string) => `${baseUrl.replace(/\/+$/, '')}${path}`;
+const joinUrl = (baseUrl: string, path: string) => `${removeTrailingSlashes(baseUrl)}${path}`;
 
 export const useLiveLogEvents = (baseUrl: string) => {
     const [events, setEvents] = useState<LiveLogEvent[]>([]);


### PR DESCRIPTION
## Summary
Replace the inline `removeTrailingSlashes` implementations in analytics-docs scripts with the shared utility from `@trezor/utils`.

## Utility
[`removeTrailingSlashes`](https://github.com/trezor/trezor-suite/blob/develop/packages/utils/src/removeTrailingSlashes.ts)

## Related PRs (series)
- #27591 — feat(utils): add noop helper and adopt across packages
- #27592 — feat(utils): add clamp helper and adopt across packages
- #27593 — refactor: adopt unique from @trezor/utils
- #27594 — refactor: adopt resolveAfter from @trezor/utils
- #27595 — refactor: adopt filter predicates (isNotNull, isNotNullOrUndefined, isNotUndefined) from @trezor/utils
- #27596 — refactor: adopt isArrayMember from @trezor/utils
- #27597 — refactor: adopt typed object helpers (typedObjectKeys, typedObjectEntries, isSafeObjectKey) from @trezor/utils
- #27598 — refactor(suite-native): use arrayShuffle and getWeakRandomInt for TrezorFacts
- #27599 — refactor(suite): use splitStringEveryNCharacters from @trezor/utils for homescreen
- #27600 — refactor: adopt getWeakRandomInt from @trezor/utils
- #27601 — refactor: adopt capitalizeFirstLetter from @trezor/utils
- #27602 — refactor(analytics-docs): use removeTrailingSlashes from @trezor/utils

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/analytics-docs-adopt-remove-trailing-slashes&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/analytics-docs-adopt-remove-trailing-slashes&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-11T19:47:37.879Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-11T19:46:21.476Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/analytics-docs-adopt-remove-trailing-slashes/web/](https://dev.suite.sldev.cz/suite-web/mroz22/analytics-docs-adopt-remove-trailing-slashes/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->
