### PR TITLE
fix(wallet-core): remove mutating splice in send form review button request count

### DIFF
--- a/suite-common/wallet-core/src/send/__tests__/sendFormSelectors.test.ts
+++ b/suite-common/wallet-core/src/send/__tests__/sendFormSelectors.test.ts
@@ -1,0 +1,109 @@
+import {
+    selectSendFormButtonRequestCodes,
+    selectSendFormReviewButtonRequestsCount,
+    selectSendFormReviewLastButtonCode,
+} from '../sendFormSelectors';
+
+type AnyState = Parameters<typeof selectSendFormButtonRequestCodes>[0];
+
+const createDeviceState = (codes: string[]): AnyState =>
+    ({
+        device: {
+            selectedDevice: {
+                buttonRequests: codes.map(code => ({ code })),
+            },
+        },
+    }) as unknown as AnyState;
+
+describe('selectSendFormButtonRequestCodes', () => {
+    it('returns the same array reference across calls when underlying state is unchanged', () => {
+        const state = createDeviceState(['ButtonRequest_ConfirmOutput', 'ButtonRequest_SignTx']);
+
+        const first = selectSendFormButtonRequestCodes(state, 'btc' as any);
+        const second = selectSendFormButtonRequestCodes(state, 'btc' as any);
+
+        expect(second).toBe(first);
+    });
+
+    it('returns a new array reference when buttonRequests change', () => {
+        const stateA = createDeviceState(['ButtonRequest_ConfirmOutput']);
+        const stateB = createDeviceState(['ButtonRequest_ConfirmOutput', 'ButtonRequest_SignTx']);
+
+        const first = selectSendFormButtonRequestCodes(stateA, 'btc' as any);
+        const second = selectSendFormButtonRequestCodes(stateB, 'btc' as any);
+
+        expect(second).not.toBe(first);
+        expect(second).toEqual(['ButtonRequest_ConfirmOutput', 'ButtonRequest_SignTx']);
+    });
+
+    it('does not mutate the cached array when selectSendFormReviewButtonRequestsCount is called with decreaseOutputId', () => {
+        const state = createDeviceState([
+            'ButtonRequest_ConfirmOutput',
+            'ButtonRequest_ConfirmOutput',
+            'ButtonRequest_SignTx',
+        ]);
+
+        const before = selectSendFormButtonRequestCodes(state, 'btc' as any);
+        const lengthBefore = before.length;
+
+        // Trigger the RBF decrease-output path which historically called .splice(-1, 1).
+        selectSendFormReviewButtonRequestsCount(state, 'btc' as any, 0);
+
+        const after = selectSendFormButtonRequestCodes(state, 'btc' as any);
+        expect(after).toBe(before);
+        expect(after.length).toBe(lengthBefore);
+    });
+});
+
+describe('selectSendFormReviewButtonRequestsCount', () => {
+    it('returns 0 when symbol is undefined', () => {
+        const state = createDeviceState(['ButtonRequest_ConfirmOutput']);
+
+        expect(selectSendFormReviewButtonRequestsCount(state, undefined)).toBe(0);
+    });
+
+    it('returns the filtered request count for a bitcoin symbol', () => {
+        const state = createDeviceState(['ButtonRequest_ConfirmOutput', 'ButtonRequest_SignTx']);
+
+        expect(selectSendFormReviewButtonRequestsCount(state, 'btc' as any)).toBe(2);
+    });
+
+    it('drops one ConfirmOutput when decreaseOutputId is provided and there are duplicates (RBF flow)', () => {
+        const state = createDeviceState([
+            'ButtonRequest_ConfirmOutput',
+            'ButtonRequest_ConfirmOutput',
+            'ButtonRequest_SignTx',
+        ]);
+
+        expect(selectSendFormReviewButtonRequestsCount(state, 'btc' as any, 0)).toBe(2);
+    });
+
+    it('subtracts 1 for cardano network (legacy behavior)', () => {
+        const state = createDeviceState(['ButtonRequest_ConfirmOutput', 'ButtonRequest_SignTx']);
+
+        // For cardano, every code passes the filter, and the result is length - 1.
+        expect(selectSendFormReviewButtonRequestsCount(state, 'ada' as any)).toBe(1);
+    });
+});
+
+describe('selectSendFormReviewLastButtonCode', () => {
+    it('returns null when symbol is undefined', () => {
+        const state = createDeviceState(['ButtonRequest_ConfirmOutput']);
+
+        expect(selectSendFormReviewLastButtonCode(state, undefined)).toBeNull();
+    });
+
+    it('returns the last filtered button code', () => {
+        const state = createDeviceState(['ButtonRequest_ConfirmOutput', 'ButtonRequest_SignTx']);
+
+        expect(selectSendFormReviewLastButtonCode(state, 'btc' as any)).toBe(
+            'ButtonRequest_SignTx',
+        );
+    });
+
+    it('returns null when the filtered list is empty', () => {
+        const state = createDeviceState([]);
+
+        expect(selectSendFormReviewLastButtonCode(state, 'btc' as any)).toBeNull();
+    });
+});

--- a/suite-common/wallet-core/src/send/sendFormSelectors.ts
+++ b/suite-common/wallet-core/src/send/sendFormSelectors.ts
@@ -1,6 +1,7 @@
 import { G } from '@mobily/ts-belt';
 
 import { type DeviceRootState, selectDeviceButtonRequestsCodes } from '@suite-common/device';
+import { createWeakMapSelector } from '@suite-common/redux-utils';
 import { type NetworkSymbol, getNetworkType } from '@suite-common/wallet-config';
 import {
     type AccountKey,
@@ -11,6 +12,8 @@ import {
 import { getSendFormDraftKey } from '@suite-common/wallet-utils';
 
 import { type SendRootState } from './sendFormReducer';
+
+const createMemoizedSelector = createWeakMapSelector.withTypes<DeviceRootState>();
 
 export const selectSendPrecomposedTx = (state: SendRootState) => state.wallet.send.precomposedTx;
 export const selectSendSerializedTx = (state: SendRootState) => state.wallet.send.serializedTx;
@@ -42,26 +45,28 @@ export const selectSendFormDraftOutputsByAccountKey = (
     return draft?.outputs ?? null;
 };
 
-export const selectSendFormButtonRequestCodes = (state: DeviceRootState, symbol: NetworkSymbol) => {
-    const buttonRequestCodes = selectDeviceButtonRequestsCodes(state);
+export const selectSendFormButtonRequestCodes = createMemoizedSelector(
+    [selectDeviceButtonRequestsCodes, (_state: DeviceRootState, symbol: NetworkSymbol) => symbol],
+    (buttonRequestCodes, symbol) => {
+        const networkType = getNetworkType(symbol);
 
-    const networkType = getNetworkType(symbol);
+        const isCardano = networkType === 'cardano';
+        const isEthereum = networkType === 'ethereum';
+        const isStellar = networkType === 'stellar';
 
-    const isCardano = networkType === 'cardano';
-    const isEthereum = networkType === 'ethereum';
-    const isStellar = networkType === 'stellar';
-
-    return buttonRequestCodes.filter(
-        code =>
-            code === 'ButtonRequest_ConfirmOutput' ||
-            code === 'ButtonRequest_SignTx' ||
-            isCardano ||
-            (isEthereum && code === 'ButtonRequest_Other') ||
-            // This is a special case for T1B1 devices (Stellar).
-            // See https://github.com/trezor/trezor-firmware/issues/5120
-            (isStellar && (code === 'ButtonRequest_Other' || code === 'ButtonRequest_ProtectCall')),
-    );
-};
+        return buttonRequestCodes.filter(
+            code =>
+                code === 'ButtonRequest_ConfirmOutput' ||
+                code === 'ButtonRequest_SignTx' ||
+                isCardano ||
+                (isEthereum && code === 'ButtonRequest_Other') ||
+                // This is a special case for T1B1 devices (Stellar).
+                // See https://github.com/trezor/trezor-firmware/issues/5120
+                (isStellar &&
+                    (code === 'ButtonRequest_Other' || code === 'ButtonRequest_ProtectCall')),
+        );
+    },
+);
 
 export const selectSendFormReviewButtonRequestsCount = (
     state: DeviceRootState,
@@ -76,14 +81,14 @@ export const selectSendFormReviewButtonRequestsCount = (
     const sendFormReviewRequest = selectSendFormButtonRequestCodes(state, symbol);
 
     // While confirming decrease amount in RBF, 'ButtonRequest_ConfirmOutput' is called twice (confirm decrease address, confirm decrease amount).
-    if (
+    const shouldDropLast =
         G.isNumber(decreaseOutputId) &&
-        sendFormReviewRequest.filter(code => code === 'ButtonRequest_ConfirmOutput').length > 1
-    ) {
-        sendFormReviewRequest.splice(-1, 1);
-    }
+        sendFormReviewRequest.filter(code => code === 'ButtonRequest_ConfirmOutput').length > 1;
+    const adjustedLength = shouldDropLast
+        ? sendFormReviewRequest.length - 1
+        : sendFormReviewRequest.length;
 
-    return isCardano ? sendFormReviewRequest.length - 1 : sendFormReviewRequest.length;
+    return isCardano ? adjustedLength - 1 : adjustedLength;
 };
 
 export const selectSendFormReviewLastButtonCode = (


### PR DESCRIPTION
## Summary

`selectSendFormReviewButtonRequestsCount` called `sendFormReviewRequest.splice(-1, 1)` on the array returned by `selectSendFormButtonRequestCodes`. The intent was to drop the duplicate `ButtonRequest_ConfirmOutput` during the RBF decrease-output flow.

This was safe **only** because `selectSendFormButtonRequestCodes` was unmemoized — every call returned a fresh `.filter()` array, so `splice` mutated a throwaway. This PR memoizes the selector with `createWeakMapSelector`, which means a `splice` on the cached result would now corrupt cache and return wrong counts on subsequent calls.

The mutation has been replaced with non-mutating index arithmetic in `selectSendFormReviewButtonRequestsCount`.

## Why this is a fix, not just perf

This is a **latent correctness bug**. The current code is harmless, but the mutating `splice` was a trap waiting to fire as soon as anyone memoized the upstream selector — which this PR does. The fix is a prerequisite for the memoization, not an opportunistic cleanup.

The memoization itself is also valuable: the selector is consumed in 4 places, including the suite-native `selectTransactionReviewOutputs` chain and the desktop transaction review modal. The `.filter()` ran on every Redux dispatch.

## What to focus on in testing

- [ ] **RBF flow on Bitcoin** with decrease amount on a single output — confirm the transaction review screen still shows the correct number of button requests pending and confirms in order.
- [ ] Normal send on Bitcoin (no RBF) — confirm button-request counter is unchanged.
- [ ] Send on Cardano — confirm the Cardano-specific button-request count (which subtracts 1) still resolves correctly through review.
- [ ] Send on Ethereum — confirm `ButtonRequest_Other` is counted.
- [ ] Send on Stellar (T1B1 if available) — `ButtonRequest_ProtectCall` and `ButtonRequest_Other` counted.
- [ ] Unit tests in `sendFormSelectors.test.ts` verify the mutation is gone and stable references hold.

## Parent staging PR

This PR is split out of #27670 (the staging branch that bundled the full perf/correctness audit).

## Related PRs

Part of a perf/correctness audit series. The eight PRs in this series can be reviewed and merged independently except where noted in the body.

- #27671 — `fix(wallet-core)` stabilize empty-array fallback in `selectCardanoPoolsInfo`
- #27672 — `fix(wallet-core)` stable references in phishing transaction selectors
- #27673 — `fix(suite-native)` stable empty-array fallback in Solana staking selector
- #27674 — `fix(suite)` stable empty array in Suite Sync ternary `useSelector` arrows
- #27675 — `fix(wallet-core)` remove mutating `.splice` in send form review button request count
- #27676 — `fix(suite)` prevent `SendLoaded` form re-renders on every dispatch
- #27677 — `fix(redux-utils)` remove `useSelectorDeepComparison` hook and its call sites
- #27678 — `fix(suite)` convert factory selectors to parameterized memoized selectors

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/fix-send-form-mutating-splice&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/fix-send-form-mutating-splice&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/fix-send-form-mutating-splice&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > TrezorConnect.getAddress | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-13T07:33:39.228Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Send form for bitcoin > add and remove output in send form, toggle form options, input data | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-13T07:32:40.540Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/fix-send-form-mutating-splice/web/](https://dev.suite.sldev.cz/suite-web/mroz22/fix-send-form-mutating-splice/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->