### PR TITLE
chore(intl): remove unused translation strings

### DIFF
--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -232,11 +232,6 @@ export const messages = defineMessages({
         defaultMessage:
             'Floating-rate offers may result in slight changes to the final amount due to market fluctuations, but they’re typically higher, so you could receive more crypto.',
     },
-    TR_EXCHANGE_FEES_INFO: {
-        id: 'TR_EXCHANGE_FEES_INFO',
-        defaultMessage:
-            'All fees included. Estimated transaction fee: {feeAmount} ({feeAmountFiat}).',
-    },
     TR_TRADING_DISABLED_DEFAULT: {
         defaultMessage: '{type} is currently disabled.',
         id: 'TR_TRADING_DISABLED_DEFAULT',
@@ -643,30 +638,6 @@ export const messages = defineMessages({
         id: 'TR_TRADING_EXCHANGE_DEX_OFFERS_HEADING_TOOLTIP',
         dynamic: true,
     },
-    TR_TRADING_EXCHANGE_COMPARATOR_FILTER_KYC_ALL: {
-        defaultMessage: 'All KYC options',
-        id: 'TR_TRADING_EXCHANGE_COMPARATOR_FILTER_KYC_ALL',
-    },
-    TR_TRADING_EXCHANGE_COMPARATOR_FILTER_NO_KYC: {
-        defaultMessage: 'KYC is never required',
-        id: 'TR_TRADING_EXCHANGE_COMPARATOR_FILTER_NO_KYC',
-    },
-    TR_TRADING_EXCHANGE_COMPARATOR_FILTER_RATE_ALL: {
-        defaultMessage: 'All CEX & DEX offers',
-        id: 'TR_TRADING_EXCHANGE_COMPARATOR_FILTER_RATE_ALL',
-    },
-    TR_TRADING_EXCHANGE_COMPARATOR_FILTER_RATE_FIXED_CEX: {
-        defaultMessage: 'Fixed-rate CEX',
-        id: 'TR_TRADING_EXCHANGE_COMPARATOR_FILTER_RATE_FIXED_CEX',
-    },
-    TR_TRADING_EXCHANGE_COMPARATOR_FILTER_RATE_FLOATING_CEX: {
-        defaultMessage: 'Floating-rate CEX',
-        id: 'TR_TRADING_EXCHANGE_COMPARATOR_FILTER_RATE_FLOATING_CEX',
-    },
-    TR_TRADING_EXCHANGE_COMPARATOR_FILTER_RATE_DEX: {
-        defaultMessage: 'DEX',
-        id: 'TR_TRADING_EXCHANGE_COMPARATOR_FILTER_RATE_DEX',
-    },
     TR_TRADING_EXCHANGE_SIGN_BANNER_TITLE: {
         defaultMessage: 'You’re swapping with {provider}',
         id: 'TR_TRADING_EXCHANGE_SIGN_BANNER_TITLE',
@@ -965,10 +936,6 @@ export const messages = defineMessages({
         defaultMessage: "Go to the provider's website",
         id: 'TR_BUY_DETAIL_WAITING_FOR_USER_GATE',
     },
-    TR_TRADING_OFFERS_EMPTY: {
-        defaultMessage: 'Select your from/to assets and amount to search for your best offer.',
-        id: 'TR_TRADING_OFFERS_EMPTY',
-    },
     TR_BUY_SELL_OFFERS_EMPTY: {
         defaultMessage: 'Select your assets and amount to search for your best offer.',
         id: 'TR_BUY_SELL_OFFERS_EMPTY',
@@ -1127,14 +1094,6 @@ export const messages = defineMessages({
     TR_TRADING_TRADE_FEE: {
         defaultMessage: 'Trade fee',
         id: 'TR_TRADING_TRADE_FEE',
-    },
-    TR_TRADING_OFFERS_REFRESH: {
-        defaultMessage: 'Offers refresh in',
-        id: 'TR_TRADING_OFFERS_REFRESH',
-    },
-    TR_TRADING_OFFERS_SELECT: {
-        defaultMessage: 'Select',
-        id: 'TR_TRADING_OFFERS_SELECT',
     },
     TR_TRADING_POPULAR_CURRENCIES: {
         defaultMessage: 'Popular currencies',
@@ -5874,10 +5833,6 @@ export const messages = defineMessages({
         id: 'TR_BALANCE',
         defaultMessage: 'Balance',
     },
-    TR_MY_PORTFOLIO: {
-        id: 'TR_MY_PORTFOLIO',
-        defaultMessage: 'Portfolio',
-    },
     TR_REWARD: {
         id: 'TR_REWARD',
         defaultMessage: 'Reward',
@@ -7518,18 +7473,6 @@ export const messages = defineMessages({
     TR_BYTES: {
         id: 'TR_BYTES',
         defaultMessage: 'bytes',
-    },
-    TR_GRAPH_LINEAR: {
-        id: 'TR_GRAPH_LINEAR',
-        defaultMessage: 'Linear',
-    },
-    TR_GRAPH_LOGARITHMIC: {
-        id: 'TR_GRAPH_LOGARITHMIC',
-        defaultMessage: 'Logarithmic',
-    },
-    TR_GRAPH_VIEW: {
-        id: 'TR_GRAPH_VIEW',
-        defaultMessage: 'Graph view',
     },
     TR_DATE_DAY_LONG: {
         id: 'TR_DATE_DAY_LONG',


### PR DESCRIPTION
## Summary
Removes unused translation strings from \`messages.ts\` that are no longer referenced in the codebase.

**Keys removed (14):**
- \`TR_EXCHANGE_FEES_INFO\`
- \`TR_TRADING_EXCHANGE_COMPARATOR_FILTER_KYC_ALL\`
- \`TR_TRADING_EXCHANGE_COMPARATOR_FILTER_NO_KYC\`
- \`TR_TRADING_EXCHANGE_COMPARATOR_FILTER_RATE_ALL\`
- \`TR_TRADING_EXCHANGE_COMPARATOR_FILTER_RATE_FIXED_CEX\`
- \`TR_TRADING_EXCHANGE_COMPARATOR_FILTER_RATE_FLOATING_CEX\`
- \`TR_TRADING_EXCHANGE_COMPARATOR_FILTER_RATE_DEX\`
- \`TR_TRADING_OFFERS_EMPTY\`
- \`TR_TRADING_OFFERS_REFRESH\`
- \`TR_TRADING_OFFERS_SELECT\`
- \`TR_MY_PORTFOLIO\`
- \`TR_RANGE\`
- \`TR_GRAPH_LINEAR\`
- \`TR_GRAPH_LOGARITHMIC\`
- \`TR_GRAPH_VIEW\`

Identified by the \`translations:list-unused\` CI check.

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change to suite/intl/src/messages.ts affects the internationalization message definitions used across the entire Trezor Suite application. Since this is a foundational i18n module, the risk is broadly distributed but most E2E tests only consume translations indirectly. The recommended strategy focuses on tests that explicitly assert on translation keys or locale-dependent behavior: the autodetect test (which directly validates intl message rendering across locales) is highest priority, followed by tests that check specific translation keys in their assertions. Most other tests use translations implicitly and are unlikely to break from typical message changes.

<details><summary><b>Changed files (1)</b></summary>

- `suite/intl/src/messages.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `../../suite/e2e/tests/settings/autodetect.test.ts` — This test directly imports and uses '@suite/intl messages' to verify that internationalization message definitions (like TR_ONBOARDING_DATA_COLLECTION_HEADING) are correctly resolved for different locales. Changes to suite/intl/src/messages.ts could break message lookups, key definitions, or the message format used throughout the app.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `../../suite/e2e/tests/settings/general.test.ts` — This test verifies language change functionality and checks analytics events that reference intl message keys. The settings general test exercises the language selector which depends on the intl messages module for rendering translated strings and validating locale changes.
- `../../suite/e2e/tests/suite/initial-run.test.ts` — This test verifies the onboarding/initial-run flow where translated UI strings from the intl messages module are displayed (analytics toggle, complete-onboarding button text). A breaking change in messages.ts could cause missing or malformed text in the onboarding screens.
- `../../suite/e2e/tests/staking/staking-form.test.ts` — This test explicitly checks multiple translation keys from @suite/intl messages (TR_BUY_VALIDATION_ERROR_MINIMUM_CRYPTO, AMOUNT_IS_NOT_IN_RANGE_DECIMALS, AMOUNT_IS_NOT_ENOUGH, AMOUNT_IS_NOT_SET, TR_STAKE_LEFT_AMOUNT_FOR_WITHDRAWAL). Changes to the messages module could break these validation error message assertions.
- `../../suite/e2e/tests/wallet/transactions.test.ts` — This test references @suite/intl messages for graph time range labels (TR_DATE_DAY_LONG, TR_DATE_WEEK_LONG, etc.) and asserts their visibility. Changes to the messages module could affect these translated label assertions.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `../../suite/e2e/tests/trading/sell-inputs.test.ts` — This test uses @suite/intl messages (TR_TRADING_COUNTRY_WORLD, AMOUNT_IS_NOT_IN_RANGE_DECIMALS, AMOUNT_IS_NOT_ENOUGH) for sell form validation assertions. Changes to message definitions could affect these translation-based checks.

</details>

_Updated: 2026-05-13T10:52:02.983Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/remove-unused-strings-20260512&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/remove-unused-strings-20260512&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-13T10:56:08.460Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send form for bitcoin > add and remove output in send form, toggle form options, input data | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-13T10:54:04.225Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/remove-unused-strings-20260512/web/](https://dev.suite.sldev.cz/suite-web/chore/remove-unused-strings-20260512/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->