### PR TITLE
Don't automatically rescan BT devices in web suite

### DIFF
--- a/packages/suite/src/components/connection/CantSeeTrezorModal.tsx
+++ b/packages/suite/src/components/connection/CantSeeTrezorModal.tsx
@@ -46,8 +46,8 @@ export const CantSeeTrezorModal = ({ onClose }: DontSeeYourTrezorModalProps) => 
 
     // when this modal is displayed, scanning should start again in case it stopped due to timeout, so that user can act on the additional instructions
     useEffect(() => {
-        onReScanClick();
-    }, [onReScanClick]);
+        if (isBluetoothMode) onReScanClick();
+    }, [isBluetoothMode, onReScanClick]);
 
     const isWebUsbTransport = useSelector(selectHasTransportOfType('WebUsbTransport'));
 


### PR DESCRIPTION
## Description

Clicking `Don't see your Trezor?` in web Suite threw a console error, as it tried to automatically scan BT devices. Resolved by checking whether `isBluetoothMode` (which should never be the case on web).

<img width="507" height="429" alt="image" src="https://github.com/user-attachments/assets/e8291a75-6227-4c5c-b827-8be266fea040" />

## Notes for QA

Please check a) that the console error is not there anymore in web Suite and b) that the button still does what it should in desktop Suite.

## Related Issue

Resolve #27625

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is `CantSeeTrezorModal.tsx`, a connection-related modal component. It maps to 121 tests via static coverage, indicating it is a broadly imported shared component (likely part of the app shell or layout). None of the 121 tests in the LLM analysis descriptions directly exercise "can't see Trezor" modal behavior — they all focus on unrelated flows (analytics, backup, trading, staking, etc.) that merely transitively import this component as part of the app layout. Since no test specifically validates the CantSeeTrezorModal's rendering, interaction, or visibility logic, there are no tests worth recommending at high or medium priority. The risk of regression is low for end-to-end flows unless the modal change introduces a crash or layout breakage, which would be caught by virtually any test that loads the app — but no single test is more targeted than another for this purpose.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/connection/CantSeeTrezorModal.tsx`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/components/connection/CantSeeTrezorModal.tsx`

_Updated: 2026-05-12T08:03:17.074Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/bluetooth-ipcProxy-not-found&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/bluetooth-ipcProxy-not-found&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/bluetooth-ipcProxy-not-found/web/](https://dev.suite.sldev.cz/suite-web/fix/bluetooth-ipcProxy-not-found/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-12T08:08:36.189Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-12T08:06:32.401Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->