### PR TITLE
fix(trading): show insufficient gas in approval and revoke modal

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/useModalLastValidParams.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useModalLastValidParams.ts
@@ -1,0 +1,18 @@
+import { useRef } from 'react';
+
+/**
+ * Returns the last non-null `params` value while `isOpen` is true.
+ * Prevents modal flicker when params temporarily become null (e.g. during a quote refetch).
+ * Clears the cached value once the modal closes so the next open starts fresh.
+ */
+export const useModalLastValidParams = <T>(params: T | null, isOpen: boolean): T | null => {
+    const ref = useRef<T | null>(params);
+
+    if (!isOpen) {
+        ref.current = null;
+    } else if (params) {
+        ref.current = params;
+    }
+
+    return ref.current;
+};

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingApproveModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingApproveModal.tsx
@@ -8,6 +8,7 @@ import { useCurrentRef } from '@trezor/react-utils';
 
 import { ApproveModal } from 'src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModal';
 import { useAllowanceContext } from 'src/hooks/wallet/allowance';
+import { useModalLastValidParams } from 'src/hooks/wallet/trading/form/useModalLastValidParams';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { useTradingExchangeCryptoAndProviderInfo } from 'src/hooks/wallet/trading/form/useTradingExchangeCryptoAndProviderInfo';
 import { useAnalytics } from 'src/support/useAnalytics';
@@ -84,9 +85,7 @@ export const TradingApproveModal = ({ amount, cryptoId }: TradingApproveModalPro
 
     const approveParams = useMemo(() => {
         const ctx = contextRef.current;
-        if (!isTradingExchangeContext(ctx)) {
-            return null;
-        }
+        if (!isTradingExchangeContext(ctx)) return null;
 
         const providersInfo = getProvidersInfoProps(ctx);
         const exchange = selectedQuote?.exchange;
@@ -95,13 +94,11 @@ export const TradingApproveModal = ({ amount, cryptoId }: TradingApproveModalPro
         const approvalData = getEvmApprovalTxData(selectedQuote?.dexTx?.data);
         const spender = approvalData?.spender ?? null;
 
-        return {
-            provider,
-            spender,
-        };
+        return provider && spender ? { provider, spender } : null;
     }, [selectedQuote, contextRef]);
 
-    const { provider, spender } = approveParams ?? {};
+    const { provider, spender } =
+        useModalLastValidParams(approveParams, state.isApproveModalOpen) ?? {};
 
     if (!state.isApproveModalOpen || !provider || !spender) return null;
 

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingRevokeModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingRevokeModal.tsx
@@ -7,6 +7,7 @@ import { getEvmApprovalTxData } from '@suite-common/wallet-utils';
 
 import { RevokeModal } from 'src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/RevokeModal';
 import { useAllowanceContext } from 'src/hooks/wallet/allowance';
+import { useModalLastValidParams } from 'src/hooks/wallet/trading/form/useModalLastValidParams';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { useTradingExchangeCryptoAndProviderInfo } from 'src/hooks/wallet/trading/form/useTradingExchangeCryptoAndProviderInfo';
 import { useAnalytics } from 'src/support/useAnalytics';
@@ -71,14 +72,11 @@ export const TradingRevokeModal = ({ cryptoId }: TradingRevokeModalProps) => {
 
         const preapprovedAmount = context.selectedQuote?.preapprovedStringAmount;
 
-        return {
-            provider,
-            spender,
-            preapprovedAmount,
-        };
+        return provider && spender ? { provider, spender, preapprovedAmount } : null;
     }, [context]);
 
-    const { provider, spender, preapprovedAmount } = revokeParams || {};
+    const { provider, spender, preapprovedAmount } =
+        useModalLastValidParams(revokeParams, state.isRevokeModalOpen) ?? {};
 
     if (!state.isRevokeModalOpen || !provider || !spender) return null;
 


### PR DESCRIPTION
## Description

- Show the insufficient-gas alert in the trading approve modal and keep Continue disabled when the account cannot cover network fees.
- Apply the same insufficient-gas alert and disabled Continue behavior to the trading revoke modal.
- Keep the approve and revoke modal params stable during quote refresh while the modal is open so the insufficient-gas state stays visible instead of falling through to the missing fee level error.
- Clear the cached modal params after the modal closes so a new open starts from current quote data.

## Notes for QA

- Open an exchange trade that requires token approval with insufficient gas for fees, open the approve modal, and verify the insufficient-gas alert is shown and Continue is disabled.
- Repeat the same check for the revoke modal and verify it stays in the modal with the same disabled-button behavior instead of showing the missing fee level error.
- Repeat with sufficient gas and verify the alert is not shown and Continue is enabled in both flows.

## Related Issue

Resolve #24588

## Screenshots:
<img width="657" height="751" alt="image" src="https://github.com/user-attachments/assets/9da649df-a99a-4a67-ab63-d62f33b8e52a" />

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are focused on trading/swap allowance modals (approve and revoke) and a supporting hook (useModalLastValidParams). These components are part of the token swap flow where users approve or revoke token spending allowances. While the changed files are statically imported by 17 tests (indicating broad component tree inclusion), only swap-related tests that involve token transactions are likely to exercise the approve/revoke modal logic. The recommended strategy prioritizes token-to-token and token-to-coin swap tests at high priority, with coin-to-coin swaps and live trading tests at medium priority, since the approval modal may not be triggered in every swap scenario but is still in the component tree.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModal.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/RevokeModal.tsx`
- `packages/suite/src/hooks/wallet/trading/form/useModalLastValidParams.ts`
- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingApproveModal.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingRevokeModal.tsx`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — This test exercises the swap flow including token approval modals (TradingApproveModal). Swapping to a token on a different network (SOL to USDC on Ethereum) is a primary use case for the approve/allowance modal flow that was changed.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — This test swaps a token (USDT) to a coin (BTC), which involves token allowance/approval flows. The TradingApproveModal and ApproveModal changes directly affect this swap path where token spending approval is needed.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — This test swaps between two SPL tokens (USDT to USDC), which is the most likely scenario to trigger token allowance approval and revocation modals. Changes to TradingApproveModal, TradingRevokeModal, and their underlying AllowanceModals directly affect this flow.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Ethereum-to-BTC swap with custom fees exercises the swap confirmation flow where token approval modals may appear. The TradingApproveModal is part of the swap form component tree that this test traverses.
- `suite/e2e/tests/trading/swap-coins.test.ts` — This test covers the SOL-to-BTC swap flow end-to-end. While coin-to-coin swaps may not always trigger approval modals, the TradingApproveModal is in the swap form component tree and changes to useModalLastValidParams could affect the swap confirmation behavior.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — BTC-to-ETH swap with custom fees exercises the swap form flow. The changed TradingApproveModal and useModalLastValidParams hook are part of this component tree and could affect swap confirmation behavior.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — This test swaps a token (USDT on Solana) to a disabled network asset (XLM). Token swaps specifically exercise the allowance/approval flow where the changed ApproveModal and TradingApproveModal are relevant.
- `suite/e2e/tests/trading-live/live-swap-coin-to-token.test.ts` — Live swap test from SOL to USDC on Base exercises the real swap flow including potential token approval steps. Changes to TradingApproveModal and useModalLastValidParams could affect this live trading path.
- `suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts` — Live swap from SPL token (USDT) to SOL exercises the real token swap flow where allowance approval modals are most likely triggered. The changed approve/revoke modal components are directly relevant.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/hooks/wallet/trading/form/useModalLastValidParams.ts`

_Updated: 2026-05-13T12:58:30.032Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/trading-approval-insufficient-gas/web/](https://dev.suite.sldev.cz/suite-web/fix/trading-approval-insufficient-gas/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trading-approval-insufficient-gas&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trading-approval-insufficient-gas&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-13T13:03:31.742Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send form for bitcoin > add and remove output in send form, toggle form options, input data | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-13T13:02:19.907Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->