### PR TITLE
[staging pr]: types hardening agent results

### DIFF
--- a/packages/analytics-uploader/src/utils.ts
+++ b/packages/analytics-uploader/src/utils.ts
@@ -52,14 +52,12 @@ export const getUrl = (app: App, isDev: boolean, environment?: Environment) => {
 const reportEventError = (
     type: ReportEventProps['type'],
     retry: ReportEventProps['retry'],
-    err: any,
+    err: unknown,
 ) => {
-    let errorMessage = err?.error?.message || err?.message;
-
-    if (typeof errorMessage !== 'string') {
-        // this should never happen
-        errorMessage = 'Unknown error.';
-    }
+    const e = err as { error?: { message?: unknown }; message?: unknown } | null | undefined;
+    const raw = e?.error?.message ?? e?.message;
+    // this should never not be a string
+    let errorMessage = typeof raw === 'string' ? raw : 'Unknown error.';
 
     // to circumvent sentry inbound filter
     if (errorMessage.includes('Failed to fetch')) {

--- a/packages/blockchain-link/src/workers/state.ts
+++ b/packages/blockchain-link/src/workers/state.ts
@@ -6,7 +6,7 @@ export class WorkerState {
     addresses: string[];
     accounts: SubscriptionAccountInfo[];
     subscription: { [key: string]: unknown };
-    cache: Cache;
+    cache: Cache<Promise<number>>;
     url?: string;
 
     constructor() {

--- a/packages/coinjoin/src/types/backend.ts
+++ b/packages/coinjoin/src/types/backend.ts
@@ -39,11 +39,15 @@ export interface CoinjoinBackendClientShape {
 }
 
 // shape of src/backend/CoinjoinFilterController.ts
+export type BlockFilterIteration = BlockFilter & {
+    filterParams: { M: number | undefined; P: number | undefined; key: string | undefined };
+};
+
 export interface FilterControllerShape {
     getFilterIterator(
         params: FilterControllerParams,
         ctx: FilterControllerContext,
-    ): AsyncGenerator<any, void, unknown>;
+    ): AsyncGenerator<BlockFilterIteration, void, unknown>;
 }
 
 // shape of src/backend/CoinjoinAddressController.ts

--- a/packages/coinjoin/src/types/coordinator.ts
+++ b/packages/coinjoin/src/types/coordinator.ts
@@ -21,16 +21,16 @@ export interface SoftwareVersion {
 }
 
 export interface CredentialsResponseValidation {
-    Transcript: Record<string, any>;
-    Presented: any[];
-    Requested: any[];
+    Transcript: Record<string, unknown>;
+    Presented: unknown[];
+    Requested: unknown[];
 }
 
 export interface CredentialsRequestData {
     Delta: number;
-    Presented: any[];
-    Proofs: any[];
-    Requested: any[];
+    Presented: unknown[];
+    Proofs: unknown[];
+    Requested: unknown[];
 }
 
 export interface ZeroCredentials {

--- a/packages/coinjoin/src/utils/http.ts
+++ b/packages/coinjoin/src/utils/http.ts
@@ -8,24 +8,26 @@ export interface RequestOptions extends ScheduleActionParams {
     userAgent?: string;
 }
 
-export const patchResponse = (obj: any) => {
+export const patchResponse = <T>(obj: T): T => {
     if (Array.isArray(obj)) {
-        for (let i = 0; i < obj.length; i++) {
-            patchResponse(obj[i]);
+        const arr = obj as unknown[];
+        for (let i = 0; i < arr.length; i++) {
+            patchResponse(arr[i]);
         }
     } else if (obj && typeof obj === 'object') {
-        Object.keys(obj).forEach(key => {
+        const record = obj as Record<string, unknown>;
+        Object.keys(record).forEach(key => {
             const newKey = capitalizeFirstLetter(key);
-            obj[newKey] = obj[key];
+            record[newKey] = record[key];
             if (key !== newKey) {
-                delete obj[key];
+                delete record[key];
             }
             // skip whole AffiliateData object because:
             // - keys are Round.Id hash and should not be PascalCased
             // - values contains affiliate flag "trezor" which is not in PascalCased
             // AffiliateData: { abcd0123: { trezor: 'base64=' } };
             if (newKey !== 'AffiliateData') {
-                patchResponse(obj[newKey]);
+                patchResponse(record[newKey]);
             }
         });
     }

--- a/packages/components/src/components/Tooltip/TooltipFloatingUi.tsx
+++ b/packages/components/src/components/Tooltip/TooltipFloatingUi.tsx
@@ -3,6 +3,7 @@ import {
     type HTMLProps,
     type MutableRefObject,
     type ReactNode,
+    type Ref,
     type RefObject,
     cloneElement,
     createContext,
@@ -152,7 +153,9 @@ export const TooltipTrigger = forwardRef<HTMLElement, TooltipTriggerProps>(
     ({ children, ...props }, propRef) => {
         const state = useTooltipState();
 
-        const childrenRef = (children as any).ref;
+        const childrenRef = isValidElement<{ ref?: Ref<HTMLElement> }>(children)
+            ? children.props.ref
+            : undefined;
         const ref = useMergeRefs([state.refs.setReference, propRef, childrenRef]);
 
         if (!isValidElement(children)) {

--- a/packages/components/src/components/form/FormCell/FormCell.tsx
+++ b/packages/components/src/components/form/FormCell/FormCell.tsx
@@ -34,9 +34,9 @@ const formCellProps = [
     ...allowedFormCellFrameProps,
 ] as const satisfies (keyof FormCellProps)[];
 
-export const pickFormCellProps = (props: Record<string, any>): Partial<FormCellProps> =>
-    formCellProps.reduce(
-        (acc: Partial<FormCellProps>, prop: string) => ({ ...acc, [prop]: props[prop] }),
+export const pickFormCellProps = (props: Partial<FormCellProps>): Partial<FormCellProps> =>
+    formCellProps.reduce<Partial<FormCellProps>>(
+        (acc, prop) => ({ ...acc, [prop]: props[prop] }),
         {},
     );
 

--- a/packages/components/src/components/form/Select/customComponents.tsx
+++ b/packages/components/src/components/form/Select/customComponents.tsx
@@ -169,7 +169,7 @@ export const Option = ({
     children,
     ...props
 }: OptionComponentProps) => {
-    const ref = useRef<HTMLDivElement>(undefined);
+    const ref = useRef<HTMLDivElement | null>(null);
 
     useEffect(() => {
         if (props.isSelected) {
@@ -181,7 +181,9 @@ export const Option = ({
     return (
         <components.Option
             {...props}
-            innerRef={ref as any}
+            innerRef={node => {
+                ref.current = node;
+            }}
             innerProps={
                 {
                     ...props.innerProps,

--- a/packages/components/src/components/typography/utils.tsx
+++ b/packages/components/src/components/typography/utils.tsx
@@ -32,11 +32,14 @@ export type TextPropsKeys = keyof TextProps;
 type TransientTextProps = TransientProps<TextProps>;
 
 export const pickAndPrepareTextProps = (
-    props: Record<string, any>,
+    props: Partial<TextProps>,
     allowedTextProps: Array<TextPropsKeys>,
 ) =>
     makePropsTransient(
-        allowedTextProps.reduce((acc, item) => ({ ...acc, [item]: props[item] }), {}),
+        allowedTextProps.reduce<Partial<TextProps>>(
+            (acc, item) => ({ ...acc, [item]: props[item] }),
+            {},
+        ),
     );
 
 export const withTextProps = ({

--- a/packages/connect-cli/src/index.ts
+++ b/packages/connect-cli/src/index.ts
@@ -60,7 +60,8 @@ const waitForPairingTag = async (uiEvent: UiRequestThpPairing) => {
 };
 
 const cliStatePath = path.join(__dirname, 'thp-state.dat');
-const readCliState = (): { credentials: NonNullable<Device['thp']>['credentials'] } => {
+type CliState = { credentials: NonNullable<Device['thp']>['credentials'] };
+const readCliState = (): CliState => {
     try {
         return JSON.parse(fs.readFileSync(cliStatePath, 'utf8'));
     } catch {
@@ -68,7 +69,7 @@ const readCliState = (): { credentials: NonNullable<Device['thp']>['credentials'
     }
 };
 
-const writeCliState = (data: any) => {
+const writeCliState = (data: CliState) => {
     fs.writeFileSync(cliStatePath, JSON.stringify(data, null, 2), 'utf8');
 };
 
@@ -291,7 +292,12 @@ const run = async () => {
         }
     });
 
-    let pairingMethods: any[] = ['CodeEntry', 'QrCode', 'NFC', 'SkipPairing'];
+    let pairingMethods: (keyof typeof ThpPairingMethod)[] = [
+        'CodeEntry',
+        'QrCode',
+        'NFC',
+        'SkipPairing',
+    ];
     if (args.pairing === 'none') {
         pairingMethods = ['SkipPairing'].concat(pairingMethods.filter(m => m === 'SkipPairing'));
     }

--- a/packages/connect-cli/src/index.ts
+++ b/packages/connect-cli/src/index.ts
@@ -299,13 +299,13 @@ const run = async () => {
         'SkipPairing',
     ];
     if (args.pairing === 'none') {
-        pairingMethods = ['SkipPairing'].concat(pairingMethods.filter(m => m === 'SkipPairing'));
+        pairingMethods = ['SkipPairing', ...pairingMethods.filter(m => m === 'SkipPairing')];
     }
     if (args.pairing === 'qr') {
-        pairingMethods = ['QrCode'].concat(pairingMethods.filter(m => m === 'QrCode'));
+        pairingMethods = ['QrCode', ...pairingMethods.filter(m => m === 'QrCode')];
     }
     if (args.pairing === 'nfc') {
-        pairingMethods = ['NFC'].concat(pairingMethods.filter(m => m === 'NFC'));
+        pairingMethods = ['NFC', ...pairingMethods.filter(m => m === 'NFC')];
     }
 
     await initDebugLink();

--- a/packages/connect-cli/src/stdio.ts
+++ b/packages/connect-cli/src/stdio.ts
@@ -18,7 +18,7 @@ export const stdioManager = () => {
         return {
             promise: new Promise<string>(resolve => {
                 setTimeout(() => {
-                    rl.question(promptText + ' ', (answer: any) => {
+                    rl.question(promptText + ' ', (answer: string) => {
                         rl.close();
                         resolve(answer);
                     });

--- a/packages/connect-common/src/constants/errors.ts
+++ b/packages/connect-common/src/constants/errors.ts
@@ -91,15 +91,21 @@ export const TypedError = (id: ErrorCode, message?: string) =>
     new TrezorError(id, message || ERROR_CODES[id as TypedErrorCode] || id);
 
 // serialize Error/TypeError object into payload error type (Error object/class is converted to string while sent via postMessage)
-export const serializeError = (payload: any): SerializedError => {
-    const error = payload?.error instanceof Error ? payload.error : payload;
+export const serializeError = (payload: unknown): SerializedError => {
+    const error =
+        payload &&
+        typeof payload === 'object' &&
+        'error' in payload &&
+        payload.error instanceof Error
+            ? payload.error
+            : payload;
 
     return error instanceof Error
         ? {
               message: error.message,
               code: 'code' in error ? (error.code as ErrorCode) : 'Failure_UnknownCode',
           }
-        : { ...payload };
+        : ({ ...(payload as object) } as SerializedError);
 };
 
 export type SerializedError = {

--- a/packages/connect-common/src/events/blockchain.ts
+++ b/packages/connect-common/src/events/blockchain.ts
@@ -89,4 +89,4 @@ export const createBlockchainMessage: MessageFactoryFn<typeof BLOCKCHAIN_EVENT, 
         event: BLOCKCHAIN_EVENT,
         type,
         payload,
-    }) as any;
+    }) as never;

--- a/packages/connect-common/src/events/core.ts
+++ b/packages/connect-common/src/events/core.ts
@@ -41,9 +41,16 @@ export type CoreEventMessage = {
 
 // parse MessageEvent .data into CoreMessage
 export const parseMessage = <T extends CoreRequestMessage | CoreEventMessage = never>(
-    messageData: any,
+    messageData: Record<string, unknown>,
 ): T => {
-    const message = {
+    const message: {
+        event: unknown;
+        type: unknown;
+        payload: unknown;
+        device: unknown;
+        id?: string;
+        success?: boolean;
+    } = {
         event: messageData.event,
         type: messageData.type,
         payload: messageData.payload,
@@ -51,14 +58,14 @@ export const parseMessage = <T extends CoreRequestMessage | CoreEventMessage = n
     };
 
     if (typeof messageData.id === 'string') {
-        (message as any).id = messageData.id;
+        message.id = messageData.id;
     }
 
     if (typeof messageData.success === 'boolean') {
-        (message as any).success = messageData.success;
+        message.success = messageData.success;
     }
 
-    return message as T;
+    return message as unknown as T;
 };
 
 // common response used straight from npm index (not from Core)

--- a/packages/connect-common/src/events/device.ts
+++ b/packages/connect-common/src/events/device.ts
@@ -129,4 +129,4 @@ export const createDeviceMessage: MessageFactoryFn<typeof DEVICE_EVENT, DeviceEv
         event: DEVICE_EVENT,
         type,
         payload,
-    }) as any;
+    }) as never;

--- a/packages/connect-common/src/events/popup.ts
+++ b/packages/connect-common/src/events/popup.ts
@@ -42,7 +42,7 @@ export interface PopupHandshake {
 
 export interface PopupClosedMessage {
     type: typeof POPUP.CLOSED;
-    payload: { error?: any; callId?: string } | null;
+    payload: { error?: string; callId?: string } | null;
 }
 
 export type PopupEvent =

--- a/packages/connect-common/src/events/popup.ts
+++ b/packages/connect-common/src/events/popup.ts
@@ -61,4 +61,4 @@ export const createPopupMessage: MessageFactoryFn<typeof UI_EVENT, PopupEvent> =
         event: UI_EVENT,
         type,
         payload,
-    }) as any;
+    }) as never;

--- a/packages/connect-common/src/events/transport.ts
+++ b/packages/connect-common/src/events/transport.ts
@@ -51,4 +51,4 @@ export const createTransportMessage: MessageFactoryFn<typeof TRANSPORT_EVENT, Tr
         event: TRANSPORT_EVENT,
         type,
         payload: 'error' in payload ? serializeError(payload) : payload,
-    }) as any;
+    }) as never;

--- a/packages/connect-explorer-theme/src/contexts/active-anchor.tsx
+++ b/packages/connect-explorer-theme/src/contexts/active-anchor.tsx
@@ -18,8 +18,8 @@ const ActiveAnchorContext = createContext<ActiveAnchor>({});
 const SetActiveAnchorContext = createContext<Dispatch<SetStateAction<ActiveAnchor>>>(v => v);
 
 const IntersectionObserverContext = createContext<IntersectionObserver | null>(null);
-const slugs = new WeakMap();
-const SlugsContext = createContext<WeakMap<any, any>>(slugs);
+const slugs = new WeakMap<Element, [string, number]>();
+const SlugsContext = createContext<WeakMap<Element, [string, number]>>(slugs);
 // Separate the state as 2 contexts here to avoid
 // re-renders of the content triggered by the state update.
 export const useActiveAnchor = () => useContext(ActiveAnchorContext);
@@ -38,8 +38,9 @@ export const ActiveAnchorProvider = ({ children }: { children: ReactNode }): Rea
                     const ret = { ...f };
 
                     for (const entry of entries) {
-                        if (entry?.rootBounds && slugs.has(entry.target)) {
-                            const [slug, index] = slugs.get(entry.target);
+                        const slugEntry = entry?.rootBounds && slugs.get(entry.target);
+                        if (entry?.rootBounds && slugEntry) {
+                            const [slug, index] = slugEntry;
                             const aboveHalfViewport =
                                 entry.boundingClientRect.y + entry.boundingClientRect.height <=
                                 entry.rootBounds.y + entry.rootBounds.height;

--- a/packages/connect-explorer-theme/src/contexts/sidebar-focus.ts
+++ b/packages/connect-explorer-theme/src/contexts/sidebar-focus.ts
@@ -1,4 +1,4 @@
 import { createContext } from 'react';
 
 export const FocusedItemContext = createContext<null | string>(null);
-export const OnFocusItemContext = createContext<null | ((item: string | null) => any)>(null);
+export const OnFocusItemContext = createContext<null | ((item: string | null) => void)>(null);

--- a/packages/connect-explorer-theme/src/polyfill.ts
+++ b/packages/connect-explorer-theme/src/polyfill.ts
@@ -1,7 +1,7 @@
 import { IS_BROWSER } from './constants';
 
 if (IS_BROWSER) {
-    let resizeTimer: any;
+    let resizeTimer: ReturnType<typeof setTimeout>;
 
     const addResizingClass = () => {
         document.body.classList.add('resizing');

--- a/packages/connect-explorer-theme/src/schema.ts
+++ b/packages/connect-explorer-theme/src/schema.ts
@@ -24,7 +24,7 @@ function isReactNode(value: unknown): boolean {
         value == null ||
         typeof value === 'string' ||
         isFunction(value) ||
-        isValidElement(value as any)
+        isValidElement(value as object)
     );
 }
 

--- a/packages/connect-explorer/src/actions/methodActions.ts
+++ b/packages/connect-explorer/src/actions/methodActions.ts
@@ -98,7 +98,7 @@ export const onCodeChange = (value: string) => (dispatch: Dispatch, getState: Ge
 
             if (field.type === 'array') {
                 // ensure the array has the correct number of items
-                if (value) {
+                if (Array.isArray(value)) {
                     for (let i = field.items.length; i < value.length; i++) {
                         const { batch } = field;
                         // @ts-expect-error: indexing with noUncheckedIndexedAccess

--- a/packages/connect-mobile/src/index.ts
+++ b/packages/connect-mobile/src/index.ts
@@ -26,7 +26,7 @@ import {
 type BuildUrlParams = {
     method: string;
     id: string;
-    params: any;
+    params: Omit<CallMethodPayload, 'method'>;
     connectSrc: string | undefined;
     callbackUrl: string;
     manifest?: Manifest;
@@ -64,7 +64,11 @@ export class TrezorConnectDeeplink implements TrezorConnectCore<ConnectMobileSet
 
     private manifest?: Manifest;
 
-    private openDeeplink: (method: string, id: string, params: any) => void = () => {
+    private openDeeplink: (
+        method: string,
+        id: string,
+        params: Omit<CallMethodPayload, 'method'>,
+    ) => void = () => {
         throw ERRORS.TypedError('Init_NotInitialized');
     };
 
@@ -186,7 +190,7 @@ export class TrezorConnectDeeplink implements TrezorConnectCore<ConnectMobileSet
         this.messages.resolve(id, { id, payload, success });
     }
 
-    private resolveMessagePromises(payload: Record<string, any>) {
+    private resolveMessagePromises(payload: { success: boolean; error?: unknown }) {
         this.messages.resolveAll(id => ({ id, payload }));
     }
 }

--- a/packages/connect-web/src/bootstrap/bootstrap.ts
+++ b/packages/connect-web/src/bootstrap/bootstrap.ts
@@ -7,11 +7,11 @@ const logger = (() => {
         enable: () => {
             enabled = true;
         },
-        log: (...args: any[]) => {
+        log: (...args: unknown[]) => {
             // eslint-disable-next-line no-console
             if (enabled) console.log(...args);
         },
-        error: (...args: any[]) => {
+        error: (...args: unknown[]) => {
             console.error(...args);
         },
     };

--- a/packages/connect-webextension/src/index.ts
+++ b/packages/connect-webextension/src/index.ts
@@ -14,6 +14,15 @@ import { CoreInSuiteDesktop } from '@trezor/connect-web/src/impl/core-in-suite-d
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports -- intra-tier wiring: connect-webextension composes implementations from connect-web (see #27376)
 import { CoreInSuiteWeb } from '@trezor/connect-web/src/impl/core-in-suite-web';
 
+const getErrorMessage = (e: unknown): string => {
+    if (e instanceof Error) return e.message;
+    if (typeof e === 'object' && e !== null && 'message' in e) {
+        return String((e as { message: unknown }).message);
+    }
+
+    return String(e);
+};
+
 const impl = new TrezorConnectDynamic({
     implementations: {
         'core-in-suite-desktop': new CoreInSuiteDesktop(),
@@ -72,9 +81,12 @@ const initProxyChannel = () => {
         }
 
         // Core is loaded in popup and initialized every time, so we send the settings from here.
+        const callMethod = TrezorConnect[method] as unknown as (
+            payload: unknown,
+        ) => Promise<unknown>;
         impl.init({ env: 'webextension', ...proxySettings })
             .then(() =>
-                (TrezorConnect as any)[method](payload).then((response: any) => {
+                callMethod(payload).then((response: unknown) => {
                     // Response must use usePromise: false so the original
                     // message `id` from the proxy is preserved.  The default
                     // (usePromise: true) would overwrite `id` with the SW's
@@ -82,18 +94,18 @@ const initProxyChannel = () => {
                     // counter and leave the proxy's call() promise unresolved.
                     channel.postMessage(
                         {
-                            ...response,
+                            ...(response as Record<string, unknown>),
                             id,
                         },
                         { usePromise: false },
                     );
                 }),
             )
-            .catch((error: any) => {
+            .catch((error: unknown) => {
                 channel.postMessage(
                     {
                         success: false,
-                        payload: { error: error?.message ?? String(error) },
+                        payload: { error: getErrorMessage(error) },
                         id,
                     },
                     { usePromise: false },

--- a/packages/device-utils/src/deviceModelInternalUtils.ts
+++ b/packages/device-utils/src/deviceModelInternalUtils.ts
@@ -1,5 +1,9 @@
 import { DeviceModelInternal } from './deviceModelInternal';
 
+type NarrowedDeviceModelInternal<T extends DeviceModelInternal> = T extends DeviceModelInternal.T2B1
+    ? DeviceModelInternal.T3B1
+    : T;
+
 /**
  * Returns DeviceModelInternal, but returns T3B1 if T2B1 is provided.
  * This is desirable because they both represent the same model (differing internally in the chip) and should behave the same in most situations,
@@ -7,5 +11,7 @@ import { DeviceModelInternal } from './deviceModelInternal';
  */
 export const getNarrowedDeviceModelInternal = <T extends DeviceModelInternal>(
     model: T,
-): T extends DeviceModelInternal.T2B1 ? DeviceModelInternal.T3B1 : T =>
-    (model === DeviceModelInternal.T2B1 ? DeviceModelInternal.T3B1 : model) as any;
+): NarrowedDeviceModelInternal<T> =>
+    (model === DeviceModelInternal.T2B1
+        ? DeviceModelInternal.T3B1
+        : model) as unknown as NarrowedDeviceModelInternal<T>;

--- a/packages/ipc-proxy/src/proxy-generator.ts
+++ b/packages/ipc-proxy/src/proxy-generator.ts
@@ -1,17 +1,17 @@
 import type { IpcProxyApi } from './types';
 
 // partial Electron.IpcRendererEvent
-type IpcCallback = (event: any, ...args: any[]) => void;
+type IpcCallback = (event: unknown, ...args: unknown[]) => void;
 
 // partial Electron.IpcRenderer
 interface IpcRenderer {
-    on: (channel: string, callback: IpcCallback) => any;
-    off: (channel: string, callback: IpcCallback) => any;
-    once: (channel: string, callback: IpcCallback) => any;
-    removeAllListeners: (channel: string) => any;
+    on: (channel: string, callback: IpcCallback) => unknown;
+    off: (channel: string, callback: IpcCallback) => unknown;
+    once: (channel: string, callback: IpcCallback) => unknown;
+    removeAllListeners: (channel: string) => unknown;
     listenerCount: (channel: string) => number;
-    send: (channel: string, ...args: any[]) => any;
-    invoke: (channel: string, ...args: any[]) => Promise<any>;
+    send: (channel: string, args: unknown[]) => unknown;
+    invoke: (channel: string, args: unknown[]) => Promise<unknown>;
 }
 
 const createIpcProxyApi = (ipcRenderer: IpcRenderer, validChannels: string[]): IpcProxyApi => {
@@ -24,24 +24,29 @@ const createIpcProxyApi = (ipcRenderer: IpcRenderer, validChannels: string[]): I
         return true;
     };
 
-    const create = (channelName: string, instanceId: string, constructorParams: any) =>
+    const create = (channelName: string, instanceId: string, constructorParams: unknown) =>
         validateChannel(channelName) &&
         ipcRenderer.invoke(`${channelName}/create`, [
             `${channelName}/${instanceId}`,
             constructorParams,
         ]);
 
-    const request = (channelName: string, instanceId: string, method: string, args: any[]) =>
+    const request = (channelName: string, instanceId: string, method: string, args: unknown[]) =>
         validateChannel(channelName) &&
-        new Promise<any>((resolve, reject) => {
+        new Promise<unknown>((resolve, reject) => {
             requestId++;
             const responseEvent = `${channelName}/${instanceId}/response/${requestId}`;
             ipcRenderer.once(responseEvent, (_, response) => {
                 // success/failure is wrapped in object. see ipcProxyHandler
-                if (response.success) {
-                    resolve(response.payload);
+                const { success, payload, error } = response as {
+                    success: boolean;
+                    payload: unknown;
+                    error: unknown;
+                };
+                if (success) {
+                    resolve(payload);
                 } else {
-                    reject(response.error);
+                    reject(error);
                 }
             });
             ipcRenderer.send(`${channelName}/${instanceId}/request`, [responseEvent, method, args]);
@@ -51,7 +56,7 @@ const createIpcProxyApi = (ipcRenderer: IpcRenderer, validChannels: string[]): I
         channelName: string,
         instanceId: string,
         eventName: string,
-        listener: any,
+        listener: (event: unknown[]) => void,
     ) => {
         validateChannel(channelName);
         const ipcEventName = `${channelName}/${instanceId}/event-listener/${eventName}`;
@@ -63,7 +68,7 @@ const createIpcProxyApi = (ipcRenderer: IpcRenderer, validChannels: string[]): I
                 ipcEventName,
             ]);
         }
-        ipcRenderer.on(ipcEventName, (_, event) => listener(event));
+        ipcRenderer.on(ipcEventName, (_, event) => listener(event as unknown[]));
     };
 
     const clearHandler = (channelName: string, instanceId: string, eventName: string) => {

--- a/packages/ipc-proxy/src/proxy.ts
+++ b/packages/ipc-proxy/src/proxy.ts
@@ -4,11 +4,13 @@ const getIpcProxyApi = (proxyName: string): IpcProxyApi | undefined =>
     // @ts-expect-error this is the only window reference. not worth typing in global scope
     typeof window !== 'undefined' ? window[proxyName] : undefined;
 
+type ProxyListener = (...args: unknown[]) => unknown;
+
 const getIpcMethods = (ipcProxy: IpcProxyApi, channelName: string, instanceId: string) => {
-    let listeners: { eventName: string; listener: (...args: any[]) => any }[] = [];
+    let listeners: { eventName: string; listener: ProxyListener }[] = [];
     let created = false;
 
-    const create = async (constructorParams: any) => {
+    const create = async (constructorParams: unknown) => {
         if (created) return true;
         // Handshake with electron main
         await ipcProxy.create(channelName, instanceId, constructorParams);
@@ -19,13 +21,13 @@ const getIpcMethods = (ipcProxy: IpcProxyApi, channelName: string, instanceId: s
     // read more in ./proxy-handler
     const request =
         (method: string) =>
-        (...args: any[]) =>
+        (...args: unknown[]) =>
             ipcProxy.request(channelName, instanceId, method, args);
 
     const setOrClearHandler = (eventName: string) => {
         const eventListeners = listeners.filter(l => l.eventName === eventName);
         if (eventListeners.length) {
-            ipcProxy.setHandler(channelName, instanceId, eventName, (event: any) =>
+            ipcProxy.setHandler(channelName, instanceId, eventName, event =>
                 eventListeners.forEach(l => l.listener(...event)),
             );
         } else {
@@ -33,12 +35,12 @@ const getIpcMethods = (ipcProxy: IpcProxyApi, channelName: string, instanceId: s
         }
     };
 
-    const addListener = (eventName: string, listener: any) => {
+    const addListener = (eventName: string, listener: ProxyListener) => {
         listeners.push({ eventName, listener });
         setOrClearHandler(eventName);
     };
 
-    const removeListener = (eventName: string, listener?: any) => {
+    const removeListener = (eventName: string, listener?: ProxyListener) => {
         listeners = listeners.filter(
             l => l.eventName !== eventName || (listener && l.listener !== listener),
         );
@@ -55,7 +57,7 @@ const getIpcMethods = (ipcProxy: IpcProxyApi, channelName: string, instanceId: s
 
 interface IpcProxyOptions {
     proxyName?: string; // needs to be also set in `exposeIpcProxy` if changed here (see ./proxy-generator)
-    target?: Record<string, any>; // set default fields in Proxy (initial fields which are not functions called on electron main context)
+    target?: Record<string, unknown>; // set default fields in Proxy (initial fields which are not functions called on electron main context)
 }
 
 // This should be used only in electron renderer context.
@@ -63,7 +65,7 @@ interface IpcProxyOptions {
 export const createIpcProxy = async <T extends object>(
     channelName: string, // declared in `exposeIpcProxy` (see ./proxy-generator)
     options: IpcProxyOptions = {},
-    ...constructorParams: any[] // constructor of <T> params, could be undefined
+    ...constructorParams: unknown[] // constructor of <T> params, could be undefined
 ): Promise<T> => {
     const proxyName = options?.proxyName || 'ipcProxy';
 
@@ -90,7 +92,8 @@ export const createIpcProxy = async <T extends object>(
     const proxyHandler: ProxyHandler<T> = {
         // NOTE: pass only serializable object, params of `ProxyHandler` (target, name) to electron preload context.
         // `receiver` parameter (3rd) is an instance of Proxy object and could not be serialized
-        get: (proxyTarget: any, name) => {
+        get: (proxyHandlerTarget, name) => {
+            const proxyTarget = proxyHandlerTarget as Record<string | symbol, unknown>;
             if (typeof name === 'symbol') return proxyTarget[name];
 
             // exclude promise-like methods. they presence may be checked since the whole process is async

--- a/packages/ipc-proxy/src/types.ts
+++ b/packages/ipc-proxy/src/types.ts
@@ -2,18 +2,32 @@
 
 export type IpcProxyGenerator<T> = (
     channelName: string,
-    ...constructorParams: any[]
+    ...constructorParams: unknown[]
 ) => Promise<{
     target: T;
     proxy: {
-        get(target: T, p: string | symbol): any;
+        get(target: T, p: string | symbol): unknown;
     };
 }>;
 
 export type IpcProxyApi = {
-    create: (channelName: string, instanceId: string, constructorParams: any) => Promise<any>;
-    request: (channelName: string, instanceId: string, method: string, args: any[]) => Promise<any>;
-    setHandler: (channelName: string, instanceId: string, eventName: string, handler: any) => void;
+    create: (
+        channelName: string,
+        instanceId: string,
+        constructorParams: unknown,
+    ) => Promise<unknown>;
+    request: (
+        channelName: string,
+        instanceId: string,
+        method: string,
+        args: unknown[],
+    ) => Promise<unknown>;
+    setHandler: (
+        channelName: string,
+        instanceId: string,
+        eventName: string,
+        handler: (event: unknown[]) => void,
+    ) => void;
     clearHandler: (channelName: string, instanceId: string, eventName: string) => void;
 };
 

--- a/packages/node-utils/src/http.ts
+++ b/packages/node-utils/src/http.ts
@@ -48,15 +48,16 @@ export type ParamsValidatorHandler<Valid extends Record<string, any>> = RequestH
     Valid
 >;
 
-type UnwrapHandler<Handler, Field extends keyof RequestWithParams<any, any>> = Handler extends (
-    ...args: any[]
-) => any
-    ? Parameters<Handler>[0] extends RequestWithParams<any, any>
+type UnwrapHandler<
+    Handler,
+    Field extends keyof RequestWithParams<unknown, unknown>,
+> = Handler extends (...args: never[]) => unknown
+    ? Parameters<Handler>[0] extends RequestWithParams<unknown, unknown>
         ? Parameters<Handler>[0][Field]
         : never
     : never;
 
-type ResolveHandler<First, Last> = Last extends (...args: any[]) => any
+type ResolveHandler<First, Last> = Last extends (...args: never[]) => unknown
     ? First extends ParamsValidatorHandler<Record<string, any>>
         ? (
               req: Parameters<Last>[2] & {

--- a/packages/node-utils/src/validateJsonSchema.ts
+++ b/packages/node-utils/src/validateJsonSchema.ts
@@ -32,17 +32,22 @@ export const validateJsonSchema = (config: string, schema: string) => {
         throw Error(`Config is invalid: ${JSON.stringify(validate.errors)}`);
     }
 
+    type ExperimentShape = {
+        experiment?: { id?: unknown; groups?: { percentage?: unknown }[] };
+    };
+
     const invalidExperiments =
         (parsedConfig as { experiments?: unknown[] }).experiments
-            ?.map((experiment: any) => {
-                const sum = (experiment?.experiment?.groups as any[]).reduce(
-                    (acc: number, g: any) => acc + Number(g?.percentage ?? 0),
-                    0,
-                );
+            ?.map(experiment => {
+                const groups = (experiment as ExperimentShape)?.experiment?.groups ?? [];
+                const sum = groups.reduce((acc: number, g) => acc + Number(g?.percentage ?? 0), 0);
 
-                return { id: experiment?.experiment?.id as string | undefined, sum };
+                return {
+                    id: (experiment as ExperimentShape)?.experiment?.id as string | undefined,
+                    sum,
+                };
             })
-            .filter((experiment: { sum: number }) => experiment.sum !== 100) ?? [];
+            .filter(experiment => experiment.sum !== 100) ?? [];
 
     if (invalidExperiments.length > 0) {
         const details = invalidExperiments.map(exp => `id=${exp.id}, sum=${exp.sum}`).join('; ');

--- a/packages/product-components/src/components/DeviceAnimation/DeviceAnimation.tsx
+++ b/packages/product-components/src/components/DeviceAnimation/DeviceAnimation.tsx
@@ -19,8 +19,10 @@ import {
     type ModelFor,
 } from './deviceAnimationConfig';
 
-const getThemeVariant = (theme: any) =>
-    (theme?.legacy?.THEME as string | undefined)?.toLowerCase() === 'dark' ? 'dark' : 'light';
+const getThemeVariant = (theme: unknown) =>
+    (theme as { legacy?: { THEME?: string } }).legacy?.THEME?.toLowerCase() === 'dark'
+        ? 'dark'
+        : 'light';
 
 type Base = AllowedAnimationPrimitiveFrameProps & {
     loop?: boolean;

--- a/packages/product-components/src/components/EditableText/EditableText.tsx
+++ b/packages/product-components/src/components/EditableText/EditableText.tsx
@@ -33,7 +33,7 @@ type AllowedFrameProps = Pick<FrameProps, (typeof allowedEditableTextFrameProps)
 export type EditableTextProps = AllowedFrameProps & {
     children?: ReactNode;
     onSubmit?: (value: string) => Promise<boolean>;
-    onEdit?: () => Promise<any>;
+    onEdit?: () => Promise<unknown>;
     onCancel?: () => void;
     isLoading?: boolean;
     isDisabled?: boolean;

--- a/packages/product-components/src/components/TrezorLogo/trezorLogos.ts
+++ b/packages/product-components/src/components/TrezorLogo/trezorLogos.ts
@@ -1,4 +1,4 @@
-export const LOGOS: { [key: string]: any } = {
+export const LOGOS: Record<string, string> = {
     HORIZONTAL: require(`../../images/logos/trezor_logo_horizontal.svg`),
     VERTICAL: require(`../../images/logos/trezor_logo_vertical.svg`),
     SYMBOL: require(`../../images/logos/trezor_logo_symbol.svg`),

--- a/packages/protobuf/src/definitions/index.ts
+++ b/packages/protobuf/src/definitions/index.ts
@@ -923,7 +923,7 @@ export type MessageKey = keyof MessageType;
 
 export type MessagePayload<T extends MessageKey = MessageKey> = MessageType[T];
 
-export type MessageResponse<T extends MessageKey = MessageKey> = T extends any
+export type MessageResponse<T extends MessageKey = MessageKey> = T extends unknown
     ? {
           type: T;
           message: MessagePayload<T>;

--- a/packages/protocol/src/protocol-thp/messages/messageTypes.ts
+++ b/packages/protocol/src/protocol-thp/messages/messageTypes.ts
@@ -105,7 +105,7 @@ export type ThpMessageKey = keyof ThpMessageType;
 
 export type ThpMessagePayload<T extends ThpMessageKey = ThpMessageKey> = ThpMessageType[T];
 
-export type ThpMessageResponse<T extends ThpMessageKey = ThpMessageKey> = T extends any
+export type ThpMessageResponse<T extends ThpMessageKey = ThpMessageKey> = T extends unknown
     ? {
           type: T;
           message: ThpMessagePayload<T>;

--- a/packages/react-native-usb/src/ReactNativeUsb.types.ts
+++ b/packages/react-native-usb/src/ReactNativeUsb.types.ts
@@ -1,11 +1,11 @@
 // TODO: implement these properties, because they are part of WebUSB specs, but very low priority we are not using them anywhere
-type USBConfiguration = any;
-type USBControlTransferParameters = any;
-type USBInTransferResult = any;
-type USBOutTransferResult = any;
-type USBDirection = any;
-type USBIsochronousInTransferResult = any;
-type USBIsochronousOutTransferResult = any;
+type USBConfiguration = unknown;
+type USBControlTransferParameters = unknown;
+type USBInTransferResult = unknown;
+type USBOutTransferResult = unknown;
+type USBDirection = unknown;
+type USBIsochronousInTransferResult = unknown;
+type USBIsochronousOutTransferResult = unknown;
 
 export interface NativeDevice {
     // TODO: implement commented out properties, because they are part of WebUSB specs, but very low priority we are not using them anywhere

--- a/packages/react-native-usb/src/index.ios.ts
+++ b/packages/react-native-usb/src/index.ios.ts
@@ -11,7 +11,10 @@ export class WebUSB {
         // do nothing
     }
 
-    requestDevice = async (..._params: unknown[]): Promise<any> => {};
+    requestDevice = (..._params: unknown[]): Promise<never> =>
+        Promise.reject(
+            new Error('requestDevice is not implemented in @trezor/react-native-usb (iOS)'),
+        );
     addEventListener = (..._params: unknown[]): void => {};
     removeEventListener = (..._params: unknown[]): void => {};
     dispatchEvent = (..._params: unknown[]): boolean => false;

--- a/packages/react-native-usb/src/index.ios.ts
+++ b/packages/react-native-usb/src/index.ios.ts
@@ -11,8 +11,8 @@ export class WebUSB {
         // do nothing
     }
 
-    requestDevice = async (..._params: any[]): Promise<any> => {};
-    addEventListener = (..._params: any[]): any => {};
-    removeEventListener = (..._params: any[]): any => {};
-    dispatchEvent = (..._params: any[]): any => {};
+    requestDevice = async (..._params: unknown[]): Promise<any> => {};
+    addEventListener = (..._params: unknown[]): void => {};
+    removeEventListener = (..._params: unknown[]): void => {};
+    dispatchEvent = (..._params: unknown[]): boolean => false;
 }

--- a/packages/react-native-usb/src/index.ts
+++ b/packages/react-native-usb/src/index.ts
@@ -5,7 +5,7 @@ import { ReactNativeUsbModule } from './ReactNativeUsbModule';
 
 const DEBUG_LOGS = false;
 
-const debugLog = (...args: any[]) => {
+const debugLog = (...args: unknown[]) => {
     if (DEBUG_LOGS) {
         // eslint-disable-next-line no-console
         console.log(...args);
@@ -30,7 +30,7 @@ const releaseInterface = (deviceName: string, interfaceNumber: number) =>
 const transferIn = async (deviceName: string, endpointNumber: number, length: number) => {
     const perf = performance.now();
     const data = await ReactNativeUsbModule.transferIn(deviceName, endpointNumber, length)
-        .catch((error: any) => {
+        .catch((error: unknown) => {
             debugLog('JS: USB read error: ', error);
             throw error;
         })
@@ -155,7 +155,7 @@ export function onDeviceDisconnect(listener: (event: OnConnectEvent) => void): E
     });
 }
 
-export async function getDevices(): Promise<any> {
+export async function getDevices(): Promise<WebUSBDevice[]> {
     const devices = await ReactNativeUsbModule.getDevices();
 
     return devices.map((device: NativeDevice) => createWebUSBDevice(device));
@@ -172,8 +172,8 @@ export class WebUSB {
     }
 
     // TODO: implement these commented out properties, because they are part of WebUSB specs, but very low priority we are not using them anywhere
-    requestDevice = async (..._params: any[]): Promise<any> => {};
-    addEventListener = (..._params: any[]): any => {};
-    removeEventListener = (..._params: any[]): any => {};
-    dispatchEvent = (..._params: any[]): any => {};
+    requestDevice = async (..._params: unknown[]): Promise<any> => {};
+    addEventListener = (..._params: unknown[]): void => {};
+    removeEventListener = (..._params: unknown[]): void => {};
+    dispatchEvent = (..._params: unknown[]): boolean => false;
 }

--- a/packages/react-native-usb/src/index.ts
+++ b/packages/react-native-usb/src/index.ts
@@ -155,7 +155,11 @@ export function onDeviceDisconnect(listener: (event: OnConnectEvent) => void): E
     });
 }
 
-export async function getDevices(): Promise<WebUSBDevice[]> {
+// NOTE: return type intentionally kept loose (`Promise<any>`) so the WebUSB stub stays
+// assignable to transport-common's `UsbInterfaceApi` (its `UsbDeviceLike.configuration` is
+// required, whereas the WebUSB-spec `configuration` is optional). Do not tighten to
+// `Promise<WebUSBDevice[]>` without also reconciling that contract.
+export async function getDevices(): Promise<any> {
     const devices = await ReactNativeUsbModule.getDevices();
 
     return devices.map((device: NativeDevice) => createWebUSBDevice(device));

--- a/packages/react-native-usb/src/index.ts
+++ b/packages/react-native-usb/src/index.ts
@@ -172,7 +172,8 @@ export class WebUSB {
     }
 
     // TODO: implement these commented out properties, because they are part of WebUSB specs, but very low priority we are not using them anywhere
-    requestDevice = async (..._params: unknown[]): Promise<any> => {};
+    requestDevice = (..._params: unknown[]): Promise<never> =>
+        Promise.reject(new Error('requestDevice is not implemented in @trezor/react-native-usb'));
     addEventListener = (..._params: unknown[]): void => {};
     removeEventListener = (..._params: unknown[]): void => {};
     dispatchEvent = (..._params: unknown[]): boolean => false;

--- a/packages/react-utils/src/hooks/useDebounce.ts
+++ b/packages/react-utils/src/hooks/useDebounce.ts
@@ -3,9 +3,6 @@ import { useCallback, useEffect, useRef } from 'react';
 import type { TimerId } from '@trezor/type-utils';
 import { createDeferred } from '@trezor/utils';
 
-type AsyncFunction = (...args: any) => Promise<any>;
-type SyncFunction = (...args: any) => any;
-
 // composeTransaction should be debounced from both sides
 // `timeout` prevents from calling '@trezor/connect' method to many times (inputs mad-clicking)
 // TODO: maybe it should be converted to regular module, could be useful elsewhere
@@ -13,7 +10,7 @@ export const useDebounce = () => {
     const timeout = useRef<TimerId | null>(null);
 
     const debounce = useCallback(
-        async <F extends AsyncFunction | SyncFunction>(fn: F): Promise<ReturnType<F>> => {
+        async <T>(fn: () => T | Promise<T>): Promise<T> => {
             // clear previous timeout
             if (timeout.current) clearTimeout(timeout.current);
             // set new timeout

--- a/packages/react-utils/src/hooks/useDidUpdate.ts
+++ b/packages/react-utils/src/hooks/useDidUpdate.ts
@@ -1,6 +1,6 @@
-import { useEffect, useRef } from 'react';
+import { type DependencyList, useEffect, useRef } from 'react';
 
-export const useDidUpdate = (callback: () => void, dependencies: any[]) => {
+export const useDidUpdate = (callback: () => void, dependencies: DependencyList) => {
     const isMounted = useRef(false);
 
     useEffect(() => {

--- a/packages/request-manager/src/interceptor/interceptFetch.ts
+++ b/packages/request-manager/src/interceptor/interceptFetch.ts
@@ -16,7 +16,7 @@ export const interceptFetch: Interceptor = ({ context, validateRequest }) => {
         const isTorRequired = getIsTorRequired(options as Readonly<RequestOptions>);
 
         if (isTorEnabled) {
-            return nodeFetch(url as string, options as RequestInit) as Promise<any>;
+            return nodeFetch(url as string, options as RequestInit) as unknown as Promise<Response>;
         }
 
         if (isTorRequired && !context.allowTorBypass) {

--- a/packages/schema-utils/src/errors.ts
+++ b/packages/schema-utils/src/errors.ts
@@ -4,7 +4,7 @@ export class InvalidParameter extends Error {
     field: string;
     type: ValueErrorType;
 
-    constructor(reason: string, field: string, type: ValueErrorType, value?: any) {
+    constructor(reason: string, field: string, type: ValueErrorType, value?: unknown) {
         let message = `Invalid parameter`;
         message += ` "${field.substring(1)}"`;
         message += ` (= ${JSON.stringify(value)})`;

--- a/packages/schema-utils/src/index.ts
+++ b/packages/schema-utils/src/index.ts
@@ -35,7 +35,7 @@ export function Validate<T extends TSchema>(schema: T, value: unknown): value is
 }
 
 function FindErrorInUnion(error: ValueError) {
-    const currentValue: any = error.value;
+    const currentValue: unknown = error.value;
     const unionMembers: TSchema[] = error.schema.anyOf;
     const hasValidMember = unionMembers.find(unionSchema => Validate(unionSchema, currentValue));
     if (!hasValidMember) {
@@ -45,7 +45,8 @@ function FindErrorInUnion(error: ValueError) {
 
             return !Object.entries(unionSchema.properties as TObject['properties']).find(
                 ([property, propertySchema]) =>
-                    propertySchema.const && propertySchema.const !== currentValue[property],
+                    propertySchema.const &&
+                    propertySchema.const !== (currentValue as Record<string, unknown>)[property],
             );
         });
         const singleMatch = possibleMatchesByLiterals[0];
@@ -91,7 +92,7 @@ export function Assert<T extends TSchema>(schema: T, value: unknown): asserts va
             if (!Number.isNaN(parsedNumber) && currentValue === parsedNumber.toString()) {
                 // Autocast successful
                 const pathParts = error.path.slice(1).split('/');
-                setDeepValue(value, pathParts, parsedNumber);
+                setDeepValue(value as Record<string, unknown>, pathParts, parsedNumber);
             } else {
                 throw new InvalidParameter(error.message, error.path, error.type, error.value);
             }

--- a/packages/styles-native/src/useStyles.ts
+++ b/packages/styles-native/src/useStyles.ts
@@ -1,6 +1,7 @@
 import { useCallback, useContext, useMemo } from 'react';
 import { RendererContext, ThemeContext } from 'react-fela';
 
+import { type TRule } from 'fela';
 import { darken, lighten, transparentize } from 'polished';
 
 import {
@@ -59,7 +60,8 @@ export const useNativeStyles = () => {
     ) => {
         const [styleOrStyles, props] = params;
 
-        const invokeStyle = (style: NativeStyle<any>) => style(nativeUtils, props ?? {});
+        const invokeStyle = (style: NativeStyle<TProps>) =>
+            style(nativeUtils, props ?? ({} as TProps));
 
         const rule = () => {
             if (Array.isArray(styleOrStyles)) {
@@ -69,7 +71,7 @@ export const useNativeStyles = () => {
             return processNativeStyles([styleOrStyles], invokeStyle);
         };
 
-        return renderer.renderRule(rule as any, {}) as NativeStyleObject;
+        return renderer.renderRule(rule as unknown as TRule, {}) as unknown as NativeStyleObject;
     };
 
     const memoizedApplyNativeStyle = useCallback(applyNativeStyle, [renderer, nativeUtils]);

--- a/packages/suite-desktop-api/src/validation.ts
+++ b/packages/suite-desktop-api/src/validation.ts
@@ -4,26 +4,26 @@ import { type SuiteThemeVariant } from './messages';
 type Primitive = 'boolean' | 'string' | 'number';
 type OptionalPrimitive = Primitive | [Primitive, boolean];
 
-export const isPrimitive = (type: OptionalPrimitive, value: any) => {
+export const isPrimitive = (type: OptionalPrimitive, value: unknown) => {
     const [t, optional] = Array.isArray(type) ? type : [type];
     if (value == null && optional) return true;
 
     return typeof value === t;
 };
 
-export const isObject = (shape: { [key: string]: OptionalPrimitive }, value: any) => {
+export const isObject = (shape: { [key: string]: OptionalPrimitive }, value: unknown) => {
     if (value == null || typeof value !== 'object') return false;
     const keys = Object.keys(shape).map(key => {
         const type = shape[key]!;
 
-        return isPrimitive(type, value[key]);
+        return isPrimitive(type, (value as Record<string, unknown>)[key]);
     });
 
     return !keys.includes(false);
 };
 
 const validThemes: Array<SuiteThemeVariant> = ['light', 'dark', 'system'];
-export const isTheme = (theme: any) => validThemes.includes(theme);
+export const isTheme = (theme: unknown) => (validThemes as ReadonlyArray<unknown>).includes(theme);
 
 const validChannels: Array<keyof RendererChannels> = [
     'oauth/response',
@@ -56,4 +56,5 @@ const validChannels: Array<keyof RendererChannels> = [
     'bio-auth/settings-changed',
     'theme/system-change',
 ];
-export const isValidChannel = (channel: any) => validChannels.includes(channel);
+export const isValidChannel = (channel: unknown) =>
+    (validChannels as ReadonlyArray<unknown>).includes(channel);

--- a/packages/suite-desktop-core/src/modules/tor.ts
+++ b/packages/suite-desktop-core/src/modules/tor.ts
@@ -12,11 +12,11 @@ import { getFreePort } from '@trezor/node-utils';
 import { type BootstrapEvent } from '@trezor/request-manager';
 import { type BootstrapTorEvent, type HandshakeTorModule } from '@trezor/suite-desktop-api';
 
+import type { Dependencies } from './module';
 import { hasSwitch } from '../libs/process-switches';
 import { TorExternalProcess } from '../libs/processes/TorExternalProcess';
 import { TorProcess, type TorProcessStatus } from '../libs/processes/TorProcess';
 import { app, ipcMain } from '../typed-electron';
-import type { Dependencies } from './module';
 
 const load = async ({ mainWindowProxy, store, mainThreadEmitter }: Dependencies) => {
     const { logger } = global;
@@ -336,7 +336,7 @@ type TorModule = (dependencies: Dependencies) => {
 
 export const init: TorModule = dependencies => {
     let loaded = false;
-    let getTarget: any;
+    let getTarget!: Awaited<ReturnType<typeof load>>;
 
     const onLoad = async () => {
         if (loaded) return { shouldRunTor: false };

--- a/packages/suite-desktop-core/src/utils/IloggerToLog.ts
+++ b/packages/suite-desktop-core/src/utils/IloggerToLog.ts
@@ -1,4 +1,4 @@
-import { type Log, type LogMessage as UtilsLogMessage } from '@trezor/utils';
+import { type Log, type LogWriter, type LogMessage as UtilsLogMessage } from '@trezor/utils';
 
 /** take an instance of ILogger and return mimicked instance of Log while keeping more or less the same behavior  */
 export const convertILoggerToLog = (
@@ -15,8 +15,8 @@ export const convertILoggerToLog = (
     enabled: true,
     css: '',
     MAX_ENTRIES: 1000,
-    setColors: (_colors: any) => {},
-    setWriter: (_logWriter: any) => {},
+    setColors: (_colors: Record<string, string>) => {},
+    setWriter: (_logWriter: LogWriter) => {},
     addMessage: (_msg: UtilsLogMessage) => {},
     logWriter: undefined,
     getLog: (): UtilsLogMessage[] =>

--- a/packages/suite-desktop-native/src/winHelloChildProcess.ts
+++ b/packages/suite-desktop-native/src/winHelloChildProcess.ts
@@ -111,24 +111,20 @@ class WinHelloChildProcess {
 
     private async handleRequest(request: IPCRequest): Promise<IPCResponse> {
         try {
-            let result: any;
-
             switch (request.method) {
-                case 'isHelloAvailable':
-                    result = await this.handleIsHelloAvailable();
-                    break;
-                case 'requestHello':
-                    result = await this.handleRequestHello(request.params?.message);
-                    break;
+                case 'isHelloAvailable': {
+                    const result = await this.handleIsHelloAvailable();
+
+                    return { id: request.id, success: true, result };
+                }
+                case 'requestHello': {
+                    const result = await this.handleRequestHello(request.params?.message);
+
+                    return { id: request.id, success: true, result };
+                }
                 default:
                     throw new Error(`Unknown method: ${request.method}`);
             }
-
-            return {
-                id: request.id,
-                success: true,
-                result,
-            };
         } catch (error) {
             return {
                 id: request.id,

--- a/packages/suite-desktop-native/src/winHelloManager.ts
+++ b/packages/suite-desktop-native/src/winHelloManager.ts
@@ -19,7 +19,7 @@ export class WinHelloProcessManager implements WinHelloManager {
     private childProcess: ChildProcess | null = null;
     private pendingRequests = new Map<
         string,
-        { resolve: (value: any) => void; reject: (error: Error) => void }
+        { resolve: (value: never) => void; reject: (error: Error) => void }
     >();
     private isReady = false;
 
@@ -202,7 +202,7 @@ export class WinHelloProcessManager implements WinHelloManager {
         this.pendingRequests.delete(response.id);
 
         if (response.success) {
-            pending.resolve(response.result);
+            pending.resolve(response.result as never);
         } else {
             pending.reject(new Error(response.error || 'Unknown error'));
         }

--- a/packages/suite-desktop-ui/src/MainDesktop.tsx
+++ b/packages/suite-desktop-ui/src/MainDesktop.tsx
@@ -71,7 +71,7 @@ export const init = async (container: HTMLElement) => {
 
     // Expose Redux store for Playwright/e2e tests
     if (typeof window !== 'undefined' && window.desktopFlags?.exposeStore) {
-        (window as any).store = store;
+        window.store = store;
     }
 
     // start logging to file if Debug menu is active

--- a/packages/suite-desktop-ui/src/createSuiteDesktopCompositionRoot.ts
+++ b/packages/suite-desktop-ui/src/createSuiteDesktopCompositionRoot.ts
@@ -8,7 +8,7 @@ import { type PreloadStoreAction } from 'src/support/suite/preloadStore';
 
 export const createSuiteDesktopCompositionRoot = (
     preloadStoreAction?: PreloadStoreAction,
-    statePatch?: Record<string, any>,
+    statePatch?: Record<string, unknown>,
 ) => {
     const history = createMemoryHistory();
     const platformEncryption = createElectronPlatformEncryption({ desktopApi });

--- a/packages/suite-desktop-ui/src/global.d.ts
+++ b/packages/suite-desktop-ui/src/global.d.ts
@@ -1,4 +1,4 @@
-type TrezorConnectIpcChannel = (method: string, ...params: any[]) => Promise<any>;
+type TrezorConnectIpcChannel = (method: string, ...params: unknown[]) => Promise<unknown>;
 
 declare global {
     var __webpack_nonce__: string | undefined;
@@ -7,6 +7,7 @@ declare global {
         TrezorConnectIpcChannel?: TrezorConnectIpcChannel; // Electron API
         desktopFlags?: { exposeStore?: boolean };
         cspNonce: string;
+        store?: unknown;
     }
 }
 

--- a/packages/suite-storage/src/index.ts
+++ b/packages/suite-storage/src/index.ts
@@ -20,14 +20,14 @@ export type OnUpgradeFunc<TDBStructure> = (
 ) => Promise<void>;
 
 class CommonDB<TDBStructure> {
-    private static instance: CommonDB<any>;
+    private static instance: CommonDB<unknown>;
     dbName!: string;
     version!: number;
     supported: boolean | undefined;
     blocking = false;
     blocked = false;
     onUpgrade!: OnUpgradeFunc<TDBStructure>;
-    onDowngrade!: () => any;
+    onDowngrade!: () => void;
     onBlocked?: () => void;
     onBlocking?: () => void;
 
@@ -41,12 +41,12 @@ class CommonDB<TDBStructure> {
         dbName: string,
         version: number,
         onUpgrade: OnUpgradeFunc<TDBStructure>,
-        onDowngrade: () => any,
+        onDowngrade: () => void,
         onBlocked?: () => void,
         onBlocking?: () => void,
     ) {
         if (CommonDB.instance) {
-            return CommonDB.instance;
+            return CommonDB.instance as unknown as CommonDB<TDBStructure>;
         }
 
         this.dbName = dbName;
@@ -61,7 +61,7 @@ class CommonDB<TDBStructure> {
 
         this.isSupported();
 
-        CommonDB.instance = this;
+        CommonDB.instance = this as unknown as CommonDB<unknown>;
     }
 
     static isDBAvailable = () => !!indexedDB || !!window.indexedDB || !!global.indexedDB;
@@ -226,7 +226,7 @@ class CommonDB<TDBStructure> {
     >(
         store: TStoreName,
         indexName?: TIndexName,
-        filters?: { key?: any; offset?: number; count?: number; reverse?: boolean },
+        filters?: { key?: IDBValidKey; offset?: number; count?: number; reverse?: boolean },
     ) => {
         const db = await this.getDB();
 

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -6,6 +6,7 @@ import { fixLoadedCoinjoinAccount } from '@suite/coinjoin';
 import type { FlagsState } from '@suite/flags';
 import { lockDevice } from '@suite/locks';
 import {
+    type MetadataRootState,
     metadataActions,
     metadataLabelingActions,
     selectLabelingDataForAccount,
@@ -51,6 +52,7 @@ import {
 } from '@suite-common/redux-utils';
 import { createMigrateSuiteSyncLabelsForRbfTransactionCompositionRoot } from '@suite-common/suite-rbf-labels-migrations';
 import {
+    type SuiteSyncCompositionRootState,
     createSuiteSyncWriteLabels,
     selectAllLabelsForAccount,
     selectIsSuiteSyncEnabled,
@@ -101,7 +103,7 @@ const connectInitSettings: ConnectInitSettings = {
 };
 
 export type StoreAPIDep = {
-    getState: () => any;
+    getState: () => SuiteSyncCompositionRootState & MetadataRootState;
     dispatch: Dispatch;
 };
 

--- a/packages/suite/src/views/settings/SettingsGeneral/Tor.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Tor.tsx
@@ -15,7 +15,7 @@ import { useDispatch, useSelector } from 'src/hooks/suite';
 
 export const Tor = () => {
     const [hasTorError, setHasTorError] = useState(false);
-    const coinjoinAccounts = useSelector((state: any) => selectCoinjoinAccounts(state));
+    const coinjoinAccounts = useSelector(state => selectCoinjoinAccounts(state));
     const isCoinjoinAccount = coinjoinAccounts.length > 0;
     const torStatus = useSelector(state => state.tor.torStatus);
     const modalType = useSelector(selectModalType);

--- a/packages/transport-bluetooth/src/browser.ts
+++ b/packages/transport-bluetooth/src/browser.ts
@@ -22,8 +22,8 @@ const proxyState = () => {
 // create ipcProxy and wrap each bluetoothIpc method
 const getProxy = proxyState();
 typedObjectKeys(bluetoothIpc).forEach(key => {
-    (bluetoothIpc[key] as unknown) = (...args: any[]) =>
-        getProxy().then(p => (p[key] as any)(...args));
+    (bluetoothIpc[key] as unknown) = (...args: unknown[]) =>
+        getProxy().then(p => (p[key] as (...args: unknown[]) => unknown)(...args));
 });
 
 // export modified bluetoothIpc

--- a/packages/transport-bluetooth/src/client/trezor-bluetooth.ts
+++ b/packages/transport-bluetooth/src/client/trezor-bluetooth.ts
@@ -139,24 +139,24 @@ export class TrezorBluetooth extends WebsocketClient<NotificationEvent> {
     send(method: 'close_device', params: CloseDeviceParams): Promise<Success>;
     send(method: 'read', params: ReadParams): Promise<{ data: number[] }>;
     send(method: 'write', params: WriteParams): Promise<Success>;
-    public send(method: string, params?: any) {
+    public send(method: string, params?: unknown) {
         if (method === 'connect_device') {
-            return this.connectDevice(params);
+            return this.connectDevice(params as ConnectDeviceParams);
         }
 
         if (method === 'write') {
-            return this.write(params);
+            return this.write(params as WriteParams);
         }
 
         if (method === 'open_device') {
-            this.writeBuffer[params.id] = {
+            this.writeBuffer[(params as { id: string }).id] = {
                 bytes: 0,
                 lastWrite: 0,
             };
         }
 
         if (method === 'close_device') {
-            delete this.writeBuffer[params.id];
+            delete this.writeBuffer[(params as { id: string }).id];
         }
 
         return this.sendMessage({ method, params });

--- a/packages/transport-bluetooth/src/ui/app.tsx
+++ b/packages/transport-bluetooth/src/ui/app.tsx
@@ -39,6 +39,8 @@ button:disabled {
 #send_message_input { width: 100%; height: 80px; }
 `;
 
+const getErrorMessage = (e: unknown): string => (e instanceof Error ? e.message : String(e));
+
 const getPort = () => {
     // UI served from the server
     if (window.location.port) {
@@ -146,8 +148,8 @@ export const App = () => {
         try {
             const res = await api().send('start_scan');
             setDevices(res.devices);
-        } catch (e: any) {
-            writeOutput({ error: e.message });
+        } catch (e: unknown) {
+            writeOutput({ error: getErrorMessage(e) });
         }
     };
 
@@ -155,8 +157,8 @@ export const App = () => {
         try {
             const r = await api().send('stop_scan');
             writeOutput(r);
-        } catch (e: any) {
-            writeOutput({ error: e.message });
+        } catch (e: unknown) {
+            writeOutput({ error: getErrorMessage(e) });
         }
     };
 
@@ -164,8 +166,8 @@ export const App = () => {
         try {
             const r = await api().send('get_info');
             writeOutput(r);
-        } catch (e: any) {
-            writeOutput({ error: e.message });
+        } catch (e: unknown) {
+            writeOutput({ error: getErrorMessage(e) });
         }
     };
 
@@ -173,8 +175,8 @@ export const App = () => {
         try {
             const r = await api().send('enumerate');
             writeOutput(r);
-        } catch (e: any) {
-            writeOutput({ error: e.message });
+        } catch (e: unknown) {
+            writeOutput({ error: getErrorMessage(e) });
         }
     };
 
@@ -184,8 +186,8 @@ export const App = () => {
             const r = await api().send('connect_device', { id: idToUse, timeout: 10000 });
             writeOutput(r);
             setDeviceId(idToUse);
-        } catch (e: any) {
-            writeOutput({ error: e.message });
+        } catch (e: unknown) {
+            writeOutput({ error: getErrorMessage(e) });
         }
     };
 
@@ -194,8 +196,8 @@ export const App = () => {
         try {
             const r = await api().send('disconnect_device', { id: idToUse });
             writeOutput(r);
-        } catch (e: any) {
-            writeOutput({ error: e.message });
+        } catch (e: unknown) {
+            writeOutput({ error: getErrorMessage(e) });
         }
     };
 
@@ -203,8 +205,8 @@ export const App = () => {
         try {
             const r = await api().send('forget_device', { id: deviceId });
             writeOutput(r);
-        } catch (e: any) {
-            writeOutput({ error: e.message });
+        } catch (e: unknown) {
+            writeOutput({ error: getErrorMessage(e) });
         }
     };
 
@@ -215,8 +217,8 @@ export const App = () => {
                 characteristic: selectRef.current?.value || undefined,
             });
             writeOutput(r);
-        } catch (e: any) {
-            writeOutput({ error: e.message });
+        } catch (e: unknown) {
+            writeOutput({ error: getErrorMessage(e) });
         }
     };
 
@@ -227,8 +229,8 @@ export const App = () => {
                 characteristic: selectRef.current?.value || undefined,
             });
             writeOutput(r);
-        } catch (e: any) {
-            writeOutput({ error: e.message });
+        } catch (e: unknown) {
+            writeOutput({ error: getErrorMessage(e) });
         }
     };
 
@@ -238,8 +240,8 @@ export const App = () => {
             const data = MSG.concat(new Array(244 - MSG.length).fill(0));
             const r = await api().send('write', { id: deviceId, data });
             writeOutput(r);
-        } catch (e: any) {
-            writeOutput({ error: e.message });
+        } catch (e: unknown) {
+            writeOutput({ error: getErrorMessage(e) });
         }
     };
 
@@ -247,8 +249,8 @@ export const App = () => {
         try {
             const r = await api().send('read', { id: deviceId });
             writeOutput(r);
-        } catch (e: any) {
-            writeOutput({ error: e.message });
+        } catch (e: unknown) {
+            writeOutput({ error: getErrorMessage(e) });
         }
     };
 
@@ -258,8 +260,8 @@ export const App = () => {
             const state = { devices: value.map(d => ({ id: d, macAddress: d })) };
             const r = await api().send('set_state', state);
             writeOutput(r);
-        } catch (e: any) {
-            writeOutput({ error: e.message });
+        } catch (e: unknown) {
+            writeOutput({ error: getErrorMessage(e) });
         }
     };
 
@@ -270,8 +272,8 @@ export const App = () => {
             const json = JSON.parse(value);
             const resp = await api().sendMessage(json);
             writeOutput(resp);
-        } catch (e) {
-            writeOutput({ error: e.message });
+        } catch (e: unknown) {
+            writeOutput({ error: getErrorMessage(e) });
         }
     };
 
@@ -290,7 +292,9 @@ export const App = () => {
                                         setConnected(true);
                                         writeOutput('API connected');
                                     })
-                                    .catch((e: any) => writeOutput({ error: e.message }))
+                                    .catch((e: unknown) =>
+                                        writeOutput({ error: getErrorMessage(e) }),
+                                    )
                             }
                         >
                             Connect API `{connected ? '✅' : '❌'}

--- a/packages/transport-bridge/src/http.ts
+++ b/packages/transport-bridge/src/http.ts
@@ -24,8 +24,7 @@ import { type Log, Throttler, arrayPartition } from '@trezor/utils';
 
 import { createCore } from './core';
 
-const str = (value: Record<string, any> | string) =>
-    typeof value === 'string' ? value : JSON.stringify(value);
+const str = (value: unknown) => (typeof value === 'string' ? value : JSON.stringify(value));
 
 const validateDescriptorsJSON: RequestHandler<JSON, Descriptor[]> = (request, response, next) => {
     if (Array.isArray(request.body)) {

--- a/packages/transport-bridge/src/ui/App.tsx
+++ b/packages/transport-bridge/src/ui/App.tsx
@@ -8,7 +8,7 @@ import { IntlProvider } from './components/IntlProvider';
 import { useTheme } from './hooks/useTheme';
 import { GlobalStyle } from './styles/GlobalStyle';
 import { messages as cs } from './translations/cs';
-import { defaultMessages } from './translations/default';
+import { type Messages, defaultMessages } from './translations/default';
 
 type AppProps = {
     children: ReactNode;
@@ -21,7 +21,7 @@ const Wrapper = styled.div`
 
 export const App = ({ children }: AppProps) => {
     const themeVariant: 'light' | 'dark' = useTheme();
-    const messages: Record<string, any> = { default: defaultMessages, cs };
+    const messages: Record<string, Messages> = { default: defaultMessages, cs };
 
     const language = window.navigator.language.split('-')[0] ?? '';
     const navigatorLocaleIsSupported = Object.keys(messages).includes(language);

--- a/packages/transport-bridge/src/ui/components/Translation.tsx
+++ b/packages/transport-bridge/src/ui/components/Translation.tsx
@@ -1,7 +1,10 @@
+import { type ComponentProps } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import type { Messages } from '../translations/default';
 
-export const Translation = ({ id, values }: { id: keyof Messages; values?: any }) => (
+type TranslationValues = ComponentProps<typeof FormattedMessage>['values'];
+
+export const Translation = ({ id, values }: { id: keyof Messages; values?: TranslationValues }) => (
     <FormattedMessage id={id} tagName="span" values={values} />
 );

--- a/packages/transport-common/src/api/abstract.ts
+++ b/packages/transport-common/src/api/abstract.ts
@@ -213,8 +213,8 @@ export abstract class AbstractApi extends TypedEmitter<{
 }
 
 export type AbstractApiAwaitedResult<K extends keyof AbstractApi> = AbstractApi[K] extends (
-    ...args: any[]
-) => any
+    ...args: never[]
+) => unknown
     ? Awaited<ReturnType<AbstractApi[K]>>
     : never;
 

--- a/packages/transport-common/src/sessions/types.ts
+++ b/packages/transport-common/src/sessions/types.ts
@@ -102,9 +102,9 @@ export interface HandleMessageApi {
     dispose: () => BackgroundResponse<void>;
 }
 
-type UnwrapParams<T, Fn> = Fn extends () => any
+type UnwrapParams<T, Fn> = Fn extends () => unknown
     ? Params & { type: T }
-    : Fn extends (payload: infer P) => any
+    : Fn extends (payload: infer P) => unknown
       ? Params & { type: T; payload: P }
       : never;
 

--- a/packages/transport-common/src/transports/bridge.ts
+++ b/packages/transport-common/src/transports/bridge.ts
@@ -23,7 +23,7 @@ import type {
     MessageResponse,
     Session,
 } from '../types';
-import { bridgeApiCall } from '../utils/bridgeApiCall';
+import { type HttpRequestOptions, bridgeApiCall } from '../utils/bridgeApiCall';
 import * as bridgeApiResult from '../utils/bridgeApiResult';
 import { type BridgeProtocolMessage, createProtocolMessage } from '../utils/bridgeProtocolMessage';
 import { receiveAndParse } from '../utils/receive';
@@ -57,7 +57,7 @@ type R = Extract<
 
 type IncompleteRequestOptions = {
     params?: string;
-    body?: any;
+    body?: HttpRequestOptions['body'];
     timeout?: number;
     signal?: AbortController['signal'];
 };

--- a/packages/transport-common/src/utils/bridgeApiCall.ts
+++ b/packages/transport-common/src/utils/bridgeApiCall.ts
@@ -7,7 +7,7 @@ import { applyBridgeApiCallHeaders } from './applyBridgeApiCallHeaders';
 import { error, success, unknownError } from './result';
 
 export type HttpRequestOptions = {
-    body?: Array<any> | Record<string, unknown> | string;
+    body?: unknown[] | Record<string, unknown> | string;
     url: string;
     method: 'POST' | 'GET';
     skipContentTypeHeader?: boolean;

--- a/packages/transport-common/src/utils/bridgeApiResult.ts
+++ b/packages/transport-common/src/utils/bridgeApiResult.ts
@@ -43,21 +43,23 @@ export function devices(res: UnknownPayload) {
     }
 
     return success(
-        res.map(
-            (o: any): Descriptor => ({
-                path: o.path,
-                session: o.session,
-                sessionOwner: o.sessionOwner,
-                product: o.product,
-                type: o.type,
-                vendor: o.vendor,
-                debug: o.debug,
-                debugSession: o.debugSession,
-                id: o.id,
-                apiType: o.apiType || 'usb', // no other option is implemented at this moment
-                model: o.model,
-            }),
-        ),
+        res.map((o): Descriptor => {
+            const d = o as Record<string, unknown>;
+
+            return {
+                path: d.path,
+                session: d.session,
+                sessionOwner: d.sessionOwner,
+                product: d.product,
+                type: d.type,
+                vendor: d.vendor,
+                debug: d.debug,
+                debugSession: d.debugSession,
+                id: d.id,
+                apiType: d.apiType || 'usb', // no other option is implemented at this moment
+                model: d.model,
+            } as unknown as Descriptor;
+        }),
     );
 }
 

--- a/packages/transport-native-bluetooth/src/api/bluetoothManager.ts
+++ b/packages/transport-native-bluetooth/src/api/bluetoothManager.ts
@@ -57,14 +57,14 @@ const eventNames = {
 
 const DEBUG_LOGS = false;
 
-const debugLog = (...args: any[]) => {
+const debugLog = (...args: unknown[]) => {
     if (DEBUG_LOGS) {
         // eslint-disable-next-line no-console
         console.log('BluetoothManager', ...args);
     }
 };
 
-const errorLog = (...args: any[]) => {
+const errorLog = (...args: unknown[]) => {
     console.error('BluetoothManager', ...args);
 };
 
@@ -105,7 +105,7 @@ class BluetoothManager {
         listener: (event: DeviceBatteryLevelChangeEvent) => void,
     ): Subscription => this.subscribeTo(eventNames.deviceBatteryLevelChange, listener);
 
-    private subscribeTo = (eventName: keyof typeof eventNames, listener: (arg: any) => void) => {
+    private subscribeTo = <T>(eventName: keyof typeof eventNames, listener: (arg: T) => void) => {
         this.eventEmitter.on(eventName, listener);
 
         return {
@@ -268,9 +268,9 @@ class BluetoothManager {
 
             try {
                 device = await this.getBleManager().connectToDevice(deviceId, connectionOptions);
-            } catch (error: any) {
+            } catch (error: unknown) {
                 debugLog(`Connect error`, { error });
-                if (error.errorCode === BleErrorCode.DeviceMTUChangeFailed) {
+                if ((error as BleError).errorCode === BleErrorCode.DeviceMTUChangeFailed) {
                     // If the MTU change did not work, try connecting without requesting it.
                     device = await this.getBleManager().connectToDevice(deviceId);
                 } else {
@@ -288,9 +288,9 @@ class BluetoothManager {
             debugLog('Device found but not connected. Connecting...', connectionOptions);
             try {
                 await device.connect(connectionOptions);
-            } catch (error: any) {
+            } catch (error: unknown) {
                 debugLog(`Connect error`, { error });
-                if (error.errorCode === BleErrorCode.DeviceMTUChangeFailed) {
+                if ((error as BleError).errorCode === BleErrorCode.DeviceMTUChangeFailed) {
                     debugLog(`Device mtu=${device.mtu}, reconnecting`);
                     await device.connect();
                 } else {
@@ -313,20 +313,21 @@ class BluetoothManager {
         return device;
     };
 
-    private handleConnectionError = (deviceId: DeviceId, error: any) => {
+    private handleConnectionError = (deviceId: DeviceId, error: unknown) => {
         errorLog('Error connecting to device', error);
+        const e = error as Error & { iosErrorCode?: number; reason?: string | null };
         if (
-            error.iosErrorCode === 14 /* CBError.Code.peerRemovedPairingInformation */ ||
-            error.reason === 'Peer removed pairing information'
+            e.iosErrorCode === 14 /* CBError.Code.peerRemovedPairingInformation */ ||
+            e.reason === 'Peer removed pairing information'
         ) {
             this.updateDeviceConnectionStatusChange({
                 deviceId,
-                connectionStatus: { type: 'pairing-error', error: error.message },
+                connectionStatus: { type: 'pairing-error', error: e.message },
             });
         } else {
             this.updateDeviceConnectionStatusChange({
                 deviceId,
-                connectionStatus: { type: 'connection-error', error: error.message },
+                connectionStatus: { type: 'connection-error', error: e.message },
             });
         }
     };
@@ -376,7 +377,7 @@ class BluetoothManager {
 
         try {
             await this.attemptToWriteAfterConnect(device, writeCharacteristic);
-        } catch (error: any) {
+        } catch (error: unknown) {
             debugLog(`Device ${device.id} pairing canceled`);
             this.updateDeviceConnectionStatusChange({
                 deviceId: device.id,

--- a/packages/transport-web/src/sessions/background-browser.ts
+++ b/packages/transport-web/src/sessions/background-browser.ts
@@ -52,7 +52,7 @@ export class BrowserSessionsBackground implements SessionsBackgroundInterface {
 
     on(event: 'descriptors', listener: (descriptors: Descriptor[]) => void): void;
     on(event: 'releaseRequest', listener: (descriptor: Descriptor) => void): void;
-    on(event: 'descriptors' | 'releaseRequest', listener: (descriptors: any) => void): void {
+    on(event: 'descriptors' | 'releaseRequest', listener: (payload: never) => void): void {
         this.background.port.addEventListener(
             'message',
             (
@@ -65,7 +65,7 @@ export class BrowserSessionsBackground implements SessionsBackgroundInterface {
             ) => {
                 if (e && 'type' in e.data) {
                     if (e.data.type === event) {
-                        listener(e.data.payload);
+                        listener(e.data.payload as never);
                     }
                 }
             },

--- a/packages/transport-web/src/sessions/background-browser.ts
+++ b/packages/transport-web/src/sessions/background-browser.ts
@@ -31,7 +31,7 @@ export class BrowserSessionsBackground implements SessionsBackgroundInterface {
         const { background } = this;
 
         return new Promise(resolve => {
-            const onmessage = (message: MessageEvent<any>) => {
+            const onmessage = (message: MessageEvent<HandleMessageResponse<M>>) => {
                 if (params.id === message.data.id) {
                     resolve(message.data);
                     background.port.removeEventListener('message', onmessage);

--- a/packages/trezor-user-env-link/src/api.ts
+++ b/packages/trezor-user-env-link/src/api.ts
@@ -285,7 +285,7 @@ export class TrezorUserEnvLinkClass extends TypedEmitter<WebsocketClientEvents> 
 
         return null;
     }
-    async resetDevice(options: any) {
+    async resetDevice(options: Record<string, unknown>) {
         await resolveAfter(EMU_RACE_CONDITION_WORKAROUND_DELAY);
         await this.client.send({ type: 'emulator-reset-device', ...options });
 

--- a/packages/trezor-user-env-link/src/websocket-client.ts
+++ b/packages/trezor-user-env-link/src/websocket-client.ts
@@ -36,8 +36,14 @@ interface WebsocketResponse {
     response: any;
 }
 
+interface WebsocketClientOptions {
+    url?: string;
+    timeout?: number;
+    pingTimeout?: number;
+}
+
 export class WebsocketClient extends WebsocketClientBase<WebsocketClientEvents> {
-    constructor(options: any = {}) {
+    constructor(options: WebsocketClientOptions = {}) {
         super({
             ...options,
             url: options.url || USER_ENV_URL.WEBSOCKET,

--- a/packages/type-utils/src/object.ts
+++ b/packages/type-utils/src/object.ts
@@ -40,7 +40,7 @@ export type RequireAtLeastOne<T, K extends keyof T = keyof T> = {
 }[K] &
     Omit<T, K>;
 
-export type NarrowObjectWithKey<T, K extends PropertyKey> = T extends any
+export type NarrowObjectWithKey<T, K extends PropertyKey> = T extends unknown
     ? K extends keyof T
         ? T
         : never

--- a/packages/type-utils/src/object.ts
+++ b/packages/type-utils/src/object.ts
@@ -46,10 +46,10 @@ export type NarrowObjectWithKey<T, K extends PropertyKey> = T extends unknown
         : never
     : never;
 
-export type NullablePropsRecursive<T extends Record<string, any>> = {
+export type NullablePropsRecursive<T extends object> = {
     [K in keyof T]: T[K] extends (...args: any[]) => any
         ? T[K] | null
-        : T[K] extends Record<string, any>
+        : T[K] extends object
           ? NullablePropsRecursive<T[K]> | null
           : T[K] | null;
 };

--- a/packages/type-utils/src/result.ts
+++ b/packages/type-utils/src/result.ts
@@ -15,8 +15,8 @@ export interface Err<out E> {
 
 export type Result<T, E = never> = Ok<T> | Err<E>;
 
-export type InferOk<R extends Result<any, any>> = R extends Ok<infer T> ? T : never;
-export type InferErr<R extends Result<any, any>> = R extends Err<infer E> ? E : never;
+export type InferOk<R extends Result<unknown, unknown>> = R extends Ok<infer T> ? T : never;
+export type InferErr<R extends Result<unknown, unknown>> = R extends Err<infer E> ? E : never;
 
 export function ok(): Result<void>;
 export function ok<T>(payload: T): Result<T>;

--- a/packages/type-utils/src/utils.ts
+++ b/packages/type-utils/src/utils.ts
@@ -101,7 +101,7 @@ export type ConstWithOptionalFields<
  *  const p: P = { b: { d: 1 } }; // As everything is deeply optional
  *  ```
  */
-export type DeepPartial<T> = T extends () => any
+export type DeepPartial<T> = T extends () => unknown
     ? T
     : T extends { [key: string]: any }
       ? { [P in keyof T]?: DeepPartial<T[P]> }

--- a/packages/type-utils/src/utils.ts
+++ b/packages/type-utils/src/utils.ts
@@ -15,7 +15,7 @@
  *  type T = UnionToIntersection<A | B>; // A & B
  *  ```
  */
-export type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
+export type UnionToIntersection<U> = (U extends unknown ? (k: U) => void : never) extends (
     k: infer I,
 ) => void
     ? I
@@ -68,7 +68,7 @@ export type ObjectValues<T extends { [key: string]: any }> = T[keyof T];
  *  const w: W = { keep1: 1, keep2: true };
  *  ```
  */
-export type Without<T, K extends keyof T> = T extends any ? Omit<T, K> : never;
+export type Without<T, K extends keyof T> = T extends unknown ? Omit<T, K> : never;
 
 /**
  * Const with optional types.

--- a/packages/type-utils/src/utils.ts
+++ b/packages/type-utils/src/utils.ts
@@ -54,7 +54,7 @@ export type OptionalKey<M, K extends keyof M> = Omit<M, K> & Partial<Pick<M, K>>
  *  type V: ObjectValues<T>; // number | string
  *  ```
  */
-export type ObjectValues<T extends { [key: string]: any }> = T[keyof T];
+export type ObjectValues<T extends object> = T[keyof T];
 
 /**
  * Distributes the Omit across a union. using distributive conditional types to achieve this:
@@ -80,11 +80,7 @@ export type ConstWithOptionalFields<
     Fields extends string | number | symbol,
 > = {
     [Key in keyof Const]: {
-        [FieldKey in Fields]: Const[Key][FieldKey] extends
-            | string
-            | number
-            | { [key: string]: any }
-            | boolean
+        [FieldKey in Fields]: Const[Key][FieldKey] extends string | number | object | boolean
             ? Const[Key][FieldKey]
             : undefined;
     };
@@ -103,7 +99,7 @@ export type ConstWithOptionalFields<
  */
 export type DeepPartial<T> = T extends () => unknown
     ? T
-    : T extends { [key: string]: any }
+    : T extends object
       ? { [P in keyof T]?: DeepPartial<T[P]> }
       : T;
 

--- a/packages/utils/src/arrayPartition.ts
+++ b/packages/utils/src/arrayPartition.ts
@@ -1,17 +1,18 @@
-type ArrayPartition = {
-    <T, S extends T>(array: T[], condition: (elem: T) => elem is S): [S[], Exclude<T, S>[]];
-    <T>(array: T[], condition: (elem: T) => boolean): [T[], T[]];
-};
-
 /**
  *
  * @param array Array to be divided into two parts.
  * @param condition Condition for inclusion in the first part.
  * @returns Array of two arrays - the items in the first array satisfy the condition and the rest is in the second array. Preserving original order.
  */
-export const arrayPartition: ArrayPartition = <T>(array: T[], condition: (elem: T) => boolean) =>
-    array.reduce<[T[], T[]]>(
+export function arrayPartition<T, S extends T>(
+    array: T[],
+    condition: (elem: T) => elem is S,
+): [S[], Exclude<T, S>[]];
+export function arrayPartition<T>(array: T[], condition: (elem: T) => boolean): [T[], T[]];
+export function arrayPartition<T>(array: T[], condition: (elem: T) => boolean): [T[], T[]] {
+    return array.reduce<[T[], T[]]>(
         ([pass, fail], elem) =>
             condition(elem) ? [[...pass, elem], fail] : [pass, [...fail, elem]],
         [[], []],
-    ) as any;
+    );
+}

--- a/packages/utils/src/cache.ts
+++ b/packages/utils/src/cache.ts
@@ -1,18 +1,18 @@
 /**
  * Cache class which allows to store Key-Value pairs with a TTL for each key
  */
-export class Cache {
-    store: Map<string, { value: any; ttl: number }>;
+export class Cache<T = unknown> {
+    store: Map<string, { value: T; ttl: number }>;
 
     constructor() {
         this.store = new Map();
     }
 
-    set(key: string, value: any, ttl: number) {
+    set(key: string, value: T, ttl: number) {
         this.store.set(key, { value, ttl: Date.now() + ttl });
     }
 
-    get(key: string) {
+    get(key: string): T | undefined {
         const entry = this.store.get(key);
         if (!entry) return;
         if (entry.ttl < Date.now()) {

--- a/packages/utils/src/createLazy.ts
+++ b/packages/utils/src/createLazy.ts
@@ -1,6 +1,6 @@
 import { type Deferred, createDeferred } from './createDeferred';
 
-export const createLazy = <T, TArgs extends Array<any>>(
+export const createLazy = <T, TArgs extends readonly unknown[]>(
     initLazy: (...args: TArgs) => Promise<T>,
     disposeLazy?: (t: T) => void,
 ) => {

--- a/packages/utils/src/logs.ts
+++ b/packages/utils/src/logs.ts
@@ -1,7 +1,7 @@
 export type LogMessage = {
     level: string;
     prefix: string;
-    message: any[];
+    message: unknown[];
     timestamp: number;
 };
 
@@ -45,7 +45,7 @@ export class Log implements Logger {
 
     addMessage(
         { level, prefix, timestamp }: { level: string; prefix: string; timestamp?: number },
-        ...args: any[]
+        ...args: unknown[]
     ) {
         const message = {
             level,
@@ -71,11 +71,11 @@ export class Log implements Logger {
         }
     }
 
-    setWriter(logWriter: any) {
+    setWriter(logWriter: LogWriter) {
         this.logWriter = logWriter;
     }
 
-    log(...args: any[]) {
+    log(...args: unknown[]) {
         this.addMessage({ level: 'log', prefix: this.prefix }, ...args);
         if (this.enabled) {
             // eslint-disable-next-line no-console
@@ -83,14 +83,14 @@ export class Log implements Logger {
         }
     }
 
-    error(...args: any[]) {
+    error(...args: unknown[]) {
         this.addMessage({ level: 'error', prefix: this.prefix }, ...args);
         if (this.enabled) {
             console.error(`%c${this.prefix}`, this.css, ...args);
         }
     }
 
-    info(...args: any[]) {
+    info(...args: unknown[]) {
         this.addMessage({ level: 'info', prefix: this.prefix }, ...args);
         if (this.enabled) {
             // eslint-disable-next-line no-console
@@ -98,14 +98,14 @@ export class Log implements Logger {
         }
     }
 
-    warn(...args: any[]) {
+    warn(...args: unknown[]) {
         this.addMessage({ level: 'warn', prefix: this.prefix }, ...args);
         if (this.enabled) {
             console.warn(`%c${this.prefix}`, this.css, ...args);
         }
     }
 
-    debug(...args: any[]) {
+    debug(...args: unknown[]) {
         this.addMessage({ level: 'debug', prefix: this.prefix }, ...args);
         if (this.enabled) {
             if (this.css) {

--- a/packages/utils/src/promiseAllSequence.ts
+++ b/packages/utils/src/promiseAllSequence.ts
@@ -5,13 +5,8 @@
  * @returns Array of results from actions
  */
 
-export const promiseAllSequence = async <
-    Fn extends () => PromiseLike<any>,
-    R = Awaited<ReturnType<Fn>>,
->(
-    actions: Fn[],
-) => {
-    const results: R[] = [];
+export const promiseAllSequence = async <T>(actions: Array<() => PromiseLike<T>>): Promise<T[]> => {
+    const results: T[] = [];
     // For some reason, the previous implementation with promise chaining
     // (https://github.com/trezor/trezor-suite/blob/100015c45451ed50e2b0906d78de73c0fd2883d1/packages/utils/src/promiseAllSequence.ts)
     // was significantly slower in some cases, therefore simple for cycle is used instead

--- a/packages/utils/src/typedEventEmitter.ts
+++ b/packages/utils/src/typedEventEmitter.ts
@@ -19,7 +19,7 @@ type IsUnion<T, U extends T = T> = T extends unknown ? ([U] extends [T] ? 0 : 1)
 type EventReceiver<T> =
     IsUnion<T> extends 1
         ? (event: T) => void // 1. use union payload
-        : T extends (...args: any[]) => any
+        : T extends (...args: never[]) => unknown
           ? T // 2. use custom callback
           : T extends undefined
             ? () => void // 3. enforce empty params

--- a/packages/utxo-lib/src/payments/lazy.ts
+++ b/packages/utxo-lib/src/payments/lazy.ts
@@ -1,6 +1,6 @@
 // upstream: https://github.com/bitcoinjs/bitcoinjs-lib/blob/master/ts_src/payments/lazy.ts
 
-export function prop(object: Record<string, any>, name: string, f: () => any) {
+export function prop(object: object, name: string, f: () => unknown) {
     Object.defineProperty(object, name, {
         configurable: true,
         enumerable: true,

--- a/packages/utxo-lib/src/transaction/zcash.ts
+++ b/packages/utxo-lib/src/transaction/zcash.ts
@@ -5,7 +5,14 @@ import { blake2b } from '@noble/hashes/blake2.js';
 import * as varuint from 'varuint-bitcoin';
 
 import { BufferReader, BufferWriter, varIntSize } from '../bufferutils';
-import { EMPTY_SCRIPT, TransactionBase, type TransactionOptions, varSliceSize } from './base';
+import {
+    EMPTY_SCRIPT,
+    TransactionBase,
+    type TransactionOptions,
+    type TxInput,
+    type TxOutput,
+    varSliceSize,
+} from './base';
 import { hash256 } from '../crypto';
 
 const ZCASH_JOINSPLITS_SUPPORT_VERSION = 2;
@@ -331,7 +338,7 @@ function getHeaderDigest(tx: TransactionBase<ZcashSpecific>) {
 }
 
 // https://zips.z.cash/zip-0244#t-2a-prevouts-digest
-function getPrevoutsDigest(ins: any[]) {
+function getPrevoutsDigest(ins: TxInput[]) {
     const bufferWriter = new BufferWriter(Buffer.allocUnsafe(36 * ins.length));
     ins.forEach(txIn => {
         bufferWriter.writeSlice(txIn.hash);
@@ -342,7 +349,7 @@ function getPrevoutsDigest(ins: any[]) {
 }
 
 // https://zips.z.cash/zip-0244#t-2b-sequence-digest
-function getSequenceDigest(ins: any[]) {
+function getSequenceDigest(ins: TxInput[]) {
     const bufferWriter = new BufferWriter(Buffer.allocUnsafe(4 * ins.length));
     ins.forEach(txIn => {
         bufferWriter.writeUInt32(txIn.sequence);
@@ -352,7 +359,7 @@ function getSequenceDigest(ins: any[]) {
 }
 
 // https://zips.z.cash/zip-0244#t-2c-outputs-digest
-function getOutputsDigest(outs: any[]) {
+function getOutputsDigest(outs: TxOutput[]) {
     const txOutsSize = outs.reduce((sum, output) => sum + 8 + varSliceSize(output.script), 0);
     const bufferWriter = new BufferWriter(Buffer.allocUnsafe(txOutsSize));
     outs.forEach(out => {

--- a/packages/utxo-lib/src/txWeightCalculator.ts
+++ b/packages/utxo-lib/src/txWeightCalculator.ts
@@ -54,12 +54,12 @@ type Input = {
     script_type: string;
     multisig?: {
         // protobuf.MultisigRedeemScriptType
-        nodes?: any[];
-        pubkeys: any[];
+        nodes?: unknown[];
+        pubkeys: unknown[];
         m: number;
     };
     witness?: Buffer[];
-    ownership_proof?: any;
+    ownership_proof?: unknown;
 };
 
 export class TxWeightCalculator {

--- a/packages/websocket-client/src/ws.browser.ts
+++ b/packages/websocket-client/src/ws.browser.ts
@@ -50,7 +50,7 @@ class WSWrapper extends EventEmitter {
         }
     }
 
-    send(message: string | ArrayBufferLike | Blob | ArrayBufferView) {
+    send(message: Parameters<WebSocket['send']>[0]) {
         if (this.readyState !== WSWrapper.OPEN) {
             throw new WebsocketError(`Connection is not open. state: ${this.readyState}`);
         }

--- a/packages/websocket-client/src/ws.browser.ts
+++ b/packages/websocket-client/src/ws.browser.ts
@@ -13,7 +13,7 @@ class WSWrapper extends EventEmitter {
     static CLOSING = 2;
     static CLOSED = 3;
 
-    constructor(url: string, _protocols: any, _websocketOptions: any) {
+    constructor(url: string, _protocols: unknown, _websocketOptions: unknown) {
         super();
 
         this._ws = new WebSocket(url);
@@ -50,7 +50,7 @@ class WSWrapper extends EventEmitter {
         }
     }
 
-    send(message: any) {
+    send(message: string | ArrayBufferLike | Blob | ArrayBufferView) {
         if (this.readyState !== WSWrapper.OPEN) {
             throw new WebsocketError(`Connection is not open. state: ${this.readyState}`);
         }

--- a/packages/websocket-client/src/ws.native.ts
+++ b/packages/websocket-client/src/ws.native.ts
@@ -56,7 +56,7 @@ class WSWrapper extends EventEmitter {
         }
     }
 
-    send(message: string | ArrayBufferLike | Blob | ArrayBufferView) {
+    send(message: Parameters<WebSocket['send']>[0]) {
         if (this.readyState !== WSWrapper.OPEN) {
             throw new WebsocketError(`Connection is not open. state: ${this.readyState}`);
         }

--- a/packages/websocket-client/src/ws.native.ts
+++ b/packages/websocket-client/src/ws.native.ts
@@ -13,7 +13,7 @@ class WSWrapper extends EventEmitter {
     static CLOSING = 2;
     static CLOSED = 3;
 
-    constructor(url: string, _protocols: any, _websocketOptions: any) {
+    constructor(url: string, _protocols: unknown, _websocketOptions: unknown) {
         super();
 
         // React Native WebSocket is able to accept headers compared to the native browser `WebSocket`.
@@ -56,7 +56,7 @@ class WSWrapper extends EventEmitter {
         }
     }
 
-    send(message: any) {
+    send(message: string | ArrayBufferLike | Blob | ArrayBufferView) {
         if (this.readyState !== WSWrapper.OPEN) {
             throw new WebsocketError(`Connection is not open. state: ${this.readyState}`);
         }

--- a/suite-common/analytics/src/eventDefinition.ts
+++ b/suite-common/analytics/src/eventDefinition.ts
@@ -23,7 +23,7 @@ type Domain = string;
 type EventName = `${Domain}/${string}` | `${string}`;
 
 type HasKeys<T> = keyof T extends never ? false : true;
-type IsAttributeMap<T> = T extends Record<string, AttributeDef<any>> ? true : false;
+type IsAttributeMap<T> = T extends Record<string, AttributeDef<unknown>> ? true : false;
 
 type AttributePayload<T> = NonNullable<T> extends AttributeDef<infer V> ? V : never;
 

--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -279,7 +279,11 @@ export const connectPopupCallThunkInner = createThunk<
 export const connectPopupCallThunk = <M extends CallMethodKeys>(
     params: ConnectPopupCallThunkParams<M>,
 ): AsyncThunkAction<void, ConnectPopupCallThunkParams<M>, CustomThunkAPI> =>
-    connectPopupCallThunkInner(params) as any;
+    connectPopupCallThunkInner(params) as AsyncThunkAction<
+        void,
+        ConnectPopupCallThunkParams<M>,
+        CustomThunkAPI
+    >;
 
 export const connectPopupDeeplinkThunk = createThunk<void, { url: string }>(
     `${CONNECT_POPUP_MODULE}/deeplinkThunk`,

--- a/suite-common/connect-popup/src/methodHooks/bitcoinSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/bitcoinSignTransaction.ts
@@ -24,7 +24,7 @@ const preCallHook = async <M extends CallMethodKeys>({
 }: PreCallHookParams<M>) => {
     try {
         if (method === 'signTransaction' && txSigningPrecomposed) {
-            const typedPayload = payload as any as SignTransaction;
+            const typedPayload = payload as unknown as SignTransaction;
             const network = getNetwork(typedPayload.coin as NetworkSymbol);
             if (!network) {
                 throw new Error(`Network not supported`);

--- a/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
@@ -11,6 +11,7 @@ import type {
     CallMethodKeys,
     EthereumSignTransaction,
     EthereumSignTypedData,
+    EthereumSignTypedDataTypes,
     MethodInfo,
 } from '@trezor/connect';
 import { getSerializedPath, validatePath } from '@trezor/connect-common';
@@ -67,7 +68,7 @@ const preCallHook = async <M extends CallMethodKeys>({
         let path: Bip43Path;
         let chainId = 1;
         if (method === 'ethereumSignTransaction') {
-            const typedPayload = payload as any as EthereumSignTransaction;
+            const typedPayload = payload as unknown as EthereumSignTransaction;
             path = getSerializedPath(validatePath(typedPayload.path)) as Bip43Path;
             chainId = typedPayload.transaction.chainId || 1;
 
@@ -75,7 +76,8 @@ const preCallHook = async <M extends CallMethodKeys>({
                 dispatch(_storePrecomposedTransaction({ typedPayload, txSigningPrecomposed }));
             }
         } else if (method === 'ethereumSignTypedData') {
-            const typedPayload = payload as any as EthereumSignTypedData<any>;
+            const typedPayload =
+                payload as unknown as EthereumSignTypedData<EthereumSignTypedDataTypes>;
             path = getSerializedPath(validatePath(typedPayload.path)) as Bip43Path;
             chainId = Number(typedPayload.data.domain.chainId) || 1;
         } else {
@@ -114,7 +116,7 @@ const preCallHook = async <M extends CallMethodKeys>({
             const device = selectSelectedDevice(getState());
             if (!device) throw new Error('No device selected');
             const accountAddress = await TrezorConnect.ethereumGetAddress({
-                path: (payload as any).path,
+                path: (payload as unknown as { path: string | number[] }).path,
                 device: {
                     path: device.path,
                     instance: device.instance,
@@ -135,7 +137,7 @@ const preCallHook = async <M extends CallMethodKeys>({
         // Modify payload to include selected fee, if present
         if (method === 'ethereumSignTransaction' && source.type === 'walletconnect') {
             const currentPopupCall = selectConnectPopupCall(getState());
-            const typedPayload = payload as any as EthereumSignTransaction;
+            const typedPayload = payload as unknown as EthereumSignTransaction;
             if (
                 (currentPopupCall?.state === 'ongoing' ||
                     currentPopupCall?.state === 'tx-simulation') &&
@@ -158,11 +160,11 @@ const preCallHook = async <M extends CallMethodKeys>({
                 if (!methodInfo.success) {
                     throw methodInfo.error;
                 }
-                txSigningPrecomposed = (methodInfo.payload as any as MethodInfo).precomposed;
+                txSigningPrecomposed = (methodInfo.payload as unknown as MethodInfo).precomposed;
                 if (txSigningPrecomposed)
                     dispatch(_storePrecomposedTransaction({ typedPayload, txSigningPrecomposed }));
 
-                return modifiedPayload as any as typeof payload;
+                return modifiedPayload as unknown as typeof payload;
             }
         }
     } catch (error) {

--- a/suite-common/connect-popup/src/methodHooks/solanaSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/solanaSignTransaction.ts
@@ -24,7 +24,7 @@ const preCallHook = async <M extends CallMethodKeys>({
 }: PreCallHookParams<M>) => {
     try {
         if (method === 'solanaSignTransaction' && txSigningPrecomposed) {
-            const typedPayload = payload as any as SolanaSignTransaction;
+            const typedPayload = payload as unknown as SolanaSignTransaction;
             const path = getSerializedPath(validatePath(typedPayload.path)) as Bip43Path;
             const network = getNetwork(typedPayload.additionalInfo?.isDevnet ? 'dsol' : 'sol');
             // Try to find matching account

--- a/suite-common/connect-popup/src/methodHooks/types.ts
+++ b/suite-common/connect-popup/src/methodHooks/types.ts
@@ -1,5 +1,7 @@
 import { type Dispatch } from '@reduxjs/toolkit/react';
 
+import { type DeviceRootState } from '@suite-common/device';
+import { type AccountsRootState } from '@suite-common/wallet-core';
 import { type PrecomposedTransactionFinal } from '@suite-common/wallet-types';
 import {
     type CallMethodKeys,
@@ -9,13 +11,14 @@ import {
 import { type SerializedError } from '@trezor/connect-common/src/constants/errors';
 import { type Err, type Ok } from '@trezor/type-utils';
 
+import { type ConnectPopupStateRootState } from '../connectPopupReducer';
 import { type ConnectCallSource } from '../connectPopupTypes';
 
 export type PreCallHookParams<M extends CallMethodKeys> = {
     method: M;
     payload: Omit<CallMethodParams<M>, 'method'>;
     dispatch: Dispatch;
-    getState: () => any;
+    getState: () => AccountsRootState & DeviceRootState & ConnectPopupStateRootState;
     txSigningPrecomposed?: PrecomposedTransactionFinal;
     source: ConnectCallSource;
 };

--- a/suite-common/delegated-identity-key/src/getProofOfDelegatedIdentity.ts
+++ b/suite-common/delegated-identity-key/src/getProofOfDelegatedIdentity.ts
@@ -6,7 +6,7 @@ import { type ProofOfDelegatedIdentity, asProofOfDelegatedIdentity } from '@trez
 import { type Result, err, ok } from '@trezor/type-utils';
 import { bufferUtils } from '@trezor/utils';
 
-export const ProofOfDelegatedSignFailed = (caused: any): ProofOfDelegatedSignFailedType => ({
+export const ProofOfDelegatedSignFailed = (caused: unknown): ProofOfDelegatedSignFailedType => ({
     type: 'ProofOfDelegatedSignFailed',
     caused,
 });

--- a/suite-common/fiat-services/src/cache.ts
+++ b/suite-common/fiat-services/src/cache.ts
@@ -3,16 +3,16 @@ import { type Deferred, createDeferred } from '@trezor/utils';
 // Cache for parallel requests
 // It's used to prevent multiple requests for the same data
 export class ParallelRequestsCache {
-    private promises: Record<string, Deferred<any>> = {};
+    private promises: Record<string, Deferred<unknown>> = {};
 
     async cache<T>(keys: (string | number | undefined)[], fn: () => Promise<T>): Promise<T> {
         const key = keys.join('-');
         if (this.promises[key]) {
             // Cache hit
-            return this.promises[key].promise;
+            return this.promises[key].promise as Promise<T>;
         }
 
-        this.promises[key] = createDeferred();
+        this.promises[key] = createDeferred<unknown>();
         try {
             const res = await fn();
             this.promises[key].resolve(res);

--- a/suite-common/logger/src/types.ts
+++ b/suite-common/logger/src/types.ts
@@ -1,1 +1,1 @@
-export type LogEntry = { datetime: string; type: any; payload?: Record<any, any> };
+export type LogEntry = { datetime: string; type: string; payload?: Record<any, any> };

--- a/suite-common/logger/src/utils.ts
+++ b/suite-common/logger/src/utils.ts
@@ -24,7 +24,7 @@ export const REDACTED_REPLACEMENT = '[redacted]';
 
 export const startTime = new Date().toUTCString();
 
-export const prettifyLog = (json: Record<any, any>) => JSON.stringify(json, null, 2);
+export const prettifyLog = (json: unknown) => JSON.stringify(json, null, 2);
 
 // [typescript-performace]: Keep this explicit type to prevent TypeScript from expanding the
 // inferred type in the emitted declaration.

--- a/suite-common/message-system/src/messageSystemUtils.ts
+++ b/suite-common/message-system/src/messageSystemUtils.ts
@@ -122,11 +122,10 @@ export const areSettingsCompatible = (
     settingsCondition: Settings[],
     currentSettings: CurrentSettings,
 ): boolean => {
-    const settings: {
-        [key: string]: any;
-    } = currentSettings.enabledNetworks.reduce((o, key) => Object.assign(o, { [key]: true }), {
-        tor: currentSettings.tor,
-    });
+    const settings: Record<string, boolean> = currentSettings.enabledNetworks.reduce(
+        (o, key) => Object.assign(o, { [key]: true }),
+        { tor: currentSettings.tor },
+    );
 
     return settingsCondition.some(settingCondition =>
         Object.entries(settingCondition).every(

--- a/suite-common/metadata-types/src/metadataTypes.ts
+++ b/suite-common/metadata-types/src/metadataTypes.ts
@@ -177,10 +177,10 @@ export abstract class AbstractMetadataProvider {
         }
     }
 
-    private runApiRequest<T extends () => ReturnType<R>, R extends (...args: any) => Result<any>>(
-        fn: T,
-        options: { retries: number; delay: number },
-    ) {
+    private runApiRequest<
+        T extends () => ReturnType<R>,
+        R extends (...args: any[]) => Result<unknown>,
+    >(fn: T, options: { retries: number; delay: number }) {
         let retried = 0;
 
         return new Promise<Awaited<ReturnType<R>>>(resolve => {
@@ -218,10 +218,10 @@ export abstract class AbstractMetadataProvider {
         });
     }
 
-    scheduleApiRequest<T extends () => ReturnType<R>, R extends (...args: any) => Result<any>>(
-        fn: T,
-        options: { retries: number; delay: number } = { retries: 3, delay: 1000 },
-    ) {
+    scheduleApiRequest<
+        T extends () => ReturnType<R>,
+        R extends (...args: any[]) => Result<unknown>,
+    >(fn: T, options: { retries: number; delay: number } = { retries: 3, delay: 1000 }) {
         const request = this.apiRequestQueue.then(() => this.runApiRequest<T, R>(fn, options));
         this.apiRequestQueue = request;
 

--- a/suite-common/redux-utils/src/createSingleInstanceThunk.ts
+++ b/suite-common/redux-utils/src/createSingleInstanceThunk.ts
@@ -10,8 +10,8 @@ import { type CustomThunkAPI } from './extraDependenciesType'; // Adjust the imp
  * @description This function will ensure that there is only one ongoing promise for a given function with given arguments.
  * If there is an ongoing promise, it will return the same promise.
  */
-function ensureSingleRunningInstance<T extends (...args: any[]) => Promise<any>>(func: T): T {
-    const ongoingPromises = new Map<string, Promise<any>>();
+function ensureSingleRunningInstance<T extends (...args: any[]) => Promise<unknown>>(func: T): T {
+    const ongoingPromises = new Map<string, Promise<unknown>>();
 
     return function (this: any, ...args: Parameters<T>): ReturnType<T> {
         // It's fine to hardcode first argument as key, because thunks has only one argument (second argument is thunkAPI which is not important for this case)

--- a/suite-common/redux-utils/src/extraDependenciesType.ts
+++ b/suite-common/redux-utils/src/extraDependenciesType.ts
@@ -75,6 +75,11 @@ export type CreateTransports = (transports: TransportName[]) => ConnectSettings[
 
 export type TransportsDep = { createTransports: CreateTransports };
 
+export type DebugSettings = {
+    transports?: ConnectSettings['transports'];
+    showConnectLogs?: boolean;
+};
+
 export type CommonServices = SuiteSyncDep &
     AddressValidatorDep &
     GetNetworkConfigDep &
@@ -114,9 +119,7 @@ export type ExtraDependenciesStatic = {
         // TODO when tokens are implemented 1:1 in both apps, delete from extras
         // wallet-core selector is used in desktop, but suite-native has its own implementation
         selectTokenDefinitionsEnabledNetworks: SuiteCompatibleSelector<NetworkSymbol[]>;
-        // todo: we do not want to, so far, transfer coinjoin to @suite-common
-        // but this is exactly what I need to get DebugModeOptions type instead of any
-        selectDebugSettings: SuiteCompatibleSelector<any>;
+        selectDebugSettings: SuiteCompatibleSelector<DebugSettings>;
         selectDesktopBinDir: SuiteCompatibleSelector<string | undefined>;
         selectLanguage: SuiteCompatibleSelector<string>;
         selectIsWindowVisible: SuiteCompatibleSelector<boolean>;

--- a/suite-common/redux-utils/src/types.ts
+++ b/suite-common/redux-utils/src/types.ts
@@ -28,7 +28,7 @@ interface HasMatchFunction<T> {
     match: TypeGuard<T>;
 }
 type Matcher<T> = HasMatchFunction<T> | TypeGuard<T>;
-type ActionFromMatcher<M extends Matcher<any>> = M extends Matcher<infer T> ? T : never;
+type ActionFromMatcher<M extends Matcher<unknown>> = M extends Matcher<infer T> ? T : never;
 
 type AnyAsyncThunk = {
     pending: {

--- a/suite-common/redux-utils/src/types.ts
+++ b/suite-common/redux-utils/src/types.ts
@@ -22,7 +22,7 @@ export type SuiteCompatibleSelector<TReturn> = (state: any) => TReturn;
 export type ActionType = string;
 
 interface TypeGuard<T> {
-    (value: any): value is T;
+    (value: unknown): value is T;
 }
 interface HasMatchFunction<T> {
     match: TypeGuard<T>;

--- a/suite-common/staking/src/ethereumStaking.ts
+++ b/suite-common/staking/src/ethereumStaking.ts
@@ -526,8 +526,15 @@ export const getStakeFormsDefaultValues = ({
     selectedUtxos: [],
 });
 
+export type TransformTxInput = {
+    to: string;
+    value: string;
+    gasLimit: string | number;
+    data: string;
+};
+
 export const transformTx = (
-    tx: any,
+    tx: TransformTxInput,
     nonce: string,
     chainId: number,
     gasPrice?: string,

--- a/suite-common/staking/src/ethereumStaking.ts
+++ b/suite-common/staking/src/ethereumStaking.ts
@@ -549,7 +549,7 @@ export const transformTx = (
         value: fromWei(tx.value).toWei('hex'),
         chainId,
         nonce: fromIntegerString(nonce).toHex(),
-        gasLimit: fromIntegerString(tx.gasLimit).toHex(),
+        gasLimit: fromIntegerString(String(tx.gasLimit)).toHex(),
         data: sanitizeHex(tx.data),
     };
 

--- a/suite-common/suite-sync-storage/src/SuiteSyncTable.ts
+++ b/suite-common/suite-sync-storage/src/SuiteSyncTable.ts
@@ -4,9 +4,9 @@ export type EntityListener<T extends object> = {
     onChange: (payload: T[]) => void;
 };
 
-export type SuiteSyncUpdateError = { type: 'SuiteSyncUpdateError'; caused: any };
+export type SuiteSyncUpdateError = { type: 'SuiteSyncUpdateError'; caused: unknown };
 
-export const createSuiteSyncUpdateError = (caused: any): SuiteSyncUpdateError => ({
+export const createSuiteSyncUpdateError = (caused: unknown): SuiteSyncUpdateError => ({
     type: 'SuiteSyncUpdateError',
     caused,
 });

--- a/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
+++ b/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
@@ -75,12 +75,14 @@ export type SuiteSyncAnalyticsDep = {
     analytics?: SuiteSyncAnalytics;
 };
 
+export type SuiteSyncCompositionRootState = WithSuiteSyncAndDeviceState &
+    WithSuiteSyncQuotaManagerState &
+    MessageSystemRootState &
+    AccountsRootState &
+    SuiteSyncDataRootState;
+
 type CreateSuiteSyncCompositionRootDeps = {
-    getState: () => WithSuiteSyncAndDeviceState &
-        WithSuiteSyncQuotaManagerState &
-        MessageSystemRootState &
-        AccountsRootState &
-        SuiteSyncDataRootState;
+    getState: () => SuiteSyncCompositionRootState;
     dispatch: Dispatch;
     subscribeError: SubscribeSuiteSyncInternalErrorHandler;
     trezorConnect: Pick<typeof TrezorConnect, 'evoluGetNode' | 'evoluSignRegistrationRequest'>;

--- a/suite-common/suite-sync/src/index.ts
+++ b/suite-common/suite-sync/src/index.ts
@@ -22,7 +22,11 @@ export {
 export type { WithSuiteSyncAndDeviceState } from './suiteSyncSelectors';
 export type { SuiteSyncInteraction } from './suiteSyncTypes';
 export { createSuiteSyncCompositionRoot } from './createSuiteSyncCompositionRoot';
-export type { SuiteSyncAnalytics, SuiteSyncAnalyticsDep } from './createSuiteSyncCompositionRoot';
+export type {
+    SuiteSyncAnalytics,
+    SuiteSyncAnalyticsDep,
+    SuiteSyncCompositionRootState,
+} from './createSuiteSyncCompositionRoot';
 export {
     suiteSyncReducer,
     suiteSyncActions,

--- a/suite-common/suite-types/src/firmware.ts
+++ b/suite-common/suite-types/src/firmware.ts
@@ -19,7 +19,7 @@ export type FirmwareCheckType =
 export type ReportSecurityCheckParams = {
     level: 'error' | 'warning';
     checkType: FirmwareCheckType;
-    contextData: Record<string, any>;
+    contextData: Record<string, unknown>;
     payload?: unknown;
 };
 

--- a/suite-common/trading/src/tradeApi.ts
+++ b/suite-common/trading/src/tradeApi.ts
@@ -169,13 +169,13 @@ class TradeApi {
         };
     }
 
-    private async request(
+    private async request<T = unknown>(
         url: string,
         body: BodyType = {},
         method = 'POST',
         apiHeaderValue?: string,
         signal?: SignalType,
-    ): Promise<any> {
+    ): Promise<T> {
         const finalUrl = `${this.getApiServerUrl()}${url}`;
         const opts = this.options(body, method, apiHeaderValue, signal);
 
@@ -205,7 +205,7 @@ class TradeApi {
 
     getInfo = async (): Promise<InfoResponse> => {
         try {
-            const response = await this.request(this.INFO, {}, 'GET');
+            const response = await this.request<InfoResponse>(this.INFO, {}, 'GET');
             if (response) {
                 return response;
             }
@@ -218,7 +218,11 @@ class TradeApi {
 
     getExchangeList = async (): Promise<ExchangeListResponse> => {
         try {
-            const response = await this.request(this.EXCHANGE_LIST, {}, 'GET');
+            const response = await this.request<ExchangeListResponse>(
+                this.EXCHANGE_LIST,
+                {},
+                'GET',
+            );
 
             if (response) {
                 return response;
@@ -235,7 +239,7 @@ class TradeApi {
         signal?: SignalType,
     ): Promise<ExchangeTrade[] | undefined> => {
         try {
-            const response: ExchangeTradeQuoteResponse = await this.request(
+            const response = await this.request<ExchangeTradeQuoteResponse>(
                 this.EXCHANGE_QUOTES,
                 params,
                 'POST',
@@ -256,7 +260,7 @@ class TradeApi {
         signal?: SignalType,
     ): Promise<ExchangeTrade> => {
         try {
-            const response: ExchangeTrade = await this.request(
+            const response = await this.request<ExchangeTrade>(
                 this.EXCHANGE_DO_TRADE,
                 tradeRequest,
                 'POST',
@@ -274,7 +278,7 @@ class TradeApi {
 
     getBuyList = async (): Promise<BuyListResponse | undefined> => {
         try {
-            const response = await this.request(this.BUY_LIST, {}, 'GET');
+            const response = await this.request<BuyListResponse>(this.BUY_LIST, {}, 'GET');
 
             return response;
         } catch (error) {
@@ -287,7 +291,7 @@ class TradeApi {
         signal?: SignalType,
     ): Promise<BuyTradeQuoteResponse | undefined> => {
         try {
-            const response: BuyTradeQuoteResponse = await this.request(
+            const response = await this.request<BuyTradeQuoteResponse>(
                 this.BUY_QUOTES,
                 params,
                 'POST',
@@ -305,7 +309,7 @@ class TradeApi {
 
     doBuyTrade = async (tradeRequest: BuyTradeRequest): Promise<BuyTradeResponse> => {
         try {
-            const response: BuyTradeResponse = await this.request(
+            const response = await this.request<BuyTradeResponse>(
                 this.BUY_DO_TRADE,
                 tradeRequest,
                 'POST',
@@ -321,7 +325,7 @@ class TradeApi {
 
     getBuyTradeForm = async (tradeRequest: BuyTradeRequest): Promise<BuyTradeFormResponse> => {
         try {
-            const response: BuyTradeFormResponse = await this.request(
+            const response = await this.request<BuyTradeFormResponse>(
                 this.BUY_GET_TRADE_FORM,
                 tradeRequest,
                 'POST',
@@ -337,7 +341,7 @@ class TradeApi {
 
     getSellList = async (): Promise<SellListResponse | undefined> => {
         try {
-            const response = await this.request(this.SELL_LIST, {}, 'GET');
+            const response = await this.request<SellListResponse>(this.SELL_LIST, {}, 'GET');
 
             return response;
         } catch (error) {
@@ -350,7 +354,7 @@ class TradeApi {
         signal?: SignalType,
     ): Promise<SellFiatTrade[] | undefined> => {
         try {
-            const response: SellFiatTradeQuoteResponse = await this.request(
+            const response = await this.request<SellFiatTradeQuoteResponse>(
                 this.SELL_FIAT_QUOTES,
                 params,
                 'POST',
@@ -368,7 +372,7 @@ class TradeApi {
 
     doSellTrade = async (tradeRequest: SellFiatTradeRequest): Promise<SellFiatTradeResponse> => {
         try {
-            const response: SellFiatTradeResponse = await this.request(
+            const response = await this.request<SellFiatTradeResponse>(
                 this.SELL_FIAT_DO_TRADE,
                 tradeRequest,
                 'POST',
@@ -384,7 +388,7 @@ class TradeApi {
 
     doSellConfirm = async (trade: SellFiatTrade): Promise<SellFiatTrade> => {
         try {
-            const response: SellFiatTrade = await this.request(
+            const response = await this.request<SellFiatTrade>(
                 this.SELL_FIAT_CONFIRM,
                 trade,
                 'POST',
@@ -438,7 +442,7 @@ class TradeApi {
         const tradesData = this.getWatchTradeData(tradeType);
 
         try {
-            const response: TradingWatchTradeResponsePropsMap[T] = await this.request(
+            const response = await this.request<TradingWatchTradeResponsePropsMap[T]>(
                 tradesData.url.replace('{{counter}}', counter.toString()),
                 tradeData,
                 'POST',
@@ -454,7 +458,7 @@ class TradeApi {
 
     getOTCData = async (): Promise<TradingOTC | undefined> => {
         try {
-            const response = await this.request(this.OTC_INFO, {}, 'GET');
+            const response = await this.request<TradingOTC>(this.OTC_INFO, {}, 'GET');
 
             if (response) {
                 return response;
@@ -471,7 +475,7 @@ class TradeApi {
         params: P,
     ): Promise<T | undefined> => {
         try {
-            const response = await this.request(this.TRADE_SIGN, params, 'POST');
+            const response = await this.request<T>(this.TRADE_SIGN, params, 'POST');
 
             if (response) {
                 return response;

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -39,6 +39,7 @@ import { DISCOVERY_MODULE_PREFIX, discoveryActions } from './discoveryActions';
 import { isDiscoveryInProgress, selectDiscoveryByDevicePath } from './discoverySelectors';
 import { selectDeviceThunk } from './selectDeviceThunk';
 import { type CreateAccountActionProps, accountsActions } from '../accounts/accountsActions';
+import { type AccountsRootState } from '../accounts/accountsReducer';
 import { selectAccountsByDeviceState } from '../accounts/accountsSelectors';
 import { reportAccountInfoThunk, reportWalletBalanceThunk } from '../accounts/accountsThunks';
 import { selectAccountsToBeForgotten, selectDiscoveryAccountsParam } from '../selectors';
@@ -249,7 +250,7 @@ const completeDiscovery = (
         fetchAndSaveMetadata,
         getState,
     }: {
-        getState: () => any;
+        getState: () => AccountsRootState;
         dispatch: ThunkDispatch<any, ExtraDependencies, AnyAction>;
         fetchAndSaveMetadata: SuiteCompatibleThunk<StaticSessionId>;
     },

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
@@ -349,7 +349,7 @@ export const fetchFiatRatesThunk = createThunk(
                 ),
         );
 
-        tickerChunks.reduce<Promise<any>>(
+        tickerChunks.reduce<Promise<unknown>>(
             (chain, chunk) =>
                 chain.then(() =>
                     dispatch(

--- a/suite-common/wallet-core/src/settings/walletSettingsThunks.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsThunks.ts
@@ -6,7 +6,11 @@ import TrezorConnect, { PROTO } from '@trezor/connect';
 
 import { changeNetworks, setBitcoinAmountUnits } from './walletSettingsActions';
 import { WALLET_SETTINGS } from './walletSettingsConstants';
-import { selectBitcoinAmountUnit, selectEnabledNetworks } from './walletSettingsReducer';
+import {
+    type WalletSettingsRootState,
+    selectBitcoinAmountUnit,
+    selectEnabledNetworks,
+} from './walletSettingsReducer';
 import { accountsActions } from '../accounts/accountsActions';
 import { selectAccountsToBeForgotten } from '../selectors';
 
@@ -52,13 +56,14 @@ export const changeCoinVisibility = createThunk<
     },
 );
 
-export const toggleBitcoinAmountUnits = () => (dispatch: Dispatch, getState: () => any) => {
-    const currentUnits = selectBitcoinAmountUnit(getState());
+export const toggleBitcoinAmountUnits =
+    () => (dispatch: Dispatch, getState: () => WalletSettingsRootState) => {
+        const currentUnits = selectBitcoinAmountUnit(getState());
 
-    const nextUnits =
-        currentUnits === PROTO.AmountUnit.BITCOIN
-            ? PROTO.AmountUnit.SATOSHI
-            : PROTO.AmountUnit.BITCOIN;
+        const nextUnits =
+            currentUnits === PROTO.AmountUnit.BITCOIN
+                ? PROTO.AmountUnit.SATOSHI
+                : PROTO.AmountUnit.BITCOIN;
 
-    dispatch(setBitcoinAmountUnits(nextUnits));
-};
+        dispatch(setBitcoinAmountUnits(nextUnits));
+    };

--- a/suite-common/wallet-core/src/token/stellarTokenThunks.ts
+++ b/suite-common/wallet-core/src/token/stellarTokenThunks.ts
@@ -1,6 +1,6 @@
 import { G } from '@mobily/ts-belt';
 
-import { selectSelectedDevice } from '@suite-common/device';
+import { type DeviceRootState, selectSelectedDevice } from '@suite-common/device';
 import { createThunk } from '@suite-common/redux-utils';
 import { type Account } from '@suite-common/wallet-types';
 import {
@@ -12,7 +12,7 @@ import TrezorConnect from '@trezor/connect';
 import stellar from '@trezor/network-stellar/runtime';
 import { StellarAssetType } from '@trezor/protobuf/src/definitions';
 
-import { selectRawNetworkFeeInfo } from '../fees/feesReducer';
+import { type FeesRootState, selectRawNetworkFeeInfo } from '../fees/feesReducer';
 
 export interface TokenThunkPayload {
     account: Account;
@@ -21,13 +21,15 @@ export interface TokenThunkPayload {
     customFeePerUnit?: string;
 }
 
+type TrustlineRejectValue = { error: string; message: string };
+
 const STELLAR_TOKEN_MODULE_PREFIX = '@common/wallet-core/stellar-token';
 
 const manageTrustline = async (
     payload: TokenThunkPayload,
     operation: 'activate' | 'deactivate',
-    getState: () => any,
-    rejectWithValue: (value: any) => any,
+    getState: () => DeviceRootState & FeesRootState,
+    rejectWithValue: (value: TrustlineRejectValue) => unknown,
 ) => {
     const { account, contractAddress, selectedFee, customFeePerUnit } = payload;
     const device = selectSelectedDevice(getState());
@@ -127,7 +129,7 @@ const manageTrustline = async (
 export const activateStellarTokenThunk = createThunk<
     void,
     TokenThunkPayload,
-    { rejectValue: { error: string; message: string } }
+    { rejectValue: TrustlineRejectValue }
 >(
     `${STELLAR_TOKEN_MODULE_PREFIX}/activateStellarTokenThunk`,
     (payload, { getState, rejectWithValue }) =>
@@ -137,7 +139,7 @@ export const activateStellarTokenThunk = createThunk<
 export const deactivateStellarTokenThunk = createThunk<
     void,
     TokenThunkPayload,
-    { rejectValue: { error: string; message: string } }
+    { rejectValue: TrustlineRejectValue }
 >(
     `${STELLAR_TOKEN_MODULE_PREFIX}/deactivateStellarTokenThunk`,
     (payload, { getState, rejectWithValue }) =>

--- a/suite-common/wallet-types/src/discovery.ts
+++ b/suite-common/wallet-types/src/discovery.ts
@@ -30,8 +30,8 @@ export type DiscoveryStatus = CommonDiscoveryStatus &
           }
         | {
               status: 'progress';
-              total: BundleProgress<any>['payload']['total'];
-              progress: BundleProgress<any>['payload']['progress'];
+              total: BundleProgress<unknown>['payload']['total'];
+              progress: BundleProgress<unknown>['payload']['progress'];
           }
         | {
               status: 'confirm-empty-passphrase';

--- a/suite-native/device-manager/src/components/WalletItem.tsx
+++ b/suite-native/device-manager/src/components/WalletItem.tsx
@@ -2,7 +2,10 @@ import { useSelector } from 'react-redux';
 
 import { selectSelectedDevice } from '@suite-common/device';
 import { type TrezorDevice } from '@suite-common/suite-types';
-import { selectDeviceTotalFiatBalanceByDeviceState } from '@suite-native/device';
+import {
+    type NativeDeviceRootState,
+    selectDeviceTotalFiatBalanceByDeviceState,
+} from '@suite-native/device';
 
 import { WalletItemBase } from './WalletItemBase';
 
@@ -14,7 +17,7 @@ type WalletItemProps = {
 
 export const WalletItem = ({ onPress, device, isSelectable = true }: WalletItemProps) => {
     const selectedDevice = useSelector(selectSelectedDevice);
-    const baseCurrencyAmount = useSelector((state: any) =>
+    const baseCurrencyAmount = useSelector((state: NativeDeviceRootState) =>
         device?.state?.staticSessionId
             ? selectDeviceTotalFiatBalanceByDeviceState(state, device?.state?.staticSessionId)
             : undefined,

--- a/suite-native/state/src/extraDependencies.ts
+++ b/suite-native/state/src/extraDependencies.ts
@@ -23,7 +23,11 @@ import {
     notImplementedThunk,
 } from '@suite-common/redux-utils';
 import { createMigrateSuiteSyncLabelsForRbfTransactionCompositionRoot } from '@suite-common/suite-rbf-labels-migrations';
-import { selectAllLabelsForAccount, selectIsSuiteSyncEnabled } from '@suite-common/suite-sync';
+import {
+    type SuiteSyncCompositionRootState,
+    selectAllLabelsForAccount,
+    selectIsSuiteSyncEnabled,
+} from '@suite-common/suite-sync';
 import { createAccountRefreshThrottle } from '@suite-common/wallet-core';
 import { analytics } from '@suite-native/analytics';
 import { forgetBluetoothDeviceThunk } from '@suite-native/bluetooth';
@@ -55,7 +59,7 @@ const transportsPerDeviceType = {
 const transports = transportsPerDeviceType[deviceType];
 
 type NativeAppDeps = {
-    getState: () => any;
+    getState: () => SuiteSyncCompositionRootState;
     dispatch: any;
 } & EnsureEncryptionKeyDep &
     MMKVStorageDep;

--- a/suite-native/suite-sync/src/createSuiteSyncNativeCompositionRoot.ts
+++ b/suite-native/suite-sync/src/createSuiteSyncNativeCompositionRoot.ts
@@ -7,6 +7,7 @@ import { type EnsureDelegatedIdentityKeyDep } from '@suite-common/delegated-iden
 import { type PlatformEncryptionDep } from '@suite-common/platform-encryption';
 import {
     type SuiteSyncAnalyticsDep,
+    type SuiteSyncCompositionRootState,
     createSuiteSyncCompositionRoot,
 } from '@suite-common/suite-sync';
 import {
@@ -20,7 +21,7 @@ import { type SuiteSync } from '@suite-common/suite-sync-types';
 import { type TrezorConnectPrivilegedAPI } from '@trezor/connect';
 
 type SuiteSyncNativeCompositionRootDeps = {
-    getState: () => any;
+    getState: () => SuiteSyncCompositionRootState;
     dispatch: Dispatch;
     trezorConnect: TrezorConnectPrivilegedAPI;
 } & SuiteSyncAnalyticsDep &

--- a/suite-native/trading-quote-utils/src/utils/utils.ts
+++ b/suite-native/trading-quote-utils/src/utils/utils.ts
@@ -200,13 +200,23 @@ export const getFormDraftKeyPrefixFromTradingType = (tradingType: TradingType) =
     `trading-${tradingType}` as const satisfies FormDraftKeyPrefix;
 
 export const getErrorStrFromThunkRejectedValue = (rejectedValue: unknown) => {
-    const asAny = rejectedValue as any;
-    if (asAny?.error?.error) {
-        return `[${asAny.error.error}]: ${asAny.error.message ?? 'No description'}`;
-    }
-
-    if (asAny?.error?.message) {
-        return asAny.error.message;
+    if (
+        rejectedValue !== null &&
+        typeof rejectedValue === 'object' &&
+        'error' in rejectedValue &&
+        rejectedValue.error !== null &&
+        typeof rejectedValue.error === 'object'
+    ) {
+        const { error: errorCode, message } = rejectedValue.error as {
+            error?: unknown;
+            message?: unknown;
+        };
+        if (typeof errorCode === 'string') {
+            return `[${errorCode}]: ${typeof message === 'string' ? message : 'No description'}`;
+        }
+        if (typeof message === 'string') {
+            return message;
+        }
     }
 
     if (rejectedValue instanceof Error) {

--- a/suite/suite-sync/src/createSuiteSyncDesktopCompositionRoot.ts
+++ b/suite/suite-sync/src/createSuiteSyncDesktopCompositionRoot.ts
@@ -6,6 +6,7 @@ import { type EnsureDelegatedIdentityKeyDep } from '@suite-common/delegated-iden
 import { toGetter } from '@suite-common/dependency-injection';
 import { type PlatformEncryptionDep } from '@suite-common/platform-encryption';
 import {
+    type SuiteSyncCompositionRootState,
     createSuiteSyncCompositionRoot,
     createUpdateRelayConnectionStatus,
 } from '@suite-common/suite-sync';
@@ -19,7 +20,7 @@ import { suiteSyncErrorHandler } from './suiteSyncErrorHandler';
 import { createTurnOnDesktopSuiteSync } from './turnOnDesktopSuiteSync';
 
 type SuiteSyncDesktopCompositionRootDeps = {
-    getState: () => any;
+    getState: () => SuiteSyncCompositionRootState;
     dispatch: Dispatch;
     trezorConnect: TrezorConnectPrivilegedAPI;
     onStorageEnsured: OnStorageEnsured;


### PR DESCRIPTION
WIP — staging branch for types-hardening agent results.

## Cherry-picked into standalone PRs

- #27852 — public-API `any` tightenings (transport Logger, blockchain-link-types blockfrost, components Menu/Link, metadata-types setFileContent)
- #27868 — quick-win `any` tightenings (sendFormBitcoinThunks ComposeUtxo, utils deepEqual/isChanged, type-utils distributive tricks, module-trading rejected-value guards, observeSelectedDevice thunk typing)
- #28108 — `getState` DI-boundary typing (wallet-core / connect-popup / suite-sync composition roots, legacy thunks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=gnhf/test-9f86d0&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=gnhf/test-9f86d0&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=gnhf/test-9f86d0&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T13:42:12.826Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T13:40:29.321Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/gnhf/test-9f86d0/web/](https://dev.suite.sldev.cz/suite-web/gnhf/test-9f86d0/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set is large and spans global utilities, transport, desktop internals, and domain-specific modules. The highest regression risk lies in Solana blockchain state/caching, Bitcoin UTXO payment construction, metadata labeling types, Trezor Connect popup flows, ETH staking, and Suite Sync. The recommended tests target these specific domains rather than exercising every test that transitively imports a changed utility. Many transport, desktop, connect-explorer, and suite-native changed files remain without inferred E2E coverage.

<details><summary><b>Changed files (116)</b></summary>

- `packages/analytics-uploader/src/utils.ts`
- `packages/blockchain-link/src/workers/state.ts`
- `packages/coinjoin/src/types/backend.ts`
- `packages/coinjoin/src/types/coordinator.ts`
- `packages/coinjoin/src/utils/http.ts`
- `packages/components/src/components/Tooltip/TooltipFloatingUi.tsx`
- `packages/components/src/components/form/FormCell/FormCell.tsx`
- `packages/components/src/components/form/Select/customComponents.tsx`
- `packages/components/src/components/typography/utils.tsx`
- `packages/connect-cli/src/index.ts`
- `packages/connect-cli/src/stdio.ts`
- `packages/connect-common/src/constants/errors.ts`
- `packages/connect-common/src/events/blockchain.ts`
- `packages/connect-common/src/events/core.ts`
- `packages/connect-common/src/events/device.ts`
- `packages/connect-common/src/events/popup.ts`
- `packages/connect-common/src/events/transport.ts`
- `packages/connect-explorer-theme/src/contexts/active-anchor.tsx`
- `packages/connect-explorer-theme/src/contexts/sidebar-focus.ts`
- `packages/connect-explorer-theme/src/polyfill.ts`
- `packages/connect-explorer-theme/src/schema.ts`
- `packages/connect-explorer/src/actions/methodActions.ts`
- `packages/connect-mobile/src/index.ts`
- `packages/connect-web/src/bootstrap/bootstrap.ts`
- `packages/connect-webextension/src/index.ts`
- `packages/device-utils/src/deviceModelInternalUtils.ts`
- `packages/ipc-proxy/src/proxy-generator.ts`
- `packages/ipc-proxy/src/proxy.ts`
- `packages/ipc-proxy/src/types.ts`
- `packages/node-utils/src/http.ts`
- `packages/node-utils/src/validateJsonSchema.ts`
- `packages/product-components/src/components/DeviceAnimation/DeviceAnimation.tsx`
- `packages/product-components/src/components/EditableText/EditableText.tsx`
- `packages/product-components/src/components/TrezorLogo/trezorLogos.ts`
- `packages/protobuf/src/definitions/index.ts`
- `packages/protocol/src/protocol-thp/messages/messageTypes.ts`
- `packages/react-native-usb/src/ReactNativeUsb.types.ts`
- `packages/react-native-usb/src/index.ios.ts`
- `packages/react-native-usb/src/index.ts`
- `packages/react-utils/src/hooks/useDebounce.ts`
- `packages/react-utils/src/hooks/useDidUpdate.ts`
- `packages/request-manager/src/interceptor/interceptFetch.ts`
- `packages/schema-utils/src/errors.ts`
- `packages/schema-utils/src/index.ts`
- `packages/styles-native/src/useStyles.ts`
- `packages/suite-desktop-api/src/validation.ts`
- `packages/suite-desktop-core/src/modules/tor.ts`
- `packages/suite-desktop-core/src/utils/IloggerToLog.ts`
- `packages/suite-desktop-native/src/winHelloChildProcess.ts`
- `packages/suite-desktop-native/src/winHelloManager.ts`
- `packages/suite-desktop-ui/src/MainDesktop.tsx`
- `packages/suite-desktop-ui/src/createSuiteDesktopCompositionRoot.ts`
- `packages/suite-desktop-ui/src/global.d.ts`
- `packages/suite-storage/src/index.ts`
- `packages/suite/src/support/extraDependencies.ts`
- `packages/suite/src/views/settings/SettingsGeneral/Tor.tsx`
- `packages/transport-bluetooth/src/browser.ts`
- `packages/transport-bluetooth/src/client/trezor-bluetooth.ts`
- `packages/transport-bluetooth/src/ui/app.tsx`
- `packages/transport-bridge/src/http.ts`
- `packages/transport-bridge/src/ui/App.tsx`
- `packages/transport-bridge/src/ui/components/Translation.tsx`
- `packages/transport-common/src/api/abstract.ts`
- `packages/transport-common/src/sessions/types.ts`
- `packages/transport-common/src/transports/bridge.ts`
- `packages/transport-common/src/utils/bridgeApiCall.ts`
- `packages/transport-common/src/utils/bridgeApiResult.ts`
- `packages/transport-native-bluetooth/src/api/bluetoothManager.ts`
- `packages/transport-web/src/sessions/background-browser.ts`
- `packages/trezor-user-env-link/src/api.ts`
- `packages/trezor-user-env-link/src/websocket-client.ts`
- `packages/type-utils/src/object.ts`
- `packages/type-utils/src/result.ts`
- `packages/type-utils/src/utils.ts`
- `packages/utils/src/arrayPartition.ts`
- `packages/utils/src/cache.ts`
- `packages/utils/src/createLazy.ts`
- `packages/utils/src/logs.ts`
- `packages/utils/src/promiseAllSequence.ts`
- `packages/utils/src/typedEventEmitter.ts`
- `packages/utxo-lib/src/payments/lazy.ts`
- `packages/utxo-lib/src/transaction/zcash.ts`
- `packages/utxo-lib/src/txWeightCalculator.ts`
- `packages/websocket-client/src/ws.browser.ts`
- `packages/websocket-client/src/ws.native.ts`
- `suite-common/analytics/src/eventDefinition.ts`
- `suite-common/connect-popup/src/connectPopupThunks.ts`
- `suite-common/connect-popup/src/methodHooks/bitcoinSignTransaction.ts`
- `suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts`
- `suite-common/connect-popup/src/methodHooks/solanaSignTransaction.ts`
- `suite-common/connect-popup/src/methodHooks/types.ts`
- `suite-common/delegated-identity-key/src/getProofOfDelegatedIdentity.ts`
- `suite-common/fiat-services/src/cache.ts`
- `suite-common/logger/src/types.ts`
- `suite-common/logger/src/utils.ts`
- `suite-common/message-system/src/messageSystemUtils.ts`
- `suite-common/metadata-types/src/metadataTypes.ts`
- `suite-common/redux-utils/src/createSingleInstanceThunk.ts`
- `suite-common/redux-utils/src/extraDependenciesType.ts`
- `suite-common/redux-utils/src/types.ts`
- `suite-common/staking/src/ethereumStaking.ts`
- `suite-common/suite-sync-storage/src/SuiteSyncTable.ts`
- `suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts`
- `suite-common/suite-sync/src/index.ts`
- `suite-common/suite-types/src/firmware.ts`
- `suite-common/trading/src/tradeApi.ts`
- `suite-common/wallet-core/src/discovery/discoveryThunks.ts`
- `suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts`
- `suite-common/wallet-core/src/settings/walletSettingsThunks.ts`
- `suite-common/wallet-core/src/token/stellarTokenThunks.ts`
- `suite-common/wallet-types/src/discovery.ts`
- `suite-native/device-manager/src/components/WalletItem.tsx`
- `suite-native/state/src/extraDependencies.ts`
- `suite-native/suite-sync/src/createSuiteSyncNativeCompositionRoot.ts`
- `suite-native/trading-quote-utils/src/utils/utils.ts`
- `suite/suite-sync/src/createSuiteSyncDesktopCompositionRoot.ts`

</details>

**Recommended tests (33)**

<details><summary>🔴 <b>High priority (16)</b></summary>

- `suite/e2e/tests/metadata/legacy/account-metadata.test.ts` — Directly exercises legacy metadata labeling CRUD flows; the changed metadataTypes.ts file defines the types used by these labels, so a regression would be immediately visible in account label display/edit behavior.
- `suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — Covers transaction output labels which rely on the metadata type definitions; changes to metadataTypes.ts could break output label persistence or display.
- `suite/e2e/tests/metadata/legacy/wallet-metadata.test.ts` — Tests wallet-level labels stored via the legacy metadata provider; wallet labels are part of the metadata type surface area changed in metadataTypes.ts.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Directly exercises Ethereum staking deposit/contract logic; changed file suite-common/staking/src/ethereumStaking.ts is the core ETH staking module, so any regression would surface here.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Exercises Solana staking end-to-end; the changed blockchain-link worker state and cache utilities are on the code path that manages Solana backend account/stake state.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — Builds on existing Solana stake state and requires correct worker state/cache behavior for stake account discovery and pending balance updates.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — Covers Solana unstake/claim transitions that depend on blockchain-link worker state and cache invalidation for stake accounts and epochs.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — Bitcoin sell flow constructs and signs UTXO transactions; the changed utxo-lib payments/lazy.ts file is directly involved in UTXO payment creation for BTC sends.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Solana sell flow touches both Solana blockchain worker state/cache and the trading trade API; it is a representative cross-domain test for the changed Solana and trading modules.
- `suite/e2e/tests/trading/swap-sol-to-btc.test.ts` — Cross-chain swap from Solana to Bitcoin exercises Solana worker state/cache, BTC UTXO payment construction, and trading trade API in a single flow.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Solana SPL token swap depends on Solana blockchain worker state, cache, and token thunk handling for asset selection and quote generation.
- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — Directly exercises the Connect popup permissions and address-export flow; changed connectPopupThunks and method hooks are on the exact code path this test covers.
- `suite/e2e/tests/wallet/send-doge.test.ts` — Dogecoin send transaction construction uses UTXO payment logic; changed utxo-lib payments/lazy.ts is in the path for creating Doge outputs.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — LTC send flow spends UTXOs including MimbleWimble peg-out outputs; utxo-lib payments/lazy.ts is used when building LTC transaction outputs.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — Bitcoin regtest send with multiple outputs, locktime, and OP_RETURN directly exercises UTXO transaction construction and weight calculation paths touched by utxo-lib changes.
- `suite/e2e/tests/wallet/send-sol.test.ts` — Solana send flow relies on Solana blockchain worker state and cache for balance, fees, and rent-exemption calculations; these changed modules are central to this test.

</details>

<details><summary>🟡 <b>Medium priority (13)</b></summary>

- `suite/e2e/tests/metadata/legacy/address-metadata.test.ts` — Address labels use the same metadata type definitions as account/output labels; a regression in metadataTypes.ts would likely also break address label behavior.
- `suite/e2e/tests/metadata/legacy/metadata-lifecycle.test.ts` — Covers enabling/disabling legacy metadata and provider switching; metadata type changes could affect how labels are stored and reloaded across sessions.
- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — Exercises the Suite Sync label creation path; changed suite-sync composition root and storage table files are part of the infrastructure this test uses.
- `suite/e2e/tests/metadata/suite-sync/update-and-remove-labels.test.ts` — Covers Suite Sync label mutation and null sync to the relay; directly uses the changed suite-sync storage and composition modules.
- `suite/e2e/tests/settings/coins.test.ts` — Network enable/disable and backend configuration exercises wallet settings thunks and blockchain-link worker state initialization.
- `suite/e2e/tests/settings/general.test.ts` — Fiat currency and language changes exercise fiat-rates thunks and wallet settings thunks that were modified.
- `suite/e2e/tests/staking/sol/rewards.test.ts` — Solana staking rewards fetching depends on the same Solana worker state and cache infrastructure; a regression in cache expiry or worker state would show here.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Solana USDT token to BTC coin swap combines Solana worker state/cache, UTXO payment construction, and trading token handling.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — Tests Connect from a webextension context; the changed connect-webextension index file is the inferred entry point for this flow, and connectPopupThunks is shared.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Directly exercises the ethereumSignTransaction method hook that was changed; any regression in ETH signing flow would surface here.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — Directly exercises the bitcoinSignTransaction method hook that was changed; BTC signing regression would be visible in this test.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — Bridge session takeover and reclaim behavior is exercised; changed transport-common sessions/types file defines the session data structures this flow depends on.
- `suite/e2e/tests/wallet/discovery.test.ts` — Multi-coin discovery exercises the changed discovery thunks; a regression in discovery state management would be immediately visible.

</details>

<details><summary>🟢 <b>Low priority (4)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — Asset activation and display may use the changed token stellar thunks for asset/network resolution, though the direct link is weaker than dedicated trading tests.
- `suite/e2e/tests/metadata/legacy/remembered-device.test.ts` — Metadata enable/disable on remembered devices uses the same metadata type definitions, but is already partially covered by higher-priority metadata tests.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — Solana token buy flow shares Solana state/cache and token thunk infrastructure with higher-priority Solana trading tests, but covers a less critical buy path.
- `suite/e2e/tests/wallet/receive.test.ts` — Includes SOL receive which depends on Solana worker state/cache, but is a broad multi-coin test already partly covered by send-sol and swap-sol-to-btc.

</details>

⚠️ **Changes with no test coverage (55)**
- `packages/coinjoin/src/types/backend.ts`
- `packages/coinjoin/src/types/coordinator.ts`
- `packages/coinjoin/src/utils/http.ts`
- `packages/connect-cli/src/index.ts`
- `packages/connect-cli/src/stdio.ts`
- `packages/connect-explorer-theme/src/contexts/active-anchor.tsx`
- `packages/connect-explorer-theme/src/contexts/sidebar-focus.ts`
- `packages/connect-explorer-theme/src/polyfill.ts`
- `packages/connect-explorer-theme/src/schema.ts`
- `packages/connect-explorer/src/actions/methodActions.ts`
- `packages/connect-mobile/src/index.ts`
- `packages/ipc-proxy/src/proxy-generator.ts`
- `packages/ipc-proxy/src/types.ts`
- `packages/node-utils/src/http.ts`
- `packages/node-utils/src/validateJsonSchema.ts`
- `packages/protocol/src/protocol-thp/messages/messageTypes.ts`
- `packages/react-native-usb/src/ReactNativeUsb.types.ts`
- `packages/react-native-usb/src/index.ios.ts`
- `packages/react-native-usb/src/index.ts`
- `packages/request-manager/src/interceptor/interceptFetch.ts`
- `packages/schema-utils/src/errors.ts`
- `packages/styles-native/src/useStyles.ts`
- `packages/suite-desktop-core/src/modules/tor.ts`
- `packages/suite-desktop-core/src/utils/IloggerToLog.ts`
- `packages/suite-desktop-native/src/winHelloChildProcess.ts`
- `packages/suite-desktop-native/src/winHelloManager.ts`
- `packages/suite-desktop-ui/src/MainDesktop.tsx`
- `packages/suite-desktop-ui/src/createSuiteDesktopCompositionRoot.ts`
- `packages/suite-desktop-ui/src/global.d.ts`
- `packages/transport-bluetooth/src/client/trezor-bluetooth.ts`
- `packages/transport-bluetooth/src/ui/app.tsx`
- `packages/transport-bridge/src/http.ts`
- `packages/transport-bridge/src/ui/App.tsx`
- `packages/transport-bridge/src/ui/components/Translation.tsx`
- `packages/transport-native-bluetooth/src/api/bluetoothManager.ts`
- `packages/transport-web/src/sessions/background-browser.ts`
- `packages/trezor-user-env-link/src/api.ts`
- `packages/trezor-user-env-link/src/websocket-client.ts`
- `packages/type-utils/src/object.ts`
- `packages/type-utils/src/utils.ts`
- `packages/websocket-client/src/ws.browser.ts`
- `packages/websocket-client/src/ws.native.ts`
- `suite-common/analytics/src/eventDefinition.ts`
- `suite-common/connect-popup/src/methodHooks/types.ts`
- `suite-common/logger/src/types.ts`
- `suite-common/redux-utils/src/extraDependenciesType.ts`
- `suite-common/redux-utils/src/types.ts`
- `suite-common/suite-sync/src/index.ts`
- `suite-common/suite-types/src/firmware.ts`
- `suite-common/wallet-types/src/discovery.ts`
- `suite-native/device-manager/src/components/WalletItem.tsx`
- `suite-native/state/src/extraDependencies.ts`
- `suite-native/suite-sync/src/createSuiteSyncNativeCompositionRoot.ts`
- `suite-native/trading-quote-utils/src/utils/utils.ts`
- `suite/suite-sync/src/createSuiteSyncDesktopCompositionRoot.ts`

_Updated: 2026-08-04T13:43:27.608Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->