### PR TITLE
Fix webusb transport on browsers without native SharedWorker support

### DIFF
--- a/packages/transport/src/sessions/background-browser.ts
+++ b/packages/transport/src/sessions/background-browser.ts
@@ -21,6 +21,10 @@ export class BrowserSessionsBackground implements SessionsBackgroundInterface {
         this.background = new SharedWorker(sessionsBackgroundUrl, {
             name: '@trezor/connect-web transport sessions worker',
         });
+        // When using MessagePort with addEventListener(), start() may be required
+        // to begin dispatching messages. Native implementations often do this implicitly.
+        // For polyfilled SharedWorker, we need to call it explicitly.
+        this.background.port.start();
     }
 
     handleMessage<M extends HandleMessageParams>(params: M): Promise<HandleMessageResponse<M>> {


### PR DESCRIPTION




<!--- Provide a general summary of your changes in the Title above -->

## Description

Call port.start() for SharedWorker polyfill compatibility

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27579
Alternative to https://github.com/trezor/trezor-suite/pull/27619


<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to `packages/transport/src/sessions/background-browser.ts`, which handles browser-side transport session management for communicating with Trezor devices via the bridge. No tests have static coverage mapping to this file, so recommendations are inferred from test behavior descriptions. The highest risk is in tests that directly exercise bridge connectivity, session management, and multi-client session contention. Most other tests use the transport layer indirectly and are unlikely to be affected unless the change fundamentally breaks device connectivity.

<details><summary><b>Changed files (1)</b></summary>

- `packages/transport/src/sessions/background-browser.ts`

</details>

**Recommended tests (4)**

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `../../suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — The changed file `background-browser.ts` is part of the transport sessions layer, which manages how the browser communicates with the Trezor bridge. This test directly exercises bridge spawning, reconnection after bridge restart, and device communication through the bridge transport — all of which rely on the sessions/transport infrastructure that was modified.
- `../../suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — This test validates bridge daemon mode lifecycle (spawning, persistence, stopping). The sessions background-browser module handles browser-side session management for transport, and changes there could affect how Suite establishes and maintains bridge connections in daemon mode.
- `../../suite/e2e/tests/suite/multiple-sessions.test.ts` — This test explicitly validates Bridge session stealing, reclaiming, and multi-tab session management. The `background-browser.ts` file in the sessions module directly governs how browser-based transport sessions are acquired and managed, making session contention scenarios highly relevant to this change.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `../../suite/e2e/tests/analytics/events.test.ts` — This test asserts on TransportType events reporting 'BridgeTransport' with a valid version. Changes to the browser session background could affect how the transport type is reported or how the transport initializes, potentially impacting this specific assertion.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/transport/src/sessions/background-browser.ts`

_Updated: 2026-05-12T11:48:56.635Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/shared-worker-polyfill-usage&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/shared-worker-polyfill-usage&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > call cancellation | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-12T11:53:49.148Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-12T11:52:29.961Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/shared-worker-polyfill-usage/web/](https://dev.suite.sldev.cz/suite-web/fix/shared-worker-polyfill-usage/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->