### PR TITLE
Add missing fields to `portfolioTrackerDevice`

### DIFF
--- a/suite-common/device/src/deviceConstants.ts
+++ b/suite-common/device/src/deviceConstants.ts
@@ -1,4 +1,5 @@
 import { type TrezorDevice } from '@suite-common/suite-types';
+import { asDeviceUniquePath } from '@trezor/connect-common';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
 // These hidden device constants are used in mobile app to hold all imported accounts.
@@ -18,9 +19,12 @@ export const portfolioTrackerDevice: TrezorDevice = {
     state: {
         staticSessionId: PORTFOLIO_TRACKER_DEVICE_STATE,
     },
+    descriptor: {
+        apiType: 'usb',
+    },
+    firstConnectedTimestamp: 0,
     label: 'My assets',
-    // @ts-expect-error - local override
-    path: 'imported-1',
+    path: asDeviceUniquePath('imported-1'),
     firmware: 'valid',
     name: 'Portfolio Tracker',
     features: {


### PR DESCRIPTION
## Description

Because of one `@ts-expect-error`, `portfolioTrackerDevice` didn't conform to `TrezorDevice` type, which probably caused an issue in `deviceReducer` (because of missing descriptor). Now it should be correct <strike>(in fact I've used nonexistent `apiType` for this device because it feels safer)</strike>.

## Related Issue

Hopefully resolve #27630

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file `suite-common/device/src/deviceConstants.ts` is a broad shared utility that maps to 121 tests via static coverage. Since it contains device constants, changes here would typically affect device identification, model detection, or device state management. However, without knowing the specific nature of the change (e.g., adding a new device model constant, modifying an existing threshold, or renaming an enum), none of the 121 tests can be identified as having a direct, specific dependency on particular constant values based on the LLM test analyses. The test descriptions reference device models, device states, and device settings but none explicitly test or assert on values that would originate from `deviceConstants.ts` in a way that distinguishes them from the other 120 tests. Given this is a constants file with extremely broad transitive usage, the recommended strategy is to rely on unit tests for this file and run a small representative smoke test from the CI suite rather than triggering a large E2E run.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/device/src/deviceConstants.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `suite-common/device/src/deviceConstants.ts`

_Updated: 2026-05-12T08:49:53.697Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/portfolio-device-typing&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/portfolio-device-typing&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/portfolio-device-typing&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > call cancellation | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-12T09:55:00.192Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-12T08:53:07.912Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/portfolio-device-typing/web/](https://dev.suite.sldev.cz/suite-web/fix/portfolio-device-typing/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->