### PR TITLE
fix(send): keep modals visible during device signing

### DIFF
--- a/packages/suite/src/reducers/suite/__fixtures__/modalReducer.ts
+++ b/packages/suite/src/reducers/suite/__fixtures__/modalReducer.ts
@@ -199,18 +199,19 @@ export default [
         result: initialState,
     },
     {
-        description: 'UI_REQUEST.CLOSE_UI_WINDOW with preserve=true closes device context modal',
+        description:
+            'UI_REQUEST.CLOSE_UI_WINDOW with preserve=true keeps device context modal open (preserve cleared)',
         initialState: { ...deviceContextState, preserve: true },
         actions: [
             {
                 type: UI_REQUEST.CLOSE_UI_WINDOW,
             },
         ],
-        result: initialState,
+        result: { ...deviceContextState, preserve: false },
     },
     {
         description:
-            'UI_REQUEST.CLOSE_UI_WINDOW with preserve=true closes device confirmation context modal',
+            'UI_REQUEST.CLOSE_UI_WINDOW with preserve=true keeps device confirmation context modal open (preserve cleared)',
         initialState: {
             context: MODAL_CONTEXT_DEVICE_CONFIRMATION,
             windowType: 'no-backup' as const,
@@ -221,7 +222,11 @@ export default [
                 type: UI_REQUEST.CLOSE_UI_WINDOW,
             },
         ],
-        result: initialState,
+        result: {
+            context: MODAL_CONTEXT_DEVICE_CONFIRMATION,
+            windowType: 'no-backup',
+            preserve: false,
+        },
     },
     {
         description: 'UI_REQUEST.CLOSE_UI_WINDOW with preserve=true keeps user context modal open',

--- a/suite/modal/src/modalReducer.ts
+++ b/suite/modal/src/modalReducer.ts
@@ -152,16 +152,21 @@ const modalReducer = (state: State = initialState, action: AnyAction): State => 
             return initialState;
 
         case UI_REQUEST.CLOSE_UI_WINDOW:
-            // Always close device-driven modals when the device signals CLOSE_UI_WINDOW,
-            // even if preserve is set (preserve protects user-context modals, not device prompts).
-            // Exception: preserveOnTxTimeout is set when the timer cancels signing — the modal
-            // must stay open to show the expired state. The flag is cleared after one use.
             if (
                 state.context === MODAL_CONTEXT_DEVICE ||
                 state.context === MODAL_CONTEXT_DEVICE_CONFIRMATION
             ) {
+                // preserveOnTxTimeout: timer cancelled signing — keep modal open to show expired state.
                 if (state.preserveOnTxTimeout) {
                     return { ...state, preserveOnTxTimeout: false };
+                }
+
+                // preserve: signing flow is about to replace this device modal with a user-context
+                // modal (openDeferredModal). On desktop, CLOSE_UI_WINDOW arrives via IPC in a
+                // separate event loop turn, so closing here causes a visible flash. Keep the modal
+                // open but clear preserve so the next action can take over cleanly.
+                if (state.preserve) {
+                    return { ...state, preserve: false };
                 }
 
                 return initialState;


### PR DESCRIPTION
## Description

- Keep preserved device and device-confirmation modals open when UI_REQUEST.CLOSE_UI_WINDOW fires.
- Clear the preserve flag so the next deferred modal action can replace the device modal without a visible flash on desktop.
- Update the reducer fixtures to cover the preserved device-modal behavior.

## Notes for QA

- In Suite Desktop, go to Send, submit a transaction, confirm it on the device, and verify the send modal stays visible without disappearing and flashing back after signing.
- Verify a preserved user-context modal still stays open on UI_REQUEST.CLOSE_UI_WINDOW, and a non-preserved device modal still closes normally.

## Related Issue

Resolve #27570

## Screenshots:

N/A

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are a modal reducer (`suite/modal/src/modalReducer.ts`) and its corresponding test fixtures (`packages/suite/src/reducers/suite/__fixtures__/modalReducer.ts`). These are unit-level changes to the modal reducer logic and its test data. No E2E tests have static coverage mapping to these files, and after reviewing all available E2E test descriptions, none directly exercise modal reducer state transitions in a way that would be specifically affected by fixture or reducer logic changes. The modal reducer is a foundational piece used broadly across the app (backup modals, passphrase modals, device prompts, etc.), but changes to its fixtures and internal reducer logic are best validated by unit tests rather than E2E tests. No E2E tests are recommended for this change set.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/reducers/suite/__fixtures__/modalReducer.ts`
- `suite/modal/src/modalReducer.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/reducers/suite/__fixtures__/modalReducer.ts`
- `suite/modal/src/modalReducer.ts`

_Updated: 2026-05-14T07:26:43.810Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/27570-send-modal-signing-flash&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/27570-send-modal-signing-flash&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-14T07:31:48.758Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-14T07:29:55.314Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/27570-send-modal-signing-flash/web/](https://dev.suite.sldev.cz/suite-web/fix/27570-send-modal-signing-flash/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->