### PR TITLE
fix(suite): Add tooltip for filter

### DIFF
--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/FilterAction.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/FilterAction.tsx
@@ -80,54 +80,58 @@ export const FilterAction = () => {
                 </Row>
             }
         >
-            <Dropdown
-                iconName="funnelSimple"
-                ref={dropdownRef}
-                placement={{ position: 'bottom', alignment: 'end' }}
-                isDisabled={false}
-                content={
-                    <Column maxWidth={250} padding={spacings.xxs} gap={spacings.md}>
-                        {options.map(option => (
-                            <Radio
-                                key={option.id}
-                                isChecked={
-                                    Boolean(suspiciousTransactionsHidden) === Boolean(option.id)
-                                }
-                                onChange={() => {
-                                    handleToggleSuspiciousTransactionsRequest(Boolean(option.id));
-                                }}
-                                data-testid={dataTest}
-                                verticalAlignment="center"
-                            >
-                                <Column>
-                                    <Text
-                                        typographyStyle="body-sm-strong"
-                                        intent={
-                                            Boolean(suspiciousTransactionsHidden) ===
-                                            Boolean(option.id)
-                                                ? 'brand'
-                                                : 'neutral'
-                                        }
-                                    >
-                                        {option.label}
-                                    </Text>
-                                    {'description' in option && option.description && (
-                                        <Paragraph
-                                            typographyStyle="body-xs"
-                                            intent="neutral"
-                                            priority="secondary"
-                                            textWrap="pretty"
+            <Tooltip content={<Translation id="TR_FILTER" />} placement="top">
+                <Dropdown
+                    iconName="funnelSimple"
+                    ref={dropdownRef}
+                    placement={{ position: 'bottom', alignment: 'end' }}
+                    isDisabled={false}
+                    content={
+                        <Column maxWidth={250} padding={spacings.xxs} gap={spacings.md}>
+                            {options.map(option => (
+                                <Radio
+                                    key={option.id}
+                                    isChecked={
+                                        Boolean(suspiciousTransactionsHidden) === Boolean(option.id)
+                                    }
+                                    onChange={() => {
+                                        handleToggleSuspiciousTransactionsRequest(
+                                            Boolean(option.id),
+                                        );
+                                    }}
+                                    data-testid={dataTest}
+                                    verticalAlignment="center"
+                                >
+                                    <Column>
+                                        <Text
+                                            typographyStyle="body-sm-strong"
+                                            intent={
+                                                Boolean(suspiciousTransactionsHidden) ===
+                                                Boolean(option.id)
+                                                    ? 'brand'
+                                                    : 'neutral'
+                                            }
                                         >
-                                            {option.description}
-                                        </Paragraph>
-                                    )}
-                                </Column>
-                            </Radio>
-                        ))}
-                    </Column>
-                }
-                data-testid={`${dataTest}/dropdown`}
-            />
+                                            {option.label}
+                                        </Text>
+                                        {'description' in option && option.description && (
+                                            <Paragraph
+                                                typographyStyle="body-xs"
+                                                intent="neutral"
+                                                priority="secondary"
+                                                textWrap="pretty"
+                                            >
+                                                {option.description}
+                                            </Paragraph>
+                                        )}
+                                    </Column>
+                                </Radio>
+                            ))}
+                        </Column>
+                    }
+                    data-testid={`${dataTest}/dropdown`}
+                />
+            </Tooltip>
         </Tooltip>
     );
 };

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -84,6 +84,10 @@ export const messages = defineMessages({
         description: 'Used as a variable for device name',
         id: 'TR_ANY_TREZOR',
     },
+    TR_FILTER: {
+        defaultMessage: 'Filter',
+        id: 'TR_FILTER',
+    },
     TR_HIDE_SCAM_TRANSACTIONS_TOOLTIP: {
         defaultMessage: 'Hide suspicious transactions for a cleaner view.',
         id: 'TR_HIDE_SCAM_TRANSACTIONS_TOOLTIP',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<img width="627" height="266" alt="image" src="https://github.com/user-attachments/assets/c99fe05c-b0a6-45ca-abd1-457860f312e3" />

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes involve two files: FilterAction.tsx (a transaction list filter component) and messages.ts (the global internationalization messages file). FilterAction.tsx is a UI component in the transaction list view, so tests that directly exercise the transaction list are highest priority. The messages.ts file is a global utility mapping to virtually all tests, but only tests that specifically exercise newly added or modified translation keys would be affected. The risk is moderate — FilterAction changes could break the transaction list UI, while messages.ts changes are likely additive (new keys for FilterAction) and low-risk for existing functionality.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/FilterAction.tsx`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/transactions.test.ts` — This test directly exercises the transaction list view including graph time range filters and transaction search. The changed FilterAction.tsx is part of the TransactionListActions component, which renders filter controls in the transaction list view. Changes to FilterAction could break transaction filtering or the transaction list UI.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/wallet/export-transactions.test.ts` — This test navigates to account transaction pages and exports transactions. The FilterAction component is part of the TransactionList view that hosts the export functionality. A rendering failure in FilterAction could prevent the transaction page from loading correctly, blocking export.
- `suite/e2e/tests/wallet/pagination.test.ts` — This test navigates through paginated transaction pages on a BTC account. The FilterAction component is part of the TransactionListActions rendered alongside pagination controls. A broken FilterAction could affect the transaction list page rendering.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — This test verifies pending transaction display and labels in the transaction list. FilterAction is rendered as part of the transaction list actions bar, so a rendering error could affect the transaction list view where pending transactions are displayed.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/settings/autodetect.test.ts` — This test validates localized text from intl messages (TR_ONBOARDING_DATA_COLLECTION_HEADING). Changes to messages.ts could affect translation keys used in the autodetect test, though only if the specific keys referenced were modified.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/intl/src/messages.ts`

_Updated: 2026-05-12T09:58:19.733Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=add-tooltip-for-filter&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=add-tooltip-for-filter&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/add-tooltip-for-filter/web/](https://dev.suite.sldev.cz/suite-web/add-tooltip-for-filter/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > call cancellation | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-12T11:29:21.037Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-12T11:27:26.831Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->