### PR TITLE
chore(suite-native): replace "Confirm selection" with "Confirm"

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -10,7 +10,6 @@ export const messages = {
             cancel: 'Cancel',
             close: 'Close',
             confirm: 'Confirm',
-            confirmSelection: 'Confirm selection',
             continue: 'Continue',
             done: 'Done',
             dismiss: 'Dismiss',

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -3066,7 +3066,6 @@ export const messages = {
             title: 'To manage your staked accounts, use the Trezor Suite app for desktop.',
             description: 'We currently support staking as view-only in Trezor Suite.',
         },
-        vaultName: '{vaultName} Vault',
         stakingAccountSelection: {
             title: 'Choose account',
         },

--- a/suite-native/module-send/src/components/CoinControl/SendUtxoScreenFooter.tsx
+++ b/suite-native/module-send/src/components/CoinControl/SendUtxoScreenFooter.tsx
@@ -83,7 +83,7 @@ export const SendUtxoScreenFooter = ({
                 {!missingToAmount && (
                     <Animated.View entering={SlideInDown.duration(300)} exiting={SlideOutDown}>
                         <Button onPress={onSubmit}>
-                            <Translation id="generic.buttons.confirmSelection" />
+                            <Translation id="generic.buttons.confirm" />
                         </Button>
                     </Animated.View>
                 )}

--- a/suite-native/module-send/src/components/CoinControl/__tests__/SendUtxoScreenFooter.test.tsx
+++ b/suite-native/module-send/src/components/CoinControl/__tests__/SendUtxoScreenFooter.test.tsx
@@ -14,7 +14,7 @@ describe('SendUtxosScreenFooter', () => {
 
         expect(getByText('Selected')).toBeTruthy();
         expect(getByText('8 BTC')).toBeTruthy();
-        expect(getByText('Confirm selection')).toBeTruthy();
+        expect(getByText('Confirm')).toBeTruthy();
     });
 
     it('should show remaining amount when amount is provided and selected total is less than amount', () => {


### PR DESCRIPTION
Legacy variant removed as requested by Jason.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/confirm-selection-removal&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->