### PR TITLE
fix(scripts): connect release dependencies missing remote version

### DIFF
--- a/scripts/ci/get-connect-dependencies-to-release.ts
+++ b/scripts/ci/get-connect-dependencies-to-release.ts
@@ -30,7 +30,7 @@ const checkNonReleasedDependencies = async (packageName: string) => {
     const remoteGreatestVersion = await getNpmRemoteGreatestVersion(`@trezor/${packageName}`);
 
     // If local version is greatest than the greatest one in NPM we add it to the release.
-    if (semver.gt(localVersion, remoteGreatestVersion as string)) {
+    if (!remoteGreatestVersion || semver.gt(localVersion, remoteGreatestVersion as string)) {
         const index = nonReleaseDependencies.indexOf(packageName);
         if (index > -1) {
             nonReleaseDependencies.splice(index, 1);


### PR DESCRIPTION
## Description

Fix case in `get-connect-dependencies-to-release.ts` when publishing a new package there would be no remote version. 
In this case the new package is `@trezor/connect-data`
Failing run here: https://github.com/trezor/trezor-suite/actions/runs/25793655939/job/75765523167

## Notes for QA

Nothing to test, CI only

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file `scripts/ci/get-connect-dependencies-to-release.ts` is a CI utility script used to determine which @trezor/connect dependencies need to be released. It is not part of the application runtime, is not imported by any application code or test, and has no static test coverage mapping. No E2E tests exercise this script's functionality, and no tests are at risk of regression from changes to it. No E2E tests are recommended.

<details><summary><b>Changed files (1)</b></summary>

- `scripts/ci/get-connect-dependencies-to-release.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `scripts/ci/get-connect-dependencies-to-release.ts`

_Updated: 2026-05-13T11:09:32.122Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/connect-release-dependencies-new-package&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/connect-release-dependencies-new-package&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-13T11:14:42.943Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send form for bitcoin > add and remove output in send form, toggle form options, input data | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-13T11:13:19.112Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/connect-release-dependencies-new-package/web/](https://dev.suite.sldev.cz/suite-web/fix/connect-release-dependencies-new-package/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->