### PR TITLE
fix(suite): handle Solana tx timeout in review modal

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModal.tsx
@@ -1,3 +1,4 @@
+import { goto } from '@suite/router';
 import {
     cancelSignSendFormTransactionThunk,
     selectPrecomposedSendForm,
@@ -9,7 +10,10 @@ import {
 } from '@suite-common/wallet-core';
 import { type PrecomposedTransactionFinal } from '@suite-common/wallet-types';
 
-import { signAndPushSendFormTransactionThunk } from 'src/actions/wallet/send/sendFormThunks';
+import {
+    removeSendFormDraftThunk,
+    signAndPushSendFormTransactionThunk,
+} from 'src/actions/wallet/send/sendFormThunks';
 import { cancelSignYieldTx } from 'src/actions/wallet/stablecoin-yield';
 import {
     cancelSignTx as cancelSignStakingTx,
@@ -60,16 +64,23 @@ export const TransactionReviewModal = ({ type, decision }: TransactionReviewModa
         }
     };
 
-    const handleSendTx = async () => {
-        await dispatch(
-            signAndPushSendFormTransactionThunk({
-                formState: send.precomposedForm!,
-                precomposedTransaction: send.precomposedTx!,
-                selectedAccount: selectedAccount.account,
-            }),
-        );
+    const handleSignAndPushSendTx = async () => {
+        try {
+            const result = await dispatch(
+                signAndPushSendFormTransactionThunk({
+                    formState: send.precomposedForm!,
+                    precomposedTransaction: send.precomposedTx!,
+                    selectedAccount: selectedAccount.account,
+                }),
+            ).unwrap();
 
-        dispatch(sendFormActions.discardTransaction());
+            if (result?.success) {
+                dispatch(removeSendFormDraftThunk());
+                dispatch(goto({ routeName: 'wallet-index', preserveParams: true }));
+            }
+        } catch {
+            // Error state is handled by signAndPushSendFormTransactionThunk.
+        }
     };
 
     const handleStakeTx = async () => {
@@ -84,7 +95,8 @@ export const TransactionReviewModal = ({ type, decision }: TransactionReviewModa
 
     const handleTryAgainSignTx = async () => {
         if (send.precomposedForm && send.precomposedTx) {
-            await handleSendTx();
+            dispatch(sendFormActions.clearSignedTransactionData());
+            await handleSignAndPushSendTx();
         } else if (stake.precomposedForm && stake.precomposedTx) {
             await handleStakeTx();
         }

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBody.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBody.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { events } from '@suite/analytics';
+import { preserveModalOnTxTimeout } from '@suite/modal';
 import { selectRouterUrl } from '@suite/router';
 import { selectSelectedDevice } from '@suite-common/device';
 import { type FormState } from '@suite-common/wallet-types';
@@ -12,7 +13,7 @@ import {
 import TrezorConnect from '@trezor/connect';
 import { type Deferred } from '@trezor/utils';
 
-import { useSelector } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectAccountIncludingChosenInTrading } from 'src/reducers/wallet/selectedAccountReducer';
 import { useAnalytics } from 'src/support/useAnalytics';
 import { redactRouterUrl } from 'src/utils/suite/analytics';
@@ -39,13 +40,25 @@ export const TransactionReviewModalBody = ({
     isRbfConfirmedError,
 }: TransactionReviewModalBodyProps) => {
     const analytics = useAnalytics();
+    const dispatch = useDispatch();
     const account = useSelector(selectAccountIncludingChosenInTrading);
     const device = useSelector(selectSelectedDevice);
     const [isSending, setIsSending] = useState(false);
-    const { precomposedTx } = txInfoState;
-    const [hasTxExpired, setHasTxExpired] = useState(false);
+    const { precomposedTx, serializedTx } = txInfoState;
+    const [hasTxReviewExpired, setHasTxReviewExpired] = useState(false);
+    const prevSerializedTxRef = useRef(serializedTx);
 
     const url = useSelector(selectRouterUrl);
+
+    // If the push fails (e.g. ExpiredTxValidity), clearSignedTransactionData clears serializedTx
+    // while isSending remains true, blocking the expired-state "Try again" button.
+    // Reset isSending so the expired UI can appear.
+    useEffect(() => {
+        if (prevSerializedTxRef.current && !serializedTx && isSending) {
+            setIsSending(false);
+        }
+        prevSerializedTxRef.current = serializedTx;
+    }, [isSending, serializedTx]);
 
     const createdTxTimestamp = txInfoState?.precomposedTx?.createdTimestamp ?? 0;
     const shouldCheckTxTimeValidity = account?.networkType === 'solana' && createdTxTimestamp !== 0;
@@ -63,7 +76,8 @@ export const TransactionReviewModalBody = ({
 
         const timeoutId = setTimeout(() => {
             if (mounted && !isSending) {
-                setHasTxExpired(true);
+                setHasTxReviewExpired(true);
+                dispatch(preserveModalOnTxTimeout());
                 TrezorConnect.cancel('tx-timeout');
             }
         }, timeLeft);
@@ -72,7 +86,7 @@ export const TransactionReviewModalBody = ({
             mounted = false;
             clearTimeout(timeoutId);
         };
-    }, [deadline, isSending, shouldCheckTxTimeValidity]);
+    }, [deadline, dispatch, isSending, shouldCheckTxTimeValidity]);
 
     const isBumpFeeRbfAction =
         precomposedTx !== undefined && isRbfBumpFeeTransaction(precomposedTx);
@@ -92,10 +106,12 @@ export const TransactionReviewModalBody = ({
 
     const handleTryAgain = useCallback(
         (cancel: boolean) => {
-            if (cancel) {
+            if (cancel && !serializedTx && !isSending) {
+                dispatch(preserveModalOnTxTimeout());
                 TrezorConnect.cancel('tx-timeout');
             }
 
+            setHasTxReviewExpired(false);
             tryAgainSignTx();
 
             analytics.report({
@@ -103,7 +119,7 @@ export const TransactionReviewModalBody = ({
                 payload: { url: redactRouterUrl(url) },
             });
         },
-        [tryAgainSignTx, url, analytics],
+        [dispatch, isSending, serializedTx, tryAgainSignTx, url, analytics],
     );
 
     if (!device) return null;
@@ -130,7 +146,7 @@ export const TransactionReviewModalBody = ({
             isSending={isSending}
             setIsSending={setIsSending}
             handleTryAgain={handleTryAgain}
-            hasTxExpired={hasTxExpired}
+            hasTxReviewExpired={hasTxReviewExpired}
             isRbfConfirmedError={isRbfConfirmedError}
         />
     );

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx
@@ -84,7 +84,7 @@ export type TransactionReviewModalBodyInnerProps = {
     isSending: boolean;
     setIsSending: (value: boolean) => void;
     handleTryAgain: (cancel: boolean) => void;
-    hasTxExpired: boolean;
+    hasTxReviewExpired: boolean;
     isRbfConfirmedError?: boolean;
 };
 
@@ -100,7 +100,7 @@ export const TransactionReviewModalBodyInner = ({
     precomposedForm,
     isSending,
     setIsSending,
-    hasTxExpired,
+    hasTxReviewExpired,
 }: TransactionReviewModalBodyInnerProps) => {
     const analytics = useAnalytics();
     const dispatch = useDispatch();
@@ -185,8 +185,6 @@ export const TransactionReviewModalBodyInner = ({
     const isCancelRbfAction = isRbfCancelTransaction(precomposedTx);
     const showSummary =
         !(isBumpFeeRbfAction && networkType === 'bitcoin') && networkType !== 'tron';
-
-    const isTxExpired = hasTxValidityExpired(deadline);
 
     const showTxValidityTimer = shouldShowTxValidityTimer({
         deadline,
@@ -281,8 +279,7 @@ export const TransactionReviewModalBodyInner = ({
                             handleTryAgain={handleTryAgain}
                             txInfoState={txInfoState}
                             actionTranslation={actionTranslation('button')}
-                            isTxExpired={isTxExpired}
-                            hasTxExpired={hasTxExpired}
+                            hasTxReviewExpired={hasTxReviewExpired}
                             stakeType={stakeType || undefined}
                             isRbfConfirmedError={isRbfConfirmedError}
                             account={account}
@@ -303,6 +300,7 @@ export const TransactionReviewModalBodyInner = ({
                     isRbfConfirmedError={isRbfConfirmedError}
                     onTryAgain={handleTryAgain}
                     areDetailsVisible={areDetailsVisible}
+                    hasTxReviewExpired={hasTxReviewExpired}
                 />
             </Modal.ModalBase>
         </ConnectModalBackdrop>

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalBottomContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalBottomContent.tsx
@@ -10,7 +10,11 @@ import {
     type RbfTransactionType,
     type ReviewOutput,
 } from '@suite-common/wallet-types';
-import { isRbfCancelTransaction, isRbfTransaction } from '@suite-common/wallet-utils';
+import {
+    getTxValidityTimeoutInMs,
+    isRbfCancelTransaction,
+    isRbfTransaction,
+} from '@suite-common/wallet-utils';
 import { type StakeType } from '@trezor/blockchain-link-types';
 import { Modal } from '@trezor/components';
 import { copyToClipboard, download } from '@trezor/dom-utils';
@@ -18,7 +22,7 @@ import { type Deferred } from '@trezor/utils';
 
 import { useAnalytics } from 'src/support/useAnalytics';
 
-import { type TxInfoState, getTxType } from '../utils';
+import { type TxInfoState, getTxType, hasTxValidityExpired } from '../utils';
 
 const mapRbfTypeToReporting: Record<RbfTransactionType, TransactionCreatedEventAction> = {
     'bump-fee': 'replaced',
@@ -33,8 +37,7 @@ type TransactionReviewModalBottomContentProps = {
     handleTryAgain: (close: boolean) => void;
     txInfoState: TxInfoState;
     actionTranslation: ExtendedMessageDescriptor;
-    isTxExpired: boolean;
-    hasTxExpired: boolean;
+    hasTxReviewExpired: boolean;
     stakeType?: StakeType;
     isRbfConfirmedError?: boolean;
     account: Account;
@@ -51,8 +54,7 @@ export const TransactionReviewModalBottomContent = ({
     handleTryAgain,
     txInfoState,
     actionTranslation,
-    isTxExpired,
-    hasTxExpired,
+    hasTxReviewExpired,
     stakeType,
     account,
     precomposedForm,
@@ -73,6 +75,8 @@ export const TransactionReviewModalBottomContent = ({
 
     const createdTxTimestamp = txInfoState?.precomposedTx?.createdTimestamp ?? 0;
     const shouldCheckTxTimeValidity = account?.networkType === 'solana' && createdTxTimestamp !== 0;
+    const deadline = createdTxTimestamp + getTxValidityTimeoutInMs(account.networkType);
+    const hasTxDeadlineExpired = shouldCheckTxTimeValidity && hasTxValidityExpired(deadline);
 
     const reportTransactionCreatedEvent = (action: TransactionCreatedEventAction) =>
         analytics.report({
@@ -142,7 +146,7 @@ export const TransactionReviewModalBottomContent = ({
         );
     }
 
-    if (shouldCheckTxTimeValidity && isTxExpired && !isSending) {
+    if (shouldCheckTxTimeValidity && hasTxReviewExpired && !isSending) {
         return (
             <>
                 <Modal.Button onClick={() => handleTryAgain(false)}>
@@ -163,7 +167,7 @@ export const TransactionReviewModalBottomContent = ({
         return (
             <Modal.Button
                 data-testid="@modal/send"
-                isDisabled={!serializedTx || hasTxExpired}
+                isDisabled={!serializedTx || hasTxDeadlineExpired}
                 isLoading={isSending}
                 intent={isCancelRbfAction ? 'critical' : 'brand'}
                 onClick={handleSend}

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalContent.tsx
@@ -26,7 +26,6 @@ import { TransactionReviewOutputList } from './TransactionReviewOutputList';
 import { ExpiredTxValidity } from '../../UserContextModal/TxDetailModal/ExpiredTxValidity';
 import { ReplaceByFeeFailedOriginalTxConfirmed } from '../../UserContextModal/TxDetailModal/ReplaceByFeeFailedOriginalTxConfirmed';
 import { TransactionReviewDetails } from '../TransactionReviewDetails';
-import { hasTxValidityExpired } from '../utils';
 
 type TransactionReviewModalContentProps = {
     account: Account;
@@ -37,6 +36,7 @@ type TransactionReviewModalContentProps = {
     reviewStep: number;
     serializedTx?: SerializedTx;
     areDetailsVisible: boolean;
+    hasTxReviewExpired: boolean;
     isRbfConfirmedError?: boolean;
 };
 
@@ -49,6 +49,7 @@ export const TransactionReviewModalContent = ({
     precomposedForm,
     onTryAgain,
     isSending,
+    hasTxReviewExpired,
     isRbfConfirmedError,
 }: TransactionReviewModalContentProps) => {
     const { symbol, networkType } = account;
@@ -60,7 +61,6 @@ export const TransactionReviewModalContent = ({
     );
 
     const deadline = createdTxTimestamp + getTxValidityTimeoutInMs(account?.networkType);
-    const isTxExpired = hasTxValidityExpired(deadline);
 
     const isBumpFeeRbfAction =
         precomposedTx !== undefined && isRbfBumpFeeTransaction(precomposedTx);
@@ -106,7 +106,7 @@ export const TransactionReviewModalContent = ({
         );
     }
 
-    if (shouldCheckTxTimeValidity && isTxExpired && !isSending) {
+    if (shouldCheckTxTimeValidity && hasTxReviewExpired && !isSending) {
         return <ExpiredTxValidity symbol={symbol} />;
     }
 

--- a/suite/modal/src/constants.ts
+++ b/suite/modal/src/constants.ts
@@ -8,6 +8,7 @@ export const MODAL_OPEN_USER_CONTEXT = '@modal/open-user-context' as const;
 export const MODAL_CONTEXT_USER = '@modal/context-user' as const;
 export const MODAL_PRESERVE = '@modal/preserve' as const;
 export const MODAL_REMOVE_PRESERVE = '@modal/remove_preserve' as const;
+export const MODAL_PRESERVE_ON_TX_TIMEOUT = '@modal/preserve-on-tx-timeout' as const;
 
 export const REFETCH_FEES_EXCLUDED_MODAL_WINDOW_TYPES = [
     UI_REQUEST.REQUEST_PASSPHRASE,

--- a/suite/modal/src/modalActions.ts
+++ b/suite/modal/src/modalActions.ts
@@ -8,6 +8,7 @@ import {
     MODAL_CLOSE,
     MODAL_OPEN_USER_CONTEXT,
     MODAL_PRESERVE,
+    MODAL_PRESERVE_ON_TX_TIMEOUT,
     MODAL_REMOVE_PRESERVE,
 } from './constants';
 import { type ModalRootState, selectModalConfirmationRequestId } from './modalReducer';
@@ -16,6 +17,7 @@ export type ModalAction =
     | { type: typeof MODAL_CLOSE }
     | { type: typeof MODAL_PRESERVE }
     | { type: typeof MODAL_REMOVE_PRESERVE }
+    | { type: typeof MODAL_PRESERVE_ON_TX_TIMEOUT }
     | {
           type: typeof MODAL_OPEN_USER_CONTEXT;
           payload: UserContextPayload;
@@ -34,6 +36,13 @@ export const preserveModal = createAction(MODAL_PRESERVE);
  * is only replaced by another one, and that one must no longer be preserved.
  */
 export const removePreserveModal = createAction(MODAL_REMOVE_PRESERVE);
+
+/**
+ * Keep the device-context modal open for exactly one CLOSE_UI_WINDOW event.
+ * Dispatch this before calling TrezorConnect.cancel() on Solana tx timeout so that
+ * the expired-transaction UI stays visible instead of flashing and disappearing.
+ */
+export const preserveModalOnTxTimeout = createAction(MODAL_PRESERVE_ON_TX_TIMEOUT);
 
 export const onReceiveConfirmation =
     (confirmation: boolean) => (dispatch: Dispatch, getState: () => ModalRootState) => {

--- a/suite/modal/src/modalReducer.ts
+++ b/suite/modal/src/modalReducer.ts
@@ -21,10 +21,11 @@ import {
     MODAL_CONTEXT_USER,
     MODAL_OPEN_USER_CONTEXT,
     MODAL_PRESERVE,
+    MODAL_PRESERVE_ON_TX_TIMEOUT,
     MODAL_REMOVE_PRESERVE,
 } from './constants';
 
-export type State = ModalState & { preserve?: boolean };
+export type State = ModalState & { preserve?: boolean; preserveOnTxTimeout?: boolean };
 
 export type ModalState =
     | { context: typeof MODAL_CONTEXT_NONE }
@@ -153,10 +154,16 @@ const modalReducer = (state: State = initialState, action: AnyAction): State => 
         case UI_REQUEST.CLOSE_UI_WINDOW:
             // Always close device-driven modals when the device signals CLOSE_UI_WINDOW,
             // even if preserve is set (preserve protects user-context modals, not device prompts).
+            // Exception: preserveOnTxTimeout is set when the timer cancels signing — the modal
+            // must stay open to show the expired state. The flag is cleared after one use.
             if (
                 state.context === MODAL_CONTEXT_DEVICE ||
                 state.context === MODAL_CONTEXT_DEVICE_CONFIRMATION
             ) {
+                if (state.preserveOnTxTimeout) {
+                    return { ...state, preserveOnTxTimeout: false };
+                }
+
                 return initialState;
             }
 
@@ -164,6 +171,9 @@ const modalReducer = (state: State = initialState, action: AnyAction): State => 
 
         case MODAL_PRESERVE:
             return { ...state, preserve: true };
+
+        case MODAL_PRESERVE_ON_TX_TIMEOUT:
+            return { ...state, preserveOnTxTimeout: true };
 
         case MODAL_REMOVE_PRESERVE:
             return { ...state, preserve: false };


### PR DESCRIPTION
## Description

Fixes Solana transaction timeout handling in the transaction review modal.

- Keeps the device-context modal open when timeout cancellation emits `CLOSE_UI_WINDOW`
- Uses explicit review expiration state for expired UI instead of raw deadline checks
- Clears signed transaction data before retrying
- Restores successful retry cleanup and navigation

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27555

## Screenshots:

https://github.com/user-attachments/assets/aefb4537-05aa-493a-a0ac-05d81bbd2265


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/solana-tx-timeout-review-modal&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/solana-tx-timeout-review-modal&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-13T22:56:04.112Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-14T07:58:38.652Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/solana-tx-timeout-review-modal/web/](https://dev.suite.sldev.cz/suite-web/fix/solana-tx-timeout-review-modal/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->