### PR TITLE
docs(connect-examples): fix webextension double opening

### DIFF
--- a/packages/connect-examples/webextension/README.md
+++ b/packages/connect-examples/webextension/README.md
@@ -1,0 +1,40 @@
+# Trezor Connect – Web Extension Example (MV3)
+
+A minimal Chrome extension (Manifest V3) showing how to integrate `@trezor/connect-webextension` using a service worker and a managed tab.
+
+## Build
+
+From the monorepo root, install dependencies first if you haven't already:
+
+```sh
+yarn
+```
+
+Then build the extension:
+
+```sh
+yarn workspace @trezor/webextension-mv3-sw-ts build
+```
+
+The output is written to `packages/connect-examples/webextension/build/`.
+
+### Build against a local Suite instance
+
+By default the extension connects to the production Trezor Suite. To point it at a locally running Suite (e.g. `http://localhost:8000`) pass the `SUITE_WEB_URL` environment variable:
+
+```sh
+SUITE_WEB_URL=http://localhost:8000 yarn workspace @trezor/webextension-mv3-sw-ts build
+```
+
+Start Suite locally in a separate terminal before using the extension:
+
+```sh
+yarn suite:dev   # serves Suite at http://localhost:8000
+```
+
+## Load the extension in Chrome
+
+1. Open `chrome://extensions`.
+2. Enable **Developer mode** (toggle in the top-right corner).
+3. Click **Load unpacked** and select the `build/` folder.
+4. Click the extension icon in the toolbar to open the popup, then press **Connect manager** to open the manager tab.

--- a/packages/connect-examples/webextension/src/connect-manager.html
+++ b/packages/connect-examples/webextension/src/connect-manager.html
@@ -9,6 +9,5 @@
         <button id="get-features" data-testid="get-features">Get features</button>
         <button id="get-address" data-testid="get-address">Get Address</button>
         <div id="result"></div>
-        <script src="./connect-manager.js" type="module"></script>
     </body>
 </html>

--- a/packages/connect-examples/webextension/src/manifest.json
+++ b/packages/connect-examples/webextension/src/manifest.json
@@ -8,5 +8,9 @@
     "background": {
         "service_worker": "service-worker.js"
     },
-    "host_permissions": ["http://*/*", "https://*/*"]
+    "host_permissions": ["http://*/*", "https://*/*"],
+    "externally_connectable": {
+        "ids": [],
+        "matches": ["https://*.trezor.io/*", "http://localhost/*", "https://*.suite.sldev.cz/*"]
+    }
 }

--- a/packages/connect-examples/webextension/src/popup.html
+++ b/packages/connect-examples/webextension/src/popup.html
@@ -7,6 +7,5 @@
     </head>
     <body>
         <button id="tab">Connect manager</button>
-        <script src="./popup.js" type="module"></script>
     </body>
 </html>

--- a/packages/connect-examples/webextension/webpack.config.js
+++ b/packages/connect-examples/webextension/webpack.config.js
@@ -1,6 +1,7 @@
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const path = require('path');
+const webpack = require('webpack');
 
 module.exports = {
     entry: {
@@ -47,6 +48,11 @@ module.exports = {
         }),
         new CopyWebpackPlugin({
             patterns: [{ from: 'src/manifest.json', to: 'manifest.json' }],
+        }),
+        new webpack.DefinePlugin({
+            // Override the Suite web URL hosting connect-popup.
+            // Example: SUITE_WEB_URL=http://localhost:8000 yarn build
+            __SUITE_WEB_URL__: JSON.stringify(process.env.SUITE_WEB_URL || ''),
         }),
     ],
     mode: process.env.NODE_ENV || 'development',


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

The example webextension was opening 2 tabs when the button in popup was cliked, that was because the popup.js file was defined 2 times, once in the static html file and other added by webpack

Also adding __SUITE_WEB_URL__ to webpack so it can be built using custom suite

## Notes for QA
Test connect example webextension. Before it was adding 2 tabs when clicking on the button in the webextension popup now it should correctly just open one.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/connect-example-webextension-docs/web/](https://dev.suite.sldev.cz/suite-web/connect-example-webextension-docs/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=connect-example-webextension-docs&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-14T09:42:54.829Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->