### PR TITLE
Fix Chrome Android WebUSB

### DIFF
--- a/packages/transport/src/transports/webusb.browser.ts
+++ b/packages/transport/src/transports/webusb.browser.ts
@@ -31,6 +31,10 @@ export class WebUsbTransport extends AbstractApiTransport {
     }
 
     private async trySetSessionsBackground() {
+        if (typeof SharedWorker === 'undefined') return;
+        // detect SharedWorker polyfill, don't use it
+        if (Object.prototype.toString.call(SharedWorker.prototype) === '[object Object]') return;
+
         try {
             const response = await fetch(this.sessionsBackgroundUrl, { method: 'HEAD' });
             if (!response.ok) {


### PR DESCRIPTION
## Description

Recently, Evolu added a global [polyfill for SharedWorker](https://github.com/evoluhq/evolu/commit/c1f97ffa471f6309e2df47633aab113fd816a109). Unfortunately Connect does not work with this polyfill. 
This PR adds a quick fix to check whether we have the real or polyfilled implmentation.

## Notes for QA

See that Suite in Chrome on Android can connect via WebUSB, both v148 and older version

## Related Issue

Resolve #27579

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to a single file: the WebUSB browser transport implementation. This is a broadly-imported transport module (121 static test mappings), but most tests use Bridge transport via emulator and don't directly exercise WebUSB code paths. The highest-risk test is the Bridge page test which explicitly tests WebUSB selection. A few tests covering transport type detection, session management, and bridge lifecycle warrant medium priority. Most of the 121 mapped tests are unaffected since they operate through BridgeTransport with emulators and don't trigger WebUSB-specific logic.

<details><summary><b>Changed files (1)</b></summary>

- `packages/transport/src/transports/webusb.browser.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/suite/bridge.test.ts` — This test directly exercises WebUSB transport selection on the Bridge page. The changed file is the WebUSB browser transport implementation, and this test verifies the user flow of choosing WebUSB over Bridge and seeing the connect device prompt with WebUSB enabled.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — This test covers bridge transport lifecycle including version endpoint checks and device reconnection after bridge restart. Changes to the WebUSB browser transport could affect fallback behavior or transport initialization when bridge is present alongside WebUSB.
- `suite/e2e/tests/analytics/events.test.ts` — This test explicitly asserts on TransportType events (type 'BridgeTransport' and version). Changes to the WebUSB transport could affect transport type detection and reporting, which this test directly validates.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test validates Bridge session management including session stealing and reclamation. WebUSB transport changes could affect how sessions are acquired/enumerated alongside BridgeTransport, which this test exercises.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/browser/safari.test.ts` — Safari is an unsupported browser where WebUSB is not available. Changes to the WebUSB browser transport could affect the unsupported browser detection or fallback path that this test exercises when the user clicks 'Continue at my own risk'.

</details>

_Updated: 2026-05-12T07:39:18.221Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/27579-android-webusb&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/27579-android-webusb&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > call cancellation | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-12T10:57:43.895Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-12T08:16:31.997Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/27579-android-webusb/web/](https://dev.suite.sldev.cz/suite-web/fix/27579-android-webusb/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->