### PR TITLE
refactor(suite): replace Card components with Banner for improved UI consistency in staking dashboard

### DIFF
--- a/packages/components/src/components/Banner/Banner.tsx
+++ b/packages/components/src/components/Banner/Banner.tsx
@@ -75,7 +75,12 @@ export const Banner = ({
                             </H4>
                         )}
                         {description && (
-                            <Paragraph typographyStyle="body-sm" intent={intent} priority="primary">
+                            <Paragraph
+                                typographyStyle="body-sm"
+                                intent={intent}
+                                priority="primary"
+                                textWrap="pretty"
+                            >
                                 {description}
                             </Paragraph>
                         )}

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/ExternalStakingProviderCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/ExternalStakingProviderCard.tsx
@@ -1,7 +1,7 @@
 import { Translation } from '@suite/intl';
 import { type NetworkSymbol, getDisplaySymbol } from '@suite-common/wallet-config';
 import { asAmountSubunit, subunitsToUnits } from '@suite-common/wallet-utils';
-import { Card, Column, H3, IconCircle, Paragraph, Row } from '@trezor/components';
+import { Banner } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
 
 import { DashboardSection } from 'src/components/dashboard';
@@ -24,31 +24,21 @@ export const ExternalStakingProviderCard = ({
 
     return (
         <DashboardSection data-testid="@wallet/staking/outside-staking-card">
-            <Card paddingType="large">
-                <Row alignItems="start" gap={16}>
-                    <IconCircle name="puzzlePiece" intent="brand" size={40} />
-                    <Column gap={4}>
-                        <H3>
-                            <Translation id="TR_OUTSIDE_STAKING_CARD_TITLE" />
-                        </H3>
-                        <Paragraph intent="neutral" priority="secondary" maxWidth={700}>
-                            <Translation
-                                id="TR_OUTSIDE_STAKING_CARD_TEXT"
-                                values={{
-                                    amount: totalStakedInUnits,
-                                    displaySymbol,
-                                    fiat: (
-                                        <BaseCurrencyValue
-                                            amount={totalStakedInUnits}
-                                            symbol={symbol}
-                                        />
-                                    ),
-                                }}
-                            />
-                        </Paragraph>
-                    </Column>
-                </Row>
-            </Card>
+            <Banner
+                icon="puzzlePiece"
+                intent="neutral"
+                title={<Translation id="TR_OUTSIDE_STAKING_CARD_TITLE" />}
+                description={
+                    <Translation
+                        id="TR_OUTSIDE_STAKING_CARD_TEXT"
+                        values={{
+                            amount: totalStakedInUnits,
+                            displaySymbol,
+                            fiat: <BaseCurrencyValue amount={totalStakedInUnits} symbol={symbol} />,
+                        }}
+                    />
+                }
+            />
         </DashboardSection>
     );
 };

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/NewProviderCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/NewProviderCard.tsx
@@ -5,8 +5,7 @@ import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { selectPoolStatsApy } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { isCardanoStakedWithFiveBinaries } from '@suite-common/wallet-utils';
-import { Button, Card, Column, H3, Icon, Paragraph, Row, Tooltip } from '@trezor/components';
-import { spacings } from '@trezor/theme';
+import { Banner, Tooltip } from '@trezor/components';
 
 import { formatApyValue } from 'src/components/earn/utils/earnApyUtils';
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -42,46 +41,41 @@ export const NewProviderCard = ({ account }: NewProviderCardProps) => {
     };
 
     return (
-        <Card paddingType="large">
-            <Row alignItems="start" gap={spacings.xs}>
-                <Icon name="warning" intent="warning" size={32} />
-
-                <Column gap={spacings.xxxl}>
-                    <Column gap={spacings.xs}>
-                        <H3>
-                            <Translation
-                                id={
-                                    isStakedWithFiveBinaries
-                                        ? 'TR_STAKING_NEW_PROVIDER_OUTDATED_TITLE'
-                                        : 'TR_STAKING_NEW_PROVIDER_TITLE'
-                                }
-                                values={{ apy: formatApyValue(apy) }}
-                            />
-                        </H3>
-                        <Paragraph intent="neutral" priority="secondary" maxWidth={700}>
-                            <Translation
-                                id={
-                                    isStakedWithFiveBinaries
-                                        ? 'TR_STAKING_NEW_PROVIDER_OUTDATED_TEXT'
-                                        : 'TR_STAKING_NEW_PROVIDER_TEXT'
-                                }
-                                values={{ apy: formatApyValue(apy), displaySymbol }}
-                            />
-                        </Paragraph>
-                    </Column>
-
-                    <Tooltip content={stakingMessageContent}>
-                        <Button
-                            onClick={openStakeInANutshellModal}
-                            isDisabled={isStakingDisabled}
-                            iconLeft={isStakingDisabled ? 'info' : undefined}
-                            data-testid="@wallet/staking/empty-card/start-staking-button"
-                        >
-                            <Translation id="TR_EARN_UPDATE_PROVIDER" />
-                        </Button>
-                    </Tooltip>
-                </Column>
-            </Row>
-        </Card>
+        <Banner
+            icon
+            intent="warning"
+            title={
+                <Translation
+                    id={
+                        isStakedWithFiveBinaries
+                            ? 'TR_STAKING_NEW_PROVIDER_OUTDATED_TITLE'
+                            : 'TR_STAKING_NEW_PROVIDER_TITLE'
+                    }
+                    values={{ apy: formatApyValue(apy) }}
+                />
+            }
+            description={
+                <Translation
+                    id={
+                        isStakedWithFiveBinaries
+                            ? 'TR_STAKING_NEW_PROVIDER_OUTDATED_TEXT'
+                            : 'TR_STAKING_NEW_PROVIDER_TEXT'
+                    }
+                    values={{ apy: formatApyValue(apy), displaySymbol }}
+                />
+            }
+            rightContent={
+                <Tooltip content={stakingMessageContent}>
+                    <Banner.Button
+                        onClick={openStakeInANutshellModal}
+                        isDisabled={isStakingDisabled}
+                        iconLeft={isStakingDisabled ? 'info' : undefined}
+                        data-testid="@wallet/staking/empty-card/start-staking-button"
+                    >
+                        <Translation id="TR_EARN_UPDATE_PROVIDER" />
+                    </Banner.Button>
+                </Tooltip>
+            }
+        />
     );
 };


### PR DESCRIPTION
## Notes for QA

Replaced custom cards with Banners.

## Screenshots:

### Before
<img width="1346" height="270" alt="image" src="https://github.com/user-attachments/assets/142d70c9-231d-413d-9ed2-45b3b73d7bed" />
<img width="1500" height="458" alt="image" src="https://github.com/user-attachments/assets/213140d9-b0a1-4464-84c7-9e0c9ab69861" />


### After
<img width="886" height="96" alt="Screenshot 2026-05-13 at 10 14 13" src="https://github.com/user-attachments/assets/85968a8b-7e7b-48df-bfb9-608a7e5be32d" />
<img width="965" height="111" alt="Screenshot 2026-05-13 at 10 14 35" src="https://github.com/user-attachments/assets/84f282a8-f25a-48be-8402-1e7144ba9cfc" />


<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect three files: a shared Banner component (used by 121+ tests) and two staking dashboard card components (ExternalStakingProviderCard and NewProviderCard). The staking card changes pose the highest regression risk since they are directly rendered in staking dashboard views across ETH, ADA, and SOL flows. All 12 staking-related tests should be run as they directly exercise the changed staking components. The Banner component change is broad but only the safety-checks-warning test specifically validates banner-specific behaviors (dismissal, CTA buttons) that would be affected by Banner.tsx changes; other tests merely transitively import it without directly testing banner functionality.

<details><summary><b>Changed files (3)</b></summary>

- `packages/components/src/components/Banner/Banner.tsx`
- `packages/suite/src/views/wallet/staking/components/StakingDashboard/components/ExternalStakingProviderCard.tsx`
- `packages/suite/src/views/wallet/staking/components/StakingDashboard/components/NewProviderCard.tsx`

</details>

**Recommended tests (13)**

<details><summary>🔴 <b>High priority (12)</b></summary>

- `suite/e2e/tests/analytics/staking-events.test.ts` — This test directly exercises staking navigation UI which uses both ExternalStakingProviderCard and NewProviderCard components. It verifies staking navigate analytics events triggered from account menus and dashboard, which are the primary user-facing paths through the changed staking card components.
- `suite/e2e/tests/staking/ada/claim.test.ts` — This test navigates to the ADA staking dashboard and exercises claim rewards functionality, directly rendering the staking dashboard components including ExternalStakingProviderCard and NewProviderCard. Changes to these card components could affect the staking UI layout and interactions.
- `suite/e2e/tests/staking/ada/stake.test.ts` — This test exercises the full ADA staking flow including viewing the staking dashboard where ExternalStakingProviderCard and NewProviderCard are rendered. It checks visibility of start staking, claim rewards, and unstake buttons that coexist with these provider cards.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — This test verifies ADA unstaking from the staking dashboard view where the changed provider card components are rendered. It checks post-unstake UI state including visibility of staking-related elements that may be affected by layout changes in provider cards.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test covers the ETH initial staking flow including the staking dashboard empty state and staking form, where ExternalStakingProviderCard is displayed. It verifies staking dashboard card visibility and staking amount progression which could be affected by provider card changes.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — This test exercises the ETH stake-more flow on the staking dashboard where ExternalStakingProviderCard is rendered. It verifies staking amounts, instant staking banner, and progress indicators that share the dashboard view with the changed component.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — This test covers the ETH unstake and claim flow on the staking dashboard where ExternalStakingProviderCard is displayed. Changes to the provider card could affect the dashboard layout and button states verified by this test.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — This test covers Solana initial staking including the empty staking dashboard state and first stake flow. ExternalStakingProviderCard is rendered in the staking dashboard view and changes could affect element visibility assertions.
- `suite/e2e/tests/staking/sol/rewards.test.ts` — This test verifies the Solana staking dashboard with staked amounts and rewards display. ExternalStakingProviderCard is part of the staking dashboard view being tested, and changes to it could affect layout or visibility of staking amount elements.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — This test exercises the SOL stake-more flow from the staking dashboard where ExternalStakingProviderCard is rendered. It checks staking amounts and button states that could be impacted by provider card changes.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — This test covers SOL unstaking and claiming from the staking dashboard. ExternalStakingProviderCard is part of this dashboard view and changes could affect the visibility and layout of claim cards and staking empty states.
- `suite/e2e/tests/staking/staking-form.test.ts` — This test directly exercises the ETH staking form including validation, percentage buttons, and input switching on the staking dashboard. ExternalStakingProviderCard is part of this view and changes could affect form rendering or navigation to the staking form.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/suite/safety-checks-warning.test.ts` — This test specifically verifies a dismissible warning banner with CTA and dismiss buttons. Changes to the Banner component could affect banner rendering, dismiss behavior, and CTA button functionality that this test directly validates.

</details>

_Updated: 2026-05-13T08:19:06.909Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/custom-banners&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/custom-banners&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-13T08:23:17.430Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send form for bitcoin > add and remove output in send form, toggle form options, input data | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-13T08:21:46.906Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/custom-banners/web/](https://dev.suite.sldev.cz/suite-web/refactor/custom-banners/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->