### PR TITLE
fix(transport): handle packet loss

### DIFF
--- a/packages/transport/src/utils/receive.ts
+++ b/packages/transport/src/utils/receive.ts
@@ -29,6 +29,13 @@ export async function receive<T extends Receiver>(receiver: T, protocol: Transpo
             const data = readResult.payload;
             const dataChunkHeader = data.subarray(0, chunkHeader.length);
             if (dataChunkHeader.compare(chunkHeader) !== 0) {
+                if (header.compare(data.subarray(0, header.length)) === 0) {
+                    offset = payload.length;
+                    console.warn('Restart message reception');
+
+                    continue;
+                }
+
                 throw new Error(`Unexpected chunkHeader ${dataChunkHeader.toString('hex')}`);
             }
 

--- a/packages/transport/tests/build-receive.test.ts
+++ b/packages/transport/tests/build-receive.test.ts
@@ -89,6 +89,10 @@ describe('receive', () => {
             } as const),
         );
 
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
     test('protocol-v1 ne chunk', async () => {
         const result = await receive(getApiRead(['3f23230002000000060a046d656f77']), protocolV1);
         expect(result).toMatchObject({
@@ -109,18 +113,22 @@ describe('receive', () => {
     });
 
     test('protocol-v1 malformed initial packet', async () => {
+        const spyWarn = jest.spyOn(console, 'warn').mockImplementation();
         // protocol-v2 message
         const result = await receive(getApiRead(['2833da0004527eb068']), protocolV1);
         expect(result.success).toBe(false);
+        expect(spyWarn).toHaveBeenCalledTimes(1);
     });
 
     test('protocol-v1 malformed continuation packet', async () => {
+        const spyWarn = jest.spyOn(console, 'warn').mockImplementation();
         // missing 3f in second chunk
         const result = await receive(
             getApiRead(['3f23230002000000060a', '046d656f77']),
             protocolV1,
         );
         expect(result.success).toBe(false);
+        expect(spyWarn).toHaveBeenCalledTimes(1);
     });
 
     test('protocol-v2 receive one chunk', async () => {
@@ -139,6 +147,26 @@ describe('receive', () => {
             payload: { messageType: 32 },
         });
         expect(apiRead).toHaveBeenCalledTimes(3);
+    });
+
+    test('protocol-v2 handle packet loss', async () => {
+        const apiRead = getApiRead([
+            '2833da0004',
+            '8033da527e',
+            '2833da0004', // first chunk again
+            '8033da527e',
+            '2833da0004', // first chunk again
+            '8033da527e',
+            '8033dab068',
+        ]);
+        const spyWarn = jest.spyOn(console, 'warn').mockImplementation();
+        const result = await receive(apiRead, protocolV2);
+        expect(result).toMatchObject({
+            success: true,
+            payload: { messageType: 32 },
+        });
+        expect(apiRead).toHaveBeenCalledTimes(7);
+        expect(spyWarn).toHaveBeenCalledTimes(2);
     });
 
     test('protocol-v2 malformed initial packet', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
restart receiving if 1st chunk was received again

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are confined to `packages/transport/src/utils/receive.ts` and its corresponding unit test `packages/transport/tests/build-receive.test.ts`. The `receive.ts` utility is a low-level transport layer file that is transitively imported by 114 E2E tests, making it a broad global dependency. However, none of the 114 mapped E2E tests directly exercise or assert on transport-level receive buffer logic — they all interact with high-level Suite UI features (analytics, backup, staking, trading, etc.) that only transitively depend on the transport layer. Since the unit test (`build-receive.test.ts`) directly covers the changed logic and no E2E test has specific behavioral relevance to transport receive utilities, the recommended strategy is to rely on the unit test for validation and skip running E2E tests for this change.

<details><summary><b>Changed files (2)</b></summary>

- `packages/transport/src/utils/receive.ts`
- `packages/transport/tests/build-receive.test.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/transport/tests/build-receive.test.ts`

_Updated: 2026-05-13T13:39:31.083Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/transport-receive-retransmission&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/transport-receive-retransmission&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-13T13:45:24.775Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send form for bitcoin > add and remove output in send form, toggle form options, input data | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-13T13:43:14.954Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/transport-receive-retransmission/web/](https://dev.suite.sldev.cz/suite-web/fix/transport-receive-retransmission/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->