### PR TITLE
test(e2e-native): switch CI to run debug android version for consistency

### DIFF
--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -21,7 +21,7 @@ on:
       runner_config:
         description: "Path to the Detox runner config file"
         required: false
-        default: e2e/trezorDetoxRunner/config/runner-android-release.config.js
+        default: e2e/trezorDetoxRunner/config/runner-android.config.js
         type: string
     secrets:
       TREZOR_BOT_APP_ID:
@@ -164,6 +164,8 @@ jobs:
           docker cp trezor-user-env.unix:/trezor-user-env/logs/emulator_bridge.log "$LOG_DIR/tenv-emulator-bridge-debugging.log" || true
           docker cp trezor-user-env.unix:/trezor-user-env/docker/version.txt "$LOG_DIR/trezor-user-env-version.txt" || true
           docker logs trezor-user-env-regtest > "$LOG_DIR/electrum-regtest.txt" || true
+          docker logs suite-sync > "$LOG_DIR/suite-sync.log" 2>&1 || true
+          docker logs quota-db > "$LOG_DIR/quota-db.log" 2>&1 || true
 
       - name: "Store test artifacts"
         if: ${{ !cancelled() }}

--- a/.github/workflows/template-suite-native-prepare-test-app-android.yml
+++ b/.github/workflows/template-suite-native-prepare-test-app-android.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Check if native build exists in AWS bucket
         id: s3_build_cache
         run: |
-          if aws s3 ls s3://dev.suite.sldev.cz/suite-mobile/${{ steps.expo-fingerprint.outputs.HASH }} --summarize;
+          if aws s3 ls s3://dev.suite.sldev.cz/suite-mobile/${{ steps.expo-fingerprint.outputs.HASH }}-debug --summarize;
            then
              echo "hit=true"  >> $GITHUB_OUTPUT;
            else
@@ -149,12 +149,12 @@ jobs:
       - name: Build a new Detox test .apk
         if: steps.s3_build_cache.outputs.hit == 'false'
         working-directory: ./suite-native/app
-        run: yarn exec detox build -PreactNativeArchitectures=x86_64 --configuration android.emu.release
+        run: yarn exec detox build -PreactNativeArchitectures=x86_64 --configuration android.emu.debug
 
       - name: save .apk to the aws s3 bucket
         if: steps.s3_build_cache.outputs.hit == 'false'
         working-directory: ./suite-native/app/android/app/build/outputs
-        run: aws s3 cp . s3://dev.suite.sldev.cz/suite-mobile/${{ steps.expo-fingerprint.outputs.HASH }}/ --recursive
+        run: aws s3 cp . s3://dev.suite.sldev.cz/suite-mobile/${{ steps.expo-fingerprint.outputs.HASH }}-debug/ --recursive
 
       - name: Upload Android build artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/suite-common/e2e-evolu-client/package.json
+++ b/suite-common/e2e-evolu-client/package.json
@@ -11,6 +11,7 @@
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
+        "@trezor/utils": "workspace:*",
         "ws": "^8.20.0"
     },
     "devDependencies": {

--- a/suite-common/e2e-evolu-client/src/baseEvoluClient.ts
+++ b/suite-common/e2e-evolu-client/src/baseEvoluClient.ts
@@ -14,6 +14,7 @@ import path from 'path';
 
 import { Schema, createEvoluAppOwnerFromTrezorData } from '@suite-common/suite-sync-evolu';
 import { type SuiteSyncOwnerSecretHex } from '@suite-common/suite-sync-storage';
+import { scheduleAction } from '@trezor/utils';
 
 import { createNodeEvoluDeps } from './createEvoluNodeDeps';
 
@@ -161,20 +162,25 @@ const QUOTA_TOTAL_STORAGE_SIZE = 1048576;
 const QUOTA_UNSPENT_STORAGE_SIZE = 1038090;
 const QUOTA_DB_CREDENTIALS = '-U suite-sync -d suite-sync-gate';
 
-const waitForRelayReady = async (maxWaitMs = 30_000) => {
-    const pollIntervalMs = 500;
-    const deadline = Date.now() + maxWaitMs;
-
-    while (Date.now() < deadline) {
-        try {
+const waitForRelayReady = async (timeout = 30_000) => {
+    await scheduleAction(
+        async () => {
             await fetch(RELAY_HEALTH_URL);
 
-            return;
-        } catch {
-            await new Promise(resolve => setTimeout(resolve, pollIntervalMs));
-        }
-    }
-    throw new Error(`Evolu relay did not become healthy within ${maxWaitMs}ms after restart`);
+            // Verify the quota manager is up and its DB connection is live by making a real API call.
+            const quotaResponse = await fetch(`${QUOTA_URL}/storage/ask`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ publicKey: QUOTA_PUBLIC_KEY }),
+            });
+
+            // 5xx means the DB connection is not yet established — retry.
+            if (quotaResponse.status >= 500) {
+                throw new Error(`Quota manager not ready: HTTP ${quotaResponse.status}`);
+            }
+        },
+        { deadline: Date.now() + timeout, gap: 500 },
+    );
 };
 
 export const wipeAndRestartEvoluRelayServer = async () => {

--- a/suite-common/e2e-evolu-client/tsconfig.json
+++ b/suite-common/e2e-evolu-client/tsconfig.json
@@ -2,6 +2,7 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
     "references": [
+        { "path": "../../packages/utils" },
         { "path": "../suite-sync-evolu" },
         { "path": "../suite-sync-storage" },
         { "path": "../wallet-config" },

--- a/suite-native/app/e2e/support/utils.ts
+++ b/suite-native/app/e2e/support/utils.ts
@@ -83,16 +83,19 @@ export const waitToHaveText = async (
 ) => {
     const target = getTarget(elementOrMatcher);
     await waitForVisible(target, { timeout });
-    await scheduleAction(async () => {
-        const attributes = await target.getAttributes();
-        const actualText = (attributes as ElementAttributes).text;
+    await scheduleAction(
+        async () => {
+            const attributes = await target.getAttributes();
+            const actualText = (attributes as ElementAttributes).text;
 
-        if (actualText !== expectedText) {
-            throw new Error(
-                `waitForText(): target text "${actualText}" did not equal expected "${expectedText}" after ${timeout}ms`,
-            );
-        }
-    }, RETRY_CONF);
+            if (actualText !== expectedText) {
+                throw new Error(
+                    `waitForText(): target text "${actualText}" did not equal expected "${expectedText}" after ${timeout}ms`,
+                );
+            }
+        },
+        { ...RETRY_CONF, attempts: Math.ceil(timeout / RETRY_CONF.gap) },
+    );
 };
 
 export const waitToHaveRegex = async (

--- a/suite-native/app/e2e/tests/suiteSync.test.ts
+++ b/suite-native/app/e2e/tests/suiteSync.test.ts
@@ -75,7 +75,7 @@ const preloadedState = preparePreloadedReduxState(
     deviceChecksDisabledState,
 );
 
-describe.skip('Suite Sync - Labelling [@androidOnly @T3T1 @smoke]', () => {
+describe('Suite Sync - Labelling [@androidOnly @T3T1 @smoke]', () => {
     let evoluClient: NativeEvoluClient;
 
     beforeEach(async () => {
@@ -163,12 +163,19 @@ describe.skip('Suite Sync - Labelling [@androidOnly @T3T1 @smoke]', () => {
         // Seed the relay before enabling SuiteSync so the labels are ready to sync on connect.
         const addressSeed = immuneFixtures.createAddressSeed(FIRST_BTC_RECEIVE_ADDRESS);
         const outputSeed = immuneFixtures.createOutputSeed();
+        seedQuotaManagerData({ ownerId: immuneFixtures.ownerId });
         await evoluClient.init({ ownerSecret: immuneFixtures.ownerSecret });
         evoluClient.writeTo('wallet', immuneFixtures.walletSeed);
         evoluClient.writeTo('account', immuneFixtures.accountSeed);
         evoluClient.writeTo('address', addressSeed);
         evoluClient.writeTo('output', outputSeed);
-        seedQuotaManagerData({ ownerId: immuneFixtures.ownerId });
+
+        // Verify relay received the seeded data before the app connects.
+        await evoluClient.expectInTable(
+            'account',
+            [immuneFixtures.buildExpectedAccount({ label: immuneFixtures.accountSeed.label })],
+            { timeout: 30_000 },
+        );
 
         await onTabBar.navigateToSettings();
         await onSettings.enableSuiteSync();

--- a/suite-native/app/e2e/trezorDetoxRunner/config/runner-android-release-nightly.config.js
+++ b/suite-native/app/e2e/trezorDetoxRunner/config/runner-android-release-nightly.config.js
@@ -1,4 +1,4 @@
-const target = 'android.emu.release';
+const target = 'android.emu.debug';
 
 /*
  * Android Release Nightly config

--- a/suite-native/app/e2e/trezorDetoxRunner/config/runner-android-release.config.js
+++ b/suite-native/app/e2e/trezorDetoxRunner/config/runner-android-release.config.js
@@ -1,6 +1,6 @@
 const { noOtherDevice } = require('@trezor/e2e-utils');
 
-const target = 'android.emu.release';
+const target = 'android.emu.debug';
 
 /*
  * Android Release config

--- a/yarn.lock
+++ b/yarn.lock
@@ -10435,6 +10435,7 @@ __metadata:
     "@suite-common/suite-sync-storage": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
+    "@trezor/utils": "workspace:*"
     ws: "npm:^8.20.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
fixes suiteSync tests (needs dev keys)
stability improvement for suiteSync tests

Suite Sync relies on dev keys that are not present in our production Android build. Because of we will never be able to use emulator with prod android App.

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes involve a tsconfig.json modification in the e2e-evolu-client package (which could affect TypeScript compilation/module resolution for Suite Sync tests), and direct modifications to suite-native mobile E2E test files (utils.ts and suiteSync.test.ts). The Suite desktop/web E2E tests that depend on @suite-common/e2e-evolu-client should be validated to ensure the tsconfig change doesn't break imports. The suite-native test changes are self-contained mobile E2E tests with no corresponding desktop test coverage in the available test suite.

<details><summary><b>Changed files (3)</b></summary>

- `suite-common/e2e-evolu-client/tsconfig.json`
- `suite-native/app/e2e/support/utils.ts`
- `suite-native/app/e2e/tests/suiteSync.test.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `../../suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts` — This test directly uses the e2e-evolu-client package (whose tsconfig.json was changed) and tests Suite Sync migration from legacy labeling. Changes to the evolu client's TypeScript configuration could affect how the client is built/imported in tests.
- `../../suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — This test imports from @suite-common/e2e-evolu-client (mnemonic12Fixtures, evoluClient) and exercises Suite Sync label creation with Evolu relay. The tsconfig.json change in e2e-evolu-client could affect module resolution or compilation of this dependency.
- `../../suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — This test imports multiple utilities from @suite-common/e2e-evolu-client (createAccountRowId, createOwnerIdFromSecret, etc.) and validates multi-wallet Suite Sync scenarios. Changes to the evolu client's tsconfig could break these imports or their type resolution.
- `../../suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts` — This test uses @suite-common/e2e-evolu-client fixtures and evoluClient helpers to seed and verify label removal via Suite Sync. The tsconfig.json change directly impacts how this dependency compiles.
- `../../suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — This test seeds Evolu relay with data from @suite-common/e2e-evolu-client and validates that labels sync correctly from the relay to Suite. The tsconfig change could affect the evolu client module used for seeding.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-native/app/e2e/support/utils.ts`
- `suite-native/app/e2e/tests/suiteSync.test.ts`

_Updated: 2026-05-13T03:17:53.543Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-native-suite-sync-fix&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-native-suite-sync-fix&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test-native-suite-sync-fix&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > call cancellation | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-13T03:33:49.719Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Send form for bitcoin > add and remove output in send form, toggle form options, input data | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-13T03:31:33.173Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test-native-suite-sync-fix/web/](https://dev.suite.sldev.cz/suite-web/test-native-suite-sync-fix/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->