### PR TITLE
test(e2e): use dropdown with retry for send-form-regtest

### DIFF
--- a/suite/e2e/tests/wallet/send-form-regtest.test.ts
+++ b/suite/e2e/tests/wallet/send-form-regtest.test.ts
@@ -43,11 +43,14 @@ test.describe('Send form for bitcoin', { tag: ['@T3W1', '@T3T1'] }, () => {
         await tradingPage.sendAddressInput.fill(ADDRESS_INDEX_1);
 
         // add locktime
-        await page.getByTestId('@send/header-dropdown').click();
-        await page.getByTestId('@send/header-dropdown/locktime').click();
-        await page.getByTestId('locktime-option/input').click();
-        await page.getByTestId('locktime-option/option/block').click();
-        await expect(page.getByTestId('locktime-blockheight-input')).toBeVisible();
+        await page.selectDropdownOptionWithRetry(
+            page.getByTestId('@send/header-dropdown'),
+            page.getByTestId('@send/header-dropdown/locktime'),
+        );
+        await page.selectDropdownOptionWithRetry(
+            page.getByTestId('locktime-option/input'),
+            page.getByTestId('locktime-option/option/block'),
+        );
         await page.getByTestId('locktime-blockheight-input').fill('1000');
 
         await tradingPage.sendButton.click();


### PR DESCRIPTION


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-fixes-05-2&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-fixes-05-2&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-13T10:58:02.944Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send form for bitcoin > add and remove output in send form, toggle form options, input data | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-13T10:56:17.913Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test-fixes-05-2/web/](https://dev.suite.sldev.cz/suite-web/test-fixes-05-2/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->