### PR TITLE
fix(suite): Disable passphrase tooltip when no network is active

### DIFF
--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/AddWalletButton.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/AddWalletButton.tsx
@@ -4,7 +4,11 @@ import { useDispatch } from 'react-redux';
 import { Translation } from '@suite/intl';
 import { selectIsDeviceOrUiLocked } from '@suite/locks';
 import { closeModalApp, goto } from '@suite/router';
-import { selectDeviceThunk, startDiscoveryThunk } from '@suite-common/wallet-core';
+import {
+    selectDeviceThunk,
+    selectIsAnyNetworkEnabled,
+    startDiscoveryThunk,
+} from '@suite-common/wallet-core';
 import { WalletType } from '@suite-common/wallet-types';
 import { Button, Card, Column, IconButton, Row, Text, Tooltip } from '@trezor/components';
 
@@ -22,10 +26,34 @@ export const AddWalletButton = ({ device, instances, onCancel }: AddWalletButton
     const emptyPassphraseWalletExists = instances.find(d => d.useEmptyPassphrase && d.state);
 
     const isDeviceOrUiLocked = useSelector(selectIsDeviceOrUiLocked);
+    const isAnyNetworkEnabled = useSelector(selectIsAnyNetworkEnabled);
     const isPassphraseProtectionEnabled = Boolean(device?.features?.passphrase_protection);
     const dispatch = useDispatch();
     const isLocked = !device || !device.connected || isDeviceOrUiLocked;
+    const isPassphraseAddDisabled = isLocked || !isAnyNetworkEnabled;
+    const showNoNetworksTooltip = !isLocked && !isAnyNetworkEnabled;
     const [isPassphraseExpanded, setIsPassphraseExpanded] = useState(false);
+
+    const goToCoinsSettings = () => {
+        onCancel?.(false);
+        dispatch(closeModalApp());
+        dispatch(goto({ routeName: 'settings-coins' }));
+    };
+
+    const noNetworksTooltipContent = (
+        <Column gap={12} alignItems="flex-start" maxWidth={250} padding={4}>
+            <Translation id="TR_PASSPHRASE_WALLET_NEEDS_ENABLED_NETWORK" />
+            <Button
+                data-testid="@switch-device/passphrase-go-to-coins-settings"
+                intent="neutral"
+                priority="secondary"
+                size="small"
+                onClick={goToCoinsSettings}
+            >
+                <Translation id="TR_ENABLE_MORE_COINS" />
+            </Button>
+        </Column>
+    );
 
     if (!isPassphraseProtectionEnabled && emptyPassphraseWalletExists) {
         return null;
@@ -134,18 +162,26 @@ export const AddWalletButton = ({ device, instances, onCancel }: AddWalletButton
                     (isPassphraseExpanded ? (
                         <ExpandedPassphraseContainer />
                     ) : (
-                        <Button
-                            data-testid="@switch-device/add-hidden-wallet-button"
-                            intent="neutral"
-                            priority="secondary"
+                        <Tooltip
+                            isActive={showNoNetworksTooltip}
+                            content={showNoNetworksTooltip ? noNetworksTooltipContent : undefined}
+                            cursor="not-allowed"
+                            placement="right"
                             width="100%"
-                            size="large"
-                            iconLeft="plus"
-                            isDisabled={isLocked}
-                            onClick={() => setIsPassphraseExpanded(true)}
                         >
-                            <Translation id="TR_ADD_HIDDEN_WALLET" />
-                        </Button>
+                            <Button
+                                data-testid="@switch-device/add-hidden-wallet-button"
+                                intent="neutral"
+                                priority="secondary"
+                                width="100%"
+                                size="large"
+                                iconLeft="plus"
+                                isDisabled={isPassphraseAddDisabled}
+                                onClick={() => setIsPassphraseExpanded(true)}
+                            >
+                                <Translation id="TR_ADD_HIDDEN_WALLET" />
+                            </Button>
+                        </Tooltip>
                     ))}
             </Column>
         </Tooltip>

--- a/suite/e2e/tests/metadata/legacy/wallet-metadata.test.ts
+++ b/suite/e2e/tests/metadata/legacy/wallet-metadata.test.ts
@@ -8,9 +8,10 @@ test.describe(
     'Metadata - wallet labeling',
     { tag: ['@webOnly', '@T3W1', '@T3T1', '@smoke'] },
     () => {
-        test.beforeEach(async ({ onboardingPage, metadataMock, metadataPage }) => {
+        test.beforeEach(async ({ onboardingPage, metadataMock, metadataPage, settingsPage }) => {
             await metadataMock.start(MetadataProvider.DROPBOX);
             await onboardingPage.completeOnboarding();
+            await settingsPage.changeNetworks({ enableNetworks: ['btc'] });
             await metadataPage.enableLegacyLabeling(MetadataProvider.DROPBOX);
         });
 

--- a/suite/e2e/tests/passphrase/passphrase-cancel.test.ts
+++ b/suite/e2e/tests/passphrase/passphrase-cancel.test.ts
@@ -6,9 +6,11 @@ test.describe('Passphrase cancel', { tag: ['@T3W1', '@T3T1'] }, () => {
     test('possible to cancel passphrase', async ({
         devicePrompt,
         onboardingPage,
+        settingsPage,
         dashboardPage,
     }) => {
         await onboardingPage.completeOnboarding();
+        await settingsPage.changeNetworks({ enableNetworks: ['btc'] });
 
         await dashboardPage.deviceSwitchingOpenButton.click();
         await dashboardPage.addHiddenWalletButton.click();

--- a/suite/e2e/tests/passphrase/passphrase-duplicate.test.ts
+++ b/suite/e2e/tests/passphrase/passphrase-duplicate.test.ts
@@ -2,8 +2,9 @@ import { expect, test } from '../../support/fixtures';
 
 test.describe('Passphrase duplicate', { tag: ['@T3W1', '@T3T1'] }, () => {
     test.use({ deviceSetup: { passphrase_protection: true } });
-    test.beforeEach(async ({ onboardingPage }) => {
+    test.beforeEach(async ({ onboardingPage, settingsPage }) => {
         await onboardingPage.completeOnboarding();
+        await settingsPage.changeNetworks({ enableNetworks: ['btc'] });
     });
 
     test('attempt to add the same hidden wallet twice results in warning', async ({

--- a/suite/e2e/tests/passphrase/passphrase-numbering.test.ts
+++ b/suite/e2e/tests/passphrase/passphrase-numbering.test.ts
@@ -2,8 +2,9 @@ import { expect, test } from '../../support/fixtures';
 
 test.describe('Passphrase numbering', { tag: ['@T3W1', '@T3T1'] }, () => {
     test.use({ deviceSetup: { passphrase_protection: true } });
-    test.beforeEach(async ({ onboardingPage }) => {
+    test.beforeEach(async ({ onboardingPage, settingsPage }) => {
         await onboardingPage.completeOnboarding();
+        await settingsPage.changeNetworks({ enableNetworks: ['btc'] });
     });
 
     test('hidden wallet numbering', async ({ dashboardPage }) => {

--- a/suite/e2e/tests/settings/coins.test.ts
+++ b/suite/e2e/tests/settings/coins.test.ts
@@ -21,7 +21,7 @@ test.describe('Coin Settings', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () => {
                 stream: TestStream.Foundation,
             }),
         },
-        async ({ dashboardPage, settingsPage, assetsSection }) => {
+        async ({ page, dashboardPage, settingsPage, assetsSection }) => {
             const defaultUncheckedMainnet: NetworkSymbol[] = [
                 'btc',
                 'ltc',
@@ -75,6 +75,7 @@ test.describe('Coin Settings', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () => {
                     await assetsSection.activateAssetsModalNetworkButton(network).click();
                 }
                 await assetsSection.activateAssetsModalSaveButton.click();
+                await page.discoveryShouldFinish();
                 await settingsPage.navigateTo('coins');
                 await settingsPage.coinsTab.temporarilySetOfficialCardanoBackend();
                 for (const network of defaultUncheckedTestnet) {

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -169,6 +169,10 @@ export const messages = defineMessages({
         defaultMessage: 'Standard wallet',
         id: 'TR_ADD_WALLET',
     },
+    TR_PASSPHRASE_WALLET_NEEDS_ENABLED_NETWORK: {
+        defaultMessage: 'Activate at least one coin before adding a passphrase wallet.',
+        id: 'TR_PASSPHRASE_WALLET_NEEDS_ENABLED_NETWORK',
+    },
     TR_RECIPIENT_ADDRESS: {
         defaultMessage: 'Recipient address',
         description: 'Used as label for send address input',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<img width="666" height="468" alt="Screenshot 2026-05-13 at 15 29 47" src="https://github.com/user-attachments/assets/21f98e71-d92a-44a9-bab7-b91052d2e88b" />


<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set modifies the AddWalletButton component in the SwitchDevice view and the global messages.ts translation file. The AddWalletButton change is high-risk for any test that adds wallets through the device switcher (standard or passphrase). The messages.ts file maps to no tests statically but is a global dependency — since we lack specifics on which translation keys changed, only tests that assert specific translation content from the onboarding/autodetect flow warrant low-priority coverage. The recommended strategy focuses on device switcher wallet-addition flows and passphrase wallet tests.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/views/suite/SwitchDevice/DeviceItem/AddWalletButton.tsx`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/general/wallet-discovery.test.ts` — This test directly exercises the 'add standard wallet' flow via the device switcher, which is the exact UI path where AddWalletButton.tsx is rendered. Changes to this component could break the ability to add a new wallet and trigger discovery.
- `suite/e2e/tests/passphrase/passphrase-numbering.test.ts` — This test adds multiple wallets (standard and passphrase) via the device switcher using addStandardWallet and addUnusedHiddenWallet, directly exercising the AddWalletButton component. It validates wallet labeling and numbering after adding/ejecting wallets.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — This test adds hidden wallets via the device switcher (addHiddenWallet, addUnusedHiddenWallet), directly interacting with the AddWalletButton component. It also validates analytics events for wallet type selection triggered by this button.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/analytics/toggle.test.ts` — This test opens the device switcher (openDeviceSwitcher) to trigger analytics events, which renders the AddWalletButton component. A broken button could affect the device switcher flow tested here.
- `suite/e2e/tests/backup/t2t1-misc.test.ts` — This test uses the device switcher to add a standard wallet and eject wallets, directly exercising AddWalletButton functionality in the context of backup testing with a remembered device.
- `suite/e2e/tests/passphrase/passphrase-duplicate.test.ts` — This test adds hidden wallets via the device switcher (addUnusedHiddenWallet, addHiddenWallet), exercising AddWalletButton. It specifically validates the duplicate passphrase detection flow triggered by the wallet add action.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — This test adds a hidden wallet via the device switcher and validates wallet persistence after disconnect/reconnect. The AddWalletButton is directly exercised when adding the passphrase wallet.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — This test opens the device switcher to check wallet fiat amounts in discreet mode. While AddWalletButton is rendered in the switcher, the test doesn't directly interact with it — but a rendering error could break the switcher UI.
- `suite/e2e/tests/settings/autodetect.test.ts` — This test validates autodetection of locale and theme using translation strings from messages.ts. Changes to messages.ts could affect the TR_ONBOARDING_DATA_COLLECTION_HEADING text used in assertions.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/intl/src/messages.ts`

_Updated: 2026-05-13T09:11:12.748Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/disable-passphrase-tooltip-when-no-network-is-active/web/](https://dev.suite.sldev.cz/suite-web/disable-passphrase-tooltip-when-no-network-is-active/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=disable-passphrase-tooltip-when-no-network-is-active&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=disable-passphrase-tooltip-when-no-network-is-active&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-13T16:12:26.045Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-13T16:11:17.733Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->