### PR TITLE
chore(intl): remove unused translation strings

### DIFF
--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -228,11 +228,6 @@ export const messages = defineMessages({
         defaultMessage:
             'Floating-rate offers may result in slight changes to the final amount due to market fluctuations, but they’re typically higher, so you could receive more crypto.',
     },
-    TR_EXCHANGE_FEES_INFO: {
-        id: 'TR_EXCHANGE_FEES_INFO',
-        defaultMessage:
-            'All fees included. Estimated transaction fee: {feeAmount} ({feeAmountFiat}).',
-    },
     TR_TRADING_DISABLED_DEFAULT: {
         defaultMessage: '{type} is currently disabled.',
         id: 'TR_TRADING_DISABLED_DEFAULT',
@@ -639,30 +634,6 @@ export const messages = defineMessages({
         id: 'TR_TRADING_EXCHANGE_DEX_OFFERS_HEADING_TOOLTIP',
         dynamic: true,
     },
-    TR_TRADING_EXCHANGE_COMPARATOR_FILTER_KYC_ALL: {
-        defaultMessage: 'All KYC options',
-        id: 'TR_TRADING_EXCHANGE_COMPARATOR_FILTER_KYC_ALL',
-    },
-    TR_TRADING_EXCHANGE_COMPARATOR_FILTER_NO_KYC: {
-        defaultMessage: 'KYC is never required',
-        id: 'TR_TRADING_EXCHANGE_COMPARATOR_FILTER_NO_KYC',
-    },
-    TR_TRADING_EXCHANGE_COMPARATOR_FILTER_RATE_ALL: {
-        defaultMessage: 'All CEX & DEX offers',
-        id: 'TR_TRADING_EXCHANGE_COMPARATOR_FILTER_RATE_ALL',
-    },
-    TR_TRADING_EXCHANGE_COMPARATOR_FILTER_RATE_FIXED_CEX: {
-        defaultMessage: 'Fixed-rate CEX',
-        id: 'TR_TRADING_EXCHANGE_COMPARATOR_FILTER_RATE_FIXED_CEX',
-    },
-    TR_TRADING_EXCHANGE_COMPARATOR_FILTER_RATE_FLOATING_CEX: {
-        defaultMessage: 'Floating-rate CEX',
-        id: 'TR_TRADING_EXCHANGE_COMPARATOR_FILTER_RATE_FLOATING_CEX',
-    },
-    TR_TRADING_EXCHANGE_COMPARATOR_FILTER_RATE_DEX: {
-        defaultMessage: 'DEX',
-        id: 'TR_TRADING_EXCHANGE_COMPARATOR_FILTER_RATE_DEX',
-    },
     TR_TRADING_EXCHANGE_SIGN_BANNER_TITLE: {
         defaultMessage: 'You’re swapping with {provider}',
         id: 'TR_TRADING_EXCHANGE_SIGN_BANNER_TITLE',
@@ -961,10 +932,6 @@ export const messages = defineMessages({
         defaultMessage: "Go to the provider's website",
         id: 'TR_BUY_DETAIL_WAITING_FOR_USER_GATE',
     },
-    TR_TRADING_OFFERS_EMPTY: {
-        defaultMessage: 'Select your from/to assets and amount to search for your best offer.',
-        id: 'TR_TRADING_OFFERS_EMPTY',
-    },
     TR_BUY_SELL_OFFERS_EMPTY: {
         defaultMessage: 'Select your assets and amount to search for your best offer.',
         id: 'TR_BUY_SELL_OFFERS_EMPTY',
@@ -1123,14 +1090,6 @@ export const messages = defineMessages({
     TR_TRADING_TRADE_FEE: {
         defaultMessage: 'Trade fee',
         id: 'TR_TRADING_TRADE_FEE',
-    },
-    TR_TRADING_OFFERS_REFRESH: {
-        defaultMessage: 'Offers refresh in',
-        id: 'TR_TRADING_OFFERS_REFRESH',
-    },
-    TR_TRADING_OFFERS_SELECT: {
-        defaultMessage: 'Select',
-        id: 'TR_TRADING_OFFERS_SELECT',
     },
     TR_TRADING_POPULAR_CURRENCIES: {
         defaultMessage: 'Popular currencies',
@@ -5870,10 +5829,6 @@ export const messages = defineMessages({
         id: 'TR_BALANCE',
         defaultMessage: 'Balance',
     },
-    TR_MY_PORTFOLIO: {
-        id: 'TR_MY_PORTFOLIO',
-        defaultMessage: 'Portfolio',
-    },
     TR_REWARD: {
         id: 'TR_REWARD',
         defaultMessage: 'Reward',
@@ -7264,10 +7219,6 @@ export const messages = defineMessages({
         id: 'TR_SEARCH_FAIL',
         defaultMessage: 'Search failed.',
     },
-    TR_RANGE: {
-        id: 'TR_RANGE',
-        defaultMessage: 'range',
-    },
     TR_BUMP_FEE: {
         id: 'TR_BUMP_FEE',
         defaultMessage: 'Speed up',
@@ -7514,18 +7465,6 @@ export const messages = defineMessages({
     TR_BYTES: {
         id: 'TR_BYTES',
         defaultMessage: 'bytes',
-    },
-    TR_GRAPH_LINEAR: {
-        id: 'TR_GRAPH_LINEAR',
-        defaultMessage: 'Linear',
-    },
-    TR_GRAPH_LOGARITHMIC: {
-        id: 'TR_GRAPH_LOGARITHMIC',
-        defaultMessage: 'Logarithmic',
-    },
-    TR_GRAPH_VIEW: {
-        id: 'TR_GRAPH_VIEW',
-        defaultMessage: 'Graph view',
     },
     TR_DATE_DAY_LONG: {
         id: 'TR_DATE_DAY_LONG',


### PR DESCRIPTION
## Summary
Removes unused translation strings from \`messages.ts\` that are no longer referenced in the codebase.

**Keys removed (14):**
- \`TR_EXCHANGE_FEES_INFO\`
- \`TR_TRADING_EXCHANGE_COMPARATOR_FILTER_KYC_ALL\`
- \`TR_TRADING_EXCHANGE_COMPARATOR_FILTER_NO_KYC\`
- \`TR_TRADING_EXCHANGE_COMPARATOR_FILTER_RATE_ALL\`
- \`TR_TRADING_EXCHANGE_COMPARATOR_FILTER_RATE_FIXED_CEX\`
- \`TR_TRADING_EXCHANGE_COMPARATOR_FILTER_RATE_FLOATING_CEX\`
- \`TR_TRADING_EXCHANGE_COMPARATOR_FILTER_RATE_DEX\`
- \`TR_TRADING_OFFERS_EMPTY\`
- \`TR_TRADING_OFFERS_REFRESH\`
- \`TR_TRADING_OFFERS_SELECT\`
- \`TR_MY_PORTFOLIO\`
- \`TR_RANGE\`
- \`TR_GRAPH_LINEAR\`
- \`TR_GRAPH_LOGARITHMIC\`
- \`TR_GRAPH_VIEW\`

Identified by the \`translations:list-unused\` CI check.

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is to `suite/intl/src/messages.ts`, the internationalization message definitions module. This is a broad shared utility used across the entire Suite application for translation strings. The risk depends on whether message keys were added, removed, or modified — key renames or removals would be high risk, while additions are low risk. The recommended strategy focuses on tests that explicitly reference `@suite/intl messages` in their source hints and assert on specific translation key values, with the autodetect test being highest priority since it most directly exercises the intl message rendering pipeline.

<details><summary><b>Changed files (1)</b></summary>

- `suite/intl/src/messages.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `../../suite/e2e/tests/settings/autodetect.test.ts` — This test directly imports and uses '@suite/intl messages' to verify that internationalization message definitions (like TR_ONBOARDING_DATA_COLLECTION_HEADING) render correctly with locale autodetection. Changes to suite/intl/src/messages.ts could alter message keys, default values, or message formatting, directly breaking these assertions.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `../../suite/e2e/tests/settings/general.test.ts` — This test verifies language change functionality and checks analytics events that reference language-related properties. The intl messages module underpins the language/translation system, and changes could affect how language settings and their associated translations are resolved.
- `../../suite/e2e/tests/trading/sell-inputs.test.ts` — This test explicitly references '@suite/intl messages' for translation keys like TR_TRADING_COUNTRY_WORLD, AMOUNT_IS_NOT_IN_RANGE_DECIMALS, and AMOUNT_IS_NOT_ENOUGH. Changes to the messages module could alter these message definitions and break form validation error display assertions.
- `../../suite/e2e/tests/wallet/send-base.test.ts` — This test references '@suite/intl (messages/translations, TR_GAS_LIMIT)' and asserts that the gas limit translation text matches expected values from intl messages. A change to messages.ts could alter this translation key's definition.
- `../../suite/e2e/tests/wallet/send-eth.test.ts` — This test references '@suite/intl (messages / TR_GAS_LIMIT)' and validates that Ethereum gas limit translation strings match expected values. Changes to messages.ts could directly affect these assertions.
- `../../suite/e2e/tests/wallet/transactions.test.ts` — This test references '@suite/intl messages' for graph time range label translations (TR_DATE_DAY_LONG, TR_DATE_WEEK_LONG, etc.) and asserts their visibility. Changes to messages.ts could alter these translation definitions.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `../../suite/e2e/tests/trading/swap-history.test.ts` — This test references '@suite/intl (messages / translations)' and uses multiple translation keys for status labels and counters. While it depends on intl messages, the assertions are against translation keys rather than raw message text, reducing the likelihood of breakage from message content changes.

</details>

_Updated: 2026-05-12T09:34:36.934Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/remove-unused-strings-20260512&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/remove-unused-strings-20260512&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > call cancellation | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-12T09:45:25.447Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-12T09:43:54.165Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/remove-unused-strings-20260512/web/](https://dev.suite.sldev.cz/suite-web/chore/remove-unused-strings-20260512/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->