### PR TITLE
Feat/connect ping method

### DIFF
--- a/packages/connect-cli/README.md
+++ b/packages/connect-cli/README.md
@@ -5,3 +5,25 @@ Nodejs client for `@trezor/connect`
 Run `yarn workspace @trezor/connect-cli cli --help`
 
 [HELP](./src/args.ts)
+
+### Bridge transport
+
+**requires** `transport-bridge` process.
+
+Run
+
+```
+tsx ./packages/transport-bridge/src/bin.js
+```
+
+### Bluetooth bluetooth
+
+**requires** already paired bluetooth device.
+
+**requires** `transport-bluetooth` binary.
+
+Run
+
+```
+./packages/suite-data/files/bin/bluetooth/[your-arch]/trezor-bluetooth
+```

--- a/packages/connect-cli/package.json
+++ b/packages/connect-cli/package.json
@@ -9,7 +9,11 @@
         "depcheck": "yarn g:depcheck",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
         "type-check": "yarn g:tsc --build",
-        "cli": "tsx ./src/index.ts"
+        "cli": "tsx ./src/index.ts",
+        "usb": "tsx ./src/index.ts --usb",
+        "udp": "tsx ./src/index.ts --udp",
+        "bridge": "tsx ./src/index.ts --bridge",
+        "bluetooth": "tsx ./src/index.ts --bluetooth"
     },
     "dependencies": {
         "@trezor/connect": "workspace:*",

--- a/packages/connect-cli/src/args.ts
+++ b/packages/connect-cli/src/args.ts
@@ -1,7 +1,7 @@
 export const HELP = `@trezor/connect CLI arguments:
 
   Transport options (default: usb)
-    --usb | --bridge | --udp | --bluetooth
+    yarn workspace @trezor/connect-cli [usb | bridge | udp | bluetooth]
 
   TrezorConnect logs (default: disabled)
     --debug                                   Enable TrezorConnect logs

--- a/packages/connect-cli/src/index.ts
+++ b/packages/connect-cli/src/index.ts
@@ -133,6 +133,16 @@ const runTestCase = async (device: Device) => {
         case 'apply-settings':
             result = await TrezorConnect.applySettings({ device, ...params });
             break;
+        case 'ping-device':
+            // NOTE:
+            // firmware _PROTOBUF_BUFFER_SIZE = const(8704)
+            // T1B1 firmware Ping.message max_size:256
+            result = await TrezorConnect.pingDevice({
+                device,
+                message: 'a'.repeat(8000),
+                // button_protection: true,
+            });
+            break;
         default:
             result = await TrezorConnect.getAddress({ device, path: "m/44'/0'/0'/0/0", ...params });
     }

--- a/packages/connect-cli/src/transport.ts
+++ b/packages/connect-cli/src/transport.ts
@@ -15,6 +15,8 @@ export const getCurrentTransport = () => {
     return 'usb';
 };
 
+const getLogger = () => (args.debug ? console : undefined);
+
 // if interaction is done by the user or resolved by DebugLink decision
 export const isDebugLinkInteraction = (type: string) =>
     (typeof args.debuglink === 'boolean' && args.debuglink) ||
@@ -22,8 +24,8 @@ export const isDebugLinkInteraction = (type: string) =>
 
 const debugTransport =
     getCurrentTransport() === 'udp'
-        ? new UdpTransport({ id: 'udp', debugLink: true })
-        : new NodeUsbTransport({ id: 'usb', debugLink: true });
+        ? new UdpTransport({ id: 'udp', debugLink: true, logger: getLogger() })
+        : new NodeUsbTransport({ id: 'usb', debugLink: true, logger: getLogger() });
 
 export const initDebugLink = async () => {
     if (args['interactive']) return;
@@ -120,7 +122,7 @@ export const debugLinkDecision = async () => {
 export const getTransport = async (): Promise<ConnectSettingsTransport> => {
     const transportName = getCurrentTransport();
 
-    const bluetoothApi = new TrezorBluetooth({ url: `ws://localhost:21327/` });
+    const bluetoothApi = new TrezorBluetooth({ url: `ws://localhost:21327/`, logger: getLogger() });
     if (transportName === 'bluetooth') {
         await bluetoothApi.connect();
         const enumerate = await bluetoothApi.send('start_scan');
@@ -136,6 +138,7 @@ export const getTransport = async (): Promise<ConnectSettingsTransport> => {
         return new BluetoothTransport({
             url: 'ws://127.0.0.1:21327',
             id: 'ble',
+            logger: getLogger(),
         });
     } else if (transportName === 'bridge') {
         return 'BridgeTransport';

--- a/packages/connect-common/src/callableMethods.ts
+++ b/packages/connect-common/src/callableMethods.ts
@@ -62,6 +62,7 @@ const connectCallableMethodGroups = {
         'thpGetCredentials',
         'thpRemoveCredentials',
         'telemetryGet',
+        'pingDevice',
     ],
     blockchain: [
         'blockchainSubscribe',

--- a/packages/connect-common/src/types/api/index.ts
+++ b/packages/connect-common/src/types/api/index.ts
@@ -206,7 +206,7 @@ export const TrezorConnectDevice = Type.Object({
 
     telemetryGet: Type.Unsafe<typeof telemetryGet>(),
 
-    // todo: link docs
+    // https://connect.trezor.io/9/methods/device/pingDevice/
     pingDevice: Type.Unsafe<typeof pingDevice>(),
 });
 export type TrezorConnectDevice = Static<typeof TrezorConnectDevice>;

--- a/packages/connect-common/src/types/api/index.ts
+++ b/packages/connect-common/src/types/api/index.ts
@@ -66,6 +66,7 @@ import type { moneroKeyImageSync } from './moneroKeyImageSync';
 import type { moneroSignTransaction } from './moneroSignTransaction';
 import type { off } from './off';
 import type { on } from './on';
+import type { pingDevice } from './pingDevice';
 import type { pushTransaction } from './pushTransaction';
 import type { recoveryDevice } from './recoveryDevice';
 import type { removeAllListeners } from './removeAllListeners';
@@ -204,6 +205,9 @@ export const TrezorConnectDevice = Type.Object({
     thpRemoveCredentials: Type.Unsafe<typeof thpRemoveCredentials>(),
 
     telemetryGet: Type.Unsafe<typeof telemetryGet>(),
+
+    // todo: link docs
+    pingDevice: Type.Unsafe<typeof pingDevice>(),
 });
 export type TrezorConnectDevice = Static<typeof TrezorConnectDevice>;
 

--- a/packages/connect-common/src/types/api/pingDevice.ts
+++ b/packages/connect-common/src/types/api/pingDevice.ts
@@ -1,0 +1,9 @@
+/**
+ * Request: Test if the device is alive, device sends back the message in Success response
+ */
+
+import type { MessagesSchema as PROTO } from '@trezor/protobuf';
+
+import type { Params, Response } from '../params';
+
+export declare function pingDevice(params: Params<PROTO.Ping>): Response<PROTO.Ping>;

--- a/packages/connect-explorer/src/data/methods/management/pingDevice.ts
+++ b/packages/connect-explorer/src/data/methods/management/pingDevice.ts
@@ -1,0 +1,23 @@
+const name = 'pingDevice';
+
+export default [
+    {
+        name,
+        submitButton: 'Ping device',
+        fields: [
+            {
+                name: 'message',
+                type: 'textarea',
+                optional: true,
+                value: 'Hello Trezor',
+            },
+            {
+                label: 'button protection',
+                name: 'button_protection',
+                type: 'checkbox',
+                optional: true,
+                value: false,
+            },
+        ],
+    },
+];

--- a/packages/connect-explorer/src/pages/methods/device/pingDevice.mdx
+++ b/packages/connect-explorer/src/pages/methods/device/pingDevice.mdx
@@ -1,0 +1,72 @@
+import { Callout } from 'nextra/components';
+
+import { MessagesSchema as PROTO } from '@trezor/protobuf';
+
+import { ApiPlayground } from '../../../components/ApiPlayground';
+import { CommonParamsLink } from '../../../components/CommonParamsLink';
+import { ParamsTable } from '../../../components/ParamsTable';
+import pingDevice from '../../../data/methods/management/pingDevice.ts';
+
+<ApiPlayground options={[{ title: 'Ping device', legacyConfig: pingDevice[0] }]} />
+
+## Ping Device
+
+<Callout type="error">
+    **Management command** - this method is restricted to Trezor.io and can't be used in 3rd party
+    applications.
+</Callout>
+
+Sends a ping message to the device and waits for a response. Useful for verifying that the device is connected and responsive.
+
+T2 message size limit: 8704
+
+T1 message size limit: 256
+
+```javascript
+const result = await TrezorConnect.pingDevice(params);
+```
+
+### Params
+
+<CommonParamsLink />
+
+export const paramDescriptions = {
+    message: 'Message to send to the device',
+    button_protection: 'Require user to confirm the action on the device',
+};
+
+<ParamsTable schema={PROTO.Ping} descriptions={paramDescriptions} />
+
+### Example
+
+```javascript
+TrezorConnect.pingDevice({
+    message: 'Hello Trezor',
+    button_protection: true,
+});
+```
+
+### Result
+
+Success type
+
+```javascript
+{
+    success: true,
+    payload: {
+        message: 'Hello Trezor'
+    }
+}
+```
+
+Error
+
+```javascript
+{
+    success: false,
+    payload: {
+        error: string, // error message
+        code: string // error code
+    }
+}
+```

--- a/packages/connect/e2e/tests/device/pingDevice.test.ts
+++ b/packages/connect/e2e/tests/device/pingDevice.test.ts
@@ -1,0 +1,63 @@
+import { vi } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import TrezorConnect from '@trezor/connect';
+
+import { conditionalTest, getController, initTrezorConnect, setup } from '../../common.setup';
+
+const controller = getController();
+
+describe('TrezorConnect.pingDevice', () => {
+    beforeAll(async () => {
+        await setup(controller, {
+            mnemonic: 'mnemonic_all',
+        });
+        await initTrezorConnect(controller, { debug: false });
+    });
+
+    afterAll(() => {
+        controller.dispose();
+        TrezorConnect.dispose();
+    });
+
+    it('short message', async () => {
+        const message = 'Message from E2E test';
+        const response = await TrezorConnect.pingDevice({
+            message,
+        });
+        expect(response).toMatchObject({
+            success: true,
+            payload: {
+                message,
+            },
+        });
+    });
+
+    conditionalTest(['1'], 'long message', async () => {
+        // firmware _PROTOBUF_BUFFER_SIZE = const(8704)
+        // left some space for the headers
+        const response = await TrezorConnect.pingDevice({
+            message: 'a'.repeat(8000),
+        });
+        expect(response.success).toEqual(true);
+    });
+
+    conditionalTest(['2'], 'long message T1B1', async () => {
+        // firmware Ping.message max_size:256
+        const response = await TrezorConnect.pingDevice({
+            message: 'a'.repeat(255),
+        });
+        expect(response.success).toEqual(true);
+    });
+
+    it('with button request', async () => {
+        const buttonSpy = vi.fn();
+        TrezorConnect.on('ui-button', buttonSpy);
+
+        const response = await TrezorConnect.pingDevice({
+            button_protection: true,
+        });
+        expect(response.success).toEqual(true);
+        expect(buttonSpy).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/connect/src/api/index.ts
+++ b/packages/connect/src/api/index.ts
@@ -42,6 +42,7 @@ export { default as getOwnershipId } from './getOwnershipId';
 export { default as getOwnershipProof } from './getOwnershipProof';
 export { default as getPublicKey } from './getPublicKey';
 export { default as getSettings } from './getSettings';
+export { default as pingDevice } from './pingDevice';
 export { default as pushTransaction } from './pushTransaction';
 export { default as recoveryDevice } from './recoveryDevice';
 export { default as requestLogin } from './requestLogin';

--- a/packages/connect/src/api/pingDevice.ts
+++ b/packages/connect/src/api/pingDevice.ts
@@ -1,0 +1,34 @@
+import { type MethodPermission, UI_REQUEST } from '@trezor/connect-common';
+import { MessagesSchema as PROTO } from '@trezor/protobuf';
+import { Assert } from '@trezor/schema-utils';
+
+import type { MethodMessage } from '../core/AbstractMethod';
+import { AbstractMethod } from '../core/AbstractMethod';
+
+export default class PingDevice extends AbstractMethod<'pingDevice', PROTO.Ping> {
+    constructor(message: MethodMessage<'pingDevice'>) {
+        const { payload } = message;
+        // validate incoming parameters
+        Assert(PROTO.Ping, payload);
+
+        const params = {
+            message: payload.message,
+            button_protection: payload.button_protection,
+        };
+
+        super(message, params);
+        this.allowDeviceMode = [UI_REQUEST.INITIALIZE, UI_REQUEST.SEEDLESS, UI_REQUEST.BOOTLOADER];
+        this.useDeviceState = false;
+    }
+
+    get requiredPermissions(): MethodPermission[] {
+        return ['management'];
+    }
+
+    async run() {
+        const cmd = this.getDevice().getCommands();
+        const response = await cmd.typedCall('Ping', 'Success', this.params);
+
+        return response.message;
+    }
+}

--- a/packages/suite/src/views/settings/SettingsDebug/PingDevice.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/PingDevice.tsx
@@ -1,0 +1,69 @@
+import { useRef, useState } from 'react';
+
+import { useDevice } from '@suite/device';
+import { type ToastPayload, notificationsActions } from '@suite-common/toast-notifications';
+import { Checkbox, Input } from '@trezor/components';
+import TrezorConnect from '@trezor/connect';
+import { ActionButton, ActionColumn, SectionItem, TextColumn } from '@trezor/product-components';
+
+import { useDispatch } from 'src/hooks/suite';
+
+export const PingDevice = () => {
+    const { device, isLocked } = useDevice();
+    const [isLoading, setIsLoading] = useState(false);
+    const [buttonProtection, setButtonProtection] = useState(false);
+    const inputRef = useRef<HTMLInputElement>(null);
+    const dispatch = useDispatch();
+
+    const isDeviceLocked = isLocked();
+
+    const handleClick = async () => {
+        setIsLoading(true);
+        const response = await TrezorConnect.pingDevice({
+            device,
+            message: inputRef.current?.value ?? '',
+            button_protection: buttonProtection,
+        });
+        setIsLoading(false);
+
+        let toastPayload: ToastPayload;
+        if (response.success) {
+            toastPayload = {
+                type: 'connect-popup-success',
+                appName: 'Ping',
+            };
+        } else {
+            toastPayload = {
+                type: 'error',
+                error: response.error.message,
+            };
+        }
+        dispatch(notificationsActions.addToast(toastPayload));
+    };
+
+    return (
+        <SectionItem>
+            <ActionColumn>
+                <Input innerRef={inputRef} placeholder="Ping message" />
+            </ActionColumn>
+
+            <ActionColumn>
+                <Checkbox
+                    isChecked={buttonProtection}
+                    labelAlignment="end"
+                    onChange={() => setButtonProtection(prev => !prev)}
+                >
+                    <TextColumn description="With confirmation" />
+                </Checkbox>
+                <ActionButton
+                    onClick={handleClick}
+                    size="small"
+                    isDisabled={isDeviceLocked}
+                    isLoading={isLoading}
+                >
+                    Send
+                </ActionButton>
+            </ActionColumn>
+        </SectionItem>
+    );
+};

--- a/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
@@ -30,6 +30,7 @@ import { MessageSystemDebug } from './MessageSystem/MessageSystemDebug';
 import { Metadata } from './Metadata';
 import { N4w1Backup } from './N4w1Backup';
 import { OAuthApi } from './OAuthApi';
+import { PingDevice } from './PingDevice';
 import { PlatformEncrypton } from './PlatformEncrypton';
 import { PreField } from './PreField';
 import { QuotaManagerSettings } from './QuotaManagerSettings';
@@ -93,6 +94,7 @@ export const SettingsDebug = () => {
                 <CheckFirmwareAuthenticity />
                 <ClearDevicePersistentData />
                 <N4w1Backup />
+                <PingDevice />
             </SettingsSection>
             <SettingsSection isBelowLaptop={isBelowLaptop} title="Testing">
                 <ThrowTestingError />

--- a/scripts/ci/connect-test-matrix-generator.js
+++ b/scripts/ci/connect-test-matrix-generator.js
@@ -25,7 +25,7 @@ const groups = {
     },
     management: {
         name: 'management',
-        pattern: 'methods',
+        pattern: 'methods pingDevice',
         includeFilter:
             'applySettings,applyFlags,getFeatures,getFirmwareHash,changeLanguage,loadDevice,telemetryGet',
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

add `TrezorConect.pingDevice` method. this allow us debugging the transport (message size limitations, loosing packets issues etc.)


### connect-explorer

<img width="880" height="775" alt="Screenshot from 2026-05-12 19-31-15" src="https://github.com/user-attachments/assets/776c85f9-0b61-4c7b-80e1-bd0b967a33cd" />

### trezor-suite

<img width="1047" height="468" alt="Screenshot from 2026-05-12 19-42-34" src="https://github.com/user-attachments/assets/30ec2d73-3469-486f-bd75-3fae12277dea" />



## Related issue

https://github.com/trezor/trezor-firmware/issues/6915



<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/connect-ping-method&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/connect-ping-method&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/connect-ping-method&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Send form for bitcoin > add and remove output in send form, toggle form options, input data | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-12T17:53:41.073Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-13T12:22:30.329Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/connect-ping-method/web/](https://dev.suite.sldev.cz/suite-web/feat/connect-ping-method/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->