### PR TITLE
feat(suite-native): release native swap dexes

### DIFF
--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -21,7 +21,11 @@ import { type Account, type SelectedAccountStatus } from '@suite-common/wallet-t
 import { getCurrencies } from '@trezor/address-validator';
 import { exhaustive } from '@trezor/type-utils';
 
-import { groupTradingExchangeQuotesProjection } from './utils/groupTradingExchangeQuotesProjection';
+import {
+    EMPTY_GROUPED_TRADING_EXCHANGE_QUOTES,
+    type GroupedTradingExchangeQuotes,
+    groupTradingExchangeQuotesProjection,
+} from './utils/groupTradingExchangeQuotesProjection';
 import { bestQuotePerPaymentMethodProjection } from './utils/quotePerPaymentMethodProjection';
 import { type BuyInfo, type TradingBuyState } from '../reducers/buyReducer';
 import { type ExchangeInfo, type TradingExchangeState } from '../reducers/exchangeReducer';
@@ -48,6 +52,8 @@ import {
     getTradingPlatformsInfoByCryptoId,
     getTradingSymbolAndContractAddressByCryptoId,
 } from '../utils/infoUtils';
+
+export { EMPTY_GROUPED_TRADING_EXCHANGE_QUOTES, type GroupedTradingExchangeQuotes };
 
 type SelectedAccountRootState = {
     wallet: {

--- a/suite-common/trading/src/selectors/utils/groupTradingExchangeQuotesProjection.ts
+++ b/suite-common/trading/src/selectors/utils/groupTradingExchangeQuotesProjection.ts
@@ -6,6 +6,13 @@ export type GroupedTradingExchangeQuotes = {
     dex: ExchangeTrade[];
 };
 
+/** Read-only sentinel; do not mutate (shared empty arrays). */
+export const EMPTY_GROUPED_TRADING_EXCHANGE_QUOTES: GroupedTradingExchangeQuotes = {
+    fixed: [],
+    float: [],
+    dex: [],
+};
+
 type ExchangeProvidersMap = Record<string, Pick<ExchangeProviderInfo, 'isFixedRate'> | undefined>;
 
 export const groupTradingExchangeQuotesProjection = (

--- a/suite-native/config/src/types.ts
+++ b/suite-native/config/src/types.ts
@@ -11,7 +11,6 @@ export type LaunchArguments = {
     areExperimentalOnlyNetworksEnabled?: boolean;
     preloadedState?: string; // stringified object
     isFirmwareUpdateEnabled?: boolean;
-    areTradingExchangeDexesEnabled?: boolean;
     isTradingResidenceCheckEnabled?: boolean;
     isTradingDebugEnabled?: boolean;
     isN4w1BackupEnabled?: boolean;

--- a/suite-native/feature-flags/src/__tests__/featureFlagsSlice.test.ts
+++ b/suite-native/feature-flags/src/__tests__/featureFlagsSlice.test.ts
@@ -17,7 +17,6 @@ describe('featureFlagsSlice', () => {
             expect(initialState).toEqual({
                 areDebugOnlyNetworksEnabled: false,
                 areExperimentalOnlyNetworksEnabled: false,
-                areTradingExchangeDexesEnabled: false,
                 isCardanoSendEnabled: false,
                 isDebugKeysAllowed: false,
                 isTradingBuyEnabled: false,
@@ -45,7 +44,6 @@ describe('featureFlagsSlice', () => {
                 isTradingBuyEnabled: false,
                 isTradingExchangeEnabled: false,
                 isTradingSellEnabled: false,
-                areTradingExchangeDexesEnabled: false,
                 isTradingResidenceCheckEnabled: false,
                 isTradingConciergeEnabled: false,
                 isTradingDebugEnabled: false,

--- a/suite-native/feature-flags/src/featureFlagsSlice.ts
+++ b/suite-native/feature-flags/src/featureFlagsSlice.ts
@@ -11,7 +11,6 @@ export const FeatureFlag = {
     IsTradingExchangeEnabled: 'isTradingExchangeEnabled',
     IsTradingSellEnabled: 'isTradingSellEnabled',
     IsTradingConciergeEnabled: 'isTradingConciergeEnabled',
-    AreTradingExchangeDexesEnabled: 'areTradingExchangeDexesEnabled',
     IsTradingResidenceCheckEnabled: 'isTradingResidenceCheckEnabled',
     IsTradingDebugEnabled: 'isTradingDebugEnabled',
     IsStablecoinYieldEnabled: 'isStablecoinYieldEnabled',
@@ -41,8 +40,6 @@ export const featureFlagsInitialState: FeatureFlagsState = {
         process.env.EXPO_PUBLIC_FF_IS_TRADING_SELL_ENABLED === 'true',
     [FeatureFlag.IsTradingConciergeEnabled]:
         process.env.EXPO_PUBLIC_FF_IS_TRADING_CONCIERGE_ENABLED === 'true',
-    [FeatureFlag.AreTradingExchangeDexesEnabled]:
-        process.env.EXPO_PUBLIC_FF_ARE_TRADING_EXCHANGE_DEXES_ENABLED === 'true',
     [FeatureFlag.IsTradingResidenceCheckEnabled]:
         process.env.EXPO_PUBLIC_FF_IS_TRADING_RESIDENCE_CHECK_ENABLED === 'true' ||
         (isIOs() && process.env.EXPO_PUBLIC_FF_IS_TRADING_RESIDENCE_CHECK_ENABLED !== 'false'),
@@ -61,7 +58,6 @@ export const featureFlagsPersistedKeys: Array<keyof FeatureFlagsState> = [
     FeatureFlag.IsTradingExchangeEnabled,
     FeatureFlag.IsTradingSellEnabled,
     FeatureFlag.IsTradingConciergeEnabled,
-    FeatureFlag.AreTradingExchangeDexesEnabled,
     FeatureFlag.IsTradingResidenceCheckEnabled,
     FeatureFlag.IsTradingDebugEnabled,
     FeatureFlag.IsStablecoinYieldEnabled,

--- a/suite-native/module-dev-utils/src/components/FeatureFlagsCard.tsx
+++ b/suite-native/module-dev-utils/src/components/FeatureFlagsCard.tsx
@@ -15,7 +15,6 @@ const featureFlagsTitleMap = {
     [FeatureFlagEnum.IsTradingExchangeEnabled]: '💰 Trading Swap',
     [FeatureFlagEnum.IsTradingSellEnabled]: '💰 Trading Sell',
     [FeatureFlagEnum.IsTradingConciergeEnabled]: '💰 Trading Concierge',
-    [FeatureFlagEnum.AreTradingExchangeDexesEnabled]: '💰 Trading Exchange Dexes',
     [FeatureFlagEnum.IsTradingResidenceCheckEnabled]: '💰 Trading Residence Check',
     [FeatureFlagEnum.IsTradingDebugEnabled]: '💰 Trading Debug Mode',
     [FeatureFlagEnum.IsStablecoinYieldEnabled]: 'Stablecoin Yield',

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeAlert.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeAlert.test.tsx
@@ -13,7 +13,6 @@ describe('ExchangeAlert', () => {
     const preloadedState = {
         featureFlags: {
             ...featureFlagsInitialState,
-            [FeatureFlag.AreTradingExchangeDexesEnabled]: true,
             [FeatureFlag.IsTradingResidenceCheckEnabled]: false,
         },
         wallet: getWalletState({ tradeType: 'exchange' }),

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeForm.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeForm.test.tsx
@@ -1,4 +1,3 @@
-import { FeatureFlag } from '@suite-native/feature-flags';
 import { Form } from '@suite-native/forms';
 import {
     act,
@@ -29,9 +28,7 @@ describe('ExchangeForm', () => {
     const defaultPreloadedState = createTradingPreloadedState({
         tradeType: 'exchange',
         overrides: {
-            featureFlags: createTradingFeatureFlags({
-                [FeatureFlag.AreTradingExchangeDexesEnabled]: true,
-            }),
+            featureFlags: createTradingFeatureFlags(),
         },
     });
 

--- a/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveAccountCryptoBalance.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveAccountCryptoBalance.test.tsx
@@ -19,7 +19,6 @@ describe('ExchangeReceiveAccountCryptoBalance', () => {
     const preloadedState = {
         featureFlags: {
             ...featureFlagsInitialState,
-            [FeatureFlag.AreTradingExchangeDexesEnabled]: true,
             [FeatureFlag.IsTradingResidenceCheckEnabled]: false,
         },
         wallet: getWalletState({ tradeType: 'exchange' }),

--- a/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveAccountPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveAccountPicker.test.tsx
@@ -1,4 +1,3 @@
-import { FeatureFlag } from '@suite-native/feature-flags';
 import { Form } from '@suite-native/forms';
 import { act, fireEvent } from '@suite-native/test-utils-store';
 import { btc1NormalAccount, btcAsset } from '@suite-native/trading-fixtures';
@@ -48,9 +47,7 @@ describe('ExchangeReceiveAccountPicker', () => {
     let exchangeForm: ExchangeFormType;
 
     const baseOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {
-        featureFlags: createTradingFeatureFlags({
-            [FeatureFlag.AreTradingExchangeDexesEnabled]: true,
-        }),
+        featureFlags: createTradingFeatureFlags(),
     };
 
     const renderExchangeForm = () => {

--- a/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveAmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveAmountInput.test.tsx
@@ -22,7 +22,6 @@ describe('ExchangeReceiveAmountInput', () => {
     const baseOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {
         featureFlags: {
             ...featureFlagsInitialState,
-            [FeatureFlag.AreTradingExchangeDexesEnabled]: true,
             [FeatureFlag.IsTradingResidenceCheckEnabled]: false,
         },
     };

--- a/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveContent.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveContent.test.tsx
@@ -1,4 +1,3 @@
-import { FeatureFlag } from '@suite-native/feature-flags';
 import { Form } from '@suite-native/forms';
 import { getTranslation } from '@suite-native/intl';
 import {
@@ -21,9 +20,7 @@ describe('ExchangeReceiveContent', () => {
     const preloadedState = createTradingPreloadedState({
         tradeType: 'exchange',
         overrides: {
-            featureFlags: createTradingFeatureFlags({
-                [FeatureFlag.AreTradingExchangeDexesEnabled]: true,
-            }),
+            featureFlags: createTradingFeatureFlags(),
             wallet: {
                 trading: {
                     exchange: {

--- a/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeTradeableAssetPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeTradeableAssetPicker.test.tsx
@@ -1,4 +1,4 @@
-import { FeatureFlag, featureFlagsInitialState } from '@suite-native/feature-flags';
+import { featureFlagsInitialState } from '@suite-native/feature-flags';
 import { Form } from '@suite-native/forms';
 import { type TestStore, screen } from '@suite-native/test-utils-store';
 import { type ExchangeFormType } from '@suite-native/trading-types';
@@ -23,7 +23,6 @@ describe('ExchangeTradeableAssetPicker', () => {
                 device: { selectedDevice: { firmwareType } },
                 featureFlags: {
                     ...featureFlagsInitialState,
-                    [FeatureFlag.AreTradingExchangeDexesEnabled]: true,
                 },
             },
         });

--- a/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAmountBadge.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAmountBadge.test.tsx
@@ -1,4 +1,4 @@
-import { FeatureFlag, featureFlagsInitialState } from '@suite-native/feature-flags';
+import { featureFlagsInitialState } from '@suite-native/feature-flags';
 import { Form } from '@suite-native/forms';
 import { act } from '@suite-native/test-utils-store';
 import { btcAsset } from '@suite-native/trading-fixtures';
@@ -20,7 +20,6 @@ describe('ExchangeSendAmountBadge', () => {
     const baseOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {
         featureFlags: {
             ...featureFlagsInitialState,
-            [FeatureFlag.AreTradingExchangeDexesEnabled]: true,
         },
     };
 

--- a/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAmountInput.test.tsx
@@ -1,5 +1,5 @@
 import { type Account, type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
-import { FeatureFlag, featureFlagsInitialState } from '@suite-native/feature-flags';
+import { featureFlagsInitialState } from '@suite-native/feature-flags';
 import { Form } from '@suite-native/forms';
 import { act, userEvent } from '@suite-native/test-utils-store';
 import { btcAsset, usdcAsset } from '@suite-native/trading-fixtures';
@@ -33,7 +33,6 @@ describe('ExchangeSendAmountInput', () => {
     const baseOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {
         featureFlags: {
             ...featureFlagsInitialState,
-            [FeatureFlag.AreTradingExchangeDexesEnabled]: true,
         },
     };
 

--- a/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAssetPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAssetPicker.test.tsx
@@ -7,7 +7,7 @@ import { initialSuiteSyncDataState, initialSuiteSyncState } from '@suite-common/
 import { extraDependenciesCommonMock } from '@suite-common/test-utils';
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
 import { asBaseCurrencyAmount } from '@suite-common/wallet-types';
-import { FeatureFlag, featureFlagsInitialState } from '@suite-native/feature-flags';
+import { featureFlagsInitialState } from '@suite-native/feature-flags';
 import { Form } from '@suite-native/forms';
 import { localeReducer } from '@suite-native/intl';
 import {
@@ -77,7 +77,6 @@ describe('ExchangeSendAssetPicker', () => {
         device: deviceInitialState,
         featureFlags: {
             ...featureFlagsInitialState,
-            [FeatureFlag.AreTradingExchangeDexesEnabled]: true,
         },
         messageSystem: messageSystemInitialState,
         suiteSync: initialSuiteSyncState,

--- a/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendContent.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendContent.test.tsx
@@ -1,4 +1,3 @@
-import { FeatureFlag } from '@suite-native/feature-flags';
 import { Form } from '@suite-native/forms';
 import {
     act,
@@ -20,9 +19,7 @@ describe('ExchangeSendContent', () => {
     const preloadedState = createTradingPreloadedState({
         tradeType: 'exchange',
         overrides: {
-            featureFlags: createTradingFeatureFlags({
-                [FeatureFlag.AreTradingExchangeDexesEnabled]: true,
-            }),
+            featureFlags: createTradingFeatureFlags(),
         },
     });
 

--- a/suite-native/module-trading/src/components/general/Header/HeaderTabs.tsx
+++ b/suite-native/module-trading/src/components/general/Header/HeaderTabs.tsx
@@ -1,15 +1,12 @@
 import { useEffect, useMemo, useRef } from 'react';
 import { FlatList } from 'react-native-gesture-handler';
-import { useSelector } from 'react-redux';
 
 import { type TradingTypeWithConcierge } from '@suite-common/trading';
 import { events } from '@suite-native/analytics';
 import { HStack, IconButton, useBottomSheetModal } from '@suite-native/atoms';
-import { FeatureFlag, selectIsFeatureFlagEnabled } from '@suite-native/feature-flags';
 import { type IconName } from '@suite-native/icons';
 import { useTranslate } from '@suite-native/intl';
 import { useAnalytics } from '@suite-native/services';
-import { type TradingWithFeatureFlagsRootState } from '@suite-native/trading-state';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 import { HeaderTab } from './HeaderTab';
@@ -62,9 +59,6 @@ export const HeaderTabs = () => {
     const data = useTabsData();
     const { translate } = useTranslate();
     const { bottomSheetRef, openModal, closeModal } = useBottomSheetModal();
-    const areTradingExchangeDexesEnabled = useSelector((state: TradingWithFeatureFlagsRootState) =>
-        selectIsFeatureFlagEnabled(state, FeatureFlag.AreTradingExchangeDexesEnabled),
-    );
     const analytics = useAnalytics();
 
     const activeTabIndex = useMemo(
@@ -127,16 +121,14 @@ export const HeaderTabs = () => {
                         });
                     }}
                 />
-                {areTradingExchangeDexesEnabled && (
-                    <IconButton
-                        iconName="gear"
-                        size="medium"
-                        intent="neutral"
-                        priority="secondary"
-                        accessibilityLabel={translate('moduleTrading.tradingScreen.tabs.settings')}
-                        onPress={openModal}
-                    />
-                )}
+                <IconButton
+                    iconName="gear"
+                    size="medium"
+                    intent="neutral"
+                    priority="secondary"
+                    accessibilityLabel={translate('moduleTrading.tradingScreen.tabs.settings')}
+                    onPress={openModal}
+                />
             </HStack>
             <AdvancedSettingsSheet ref={bottomSheetRef} closeModal={closeModal} />
         </>

--- a/suite-native/module-trading/src/components/general/Header/__tests__/Header.test.tsx
+++ b/suite-native/module-trading/src/components/general/Header/__tests__/Header.test.tsx
@@ -22,14 +22,9 @@ jest.mock('@suite-native/services', () => {
 });
 
 describe('Header', () => {
-    const getFFOverrides = ({
-        areTradingExchangeDexesEnabled = true,
-    }: {
-        areTradingExchangeDexesEnabled?: boolean;
-    } = {}): PreloadedStatePartial<TradingTestPreloadedState> => ({
+    const getFFOverrides = (): PreloadedStatePartial<TradingTestPreloadedState> => ({
         featureFlags: {
             ...featureFlagsInitialState,
-            [FeatureFlag.AreTradingExchangeDexesEnabled]: areTradingExchangeDexesEnabled,
             [FeatureFlag.IsTradingResidenceCheckEnabled]: false,
         },
     });
@@ -76,7 +71,6 @@ describe('Header', () => {
             ...getFFOverrides(),
             featureFlags: {
                 ...featureFlagsInitialState,
-                [FeatureFlag.AreTradingExchangeDexesEnabled]: true,
                 [FeatureFlag.IsTradingResidenceCheckEnabled]: false,
                 [FeatureFlag.IsTradingBuyEnabled]: config.buy,
                 [FeatureFlag.IsTradingExchangeEnabled]: config.exchange,
@@ -116,14 +110,6 @@ describe('Header', () => {
         const { renderer } = renderHeader();
 
         expect(renderer.getByLabelText('Advanced settings')).toBeOnTheScreen();
-    });
-
-    it('should not display settings wheel when AreTradingExchangeDexesEnabled is disabled', () => {
-        const { renderer } = renderHeader(
-            getFFOverrides({ areTradingExchangeDexesEnabled: false }),
-        );
-
-        expect(renderer.queryByLabelText('Advanced settings')).toBeNull();
     });
 
     describe('analytics', () => {

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderSheet.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderSheet.tsx
@@ -1,13 +1,9 @@
-import { useSelector } from 'react-redux';
-
 import {
     type TradingTradeMapProps,
     type TradingTradeType,
     type TradingType,
 } from '@suite-common/trading';
-import { FeatureFlag, selectIsFeatureFlagEnabled } from '@suite-native/feature-flags';
 import { BottomSheetSectionList } from '@suite-native/trading-atoms';
-import { type TradingWithFeatureFlagsRootState } from '@suite-native/trading-state';
 import { type QuotesByCategories, type QuotesCategory } from '@suite-native/trading-types';
 import { prepareNativeStyle } from '@trezor/styles-native';
 
@@ -42,15 +38,11 @@ export const ProviderSheet = <
     selectedQuote,
     tradingType,
 }: ProviderSheetProps<K, T>) => {
-    const areTradingExchangeDexesEnabled = useSelector((state: TradingWithFeatureFlagsRootState) =>
-        selectIsFeatureFlagEnabled(state, FeatureFlag.AreTradingExchangeDexesEnabled),
-    );
-    const shouldShowFilters = tradingType === 'exchange' && areTradingExchangeDexesEnabled;
+    const shouldShowFilters = tradingType === 'exchange';
 
     const { filterItems, filteredSections, selectedFilter, setSelectedFilter } = useProviderFilters(
         quotes,
         shouldShowFilters,
-        areTradingExchangeDexesEnabled,
     );
 
     const onQuoteSelectCallback = (quote: T) => {

--- a/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderSheet.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderSheet.test.tsx
@@ -1,5 +1,8 @@
-import { type TradingTradeType, type TradingType } from '@suite-common/trading';
-import { FeatureFlag } from '@suite-native/feature-flags';
+import {
+    EMPTY_GROUPED_TRADING_EXCHANGE_QUOTES,
+    type TradingTradeType,
+    type TradingType,
+} from '@suite-common/trading';
 import { screen } from '@suite-native/test-utils-store';
 import { mercuryoApplePayBuyQuote } from '@suite-native/trading-fixtures';
 
@@ -46,25 +49,14 @@ describe('ProviderSheet', () => {
     });
 
     it('should render all section headers for exchange', () => {
-        const { getByText } = renderProviderSheet(
-            { tradingType: 'exchange', quotes: { fixed: [], float: [], dex: [] } },
-            { featureFlags: { [FeatureFlag.AreTradingExchangeDexesEnabled]: true } },
-        );
+        const { getByText } = renderProviderSheet({
+            tradingType: 'exchange',
+            quotes: EMPTY_GROUPED_TRADING_EXCHANGE_QUOTES,
+        });
 
         expect(getByText('Fixed-rate CEX')).toBeOnTheScreen();
         expect(getByText('Floating-rate CEX')).toBeOnTheScreen();
         expect(getByText('DEX')).toBeOnTheScreen();
-    });
-
-    it('should not render DEX section header for exchange when DEXes are disabled', () => {
-        const { queryByText, getByText } = renderProviderSheet(
-            { tradingType: 'exchange', quotes: { fixed: [], float: [], dex: [] } },
-            { featureFlags: { [FeatureFlag.AreTradingExchangeDexesEnabled]: false } },
-        );
-
-        expect(getByText('Fixed-rate CEX')).toBeOnTheScreen();
-        expect(getByText('Floating-rate CEX')).toBeOnTheScreen();
-        expect(queryByText('DEX')).toBeNull();
     });
 
     it('should render provided quotes', () => {

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeForm.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeForm.test.ts
@@ -7,7 +7,6 @@ import {
 } from '@suite-common/trading';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { events } from '@suite-native/analytics';
-import { FeatureFlag } from '@suite-native/feature-flags';
 import { type TestStore, act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
 import {
     btcAsset,
@@ -71,9 +70,6 @@ describe('useExchangeForm', () => {
                     settings: {
                         bitcoinAmountUnit,
                     },
-                },
-                featureFlags: {
-                    [FeatureFlag.AreTradingExchangeDexesEnabled]: true,
                 },
             },
         });

--- a/suite-native/module-trading/src/hooks/general/__tests__/useProviderFilters.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useProviderFilters.test.ts
@@ -1,5 +1,6 @@
 import type { ExchangeTrade } from 'invity-api';
 
+import { EMPTY_GROUPED_TRADING_EXCHANGE_QUOTES } from '@suite-common/trading';
 import { act, renderHookWithBasicProvider } from '@suite-native/test-utils';
 import { type QuotesByCategories } from '@suite-native/trading-types';
 
@@ -8,16 +9,12 @@ import { useProviderFilters } from '../useProviderFilters';
 type UseProviderFilterProps = {
     quotes?: QuotesByCategories<ExchangeTrade>;
     shouldShowFilters?: boolean;
-    areTradingExchangeDexesEnabled?: boolean;
 };
 describe('useProviderFilters', () => {
     const renderUseProviderFilters = (initialProps: UseProviderFilterProps) =>
         renderHookWithBasicProvider(
-            ({
-                quotes = { fixed: [], float: [], dex: [] },
-                shouldShowFilters = true,
-                areTradingExchangeDexesEnabled = true,
-            }) => useProviderFilters(quotes, shouldShowFilters, areTradingExchangeDexesEnabled),
+            ({ quotes = EMPTY_GROUPED_TRADING_EXCHANGE_QUOTES, shouldShowFilters = true }) =>
+                useProviderFilters(quotes, shouldShowFilters),
             {
                 initialProps,
             },
@@ -107,18 +104,6 @@ describe('useProviderFilters', () => {
             { key: 'fixed', data: [], label: '', sectionData: 'fixed' },
             { key: 'float', data: [], label: '', sectionData: 'float' },
             { key: 'dex', data: [], label: '', sectionData: 'dex' },
-        ]);
-    });
-
-    it('should return only CEX sections when DEX is disabled', () => {
-        const { result } = renderUseProviderFilters({
-            shouldShowFilters: false,
-            areTradingExchangeDexesEnabled: false,
-        });
-
-        expect(result.current.filteredSections).toEqual([
-            { key: 'fixed', data: [], label: '', sectionData: 'fixed' },
-            { key: 'float', data: [], label: '', sectionData: 'float' },
         ]);
     });
 });

--- a/suite-native/module-trading/src/hooks/general/useProviderFilters.ts
+++ b/suite-native/module-trading/src/hooks/general/useProviderFilters.ts
@@ -15,7 +15,6 @@ export type FilterValue = 'all' | 'cex' | 'dex';
 export const useProviderFilters = <T extends TradingTradeType>(
     quotes: QuotesByCategories<T>,
     shouldShowFilters: boolean,
-    areTradingExchangeDexesEnabled: boolean,
 ) => {
     const { translate } = useTranslate();
     const [selectedFilter, setSelectedFilter] = useState<FilterValue>('all');
@@ -30,20 +29,18 @@ export const useProviderFilters = <T extends TradingTradeType>(
     );
 
     const filteredSections: SectionListData<T, QuotesCategory> = useMemo(() => {
-        const allSections = Object.entries(quotes)
-            .filter(([category]) => areTradingExchangeDexesEnabled || category !== 'dex')
-            .map(([category, items]) => {
-                const typedCategory = category as QuotesCategory;
+        const allSections = Object.entries(quotes).map(([category, items]) => {
+            const typedCategory = category as QuotesCategory;
 
-                return {
-                    key: category,
-                    data: items as SectionListDataArray<T>,
-                    label: '',
-                    sectionData: typedCategory,
-                };
-            });
+            return {
+                key: category,
+                data: items as SectionListDataArray<T>,
+                label: '',
+                sectionData: typedCategory,
+            };
+        });
 
-        if (!areTradingExchangeDexesEnabled || !shouldShowFilters || selectedFilter === 'all') {
+        if (!shouldShowFilters || selectedFilter === 'all') {
             return allSections;
         }
 
@@ -59,7 +56,7 @@ export const useProviderFilters = <T extends TradingTradeType>(
             default:
                 return exhaustive(selectedFilter, 'Unexpected filter value');
         }
-    }, [quotes, selectedFilter, shouldShowFilters, areTradingExchangeDexesEnabled]);
+    }, [quotes, selectedFilter, shouldShowFilters]);
 
     return {
         selectedFilter,

--- a/suite-native/trading-state/src/selectors/__tests__/exchangeSelectors.test.ts
+++ b/suite-native/trading-state/src/selectors/__tests__/exchangeSelectors.test.ts
@@ -2,7 +2,11 @@ import type { CryptoId } from 'invity-api';
 
 import { type AccountsRootState } from '@suite-common/wallet-core';
 import { type Account, type AccountKey } from '@suite-common/wallet-types';
-import { FeatureFlag, type FeatureFlagsRootState } from '@suite-native/feature-flags';
+import {
+    FeatureFlag,
+    type FeatureFlagsRootState,
+    featureFlagsInitialState,
+} from '@suite-native/feature-flags';
 import { exchangeQuotes, getBtcAccount, getWalletState } from '@suite-native/trading-fixtures';
 
 import { type TradingRootState } from '../../reducers';
@@ -23,7 +27,7 @@ describe('exchangeSelectors', () => {
         state = {
             wallet: getWalletState({ tradeType: 'exchange' }),
             featureFlags: {
-                [FeatureFlag.AreTradingExchangeDexesEnabled]: true,
+                ...featureFlagsInitialState,
                 [FeatureFlag.AreDebugOnlyNetworksEnabled]: false,
                 [FeatureFlag.AreExperimentalOnlyNetworksEnabled]: false,
             } as FeatureFlagsRootState['featureFlags'],
@@ -195,7 +199,7 @@ describe('exchangeSelectors', () => {
             });
         });
 
-        it('should group quotes by fixed/float/dex when DEX feature flag is enabled', () => {
+        it('should group quotes by fixed/float/dex', () => {
             state.wallet.trading.exchange.quotes = exchangeQuotes;
 
             const groupedQuotes = selectGroupedExchangeQuotes(state);
@@ -226,15 +230,6 @@ describe('exchangeSelectors', () => {
                     }),
                 ],
             });
-        });
-
-        it('should exclude DEX quotes when DEX feature flag is disabled', () => {
-            state.wallet.trading.exchange.quotes = exchangeQuotes;
-            state.featureFlags[FeatureFlag.AreTradingExchangeDexesEnabled] = false;
-
-            const groupedQuotes = selectGroupedExchangeQuotes(state);
-
-            expect(groupedQuotes.dex).toEqual([]);
         });
 
         it('should be stable', () => {

--- a/suite-native/trading-state/src/selectors/exchangeSelectors.ts
+++ b/suite-native/trading-state/src/selectors/exchangeSelectors.ts
@@ -1,6 +1,5 @@
-import type { ExchangeTrade } from 'invity-api';
-
 import {
+    EMPTY_GROUPED_TRADING_EXCHANGE_QUOTES,
     selectGroupedTradingExchangeQuotes,
     selectTradingExchangeBuyCryptoIds,
 } from '@suite-common/trading';
@@ -94,24 +93,8 @@ export const selectGroupedExchangeQuotes = createTradingWithFeatureFlagsMemoized
         selectGroupedTradingExchangeQuotes as unknown as (
             state: TradingRootState,
         ) => ReturnType<typeof selectGroupedTradingExchangeQuotes>,
-        (state: TradingWithFeatureFlagsRootState) =>
-            selectIsFeatureFlagEnabled(state, FeatureFlag.AreTradingExchangeDexesEnabled),
     ],
-    (groupedQuotes, areTradingExchangeDexesEnabled) => {
-        if (!groupedQuotes) {
-            return { fixed: [], float: [], dex: [] as ExchangeTrade[] };
-        }
-
-        if (areTradingExchangeDexesEnabled) {
-            return groupedQuotes;
-        }
-
-        return {
-            fixed: groupedQuotes.fixed,
-            float: groupedQuotes.float,
-            dex: [] as ExchangeTrade[],
-        };
-    },
+    groupedQuotes => groupedQuotes ?? EMPTY_GROUPED_TRADING_EXCHANGE_QUOTES,
 );
 
 export const selectExchangeAmountLimits = (state: TradingRootState) =>

--- a/suite-native/trading-state/src/selectors/exchangeSelectors.ts
+++ b/suite-native/trading-state/src/selectors/exchangeSelectors.ts
@@ -1,5 +1,4 @@
 import {
-    EMPTY_GROUPED_TRADING_EXCHANGE_QUOTES,
     selectGroupedTradingExchangeQuotes,
     selectTradingExchangeBuyCryptoIds,
 } from '@suite-common/trading';
@@ -88,14 +87,9 @@ export const selectExchangeBuyTradeableAssets = createTradingWithFeatureFlagsMem
 export const selectExchangeQuotes = (state: TradingRootState) =>
     state.wallet.trading.exchange.quotes;
 
-export const selectGroupedExchangeQuotes = createTradingWithFeatureFlagsMemoizedSelector(
-    [
-        selectGroupedTradingExchangeQuotes as unknown as (
-            state: TradingRootState,
-        ) => ReturnType<typeof selectGroupedTradingExchangeQuotes>,
-    ],
-    groupedQuotes => groupedQuotes ?? EMPTY_GROUPED_TRADING_EXCHANGE_QUOTES,
-);
+export const selectGroupedExchangeQuotes = selectGroupedTradingExchangeQuotes as unknown as (
+    state: TradingRootState,
+) => ReturnType<typeof selectGroupedTradingExchangeQuotes>;
 
 export const selectExchangeAmountLimits = (state: TradingRootState) =>
     selectTradingExchange(state).amountLimits;


### PR DESCRIPTION
release native swap on dexes publicaly 

## Notes for QA

dex trades should be visible on freshly installed app (with cze or other ios enabled country)

## Related Issue

Resolve #27581 


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=27581-mobile-swap-release-dexes&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=27581-mobile-swap-release-dexes&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=27581-mobile-swap-release-dexes&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-11T23:32:42.323Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-11T23:30:54.816Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/27581-mobile-swap-release-dexes/web/](https://dev.suite.sldev.cz/suite-web/27581-mobile-swap-release-dexes/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->