### PR TITLE
Fix custom fee in TX simulation

### DIFF
--- a/packages/suite/src/components/tx-simulation/common/hooks/useEvmTxSimulationFeesForm.ts
+++ b/packages/suite/src/components/tx-simulation/common/hooks/useEvmTxSimulationFeesForm.ts
@@ -82,15 +82,16 @@ export function useEvmTxSimulationFeesForm({
 
     function getSelectedFee(): EvmSelectedFee | null {
         const values = form.getValues();
-        const selectedFeeInfo = feeInfo.levels.find(
-            level => level.label === (values.selectedFee ?? 'normal'),
-        );
+        // The synthetic 'custom' level has no fee values; read network-derived values from 'normal' instead.
+        const referenceLevelLabel =
+            values.selectedFee === 'custom' ? 'normal' : (values.selectedFee ?? 'normal');
+        const selectedFeeInfo = feeInfo.levels.find(level => level.label === referenceLevelLabel);
 
         const eip1559payload = {
             maxFeePerGas: values.maxFeePerGas ?? selectedFeeInfo?.maxFeePerGas,
             maxPriorityFeePerGas:
                 values.maxPriorityFeePerGas ?? selectedFeeInfo?.maxPriorityFeePerGas,
-            baseFeePerGas: values.baseFeePerGas ?? selectedFeeInfo?.baseFeePerGas,
+            baseFeePerGas: selectedFeeInfo?.baseFeePerGas,
         };
 
         if (

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/CustomFee/CustomFeeEthereum.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/CustomFee/CustomFeeEthereum.tsx
@@ -17,8 +17,8 @@ import { type CustomFeeBasicProps } from './CustomFeeBasicProps';
 import { FEE_LIMIT, FEE_PER_UNIT } from './constants';
 import { useFeesContext } from '../../context/FeesContext';
 
-const MAX_FEE_PER_GAS = 'maxFeePerGas';
-const MAX_PRIORITY_FEE_PER_GAS = 'maxPriorityFeePerGas';
+const MAX_FEE_PER_GAS = 'maxFeePerGas' satisfies keyof FormState;
+const MAX_PRIORITY_FEE_PER_GAS = 'maxPriorityFeePerGas' satisfies keyof FormState;
 
 export const CustomFeeEthereum = ({
     translationString,
@@ -28,14 +28,14 @@ export const CustomFeeEthereum = ({
     const { feeInfo, networkType } = useFeesContext();
     const locale = useSelector(selectLanguage);
 
-    const { control, getValues, setValue, trigger } = useFormContext<FormState>();
+    const { control, getValues, setValue, trigger, watch } = useFormContext<FormState>();
     const { errors } = useFormState<FormState>();
 
     const { maxFee, minFee, levels, minPriorityFee } = feeInfo;
 
-    const estimatedFeeLimit = getValues('estimatedFeeLimit');
-    const customMaxFeePerGas = getValues('maxFeePerGas');
-    const customMaxPriorityFeePerGas = getValues('maxPriorityFeePerGas');
+    // Use `watch` (not `getValues`) so the cross-field `trigger` effects re-run and validate closures see fresh values.
+    const customMaxFeePerGas = watch(MAX_FEE_PER_GAS);
+    const customMaxPriorityFeePerGas = watch(MAX_PRIORITY_FEE_PER_GAS);
 
     useEffect(() => {
         trigger?.(MAX_PRIORITY_FEE_PER_GAS);
@@ -52,6 +52,7 @@ export const CustomFeeEthereum = ({
         validate: {
             ...sharedRules.validate,
             feeLimit: (value: string) => {
+                const estimatedFeeLimit = getValues('estimatedFeeLimit');
                 const feeBig = new BigNumber(value);
                 if (estimatedFeeLimit && feeBig.lt(estimatedFeeLimit)) {
                     return translationString('CUSTOM_FEE_LIMIT_BELOW_RECOMMENDED');
@@ -61,11 +62,13 @@ export const CustomFeeEthereum = ({
     };
 
     const gasLimitValidationProps = {
-        onClick: () =>
-            estimatedFeeLimit &&
-            setValue(FEE_LIMIT, estimatedFeeLimit, {
-                shouldValidate: true,
-            }),
+        onClick: () => {
+            const estimatedFeeLimit = getValues('estimatedFeeLimit');
+
+            if (!estimatedFeeLimit) return;
+
+            setValue(FEE_LIMIT, estimatedFeeLimit, { shouldValidate: true });
+        },
         text: translationString('CUSTOM_FEE_USE_RECOMMENDED'),
     };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix custom fee handling in TX simulation.

## Related Issue

Resolve #27692

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect two files: the CustomFeeEthereum UI component for setting Ethereum-specific fee parameters (gas limit, max fee per gas, max priority fee per gas), and a hook for EVM transaction simulation fees. The CustomFeeEthereum component maps to 121 tests statically but is a broadly imported component; only tests that specifically exercise custom Ethereum fee inputs are relevant. The useEvmTxSimulationFeesForm hook has no static test coverage. Testing should focus on the 4 medium-priority tests that directly set and verify custom Ethereum gas fees in send, sell, and swap flows.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/components/tx-simulation/common/hooks/useEvmTxSimulationFeesForm.ts`
- `packages/suite/src/components/wallet/Fees/CollapsibleFees/CustomFee/CustomFeeEthereum.tsx`

</details>

**Recommended tests (7)**

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/trading/sell-ethereum.test.ts` — This test exercises Ethereum sell flow with custom gas fees (gas limit, max fee per gas, max priority fee per gas), which directly relates to the CustomFeeEthereum component change. The test sets custom Ethereum fees and verifies they display correctly in the confirmation prompt.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — This test specifically sets custom Ethereum fee parameters (gas limit, max fee per gas, max priority fee per gas) during a swap flow and verifies they are correctly displayed. It directly exercises the CustomFeeEthereum component's fee input functionality.
- `suite/e2e/tests/wallet/send-base.test.ts` — This test sets custom Ethereum fees (gas limit, max fee per gas, max priority fee per gas) when sending on the Base network (EVM chain) and verifies the fee details in the device prompt. It directly exercises the CustomFeeEthereum component.
- `suite/e2e/tests/wallet/send-eth.test.ts` — This test fills in a send form with custom Ethereum gas fees and verifies the gas limit, max fee per gas, and max priority fee per gas are correctly displayed. It directly exercises the CustomFeeEthereum component's inputs.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/staking/staking-form.test.ts` — The staking form test navigates to ETH staking and validates input amounts. The useEvmTxSimulationFeesForm hook is used in EVM transaction simulation context which could be relevant to the staking fee calculation flow, though the connection is indirect.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — This test sets custom fee rates for Bitcoin sell transactions and exercises fee-related inputs. While primarily BTC-focused, it also tests SOL sell inputs and exercises the fees component infrastructure that CustomFeeEthereum is part of.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — This test exercises custom fee settings during a swap flow. While it targets BTC fees rather than Ethereum fees, it tests the broader fee component infrastructure that CustomFeeEthereum belongs to, and changes to the fee component hierarchy could affect it.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/components/tx-simulation/common/hooks/useEvmTxSimulationFeesForm.ts`

_Updated: 2026-05-14T09:19:57.553Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/yield-custom-fee&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/yield-custom-fee&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/yield-custom-fee/web/](https://dev.suite.sldev.cz/suite-web/fix/yield-custom-fee/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-14T09:24:45.036Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->