### PR TITLE
fix(suite): validate token decimals in yield deposit/withdraw/approve inputs

### DIFF
--- a/packages/suite/src/components/earn/yield/common/YieldActionStep.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldActionStep.tsx
@@ -60,6 +60,7 @@ export const YieldActionStep = ({
         <Column gap={16}>
             <YieldAmountCard
                 tokenSymbol={token.symbol}
+                decimals={token.decimals}
                 summary={{
                     labelTranslationId: balanceLabelTranslationId,
                     value: summaryValue,

--- a/packages/suite/src/components/earn/yield/common/YieldAmountCard.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldAmountCard.tsx
@@ -1,15 +1,16 @@
-import { type ReactNode } from 'react';
+import { type ReactNode, useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
 
-import { Translation } from '@suite/intl';
+import { Translation, useTranslation } from '@suite/intl';
 import type { TranslationKey } from '@suite/intl';
 import { selectLanguage } from '@suite/settings';
 import { formInputsMaxLength } from '@suite-common/validators';
 import type { YieldFlowFormValues } from '@suite-common/wallet-core';
-import { Button, Card, Column, Row, Text, TextButton } from '@trezor/components';
+import { Banner, Button, Card, Column, Row, Text, TextButton } from '@trezor/components';
 import { NumberInput } from '@trezor/product-components';
 
 import { useSelector } from 'src/hooks/suite';
+import { validateDecimals } from 'src/utils/suite/validation';
 
 type YieldAmountCardSummaryProps = {
     value: ReactNode;
@@ -28,6 +29,7 @@ export type YieldAmountCardUnitToggleProps = {
 
 type YieldAmountCardProps = {
     tokenSymbol: string;
+    decimals?: number;
     summary?: YieldAmountCardSummaryProps;
     heading?: YieldAmountCardHeadingProps;
     unitToggle?: YieldAmountCardUnitToggleProps;
@@ -37,6 +39,7 @@ type YieldAmountCardProps = {
 
 export const YieldAmountCard = ({
     tokenSymbol,
+    decimals,
     summary,
     heading,
     unitToggle,
@@ -44,7 +47,19 @@ export const YieldAmountCard = ({
     isDisabled = false,
 }: YieldAmountCardProps) => {
     const locale = useSelector(selectLanguage);
-    const { control } = useFormContext<YieldFlowFormValues>();
+    const { translationString } = useTranslation();
+    const {
+        control,
+        formState: { errors },
+    } = useFormContext<YieldFlowFormValues>();
+
+    const rules = useMemo(
+        () =>
+            decimals !== undefined
+                ? { validate: { decimals: validateDecimals(translationString, { decimals }) } }
+                : undefined,
+        [translationString, decimals],
+    );
 
     return (
         <Card paddingType="none">
@@ -76,6 +91,7 @@ export const YieldAmountCard = ({
                     name="amountInput"
                     locale={locale}
                     control={control}
+                    rules={rules}
                     maxLength={formInputsMaxLength.amount}
                     isDisabled={isDisabled}
                     rightContent={
@@ -104,6 +120,13 @@ export const YieldAmountCard = ({
                             </Button>
                         )}
                     </Row>
+                )}
+
+                {errors.amountInput?.message && (
+                    <Banner
+                        intent="warning"
+                        description={<Text>{errors.amountInput.message}</Text>}
+                    />
                 )}
 
                 {warning}

--- a/packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx
@@ -118,6 +118,7 @@ export const YieldApproveStep = ({
 
                     <YieldAmountCard
                         tokenSymbol={token.symbol}
+                        decimals={token.decimals}
                         summary={{
                             labelTranslationId: balanceLabelTranslationId,
                             value: summaryValue,

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -91,6 +91,7 @@ export type UseYieldFlowResult = {
     actionNetworkFeeWarning: YieldNetworkFeeWarning | null;
     isAmountEmpty: boolean;
     isAmountTooHigh: boolean;
+    isAmountInvalidDecimals: boolean;
     isApprovalInsufficient: boolean;
     isSubmittingApprove: boolean;
     isSubmittingAction: boolean;
@@ -125,6 +126,7 @@ export const useYieldFlow = ({
     const dispatch = useDispatch();
     const { device } = useDevice();
     const methods = useForm<YieldFlowFormValues>({
+        mode: 'onChange',
         defaultValues: {
             amountInput: '',
             withdrawInputUnit: 'asset',
@@ -522,6 +524,7 @@ export const useYieldFlow = ({
     const allowanceAmount = session.approval.allowanceAmount ?? '0';
     const canRevokeAllowance = isAmountGreaterThan({ amount: allowanceAmount, threshold: '0' });
     const isAmountTooHigh = isAmountGreaterThan({ amount: liveAmount, threshold: maxAmount });
+    const isAmountInvalidDecimals = !!methods.formState.errors.amountInput;
     const isApprovalInsufficient =
         !session.approval.isModifyMode &&
         session.approval.allowanceStatus === 'loaded' &&
@@ -588,6 +591,7 @@ export const useYieldFlow = ({
         actionNetworkFeeWarning: networkFeeWarning.actionNetworkFeeWarning,
         isAmountEmpty,
         isAmountTooHigh,
+        isAmountInvalidDecimals,
         isApprovalInsufficient,
         isSubmittingApprove:
             session.approval.isSubmitting ||

--- a/packages/suite/src/components/earn/yield/supply/YieldSupplyForm.tsx
+++ b/packages/suite/src/components/earn/yield/supply/YieldSupplyForm.tsx
@@ -39,6 +39,7 @@ export const YieldSupplyForm = () => {
         actionNetworkFeeWarning,
         isAmountEmpty,
         isAmountTooHigh,
+        isAmountInvalidDecimals,
         isApprovalInsufficient,
         isSubmittingApprove,
         isSubmittingAction,
@@ -219,7 +220,7 @@ export const YieldSupplyForm = () => {
                                         approvalAction={approvalAction}
                                         canRevokeAllowance={canRevokeAllowance}
                                         warning={
-                                            isAmountTooHigh ? (
+                                            !isAmountInvalidDecimals && isAmountTooHigh ? (
                                                 <YieldActionStepWarning
                                                     isInsufficientFunds={isAmountTooHigh}
                                                 />
@@ -234,7 +235,10 @@ export const YieldSupplyForm = () => {
                                             ) : undefined
                                         }
                                         isDisabled={
-                                            isAmountEmpty || isAmountTooHigh || isSubmittingApprove
+                                            isAmountEmpty ||
+                                            isAmountTooHigh ||
+                                            isAmountInvalidDecimals ||
+                                            isSubmittingApprove
                                         }
                                         isLoading={isSubmittingApprove}
                                         pendingApproveTransaction={approvalPendingTransaction}
@@ -260,11 +264,15 @@ export const YieldSupplyForm = () => {
                                                 />
                                             }
                                             warning={
-                                                <YieldActionStepWarning
-                                                    isInsufficientFunds={isAmountTooHigh}
-                                                    isApprovalInsufficient={isApprovalInsufficient}
-                                                    onModifyApproval={enterModifyApproval}
-                                                />
+                                                !isAmountInvalidDecimals ? (
+                                                    <YieldActionStepWarning
+                                                        isInsufficientFunds={isAmountTooHigh}
+                                                        isApprovalInsufficient={
+                                                            isApprovalInsufficient
+                                                        }
+                                                        onModifyApproval={enterModifyApproval}
+                                                    />
+                                                ) : undefined
                                             }
                                             networkFeeWarning={
                                                 actionNetworkFeeWarning ? (
@@ -276,6 +284,7 @@ export const YieldSupplyForm = () => {
                                             isDisabled={
                                                 isAmountEmpty ||
                                                 isAmountTooHigh ||
+                                                isAmountInvalidDecimals ||
                                                 isApprovalInsufficient ||
                                                 isSubmittingAction
                                             }

--- a/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
+++ b/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
@@ -27,6 +27,7 @@ export const YieldWithdrawForm = () => {
         actionNetworkFeeWarning,
         isAmountEmpty,
         isAmountTooHigh,
+        isAmountInvalidDecimals,
         isSubmittingAction,
         inputTokenSymbol,
         otherUnitTokenSymbol,
@@ -122,7 +123,9 @@ export const YieldWithdrawForm = () => {
                                 />
                             }
                             warning={
-                                <YieldActionStepWarning isInsufficientFunds={isAmountTooHigh} />
+                                !isAmountInvalidDecimals && isAmountTooHigh ? (
+                                    <YieldActionStepWarning isInsufficientFunds={isAmountTooHigh} />
+                                ) : undefined
                             }
                             networkFeeWarning={
                                 actionNetworkFeeWarning ? (
@@ -131,7 +134,12 @@ export const YieldWithdrawForm = () => {
                                     />
                                 ) : undefined
                             }
-                            isDisabled={isAmountEmpty || isAmountTooHigh || isSubmittingAction}
+                            isDisabled={
+                                isAmountEmpty ||
+                                isAmountTooHigh ||
+                                isAmountInvalidDecimals ||
+                                isSubmittingAction
+                            }
                             isPending={isSubmittingAction}
                             pendingTransaction={withdrawPendingTransaction}
                             unitToggle={


### PR DESCRIPTION
## Description

Adds token decimal validation to the stablecoin yield deposit, withdraw, and approve amount inputs (e.g. USDT only supports 6 decimal places). The error is shown as a warning banner inside the amount card, consistent with the existing insufficient funds warning.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27541

## Screenshots:

<img width="569" height="602" alt="image" src="https://github.com/user-attachments/assets/e898697f-94cf-4750-9ab0-676e5d3739f7" />

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All 6 changed files are within the earn/yield component tree (supply form, withdraw form, amount card, action step, approve step, and the useYieldFlow hook), making this a focused change to the staking/yield feature. The highest risk is to ETH staking flows (initial stake, stake more, unstake) which directly exercise these components. SOL and ADA staking tests share the same yield infrastructure and should be run at medium priority. The 121 tests mapped via static coverage are due to broad transitive imports and are almost entirely irrelevant (backup, metadata, browser, trading tests etc.) — only staking-specific tests need to run. The useYieldFlow hook has no static test coverage but is heavily exercised through the staking E2E tests.

<details><summary><b>Changed files (6)</b></summary>

- `packages/suite/src/components/earn/yield/common/YieldActionStep.tsx`
- `packages/suite/src/components/earn/yield/common/YieldAmountCard.tsx`
- `packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx`
- `packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts`
- `packages/suite/src/components/earn/yield/supply/YieldSupplyForm.tsx`
- `packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/analytics/staking-events.test.ts` — This test directly exercises staking navigation flows for ETH and ADA, which are the primary entry points to the yield/staking UI. Changes to YieldSupplyForm, YieldWithdrawForm, and the useYieldFlow hook could affect how staking pages render and behave when navigated to from the account menu or dashboard.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test covers the full first-time ETH staking flow including the staking form, amount entry, device confirmation, and post-stake UI updates. YieldSupplyForm, YieldAmountCard, YieldActionStep, and useYieldFlow are all directly exercised in the supply/stake flow.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — This test exercises the 'stake more' flow for ETH which uses the YieldSupplyForm for entering additional staking amounts. Changes to the supply form, amount card, action step, and approve step components directly affect this flow.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — This test covers the full ETH unstake and claim flow. YieldWithdrawForm is directly used for the unstaking form, and YieldAmountCard, YieldActionStep, and useYieldFlow orchestrate the withdrawal UI and transaction confirmation.
- `suite/e2e/tests/staking/staking-form.test.ts` — This test validates the ETH staking form's input validation (min amount, decimals, insufficient funds), percentage buttons, max button with withdrawal buffer, and crypto/fiat switching. These directly exercise YieldSupplyForm and YieldAmountCard components.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — SOL staking flow exercises the yield supply form and amount card for Solana staking. While the primary changed components are yield-related, SOL staking may use different code paths but still shares the YieldSupplyForm and useYieldFlow infrastructure.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — SOL 'stake more' flow uses the yield supply form for additional staking amounts and shares the same YieldAmountCard and YieldActionStep components for the transaction confirmation flow.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — SOL unstake and claim flow exercises YieldWithdrawForm and related yield common components. Changes to the withdraw form and action step could affect how SOL unstaking and claiming behaves.
- `suite/e2e/tests/staking/sol/rewards.test.ts` — SOL rewards display test verifies the staking dashboard amounts and reward entries. While primarily a read-only view, the staking section components may share state management with useYieldFlow and rendering with YieldAmountCard.
- `suite/e2e/tests/staking/ada/stake.test.ts` — Cardano staking flow exercises the staking form and confirmation steps. While ADA staking has its own specific logic, the yield supply form and action step components are shared infrastructure that could be affected by these changes.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — Cardano unstaking flow uses the withdraw form components. Changes to YieldWithdrawForm and YieldActionStep could affect the ADA unstaking confirmation and transaction flow.
- `suite/e2e/tests/staking/ada/claim.test.ts` — Cardano claim rewards flow involves the yield action step for transaction confirmation. Changes to YieldActionStep and YieldApproveStep could affect how the claim rewards modal and device confirmation behave.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts`

_Updated: 2026-05-12T17:06:28.414Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/earn-yield-amount-decimals&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/earn-yield-amount-decimals&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > call cancellation | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-12T17:11:45.764Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send form for bitcoin > add and remove output in send form, toggle form options, input data | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-13T08:01:09.853Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/earn-yield-amount-decimals/web/](https://dev.suite.sldev.cz/suite-web/fix/earn-yield-amount-decimals/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->