### PR TITLE
chore(suite): allow approving over balance in yield deposit

### DIFF
--- a/packages/suite/src/components/earn/yield/common/YieldActionStepWarning.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldActionStepWarning.tsx
@@ -4,14 +4,29 @@ import { Banner, Button, Column, Text } from '@trezor/components';
 type YieldActionStepWarningProps = {
     isInsufficientFunds?: boolean;
     isApprovalInsufficient?: boolean;
+    isApproveOverBalance?: boolean;
     onModifyApproval?: () => void;
 };
 
 export const YieldActionStepWarning = ({
     isInsufficientFunds = false,
     isApprovalInsufficient = false,
+    isApproveOverBalance = false,
     onModifyApproval,
 }: YieldActionStepWarningProps) => {
+    if (isApproveOverBalance) {
+        return (
+            <Banner
+                intent="info"
+                description={
+                    <Text>
+                        <Translation id="TR_APPROVE_OVER_BALANCE" />
+                    </Text>
+                }
+            />
+        );
+    }
+
     if (isApprovalInsufficient) {
         return (
             <Banner

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -241,8 +241,15 @@ export const useYieldFlow = ({
 
         if (prevStep !== null && prevStep !== nextStep) {
             if (prevStep === 'approve' && nextStep === 'action') {
+                const actionAmount = session.action.amount ?? '';
+                const cappedAmount = isAmountGreaterThan({
+                    amount: actionAmount,
+                    threshold: maxAmount,
+                })
+                    ? maxAmount
+                    : actionAmount;
                 methodsRef.current.reset({
-                    amountInput: session.action.amount ?? '',
+                    amountInput: cappedAmount,
                     withdrawInputUnit: methodsRef.current.getValues('withdrawInputUnit'),
                 });
             }

--- a/packages/suite/src/components/earn/yield/supply/YieldSupplyForm.tsx
+++ b/packages/suite/src/components/earn/yield/supply/YieldSupplyForm.tsx
@@ -220,13 +220,12 @@ export const YieldSupplyForm = () => {
                                         warning={
                                             !isAmountInvalidDecimals && isAmountTooHigh ? (
                                                 <YieldActionStepWarning
-                                                    isInsufficientFunds={isAmountTooHigh}
+                                                    isApproveOverBalance={isAmountTooHigh}
                                                 />
                                             ) : undefined
                                         }
                                         isDisabled={
                                             isAmountEmpty ||
-                                            isAmountTooHigh ||
                                             isAmountInvalidDecimals ||
                                             isSubmittingApprove ||
                                             !!approvalPendingTransaction

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -9640,6 +9640,11 @@ export const messages = defineMessages({
         id: 'TR_EARN_YIELD_APPROVAL_TOO_LOW',
         defaultMessage: 'Approval is too low. Change approval or lower amount.',
     },
+    TR_APPROVE_OVER_BALANCE: {
+        id: 'TR_APPROVE_OVER_BALANCE',
+        defaultMessage:
+            'You can approve more than your current balance, reuse it later, and revoke it anytime.',
+    },
     TR_EARN_YIELD_MODIFY_APPROVAL: {
         id: 'TR_EARN_YIELD_MODIFY_APPROVAL',
         defaultMessage: 'Change approval',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Changed "Insufficient funds" banner in yield deposit approve step to info banner explaining that approving more than balance is fine
- Supply amount auto-caps to balance after approve if approved amount is higher than users balance

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27324

## Screenshots:

<img width="556" height="609" alt="Screenshot 2026-05-14 at 09 53 25" src="https://github.com/user-attachments/assets/4a69fbf9-f39d-474b-9b70-ac473490c636" />

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies core earn/yield staking components: the supply form (YieldSupplyForm.tsx), the flow management hook (useYieldFlow.ts), a warning step component (YieldActionStepWarning.tsx), and the internationalization messages file (messages.ts). The primary risk is regression in staking/yield flows across all supported networks (ETH, ADA, SOL). The messages.ts file maps to 100+ tests but since it's a broad global file, only staking-specific tests that directly assert earn/staking translation keys are recommended. Testing should focus on ETH staking flows first (initial stake, stake more, unstake, form validation) as the most directly affected, then extend to ADA and SOL staking flows that share the same infrastructure.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite/src/components/earn/yield/common/YieldActionStepWarning.tsx`
- `packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts`
- `packages/suite/src/components/earn/yield/supply/YieldSupplyForm.tsx`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/analytics/staking-events.test.ts` — This test directly exercises staking navigation analytics events for ETH and ADA, which are entry points to the yield/earn staking flows. Changes to YieldSupplyForm.tsx and useYieldFlow.ts modify the staking supply form and flow hook, and the staking navigation paths tested here lead directly into those components.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test exercises the full ETH initial staking flow including the staking form, confirmation, and transaction progression. YieldSupplyForm.tsx is the supply/stake form component, useYieldFlow.ts manages the flow logic, and YieldActionStepWarning.tsx handles warnings shown during the staking process. Changes to messages.ts may affect translated strings displayed in the staking UI.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — This test covers staking more ETH on an existing position, directly using the staking supply form (YieldSupplyForm.tsx) and flow hook (useYieldFlow.ts). It also tests instant staking banners which may use warning components (YieldActionStepWarning.tsx) and translated messages.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — The unstake flow for ETH exercises the yield flow hook (useYieldFlow.ts) and potentially warning components (YieldActionStepWarning.tsx). Changes to the flow logic could break unstaking and claiming workflows. The test also validates translated strings from messages.ts.
- `suite/e2e/tests/staking/staking-form.test.ts` — This test directly validates the ETH staking form input validation (min amounts, decimals, insufficient funds, percentage buttons, max button, crypto/fiat switching). YieldSupplyForm.tsx is the staking supply form being tested, and messages.ts provides the validation error translation keys asserted in this test.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — Cardano staking claim flow tests reward claiming with warning banners (TR_EARN_REWARDS_NETWORK_FEE_WARNING) that may be rendered by YieldActionStepWarning.tsx. Changes to the warning component or messages.ts could affect the fee warning banner behavior.
- `suite/e2e/tests/staking/ada/stake.test.ts` — ADA staking flow tests the full staking process including info modals and deposit confirmation. The yield flow hook (useYieldFlow.ts) likely manages the staking flow state, and translated strings from messages.ts are asserted throughout.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — ADA unstaking flow shares the yield flow infrastructure (useYieldFlow.ts) and asserts translated strings (TR_STAKE_UNSTAKE_TOKEN, TR_STAKE_FULL_BALANCE) from messages.ts that may have been modified.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — SOL initial staking exercises the staking form and flow which share infrastructure with the yield supply form and flow hook. Changes to useYieldFlow.ts could affect the Solana staking flow behavior.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — SOL stake-more flow uses the same yield supply form and flow hook infrastructure. Changes to YieldSupplyForm.tsx or useYieldFlow.ts could break the Solana stake-more functionality.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — SOL unstake and claim flow shares the yield flow hook infrastructure. Changes to useYieldFlow.ts or warning components could affect the unstake/claim workflow.
- `suite/e2e/tests/staking/sol/rewards.test.ts` — SOL rewards display test exercises the staking dashboard which is part of the yield/earn feature area. Changes to the yield flow hook could affect how staking amounts and rewards are displayed.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/suite/src/components/earn/yield/common/YieldActionStepWarning.tsx`
- `packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts`
- `suite/intl/src/messages.ts`

_Updated: 2026-05-14T08:06:34.088Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/yield-approve-amount&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/yield-approve-amount&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-14T08:10:43.946Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-14T08:09:09.967Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/yield-approve-amount/web/](https://dev.suite.sldev.cz/suite-web/chore/yield-approve-amount/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->