### PR TITLE
test(e2e): fix bridge tests

### DIFF
--- a/suite/e2e/support/setup.ts
+++ b/suite/e2e/support/setup.ts
@@ -58,7 +58,9 @@ export const electronTeardown = async (
     const tracingPath =
         (testInfo as any)._tracing.maybeGenerateNextTraceRecordingPath() ??
         `${testInfo.outputDir}/trace.electron.zip`;
-    await suite.window.context().tracing.stop({ path: tracingPath });
+    if (!suite.window.isClosed()) {
+        await suite.window.context().tracing.stop({ path: tracingPath });
+    }
     testInfo.attachments.push({
         name: 'electron-logs.txt',
         path: `${testInfo.outputDir}/electron-logs.txt`,

--- a/suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts
+++ b/suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts
@@ -7,15 +7,13 @@ import { skipFixture } from '../../support/common';
 import { launchSuite, launchSuiteElectronApp } from '../../support/electron';
 import { expect, test } from '../../support/fixtures';
 
-test.use({ exceptionLogger: skipFixture });
-test.use({ context: undefined }); // disable default context fixture to be able to use beforeAll
 test.describe('Bridge', { tag: ['@desktopOnly', '@T3W1', '@T3T1'] }, () => {
-    test.describe.configure({ mode: 'serial' });
-    test.beforeAll(async ({ trezorUserEnv, onboardingPage }) => {
+    test.use({ exceptionLogger: skipFixture, startEmulator: false, setupEmulator: false });
+    test.beforeEach(async ({ trezorUserEnv, page }) => {
+        await page.close();
         // Ensure bridge is stopped so we properly test the electron app starting node-bridge module.
         await trezorUserEnv.connect();
         await trezorUserEnv.stopBridge();
-        await onboardingPage.verifySuiteIsLoaded();
     });
 
     test('App in daemon mode spawns node-bridge', async ({ request }, testInfo) => {

--- a/suite/e2e/tests/bridge-tor/spawn-bridge.test.ts
+++ b/suite/e2e/tests/bridge-tor/spawn-bridge.test.ts
@@ -14,11 +14,10 @@ import { OnboardingPage } from '../../support/pageObjects/onboarding/onboardingP
 import { SettingsPage } from '../../support/pageObjects/settings/settingsPage';
 import { enhancePage } from '../../support/testExtends/enhancePage';
 
-test.use({ exceptionLogger: skipFixture });
 test.describe('Bridge', { tag: ['@desktopOnly', '@T3W1', '@T3T1'] }, () => {
-    test.describe.configure({ mode: 'serial' });
-
-    test.beforeEach(async ({ trezorUserEnv }) => {
+    test.use({ exceptionLogger: skipFixture, startEmulator: false, setupEmulator: false });
+    test.beforeEach(async ({ page, trezorUserEnv }) => {
+        await page.close();
         //Ensure bridge is stopped so we properly test the electron app starting node-bridge module.
         await trezorUserEnv.connect();
         await trezorUserEnv.stopBridge();
@@ -55,7 +54,6 @@ test.describe('Bridge', { tag: ['@desktopOnly', '@T3W1', '@T3T1'] }, () => {
         await expectBridgeToBeStopped(request);
     });
 
-    test.use({ startEmulator: false, setupEmulator: false });
     test('App acquired device, EXTERNAL bridge is restarted, app reconnects', async ({
         device,
         trezorUserEnv,


### PR DESCRIPTION
cleans up setup for bridge tests.

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies two bridge-tor E2E test files and the shared E2E support/setup file. The two test files that were directly changed are the highest priority to run. The setup.ts file is a shared test infrastructure file, but since no static coverage mapping is available, and the bridge-tor tests are the ones most likely to exercise the setup changes in context, running those two tests provides the most targeted confidence. Other tests that depend on setup.ts could theoretically be affected, but without specific evidence of what changed in setup.ts, broad test execution is not warranted.

<details><summary><b>Changed files (3)</b></summary>

- `suite/e2e/support/setup.ts`
- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts`
- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — This test file was directly changed. It must be run to verify the modifications to the bridge daemon spawning test itself are correct and pass.
- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — This test file was directly changed. It must be run to verify the modifications to the bridge spawning test itself are correct and pass.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/e2e/support/setup.ts`

_Updated: 2026-05-12T08:24:29.800Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-fixes-05-1&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-fixes-05-1&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-12T08:29:11.937Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-12T08:27:58.657Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test-fixes-05-1/web/](https://dev.suite.sldev.cz/suite-web/test-fixes-05-1/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->