### PR TITLE
fix(suite-native): show correct firmware progress indicator for THP devices

### DIFF
--- a/suite-native/firmware/src/components/FirmwareInstallationScreenContent.tsx
+++ b/suite-native/firmware/src/components/FirmwareInstallationScreenContent.tsx
@@ -222,16 +222,15 @@ export const FirmwareInstallationScreenContent = ({
 
     const indicatorStatus: UpdateProgressIndicatorStatus = useMemo(() => {
         const isStarting = (status === 'started' && operation === null) || status === 'initial';
-        const isSuccess = operation === 'completed';
 
         if (isError) return 'error';
         if (isStarting) return 'starting';
-        if (isSuccess) return 'success';
-        if (!isStarting && !isSuccess && !isError) return 'inProgress';
+        if (isDone) return 'success';
+        if (!isStarting && !isError && !isDone) return 'inProgress';
 
         // shouldn't happen, but just to be safe
         return 'starting';
-    }, [status, operation, isError]);
+    }, [status, operation, isError, isDone]);
 
     const indicatorProgress = useMemo(() => {
         switch (indicatorStatus) {

--- a/suite-native/firmware/src/components/UpdateProgressIndicator.tsx
+++ b/suite-native/firmware/src/components/UpdateProgressIndicator.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-self-assign */
 import { useEffect } from 'react';
 import {
     type SharedValue,
@@ -124,7 +123,6 @@ export const UpdateProgressIndicator = ({
     useEffect(() => {
         if (isStarting) {
             animatedBackgroundRadius.value = withTiming(0, { duration: 600 });
-            backgroundColorFinished.value = backgroundColorFinished.value;
 
             checkmarkAnimationProgress.value = 0;
             progressEnd.value = withSpring(0);
@@ -135,7 +133,6 @@ export const UpdateProgressIndicator = ({
         }
         if (isInProgress) {
             animatedBackgroundRadius.value = withTiming(0, { duration: 600 });
-            backgroundColorFinished.value = backgroundColorFinished.value;
 
             checkmarkAnimationProgress.value = 0;
             progressEnd.value = withSpring(progress / 100);
@@ -146,7 +143,7 @@ export const UpdateProgressIndicator = ({
         }
         if (isSuccess) {
             animatedBackgroundRadius.value = withSpring(CIRCLE_DIAMETER / 2);
-            backgroundColorFinished.value = utils.colors.contentBrand;
+            backgroundColorFinished.value = utils.colors.borderBrand;
 
             checkmarkAnimationProgress.value = withDelay(300, withSpring(1));
             progressEnd.value = 0;
@@ -157,7 +154,7 @@ export const UpdateProgressIndicator = ({
         }
         if (isError) {
             animatedBackgroundRadius.value = withSpring(CIRCLE_DIAMETER / 2);
-            backgroundColorFinished.value = utils.colors.legacyBackgroundAlertRedBold;
+            backgroundColorFinished.value = utils.colors.borderCritical;
 
             checkmarkAnimationProgress.value = 0;
             progressEnd.value = 0;
@@ -175,16 +172,13 @@ export const UpdateProgressIndicator = ({
         isError,
         isStarting,
         backgroundColorFinished,
-        utils.colors.legacyBackgroundAlertRedBold,
-        utils.colors.contentBrand,
+        utils.colors.borderBrand,
+        utils.colors.borderCritical,
         isInProgress,
         trezorLogoOpacity,
         errorSvgOpacity,
         paragraphOpacity,
     ]);
-
-    const paint = Skia.Paint();
-    paint.setColor(Skia.Color('#00FF00')); // green
 
     return (
         <Canvas style={{ width: CANVAS_SIZE, height: CANVAS_SIZE }}>
@@ -201,7 +195,7 @@ export const UpdateProgressIndicator = ({
                     path={progressCirclePath}
                     start={0}
                     end={progressEnd}
-                    color={utils.colors.contentBrand}
+                    color={utils.colors.borderBrand}
                     strokeCap="round"
                     strokeJoin="round"
                     strokeWidth={PROGRESS_STROKE_WIDTH}
@@ -249,7 +243,6 @@ export const UpdateProgressIndicator = ({
                         svg={crossSvg}
                         x={CIRCLE_CENTER - CIRCLE_DIAMETER / 4}
                         y={CIRCLE_CENTER - CIRCLE_DIAMETER / 4}
-                        color={utils.colors.legacyBackgroundAlertRedBold}
                         width={CIRCLE_DIAMETER / 2}
                         height={CIRCLE_DIAMETER / 2}
                     />


### PR DESCRIPTION
- Success indicator status shown for THP devices once done.
- Progress, success and error colours updated to better match the current DS.
- Self-assignments removed.

## Screen recordings:

It's sufficient to view the last 10 seconds of each video.

### Before

https://github.com/user-attachments/assets/4bfb5fc9-29e9-4587-baf5-4475a7b27824

### After

https://github.com/user-attachments/assets/50a7312a-a1fa-4b82-9c2f-6eeaba0c872a


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/firmware-installation-progress&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->