### PR TITLE
fix(suite-native): stable empty-array fallback in Solana staking selector

### DIFF
--- a/suite-native/staking/src/__tests__/solanaStakingSelectors.test.ts
+++ b/suite-native/staking/src/__tests__/solanaStakingSelectors.test.ts
@@ -221,6 +221,41 @@ describe('selectors', () => {
                 ),
             ).toEqual([solAccountWithStaking]);
         });
+
+        it('should return the same stable empty-array reference when no sol account has staking', () => {
+            const testState = getTestState({
+                accounts: [solAccountNoStaking, etcAccount],
+            });
+
+            const first = selectVisibleDeviceSolanaAccountsWithStakingByNetworkSymbol(
+                testState,
+                'sol',
+            );
+            const second = selectVisibleDeviceSolanaAccountsWithStakingByNetworkSymbol(
+                testState,
+                'sol',
+            );
+
+            expect(first).toEqual([]);
+            expect(first).toBe(second);
+        });
+
+        it('should return the same array reference across calls when underlying state is unchanged', () => {
+            const testState = getTestState({
+                accounts: [solAccountWithStaking, solAccountNoStaking, etcAccount],
+            });
+
+            const first = selectVisibleDeviceSolanaAccountsWithStakingByNetworkSymbol(
+                testState,
+                'sol',
+            );
+            const second = selectVisibleDeviceSolanaAccountsWithStakingByNetworkSymbol(
+                testState,
+                'sol',
+            );
+
+            expect(first).toBe(second);
+        });
     });
 
     describe('selectSolStakingAccountsInfoByAccountKey', () => {

--- a/suite-native/staking/src/solanaStakingSelectors.ts
+++ b/suite-native/staking/src/solanaStakingSelectors.ts
@@ -1,4 +1,4 @@
-import { createWeakMapSelector } from '@suite-common/redux-utils';
+import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import type { NetworkSymbol } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
@@ -21,12 +21,14 @@ export const createMemoizedSelector = createWeakMapSelector.withTypes<NativeStak
 export const selectVisibleDeviceSolanaAccountsWithStakingByNetworkSymbol = createMemoizedSelector(
     [selectDeviceAccounts, (_state, symbol: NetworkSymbol) => symbol],
     (accounts, symbol) =>
-        accounts.filter(
-            account =>
-                account.symbol === symbol &&
-                account.visible &&
-                account.networkType === 'solana' &&
-                !!account.misc?.solStakingAccounts?.length,
+        returnStableArrayIfEmpty(
+            accounts.filter(
+                account =>
+                    account.symbol === symbol &&
+                    account.visible &&
+                    account.networkType === 'solana' &&
+                    !!account.misc?.solStakingAccounts?.length,
+            ),
         ),
 );
 


### PR DESCRIPTION
## Summary

`selectVisibleDeviceSolanaAccountsWithStakingByNetworkSymbol` in `suite-native/assets` had the same identity-unstable empty-array fallback as its Cardano and Ethereum siblings — but those had already been fixed. This PR aligns Solana with the established pattern using `returnStableArrayIfEmpty`.

## Why this is a fix, not just perf

The selector is consumed by `AssetItem` on the always-mounted suite-native home/dashboard. Every Solana asset row re-rendered on every Redux dispatch for users with **or without** Solana accounts (the fallback path triggers in both cases). This was the last unfixed sibling in the staking selector trio.

## What to focus on in testing

- [ ] Suite-native dashboard for a wallet with **no** Solana account — confirm asset rows do not re-render on unrelated dispatches (React DevTools Profiler).
- [ ] Suite-native dashboard for a wallet **with** a Solana account — SOL row, staking balance, and unstaking balance still render correctly.
- [ ] Solana staking dashboard renders pool list and validator information without regression.

## Parent staging PR

This PR is split out of #27670 (the staging branch that bundled the full perf/correctness audit).

## Related PRs

Part of a perf/correctness audit series. The eight PRs in this series can be reviewed and merged independently except where noted in the body.

- #27671 — `fix(wallet-core)` stabilize empty-array fallback in `selectCardanoPoolsInfo`
- #27672 — `fix(wallet-core)` stable references in phishing transaction selectors
- #27673 — `fix(suite-native)` stable empty-array fallback in Solana staking selector
- #27674 — `fix(suite)` stable empty array in Suite Sync ternary `useSelector` arrows
- #27675 — `fix(wallet-core)` remove mutating `.splice` in send form review button request count
- #27676 — `fix(suite)` prevent `SendLoaded` form re-renders on every dispatch
- #27677 — `fix(redux-utils)` remove `useSelectorDeepComparison` hook and its call sites
- #27678 — `fix(suite)` convert factory selectors to parameterized memoized selectors

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/fix-solana-staking-stable-empty-fallback&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->