### PR TITLE
fix(suite): Fix mobile promo on dark mode

### DIFF
--- a/packages/suite/src/components/suite/StoreBadge.tsx
+++ b/packages/suite/src/components/suite/StoreBadge.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 
+import styled, { useTheme } from 'styled-components';
+
 import { Box, Image, Row } from '@trezor/components';
 
 import { TrezorLink } from './TrezorLink';
@@ -11,8 +13,16 @@ type StoreBadgeProps = {
     onClick?: () => void;
 };
 
+const ImageContainer = styled.div<{ $isDarkTheme: boolean }>`
+    img {
+        ${({ $isDarkTheme }) => ($isDarkTheme ? `filter: invert(1);` : '')}
+    }
+`;
+
 export const StoreBadge = ({ url, image, isHighlighted, onClick }: StoreBadgeProps) => {
     const [isHovered, setIsHovered] = useState(false);
+    const theme = useTheme();
+    const isDarkTheme = theme.variant === 'dark';
 
     const onMouseEnter = () => {
         setIsHovered(true);
@@ -33,9 +43,11 @@ export const StoreBadge = ({ url, image, isHighlighted, onClick }: StoreBadgePro
                 backgroundColor="elementFillNeutralSoft"
                 onMouseLeave={onMouseLeave}
             >
-                <Row alignItems="center">
-                    <Image image={image} height={26} maxWidth="unset" />
-                </Row>
+                <ImageContainer $isDarkTheme={isDarkTheme}>
+                    <Row alignItems="center">
+                        <Image image={image} height={26} maxWidth="unset" />
+                    </Row>
+                </ImageContainer>
             </Box>
         </TrezorLink>
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Still ugly, but hopefully more readable

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/13686

## Screenshots:

after

<img width="441" height="319" alt="Screenshot 2026-05-12 at 11 05 04" src="https://github.com/user-attachments/assets/81fca017-da0b-4516-96a9-53f63dbd9131" />


<img width="416" height="320" alt="Screenshot 2026-05-12 at 11 05 12" src="https://github.com/user-attachments/assets/7680ff16-3615-4a59-b173-26c619869f3c" />

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** Both changed files are broad UI components that are transitively imported by many tests (99 and 59 respectively). StoreBadge.tsx is a presentational component for app store badges, and FilterAction.tsx is a transaction list filter action component. Neither file is directly exercised by any specific E2E test based on the LLM analysis — no test descriptions mention store badges, transaction filtering UI, or filter actions as tested behaviors. The StoreBadge component is likely rendered in a footer or settings area but not asserted on by any test. The FilterAction component lives in the transaction list but none of the mapped tests specifically test transaction filtering behavior. Given the lack of direct behavioral coverage, no tests are recommended at high or medium priority, and the risk of user-visible regression from these changes is low since no E2E test directly validates either component's functionality.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/components/suite/StoreBadge.tsx`
- `packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/FilterAction.tsx`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/components/suite/StoreBadge.tsx`
- `packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/FilterAction.tsx`

_Updated: 2026-05-12T09:10:01.179Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-mobile-promo-on-dark-theme&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-mobile-promo-on-dark-theme&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > call cancellation | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-12T09:14:29.572Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-12T09:13:02.560Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-mobile-promo-on-dark-theme/web/](https://dev.suite.sldev.cz/suite-web/fix-mobile-promo-on-dark-theme/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->