### PR TITLE
fix(suite): send empty homescreen on pre-2.9.0 firmware to fix wallpa…

### DIFF
--- a/packages/suite/src/components/suite/HomescreenGallery.tsx
+++ b/packages/suite/src/components/suite/HomescreenGallery.tsx
@@ -2,10 +2,15 @@ import styled from 'styled-components';
 
 import { useDevice } from '@suite/device';
 import { Grid } from '@trezor/components';
-import { DeviceModelInternal, hasBitcoinOnlyFirmware } from '@trezor/device-utils';
+import {
+    DeviceModelInternal,
+    getFirmwareVersionArray,
+    hasBitcoinOnlyFirmware,
+} from '@trezor/device-utils';
 import { resolveStaticPath } from '@trezor/env-utils';
 import { borders, spacings } from '@trezor/theme';
 import { exhaustive } from '@trezor/type-utils';
+import { versionUtils } from '@trezor/utils';
 
 import { applySettings } from 'src/actions/settings/deviceSettingsActions';
 import { getDefaultHomeScreenImage, getHomescreens } from 'src/constants/suite/homescreens';
@@ -55,14 +60,25 @@ export const HomescreenGallery = ({ onConfirm }: HomescreenGalleryProps) => {
     const setHomescreen = async (imagePath: string, image: AnyImageName) => {
         if (isLocked()) return;
 
-        // original image is the default image already available in device, set it by empty string
         const isOriginalImage =
             getDefaultHomeScreenImage({ deviceModelInternal, isBitcoinOnlyFirmware }) === image;
 
         if (isOriginalImage) {
-            dispatch(applySettings({ homescreen_length: 0 }));
+            // Reset homescreen to factory default. Firmware >= 2.9.0 expects
+            // homescreen_length: 0; older firmware (e.g. Trezor One 1.x) does
+            // not recognize that field and returns "No setting provided", so
+            // fall back to an empty homescreen string.
+            const fwVersion = getFirmwareVersionArray(device);
+            const supportsHomescreenLength =
+                fwVersion !== null && versionUtils.isNewerOrEqual(fwVersion, '2.9.0');
+
+            dispatch(
+                applySettings(
+                    supportsHomescreenLength ? { homescreen_length: 0 } : { homescreen: '' },
+                ),
+            );
         } else {
-            const hex = isOriginalImage ? '' : await imagePathToHex(imagePath, deviceModelInternal);
+            const hex = await imagePathToHex(imagePath, deviceModelInternal);
             dispatch(applySettings({ homescreen: hex }));
         }
 


### PR DESCRIPTION
…per reset on Trezor One

Selecting the default wallpaper in the gallery dispatched applySettings({ homescreen_length: 0 }), which only firmware >= 2.9.0 recognizes. Trezor One (1.x) treats it as an unknown field and returns "No setting provided" (issue #26562). Branch on firmware version and fall back to applySettings({ homescreen: '' }) for older firmware.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve  https://github.com/trezor/trezor-suite/issues/26562

## Screenshots:

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to HomescreenGallery.tsx, which is the component responsible for selecting and applying homescreen/background images on Trezor devices. Despite mapping to 121 tests via static analysis, this is clearly a shared/global dependency import. The only tests that directly exercise homescreen gallery functionality are the device settings tests for T1B1, T2T1, and T3B1, which explicitly test changing device background images. All other mapped tests are unrelated to homescreen functionality and should be omitted.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/suite/HomescreenGallery.tsx`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/settings/t1b1-device-settings.test.ts` — This test directly exercises changing the homescreen background image on a Trezor T1B1 device via device settings, which is the core functionality of HomescreenGallery.tsx. A change to the gallery component could break the homescreen selection flow.
- `suite/e2e/tests/settings/t2t1-device-settings.test.ts` — This test includes changing the homescreen background on T2T1 devices (changeDeviceBackground to 'original_t2t1'), directly exercising the HomescreenGallery component's functionality for selecting and applying device backgrounds.
- `suite/e2e/tests/settings/t3b1-device-settings.test.ts` — This test changes the device background image on T3B1 devices (changeDeviceBackground to 'circleweb'), directly testing the HomescreenGallery component's image selection and application flow for this device model.

</details>

_Updated: 2026-05-13T09:34:30.241Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=26562-cannot-chang-wallpaper&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=26562-cannot-chang-wallpaper&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-13T09:39:30.872Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send form for bitcoin > add and remove output in send form, toggle form options, input data | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-13T09:37:58.407Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/26562-cannot-chang-wallpaper/web/](https://dev.suite.sldev.cz/suite-web/26562-cannot-chang-wallpaper/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->