### PR TITLE
fix(suite-native): fee selector balance error

### DIFF
--- a/suite-native/module-earn/src/hooks/useComposeEarnFees.ts
+++ b/suite-native/module-earn/src/hooks/useComposeEarnFees.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { isFulfilled } from '@reduxjs/toolkit';
@@ -11,6 +11,7 @@ import {
     composeSendFormTransactionFeeLevelsThunk,
     formDraftActions,
     selectAccountByKey,
+    selectAreFeesLoading,
     selectConvertedNetworkFeeInfo,
     selectDeepCopyOfFormDraft,
     useFormDraft,
@@ -21,7 +22,10 @@ import {
     isFinalPrecomposedTransaction,
 } from '@suite-common/wallet-types';
 import {
+    type NativeSendRootState,
     type UpdateSelectedFeeLevelThunkParams,
+    getFeeAvailability,
+    selectFeeLevels,
     transactionManagementActions,
 } from '@suite-native/transaction-management';
 import { useDebounce } from '@trezor/react-utils';
@@ -83,6 +87,7 @@ export const useComposeEarnFees = ({
         formDraftKey,
         saveDraft,
     } = useFormDraft<FormState>(formDraftPrefix, accountKey);
+    const [isComposingFeeLevels, setIsComposingFeeLevels] = useState(false);
     const formDraftRef = useRef(formDraft);
     formDraftRef.current = formDraft;
     const account = useSelector((state: AccountsRootState) =>
@@ -91,43 +96,77 @@ export const useComposeEarnFees = ({
     const feeInfo = useSelector((state: FeesRootState) =>
         selectConvertedNetworkFeeInfo(state, account?.symbol),
     );
+    const areFeesLoading = useSelector((state: FeesRootState) =>
+        selectAreFeesLoading(state, account?.symbol),
+    );
+    const feeLevels = useSelector((state: NativeSendRootState) => selectFeeLevels(state));
+    const selectedFee = formDraft?.selectedFee;
+    const selectedFeeLevel = selectedFee ? feeLevels[selectedFee] : undefined;
+    const fee = isFinalPrecomposedTransaction(selectedFeeLevel) ? selectedFeeLevel.fee : null;
+    const { isFeeUnavailable } = getFeeAvailability({
+        fee,
+        feeLevels,
+        selectedFee,
+        isLoading: areFeesLoading || isComposingFeeLevels,
+    });
 
     const composeFeeLevels = useCallback(async () => {
-        if (!formState || !account || !feeInfo) return;
+        if (!formState || !account || !feeInfo) {
+            setIsComposingFeeLevels(false);
 
-        const { selectedFee, feePerUnit, feeLimit, maxFeePerGas, maxPriorityFeePerGas } =
-            formDraftRef.current ?? {};
-
-        const mergedFormState = {
-            ...formState,
-            selectedFee: selectedFee ?? formState.selectedFee,
-            feePerUnit: feePerUnit ?? formState.feePerUnit,
-            feeLimit: feeLimit ?? formState.feeLimit,
-            maxFeePerGas: maxFeePerGas ?? formState.maxFeePerGas,
-            maxPriorityFeePerGas: maxPriorityFeePerGas ?? formState.maxPriorityFeePerGas,
-        };
-
-        const response = await dispatch(
-            composeSendFormTransactionFeeLevelsThunk({
-                formState: mergedFormState,
-                composeContext: { account, feeInfo, network: getNetwork(account.symbol) },
-            }),
-        );
-        if (!isFulfilled(response)) return;
-
-        dispatch(transactionManagementActions.storeFeeLevels({ feeLevels: response.payload }));
-
-        const normalLevel = response.payload.normal;
-        if (!mergedFormState.feePerUnit && isFinalPrecomposedTransaction(normalLevel)) {
-            mergedFormState.feePerUnit = normalLevel.feePerByte;
+            return;
         }
 
-        saveDraft(mergedFormState);
+        setIsComposingFeeLevels(true);
+
+        try {
+            const {
+                selectedFee: draftSelectedFee,
+                feePerUnit,
+                feeLimit,
+                maxFeePerGas,
+                maxPriorityFeePerGas,
+            } = formDraftRef.current ?? {};
+
+            const mergedFormState = {
+                ...formState,
+                selectedFee: draftSelectedFee ?? formState.selectedFee,
+                feePerUnit: feePerUnit ?? formState.feePerUnit,
+                feeLimit: feeLimit ?? formState.feeLimit,
+                maxFeePerGas: maxFeePerGas ?? formState.maxFeePerGas,
+                maxPriorityFeePerGas: maxPriorityFeePerGas ?? formState.maxPriorityFeePerGas,
+            };
+
+            const response = await dispatch(
+                composeSendFormTransactionFeeLevelsThunk({
+                    formState: mergedFormState,
+                    composeContext: { account, feeInfo, network: getNetwork(account.symbol) },
+                }),
+            );
+            if (!isFulfilled(response)) return;
+
+            dispatch(transactionManagementActions.storeFeeLevels({ feeLevels: response.payload }));
+
+            const normalLevel = response.payload.normal;
+            if (!mergedFormState.feePerUnit && isFinalPrecomposedTransaction(normalLevel)) {
+                mergedFormState.feePerUnit = normalLevel.feePerByte;
+            }
+
+            saveDraft(mergedFormState);
+        } finally {
+            setIsComposingFeeLevels(false);
+        }
     }, [dispatch, formState, account, feeInfo, saveDraft]);
 
     useEffect(() => {
+        setIsComposingFeeLevels(!!formState && !!account && !!feeInfo);
         debounce(composeFeeLevels);
-    }, [debounce, composeFeeLevels]);
+    }, [account, debounce, composeFeeLevels, feeInfo, formState]);
 
-    return { formDraft, formDraftKey, updateFeeLevelThunk: updateEarnSelectedFeeLevelThunk };
+    return {
+        formDraft,
+        formDraftKey,
+        isFeeUnavailable: formState !== undefined && !isComposingFeeLevels && isFeeUnavailable,
+        updateFeeLevelThunk: updateEarnSelectedFeeLevelThunk,
+    };
 };

--- a/suite-native/module-earn/src/hooks/useEarnForm.ts
+++ b/suite-native/module-earn/src/hooks/useEarnForm.ts
@@ -50,7 +50,7 @@ export const useEarnForm = (accountKey: AccountKey) => {
         );
     }, [account, isValid, amountValue]);
 
-    const { formDraft, formDraftKey, updateFeeLevelThunk } = useComposeEarnFees({
+    const { formDraft, formDraftKey, isFeeUnavailable, updateFeeLevelThunk } = useComposeEarnFees({
         accountKey,
         formState: stakeFormState,
         formDraftPrefix: 'stake',
@@ -58,5 +58,13 @@ export const useEarnForm = (accountKey: AccountKey) => {
 
     if (!account) return null;
 
-    return { form, amountValue, account, formDraft, formDraftKey, updateFeeLevelThunk };
+    return {
+        form,
+        amountValue,
+        account,
+        formDraft,
+        formDraftKey,
+        isFeeUnavailable,
+        updateFeeLevelThunk,
+    };
 };

--- a/suite-native/module-earn/src/hooks/useUnstakeForm.ts
+++ b/suite-native/module-earn/src/hooks/useUnstakeForm.ts
@@ -61,7 +61,7 @@ export const useUnstakeForm = (accountKey: AccountKey) => {
         );
     }, [account, isValid, amountValue]);
 
-    const { formDraft, formDraftKey, updateFeeLevelThunk } = useComposeEarnFees({
+    const { formDraft, formDraftKey, isFeeUnavailable, updateFeeLevelThunk } = useComposeEarnFees({
         accountKey,
         formState: unstakeFormState,
         formDraftPrefix: 'unstake',
@@ -91,6 +91,7 @@ export const useUnstakeForm = (accountKey: AccountKey) => {
         showNetworkFeeWarning,
         formDraft,
         formDraftKey,
+        isFeeUnavailable,
         updateFeeLevelThunk,
         approximatedInstantEthAmount,
     };

--- a/suite-native/module-earn/src/hooks/useYieldApprovalFees.ts
+++ b/suite-native/module-earn/src/hooks/useYieldApprovalFees.ts
@@ -20,7 +20,12 @@ import {
     isFinalPrecomposedTransaction,
 } from '@suite-common/wallet-types';
 import { buildApprovalTransactionData } from '@suite-common/wallet-utils';
-import { transactionManagementActions } from '@suite-native/transaction-management';
+import {
+    type NativeSendRootState,
+    getFeeAvailability,
+    selectFeeLevels,
+    transactionManagementActions,
+} from '@suite-native/transaction-management';
 import { useDebounce } from '@trezor/react-utils';
 
 import { type ResolvedYieldFlowData } from './useResolvedYieldFlowData';
@@ -71,11 +76,20 @@ export const useYieldApprovalFees = ({
     const formDraft = useSelector((state: FormDraftRootState) =>
         formDraftKey ? selectFormDraft<FormState>(state, formDraftKey) : undefined,
     );
+    const feeLevels = useSelector((state: NativeSendRootState) => selectFeeLevels(state));
 
     const { customFee, selectedFee } = useMemo(
         () => getYieldApprovalFeeState(formDraft),
         [formDraft],
     );
+    const selectedFeeLevel = feeLevels[selectedFee];
+    const fee = isFinalPrecomposedTransaction(selectedFeeLevel) ? selectedFeeLevel.fee : null;
+    const { isFeeUnavailable } = getFeeAvailability({
+        fee,
+        feeLevels,
+        selectedFee,
+        isLoading: isComposingApprovalFee,
+    });
 
     const allowanceAmount = useMemo(() => {
         if (!amount || !flowData) {
@@ -204,6 +218,7 @@ export const useYieldApprovalFees = ({
         formDraft,
         formDraftKey,
         isComposingApprovalFee,
+        isFeeUnavailable,
         selectedFee,
         updateFeeLevelThunk: updateYieldApprovalSelectedFeeLevelThunk,
     };

--- a/suite-native/module-earn/src/screens/ClaimReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/ClaimReviewScreen.tsx
@@ -74,7 +74,7 @@ export const ClaimReviewScreen = () => {
         [symbol],
     );
 
-    const { formDraft, formDraftKey, updateFeeLevelThunk } = useComposeEarnFees({
+    const { formDraft, formDraftKey, isFeeUnavailable, updateFeeLevelThunk } = useComposeEarnFees({
         accountKey,
         formState: claimFormState,
         formDraftPrefix: 'claim',
@@ -120,7 +120,10 @@ export const ClaimReviewScreen = () => {
             }
             footer={
                 <Box paddingHorizontal="sp16" paddingBottom="sp16">
-                    <Button onPress={handleReviewAndSign} isDisabled={isInsufficientFeeBalance}>
+                    <Button
+                        onPress={handleReviewAndSign}
+                        isDisabled={isInsufficientFeeBalance || isFeeUnavailable}
+                    >
                         <Translation id="earn.claimReviewScreen.reviewAndSignButton" />
                     </Button>
                 </Box>

--- a/suite-native/module-earn/src/screens/EarnFormScreen.tsx
+++ b/suite-native/module-earn/src/screens/EarnFormScreen.tsx
@@ -52,7 +52,15 @@ export const EarnFormScreen = () => {
         return null;
     }
 
-    const { form, amountValue, account, formDraft, formDraftKey, updateFeeLevelThunk } = earnForm;
+    const {
+        form,
+        amountValue,
+        account,
+        formDraft,
+        formDraftKey,
+        isFeeUnavailable,
+        updateFeeLevelThunk,
+    } = earnForm;
     const {
         formState: { isValid, isDirty },
     } = form;
@@ -83,7 +91,7 @@ export const EarnFormScreen = () => {
                     accountKey={accountKey}
                     symbol={account.symbol}
                     amountValue={amountValue}
-                    isDisabled={!isValid}
+                    isDisabled={!isValid || isFeeUnavailable}
                     isDirty={isDirty}
                     onPress={() => handleSubmit()}
                 />

--- a/suite-native/module-earn/src/screens/UnstakeFlowScreen.tsx
+++ b/suite-native/module-earn/src/screens/UnstakeFlowScreen.tsx
@@ -64,6 +64,7 @@ export const UnstakeFlowScreen = () => {
         showNetworkFeeWarning,
         formDraft,
         formDraftKey,
+        isFeeUnavailable,
         updateFeeLevelThunk,
         approximatedInstantEthAmount,
     } = unstakeForm;
@@ -96,7 +97,10 @@ export const UnstakeFlowScreen = () => {
                 <>
                     <ScreenFooterGradient />
                     <Box paddingHorizontal="sp16" paddingBottom="sp16">
-                        <Button isDisabled={!isValid} onPress={handleReviewAndSign}>
+                        <Button
+                            isDisabled={!isValid || isFeeUnavailable}
+                            onPress={handleReviewAndSign}
+                        >
                             <Translation id="earn.earnFormScreen.reviewAndSign" />
                         </Button>
                     </Box>

--- a/suite-native/module-earn/src/screens/YieldSupplyFlowScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldSupplyFlowScreen.tsx
@@ -52,6 +52,7 @@ export const YieldSupplyFlowScreen = () => {
         formDraft: approvalFeeFormDraft,
         formDraftKey: approvalFeeFormDraftKey,
         isComposingApprovalFee,
+        isFeeUnavailable,
         selectedFee: selectedApprovalFee,
         updateFeeLevelThunk: updateApprovalFeeLevelThunk,
     } = useYieldApprovalFees({
@@ -110,7 +111,8 @@ export const YieldSupplyFlowScreen = () => {
                         !isValid ||
                         !isApprovalFeeReady ||
                         isComposingApprovalFee ||
-                        isCheckingApproval
+                        isCheckingApproval ||
+                        isFeeUnavailable
                     }
                     isLoading={isCheckingApproval}
                     onPress={handleSubmit}

--- a/suite-native/transaction-management/src/components/fees/FeeSelector.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeeSelector.tsx
@@ -7,14 +7,16 @@ import {
     type FormState,
     type TokenAddress,
 } from '@suite-common/wallet-types';
-import { useBottomSheetModal } from '@suite-native/atoms';
+import { InlineAlertBox, useBottomSheetModal } from '@suite-native/atoms';
 
 import { FeeSummaryCard } from './FeeSummaryCard';
 import { FeesBottomSheet } from './FeesBottomSheet';
 import { TronFeeSummaryCard } from './TronFeeSummaryCard/TronFeeSummaryCard';
 import { type FeesFormValues } from '../../feesFormSchema';
 import { type CustomFeeParams } from '../../hooks';
+import { getFeeAvailability } from '../../hooks/fees/feeAvailability';
 import { useFeesManagement } from '../../hooks/fees/useFeesManagement';
+import { usePrecomposedTransactionError } from '../../hooks/usePrecomposedTransactionError';
 import { updateFeeLimitThunk } from '../../thunks';
 import { type UpdateSelectedFeeLevelThunkParams } from '../../types';
 
@@ -43,6 +45,7 @@ export const FeeSelector = ({
         form,
         fee,
         feeLevels,
+        selectedFeeLevel,
         areFeesLoading,
         isSubmittable,
         symbol,
@@ -66,6 +69,18 @@ export const FeeSelector = ({
 
     const networkType = account?.networkType;
     const isTrc20 = networkType === 'tron' && !!tokenContract;
+    const { isFeeUnavailable, feeError } = getFeeAvailability({
+        fee,
+        feeLevels,
+        selectedFee: selectedFeeLevel,
+        isLoading: areFeesLoading,
+    });
+    const feeUnavailableErrorTitle = usePrecomposedTransactionError({
+        error: feeError,
+        networkSymbol: symbol,
+    });
+    const shouldShowFeeUnavailableAlert =
+        formDraft != null && isFeeUnavailable && !!feeUnavailableErrorTitle;
 
     const handleOpen = useCallback(() => {
         confirmedRef.current = false;
@@ -99,7 +114,13 @@ export const FeeSelector = ({
 
     const feeLimitSunOverride = isTrc20 ? form.watch('customFeeLimit') : undefined;
 
-    if (!symbol || !networkType || (!fee && !areFeesLoading)) return null;
+    if (!symbol || !networkType) return null;
+
+    if (shouldShowFeeUnavailableAlert) {
+        return <InlineAlertBox variant="critical" title={feeUnavailableErrorTitle} />;
+    }
+
+    if (!fee && !areFeesLoading) return null;
 
     return (
         <>

--- a/suite-native/transaction-management/src/hooks/fees/feeAvailability.ts
+++ b/suite-native/transaction-management/src/hooks/fees/feeAvailability.ts
@@ -1,0 +1,42 @@
+import { type FeeLevelLabel, type GeneralPrecomposedLevels } from '@suite-common/wallet-types';
+
+export type GetFeeAvailabilityParams = {
+    fee: string | null | undefined;
+    feeLevels: GeneralPrecomposedLevels;
+    selectedFee: FeeLevelLabel | undefined;
+    isLoading: boolean;
+};
+
+export type FeeAvailability = {
+    isFeeUnavailable: boolean;
+    feeError: string | null;
+};
+
+export const getFeeAvailability = ({
+    fee,
+    feeLevels,
+    selectedFee,
+    isLoading,
+}: GetFeeAvailabilityParams): FeeAvailability => {
+    const selectedFeeLevel = selectedFee ? feeLevels[selectedFee] : undefined;
+    // TODO: default fallback, will be replaced after Fee Selector refactoring
+    const normalFeeLevel = feeLevels.normal;
+    const selectedFeeError = selectedFeeLevel?.type === 'error' ? selectedFeeLevel.error : null;
+    const normalFeeError = normalFeeLevel?.type === 'error' ? normalFeeLevel.error : null;
+    const hasUnavailableComposeState =
+        normalFeeError !== null && (selectedFeeLevel === undefined || selectedFeeError !== null);
+
+    const isFeeUnavailable = !isLoading && fee == null && hasUnavailableComposeState;
+
+    if (!isFeeUnavailable) {
+        return {
+            isFeeUnavailable,
+            feeError: null,
+        };
+    }
+
+    return {
+        isFeeUnavailable,
+        feeError: 'AMOUNT_NOT_ENOUGH_CURRENCY_FEE',
+    };
+};

--- a/suite-native/transaction-management/src/hooks/fees/index.ts
+++ b/suite-native/transaction-management/src/hooks/fees/index.ts
@@ -1,3 +1,4 @@
+export * from './feeAvailability';
 export * from './useCustomFee';
 export * from './useFeeCalculation';
 export * from './useFeeSelection';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

temp fix for https://github.com/trezor/trezor-suite/issues/27144, will need to be handled properly, atm we display error if the user does not have sufficient balance to cover the standard fees (fallback si normal atm) 

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27144

## Screenshots:
<img width="603" height="1311" alt="IMG_4922" src="https://github.com/user-attachments/assets/b2325aa3-72e2-46fe-bba3-9ede4c5a8e50" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/fee-selector&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->