### PR TITLE
fix(suite): Update phising tooltip

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Sidebar.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 
 import styled from 'styled-components';
 

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionHeading.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionHeading.tsx
@@ -1,6 +1,6 @@
 import { Translation } from '@suite/intl';
 import { getTxHeaderSymbol, isSupportedEthStakingNetworkSymbol } from '@suite-common/wallet-utils';
-import { Link, Row, Tooltip } from '@trezor/components';
+import { Row, TextButton, Tooltip } from '@trezor/components';
 import { HELP_CENTER_ZERO_VALUE_ATTACKS } from '@trezor/urls';
 
 import { type WalletAccountTransaction } from 'src/types/wallet';
@@ -30,7 +30,17 @@ export const TransactionHeading = ({
                 <Translation
                     id="TR_ZERO_PHISHING_TOOLTIP"
                     values={{
-                        a: chunks => <Link href={HELP_CENTER_ZERO_VALUE_ATTACKS}>{chunks}</Link>,
+                        a: chunks => (
+                            <TextButton
+                                intent="neutral"
+                                priority="secondary"
+                                size="small"
+                                href={HELP_CENTER_ZERO_VALUE_ATTACKS}
+                                margin={{ top: 12 }}
+                            >
+                                {chunks}
+                            </TextButton>
+                        ),
                     }}
                 />
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27481

## Screenshots:

before
<img width="1116" height="246" alt="image" src="https://github.com/user-attachments/assets/81642516-f753-4e51-8096-f3d761d11003" />


after
<img width="289" height="144" alt="image" src="https://github.com/user-attachments/assets/e7c2b1db-5797-415c-8a17-5005f22c5c5f" />


<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect two UI components: the Sidebar layout component and the TransactionHeading component within wallet transaction items. Both files map to 121 tests each, indicating they are broadly imported global components, so most tests are only transitively affected. The highest risk is in tests that directly assert on transaction item headings/labels (pending-transactions, transactions) and sidebar-specific functionality (account search, wallet discovery). The recommended strategy is to run the transaction-focused tests at high priority and sidebar/navigation tests at medium priority, while skipping the vast majority of tests that only transitively import these components.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Sidebar.tsx`
- `packages/suite/src/components/wallet/TransactionItem/TransactionHeading.tsx`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/wallet/pending-transactions.test.ts` — TransactionHeading.tsx is directly responsible for rendering transaction heading labels like 'Sending to self', 'Sending', 'Receiving', 'Sent', and 'Received' which are the core assertions in this test. Any change to TransactionHeading could break these label displays.
- `suite/e2e/tests/wallet/transactions.test.ts` — This test directly interacts with transaction items and their displayed addresses on account pages. TransactionHeading.tsx renders the heading portion of each transaction item, and changes could affect how transaction addresses and labels are displayed or searched.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/wallet/export-transactions.test.ts` — Transaction export tests navigate through account pages where TransactionItem/TransactionHeading is rendered. While the export itself may not depend on the heading, the test navigates wallet pages that render these components, and a rendering crash would cause failures.
- `suite/e2e/tests/wallet/pagination.test.ts` — This test navigates paginated transaction pages and asserts on transaction addresses displayed within transaction items. TransactionHeading.tsx is part of the TransactionItem component that renders these entries, so changes could affect what's displayed on each page.
- `suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — This test labels transaction outputs and verifies output labels are displayed correctly within transaction items. TransactionHeading.tsx may render or interact with output label display within the transaction item component, and the test also verifies CSV export contains labeled output metadata.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — This test exercises the device switcher flow (eject wallet, add standard wallet) which directly involves the Sidebar component. Changes to Sidebar.tsx could affect sidebar navigation and wallet switching behavior.
- `suite/e2e/tests/wallet/account-search.test.ts` — Account search functionality lives in the wallet sidebar. Changes to Sidebar.tsx could affect the account search input, filtering behavior, and visibility of account buttons that this test directly asserts on.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — This test toggles discreet mode via a hide balance button and checks balance hiding across multiple UI areas. The Sidebar may contain account balance displays that are affected by discreet mode, and the test checks account balance in the sidebar area.

</details>

_Updated: 2026-05-12T07:41:02.600Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=update-phising-tooltip&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=update-phising-tooltip&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-12T07:45:13.131Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-12T07:43:49.321Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/update-phising-tooltip/web/](https://dev.suite.sldev.cz/suite-web/update-phising-tooltip/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->