### PR TITLE
fix(suite): Add tooltip to Export

### DIFF
--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/ExportAction.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/ExportAction.tsx
@@ -8,7 +8,7 @@ import { getNetwork } from '@suite-common/wallet-config';
 import { fetchAllTransactionsForAccountThunk } from '@suite-common/wallet-core';
 import { type ExportFileType } from '@suite-common/wallet-types';
 import { getTitleForCoinjoinAccount } from '@suite-common/wallet-utils';
-import { Dropdown, Note, Text } from '@trezor/components';
+import { Dropdown, Note, Tooltip } from '@trezor/components';
 
 import { exportTransactionsThunk } from 'src/actions/wallet/exportTransactionsActions';
 import { useDispatch } from 'src/hooks/suite';
@@ -99,34 +99,36 @@ export const ExportAction = ({ account, searchQuery }: ExportActionProps) => {
     const exportTypes = ['csv', 'pdf', 'json'] as const;
 
     return (
-        <Dropdown
-            placement={{ position: 'bottom', alignment: 'start' }}
-            content={
-                searchQuery ? (
-                    <Note iconName="checks">
-                        <Translation
-                            id={
-                                searchQuery
-                                    ? 'TR_EXPORT_SEARCH_FILTER_ACTIVE'
-                                    : 'TR_EXPORT_SEARCH_FILTER_INACTIVE'
-                            }
-                        />
-                    </Note>
-                ) : (
-                    <Text isDisabled>
-                        <Translation id="TR_EXPORT_SEARCH_FILTER_INACTIVE" />
-                    </Text>
-                )
-            }
-            items={exportTypes.map(type => ({
-                label: <Translation id="TR_EXPORT_AS" values={{ as: `.${type}` }} />,
-                onClick: () => runExport(type),
-                'data-testid': `${dataTest}/${type}`,
-            }))}
-            minWidth={240}
-            iconName="fileArrowDown"
-            isLoading={isExportRunning}
-            data-testid={`${dataTest}/dropdown`}
-        />
+        <Tooltip content={<Translation id="TR_EXPORT_TO_FILE" />}>
+            <Dropdown
+                placement={{ position: 'bottom', alignment: 'start' }}
+                content={
+                    searchQuery ? (
+                        <Note iconName="checks">
+                            <Translation
+                                id={
+                                    searchQuery
+                                        ? 'TR_EXPORT_SEARCH_FILTER_ACTIVE'
+                                        : 'TR_EXPORT_SEARCH_FILTER_INACTIVE'
+                                }
+                            />
+                        </Note>
+                    ) : (
+                        <Note iconName="info" priority="secondary">
+                            <Translation id="TR_EXPORT_SEARCH_FILTER_INACTIVE" />
+                        </Note>
+                    )
+                }
+                items={exportTypes.map(type => ({
+                    label: <Translation id="TR_EXPORT_AS" values={{ as: `.${type}` }} />,
+                    onClick: () => runExport(type),
+                    'data-testid': `${dataTest}/${type}`,
+                }))}
+                minWidth={240}
+                iconName="fileArrowDown"
+                isLoading={isExportRunning}
+                data-testid={`${dataTest}/dropdown`}
+            />
+        </Tooltip>
     );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

after

<img width="417" height="291" alt="image" src="https://github.com/user-attachments/assets/7893d093-28f7-4540-9c0d-84761790f5fe" />

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are localized to two components in the TransactionListActions toolbar: ExportAction.tsx (transaction export button/menu) and FilterAction.tsx (transaction filter button/menu). Both files map to 59 tests each, indicating they are rendered on a widely-visited transaction list view, but most of those tests merely navigate through account pages without directly interacting with export or filter functionality. The highest risk is to transaction export tests (which directly trigger exports and verify file contents) and transaction list interaction tests. A focused set of 4 tests provides strong coverage of the directly affected functionality.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/ExportAction.tsx`
- `packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/FilterAction.tsx`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/wallet/export-transactions.test.ts` — This test directly exercises transaction export functionality (PDF, CSV, JSON) via walletPage.exportTransactions. The ExportAction.tsx component is the UI trigger for transaction exports, so any changes to it could break export behavior, file downloads, or format selection.
- `suite/e2e/tests/wallet/transactions.test.ts` — This test interacts with the transaction list view including searching transactions. Both ExportAction and FilterAction are part of the TransactionListActions toolbar rendered on the transactions page, so changes could affect the layout or functionality of the transaction list UI.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — This test explicitly exports a CSV transaction file and verifies labeled output metadata is present in the exported content. It directly exercises the ExportAction component's CSV export functionality and validates export correctness with metadata labels.
- `suite/e2e/tests/wallet/pagination.test.ts` — This test navigates paginated transaction pages and verifies transaction addresses are displayed correctly. FilterAction changes could affect how the transaction list filters or renders alongside pagination controls in the TransactionListActions toolbar.

</details>

_Updated: 2026-05-12T08:54:18.078Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=add-tooltip-to-export&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=add-tooltip-to-export&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > call cancellation | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-12T09:00:33.886Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-12T08:59:00.244Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/add-tooltip-to-export/web/](https://dev.suite.sldev.cz/suite-web/add-tooltip-to-export/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->