### PR TITLE
Fix arrow in tooltip

### DIFF
--- a/packages/analytics-docs/src/components/EventCard.tsx
+++ b/packages/analytics-docs/src/components/EventCard.tsx
@@ -128,7 +128,7 @@ const Header = ({ event, onEdit }: HeaderProps) => {
                 flexWrap={isMobile ? 'wrap' : undefined}
             >
                 <Row gap={16} alignItems="center" overflow="auto" padding={{ bottom: 8 }}>
-                    <Tooltip content={toEventExportName(event.name)} hasArrow>
+                    <Tooltip content={toEventExportName(event.name)}>
                         <span
                             role="button"
                             tabIndex={0}

--- a/packages/components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/components/src/components/Tooltip/Tooltip.tsx
@@ -86,7 +86,7 @@ export const Tooltip = ({
     addon,
     title,
     isOpen,
-    hasArrow,
+    hasArrow = true,
     hasIcon = false,
     appendTo,
     shift,

--- a/packages/components/src/components/Tooltip/TooltipArrow.tsx
+++ b/packages/components/src/components/Tooltip/TooltipArrow.tsx
@@ -2,7 +2,6 @@ import { FloatingArrow } from '@floating-ui/react';
 
 import { paletteV2 } from '@trezor/theme';
 
-import { TOOLTIP_BORDER_RADIUS } from './TooltipBox';
 import { type ArrowProps } from './TooltipFloatingUi';
 
 export const TooltipArrow = ({ ref, context }: ArrowProps) => (
@@ -10,11 +9,7 @@ export const TooltipArrow = ({ ref, context }: ArrowProps) => (
         ref={ref}
         context={context}
         fill={paletteV2.darkCoolGrey50}
-        staticOffset={TOOLTIP_BORDER_RADIUS}
         strokeWidth={0}
         tipRadius={1}
-        style={{
-            transform: 'translateY(-2px)',
-        }}
     />
 );

--- a/packages/components/src/components/buttons/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/components/src/components/buttons/ButtonGroup/ButtonGroup.stories.tsx
@@ -1,12 +1,10 @@
-import React from 'react';
-
 import { type Meta, type StoryObj } from '@storybook/react';
 
-import { ButtonGroup, type ButtonGroupProps, allowedButtonGroupFrameProps } from './ButtonGroup';
 import { getFramePropsStory } from '../../../utils/frameProps';
 import { Tooltip } from '../../Tooltip/Tooltip';
 import { Button } from '../Button/Button';
 import { buttonIntents, buttonPriorities, buttonSizes } from '../types';
+import { ButtonGroup, type ButtonGroupProps, allowedButtonGroupFrameProps } from './ButtonGroup';
 
 const meta: Meta<ButtonGroupProps> = {
     title: '🫵 Buttons',
@@ -18,7 +16,7 @@ export const ButtonGroups: StoryObj<typeof meta> = {
     render: args => (
         <ButtonGroup {...args}>
             <Button isLoading>Button 1</Button>
-            <Tooltip content="Ahoj!" cursor="pointer" hasArrow>
+            <Tooltip content="Ahoj!" cursor="pointer">
                 <Button>Button 2 with tooltip</Button>
             </Tooltip>
             <Button isDisabled>Button 3</Button>

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyTooltip.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyTooltip.tsx
@@ -39,7 +39,6 @@ export const EarnYieldApyTooltip = ({
         }
         maxWidth={600}
         placement="top"
-        hasArrow
     >
         <Abbr>{children ?? <ApyValue apy={apyPercentage} />}</Abbr>
     </Tooltip>

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceSelector.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceSelector.tsx
@@ -97,7 +97,6 @@ export const DeviceSelector = () => {
             isOpen={recentlyConnectedDevice !== undefined}
             content={<RecentlyConnectedDeviceTooltipContent />}
             placement="right-end"
-            hasArrow
             zIndex={zIndices.popover /* to prevent it from appearing above modals */}
         >
             <Wrapper $isSidebarCollapsed={isSidebarCollapsed}>

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceStatus.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceStatus.tsx
@@ -57,7 +57,7 @@ export const DeviceStatus = ({
                 </Row>
             ) : (
                 <Row justifyContent="center">
-                    <Tooltip hasArrow cursor="inherit" placement="right" content={content}>
+                    <Tooltip cursor="inherit" placement="right" content={content}>
                         {image}
                     </Tooltip>
                 </Row>

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/NavigationItem.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/NavigationItem.tsx
@@ -160,7 +160,6 @@ export const NavItem = (props: NavigationItemProps) => {
                 content={<Title nameId={nameId} values={values} />}
                 isActive={!expanded}
                 placement="right"
-                hasArrow
             >
                 <Icon
                     name={icon}

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountItem.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountItem.tsx
@@ -115,7 +115,6 @@ export const AccountItem = ({
                             </Box>
                         }
                         placement="right"
-                        hasArrow
                     >
                         <GhostContainer
                             isActive={isSelected}

--- a/packages/suite/src/views/dashboard/DashboardFooter.tsx
+++ b/packages/suite/src/views/dashboard/DashboardFooter.tsx
@@ -74,7 +74,6 @@ const StoreBadgeWithQr = ({
         <Tooltip
             isOpen={isTooltipOpen}
             cursor={isBelowTablet ? 'not-allowed' : undefined}
-            hasArrow
             content={
                 <Column alignItems="center">
                     <ImageContainer>

--- a/packages/suite/src/views/settings/SettingsDevice/DisplayRotation.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/DisplayRotation.tsx
@@ -18,7 +18,7 @@ type Rotation = { label: JSX.Element; value: DisplayRotationType };
 const DISPLAY_ROTATIONS: Array<Rotation> = [
     {
         label: (
-            <Tooltip content={<Translation id="TR_NORTH" />} cursor="pointer" hasArrow>
+            <Tooltip content={<Translation id="TR_NORTH" />} cursor="pointer">
                 <Icon name="arrowUp" />
             </Tooltip>
         ),
@@ -26,7 +26,7 @@ const DISPLAY_ROTATIONS: Array<Rotation> = [
     },
     {
         label: (
-            <Tooltip content={<Translation id="TR_EAST" />} cursor="pointer" hasArrow>
+            <Tooltip content={<Translation id="TR_EAST" />} cursor="pointer">
                 <Icon name="arrowLeft" />
             </Tooltip>
         ),
@@ -34,7 +34,7 @@ const DISPLAY_ROTATIONS: Array<Rotation> = [
     },
     {
         label: (
-            <Tooltip content={<Translation id="TR_SOUTH" />} cursor="pointer" hasArrow>
+            <Tooltip content={<Translation id="TR_SOUTH" />} cursor="pointer">
                 <Icon name="arrowDown" />
             </Tooltip>
         ),
@@ -42,7 +42,7 @@ const DISPLAY_ROTATIONS: Array<Rotation> = [
     },
     {
         label: (
-            <Tooltip content={<Translation id="TR_WEST" />} cursor="pointer" hasArrow>
+            <Tooltip content={<Translation id="TR_WEST" />} cursor="pointer">
                 <Icon name="arrowRight" />
             </Tooltip>
         ),

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceItem.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceItem.tsx
@@ -26,9 +26,9 @@ import {
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import type { AcquiredDevice, ForegroundAppProps, TrezorDevice } from 'src/types/suite';
 
+import { CardWithDevice } from '../CardWithDevice';
 import { AddWalletButton } from './AddWalletButton';
 import { WalletInstance } from './WalletInstance';
-import { CardWithDevice } from '../CardWithDevice';
 
 type DeviceItemProps = {
     device: TrezorDevice;
@@ -158,7 +158,6 @@ export const DeviceItem = ({ device, instances, onCancel }: DeviceItemProps) => 
                                 isOpen={showTooltip && index === 0}
                                 width="100%"
                                 placement="right-start"
-                                hasArrow
                                 offset={30}
                             >
                                 <WalletInstance

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/FilterAction.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/FilterAction.tsx
@@ -58,7 +58,6 @@ export const FilterAction = () => {
     return (
         <Tooltip
             disableFlip
-            hasArrow
             isOpen={isOpen}
             placement="bottom-end"
             zIndex={zIndices.popover}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- fix arrow positioning in tooltip
- enable arrows by default
- delete hasArrow usages (because it's by default now)

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

before

<img width="177" height="123" alt="image" src="https://github.com/user-attachments/assets/96bf5224-b660-41cf-b59a-3fd859d6d560" />


after

<img width="236" height="138" alt="image" src="https://github.com/user-attachments/assets/ce6225db-956a-451c-bbc9-b7778de24890" />

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-arrow-in-tooltip/web/](https://dev.suite.sldev.cz/suite-web/fix-arrow-in-tooltip/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-arrow-in-tooltip&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-arrow-in-tooltip&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > call cancellation | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-12T09:13:31.162Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-12T07:56:55.184Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->