### PR TITLE
fix(suite): Fix send modal flickering when signing transaction

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModal.tsx
@@ -61,8 +61,6 @@ export const TransactionReviewModal = ({ type, decision }: TransactionReviewModa
     };
 
     const handleSendTx = async () => {
-        dispatch(sendFormActions.discardTransaction());
-
         await dispatch(
             signAndPushSendFormTransactionThunk({
                 formState: send.precomposedForm!,
@@ -70,6 +68,8 @@ export const TransactionReviewModal = ({ type, decision }: TransactionReviewModa
                 selectedAccount: selectedAccount.account,
             }),
         );
+
+        dispatch(sendFormActions.discardTransaction());
     };
 
     const handleStakeTx = async () => {


### PR DESCRIPTION
## Description

`sendFormActions.discardTransaction()` was being dispatched **before** awaiting `signAndPushSendFormTransactionThunk`, which cleared `send.precomposedTx` from the Redux state immediately. Since the modal reads this state to decide what to render, it would unmount and then remount once signing completed.

Fix: move `discardTransaction()` to after the thunk resolves so the modal stays visible throughout the entire signing process.

## Notes for QA

1. Open Send page and fill in transaction details
2. Click Send
3. Confirm on the Trezor device
4. Verify the modal remains visible without flickering during the signing step

## Related Issue

Resolve #27570

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file is TransactionReviewModal.tsx, which is a modal component shown when reviewing transactions before sending. It maps to 121 tests, indicating it is a broadly imported shared component (likely part of the Redux modal system). However, none of the 121 statically mapped tests in the LLM analysis descriptions directly exercise the transaction review modal's own behavior — they cover analytics, backups, browser checks, metadata, onboarding, settings, staking, trading, and other flows. The tests that would most directly exercise the transaction review modal are the send/wallet tests (send-eth, send-sol, send-base, send-doge, send-form-regtest, send-form-ltc, sell-bitcoin, sell-solana, sell-ethereum, swap-coins, etc.) where a user fills a send form and confirms the transaction on device — but even those tests interact with the device prompt rather than asserting on TransactionReviewModal internals. Since no test in the analyzed set has behaviors or assertions that specifically target the TransactionReviewModal component's rendering or logic, and the file maps to 121 tests (a clear broad-utility signal), the safest strategy is to run a small representative set of send-flow tests that are most likely to surface regressions in the transaction review step.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModal.tsx`

</details>

_No test recommendations found._

_Updated: 2026-05-12T11:48:10.745Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/send-modal-flicker-signing&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/send-modal-flicker-signing&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > call cancellation | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-12T11:52:48.929Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-12T11:51:13.909Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/send-modal-flicker-signing/web/](https://dev.suite.sldev.cz/suite-web/fix/send-modal-flicker-signing/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->