### PR TITLE
fix(wallet-core): stable references in phishing transaction selectors

### DIFF
--- a/suite-common/wallet-core/src/transactions/__tests__/transactionsSelectors.test.ts
+++ b/suite-common/wallet-core/src/transactions/__tests__/transactionsSelectors.test.ts
@@ -1,0 +1,97 @@
+import {
+    selectAccountTransactionsMarkedAsNotScam,
+    selectPhishingTransactionsContext,
+} from '../transactionsSelectors';
+
+type AnyState = Parameters<typeof selectPhishingTransactionsContext>[0];
+
+const createPhishingState = ({
+    phishing,
+    historic,
+    tokenDefinitions,
+}: {
+    phishing?: { [accountKey: string]: string[] };
+    historic?: object;
+    tokenDefinitions?: object;
+}): AnyState =>
+    ({
+        wallet: {
+            transactions: { phishing: phishing ?? {} },
+            fiat: { historic },
+        },
+        tokenDefinitions: tokenDefinitions ?? {},
+    }) as unknown as AnyState;
+
+describe('selectAccountTransactionsMarkedAsNotScam', () => {
+    it('returns a stable empty array reference when no phishing entry exists for the account', () => {
+        const stateA = createPhishingState({});
+        const stateB = createPhishingState({});
+
+        expect(selectAccountTransactionsMarkedAsNotScam(stateA, 'account-1' as any)).toBe(
+            selectAccountTransactionsMarkedAsNotScam(stateB, 'account-1' as any),
+        );
+    });
+
+    it('returns a stable empty array reference when phishing entry is an empty array', () => {
+        const stateA = createPhishingState({ phishing: { 'account-1': [] } });
+        const stateB = createPhishingState({ phishing: { 'account-1': [] } });
+
+        expect(selectAccountTransactionsMarkedAsNotScam(stateA, 'account-1' as any)).toBe(
+            selectAccountTransactionsMarkedAsNotScam(stateB, 'account-1' as any),
+        );
+    });
+
+    it('returns the underlying array reference when populated', () => {
+        const txids = ['tx1', 'tx2'];
+        const state = createPhishingState({ phishing: { 'account-1': txids } });
+
+        expect(selectAccountTransactionsMarkedAsNotScam(state, 'account-1' as any)).toBe(txids);
+    });
+});
+
+describe('selectPhishingTransactionsContext', () => {
+    it('returns a stable object reference across calls when underlying inputs are unchanged', () => {
+        const historic = {};
+        const tokenDefinitions = { eth: {} };
+        const phishing = { 'account-1': ['tx1'] };
+        const state = createPhishingState({ phishing, historic, tokenDefinitions });
+
+        const first = selectPhishingTransactionsContext(state, 'account-1' as any, 'eth' as any);
+        const second = selectPhishingTransactionsContext(state, 'account-1' as any, 'eth' as any);
+
+        expect(second).toBe(first);
+    });
+
+    it('returns a stable object reference when phishing entry is missing (stable empty array path)', () => {
+        const historic = {};
+        const tokenDefinitions = { eth: {} };
+        const stateA = createPhishingState({ historic, tokenDefinitions });
+        const stateB = createPhishingState({ historic, tokenDefinitions });
+
+        const first = selectPhishingTransactionsContext(stateA, 'account-1' as any, 'eth' as any);
+        const second = selectPhishingTransactionsContext(stateB, 'account-1' as any, 'eth' as any);
+
+        expect(second).toBe(first);
+    });
+
+    it('returns a new object reference when the phishing list changes', () => {
+        const historic = {};
+        const tokenDefinitions = { eth: {} };
+        const stateA = createPhishingState({
+            phishing: { 'account-1': ['tx1'] },
+            historic,
+            tokenDefinitions,
+        });
+        const stateB = createPhishingState({
+            phishing: { 'account-1': ['tx1', 'tx2'] },
+            historic,
+            tokenDefinitions,
+        });
+
+        const first = selectPhishingTransactionsContext(stateA, 'account-1' as any, 'eth' as any);
+        const second = selectPhishingTransactionsContext(stateB, 'account-1' as any, 'eth' as any);
+
+        expect(second).not.toBe(first);
+        expect(second.txsMarkedAsNotScam).toEqual(['tx1', 'tx2']);
+    });
+});

--- a/suite-common/wallet-core/src/transactions/transactionsSelectors.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsSelectors.ts
@@ -170,19 +170,26 @@ export const selectTransactionIsMarkedAsNotScam = (
 export const selectAccountTransactionsMarkedAsNotScam = (
     state: TransactionsRootState,
     accountKey: AccountKey,
-) => state.wallet.transactions.phishing[accountKey] ?? [];
+) => returnStableArrayIfEmpty(state.wallet.transactions.phishing[accountKey]);
 
-export const selectPhishingTransactionsContext = (
-    state: TokenDefinitionsRootState & TransactionsRootState & FiatRatesRootState,
-    accountKey: AccountKey,
-    symbol: NetworkSymbol,
-) => {
-    const historicRates = selectHistoricFiatRates(state);
-    const tokenDefinitions = selectNetworkTokenDefinitions(state, symbol);
-    const txsMarkedAsNotScam = selectAccountTransactionsMarkedAsNotScam(state, accountKey);
+const createPhishingMemoizedSelector = createWeakMapSelector.withTypes<
+    TokenDefinitionsRootState & TransactionsRootState & FiatRatesRootState
+>();
 
-    return { tokenDefinitions, txsMarkedAsNotScam, historicRates };
-};
+export const selectPhishingTransactionsContext = createPhishingMemoizedSelector(
+    [
+        state => selectHistoricFiatRates(state),
+        (state, _accountKey: AccountKey, symbol: NetworkSymbol) =>
+            selectNetworkTokenDefinitions(state, symbol),
+        (state, accountKey: AccountKey, _symbol: NetworkSymbol) =>
+            selectAccountTransactionsMarkedAsNotScam(state, accountKey),
+    ],
+    (historicRates, tokenDefinitions, txsMarkedAsNotScam) => ({
+        tokenDefinitions,
+        txsMarkedAsNotScam,
+        historicRates,
+    }),
+);
 
 export const selectIsPhishingTransaction = (
     state: TokenDefinitionsRootState &


### PR DESCRIPTION
## Summary

Two related identity-stability fixes in the transaction phishing pipeline:

1. **`selectAccountTransactionsMarkedAsNotScam`** — used the `?? []` pattern, allocating a fresh empty array on every call for accounts with no phishing entry.
2. **`selectPhishingTransactionsContext`** — composed several inputs into a fresh object literal on every call.

Both fed into `useVisibleTransactions`, so every consumer in the transaction list flow re-rendered on every Redux dispatch.

Replaced the unstable fallbacks with `returnStableArrayIfEmpty` + `createWeakMapSelector` memoization.

## Why this is a fix, not just perf

The transaction list view re-rendered on every Redux dispatch — fiat rate updates, discovery progress, even unrelated UI ticks — regardless of whether transactions actually changed. For users with long transaction histories the cumulative render cost is observable as scroll jank.

## What to focus on in testing

- [ ] Open the transaction list for an account with no phishing entries. In React DevTools Profiler record several dispatches; transaction rows should not re-render.
- [ ] Open a transaction list with phishing transactions (use a test account or mock). Phishing badges and "mark as not scam" actions still work end-to-end.
- [ ] Mark a transaction as not-scam; confirm it disappears from the phishing list and the transaction row updates.
- [ ] Token transactions on Ethereum — phishing context is also computed per (account, token-address) — confirm token rows behave correctly.
- [ ] Unit tests in `transactionsSelectors.test.ts` cover stable references and invalidation on phishing-list change.

## Parent staging PR

This PR is split out of #27670 (the staging branch that bundled the full perf/correctness audit).

## Related PRs

Part of a perf/correctness audit series. The eight PRs in this series can be reviewed and merged independently except where noted in the body.

- #27671 — `fix(wallet-core)` stabilize empty-array fallback in `selectCardanoPoolsInfo`
- #27672 — `fix(wallet-core)` stable references in phishing transaction selectors
- #27673 — `fix(suite-native)` stable empty-array fallback in Solana staking selector
- #27674 — `fix(suite)` stable empty array in Suite Sync ternary `useSelector` arrows
- #27675 — `fix(wallet-core)` remove mutating `.splice` in send form review button request count
- #27676 — `fix(suite)` prevent `SendLoaded` form re-renders on every dispatch
- #27677 — `fix(redux-utils)` remove `useSelectorDeepComparison` hook and its call sites
- #27678 — `fix(suite)` convert factory selectors to parameterized memoized selectors

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/fix-phishing-context-stable-references&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/fix-phishing-context-stable-references&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > TrezorConnect.getAddress | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-13T07:33:01.774Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->