### PR TITLE
chore: trivial `any` removals using existing local types

### DIFF
--- a/packages/blockchain-link-types/src/blockfrost.ts
+++ b/packages/blockchain-link-types/src/blockfrost.ts
@@ -194,7 +194,7 @@ export interface ParseAssetResult {
 
 export interface AddressNotification {
     address: string;
-    tx: any;
+    tx: BlockfrostTransaction;
 }
 
 export interface ServerInfo {

--- a/packages/utils/src/getMutex.ts
+++ b/packages/utils/src/getMutex.ts
@@ -21,9 +21,9 @@
  */
 export const getMutex = () => {
     const DEFAULT_ID = Symbol();
-    const locks: Record<keyof any, Promise<void>> = {};
+    const locks: Record<PropertyKey, Promise<void>> = {};
 
-    return async (lockId: keyof any = DEFAULT_ID) => {
+    return async (lockId: PropertyKey = DEFAULT_ID) => {
         while (locks[lockId]) {
             await locks[lockId];
         }

--- a/packages/utils/src/getSynchronize.ts
+++ b/packages/utils/src/getSynchronize.ts
@@ -18,7 +18,10 @@ import { getMutex } from './getMutex';
 export const getSynchronize = (mutex?: ReturnType<typeof getMutex>) => {
     const lock = mutex ?? getMutex();
 
-    return <T>(action: () => T, lockId?: keyof any): T extends Promise<unknown> ? T : Promise<T> =>
+    return <T>(
+        action: () => T,
+        lockId?: PropertyKey,
+    ): T extends Promise<unknown> ? T : Promise<T> =>
         lock(lockId).then(unlock => Promise.resolve().then(action).finally(unlock)) as any;
 };
 

--- a/suite-common/delegated-identity-key/src/delegatedIdentityKeyCompositionRoot.ts
+++ b/suite-common/delegated-identity-key/src/delegatedIdentityKeyCompositionRoot.ts
@@ -1,7 +1,7 @@
 import { type Dispatch } from '@reduxjs/toolkit';
 
 import { toGetter } from '@suite-common/dependency-injection';
-import { selectDeviceDelegatedIdentityKey } from '@suite-common/device';
+import { type DeviceRootState, selectDeviceDelegatedIdentityKey } from '@suite-common/device';
 import { type PlatformEncryptionDep } from '@suite-common/platform-encryption';
 
 import { createEnsureDelegatedIdentityKey } from './ensureDelegatedIdentityKey';
@@ -14,7 +14,7 @@ import { createSaveDelegatedIdentityKey } from './saveDelegatedIdentityKey';
 
 export type DelegatedIdentityKeyCompositionRootDeps = {
     dispatch: Dispatch;
-    getState: () => any;
+    getState: () => DeviceRootState;
     trezorConnect: RetrieveDelegatedIdentityKeyFromDeviceDeps['trezorConnect'];
 } & PlatformEncryptionDep;
 

--- a/suite-common/fiat-services/src/coingecko.ts
+++ b/suite-common/fiat-services/src/coingecko.ts
@@ -233,7 +233,7 @@ export const fetchLastWeekRates = async (
         const url = `${coinUrl}/${urlEndpoint}?${urlParams}`;
         const data = await fetchCoinGecko(url);
         if (data) {
-            const tickers = data.prices?.map((d: any) => ({
+            const tickers = data.prices?.map((d: [number, number]) => ({
                 ts: Math.floor(d[0] / 1000),
                 rates: { [fiatCurrencyCode]: d[1] },
             }));

--- a/suite-common/metadata-types/src/metadataTypes.ts
+++ b/suite-common/metadata-types/src/metadataTypes.ts
@@ -126,7 +126,7 @@ export abstract class AbstractMetadataProvider {
     /**
      * Upload metadata content in cloud provider for given filename and content
      */
-    abstract setFileContent(file: string, content: any): Result<void>;
+    abstract setFileContent(file: string, content: Buffer): Result<void>;
     /**
      * Get a list of metadata file names if any
      */

--- a/suite-common/suite-rbf-labels-migrations/src/createMigrateSuiteSyncLabelsForRbfTransaction.ts
+++ b/suite-common/suite-rbf-labels-migrations/src/createMigrateSuiteSyncLabelsForRbfTransaction.ts
@@ -1,3 +1,5 @@
+import { type Dispatch } from '@reduxjs/toolkit';
+
 import {
     type DeleteLabelsForSuiteSync,
     type DeleteLabelsForSuiteSyncDep,
@@ -103,7 +105,7 @@ const moveLabelsForSuiteSyncRbf =
     };
 
 export type MigrateSuiteSyncLabelsForRbfTransactionDeps = {
-    dispatch: (args: any) => void;
+    dispatch: Dispatch;
 } & GetOutputsDep &
     SetLabelsForSuiteSyncDep &
     DeleteLabelsForSuiteSyncDep;

--- a/suite-common/suite-rbf-labels-migrations/src/createMigrateSuiteSyncLabelsForRbfTransactionCompositionRoot.ts
+++ b/suite-common/suite-rbf-labels-migrations/src/createMigrateSuiteSyncLabelsForRbfTransactionCompositionRoot.ts
@@ -1,7 +1,10 @@
 import { type Dispatch } from '@reduxjs/toolkit';
 
 import { toGetter } from '@suite-common/dependency-injection';
-import { selectSuiteSyncOutputLabelsByAccount } from '@suite-common/suite-sync';
+import {
+    type SuiteSyncDataRootState,
+    selectSuiteSyncOutputLabelsByAccount,
+} from '@suite-common/suite-sync';
 import { type UpdateOutputLabelDep } from '@suite-common/suite-sync-types';
 
 import {
@@ -12,7 +15,7 @@ import {
 
 type MigrateSuiteSyncLabelsForRbfTransactionCompositionRootDeps = {
     dispatch: Dispatch;
-    getState: () => any;
+    getState: () => SuiteSyncDataRootState;
 } & UpdateOutputLabelDep;
 
 export const createMigrateSuiteSyncLabelsForRbfTransactionCompositionRoot = (

--- a/suite-common/suite-sync/src/storage/createEnsureWalletSuiteSyncOn.ts
+++ b/suite-common/suite-sync/src/storage/createEnsureWalletSuiteSyncOn.ts
@@ -1,4 +1,8 @@
-import { isTrezorDeviceWithState, selectDeviceByStaticSessionId } from '@suite-common/device';
+import {
+    type DeviceRootState,
+    isTrezorDeviceWithState,
+    selectDeviceByStaticSessionId,
+} from '@suite-common/device';
 import {
     type EnsureSubscribedStorageDep,
     type EnsureSuiteSyncKeysDep,
@@ -10,7 +14,7 @@ import { err } from '@trezor/type-utils';
 import { isFwUpgradeNeededForSuiteSync, isSuiteSyncSupportedByDevice } from '../suiteSyncUtils';
 
 export type EnsureWalletSuiteSyncOnDeps = {
-    getState: () => any;
+    getState: () => DeviceRootState;
 } & EnsureSubscribedStorageDep &
     EnsureSuiteSyncKeysDep &
     SubscriptionStorageDep;

--- a/suite-common/suite-types/src/index.ts
+++ b/suite-common/suite-types/src/index.ts
@@ -16,7 +16,6 @@ export type * from './sign';
 export type * from './thp';
 export * from './languages';
 
-export type Selector<TReturnValue> = (state: any) => TReturnValue;
 export type SuiteCompatibleAction<TPayload> = (
     payload: TPayload,
 ) => AnyAction | ActionCreatorWithPayload<TPayload> | ActionCreatorWithoutPayload;

--- a/suite-common/test-utils/src/extraDependenciesCommonMock.ts
+++ b/suite-common/test-utils/src/extraDependenciesCommonMock.ts
@@ -90,7 +90,7 @@ export const extraDependenciesCommonMock: ExtraDependencies = {
                 `Save data: ${data} into file: ${fileName}. Implementation on phone not ready.`,
             ),
         connectInitSettings,
-        migrateSuiteSyncLabelsForRbfTransaction: (_: any) => Promise.resolve([[], []]),
+        migrateSuiteSyncLabelsForRbfTransaction: () => Promise.resolve([[], []]),
     },
     selectors: {
         selectTokenDefinitionsEnabledNetworks: notImplementedSelector(

--- a/suite-common/trading/src/invityAPI.ts
+++ b/suite-common/trading/src/invityAPI.ts
@@ -142,7 +142,7 @@ class InvityAPI {
         method = 'POST',
         apiHeaderValue?: string,
         signal?: SignalType,
-    ): any {
+    ): RequestInit {
         const apiHeader = this.getOptionAPIHeader();
 
         return {

--- a/suite-common/trading/src/thunks/exchange/__tests__/sendTransactionThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/sendTransactionThunk.test.ts
@@ -171,7 +171,7 @@ describe('sendTransactionThunk', () => {
             createThunk(
                 '@trading-exchange/thunk/sendDexTransactionThunk',
                 (_, { rejectWithValue }) => rejectWithValue(rejectValue),
-            ) as any,
+            ),
         );
 
         const result = await store.dispatch(

--- a/suite-common/trading/src/thunks/exchange/signDataAndConfirmThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/signDataAndConfirmThunk.ts
@@ -1,3 +1,5 @@
+import { type ExchangeTrade } from 'invity-api';
+
 import { createThunk } from '@suite-common/redux-utils';
 import { type TrezorDevice } from '@suite-common/suite-types';
 import { type Account } from '@suite-common/wallet-types';
@@ -23,7 +25,7 @@ export type SignDataAndConfirmThunkProps = {
 
     returnUrl: string;
     triggerAnalyticsTradeConfirmation: () => void;
-    processResponseData: (response: any) => void;
+    processResponseData: (response: ExchangeTrade) => void;
     nextStep: () => void;
 };
 

--- a/suite-common/wallet-core/src/send/sendFormBitcoinThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormBitcoinThunks.ts
@@ -20,6 +20,7 @@ import {
     restoreOrigOutputsOrder,
 } from '@suite-common/wallet-utils';
 import TrezorConnect, {
+    type ComposeUtxo,
     DEFAULT_SORTING_STRATEGY,
     type FeeLevel,
     type Params,
@@ -102,10 +103,10 @@ export const composeBitcoinTransactionFeeLevelsThunk = createThunk<
         // unspendable utxos are defined in `useSendForm` hook
         const utxo = formState.isCoinControlEnabled
             ? formState.selectedUtxos?.map(u => ({ ...u, required: true }))
-            : account.utxo.filter(u => {
+            : account.utxo.filter((u: ComposeUtxo) => {
                   const outpoint = getUtxoOutpoint(u);
 
-                  return (u as any).required || (!excludedUtxos?.[outpoint] && !prison?.[outpoint]);
+                  return u.required || (!excludedUtxos?.[outpoint] && !prison?.[outpoint]);
               });
 
         // certain change addresses might be temporary blocked by coinjoin process


### PR DESCRIPTION
Cherry-picked subset of #27649 containing only the **trivial-to-review** commits — each one swaps a single `any` for a type that already exists locally (in the same package, sibling helper, or DOM/RTK built-in). No new type definitions, no generic refactors, no public-API changes that need cross-package validation.

## What's in this batch

14 commits from the gnhf series:

- **gnhf 8** — drop `(u as any).required`, use `ComposeUtxo` (already declares `required?: boolean`)
- **gnhf 23** — `keyof any → PropertyKey` in `@trezor/utils` getMutex/getSynchronize
- **gnhf 86** — `dispatch: (args: any) → Dispatch` from `@reduxjs/toolkit`
- **gnhf 90** — `tx: any → BlockfrostTransaction` (canonical pattern from blockbook sibling)
- **gnhf 94** — `content: any → Buffer` (matches all 4 implementations + sole caller)
- **gnhf 103** — `processResponseData: (response: any) → ExchangeTrade` (matches sibling exchange thunks)
- **gnhf 110** — `(d: any) → [number, number]` (tuple already used by sibling helper)
- **gnhf 111** — `options(): any → RequestInit` (DOM type expected by `fetch`)
- **gnhf 113** — drop unused `(_: any)` mock param; parent contextual type covers shape
- **gnhf 126, 129, 132** — `getState: () => any → DeviceRootState / SuiteSyncDataRootState` (already-imported root states)
- **gnhf 142** — drop unused dead `Selector` export from `@suite-common/suite-types`
- **gnhf 157** — drop unnecessary `as any` on `createThunk(...)` in test

## Relation to other PRs

Split from #27649 to make review easier. Remaining commits in #27649 are higher-effort tiers (medium production tightening, generic refactors, bulk test mocks).

## Test plan

- [ ] CI green on changed packages
- [ ] No type regressions in any consuming package

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=gnhf/trivial-anys&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=gnhf/trivial-anys&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=gnhf/trivial-anys&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-14T10:12:04.321Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-14T10:10:39.074Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/gnhf/trivial-anys/web/](https://dev.suite.sldev.cz/suite-web/gnhf/trivial-anys/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->