### PR TITLE
revert(suite): Revert swap/receive copy changes

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal/GlobalReceiveModal.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal/GlobalReceiveModal.tsx
@@ -4,7 +4,8 @@ import { events } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
-import { CardList, Column, IconCircle, Modal, Paragraph, Row } from '@trezor/components';
+import { CardList, Column, IconCircle, Link, Modal, Paragraph, Row } from '@trezor/components';
+import { HOW_TO_CHOOSE_RIGHT_NETWORK_URL } from '@trezor/urls';
 
 import { useModal } from 'src/components/suite/asset-picker/hooks/useModal';
 import { AddAccountModal } from 'src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal';
@@ -13,10 +14,10 @@ import { globalSendReceiveFilters } from 'src/slices/wallet/globalSendReceiveFil
 import { useAnalytics } from 'src/support/useAnalytics';
 import { type Account, type AccountItemType } from 'src/types/wallet';
 
-import { AssetSearchWithNetworkFilter } from '../AssetSearchWithNetworkFilter/AssetSearchWithNetworkFilter';
 import { GlobalReceiveAccountListItem } from './components/GlobalReceiveAccountListItem';
 import { useAccountsOptions } from './hooks/useAccountsOptions';
 import { useFilterAccounts } from './hooks/useFilterAccounts';
+import { AssetSearchWithNetworkFilter } from '../AssetSearchWithNetworkFilter/AssetSearchWithNetworkFilter';
 
 type GlobalReceiveModalProps = {
     onCancel: (filledSearch: boolean) => void;
@@ -40,7 +41,16 @@ export const GlobalReceiveModal = ({ onCancel, onSubmit }: GlobalReceiveModalPro
         <>
             <Modal
                 heading={<Translation id="TR_RECEIVE" />}
-                description={<Translation id="TR_RECEIVE_DESCRIPTION" />}
+                description={
+                    <Translation
+                        id="TR_RECEIVE_DESCRIPTION"
+                        values={{
+                            a: (...chunks) => (
+                                <Link href={HOW_TO_CHOOSE_RIGHT_NETWORK_URL}>{chunks}</Link>
+                            ),
+                        }}
+                    />
+                }
                 onCancel={() => onCancel(filledSearch)}
                 width={480}
                 maxHeight={640}

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/AssetPickerModal/AssetPickerModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/AssetPickerModal/AssetPickerModal.tsx
@@ -2,9 +2,8 @@ import { memo, useCallback, useState } from 'react';
 
 import { type TranslationKey } from '@suite/intl';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { Box, Divider, Link } from '@trezor/components';
+import { Box, Divider } from '@trezor/components';
 import { TopAssets } from '@trezor/product-components';
-import { HOW_TO_CHOOSE_RIGHT_NETWORK_URL } from '@trezor/urls';
 
 import {
     AssetGroupLabel,
@@ -17,12 +16,12 @@ import { ASSET_ROW_HEIGHT } from 'src/components/suite/asset-picker/constants';
 import { useSearchFilter } from 'src/components/suite/asset-picker/hooks';
 
 import { AssetListWrapper } from './AssetListWrapper';
-import { AssetSearchWithNetworkFilter } from '../../TradingFormInputAssetPicker';
 import {
     type TradingAssetListItem,
     useBuildTradingAssetOptions,
 } from './hooks/useBuildTradingAssetOptions';
 import { type UseUpdateFormInputProps, useUpdateFormInput } from './hooks/useUpdateFormInput';
+import { AssetSearchWithNetworkFilter } from '../../TradingFormInputAssetPicker';
 
 export type AssetPickerModalProps = {
     closeModal: () => void;
@@ -101,16 +100,7 @@ export const AssetPickerModal = memo(function AssetPickerModalInner({
     );
 
     return (
-        <AssetsModal
-            onClose={closeModal}
-            heading={{ id: heading }}
-            description={{
-                id: 'TR_SWAP_TO_NETWORK_DESCRIPTION',
-                values: {
-                    a: (...chunks) => <Link href={HOW_TO_CHOOSE_RIGHT_NETWORK_URL}>{chunks}</Link>,
-                },
-            }}
-        >
+        <AssetsModal onClose={closeModal} heading={{ id: heading }}>
             <AssetSearchWithNetworkFilter
                 placeholder="TR_ASSET_PICKER_SEARCH_PLACEHOLDER"
                 search={search}

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -2952,12 +2952,8 @@ export const messages = defineMessages({
         id: 'TR_RECEIVE',
     },
     TR_RECEIVE_DESCRIPTION: {
-        defaultMessage: 'Learn how to <a>select the right network</a> to receive your tokens',
-        id: 'TR_RECEIVE_DESCRIPTION',
-    },
-    TR_SWAP_TO_NETWORK_DESCRIPTION: {
         defaultMessage: 'Learn how to <a>choose the right network</a> to receive your tokens',
-        id: 'TR_SWAP_TO_NETWORK_DESCRIPTION',
+        id: 'TR_RECEIVE_DESCRIPTION',
     },
     TR_RECEIVE_SEARCH: {
         defaultMessage: 'Search account',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies two UI components (GlobalReceiveModal and trading AssetPickerModal) and the shared internationalization messages file. The GlobalReceiveModal change is high risk for the global receive/send test which directly exercises that modal. The AssetPickerModal change affects all trading buy flows and potentially swap/sell flows that use asset selection. The messages.ts file is a broadly shared utility with no direct test coverage but its impact depends on which specific message keys were changed — risks are mitigated by the component-level tests already recommended. Testing should prioritize the global receive flow and buy trading flows that directly use the changed components.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal/GlobalReceiveModal.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/AssetPickerModal/AssetPickerModal.tsx`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test directly exercises the GlobalReceiveModal component that was changed. It tests the global receive flow including opening the modal, selecting accounts via the asset picker, revealing addresses, and verifying them on the device.
- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — This test exercises the buy trading flow including the asset picker modal that was changed. It tests filling the buy form, selecting receive addresses, viewing quotes, and confirming trades — all paths that use the AssetPickerModal.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — This test opens the trading panel and selects Ethereum as the asset to buy, directly exercising the AssetPickerModal for asset selection in the buy flow.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — This test specifically selects a token asset (Jupiter/JUP) from the asset picker with network and search filters, directly exercising the changed AssetPickerModal component's filtering and selection logic.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/trading/buy-negative.test.ts` — This test interacts with the buy form asset picker modal (verifying it's actionable) and tests various input validation states. Changes to the AssetPickerModal could affect the form's initialization behavior.
- `suite/e2e/tests/trading/navigation.test.ts` — This test navigates to buy/sell/swap forms from multiple entry points and verifies the correct cryptocurrency is displayed, which involves the AssetPickerModal for asset selection in the trading forms.
- `suite/e2e/tests/dashboard/assets.test.ts` — This test initiates buy actions from the dashboard assets section and navigates to the trading page, which uses the AssetPickerModal. It also tests the 'Enable more coins' modal which may share UI patterns with the global receive modal.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — This test exercises the trading form inputs for sell flows on BTC and SOL. While primarily focused on sell inputs, it shares trading form infrastructure with the changed AssetPickerModal component.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — This swap test involves cross-network token selection (SOL to USDC on Ethereum) which exercises asset picker logic within the trading form infrastructure that includes the changed AssetPickerModal.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — This test specifically fills a swap form with assets including one from a disabled network, exercising the asset picker filtering logic that the changed AssetPickerModal manages.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/intl/src/messages.ts`

_Updated: 2026-05-13T11:59:02.076Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=revert-swap-reveive-copy-changes&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=revert-swap-reveive-copy-changes&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-13T13:27:54.343Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send form for bitcoin > add and remove output in send form, toggle form options, input data | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-13T13:26:06.816Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/revert-swap-reveive-copy-changes/web/](https://dev.suite.sldev.cz/suite-web/revert-swap-reveive-copy-changes/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->