### PR TITLE
feat(suite-native): navigate to AccountAssetsScreen instead of bottom…

### DIFF
--- a/suite-native/module-accounts-management/src/components/AccountAssets/AccountAssetsScreenHeader.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountAssets/AccountAssetsScreenHeader.tsx
@@ -9,9 +9,11 @@ import { CryptoIconWithNetwork } from '@suite-native/icons';
 import { AccountLabel } from '@suite-native/labeling';
 import { ScreenHeader } from '@suite-native/navigation';
 
-type Props = { accountKey: AccountKey };
+import { type AccountAssetsFlow } from './types';
 
-const AccountAssetsScreenHeaderContent = ({ accountKey }: Props) => {
+type Props = { accountKey: AccountKey; flowType?: AccountAssetsFlow };
+
+const AccountAssetsScreenHeaderContent = ({ accountKey }: Omit<Props, 'flowType'>) => {
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
     );
@@ -38,9 +40,9 @@ const AccountAssetsScreenHeaderContent = ({ accountKey }: Props) => {
     );
 };
 
-export const AccountAssetsScreenHeader = ({ accountKey }: Props) => (
+export const AccountAssetsScreenHeader = ({ accountKey, flowType }: Props) => (
     <ScreenHeader
         customContent={<AccountAssetsScreenHeaderContent accountKey={accountKey} />}
-        closeActionType="close"
+        closeActionType={flowType === 'send' ? 'back' : 'close'}
     />
 );

--- a/suite-native/module-accounts-management/src/components/AccountAssets/AccountAssetsTabContent.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountAssets/AccountAssetsTabContent.tsx
@@ -1,28 +1,85 @@
+import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
+
+import { useNavigation } from '@react-navigation/native';
+
+import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
+import { events } from '@suite-native/analytics';
+import {
+    type RootStackParamList,
+    RootStackRoutes,
+    SendStackRoutes,
+    type StackNavigationProps,
+} from '@suite-native/navigation';
+import { useAnalytics } from '@suite-native/services';
 import { exhaustive } from '@trezor/type-utils';
 
 import { ActiveTokensTab } from './ActiveTokensTab';
 import { DefiTokensTab } from './DefiTokensTab';
 import { HiddenTokensTab } from './HiddenTokensTab';
 import { InactiveTokensTab } from './InactiveTokensTab';
-import { type AccountAssetsTab } from './types';
+import { type AccountAssetsFlow, type AccountAssetsTab, type OnSelectAsset } from './types';
 
 type AccountAssetsTabContentProps = {
     accountKey: AccountKey;
     activeTab: AccountAssetsTab;
+    flowType: AccountAssetsFlow;
 };
 
 export const AccountAssetsTabContent = ({
     accountKey,
     activeTab,
+    flowType,
 }: AccountAssetsTabContentProps) => {
+    const navigation =
+        useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes.AccountAssets>>();
+    const analytics = useAnalytics();
+    const account = useSelector((state: AccountsRootState) =>
+        selectAccountByKey(state, accountKey),
+    );
+
+    const handleSelect = useCallback<OnSelectAsset>(
+        ({ tokenContract, tokenSymbol }) => {
+            if (flowType === 'send') {
+                if (!account) return;
+                analytics.report({
+                    type: events.sendFlowEnteredEvent.name,
+                    payload: {
+                        location: 'dashboard',
+                        assetSymbol: account.symbol,
+                        tokenContract,
+                        tokenSymbol,
+                    },
+                });
+                navigation.navigate(RootStackRoutes.SendStack, {
+                    screen: SendStackRoutes.SendOutputs,
+                    params: { accountKey, tokenContract },
+                });
+            } else {
+                navigation.navigate(RootStackRoutes.AccountDetail, {
+                    accountKey,
+                    tokenContract,
+                    closeActionType: 'back',
+                });
+            }
+        },
+        [flowType, account, accountKey, analytics, navigation],
+    );
+
     switch (activeTab) {
         case 'tokens':
-            return <ActiveTokensTab accountKey={accountKey} />;
+            return (
+                <ActiveTokensTab
+                    accountKey={accountKey}
+                    onSelect={handleSelect}
+                    isStakingDisplayed={flowType === 'assets'}
+                />
+            );
         case 'defi':
-            return <DefiTokensTab accountKey={accountKey} />;
+            return <DefiTokensTab accountKey={accountKey} onSelect={handleSelect} />;
         case 'hidden':
-            return <HiddenTokensTab accountKey={accountKey} />;
+            return <HiddenTokensTab accountKey={accountKey} onSelect={handleSelect} />;
         case 'inactive':
             return <InactiveTokensTab accountKey={accountKey} />;
         default:

--- a/suite-native/module-accounts-management/src/components/AccountAssets/ActiveTokensTab.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountAssets/ActiveTokensTab.tsx
@@ -1,8 +1,6 @@
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 
-import { useNavigation } from '@react-navigation/native';
-
 import { type AccountKey } from '@suite-common/wallet-types';
 import {
     AccountsListItem,
@@ -14,21 +12,21 @@ import {
 } from '@suite-native/accounts';
 import { Box } from '@suite-native/atoms';
 import { useStakingDetailNavigation } from '@suite-native/module-earn';
-import {
-    type RootStackParamList,
-    RootStackRoutes,
-    type StackNavigationProps,
-} from '@suite-native/navigation';
 
 import { ZeroBalanceTokensSection } from './ZeroBalanceTokensSection';
+import { type OnSelectAsset } from './types';
 
 type ActiveTokensTabProps = {
     accountKey: AccountKey;
+    onSelect: OnSelectAsset;
+    isStakingDisplayed: boolean;
 };
 
-export const ActiveTokensTab = ({ accountKey }: ActiveTokensTabProps) => {
-    const navigation =
-        useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes.AccountAssets>>();
+export const ActiveTokensTab = ({
+    accountKey,
+    onSelect,
+    isStakingDisplayed,
+}: ActiveTokensTabProps) => {
     const { navigateToStakingDetail } = useStakingDetailNavigation();
 
     const sections = useSelector((state: NativeAccountsRootState) =>
@@ -36,19 +34,15 @@ export const ActiveTokensTab = ({ accountKey }: ActiveTokensTabProps) => {
     );
 
     const handleSelectAccount: OnSelectAccount = useCallback(
-        ({ account, tokenAddress, isStaking }) => {
+        ({ account, tokenAddress, tokenSymbol, isStaking }) => {
             if (isStaking) {
                 navigateToStakingDetail({ accountKey: account.key, symbol: account.symbol });
 
                 return;
             }
-            navigation.navigate(RootStackRoutes.AccountDetail, {
-                accountKey: account.key,
-                tokenContract: tokenAddress,
-                closeActionType: 'back',
-            });
+            onSelect({ tokenContract: tokenAddress, tokenSymbol });
         },
-        [navigation, navigateToStakingDetail],
+        [onSelect, navigateToStakingDetail],
     );
 
     const items = sections.filter(item => item.type !== 'sectionTitle');
@@ -72,6 +66,8 @@ export const ActiveTokensTab = ({ accountKey }: ActiveTokensTabProps) => {
                             />
                         );
                     case 'staking':
+                        if (!isStakingDisplayed) return null;
+
                         return (
                             <AccountsListStakingItem
                                 key={`${item.account.key}-staking`}
@@ -110,6 +106,7 @@ export const ActiveTokensTab = ({ accountKey }: ActiveTokensTabProps) => {
                                 key="zero-balance"
                                 tokens={item.tokens}
                                 account={item.account}
+                                onSelect={onSelect}
                             />
                         );
                     default:

--- a/suite-native/module-accounts-management/src/components/AccountAssets/DefiTokensTab.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountAssets/DefiTokensTab.tsx
@@ -1,7 +1,5 @@
 import { useSelector } from 'react-redux';
 
-import { useNavigation } from '@react-navigation/native';
-
 import {
     type AccountsRootState,
     type TokensRootState,
@@ -11,20 +9,15 @@ import {
 import { type AccountKey } from '@suite-common/wallet-types';
 import { AccountsListTokenItem } from '@suite-native/accounts';
 import { Box } from '@suite-native/atoms';
-import {
-    type RootStackParamList,
-    RootStackRoutes,
-    type StackNavigationProps,
-} from '@suite-native/navigation';
+
+import { type OnSelectAsset } from './types';
 
 type DefiTokensTabProps = {
     accountKey: AccountKey;
+    onSelect: OnSelectAsset;
 };
 
-export const DefiTokensTab = ({ accountKey }: DefiTokensTabProps) => {
-    const navigation =
-        useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes.AccountAssets>>();
-
+export const DefiTokensTab = ({ accountKey, onSelect }: DefiTokensTabProps) => {
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
     );
@@ -45,11 +38,7 @@ export const DefiTokensTab = ({ accountKey }: DefiTokensTabProps) => {
                     isFirst={index === 0}
                     isLast={index === defiTokens.length - 1}
                     onSelectAccount={() =>
-                        navigation.navigate(RootStackRoutes.AccountDetail, {
-                            accountKey,
-                            tokenContract: token.contract,
-                            closeActionType: 'back',
-                        })
+                        onSelect({ tokenContract: token.contract, tokenSymbol: token.symbol })
                     }
                 />
             ))}

--- a/suite-native/module-accounts-management/src/components/AccountAssets/HiddenTokensTab.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountAssets/HiddenTokensTab.tsx
@@ -1,7 +1,5 @@
 import { useSelector } from 'react-redux';
 
-import { useNavigation } from '@react-navigation/native';
-
 import {
     type AccountsRootState,
     type TokensRootState,
@@ -13,20 +11,15 @@ import { type AccountKey } from '@suite-common/wallet-types';
 import { AccountsListTokenItem } from '@suite-native/accounts';
 import { Card, PictogramTitleHeader, Text, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
-import {
-    type RootStackParamList,
-    RootStackRoutes,
-    type StackNavigationProps,
-} from '@suite-native/navigation';
+
+import { type OnSelectAsset } from './types';
 
 type HiddenTokensTabProps = {
     accountKey: AccountKey;
+    onSelect: OnSelectAsset;
 };
 
-export const HiddenTokensTab = ({ accountKey }: HiddenTokensTabProps) => {
-    const navigation =
-        useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes.AccountAssets>>();
-
+export const HiddenTokensTab = ({ accountKey, onSelect }: HiddenTokensTabProps) => {
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
     );
@@ -69,10 +62,9 @@ export const HiddenTokensTab = ({ accountKey }: HiddenTokensTabProps) => {
                                 isLast={index === manuallyHiddenTokens.length - 1}
                                 showFiatValue={false}
                                 onSelectAccount={() =>
-                                    navigation.navigate(RootStackRoutes.AccountDetail, {
-                                        accountKey,
+                                    onSelect({
                                         tokenContract: token.contract,
-                                        closeActionType: 'back',
+                                        tokenSymbol: token.symbol,
                                     })
                                 }
                             />
@@ -102,10 +94,9 @@ export const HiddenTokensTab = ({ accountKey }: HiddenTokensTabProps) => {
                                 isLast={index === unrecognizedTokens.length - 1}
                                 showFiatValue={false}
                                 onSelectAccount={() =>
-                                    navigation.navigate(RootStackRoutes.AccountDetail, {
-                                        accountKey,
+                                    onSelect({
                                         tokenContract: token.contract,
-                                        closeActionType: 'back',
+                                        tokenSymbol: token.symbol,
                                     })
                                 }
                             />

--- a/suite-native/module-accounts-management/src/components/AccountAssets/ZeroBalanceTokensSection.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountAssets/ZeroBalanceTokensSection.tsx
@@ -1,23 +1,19 @@
 import { useState } from 'react';
 import { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 
-import { useNavigation } from '@react-navigation/native';
-
-import { type Account, type TokenAddress, type TokenInfoBranded } from '@suite-common/wallet-types';
+import { type Account, type TokenInfoBranded } from '@suite-common/wallet-types';
 import { AccountsListTokenItem } from '@suite-native/accounts';
 import { AccordionContent, AnimatedBox, PressableOpacity, Text } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
-import {
-    type RootStackParamList,
-    RootStackRoutes,
-    type StackNavigationProps,
-} from '@suite-native/navigation';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+
+import { type OnSelectAsset } from './types';
 
 type ZeroBalanceTokensSectionProps = {
     tokens: TokenInfoBranded[];
     account: Account;
+    onSelect: OnSelectAsset;
 };
 
 const ANIMATION_DURATION = 200;
@@ -35,9 +31,11 @@ const headerStyle = prepareNativeStyle<{ isOpen: boolean }>((utils, { isOpen }) 
     borderBottomRightRadius: isOpen ? 0 : utils.borders.radii.r16,
 }));
 
-export const ZeroBalanceTokensSection = ({ tokens, account }: ZeroBalanceTokensSectionProps) => {
-    const navigation =
-        useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes.AccountAssets>>();
+export const ZeroBalanceTokensSection = ({
+    tokens,
+    account,
+    onSelect,
+}: ZeroBalanceTokensSectionProps) => {
     const { applyStyle } = useNativeStyles();
 
     const [isOpen, setIsOpen] = useState(false);
@@ -56,13 +54,6 @@ export const ZeroBalanceTokensSection = ({ tokens, account }: ZeroBalanceTokensS
             },
         ],
     }));
-
-    const handleSelectToken = (tokenContract: TokenAddress) =>
-        navigation.navigate(RootStackRoutes.AccountDetail, {
-            accountKey: account.key,
-            tokenContract,
-            closeActionType: 'back',
-        });
 
     return (
         <>
@@ -84,7 +75,9 @@ export const ZeroBalanceTokensSection = ({ tokens, account }: ZeroBalanceTokensS
                         isFirst={false}
                         isLast={index === tokens.length - 1}
                         showFiatValue={false}
-                        onSelectAccount={() => handleSelectToken(token.contract)}
+                        onSelectAccount={() =>
+                            onSelect({ tokenContract: token.contract, tokenSymbol: token.symbol })
+                        }
                     />
                 ))}
             </AccordionContent>

--- a/suite-native/module-accounts-management/src/components/AccountAssets/types.ts
+++ b/suite-native/module-accounts-management/src/components/AccountAssets/types.ts
@@ -1,1 +1,8 @@
-export type { AccountAssetsTab } from '@suite-native/navigation';
+import { type TokenAddress, type TokenSymbol } from '@suite-common/wallet-types';
+
+export type { AccountAssetsFlow, AccountAssetsTab } from '@suite-native/navigation';
+
+export type OnSelectAsset = (params: {
+    tokenContract?: TokenAddress;
+    tokenSymbol?: TokenSymbol;
+}) => void;

--- a/suite-native/module-accounts-management/src/screens/AccountAssetsScreen.tsx
+++ b/suite-native/module-accounts-management/src/screens/AccountAssetsScreen.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 
-import { type RouteProp, useRoute } from '@react-navigation/native';
+import { type NativeStackScreenProps } from '@react-navigation/native-stack';
 
 import {
     type AccountsRootState,
@@ -22,10 +22,11 @@ import { AccountAssetsTabBar } from '../components/AccountAssets/AccountAssetsTa
 import { AccountAssetsTabContent } from '../components/AccountAssets/AccountAssetsTabContent';
 import { type AccountAssetsTab } from '../components/AccountAssets/types';
 
-export const AccountAssetsScreen = () => {
-    const { params } = useRoute<RouteProp<RootStackParamList, RootStackRoutes.AccountAssets>>();
-    const { accountKey, tab } = params;
-
+export const AccountAssetsScreen = ({
+    route: {
+        params: { accountKey, tab, flowType = 'assets' },
+    },
+}: NativeStackScreenProps<RootStackParamList, RootStackRoutes.AccountAssets>) => {
     const [activeTab, setActiveTab] = useState<AccountAssetsTab>(tab ?? 'tokens');
 
     useEffect(() => {
@@ -48,20 +49,24 @@ export const AccountAssetsScreen = () => {
     );
 
     const tokenCount = sections.filter(item => item.type === 'token').length;
-    const showInactiveTab = account?.networkType === 'stellar';
+    const showInactiveTab = account?.networkType === 'stellar' && flowType === 'assets';
 
     return (
-        <Screen header={<AccountAssetsScreenHeader accountKey={accountKey} />}>
+        <Screen header={<AccountAssetsScreenHeader accountKey={accountKey} flowType={flowType} />}>
             <VStack spacing="sp32">
                 <AccountAssetsTabBar
                     activeTab={activeTab}
                     tokenCount={tokenCount}
                     defiTokenCount={defiTokenCount}
                     hiddenTokenCount={manuallyHiddenTokens}
-                    showInactiveTab={showInactiveTab ?? false}
+                    showInactiveTab={showInactiveTab}
                     onTabChange={setActiveTab}
                 />
-                <AccountAssetsTabContent accountKey={accountKey} activeTab={activeTab} />
+                <AccountAssetsTabContent
+                    accountKey={accountKey}
+                    activeTab={activeTab}
+                    flowType={flowType}
+                />
             </VStack>
         </Screen>
     );

--- a/suite-native/module-accounts-management/src/selectors.ts
+++ b/suite-native/module-accounts-management/src/selectors.ts
@@ -10,8 +10,9 @@ import {
     type FeatureFlagsRootState,
     selectIsFeatureFlagEnabled,
 } from '@suite-native/feature-flags';
-import { type AccountAssetsTab } from '@suite-native/navigation';
 import { type TokensRootState } from '@suite-native/tokens';
+
+import { type AccountAssetsTab } from './components/AccountAssets/types';
 
 export const selectAssetTabOfAccountToken = (
     state: TokensRootState,

--- a/suite-native/module-send/src/screens/SendAccountsScreen.tsx
+++ b/suite-native/module-send/src/screens/SendAccountsScreen.tsx
@@ -1,35 +1,51 @@
+import { useNavigation } from '@react-navigation/native';
+
 import { AccountsList, type OnSelectAccount } from '@suite-native/accounts';
 import { events } from '@suite-native/analytics';
 import { Translation } from '@suite-native/intl';
 import {
+    type RootStackParamList,
+    RootStackRoutes,
     Screen,
     ScreenHeader,
     type SendStackParamList,
     SendStackRoutes,
-    type StackProps,
+    type StackToStackCompositeNavigationProps,
     useNavigateToInitialScreen,
 } from '@suite-native/navigation';
 import { useAnalytics } from '@suite-native/services';
 
-export const SendAccountsScreen = ({
-    navigation,
-}: StackProps<SendStackParamList, SendStackRoutes.SendAccounts>) => {
+type NavigationProps = StackToStackCompositeNavigationProps<
+    RootStackParamList,
+    RootStackRoutes.AccountAssets,
+    SendStackParamList
+>;
+
+export const SendAccountsScreen = () => {
     const navigateToInitialScreen = useNavigateToInitialScreen();
     const analytics = useAnalytics();
-    const navigateToSendFormScreen: OnSelectAccount = ({ account, tokenAddress, tokenSymbol }) => {
+    const navigation = useNavigation<NavigationProps>();
+
+    const handleSelectAccount: OnSelectAccount = ({ account, hasAnyKnownTokens }) => {
+        if (hasAnyKnownTokens) {
+            navigation.navigate(RootStackRoutes.AccountAssets, {
+                accountKey: account.key,
+                flowType: 'send',
+            });
+
+            return;
+        }
+
         analytics.report({
             type: events.sendFlowEnteredEvent.name,
             payload: {
                 location: 'dashboard',
                 assetSymbol: account.symbol,
-                tokenContract: tokenAddress,
-                tokenSymbol,
             },
         });
 
         navigation.navigate(SendStackRoutes.SendOutputs, {
             accountKey: account.key,
-            tokenContract: tokenAddress,
         });
     };
 
@@ -43,11 +59,7 @@ export const SendAccountsScreen = ({
                 />
             }
         >
-            <AccountsList
-                onSelectAccount={navigateToSendFormScreen}
-                isSendFilterEnabled
-                hideTokensIntoModal
-            />
+            <AccountsList onSelectAccount={handleSelectAccount} isSendFilterEnabled />
         </Screen>
     );
 };

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -56,6 +56,7 @@ type AddCoinFlowParams = RequireAllOrNone<
 
 export type CloseActionType = 'back' | 'close';
 export type AccountAssetsTab = 'tokens' | 'defi' | 'hidden' | 'inactive';
+export type AccountAssetsFlow = 'assets' | 'send';
 export type DeviceSuspicionCause =
     | 'deviceLooksDifferent'
     | 'firmwareAlreadyInstalled'
@@ -401,7 +402,11 @@ export type RootStackParamList = {
     [RootStackRoutes.AccountSettings]: { accountKey: AccountKey };
     [RootStackRoutes.TransactionDetailStack]: NavigatorScreenParams<TransactionDetailStackParamList>;
     [RootStackRoutes.DevUtils]: undefined;
-    [RootStackRoutes.AccountAssets]: { accountKey: AccountKey; tab?: AccountAssetsTab };
+    [RootStackRoutes.AccountAssets]: {
+        accountKey: AccountKey;
+        tab?: AccountAssetsTab;
+        flowType?: AccountAssetsFlow;
+    };
     [RootStackRoutes.AccountDetail]: AccountDetailParams;
     [RootStackRoutes.StakingDetail]: { accountKey: AccountKey };
     [RootStackRoutes.StakingManagement]: { accountKey: AccountKey };


### PR DESCRIPTION
## Description

- Remove `TokenSelectBottomSheet` from send flow — tapping a token account in `SendAccountsScreen` navigates to 
- Send flow: header shows back arrow, inactive tab hidden, staking rows not rendered
- Tab components (`ActiveTokensTab`, `DefiTokensTab`, `HiddenTokensTab`, `ZeroBalanceTokensSection`) no longer own navigation — all selection goes through `onSelect` callback


## Notes for QA

- **Token account in send flow (e.g. ETH):** tap account → `AccountAssetsScreen` with back arrow, no staking row, no inactive tab; tap token → `SendScreen`
- **Non-token account in send flow (e.g. BTC):** tap account → `SendScreen` directly
- **My assets flow:** unaffected — staking, inactive tab, and `AccountDetail` navigation all work as before

## Related Issue

Resolves #27233

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/token-assets-send-flow-refactor&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->