### PR TITLE
fix(suite): Wrap buttons in device tooltip

### DIFF
--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceItem.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceItem.tsx
@@ -26,9 +26,9 @@ import {
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import type { AcquiredDevice, ForegroundAppProps, TrezorDevice } from 'src/types/suite';
 
+import { CardWithDevice } from '../CardWithDevice';
 import { AddWalletButton } from './AddWalletButton';
 import { WalletInstance } from './WalletInstance';
-import { CardWithDevice } from '../CardWithDevice';
 
 type DeviceItemProps = {
     device: TrezorDevice;
@@ -125,7 +125,11 @@ export const DeviceItem = ({ device, instances, onCancel }: DeviceItemProps) => 
                                                 <Translation id="TR_DEVICE_DISCONNECTED_TOOLTIP_ITEM_2" />
                                             </ListItem>
                                         </List>
-                                        <Row gap={spacings.sm} margin={{ top: spacings.xs }}>
+                                        <Row
+                                            gap={spacings.sm}
+                                            margin={{ top: spacings.xs }}
+                                            flexWrap="wrap"
+                                        >
                                             <Button
                                                 size="small"
                                                 onClick={() => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27369

## Screenshots:

before

<img width="511" height="371" alt="image" src="https://github.com/user-attachments/assets/4b332733-674a-42c1-8e65-cf0e383e9bc8" />

after

<img width="871" height="391" alt="image" src="https://github.com/user-attachments/assets/aa308e0e-579b-4f8e-8468-4c3fabbb392d" />

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is to DeviceItem.tsx, a component within the SwitchDevice view that renders individual device/wallet entries in the device switcher panel. This is a moderately shared component (mapped to 121 tests via transitive imports), but only tests that directly interact with the device switcher UI — viewing wallet lists, switching wallets, ejecting wallets, checking device status, or editing wallet labels — are meaningfully affected. The recommended strategy focuses on tests that exercise the device switcher panel's rendering and interaction, particularly wallet numbering/labeling, device status display, and wallet management actions.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceItem.tsx`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/analytics/toggle.test.ts` — This test directly exercises the device switcher UI (openDeviceSwitcher) which renders the DeviceItem component. It verifies that opening the device switcher fires analytics events, making it a direct consumer of the changed component.
- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — This test opens the device switcher and verifies wallet fiat amounts displayed within it (walletAtIndexFiatAmount). The DeviceItem component is rendered inside the device switcher and displays wallet balance information that this test directly asserts on.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — This test uses the device switcher to eject a wallet and add a standard wallet, directly interacting with DeviceItem functionality (eject wallet, add standard wallet actions are part of the SwitchDevice/DeviceItem UI).
- `suite/e2e/tests/passphrase/passphrase-numbering.test.ts` — This test heavily exercises the device switcher's wallet listing and labeling (walletAtIndex), ejecting wallets, and adding new wallets — all of which render DeviceItem components. It verifies correct numbering/labeling of wallets displayed by DeviceItem.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/passphrase/passphrase.test.ts` — This test adds hidden wallets via the device switcher, checks wallet labels at specific indices, and verifies analytics events for wallet type selection — all of which involve the DeviceItem component rendering wallet entries.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — This test verifies that after device disconnect/reconnect, the passphrase wallet remains visible in the device switcher (walletAtIndex) with correct labeling. DeviceItem renders these wallet entries.
- `suite/e2e/tests/passphrase/passphrase-duplicate.test.ts` — This test adds hidden wallets through the device switcher and verifies duplicate wallet detection UI, which involves the DeviceItem component's wallet management interactions.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test directly interacts with the device switcher panel checking device status (TR_USE_HERE, TR_CONNECTED), wallet visibility (walletAtIndex), and solve issues button — all rendered within or alongside the DeviceItem component.
- `suite/e2e/tests/metadata/legacy/wallet-metadata.test.ts` — This test edits wallet labels via the device switcher panel and verifies label persistence. Wallet labels are displayed within the DeviceItem component in the switch device view.
- `suite/e2e/tests/backup/t2t1-misc.test.ts` — This test uses the device switcher to eject a wallet and add a standard wallet, and verifies backup behavior when device is disconnected but remembered — interactions that render DeviceItem.

</details>

_Updated: 2026-05-12T08:46:17.861Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=wrap-buttons-in-device-tooltip&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=wrap-buttons-in-device-tooltip&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > call cancellation | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-12T08:51:25.102Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-12T08:48:55.878Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/wrap-buttons-in-device-tooltip/web/](https://dev.suite.sldev.cz/suite-web/wrap-buttons-in-device-tooltip/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->