### PR TITLE
Mobile Trade: implement smart sorting for tradeable assets

### DIFF
--- a/suite-native/app/e2e/pageObjects/trading/TradingFormActions.ts
+++ b/suite-native/app/e2e/pageObjects/trading/TradingFormActions.ts
@@ -133,7 +133,7 @@ export abstract class TradingFormActions extends TradingActions {
         await waitForVisible(providersPicker);
     }
 
-    async selectReceiveAsset(asset: string, network?: string) {
+    async selectReceiveAsset(asset: string, network?: string, searchString?: string) {
         const receiveAssetButton = this.getElementById('asset-receive-button');
         await waitForVisible(receiveAssetButton, { timeout: this.SHORT_TIMEOUT });
         await receiveAssetButton.tap();
@@ -143,7 +143,8 @@ export abstract class TradingFormActions extends TradingActions {
         const searchReceiveCryptoInput = this.getSearchReceiveCryptoElement();
         await searchReceiveCryptoInput.tap();
         await wait(this.BOTTOM_SHEET_ANIMATION_DURATION);
-        await searchReceiveCryptoInput.replaceText(asset.slice(0, -1));
+        const searchForStr = searchString ?? asset;
+        await searchReceiveCryptoInput.replaceText(searchForStr.slice(0, -1));
 
         if (network) {
             const networkFilterTab = element(

--- a/suite-native/app/e2e/tests/tradingExchangeFlow.test.ts
+++ b/suite-native/app/e2e/tests/tradingExchangeFlow.test.ts
@@ -62,7 +62,7 @@ describe('Trade Exchange [@androidOnly]', () => {
 
         it('should request trezor connect before preview', async () => {
             await tradingExchangeActions.selectSendAsset('USDC');
-            await tradingExchangeActions.selectReceiveAsset('USDT', 'Ethereum');
+            await tradingExchangeActions.selectReceiveAsset('USDT', 'Ethereum', 'Tether');
             await tradingExchangeActions.selectReceiveAccount('Ethereum #1');
             await tradingExchangeActions.setSendCryptoAmount('10');
 

--- a/suite-native/module-trading/src/hooks/general/__tests__/useTradeableAssetsFilteredData.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useTradeableAssetsFilteredData.test.ts
@@ -6,7 +6,10 @@ import {
     jitoOnSolanaAsset,
     jupOnSolanaAsset,
     rethOnBaseAsset,
+    tronTetherAsset,
+    unknownAsset,
     usdcAsset,
+    usdtAsset,
     usdtOnArbAsset,
     usdtOnBscAsset,
 } from '@suite-native/trading-fixtures';
@@ -114,6 +117,106 @@ describe('useTradeableAssetsFilteredData', () => {
             result.current.setFilterValue('NonExistentAsset');
         });
         expect(result.current.filteredData).toHaveLength(0);
+    });
+
+    describe('sort order', () => {
+        it('should rank exact name match before name-startsWith', () => {
+            // tronTetherAsset.name = 'Tether' (exact match), usdtAsset.name = 'Tether USDT' (startsWith)
+            const assets = [usdtAsset, tronTetherAsset];
+            const { result } = renderHook(() => useTradeableAssetsFilteredData({ assets }));
+
+            act(() => {
+                result.current.setFilterValue('tether');
+            });
+
+            expect(result.current.filteredData[0]).toBe(tronTetherAsset);
+            expect(result.current.filteredData[1]).toBe(usdtAsset);
+        });
+
+        it('should rank exact symbol match before symbol-startsWith', () => {
+            // Inline asset with symbol starting with 'usd' but not exact; usdcAsset.symbol = 'USDC' also startsWith.
+            // We create an asset with symbol exactly 'USD' to compare against 'USDC'.
+            const usdExactAsset: TradeableAsset = {
+                ...unknownAsset,
+                symbol: 'USD' as any,
+                name: 'US Dollar',
+            };
+            const assets = [usdcAsset, usdExactAsset];
+            const { result } = renderHook(() => useTradeableAssetsFilteredData({ assets }));
+
+            act(() => {
+                result.current.setFilterValue('usd');
+            });
+
+            // usdExactAsset: symbol === 'usd' → weight 1
+            // usdcAsset: symbol startsWith 'usd' → weight 3
+            expect(result.current.filteredData[0]).toBe(usdExactAsset);
+            expect(result.current.filteredData[1]).toBe(usdcAsset);
+        });
+
+        it('should rank name-startsWith before name-contains', () => {
+            // ethAsset.name = 'Ethereum' → startsWith 'et' → weight 2
+            // rethOnBaseAsset.name = 'Rocket Pool ETH' → contains 'et' but not startsWith → weight 4
+            // Also: ethAsset.symbol = 'ETH' → 'eth' !== 'et', so no symbol exact match; name check wins at weight 2
+            const assets = [rethOnBaseAsset, ethAsset];
+            const { result } = renderHook(() => useTradeableAssetsFilteredData({ assets }));
+
+            act(() => {
+                result.current.setFilterValue('et');
+            });
+
+            expect(result.current.filteredData[0]).toBe(ethAsset);
+            expect(result.current.filteredData[1]).toBe(rethOnBaseAsset);
+        });
+
+        it('should rank asset name/symbol matches before network name matches', () => {
+            // ethAsset.name = 'Ethereum' → exact name match → weight 0
+            // usdcAsset.networkId = 'ethereum' → network name 'Ethereum' exact match → weight 6
+            const assets = [usdcAsset, ethAsset];
+            const { result } = renderHook(() => useTradeableAssetsFilteredData({ assets }));
+
+            act(() => {
+                result.current.setFilterValue('ethereum');
+            });
+
+            expect(result.current.filteredData[0]).toBe(ethAsset);
+            expect(result.current.filteredData[1]).toBe(usdcAsset);
+        });
+
+        it('should rank contract address matches after name/symbol matches', () => {
+            // Inline asset with '0xa0b' in its name → name startsWith → weight 2
+            // usdcAsset.contractAddress starts with '0xa0b' → weight 12
+            const contractNameAsset: TradeableAsset = { ...unknownAsset, name: '0xa0b Token' };
+            const assets = [usdcAsset, contractNameAsset];
+            const { result } = renderHook(() => useTradeableAssetsFilteredData({ assets }));
+
+            act(() => {
+                result.current.setFilterValue('0xa0b');
+            });
+
+            expect(result.current.filteredData[0]).toBe(contractNameAsset);
+            expect(result.current.filteredData[1]).toBe(usdcAsset);
+        });
+
+        it('should not change order when filter is empty', () => {
+            const assets = [btcAsset, ethAsset, usdcAsset];
+            const { result } = renderHook(() => useTradeableAssetsFilteredData({ assets }));
+
+            // No filter set — original order should be preserved
+            expect(result.current.filteredData).toEqual(assets);
+        });
+
+        it('should order match on token address as last', () => {
+            const assets = [btcAsset, ethAsset, usdcAsset, tronTetherAsset] as TradeableAsset[];
+
+            const { result } = renderHook(() => useTradeableAssetsFilteredData({ assets }));
+
+            act(() => {
+                result.current.setFilterValue('tc');
+            });
+
+            expect(result.current.filteredData).toEqual([btcAsset, tronTetherAsset]);
+        });
     });
 
     describe('filterValue', () => {

--- a/suite-native/module-trading/src/hooks/general/useTradeableAssetsFilteredData.ts
+++ b/suite-native/module-trading/src/hooks/general/useTradeableAssetsFilteredData.ts
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 
+import { normalizeForSearch } from '@suite-common/suite-utils';
 import { cryptoIdToSymbol, useListDataFilter } from '@suite-common/trading';
 import { type NetworkSymbol, getNetworkByCoingeckoId } from '@suite-common/wallet-config';
 import { type TradeableAsset } from '@suite-native/trading-types';
@@ -28,6 +29,73 @@ const filterCallback = (asset: TradeableAsset, filterValue: string): boolean =>
     doesNetworkSymbolIncludeValue(asset, filterValue) ||
     doesContractAddressIncludeValue(asset, filterValue);
 
+const sortCallback = (a: TradeableAsset, b: TradeableAsset, filterValue: string): number => {
+    const query = normalizeForSearch(filterValue);
+    if (!query) {
+        return 0;
+    }
+
+    const getWeight = (asset: TradeableAsset): number => {
+        const name = normalizeForSearch(asset.name);
+        const symbol = normalizeForSearch(asset.symbol);
+        const network = getNetworkByCoingeckoId(asset.networkId);
+        const networkName = normalizeForSearch(network?.name ?? '');
+        const networkSymbol = normalizeForSearch(network?.symbol ?? '');
+        const contractAddress = asset.contractAddress?.toLowerCase() ?? '';
+
+        if (name === query) {
+            return 0;
+        }
+        if (symbol === query) {
+            return 1;
+        }
+        if (name.startsWith(query)) {
+            return 2;
+        }
+        if (symbol.startsWith(query)) {
+            return 3;
+        }
+        if (name.includes(query)) {
+            return 4;
+        }
+        if (symbol.includes(query)) {
+            return 5;
+        }
+        if (networkName === query) {
+            return 6;
+        }
+        if (networkSymbol === query) {
+            return 7;
+        }
+        if (networkName.startsWith(query)) {
+            return 8;
+        }
+        if (networkSymbol.startsWith(query)) {
+            return 9;
+        }
+        if (networkName.includes(query)) {
+            return 10;
+        }
+        if (networkSymbol.includes(query)) {
+            return 11;
+        }
+        if (contractAddress.startsWith(query)) {
+            return 12;
+        }
+
+        return 13;
+    };
+
+    const weightA = getWeight(a);
+    const weightB = getWeight(b);
+
+    if (weightA !== weightB) {
+        return weightA - weightB;
+    }
+
+    return a.name.localeCompare(b.name);
+};
+
 export const useTradeableAssetsFilteredData = ({ assets }: { assets: TradeableAsset[] }) => {
     const [filterSymbol, setFilterSymbol] = useState<NetworkSymbol | undefined>(undefined);
 
@@ -42,6 +110,7 @@ export const useTradeableAssetsFilteredData = ({ assets }: { assets: TradeableAs
     const { setFilterValue, filteredData, filterValue } = useListDataFilter(
         assetsFilteredByNetwork,
         filterCallback,
+        sortCallback,
     );
 
     const filterValueWithNetwork = `Network:${filterSymbol ? filterSymbol : 'all'};Search:${filterValue}`;

--- a/suite-native/module-trading/src/hooks/general/useTradeableAssetsFilteredData.ts
+++ b/suite-native/module-trading/src/hooks/general/useTradeableAssetsFilteredData.ts
@@ -5,29 +5,49 @@ import { cryptoIdToSymbol, useListDataFilter } from '@suite-common/trading';
 import { type NetworkSymbol, getNetworkByCoingeckoId } from '@suite-common/wallet-config';
 import { type TradeableAsset } from '@suite-native/trading-types';
 
-const doesContractAddressIncludeValue = (asset: TradeableAsset, value: string) =>
-    asset.contractAddress?.toLowerCase().includes(value.toLowerCase()) ?? false;
+const doesContractAddressIncludeValue = (asset: TradeableAsset, value: string) => {
+    if (!asset.contractAddress) {
+        return false;
+    }
+
+    return normalizeForSearch(asset.contractAddress).includes(value);
+};
 
 const doesSymbolIncludeValue = (asset: TradeableAsset, value: string) =>
-    asset.symbol.toLowerCase().includes(value.toLowerCase());
+    normalizeForSearch(asset.symbol).includes(value);
 
 const doesNameIncludeValue = (asset: TradeableAsset, value: string) =>
-    asset.name.toLowerCase().includes(value.toLowerCase());
+    normalizeForSearch(asset.name).includes(value);
 
-const doesNetworkNameIncludeValue = (asset: TradeableAsset, value: string) =>
-    getNetworkByCoingeckoId(asset.networkId)?.name.toLowerCase().includes(value.toLowerCase()) ??
-    false;
+const doesNetworkNameIncludeValue = (asset: TradeableAsset, value: string) => {
+    const network = getNetworkByCoingeckoId(asset.networkId);
+    if (!network) {
+        return false;
+    }
 
-const doesNetworkSymbolIncludeValue = (asset: TradeableAsset, value: string) =>
-    getNetworkByCoingeckoId(asset.networkId)?.symbol.toLowerCase().includes(value.toLowerCase()) ??
-    false;
+    return normalizeForSearch(network.name).includes(value);
+};
 
-const filterCallback = (asset: TradeableAsset, filterValue: string): boolean =>
-    doesNameIncludeValue(asset, filterValue) ||
-    doesSymbolIncludeValue(asset, filterValue) ||
-    doesNetworkNameIncludeValue(asset, filterValue) ||
-    doesNetworkSymbolIncludeValue(asset, filterValue) ||
-    doesContractAddressIncludeValue(asset, filterValue);
+const doesNetworkSymbolIncludeValue = (asset: TradeableAsset, value: string) => {
+    const network = getNetworkByCoingeckoId(asset.networkId);
+    if (!network) {
+        return false;
+    }
+
+    return normalizeForSearch(network.symbol).includes(value);
+};
+
+const filterCallback = (asset: TradeableAsset, filterValue: string): boolean => {
+    const normalizedFilterValue = normalizeForSearch(filterValue);
+
+    return (
+        doesNameIncludeValue(asset, normalizedFilterValue) ||
+        doesSymbolIncludeValue(asset, normalizedFilterValue) ||
+        doesNetworkNameIncludeValue(asset, normalizedFilterValue) ||
+        doesNetworkSymbolIncludeValue(asset, normalizedFilterValue) ||
+        doesContractAddressIncludeValue(asset, normalizedFilterValue)
+    );
+};
 
 const sortCallback = (a: TradeableAsset, b: TradeableAsset, filterValue: string): number => {
     const query = normalizeForSearch(filterValue);


### PR DESCRIPTION
Assets now are sorted by this key:
1. Exact match on name
1. Exact match on symbol 
1. Name starts with query 
1. Symbol starts with query 
1. Name contains query 
1. Symbol contains query 
1. Exact match on network name 
1. Exact match on network symbol 
1. Network name starts with query 
1. Network symbol starts with query  
1. Network name contains query  
1. Network symbol contains query  
1. Contract address starts with query 
1. Contract address contains query  

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #26811

## Screenshots:
<img width="300" alt="Simulator Screenshot - iPhone 17 - 2026-05-14 at 10 10 31" src="https://github.com/user-attachments/assets/0314ee46-a724-4da7-b537-f9a25d8dd25d" />
<img width="300" alt="Simulator Screenshot - iPhone 17 - 2026-05-14 at 10 10 38" src="https://github.com/user-attachments/assets/f30aeec4-6565-4532-b662-13f577588b78" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=26811-mobile-swap-implement-smart-token-sorting-in-token-picker&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->