### PR TITLE
ERC-681 finalization

### DIFF
--- a/packages/suite/src/utils/suite/__fixtures__/protocol.ts
+++ b/packages/suite/src/utils/suite/__fixtures__/protocol.ts
@@ -136,9 +136,9 @@ export const getProtocolInfo: getProtocolInfoFixture[] = [
     },
     {
         description: 'should parse ERC-681 token transfer URI on other EVM network',
-        uri: 'polygon:0x89205a3a3b2a69de6dbf7f01ed13b2108b2c43e7/transfer?address=0x8e23ee67d1332ad560396262c48ffbb01f93d052&uint256=500000000000000000',
+        uri: 'ethereum:0x89205a3a3b2a69de6dbf7f01ed13b2108b2c43e7@137/transfer?address=0x8e23ee67d1332ad560396262c48ffbb01f93d052&uint256=500000000000000000',
         result: {
-            scheme: 'polygon',
+            scheme: 'pol',
             address: '0x8e23ee67d1332ad560396262c48ffbb01f93d052',
             token: '0x89205a3a3b2a69de6dbf7f01ed13b2108b2c43e7',
             tokenAmount: '500000000000000000',

--- a/packages/suite/src/utils/suite/protocol.ts
+++ b/packages/suite/src/utils/suite/protocol.ts
@@ -34,7 +34,7 @@ export const getProtocolInfo = (
         const erc681 = parseErc681TransferUri(uri);
         if (erc681) {
             return {
-                scheme,
+                scheme: erc681.networkSymbol ?? scheme,
                 address: erc681.recipientAddress,
                 token: erc681.contractAddress,
                 tokenAmount: erc681.tokenAmount,

--- a/suite-common/suite-utils/src/__fixtures__/protocol.ts
+++ b/suite-common/suite-utils/src/__fixtures__/protocol.ts
@@ -120,4 +120,28 @@ export const parseErc681TransferUri: ParseErc681TransferUriFixture[] = [
             chainId: 137,
         },
     },
+    {
+        description: 'should parse ERC-681 URI with @chainId suffix - receiving ETH, no token',
+        uri: 'ethereum:0x8e23ee67d1332ad560396262c48ffbb01f93d052@8453',
+        result: {
+            recipientAddress: '0x8e23ee67d1332ad560396262c48ffbb01f93d052',
+            chainId: 8453,
+        },
+    },
+    {
+        description:
+            'should parse ERC-681 URI with @chainId suffix - receiving ETH, no token (double slash)',
+        uri: 'ethereum://0x8e23ee67d1332ad560396262c48ffbb01f93d052@8453',
+        result: {
+            recipientAddress: '0x8e23ee67d1332ad560396262c48ffbb01f93d052',
+            chainId: 8453,
+        },
+    },
+    {
+        description: 'should parse ERC-681 URI - plain ETH mainnet',
+        uri: 'ethereum://0x8e23ee67d1332ad560396262c48ffbb01f93d052',
+        result: {
+            recipientAddress: '0x8e23ee67d1332ad560396262c48ffbb01f93d052',
+        },
+    },
 ];

--- a/suite-common/suite-utils/src/__fixtures__/protocol.ts
+++ b/suite-common/suite-utils/src/__fixtures__/protocol.ts
@@ -107,7 +107,7 @@ export const parseErc681TransferUri: ParseErc681TransferUriFixture[] = [
             contractAddress: '0x89205a3a3b2a69de6dbf7f01ed13b2108b2c43e7',
             recipientAddress: '0x8e23ee67d1332ad560396262c48ffbb01f93d052',
             tokenAmount: '1000000',
-            chainId: 1,
+            networkSymbol: 'eth',
         },
     },
     {
@@ -117,7 +117,7 @@ export const parseErc681TransferUri: ParseErc681TransferUriFixture[] = [
             contractAddress: '0x89205a3a3b2a69de6dbf7f01ed13b2108b2c43e7',
             recipientAddress: '0x8e23ee67d1332ad560396262c48ffbb01f93d052',
             tokenAmount: '500000',
-            chainId: 137,
+            networkSymbol: 'pol',
         },
     },
     {
@@ -125,7 +125,7 @@ export const parseErc681TransferUri: ParseErc681TransferUriFixture[] = [
         uri: 'ethereum:0x8e23ee67d1332ad560396262c48ffbb01f93d052@8453',
         result: {
             recipientAddress: '0x8e23ee67d1332ad560396262c48ffbb01f93d052',
-            chainId: 8453,
+            networkSymbol: 'base',
         },
     },
     {
@@ -134,7 +134,7 @@ export const parseErc681TransferUri: ParseErc681TransferUriFixture[] = [
         uri: 'ethereum://0x8e23ee67d1332ad560396262c48ffbb01f93d052@8453',
         result: {
             recipientAddress: '0x8e23ee67d1332ad560396262c48ffbb01f93d052',
-            chainId: 8453,
+            networkSymbol: 'base',
         },
     },
     {
@@ -143,5 +143,10 @@ export const parseErc681TransferUri: ParseErc681TransferUriFixture[] = [
         result: {
             recipientAddress: '0x8e23ee67d1332ad560396262c48ffbb01f93d052',
         },
+    },
+    {
+        description: 'should return null for ERC-681 URI with unsupported @chainId',
+        uri: 'ethereum:0x8e23ee67d1332ad560396262c48ffbb01f93d052@99999',
+        result: null,
     },
 ];

--- a/suite-common/suite-utils/src/protocol.ts
+++ b/suite-common/suite-utils/src/protocol.ts
@@ -22,93 +22,81 @@ export const getNetworkSymbolForProtocol = (protocol: Protocol): NetworkSymbol |
 };
 
 /**
- * Parsed information from an ERC-681 ERC-20 token transfer URI.
+ * Parsed information from an ERC-681 URI.
  * @see https://eips.ethereum.org/EIPS/eip-681
  */
 export type Erc681TransferInfo = {
-    contractAddress: string; // The ERC-20 token contract address
+    contractAddress?: string; // ERC-20 token contract address (absent for plain ETH transfers)
     recipientAddress: string; // The transfer recipient address
     tokenAmount?: string; // Raw uint256 amount in the token's smallest unit (optional)
     chainId?: number; // Optional EIP-155 chain ID from the @chainId suffix
 };
 
 const EVM_ADDRESS_REGEXP = /^0x[0-9a-fA-F]{40}$/;
+const DIGITS_REGEXP = /^\d+$/;
+const LEADING_TRAILING_SLASH_REGEXP = /^\/|\/$/g;
+
+// Ensures the URI uses the "ethereum://" form so the URL API treats it as
+// hierarchical and splits "address@chainId" into username + host.
+const ensureDoubleSlashScheme = (uri: string): string => {
+    if (uri.startsWith('ethereum://')) return uri;
+
+    return uri.replace('ethereum:', 'ethereum://');
+};
 
 /**
- * Parses an ERC-681 ERC-20 token transfer URI.
+ * Parses an ERC-681 URI.
  *
  * Supported formats:
- * - `ethereum:{contractAddress}/transfer?address={recipient}&uint256={amount}`
- * - `ethereum:{contractAddress}/transfer?address={recipient}` (amount omitted)
- * - `ethereum://{contractAddress}/transfer?address={recipient}&uint256={amount}`
+ * - `ethereum:[//]{address}[@{chainId}]` — plain ETH receive
+ * - `ethereum:[//]{contractAddress}[@{chainId}]/transfer?address={recipient}[&uint256={amount}]` — ERC-20 transfer
  *
- * @returns Parsed transfer info, or `null` if the URI is not a valid ERC-681 transfer URI.
+ * @returns Parsed info, or `null` if the URI is not a recognized ERC-681 URI.
  */
 export const parseErc681TransferUri = (uri: string): Erc681TransferInfo | null => {
+    let url: URL;
     try {
-        const url = new URL(uri);
-        const { pathname, host, searchParams, username } = url;
-
-        let contractAddress: string | null = null;
-        let functionName: string | null = null;
-
-        // Extract optional @chainId suffix (e.g. 0xContract@1 → { address: 0xContract, chainId: 1 })
-        const extractChainId = (value: string): { address: string; chainId?: number } => {
-            const match = value.match(/^(.*?)@(\d+)$/);
-            if (match) return { address: match[1], chainId: Number(match[2]) };
-
-            return { address: value };
-        };
-
-        let chainId: number | undefined;
-
-        if (host) {
-            // The URL API parses `ethereum://0xContract@chainId/...` as username=0xContract, host=chainId.
-            // Handle both the plain `ethereum://0xContract/...` and the `@chainId` variant.
-            if (username && EVM_ADDRESS_REGEXP.test(username)) {
-                // Format: ethereum://0xContract@chainId/transfer?...
-                contractAddress = username;
-                chainId = /^\d+$/.test(host) ? Number(host) : undefined;
-                functionName = pathname.replace(/^\//, '').replace(/\/$/, '');
-            } else {
-                const extracted = extractChainId(host);
-                if (EVM_ADDRESS_REGEXP.test(extracted.address)) {
-                    // Format: ethereum://0xContract/transfer?...
-                    contractAddress = extracted.address;
-                    chainId = extracted.chainId;
-                    functionName = pathname.replace(/^\//, '').replace(/\/$/, '');
-                }
-            }
-        } else if (pathname) {
-            // Format: ethereum:0xContract@chainId/transfer?...
-            const cleanPath = pathname.replace(/^\/+/, '');
-            const slashIndex = cleanPath.indexOf('/');
-            if (slashIndex !== -1) {
-                const extracted = extractChainId(cleanPath.substring(0, slashIndex));
-                if (EVM_ADDRESS_REGEXP.test(extracted.address)) {
-                    contractAddress = extracted.address;
-                    chainId = extracted.chainId;
-                    functionName = cleanPath.substring(slashIndex + 1).replace(/\/$/, '');
-                }
-            }
-        }
-
-        if (!contractAddress || functionName !== 'transfer') return null;
-
-        const recipientAddress = searchParams.get('address');
-        const rawTokenAmount = searchParams.get('uint256');
-
-        if (!recipientAddress || !EVM_ADDRESS_REGEXP.test(recipientAddress)) {
-            return null;
-        }
-
-        // Validate that tokenAmount is a valid non-negative integer when present
-        if (rawTokenAmount !== null && !/^\d+$/.test(rawTokenAmount)) return null;
-
-        const tokenAmount = rawTokenAmount ?? undefined;
-
-        return { contractAddress, recipientAddress, tokenAmount, chainId };
+        url = new URL(ensureDoubleSlashScheme(uri));
     } catch {
         return null;
     }
+
+    // After normalization, the URL API gives us:
+    //   "ethereum://addr"          → username='',   host=addr
+    //   "ethereum://addr@chainId"  → username=addr, host=chainId
+    let address: string;
+    let chainId: number | undefined;
+    if (url.username) {
+        address = url.username;
+        if (DIGITS_REGEXP.test(url.host)) chainId = Number(url.host);
+    } else {
+        address = url.host;
+    }
+
+    if (!EVM_ADDRESS_REGEXP.test(address)) return null;
+
+    const functionName = url.pathname.replace(LEADING_TRAILING_SLASH_REGEXP, '');
+
+    // No function call — plain ETH receive. Reject if there are extraneous query
+    // params (e.g. ?value=…), which signal a different URI shape we don't handle.
+    if (functionName === '') {
+        if (url.searchParams.size > 0) return null;
+
+        return { recipientAddress: address, chainId };
+    }
+
+    if (functionName !== 'transfer') return null;
+
+    const recipientAddress = url.searchParams.get('address');
+    const rawTokenAmount = url.searchParams.get('uint256');
+
+    if (!recipientAddress || !EVM_ADDRESS_REGEXP.test(recipientAddress)) return null;
+    if (rawTokenAmount !== null && !DIGITS_REGEXP.test(rawTokenAmount)) return null;
+
+    return {
+        contractAddress: address,
+        recipientAddress,
+        tokenAmount: rawTokenAmount ?? undefined,
+        chainId,
+    };
 };

--- a/suite-common/suite-utils/src/protocol.ts
+++ b/suite-common/suite-utils/src/protocol.ts
@@ -1,5 +1,9 @@
 import { NETWORK_TO_PROTOCOLS, type Protocol } from '@suite-common/suite-constants';
-import { type NetworkSymbol, isNetworkSymbol } from '@suite-common/wallet-config';
+import {
+    type NetworkSymbol,
+    getNetworkByEvmChainId,
+    isNetworkSymbol,
+} from '@suite-common/wallet-config';
 
 export type ProtocolToNetwork = {
     [P in Protocol]: NetworkSymbol;
@@ -29,7 +33,7 @@ export type Erc681TransferInfo = {
     contractAddress?: string; // ERC-20 token contract address (absent for plain ETH transfers)
     recipientAddress: string; // The transfer recipient address
     tokenAmount?: string; // Raw uint256 amount in the token's smallest unit (optional)
-    chainId?: number; // Optional EIP-155 chain ID from the @chainId suffix
+    networkSymbol?: NetworkSymbol; // Network symbol resolved from the @chainId suffix (e.g. 8453 → 'base')
 };
 
 const EVM_ADDRESS_REGEXP = /^0x[0-9a-fA-F]{40}$/;
@@ -65,10 +69,14 @@ export const parseErc681TransferUri = (uri: string): Erc681TransferInfo | null =
     //   "ethereum://addr"          → username='',   host=addr
     //   "ethereum://addr@chainId"  → username=addr, host=chainId
     let address: string;
-    let chainId: number | undefined;
+    let networkSymbol: NetworkSymbol | undefined;
     if (url.username) {
         address = url.username;
-        if (DIGITS_REGEXP.test(url.host)) chainId = Number(url.host);
+
+        const chainId = url.host;
+        if (!DIGITS_REGEXP.test(chainId)) return null;
+        networkSymbol = getNetworkByEvmChainId(Number(chainId))?.symbol;
+        if (!networkSymbol) return null;
     } else {
         address = url.host;
     }
@@ -82,7 +90,7 @@ export const parseErc681TransferUri = (uri: string): Erc681TransferInfo | null =
     if (functionName === '') {
         if (url.searchParams.size > 0) return null;
 
-        return { recipientAddress: address, chainId };
+        return { recipientAddress: address, networkSymbol };
     }
 
     if (functionName !== 'transfer') return null;
@@ -97,6 +105,6 @@ export const parseErc681TransferUri = (uri: string): Erc681TransferInfo | null =
         contractAddress: address,
         recipientAddress,
         tokenAmount: rawTokenAmount ?? undefined,
-        chainId,
+        networkSymbol,
     };
 };

--- a/suite-native/module-send/src/components/AddressInput.tsx
+++ b/suite-native/module-send/src/components/AddressInput.tsx
@@ -60,16 +60,18 @@ export const AddressInput = ({ index, accountKey }: AddressInputProps) => {
             account?.networkType === 'ethereum' ? parseErc681TransferUri(qrCodeData) : null;
         if (erc681) {
             setValue(addressFieldName, erc681.recipientAddress, { shouldValidate: true });
-            setValue(tokenFieldName, erc681.contractAddress, { shouldDirty: true });
-            const token = account?.tokens?.find(
-                t => t.contract.toLowerCase() === erc681.contractAddress.toLowerCase(),
-            );
-            if (token && erc681.tokenAmount !== undefined) {
-                setValue(
-                    amountFieldName,
-                    convertAmountSubunitsToUnits(erc681.tokenAmount, token.decimals),
-                    { shouldValidate: true },
+            if (erc681.contractAddress) {
+                setValue(tokenFieldName, erc681.contractAddress, { shouldDirty: true });
+                const token = account?.tokens?.find(
+                    t => t.contract.toLowerCase() === erc681.contractAddress!.toLowerCase(),
                 );
+                if (token && erc681.tokenAmount !== undefined) {
+                    setValue(
+                        amountFieldName,
+                        convertAmountSubunitsToUnits(erc681.tokenAmount, token.decimals),
+                        { shouldValidate: true },
+                    );
+                }
             }
             analytics.report({
                 type: events.sendAddressFilledEvent.name,


### PR DESCRIPTION
## Description

Follow-up after #26920 to handle previously uncaught case when transferring native token on Base (not ERC-20 token) and to handle networks properly

## Notes for QA

Test following QR on both mobile and desktop, should send ETH to `0x8e23ee67d1332ad560396262c48ffbb01f93d052` on Base

<img width="400" height="400" alt="qrcode" src="https://github.com/user-attachments/assets/e6850106-fe81-45be-9bab-96d821de94f4" />

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect protocol parsing utilities (`protocol.ts` in both `packages/suite/src/utils/suite/` and `suite-common/suite-utils/src/`) and their test fixtures, plus a React Native `AddressInput` component. The protocol utilities are broadly imported across 121+ tests but are only directly exercised in URI/deep-link handling scenarios (e.g., send flows that parse `bitcoin:` or `ethereum:` URIs). However, none of the 121 statically-mapped E2E tests specifically test URI/protocol parsing behavior — they merely transitively import the module. The `AddressInput.tsx` change is in the suite-native mobile package, which has zero E2E test coverage in the Playwright suite. The fixture file `__fixtures__/protocol.ts` is for unit tests, not E2E tests. Since no E2E test directly exercises protocol URI parsing or deep-link handling, and the native mobile component has no desktop/web E2E coverage, the risk of undetected E2E regressions is low. Unit tests for the protocol module (which would use the changed fixtures) provide the primary safety net here.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite/src/utils/suite/protocol.ts`
- `suite-common/suite-utils/src/__fixtures__/protocol.ts`
- `suite-common/suite-utils/src/protocol.ts`
- `suite-native/module-send/src/components/AddressInput.tsx`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (4)**
- `suite-common/suite-utils/src/__fixtures__/protocol.ts`
- `suite-native/module-send/src/components/AddressInput.tsx`
- `suite-common/suite-utils/src/protocol.ts`
- `packages/suite/src/utils/suite/protocol.ts`

_Updated: 2026-05-12T18:45:47.280Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=erc681-finalization&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=erc681-finalization&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=erc681-finalization&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > call cancellation | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-12T19:12:22.706Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Send form for bitcoin > add and remove output in send form, toggle form options, input data | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-12T19:10:52.392Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/erc681-finalization/web/](https://dev.suite.sldev.cz/suite-web/erc681-finalization/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->