### PR TITLE
Mobile trade: ensure gas limit adjustment is applied for DEX approval transactions

### DIFF
--- a/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts
@@ -107,8 +107,7 @@ export const sendDexTransactionThunk = createThunk<
                 amount: selectedQuote.dexTx.value,
                 destinationTag: selectedQuote.partnerPaymentExtraId,
                 recalculateCustomLimit: true,
-                ethereumAdjustGasLimit:
-                    selectedQuote.status === 'CONFIRM' ? ETHEREUM_ADJUST_GAS_LIMIT : undefined,
+                ethereumAdjustGasLimit: ETHEREUM_ADJUST_GAS_LIMIT,
                 setMaxOutputId,
                 signAndPushSendFormTransaction,
                 tradingFormState,

--- a/suite-native/module-trading/src/utils/__tests__/tradingFormUtils.test.ts
+++ b/suite-native/module-trading/src/utils/__tests__/tradingFormUtils.test.ts
@@ -227,7 +227,7 @@ describe('createFormStateForSendForm', () => {
             expect(formState.ethereumAdjustGasLimit).toBe('1.25');
         });
 
-        it('should not apply gas limit adjustment for DEX approval transactions', () => {
+        it('should apply gas limit adjustment for DEX approval transactions', () => {
             const dexApprovalQuote: ExchangeTrade = {
                 exchange: '1inch',
                 send: 'ethereum--0xTokenAddress' as any,
@@ -257,7 +257,7 @@ describe('createFormStateForSendForm', () => {
             expect(formState.outputs[0].address).toBe('0xDexRouterAddress');
             expect(formState.transactionData).toBe('0xapprovaldata');
             // No gas adjustment for approval transactions
-            expect(formState.ethereumAdjustGasLimit).toBe('');
+            expect(formState.ethereumAdjustGasLimit).toBe('1.25');
         });
 
         it('should not set DEX fields for CEX exchange quotes', () => {

--- a/suite-native/module-trading/src/utils/tradingFormUtils.ts
+++ b/suite-native/module-trading/src/utils/tradingFormUtils.ts
@@ -69,10 +69,7 @@ export const createFormStateForSendForm = ({
         if (exchangeQuote.isDex && exchangeQuote.dexTx) {
             outputAddress = exchangeQuote.dexTx.to;
             transactionData = exchangeQuote.dexTx.data;
-            // Gas limit adjustment only for the swap itself, not for approval transactions
-            if (exchangeQuote.status === 'CONFIRM') {
-                ethereumAdjustGasLimit = ETHEREUM_ADJUST_GAS_LIMIT;
-            }
+            ethereumAdjustGasLimit = ETHEREUM_ADJUST_GAS_LIMIT;
         }
 
         if (exchangeQuote.send) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #27357

## Screenshots:

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes involve three files: (1) `sendDexTransactionThunk.ts` in suite-common/trading — a DEX transaction sending thunk that maps to 121 tests, indicating it's a broadly imported shared module; (2) `tradingFormUtils.ts` and its unit test in suite-native/module-trading — native mobile utilities with no static E2E test coverage. The `sendDexTransactionThunk.ts` change maps to 121 tests, strongly suggesting it's a transitive dependency rather than directly exercised by any specific E2E test. None of the 121 mapped tests have behaviors related to DEX swap transactions or DEX-specific flows based on the LLM analysis. The native module changes are entirely mobile-specific with no web/desktop E2E coverage. No E2E tests need to be run for this change set — the risk is best covered by the existing unit test for tradingFormUtils and any unit/integration tests for the DEX thunk.

<details><summary><b>Changed files (3)</b></summary>

- `suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts`
- `suite-native/module-trading/src/utils/__tests__/tradingFormUtils.test.ts`
- `suite-native/module-trading/src/utils/tradingFormUtils.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (3)**
- `suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts`
- `suite-native/module-trading/src/utils/__tests__/tradingFormUtils.test.ts`
- `suite-native/module-trading/src/utils/tradingFormUtils.ts`

_Updated: 2026-05-12T16:30:45.880Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=27357-fix-inconsistent-fee-amounts-in-trading&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=27357-fix-inconsistent-fee-amounts-in-trading&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=27357-fix-inconsistent-fee-amounts-in-trading&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > call cancellation | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-12T16:36:03.388Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-12T16:34:17.471Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/27357-fix-inconsistent-fee-amounts-in-trading/web/](https://dev.suite.sldev.cz/suite-web/27357-fix-inconsistent-fee-amounts-in-trading/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->