### PR TITLE
fix(wallet-core): stabilize empty-array fallback in selectCardanoPoolsInfo

### DIFF
--- a/suite-common/wallet-core/src/stake/__tests__/stakeSelectors.test.ts
+++ b/suite-common/wallet-core/src/stake/__tests__/stakeSelectors.test.ts
@@ -1,40 +1,70 @@
-import { selectEthNextRewardPayout } from '../stakeSelectors';
+import { stakeDataSlice } from '../stakeDataSlice';
+import type { StakeDataState } from '../stakeDataSlice';
+import { stakeInitialState } from '../stakeReducer';
+import type { StakeRootState } from '../stakeReducerTypes';
+import { selectCardanoPoolsInfo, selectEthNextRewardPayout } from '../stakeSelectors';
 
-const createStateWithNextRewardPayout = (nextRewardPayout?: number) =>
-    ({
-        wallet: {
-            stake: {
-                data: {
-                    data: {
-                        eth: {
-                            stats: nextRewardPayout
-                                ? {
-                                      nextRewardPayout,
-                                  }
-                                : undefined,
-                        },
-                    },
-                },
+const stakeDataInitialState = stakeDataSlice.getInitialState();
+
+const buildStakeState = (data: Partial<StakeDataState['data']>): StakeRootState => ({
+    wallet: {
+        stake: {
+            ...stakeInitialState,
+            data: {
+                ...stakeDataInitialState,
+                data: { ...stakeDataInitialState.data, ...data },
             },
         },
-    }) as any;
+    },
+});
 
 describe('selectEthNextRewardPayout', () => {
-    it('returns null when next reward payout is unavailable', () => {
-        const state = createStateWithNextRewardPayout();
+    const createState = (nextRewardPayout?: number) =>
+        buildStakeState({
+            eth: nextRewardPayout
+                ? { stats: { apy: 0, nextRewardPayout }, validators: {} }
+                : undefined,
+        });
 
-        expect(selectEthNextRewardPayout(state)).toBeNull();
+    it('returns null when next reward payout is unavailable', () => {
+        expect(selectEthNextRewardPayout(createState())).toBeNull();
     });
 
     it('returns at least 1 day for positive payout values below 1 day', () => {
-        const state = createStateWithNextRewardPayout(60 * 60);
-
-        expect(selectEthNextRewardPayout(state)).toBe(1);
+        expect(selectEthNextRewardPayout(createState(60 * 60))).toBe(1);
     });
 
     it('returns rounded day value for payout values over 1 day', () => {
-        const state = createStateWithNextRewardPayout(2.2 * 24 * 60 * 60);
+        expect(selectEthNextRewardPayout(createState(2.2 * 24 * 60 * 60))).toBe(2);
+    });
+});
 
-        expect(selectEthNextRewardPayout(state)).toBe(2);
+describe('selectCardanoPoolsInfo', () => {
+    type AdaPools = NonNullable<StakeDataState['data']['ada']>['pools'];
+
+    const createState = (pools?: AdaPools) =>
+        buildStakeState({
+            ada: pools === undefined ? undefined : { pools },
+        });
+
+    it('returns a stable empty array reference when ada data is missing', () => {
+        const stateA = createState();
+        const stateB = createState();
+
+        expect(selectCardanoPoolsInfo(stateA)).toBe(selectCardanoPoolsInfo(stateB));
+    });
+
+    it('returns a stable empty array reference when pools array is empty', () => {
+        const stateA = createState([]);
+        const stateB = createState([]);
+
+        expect(selectCardanoPoolsInfo(stateA)).toBe(selectCardanoPoolsInfo(stateB));
+    });
+
+    it('returns the underlying pools array when populated', () => {
+        const pools: AdaPools = [{ apy: 1, saturation: 50, id: 'pool1' }];
+        const state = createState(pools);
+
+        expect(selectCardanoPoolsInfo(state)).toBe(pools);
     });
 });

--- a/suite-common/wallet-core/src/stake/stakeSelectors.ts
+++ b/suite-common/wallet-core/src/stake/stakeSelectors.ts
@@ -1,3 +1,4 @@
+import { returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { secondsToDays, selectBestCardanoPool } from '@suite-common/wallet-utils';
@@ -10,7 +11,7 @@ export const selectStake = (state: StakeRootState) => state.wallet.stake;
 export const selectStakeData = (state: StakeRootState) => selectStake(state).data.data;
 
 export const selectCardanoPoolsInfo = (state: StakeRootState) =>
-    selectStakeData(state).ada?.pools ?? [];
+    returnStableArrayIfEmpty(selectStakeData(state).ada?.pools);
 
 export const selectEthNextRewardPayout = (state: StakeRootState) => {
     const nextRewardPayout = selectStakeData(state).eth?.stats?.nextRewardPayout;


### PR DESCRIPTION
## Summary

`selectCardanoPoolsInfo` returned `selectStakeData(state).ada?.pools ?? []`. The `?? []` allocates a **fresh empty array on every call**, so every `useSelector` consumer received a new reference on every Redux dispatch and re-rendered spuriously — even when ADA pool data was absent (the common case for non-Cardano users).

Replaced the inline `?? []` with `returnStableArrayIfEmpty` from `@suite-common/redux-utils`, which returns a module-level singleton empty array.

## Why this is a fix, not just perf

For non-ADA users (the majority), the wallet sidebar account rows and the Cardano staking dashboard were re-rendering on **every** Redux dispatch. Concretely affected components: every account row in the wallet sidebar list, and the staking dashboard's pool selector. Downstream behaviour was correct via React reconciliation, but the wasted render cycles are observable as scroll jank and input lag on lower-end devices.

## What to focus on in testing

- [ ] Open a wallet with **no** ADA account. In React DevTools Profiler, record a few dispatches (e.g. fiat rate ticks or discovery progress). Sidebar account rows should not re-render.
- [ ] Open a wallet with an ADA account that has populated pools — pool selection and staking dashboard pool list still render correctly.
- [ ] Open a wallet with an ADA account whose pools are absent (early after creation) — staking dashboard fallback UI still shows.
- [ ] Unit tests in `stakeSelectors.test.ts` cover the stable-reference behaviour.

## Parent staging PR

This PR is split out of #27670 (the staging branch that bundled the full perf/correctness audit).

## Related PRs

Part of a perf/correctness audit series. The eight PRs in this series can be reviewed and merged independently except where noted in the body.

- #27671 — `fix(wallet-core)` stabilize empty-array fallback in `selectCardanoPoolsInfo`
- #27672 — `fix(wallet-core)` stable references in phishing transaction selectors
- #27673 — `fix(suite-native)` stable empty-array fallback in Solana staking selector
- #27674 — `fix(suite)` stable empty array in Suite Sync ternary `useSelector` arrows
- #27675 — `fix(wallet-core)` remove mutating `.splice` in send form review button request count
- #27676 — `fix(suite)` prevent `SendLoaded` form re-renders on every dispatch
- #27677 — `fix(redux-utils)` remove `useSelectorDeepComparison` hook and its call sites
- #27678 — `fix(suite)` convert factory selectors to parameterized memoized selectors

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/fix-cardano-pools-stable-empty-fallback&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/fix-cardano-pools-stable-empty-fallback&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > TrezorConnect.getAddress | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-13T07:32:32.505Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/fix-cardano-pools-stable-empty-fallback/web/](https://dev.suite.sldev.cz/suite-web/mroz22/fix-cardano-pools-stable-empty-fallback/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->