### PR TITLE
refactor(address-validator): replace 18 _currency any annotations with Currency type

### DIFF
--- a/packages/address-validator/src/ada_validator.ts
+++ b/packages/address-validator/src/ada_validator.ts
@@ -4,6 +4,7 @@ import CRC from 'crc';
 
 import * as base58 from './crypto/base58';
 import { addressType } from './crypto/utils';
+import type { Currency } from './currency-types';
 
 const DEFAULT_NETWORK_TYPE = 'prod';
 
@@ -61,13 +62,17 @@ function isValidBech32Address(address: string, currency: any, networkType: strin
     return true;
 }
 
-export const isValidAddress = (address: string, currency?: any, networkType?: string): boolean => {
+export const isValidAddress = (
+    address: string,
+    currency?: Currency,
+    networkType?: string,
+): boolean => {
     const network = networkType || DEFAULT_NETWORK_TYPE;
 
     return isValidLegacyAddress(address) || isValidBech32Address(address, currency, network);
 };
 
-export const getAddressType = (address: string, currency?: any, networkType?: string) => {
+export const getAddressType = (address: string, currency?: Currency, networkType?: string) => {
     if (isValidAddress(address, currency, networkType)) {
         return addressType.ADDRESS;
     }

--- a/packages/address-validator/src/ae_validator.ts
+++ b/packages/address-validator/src/ae_validator.ts
@@ -1,5 +1,6 @@
 import * as base58 from './crypto/base58';
 import { addressType } from './crypto/utils';
+import type { Currency } from './currency-types';
 
 const ALLOWED_CHARS = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
 
@@ -21,7 +22,7 @@ export const isValidAddress = (address: string): boolean => {
     return false;
 };
 
-export const getAddressType = (address: string, _currency?: any, _networkType?: string) => {
+export const getAddressType = (address: string, _currency?: Currency, _networkType?: string) => {
     if (isValidAddress(address)) {
         return addressType.ADDRESS;
     }

--- a/packages/address-validator/src/ardr_validator.ts
+++ b/packages/address-validator/src/ardr_validator.ts
@@ -1,4 +1,5 @@
 import { addressType } from './crypto/utils';
+import type { Currency } from './currency-types';
 
 const ardorRegex = new RegExp('^ARDOR(-[A-Z0-9]{4}){3}(-[A-Z0-9]{5})$');
 
@@ -10,7 +11,7 @@ export const isValidAddress = (address: string): boolean => {
     return true;
 };
 
-export const getAddressType = (address: string, _currency?: any, _networkType?: string) => {
+export const getAddressType = (address: string, _currency?: Currency, _networkType?: string) => {
     if (isValidAddress(address)) {
         return addressType.ADDRESS;
     }

--- a/packages/address-validator/src/atom_validator.ts
+++ b/packages/address-validator/src/atom_validator.ts
@@ -1,4 +1,5 @@
 import { addressType } from './crypto/utils';
+import type { Currency } from './currency-types';
 
 const ALLOWED_CHARS = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';
 
@@ -6,7 +7,7 @@ const regexp = new RegExp('^(cosmos)1([' + ALLOWED_CHARS + ']+)$');
 
 export const isValidAddress = (address: string): boolean => regexp.exec(address) !== null;
 
-export const getAddressType = (address: string, _currency?: any, _networkType?: string) => {
+export const getAddressType = (address: string, _currency?: Currency, _networkType?: string) => {
     if (isValidAddress(address)) {
         return addressType.ADDRESS;
     }

--- a/packages/address-validator/src/bch_validator.ts
+++ b/packages/address-validator/src/bch_validator.ts
@@ -2,6 +2,7 @@
 // https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/cashaddr.md
 import * as BTCValidator from './bitcoin_validator';
 import { addressType } from './crypto/utils';
+import type { Currency } from './currency-types';
 
 const DEFAULT_NETWORK_TYPE = 'prod';
 
@@ -90,11 +91,15 @@ function validateAddress(address: string, currency: any): boolean {
     return verifyChecksum(CASHADDR_PREFIX, normalized);
 }
 
-export const isValidAddress = (address: string, currency?: any, networkType?: string): boolean =>
+export const isValidAddress = (
+    address: string,
+    currency?: Currency,
+    networkType?: string,
+): boolean =>
     validateAddress(address, currency) ||
-    (currency.symbol !== 'bch' && BTCValidator.isValidAddress(address, currency, networkType));
+    (currency?.symbol !== 'bch' && BTCValidator.isValidAddress(address, currency, networkType));
 
-export const getAddressType = (address: string, currency?: any, networkType?: string) => {
+export const getAddressType = (address: string, currency?: Currency, networkType?: string) => {
     const network = networkType || DEFAULT_NETWORK_TYPE;
     if (isValidAddress(address, currency, network)) {
         return addressType.ADDRESS;

--- a/packages/address-validator/src/bitcoin_validator.ts
+++ b/packages/address-validator/src/bitcoin_validator.ts
@@ -2,6 +2,7 @@ import * as base58 from './crypto/base58';
 import * as bech32 from './crypto/bech32';
 import * as cryptoUtils from './crypto/utils';
 import { addressType } from './crypto/utils';
+import type { Currency } from './currency-types';
 
 const DEFAULT_NETWORK_TYPE = 'prod';
 
@@ -167,7 +168,7 @@ function isValidSegwitAddress(address: string, currency: any, networkType: strin
     return false;
 }
 
-export const getAddressType = (address: string, currency?: any, networkType?: string) => {
+export const getAddressType = (address: string, currency?: Currency, networkType?: string) => {
     const network = networkType || DEFAULT_NETWORK_TYPE;
     if (isValidPayToPublicKeyHashAddress(address, currency, network)) {
         return addressType.P2PKH;
@@ -191,7 +192,11 @@ export const getAddressType = (address: string, currency?: any, networkType?: st
     return undefined;
 };
 
-export const isValidAddress = (address: string, currency?: any, networkType?: string): boolean => {
+export const isValidAddress = (
+    address: string,
+    currency?: Currency,
+    networkType?: string,
+): boolean => {
     const network = networkType || DEFAULT_NETWORK_TYPE;
     const addrType = getAddressType(address, currency, network);
 

--- a/packages/address-validator/src/currencies.ts
+++ b/packages/address-validator/src/currencies.ts
@@ -4,6 +4,7 @@ import * as ARDRValidator from './ardr_validator';
 import * as ATOMValidator from './atom_validator';
 import * as BCHValidator from './bch_validator';
 import * as BTCValidator from './bitcoin_validator';
+import type { Currency } from './currency-types';
 import * as EOSValidator from './eos_validator';
 import * as ETHValidator from './ethereum_validator';
 import * as HBARValidator from './hbar_validator';
@@ -25,19 +26,7 @@ import * as XTZValidator from './tezos_validator';
 import * as TRXValidator from './tron_validator';
 import * as ZILValidator from './zil_validator';
 
-export interface Currency {
-    name: string;
-    symbol: string;
-    validator: any;
-    regexp?: string;
-    segwitHrp?: Record<string, string>;
-    addressTypes?: Record<string, (string | number)[]>;
-    iAddressTypes?: Record<string, (string | number)[]>;
-    subAddressTypes?: Record<string, (string | number)[]>;
-    expectedLength?: number;
-    hashFunction?: string;
-    regex?: RegExp;
-}
+export type { Currency, Validator } from './currency-types';
 
 const CURRENCIES: Currency[] = [
     {

--- a/packages/address-validator/src/currency-types.ts
+++ b/packages/address-validator/src/currency-types.ts
@@ -1,0 +1,26 @@
+import type { addressType } from './crypto/utils';
+
+type AddressType = (typeof addressType)[keyof typeof addressType];
+
+export interface Validator {
+    isValidAddress: (address: string, currency?: Currency, networkType?: string) => boolean;
+    getAddressType?: (
+        address: string,
+        currency?: Currency,
+        networkType?: string,
+    ) => AddressType | undefined;
+}
+
+export interface Currency {
+    name: string;
+    symbol: string;
+    validator: Validator;
+    regexp?: string;
+    segwitHrp?: Record<string, string>;
+    addressTypes?: Record<string, (string | number)[]>;
+    iAddressTypes?: Record<string, (string | number)[]>;
+    subAddressTypes?: Record<string, (string | number)[]>;
+    expectedLength?: number;
+    hashFunction?: string;
+    regex?: RegExp;
+}

--- a/packages/address-validator/src/eos_validator.ts
+++ b/packages/address-validator/src/eos_validator.ts
@@ -1,4 +1,5 @@
 import { addressType } from './crypto/utils';
+import type { Currency } from './currency-types';
 
 function isValidEOSAddress(address: string): boolean {
     const regex = /^[a-z0-9]+$/g;
@@ -11,7 +12,7 @@ function isValidEOSAddress(address: string): boolean {
 
 export const isValidAddress = (address: string): boolean => isValidEOSAddress(address);
 
-export const getAddressType = (address: string, _currency?: any, _networkType?: string) => {
+export const getAddressType = (address: string, _currency?: Currency, _networkType?: string) => {
     if (isValidAddress(address)) {
         return addressType.ADDRESS;
     }

--- a/packages/address-validator/src/ethereum_validator.ts
+++ b/packages/address-validator/src/ethereum_validator.ts
@@ -1,5 +1,6 @@
 import * as cryptoUtils from './crypto/utils';
 import { addressType } from './crypto/utils';
+import type { Currency } from './currency-types';
 
 function verifyChecksum(address: string): boolean {
     const stripped = address.replace('0x', '');
@@ -31,7 +32,7 @@ export const isValidAddress = (address: string): boolean => {
     return verifyChecksum(address);
 };
 
-export const getAddressType = (address: string, _currency?: any, _networkType?: string) => {
+export const getAddressType = (address: string, _currency?: Currency, _networkType?: string) => {
     if (isValidAddress(address)) {
         return addressType.ADDRESS;
     }

--- a/packages/address-validator/src/hbar_validator.ts
+++ b/packages/address-validator/src/hbar_validator.ts
@@ -1,4 +1,5 @@
 import { addressType } from './crypto/utils';
+import type { Currency } from './currency-types';
 
 function isValidHBarAddress(address: string): boolean {
     const split = address.split('.');
@@ -14,7 +15,7 @@ function isValidHBarAddress(address: string): boolean {
 
 export const isValidAddress = (address: string): boolean => isValidHBarAddress(address);
 
-export const getAddressType = (address: string, _currency?: any, _networkType?: string) => {
+export const getAddressType = (address: string, _currency?: Currency, _networkType?: string) => {
     if (isValidAddress(address)) {
         return addressType.ADDRESS;
     }

--- a/packages/address-validator/src/icx_validator.ts
+++ b/packages/address-validator/src/icx_validator.ts
@@ -1,4 +1,5 @@
 import { addressType } from './crypto/utils';
+import type { Currency } from './currency-types';
 
 function isValidICXAddress(address: string): boolean {
     const regex = /^hx[0-9a-f]{40}$/g;
@@ -8,7 +9,7 @@ function isValidICXAddress(address: string): boolean {
 
 export const isValidAddress = (address: string): boolean => isValidICXAddress(address);
 
-export const getAddressType = (address: string, _currency?: any, _networkType?: string) => {
+export const getAddressType = (address: string, _currency?: Currency, _networkType?: string) => {
     if (isValidAddress(address)) {
         return addressType.ADDRESS;
     }

--- a/packages/address-validator/src/index.ts
+++ b/packages/address-validator/src/index.ts
@@ -1,6 +1,6 @@
 import { addressType } from './crypto/utils';
 import * as currencies from './currencies';
-import type { Currency } from './currencies';
+import type { Currency } from './currency-types';
 
 type AddressType = (typeof addressType)[keyof typeof addressType];
 

--- a/packages/address-validator/src/iost_validator.ts
+++ b/packages/address-validator/src/iost_validator.ts
@@ -1,10 +1,11 @@
 import { addressType } from './crypto/utils';
+import type { Currency } from './currency-types';
 
 const iostRegex = new RegExp('^[a-z0-9_]{5,11}$');
 
 export const isValidAddress = (address: string): boolean => iostRegex.test(address);
 
-export const getAddressType = (address: string, _currency?: any, _networkType?: string) => {
+export const getAddressType = (address: string, _currency?: Currency, _networkType?: string) => {
     if (isValidAddress(address)) {
         return addressType.ADDRESS;
     }

--- a/packages/address-validator/src/loki_validator.ts
+++ b/packages/address-validator/src/loki_validator.ts
@@ -1,6 +1,7 @@
 import cnBase58Module from './crypto/cnBase58';
 import * as cryptoUtils from './crypto/utils';
 import { addressType } from './crypto/utils';
+import type { Currency } from './currency-types';
 
 const cnBase58 = cnBase58Module as any;
 
@@ -49,7 +50,11 @@ function hextobin(hex: string): Uint8Array | null {
     return res;
 }
 
-export const isValidAddress = (address: string, currency?: any, networkType?: string): boolean => {
+export const isValidAddress = (
+    address: string,
+    currency?: Currency,
+    networkType?: string,
+): boolean => {
     const network = networkType || DEFAULT_NETWORK_TYPE;
     let addrKind = 'standard';
     if (!addressRegTest.test(address)) {
@@ -73,7 +78,7 @@ export const isValidAddress = (address: string, currency?: any, networkType?: st
     return addrChecksum === hashChecksum;
 };
 
-export const getAddressType = (address: string, currency?: any, networkType?: string) => {
+export const getAddressType = (address: string, currency?: Currency, networkType?: string) => {
     if (isValidAddress(address, currency, networkType)) {
         return addressType.ADDRESS;
     }

--- a/packages/address-validator/src/monero_validator.ts
+++ b/packages/address-validator/src/monero_validator.ts
@@ -1,6 +1,7 @@
 import cnBase58Module from './crypto/cnBase58';
 import * as cryptoUtils from './crypto/utils';
 import { addressType } from './crypto/utils';
+import type { Currency } from './currency-types';
 
 const cnBase58 = cnBase58Module as any;
 
@@ -54,7 +55,11 @@ function hextobin(hex: string): Uint8Array | null {
     return res;
 }
 
-export const isValidAddress = (address: string, currency?: any, networkType?: string): boolean => {
+export const isValidAddress = (
+    address: string,
+    currency?: Currency,
+    networkType?: string,
+): boolean => {
     const network = networkType || DEFAULT_NETWORK_TYPE;
     let addrKind = 'standard';
     if (network === 'testnet') {
@@ -84,7 +89,7 @@ export const isValidAddress = (address: string, currency?: any, networkType?: st
     return addrChecksum === hashChecksum;
 };
 
-export const getAddressType = (address: string, currency?: any, networkType?: string) => {
+export const getAddressType = (address: string, currency?: Currency, networkType?: string) => {
     if (isValidAddress(address, currency, networkType)) {
         return addressType.ADDRESS;
     }

--- a/packages/address-validator/src/nano_validator.ts
+++ b/packages/address-validator/src/nano_validator.ts
@@ -2,6 +2,7 @@ import baseX from 'base-x';
 
 import * as cryptoUtils from './crypto/utils';
 import { addressType } from './crypto/utils';
+import type { Currency } from './currency-types';
 
 const ALLOWED_CHARS = '13456789abcdefghijkmnopqrstuwxyz';
 
@@ -27,7 +28,7 @@ export const isValidAddress = (address: string): boolean => {
     return false;
 };
 
-export const getAddressType = (address: string, _currency?: any, _networkType?: string) => {
+export const getAddressType = (address: string, _currency?: Currency, _networkType?: string) => {
     if (isValidAddress(address)) {
         return addressType.ADDRESS;
     }

--- a/packages/address-validator/src/nem_validator.ts
+++ b/packages/address-validator/src/nem_validator.ts
@@ -1,5 +1,6 @@
 import * as cryptoUtils from './crypto/utils';
 import { addressType } from './crypto/utils';
+import type { Currency } from './currency-types';
 
 export const isValidAddress = (_address: string): boolean => {
     const address = _address.toString().toUpperCase().replace(/-/g, '');
@@ -14,7 +15,7 @@ export const isValidAddress = (_address: string): boolean => {
     return stepThreeChecksum === decoded.slice(42);
 };
 
-export const getAddressType = (address: string, _currency?: any, _networkType?: string) => {
+export const getAddressType = (address: string, _currency?: Currency, _networkType?: string) => {
     if (isValidAddress(address)) {
         return addressType.ADDRESS;
     }

--- a/packages/address-validator/src/nxt_validator.ts
+++ b/packages/address-validator/src/nxt_validator.ts
@@ -1,10 +1,11 @@
 import { addressType } from './crypto/utils';
+import type { Currency } from './currency-types';
 
 const nxtRegex = new RegExp('^NXT(-[A-Z0-9]{4}){3}-[A-Z0-9]{5}$');
 
 export const isValidAddress = (address: string): boolean => nxtRegex.test(address);
 
-export const getAddressType = (address: string, _currency?: any, _networkType?: string) => {
+export const getAddressType = (address: string, _currency?: Currency, _networkType?: string) => {
     if (isValidAddress(address)) {
         return addressType.ADDRESS;
     }

--- a/packages/address-validator/src/ripple_validator.ts
+++ b/packages/address-validator/src/ripple_validator.ts
@@ -2,6 +2,7 @@ import baseX from 'base-x';
 
 import * as cryptoUtils from './crypto/utils';
 import { addressType } from './crypto/utils';
+import type { Currency } from './currency-types';
 
 const ALLOWED_CHARS = 'rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz';
 
@@ -24,7 +25,7 @@ export const isValidAddress = (address: string): boolean => {
     return false;
 };
 
-export const getAddressType = (address: string, _currency?: any, _networkType?: string) => {
+export const getAddressType = (address: string, _currency?: Currency, _networkType?: string) => {
     if (isValidAddress(address)) {
         return addressType.ADDRESS;
     }

--- a/packages/address-validator/src/siacoin_validator.ts
+++ b/packages/address-validator/src/siacoin_validator.ts
@@ -1,5 +1,6 @@
 import * as cryptoUtils from './crypto/utils';
 import { addressType } from './crypto/utils';
+import type { Currency } from './currency-types';
 
 function verifyChecksum(address: string): boolean {
     const checksumBytes = address.slice(0, 32 * 2);
@@ -17,7 +18,7 @@ export const isValidAddress = (address: string): boolean => {
     return verifyChecksum(address);
 };
 
-export const getAddressType = (address: string, _currency?: any, _networkType?: string) => {
+export const getAddressType = (address: string, _currency?: Currency, _networkType?: string) => {
     if (isValidAddress(address)) {
         return addressType.ADDRESS;
     }

--- a/packages/address-validator/src/solana_validator.ts
+++ b/packages/address-validator/src/solana_validator.ts
@@ -1,5 +1,6 @@
 import * as base58 from './crypto/base58';
 import { addressType } from './crypto/utils';
+import type { Currency } from './currency-types';
 
 export const isValidAddress = (address: string): boolean => {
     try {
@@ -11,7 +12,7 @@ export const isValidAddress = (address: string): boolean => {
     }
 };
 
-export const getAddressType = (address: string, _currency?: any, _networkType?: string) => {
+export const getAddressType = (address: string, _currency?: Currency, _networkType?: string) => {
     if (isValidAddress(address)) {
         return addressType.ADDRESS;
     }

--- a/packages/address-validator/src/steem_validator.ts
+++ b/packages/address-validator/src/steem_validator.ts
@@ -1,4 +1,5 @@
 import { addressType } from './crypto/utils';
+import type { Currency } from './currency-types';
 
 const accountRegex = new RegExp('^[a-z0-9-.]{3,}$');
 const segmentRegex = new RegExp('^[a-z][a-z0-9-]+[a-z0-9]$');
@@ -25,7 +26,7 @@ export const isValidAddress = (address: string): boolean => {
     return true;
 };
 
-export const getAddressType = (address: string, _currency?: any, _networkType?: string) => {
+export const getAddressType = (address: string, _currency?: Currency, _networkType?: string) => {
     if (isValidAddress(address)) {
         return addressType.ADDRESS;
     }

--- a/packages/address-validator/src/stellar_validator.ts
+++ b/packages/address-validator/src/stellar_validator.ts
@@ -3,6 +3,7 @@ import crc from 'crc';
 
 import * as cryptoUtils from './crypto/utils';
 import { addressType } from './crypto/utils';
+import type { Currency } from './currency-types';
 
 const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
 
@@ -38,7 +39,7 @@ export const isValidAddress = (address: string): boolean => {
     return false;
 };
 
-export const getAddressType = (address: string, _currency?: any, _networkType?: string) => {
+export const getAddressType = (address: string, _currency?: Currency, _networkType?: string) => {
     if (isValidAddress(address)) {
         return addressType.ADDRESS;
     }

--- a/packages/address-validator/src/sys_validator.ts
+++ b/packages/address-validator/src/sys_validator.ts
@@ -1,12 +1,16 @@
 import * as BTCValidator from './bitcoin_validator';
 import { addressType } from './crypto/utils';
+import type { Currency } from './currency-types';
 
 const regexp = new RegExp('^sys1[qpzry9x8gf2tvdw0s3jn54khce6mua7l]{39}$');
 
-export const isValidAddress = (address: string, currency?: any, networkType?: string): boolean =>
-    regexp.test(address) || BTCValidator.isValidAddress(address, currency, networkType);
+export const isValidAddress = (
+    address: string,
+    currency?: Currency,
+    networkType?: string,
+): boolean => regexp.test(address) || BTCValidator.isValidAddress(address, currency, networkType);
 
-export const getAddressType = (address: string, currency?: any, networkType?: string) => {
+export const getAddressType = (address: string, currency?: Currency, networkType?: string) => {
     if (isValidAddress(address, currency, networkType)) {
         return addressType.ADDRESS;
     }

--- a/packages/address-validator/src/tezos_validator.ts
+++ b/packages/address-validator/src/tezos_validator.ts
@@ -1,6 +1,7 @@
 import * as base58 from './crypto/base58';
 import * as cryptoUtils from './crypto/utils';
 import { addressType } from './crypto/utils';
+import type { Currency } from './currency-types';
 
 const prefix = new Uint8Array([6, 161, 159]);
 
@@ -36,7 +37,7 @@ export const isValidAddress = (address: string): boolean => {
     }
 };
 
-export const getAddressType = (address: string, _currency?: any, _networkType?: string) => {
+export const getAddressType = (address: string, _currency?: Currency, _networkType?: string) => {
     if (isValidAddress(address)) {
         return addressType.ADDRESS;
     }

--- a/packages/address-validator/src/tron_validator.ts
+++ b/packages/address-validator/src/tron_validator.ts
@@ -1,5 +1,6 @@
 import * as cryptoUtils from './crypto/utils';
 import { addressType } from './crypto/utils';
+import type { Currency } from './currency-types';
 
 function decodeBase58Address(base58Sting: unknown): number[] | false {
     if (typeof base58Sting !== 'string') {
@@ -45,7 +46,7 @@ function getEnv(currency: any, networkType?: string): number {
 
 export const isValidAddress = (
     mainAddress: string,
-    currency?: any,
+    currency?: Currency,
     networkType?: string,
 ): boolean => {
     const address = decodeBase58Address(mainAddress);
@@ -61,7 +62,7 @@ export const isValidAddress = (
     return getEnv(currency, networkType) === address[0];
 };
 
-export const getAddressType = (address: string, currency?: any, networkType?: string) => {
+export const getAddressType = (address: string, currency?: Currency, networkType?: string) => {
     if (isValidAddress(address, currency, networkType)) {
         return addressType.ADDRESS;
     }

--- a/packages/address-validator/src/zil_validator.ts
+++ b/packages/address-validator/src/zil_validator.ts
@@ -1,6 +1,7 @@
 import { bech32 } from '@scure/base';
 
 import { addressType } from './crypto/utils';
+import type { Currency } from './currency-types';
 
 const ALLOWED_CHARS = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';
 
@@ -16,7 +17,7 @@ export const isValidAddress = (address: string): boolean => {
     return !!(decoded && decoded.words.length === 32);
 };
 
-export const getAddressType = (address: string, _currency?: any, _networkType?: string) => {
+export const getAddressType = (address: string, _currency?: Currency, _networkType?: string) => {
     if (isValidAddress(address)) {
         return addressType.ADDRESS;
     }


### PR DESCRIPTION
Previously, \`Currency.validator\` was typed as \`any\`, meaning TypeScript applied no checks
when calling \`validator.isValidAddress\` or \`validator.getAddressType\` in the dispatcher —
a misnamed export or wrong signature in a validator module would only fail at runtime.

This PR introduces a \`Validator\` interface and changes \`validator: any\` to \`validator: Validator\`
on the \`Currency\` type. Every module registered in \`CURRENCIES[]\` now must satisfy the contract
at compile time. It also replaces all remaining \`currency?: any\` annotations across the 25
validator modules with \`currency?: Currency\`.

## Test plan

- [x] \`yarn workspace @trezor/address-validator type-check\`
- [x] \`yarn workspace @trezor/address-validator test:unit\`

Refs: #27403

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/extract-address-validator&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/extract-address-validator&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > call cancellation | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-13T06:11:40.754Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/extract-address-validator/web/](https://dev.suite.sldev.cz/suite-web/mroz22/extract-address-validator/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->