### PR TITLE
chore(connect): drop redundant publishConfig.type in ESM packages

### DIFF
--- a/packages/address-validator/package.json
+++ b/packages/address-validator/package.json
@@ -13,7 +13,6 @@
     "publishConfig": {
         "main": "./libESM/index.mjs",
         "types": "./libESM/index.d.mts",
-        "type": "module",
         "exports": {
             ".": {
                 "types": "./libESM/index.d.mts",

--- a/packages/blockchain-link-types/package.json
+++ b/packages/blockchain-link-types/package.json
@@ -8,7 +8,6 @@
     "publishConfig": {
         "main": "./libESM/index.mjs",
         "types": "./libESM/index.d.mts",
-        "type": "module",
         "exports": {
             ".": {
                 "types": "./libESM/index.d.mts",

--- a/packages/blockchain-link-utils/package.json
+++ b/packages/blockchain-link-utils/package.json
@@ -8,7 +8,6 @@
     "publishConfig": {
         "main": "./libESM/index.mjs",
         "types": "./libESM/index.d.mts",
-        "type": "module",
         "exports": {
             ".": {
                 "types": "./libESM/index.d.mts",

--- a/packages/blockchain-link/package.json
+++ b/packages/blockchain-link/package.json
@@ -35,7 +35,6 @@
     "publishConfig": {
         "main": "./libESM/index.mjs",
         "types": "./libESM/index.d.mts",
-        "type": "module",
         "exports": {
             ".": {
                 "types": "./libESM/index.d.mts",

--- a/packages/connect-common/package.json
+++ b/packages/connect-common/package.json
@@ -25,7 +25,6 @@
     "publishConfig": {
         "main": "./libESM/index.mjs",
         "types": "./libESM/index.d.mts",
-        "type": "module",
         "exports": {
             ".": {
                 "types": "./libESM/index.d.mts",

--- a/packages/connect-data/package.json
+++ b/packages/connect-data/package.json
@@ -27,7 +27,6 @@
     "publishConfig": {
         "main": "./libESM/index.mjs",
         "types": "./libESM/index.d.mts",
-        "type": "module",
         "exports": {
             ".": {
                 "types": "./libESM/index.d.mts",

--- a/packages/connect-mobile/package.json
+++ b/packages/connect-mobile/package.json
@@ -8,7 +8,6 @@
     "publishConfig": {
         "main": "./libESM/index.mjs",
         "types": "./libESM/index.d.mts",
-        "type": "module",
         "exports": {
             ".": {
                 "types": "./libESM/index.d.mts",

--- a/packages/connect-plugin-ethereum/package.json
+++ b/packages/connect-plugin-ethereum/package.json
@@ -22,7 +22,6 @@
     "publishConfig": {
         "main": "./libESM/index.mjs",
         "types": "./libESM/index.d.mts",
-        "type": "module",
         "exports": {
             ".": {
                 "types": "./libESM/index.d.mts",

--- a/packages/connect-plugin-stellar/package.json
+++ b/packages/connect-plugin-stellar/package.json
@@ -23,7 +23,6 @@
     "publishConfig": {
         "main": "./libESM/index.mjs",
         "types": "./libESM/index.d.mts",
-        "type": "module",
         "exports": {
             ".": {
                 "types": "./libESM/index.d.mts",

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -23,7 +23,6 @@
     "publishConfig": {
         "main": "./libESM/index.mjs",
         "types": "./libESM/index.d.mts",
-        "type": "module",
         "exports": {
             ".": {
                 "types": "./libESM/index.d.mts",

--- a/packages/connect-webextension/package.json
+++ b/packages/connect-webextension/package.json
@@ -24,7 +24,6 @@
     "publishConfig": {
         "main": "./libESM/index.mjs",
         "types": "./libESM/index.d.mts",
-        "type": "module",
         "exports": {
             ".": {
                 "types": "./libESM/index.d.mts",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -35,7 +35,6 @@
     "publishConfig": {
         "main": "./libESM/index.mjs",
         "types": "./libESM/index.d.mts",
-        "type": "module",
         "exports": {
             ".": {
                 "types": "./libESM/index.d.mts",

--- a/packages/crypto-utils/package.json
+++ b/packages/crypto-utils/package.json
@@ -26,7 +26,6 @@
     "publishConfig": {
         "main": "./libESM/index.mjs",
         "types": "./libESM/index.d.mts",
-        "type": "module",
         "exports": {
             ".": {
                 "types": "./libESM/index.d.mts",

--- a/packages/device-authenticity/package.json
+++ b/packages/device-authenticity/package.json
@@ -17,7 +17,6 @@
     "publishConfig": {
         "main": "./libESM/index.mjs",
         "types": "./libESM/index.d.mts",
-        "type": "module",
         "exports": {
             ".": {
                 "types": "./libESM/index.d.mts",

--- a/packages/device-utils/package.json
+++ b/packages/device-utils/package.json
@@ -8,7 +8,6 @@
     "publishConfig": {
         "main": "./libESM/index.mjs",
         "types": "./libESM/index.d.mts",
-        "type": "module",
         "exports": {
             ".": {
                 "types": "./libESM/index.d.mts",

--- a/packages/env-utils/package.json
+++ b/packages/env-utils/package.json
@@ -16,7 +16,6 @@
     "publishConfig": {
         "main": "./libESM/index.mjs",
         "types": "./libESM/index.d.mts",
-        "type": "module",
         "exports": {
             ".": {
                 "types": "./libESM/index.d.mts",

--- a/packages/protobuf/package.json
+++ b/packages/protobuf/package.json
@@ -15,7 +15,6 @@
     "publishConfig": {
         "main": "./libESM/index.mjs",
         "types": "./libESM/index.d.mts",
-        "type": "module",
         "exports": {
             ".": {
                 "types": "./libESM/index.d.mts",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -15,7 +15,6 @@
     "publishConfig": {
         "main": "./libESM/index.mjs",
         "types": "./libESM/index.d.mts",
-        "type": "module",
         "exports": {
             ".": {
                 "types": "./libESM/index.d.mts",

--- a/packages/requirements/src/requirements/package-json/__tests__/requirePublishConfig.test.ts
+++ b/packages/requirements/src/requirements/package-json/__tests__/requirePublishConfig.test.ts
@@ -28,10 +28,10 @@ const validPublicPackageJson = {
 const validEsmOnlyPackageJson = {
     name: '@trezor/example-esm',
     main: 'src/index.ts',
+    type: 'module',
     publishConfig: {
         main: './libESM/index.mjs',
         types: './libESM/index.d.mts',
-        type: 'module',
         exports: {
             '.': { types: './libESM/index.d.mts', default: './libESM/index.mjs' },
             './libESM/*': './libESM/*',
@@ -211,27 +211,34 @@ describe(requirePublishConfig.name, () => {
             expect(errors).toContain('@trezor/example: Invalid publishConfig.exports["."]');
         });
 
-        it('reports missing publishConfig.type for ESM-only package', async () => {
-            const pkg = {
-                ...validEsmOnlyPackageJson,
-                publishConfig: {
-                    ...validEsmOnlyPackageJson.publishConfig,
-                    type: undefined,
-                },
-            };
+        it('reports missing top-level "type" for ESM-only package', async () => {
+            const { type: _, ...withoutType } = validEsmOnlyPackageJson;
+            writeFileSync(join(workspaceDir, 'package.json'), JSON.stringify(withoutType));
+
+            const errors = await requirePublishConfig.verify(context);
+
+            expect(errors).toContain(
+                '@trezor/example: ESM-only package must declare top-level "type": "module" (got undefined)',
+            );
+        });
+
+        it('reports invalid top-level "type" for ESM-only package', async () => {
+            const pkg = { ...validEsmOnlyPackageJson, type: 'commonjs' };
             writeFileSync(join(workspaceDir, 'package.json'), JSON.stringify(pkg));
 
             const errors = await requirePublishConfig.verify(context);
 
-            expect(errors).toContain('@trezor/example: Missing "publishConfig.type" field');
+            expect(errors).toContain(
+                '@trezor/example: ESM-only package must declare top-level "type": "module" (got "commonjs")',
+            );
         });
 
-        it('reports invalid publishConfig.type for ESM-only package', async () => {
+        it('rejects redundant publishConfig.type', async () => {
             const pkg = {
                 ...validEsmOnlyPackageJson,
                 publishConfig: {
                     ...validEsmOnlyPackageJson.publishConfig,
-                    type: 'commonjs',
+                    type: 'module',
                 },
             };
             writeFileSync(join(workspaceDir, 'package.json'), JSON.stringify(pkg));
@@ -239,7 +246,7 @@ describe(requirePublishConfig.name, () => {
             const errors = await requirePublishConfig.verify(context);
 
             expect(errors).toContain(
-                '@trezor/example: Invalid "publishConfig.type": expected "module", got "commonjs"',
+                '@trezor/example: Redundant "publishConfig.type" field — declare "type" at the top level instead',
             );
         });
 

--- a/packages/requirements/src/requirements/package-json/requirePublishConfig.ts
+++ b/packages/requirements/src/requirements/package-json/requirePublishConfig.ts
@@ -17,6 +17,7 @@ interface ExportValueMap {
 type PackageJson = {
     readonly name?: string;
     readonly main?: string;
+    readonly type?: string;
     readonly files?: ReadonlyArray<string>;
     readonly publishConfig?: {
         readonly main?: string;
@@ -97,13 +98,19 @@ const validatePublicPackage = (
         );
     }
     if (isEsmOnly) {
-        if (!publishConfig?.type) {
-            errors.push('Missing "publishConfig.type" field');
-        } else if (publishConfig.type !== 'module') {
+        if (packageJson.type !== 'module') {
             errors.push(
-                `Invalid "publishConfig.type": expected "module", got ${JSON.stringify(publishConfig.type)}`,
+                `ESM-only package must declare top-level "type": "module" (got ${JSON.stringify(packageJson.type)})`,
             );
         }
+    }
+
+    // publishConfig.type would just shadow the top-level "type" with the same value at publish time.
+    // Keep the source of truth at the top level so local tooling and the published package agree.
+    if (publishConfig?.type !== undefined) {
+        errors.push(
+            'Redundant "publishConfig.type" field — declare "type" at the top level instead',
+        );
     }
 
     return { errors, isEsmOnly };

--- a/packages/schema-utils/package.json
+++ b/packages/schema-utils/package.json
@@ -8,7 +8,6 @@
     "publishConfig": {
         "main": "./libESM/index.mjs",
         "types": "./libESM/index.d.mts",
-        "type": "module",
         "exports": {
             ".": {
                 "types": "./libESM/index.d.mts",

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -29,7 +29,6 @@
     "publishConfig": {
         "main": "./libESM/index.mjs",
         "types": "./libESM/index.d.mts",
-        "type": "module",
         "exports": {
             ".": {
                 "types": "./libESM/index.d.mts",

--- a/packages/type-utils/package.json
+++ b/packages/type-utils/package.json
@@ -16,7 +16,6 @@
     "publishConfig": {
         "main": "./libESM/index.mjs",
         "types": "./libESM/index.d.mts",
-        "type": "module",
         "exports": {
             ".": {
                 "types": "./libESM/index.d.mts",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -18,7 +18,6 @@
     "publishConfig": {
         "main": "./libESM/index.mjs",
         "types": "./libESM/index.d.mts",
-        "type": "module",
         "exports": {
             ".": {
                 "types": "./libESM/index.d.mts",

--- a/packages/utxo-lib/package.json
+++ b/packages/utxo-lib/package.json
@@ -28,7 +28,6 @@
     "publishConfig": {
         "main": "./libESM/index.mjs",
         "types": "./libESM/index.d.mts",
-        "type": "module",
         "exports": {
             ".": {
                 "types": "./libESM/index.d.mts",

--- a/packages/websocket-client/package.json
+++ b/packages/websocket-client/package.json
@@ -25,7 +25,6 @@
     "publishConfig": {
         "main": "./libESM/index.mjs",
         "types": "./libESM/index.d.mts",
-        "type": "module",
         "exports": {
             ".": {
                 "types": "./libESM/index.d.mts",

--- a/skills/publish-config/SKILL.md
+++ b/skills/publish-config/SKILL.md
@@ -19,6 +19,7 @@ Applies to any package with `publishConfig`.
 6. **Explicit (non-wildcard) exports** — not shape-checked (intentional overrides), but must still have a counterpart. Typically used to route a directory import to its `index.js`, e.g. `"./lib/protocol-thp": { "types": "./lib/protocol-thp/index.d.ts", "default": "./lib/protocol-thp/index.js" }` — without this, the wildcard would resolve to `protocol-thp.js` instead of `protocol-thp/index.js`.
 7. **lib/libESM counterpart** — every `./lib/...` entry needs a matching `./libESM/...` pair and vice versa.
 8. **Key order** — `"types"` must come before `"default"` in every condition object (recursive). TypeScript evaluates conditions in declaration order.
+9. **ESM-only packages** — must declare top-level `"type": "module"`. Do not duplicate it under `publishConfig.type` — `publishConfig` would only shadow the top level with the same value at publish time, so we keep a single source of truth.
 
 ## Example
 
@@ -26,6 +27,7 @@ Applies to any package with `publishConfig`.
 {
     "name": "@trezor/example",
     "main": "./src/index.ts", // Rule 1
+    "type": "module", // Rule 9 — ESM-only packages only
     "files": ["lib/", "libESM/", "CHANGELOG.md"], // Rule 2
     "publishConfig": {
         "main": "./lib/index.js", // Rule 3


### PR DESCRIPTION
## Summary

Follow-up to #16944 ([9aebe9cfb0d](https://github.com/trezor/trezor-suite/commit/9aebe9cfb0d)), which moved every ESM-only package to top-level `"type": "module"`.

`publishConfig.type` would just shadow the top-level value with the same string at publish time, so:

- Drop `publishConfig.type` from all 24 ESM-only packages.
- Move the `@trezor/requirements` rule: ESM-only packages must declare top-level `"type": "module"`, and `publishConfig.type` is now rejected as redundant.
- Update `skills/publish-config/SKILL.md` with the new rule.

## Open question for reviewers

Some teams keep "redundant" `publishConfig` fields on purpose, as an explicit snapshot of what the published `package.json` will look like — `npm publish` only merges, never deletes, so the snapshot would never diverge.

I went the other way here (single source of truth at the top level) because the alternative invites drift: someone bumps `publishConfig.type` to something other than `"module"` and the local dev tree silently disagrees with the published artifact. The validator now keeps them in sync by forbidding the duplicate.

If you prefer the explicit-snapshot reading, we can flip the rule to *require* `publishConfig.type === "module"` *and* top-level `"type": "module"` instead. Happy to switch — wanted to flag the choice rather than make it unilaterally.

## Test plan

- [ ] `yarn workspace @trezor/requirements jest requirePublishConfig` is green
- [ ] `yarn requirements` (or whatever invokes `requirePublishConfig`) is green across the monorepo
- [ ] Spot-check one ESM-only package builds and publishes the same `package.json` shape as before (top-level `"type": "module"` survives the publish merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/remove-redundant-publishconfig-type&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/remove-redundant-publishconfig-type&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/remove-redundant-publishconfig-type&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-14T08:58:49.694Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-14T08:57:16.394Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/remove-redundant-publishconfig-type/web/](https://dev.suite.sldev.cz/suite-web/mroz22/remove-redundant-publishconfig-type/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->