### PR TITLE
fix(suite): convert factory selectors to parameterized memoized selectors

### DIFF
--- a/suite-common/message-system/src/__tests__/messageSystemSelectors.test.ts
+++ b/suite-common/message-system/src/__tests__/messageSystemSelectors.test.ts
@@ -1,0 +1,94 @@
+import { messageSystemInitialState } from '../messageSystemReducer';
+import {
+    selectExperimentById,
+    selectExperimentInclusionOverrideById,
+} from '../messageSystemSelectors';
+import {
+    ExperimentId,
+    type MessageSystemRootState,
+    type MessageSystemState,
+} from '../messageSystemTypes';
+
+const buildState = (overrides: Partial<MessageSystemState> = {}): MessageSystemRootState => ({
+    messageSystem: {
+        ...messageSystemInitialState,
+        ...overrides,
+    },
+});
+
+const stateWithExperiment = buildState({
+    config: {
+        version: 1,
+        timestamp: '2023-01-01',
+        sequence: 1,
+        actions: [],
+        experiments: [
+            {
+                experiment: {
+                    id: ExperimentId.tradingFeedbackForm,
+                    groups: [
+                        { variant: 'A', percentage: 50 },
+                        { variant: 'B', percentage: 50 },
+                    ],
+                },
+            },
+        ],
+    },
+    validExperiments: [ExperimentId.tradingFeedbackForm],
+} as unknown as Partial<MessageSystemState>);
+
+describe('selectExperimentById', () => {
+    it('returns the matching experiment when present', () => {
+        const result = selectExperimentById(stateWithExperiment, ExperimentId.tradingFeedbackForm);
+        expect(result?.id).toBe(ExperimentId.tradingFeedbackForm);
+    });
+
+    it('returns undefined when no experiment matches', () => {
+        const result = selectExperimentById(stateWithExperiment, ExperimentId.tradingFiatValues);
+        expect(result).toBeUndefined();
+    });
+
+    it('returns the same reference across repeated calls on unchanged state (memoization)', () => {
+        const a = selectExperimentById(stateWithExperiment, ExperimentId.tradingFeedbackForm);
+        const b = selectExperimentById(stateWithExperiment, ExperimentId.tradingFeedbackForm);
+        expect(a).toBe(b);
+    });
+});
+
+describe('selectExperimentInclusionOverrideById', () => {
+    const stateWithOverride = buildState({
+        experimentInclusionOverrides: {
+            [ExperimentId.tradingFeedbackForm]: true,
+        },
+    } as unknown as Partial<MessageSystemState>);
+
+    it('returns the matching override value when present', () => {
+        expect(
+            selectExperimentInclusionOverrideById(
+                stateWithOverride,
+                ExperimentId.tradingFeedbackForm,
+            ),
+        ).toBe(true);
+    });
+
+    it('returns null when no override is set for that id', () => {
+        expect(
+            selectExperimentInclusionOverrideById(
+                stateWithOverride,
+                ExperimentId.tradingFiatValues,
+            ),
+        ).toBeNull();
+    });
+
+    it('returns the same primitive across repeated calls on unchanged state (memoization)', () => {
+        const a = selectExperimentInclusionOverrideById(
+            stateWithOverride,
+            ExperimentId.tradingFeedbackForm,
+        );
+        const b = selectExperimentInclusionOverrideById(
+            stateWithOverride,
+            ExperimentId.tradingFeedbackForm,
+        );
+        expect(a).toBe(b);
+    });
+});

--- a/suite-common/message-system/src/messageSystemSelectors.ts
+++ b/suite-common/message-system/src/messageSystemSelectors.ts
@@ -245,12 +245,13 @@ export const selectAllValidExperiments = createMemoizedSelector(
     },
 );
 
-export const selectExperimentById = (id: ExperimentId) =>
-    createMemoizedSelector([selectAllValidExperiments], allValidExperiments =>
+export const selectExperimentById = createMemoizedSelector(
+    [selectAllValidExperiments, (_state, id: ExperimentId) => id],
+    (allValidExperiments, id) =>
         allValidExperiments.find(
             (experiment): experiment is ExperimentsItemType => experiment.id === id,
         ),
-    );
+);
 
 export const selectActiveExperimentsWithVariants = createSelector(
     [selectAnalyticsInstanceId, selectAllValidExperiments],
@@ -275,8 +276,7 @@ export const selectActiveExperimentsWithVariants = createSelector(
 export const selectAllExperimentInclusionOverrides = (state: MessageSystemRootState) =>
     state.messageSystem.experimentInclusionOverrides;
 
-export const selectExperimentInclusionOverrideById = (id: ExperimentId) =>
-    createMemoizedSelector(
-        [selectAllExperimentInclusionOverrides],
-        inclusionOverrides => inclusionOverrides?.[id] ?? null,
-    );
+export const selectExperimentInclusionOverrideById = createMemoizedSelector(
+    [selectAllExperimentInclusionOverrides, (_state, id: ExperimentId) => id],
+    (inclusionOverrides, id) => inclusionOverrides?.[id] ?? null,
+);

--- a/suite-common/message-system/src/useExperiment.ts
+++ b/suite-common/message-system/src/useExperiment.ts
@@ -8,12 +8,16 @@ import {
     selectExperimentById,
     selectExperimentInclusionOverrideById,
 } from './messageSystemSelectors';
-import type { ExperimentId } from './messageSystemTypes';
+import type { ExperimentId, MessageSystemRootState } from './messageSystemTypes';
 
 export const useExperiment = (experimentId: ExperimentId) => {
     const instanceId = useSelector(selectAnalyticsInstanceId);
-    const experiment = useSelector(selectExperimentById(experimentId));
-    const inclusionOverride = useSelector(selectExperimentInclusionOverrideById(experimentId));
+    const experiment = useSelector((state: MessageSystemRootState) =>
+        selectExperimentById(state, experimentId),
+    );
+    const inclusionOverride = useSelector((state: MessageSystemRootState) =>
+        selectExperimentInclusionOverrideById(state, experimentId),
+    );
     const activeExperimentVariant = useMemo(
         () =>
             experiment && inclusionOverride != null


### PR DESCRIPTION
## Summary

Converts the two message-system experiment selectors from a higher-order factory into proper parameterized `createMemoizedSelector` instances:

- `selectExperimentById` and `selectExperimentInclusionOverrideById` in `@suite-common/message-system` — consumed by `useExperiment` behind the trading-only `AfterTradeExperiment`.

> **Scope note.** This PR was narrowed to the message-system selectors only. The original version also converted `selectHasTransportOfType` / `selectTransportOfType` (`packages/suite`) and `selectHasExperimentalFeature` (`@suite/settings`). Those conversions were dropped: both return primitives (a `boolean`, or an existing array-element reference from `.find`), so memoizing them prevents no `useSelector` re-render — `useSelector` already compares primitives by value — and their bodies are trivial (`.some` / `.includes`). The conversion only added WeakMap + argument-extraction overhead for no measurable benefit. Only the genuine factory anti-pattern below remains.

## Why this is a fix, not just perf

`selectExperimentById` / `selectExperimentInclusionOverrideById` used a factory-that-builds-a-selector pattern:

```ts
export const selectExperimentById = (id: ExperimentId) =>
    createMemoizedSelector([selectAllValidExperiments], allValidExperiments =>
        allValidExperiments.find(e => e.id === id),
    );
```

Every call to `selectExperimentById(id)` allocates a brand-new memoized selector with its own throwaway cache. Used as `useSelector(state => selectExperimentById(id)(state))`, that cache never survives between renders, so a fresh selector is allocated and the `.find` body re-runs on every dispatch. Converting to the standard `createMemoizedSelector((state, id) => ...)` shape gives a single shared module-level cache that actually persists across renders and dispatches.

## What to focus on in testing

- [ ] **`AfterTradeExperiment`** rendering after a completed trade — the experiment variant resolves correctly.
- [ ] **`useExperiment`** hook in `ExperimentWrapper` — inclusion overrides still resolve correctly when set in the message-system payload.

## Risk notes

The change updates the call-site signature from `selectExperimentById(id)(state)` to `selectExperimentById(state, id)`. The only consumer is `useExperiment` (updated in this PR), and `id` is a stable primitive, so the parameterized cache is effective on every call.

## Parent staging PR

Split out of #27670 (the staging branch that bundled the full perf/correctness audit).

## Related PRs

- #27672 — `fix(wallet-core)` stable references in phishing transaction selectors
- #27677 — `fix(redux-utils)` remove `useSelectorDeepComparison` hook and its call sites

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/fix-factory-selectors-to-parameterized&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/fix-factory-selectors-to-parameterized&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/fix-factory-selectors-to-parameterized&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-13T08:22:25.653Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send form for bitcoin > add and remove output in send form, toggle form options, input data | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-13T08:21:05.427Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/fix-factory-selectors-to-parameterized/web/](https://dev.suite.sldev.cz/suite-web/mroz22/fix-factory-selectors-to-parameterized/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->