### PR TITLE
fix(suite): stable empty array in Suite Sync ternary useSelector arrows

### DIFF
--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TargetAddressLabel.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TargetAddressLabel.tsx
@@ -1,7 +1,9 @@
 import { Translation } from '@suite/intl';
 import { selectIsLegacyLabelingVisible } from '@suite/metadata';
 import { type AccountLabels } from '@suite-common/metadata-types';
+import { returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import { selectIsSuiteSyncEnabled, selectSuiteSyncAddressLabels } from '@suite-common/suite-sync';
+import { type SuiteSyncAddress } from '@suite-common/suite-sync-storage';
 import type { NetworkSymbol } from '@suite-common/wallet-config';
 import type { StaticSessionId } from '@trezor/connect';
 import { type ArrayElement } from '@trezor/type-utils';
@@ -30,7 +32,9 @@ export const TargetAddressLabel = ({
     const isLegacyLabelingVisible = useSelector(selectIsLegacyLabelingVisible);
 
     const suiteSyncAddressLabels = useSelector(state =>
-        isSuiteSyncEnabled ? selectSuiteSyncAddressLabels(state, deviceStaticSessionId) : [],
+        isSuiteSyncEnabled
+            ? selectSuiteSyncAddressLabels(state, deviceStaticSessionId)
+            : returnStableArrayIfEmpty<SuiteSyncAddress>(),
     );
 
     if (isLocalTarget) {

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
@@ -6,7 +6,9 @@ import {
     selectLabelingDataForAccount,
     selectLabelingValueBeingEdited,
 } from '@suite/metadata';
+import { returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import { selectIsSuiteSyncEnabled, selectSuiteSyncOutputLabels } from '@suite-common/suite-sync';
+import { type SuiteSyncOutput } from '@suite-common/suite-sync-storage';
 import {
     type Target,
     selectBaseCurrency,
@@ -78,7 +80,9 @@ export const TransactionTarget = ({
     const labelingValueBeingEdited = useSelector(selectLabelingValueBeingEdited);
 
     const suiteSyncOutputLabels = useSelector(state =>
-        isSuiteSyncEnabled ? selectSuiteSyncOutputLabels(state, transaction.deviceState) : [],
+        isSuiteSyncEnabled
+            ? selectSuiteSyncOutputLabels(state, transaction.deviceState)
+            : returnStableArrayIfEmpty<SuiteSyncOutput>(),
     );
 
     const isSolanaUnstakeTx = transaction?.solanaSpecific?.stakeOperation?.type === 'unstake';

--- a/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
+++ b/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
@@ -6,7 +6,9 @@ import {
     selectLabelingDataForSelectedAccount,
 } from '@suite/metadata';
 import { type MetadataAddPayload } from '@suite-common/metadata-types';
+import { returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import { selectIsSuiteSyncEnabled, selectSuiteSyncAddressLabels } from '@suite-common/suite-sync';
+import { type SuiteSyncAddress } from '@suite-common/suite-sync-storage';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
@@ -110,7 +112,9 @@ export const UsedAddresses = ({
     const isLegacyLabelingVisible = useSelector(selectIsLegacyLabelingVisible);
     const { addressLabels } = useSelector(selectLabelingDataForSelectedAccount);
     const suiteSyncAddressLabels = useSelector(state =>
-        isSuiteSyncEnabled ? selectSuiteSyncAddressLabels(state, account.deviceState) : [],
+        isSuiteSyncEnabled
+            ? selectSuiteSyncAddressLabels(state, account.deviceState)
+            : returnStableArrayIfEmpty<SuiteSyncAddress>(),
     );
 
     if (

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelectionList/UtxoSelection/UtxoSelection.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelectionList/UtxoSelection/UtxoSelection.tsx
@@ -6,11 +6,13 @@ import {
     selectLabelingDataForSelectedAccount,
 } from '@suite/metadata';
 import { openModal } from '@suite/modal';
+import { returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import {
     selectIsSuiteSyncEnabled,
     selectSuiteSyncAddressLabels,
     selectSuiteSyncOutputLabels,
 } from '@suite-common/suite-sync';
+import { type SuiteSyncAddress, type SuiteSyncOutput } from '@suite-common/suite-sync-storage';
 import { useDisplayBaseCurrency } from '@suite-common/wallet-core';
 import { formatNetworkAmount, isSameUtxo } from '@suite-common/wallet-utils';
 import {
@@ -89,11 +91,15 @@ export const UtxoSelection = ({ transaction, utxo }: UtxoSelectionProps) => {
     const { addressLabels, outputLabels } = useSelector(selectLabelingDataForSelectedAccount);
     const { shallDisplayBaseCurrency } = useDisplayBaseCurrency(account.symbol);
     const suiteSyncAddressLabels = useSelector(state =>
-        isSuiteSyncEnabled ? selectSuiteSyncAddressLabels(state, account.deviceState) : [],
+        isSuiteSyncEnabled
+            ? selectSuiteSyncAddressLabels(state, account.deviceState)
+            : returnStableArrayIfEmpty<SuiteSyncAddress>(),
     );
 
     const suiteSyncOutputLabels = useSelector(state =>
-        isSuiteSyncEnabled ? selectSuiteSyncOutputLabels(state, account.deviceState) : [],
+        isSuiteSyncEnabled
+            ? selectSuiteSyncOutputLabels(state, account.deviceState)
+            : returnStableArrayIfEmpty<SuiteSyncOutput>(),
     );
     const { translationString } = useTranslation();
 


### PR DESCRIPTION
## Summary

Five inline `useSelector` arrows in `packages/suite` used the pattern:

```ts
useSelector(state => isSuiteSyncEnabled ? selectSuiteSyncFoo(state, ...) : [])
```

The fresh `[]` literal in the false branch allocated a new array reference on every Redux dispatch, defeating `useSelector`'s default referential-equality check. Replaced with module-level singleton empty arrays.

Affected call sites:
- `TransactionItem/TransactionTarget/TargetAddressLabel.tsx`
- `TransactionItem/TransactionTarget/TransactionTarget.tsx`
- `views/wallet/receive/components/UsedAddresses.tsx`
- `UtxoSelectionList/UtxoSelection/UtxoSelection.tsx` (two arrows in this file)

## Why this is a fix, not just perf

For users with Suite Sync **disabled** (the default), every `TransactionTarget` and `TargetAddressLabel` row on the transaction list re-rendered on every Redux dispatch. The transaction list is the most-mounted complex UI in the suite — this is concrete render waste for the majority of users.

## What to focus on in testing

- [ ] **Suite Sync disabled** (default state): open the transaction list, profile with React DevTools — `TransactionTarget` and `TargetAddressLabel` rows should not re-render on unrelated dispatches.
- [ ] **Suite Sync enabled**: same flow — labels still populate from Suite Sync, address labels still load and display.
- [ ] UTXO selection panel during a manual send — UTXO rows still display labels and selection state correctly.
- [ ] Used Addresses panel on receive view — addresses still show their labels.

## Parent staging PR

This PR is split out of #27670 (the staging branch that bundled the full perf/correctness audit).

## Related PRs

Part of a perf/correctness audit series. The eight PRs in this series can be reviewed and merged independently except where noted in the body.

- #27671 — `fix(wallet-core)` stabilize empty-array fallback in `selectCardanoPoolsInfo`
- #27672 — `fix(wallet-core)` stable references in phishing transaction selectors
- #27673 — `fix(suite-native)` stable empty-array fallback in Solana staking selector
- #27674 — `fix(suite)` stable empty array in Suite Sync ternary `useSelector` arrows
- #27675 — `fix(wallet-core)` remove mutating `.splice` in send form review button request count
- #27676 — `fix(suite)` prevent `SendLoaded` form re-renders on every dispatch
- #27677 — `fix(redux-utils)` remove `useSelectorDeepComparison` hook and its call sites
- #27678 — `fix(suite)` convert factory selectors to parameterized memoized selectors

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > TrezorConnect.getAddress | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-13T07:33:42.552Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Send form for bitcoin > add and remove output in send form, toggle form options, input data | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-13T07:31:53.282Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/fix-suite-sync-inline-empty-arrays/web/](https://dev.suite.sldev.cz/suite-web/mroz22/fix-suite-sync-inline-empty-arrays/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/fix-suite-sync-inline-empty-arrays&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->