### PR TITLE
test(e2e): fixes device display fee asserts for send-base.tests

### DIFF
--- a/suite/e2e/support/device.ts
+++ b/suite/e2e/support/device.ts
@@ -212,20 +212,27 @@ export class DeviceFixture {
         return lines;
     };
 
-    wrapText = (text: string, options?: { isAmount?: boolean; wrapByWords?: boolean }) => {
-        const T3W1_EXACT_LINE_LENGTH = 14;
-        const T3T1_EXACT_LINE_LENGTH = 18;
-        const T3W1_LINE_LENGTH_MINUS_DASH = 13;
+    wrapText = (
+        text: string,
+        options?: { isAmount?: boolean; wrapByWords?: boolean; lengthOverride?: number },
+    ) => {
+        const T3W1_EXACT_LINE_LENGTH = options?.lengthOverride ?? 14;
+        const T3T1_EXACT_LINE_LENGTH = options?.lengthOverride ?? 18;
+        const T3W1_LINE_LENGTH_MINUS_DASH = T3W1_EXACT_LINE_LENGTH - 1;
 
         if (this.model === Model.T3W1) {
+            //1. Fits on one line without wrap
             if (text.length === T3W1_EXACT_LINE_LENGTH) {
                 return [text];
             }
 
+            //2. Needs to be wrapped by whole words
             if (options?.wrapByWords) {
                 return this.wrapTextByWords(text, T3W1_EXACT_LINE_LENGTH);
             }
 
+            //3. string is split by the size limit
+            //text string will have a dash at the end of separation
             const lineCharLimit = options?.isAmount
                 ? T3W1_LINE_LENGTH_MINUS_DASH
                 : T3W1_EXACT_LINE_LENGTH;

--- a/suite/e2e/tests/wallet/send-base.test.ts
+++ b/suite/e2e/tests/wallet/send-base.test.ts
@@ -11,6 +11,10 @@ const sendAddress = '0xdcaB74E62b9D08a9f8Fa4A3Ccb5c46AE039C9d7C';
 const formattedSendAddress = formatAddressWithNewlines(sendAddress);
 const sendAmount = '0.000008';
 const formattedSendAmount = `${localizeNumber(sendAmount)} ETH`;
+const feeWrapFormat = {
+    wrapByWords: true,
+    lengthOverride: 16,
+};
 
 // This test is vulnerable to being run twice simultaneously
 // in such case nonce will collide and second transaction will fail
@@ -83,10 +87,6 @@ test.describe(
                         body: [transformAddress(sendAddress)],
                         actions: { right_button: 'Continue' },
                     },
-                    T3T1: {
-                        header: { title: 'Address', subtitle: 'Recipient' },
-                        body: [transformAddress(sendAddress)],
-                    },
                 });
             });
 
@@ -116,9 +116,6 @@ test.describe(
                         ],
                         actions: { right_button: 'Hold to sign' },
                     },
-                    T3T1: {
-                        header: { title: 'Summary' },
-                    },
                 });
             });
 
@@ -131,22 +128,10 @@ test.describe(
                             ['Gas limit'],
                             [`${gasLimit} units`],
                             ['Max fee per gas'],
-                            [maxFeePerGas, '\n', 'Gwei'],
+                            device.wrapText(`${maxFeePerGas} Gwei`, feeWrapFormat),
                             ['Max priority fee'],
-                            [maxPriorityFeePerGas, '\n', 'Gwei'],
+                            device.wrapText(`${maxPriorityFeePerGas} Gwei`, feeWrapFormat),
                         ],
-                    },
-                    T3T1: {
-                        header: { title: 'Fee info' },
-                        body: [
-                            ['Gas limit'],
-                            [`${gasLimit} units`],
-                            ['Max fee per gas'],
-                            [`${maxFeePerGas} Gwei`],
-                            ['Max priority fee'],
-                            [`${maxPriorityFeePerGas} Gwei`],
-                        ],
-                        footer: undefined,
                     },
                 });
             });
@@ -193,10 +178,6 @@ test.describe(
                         body: [transformAddress(sendAddress)],
                         actions: { right_button: 'Continue' },
                     },
-                    T3T1: {
-                        header: { title: 'Address', subtitle: 'Recipient' },
-                        body: [transformAddress(sendAddress)],
-                    },
                 });
             });
 
@@ -216,16 +197,13 @@ test.describe(
                     errorMessageMaxCalculation,
                 ).toHaveText(ethereumMaximumFee);
                 const maxFeeWrapped = device.wrapText(`${ethereumMaximumFee} ETH`, {
-                    wrapByWords: true,
+                    isAmount: true,
                 });
                 await expect(device).toShowOnDisplay({
                     T3W1: {
                         header: { title: 'Send' },
                         body: [['Amount'], [formattedSendAmount], ['Maximum fee'], maxFeeWrapped],
                         actions: { right_button: 'Hold to sign' },
-                    },
-                    T3T1: {
-                        header: { title: 'Summary' },
                     },
                 });
             });
@@ -239,16 +217,14 @@ test.describe(
                             ['Gas limit'],
                             [`${gasLimit} units`],
                             ['Max fee per gas'],
-                            device.wrapText(`${maxFeePerGas} Gwei`, { wrapByWords: true }),
+                            device.wrapText(`${maxFeePerGas} Gwei`, feeWrapFormat),
                             ['Max priority fee'],
-                            device.wrapText(`${maxPriorityFeePerGas} Gwei`, {
-                                wrapByWords: true,
-                            }),
+                            device.wrapText(`${maxPriorityFeePerGas} Gwei`, feeWrapFormat),
                         ],
                     },
-                    T3T1: { footer: undefined },
                 });
             });
+
             await test.step('Confirm transaction', async () => {
                 await devicePrompt.waitForPromptAndConfirm();
                 // wait for transaction to be prepared


### PR DESCRIPTION


<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes involve a direct modification to a send-flow E2E test (send-base.test.ts) and the shared device support utility (device.ts). The send-base test must be run unconditionally. Since device.ts is a support file used across many tests for device emulator interactions (powerOn/Off, pressYes, type, etc.), the highest-risk secondary tests are other wallet send tests that share the same device interaction patterns and page object flows. The risk is moderate — focused on the send transaction flow and device interaction layer.

<details><summary><b>Changed files (2)</b></summary>

- `suite/e2e/support/device.ts`
- `suite/e2e/tests/wallet/send-base.test.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/send-base.test.ts` — This test file itself was directly changed, so it must be run to validate the modifications are correct and the test still passes.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/wallet/send-eth.test.ts` — send-eth.test.ts tests nearly identical Ethereum send flow behavior (custom gas fees, device prompt verification, address formatting) as the changed send-base.test.ts. If the send-base changes reflect a pattern update or shared page object change, send-eth would be affected similarly.
- `suite/e2e/tests/wallet/send-sol.test.ts` — send-sol.test.ts follows the same send flow pattern (hidden wallet, device prompt verification, fee calculation) as send-base. Changes to send-base test patterns or shared support infrastructure like device.ts could affect this test.
- `suite/e2e/tests/wallet/send-doge.test.ts` — send-doge.test.ts tests a send flow with device prompt confirmation and address formatting, sharing the same device interaction patterns potentially affected by changes to device.ts.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — send-form-ltc.test.ts tests a send flow with device prompt confirmation, sharing device interaction infrastructure that may be affected by device.ts changes.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — send-form-regtest.test.ts tests Bitcoin send form operations with device confirmation, sharing the device interaction layer modified in device.ts.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/e2e/support/device.ts`

_Updated: 2026-05-12T04:03:10.800Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-fixes-05&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-fixes-05&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-12T08:28:21.628Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-12T04:06:28.837Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test-fixes-05/web/](https://dev.suite.sldev.cz/suite-web/test-fixes-05/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->