### PR TITLE
fix(suite): prevent SendLoaded form re-renders on every dispatch

### DIFF
--- a/packages/suite/src/views/wallet/send/index.tsx
+++ b/packages/suite/src/views/wallet/send/index.tsx
@@ -4,8 +4,10 @@ import { FormProvider } from 'react-hook-form';
 import styled from 'styled-components';
 
 import { Translation } from '@suite/intl';
+import { selectIsMetadataProviderConnected } from '@suite/metadata';
 import { selectRouteName } from '@suite/router';
 import { selectIsSuiteSyncEnabled } from '@suite-common/suite-sync';
+import { selectBaseCurrency, selectFees, selectSendRaw } from '@suite-common/wallet-core';
 import { Banner, Column } from '@trezor/components';
 import { SCREEN_QUERY } from '@trezor/components/src/config/variables';
 import { spacings, spacingsPx } from '@trezor/theme';
@@ -18,6 +20,8 @@ import {
     selectRegisteredUtxosByAccountKey,
     selectTargetAnonymityByAccountKey,
 } from 'src/reducers/wallet/coinjoinReducer';
+import { selectFullSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
+import { selectIsSuiteOnline } from 'src/selectors/suite/suiteSelectors';
 
 import { Options } from './Options/Options';
 import { Outputs } from './Outputs/Outputs';
@@ -62,22 +66,32 @@ interface SendLoadedProps extends SendProps {
 // children are only for test purposes, this prop is not available in regular build
 const SendLoaded = ({ children, selectedAccount }: SendLoadedProps) => {
     const isSuiteSyncEnabled = useSelector(selectIsSuiteSyncEnabled);
+    const accountKey = selectedAccount.account.key;
 
-    const props = useSelector(state => ({
-        localCurrency: state.wallet.settings.localCurrency,
-        fees: state.wallet.fees,
-        online: state.suite.online,
-        sendRaw: state.wallet.send.sendRaw,
-        metadataEnabled:
-            (state.metadata.enabled && !!state.metadata.providers[0]) || isSuiteSyncEnabled,
-        targetAnonymity: selectTargetAnonymityByAccountKey(state, selectedAccount.account.key),
-        prison: selectRegisteredUtxosByAccountKey(state, selectedAccount.account.key),
-    }));
+    const localCurrency = useSelector(selectBaseCurrency);
+    const fees = useSelector(selectFees);
+    const online = useSelector(selectIsSuiteOnline);
+    const sendRaw = useSelector(selectSendRaw);
+    const isMetadataProviderConnected = useSelector(selectIsMetadataProviderConnected);
+    const metadataEnabled = isMetadataProviderConnected || isSuiteSyncEnabled;
+    const targetAnonymity = useSelector(state =>
+        selectTargetAnonymityByAccountKey(state, accountKey),
+    );
+    const prison = useSelector(state => selectRegisteredUtxosByAccountKey(state, accountKey));
 
-    const sendContextValues = useSendForm({ ...props, selectedAccount });
+    const sendContextValues = useSendForm({
+        selectedAccount,
+        localCurrency,
+        fees,
+        online,
+        sendRaw,
+        metadataEnabled,
+        targetAnonymity,
+        prison,
+    });
 
     const { symbol } = selectedAccount.account;
-    if (props.sendRaw) {
+    if (sendRaw) {
         return (
             <WalletLayout title="TR_NAV_SEND" isSubpage account={selectedAccount}>
                 <SendRaw account={selectedAccount.account} />
@@ -120,7 +134,7 @@ const SendLoaded = ({ children, selectedAccount }: SendLoadedProps) => {
 };
 
 const Send = ({ children }: SendProps) => {
-    const selectedAccount = useSelector(state => state.wallet.selectedAccount);
+    const selectedAccount = useSelector(selectFullSelectedAccount);
     const currentRoute = useSelector(selectRouteName);
 
     // alone selectedAccount.status is not enough, currently there is a race-condition that needs to be fixed in send form

--- a/suite-common/wallet-core/src/send/sendFormSelectors.ts
+++ b/suite-common/wallet-core/src/send/sendFormSelectors.ts
@@ -17,6 +17,7 @@ export const selectSendSerializedTx = (state: SendRootState) => state.wallet.sen
 export const selectSendSignedTx = (state: SendRootState) => state.wallet.send.signedTx;
 export const selectSendFormDrafts = (state: SendRootState) => state.wallet.send.drafts;
 export const selectSendFormAccountKey = (state: SendRootState) => state.wallet.send.accountKey;
+export const selectSendRaw = (state: SendRootState) => state.wallet.send.sendRaw;
 export const selectPrecomposedSendForm = (state: SendRootState) =>
     state.wallet.send.precomposedForm;
 

--- a/suite/metadata/src/metadataReducer.ts
+++ b/suite/metadata/src/metadataReducer.ts
@@ -144,6 +144,9 @@ export const selectMetadata = (state: MetadataRootState) => state.metadata;
 export const selectIsMetadataEnabled = (state: MetadataRootState) =>
     state.metadata.enabled && !state.metadata.initiating;
 
+export const selectIsMetadataProviderConnected = (state: MetadataRootState) =>
+    state.metadata.enabled && !!state.metadata.providers[0];
+
 /**
  * Select currently selected provider for metadata of type 'labels'
  */


### PR DESCRIPTION
## Summary

`SendLoaded` in `packages/suite/src/views/wallet/send/index.tsx` had this anti-pattern:

```ts
const props = useSelector(state => ({
    localCurrency: state.wallet.settings.localCurrency,
    fees: state.wallet.fees,
    online: state.suite.online,
    sendRaw: state.wallet.send.sendRaw,
    metadataEnabled: ...,
    targetAnonymity: selectTargetAnonymityByAccountKey(state, ...),
    prison: selectRegisteredUtxosByAccountKey(state, ...),
}));
```

The arrow returns a **fresh object literal on every dispatch**, so `useSelector`'s referential-equality check always failed and `SendLoaded` re-rendered on every Redux action — including dispatches completely unrelated to the send form (fiat rate ticks, discovery progress, button requests, blockchain updates, etc.).

Replaced with 7 individual `useSelector` calls, each returning a primitive or already-stable reference, and forwarded as individual props to `useSendForm`.

## Why this is a fix, not just perf

This is the most user-visible bug in the audit series. `SendLoaded` is the root of the entire send form tree — every input, fee picker, address field, and amount field re-rendered on every Redux dispatch while the user was on the Send screen. On a real wallet with active fiat rate polling, discovery, or backend ticks, that means **dozens of re-renders per second of the entire form** during normal use.

The most likely user-observable symptom is **input lag while typing the amount or address** on the desktop Send view, especially in the wallet's busy-state (active fee polling, transaction confirmations arriving, etc.).

## What to focus on in testing

- [ ] **Desktop Send form** on Bitcoin: type a long address into the recipient field and a multi-decimal amount. Should feel responsive even with active fiat rate polling.
- [ ] **Fee picker** updates correctly when changing fee level or custom fee inputs.
- [ ] **RBF flow**: confirm the `targetAnonymity` and `prison` (registered UTXOs) props are wired correctly — coinjoin-enabled accounts should still skip locked UTXOs.
- [ ] **`sendRaw` flow**: when `sendRaw` is true, the `SendRaw` view renders instead of the form.
- [ ] **Metadata labels**: when metadata provider is connected OR Suite Sync is enabled, recipient address labels still resolve via metadata.
- [ ] **Send form on multiple network types**: Bitcoin, Ethereum, Solana, Cardano — all forms still submit successfully.
- [ ] React DevTools Profiler: while sitting on the Send screen with no user input, dispatch unrelated actions (e.g. background fiat ticks). `SendLoaded` and its children should not re-render.

## Parent staging PR

This PR is split out of #27670 (the staging branch that bundled the full perf/correctness audit).

## Related PRs

Part of a perf/correctness audit series. The eight PRs in this series can be reviewed and merged independently except where noted in the body.

- #27671 — `fix(wallet-core)` stabilize empty-array fallback in `selectCardanoPoolsInfo`
- #27672 — `fix(wallet-core)` stable references in phishing transaction selectors
- #27673 — `fix(suite-native)` stable empty-array fallback in Solana staking selector
- #27674 — `fix(suite)` stable empty array in Suite Sync ternary `useSelector` arrows
- #27675 — `fix(wallet-core)` remove mutating `.splice` in send form review button request count
- #27676 — `fix(suite)` prevent `SendLoaded` form re-renders on every dispatch
- #27677 — `fix(redux-utils)` remove `useSelectorDeepComparison` hook and its call sites
- #27678 — `fix(suite)` convert factory selectors to parameterized memoized selectors

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/fix-send-loaded-form-rerenders/web/](https://dev.suite.sldev.cz/suite-web/mroz22/fix-send-loaded-form-rerenders/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/fix-send-loaded-form-rerenders&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/fix-send-loaded-form-rerenders&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/fix-send-loaded-form-rerenders&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > TrezorConnect.getAddress | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-13T07:34:53.709Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Send form for bitcoin > add and remove output in send form, toggle form options, input data | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-13T07:32:42.832Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->