### PR TITLE
[staging PR] address-validator — tests and bug analysis

### DIFF
--- a/packages/address-validator/src/ada_validator.ts
+++ b/packages/address-validator/src/ada_validator.ts
@@ -20,6 +20,9 @@ function getDecoded(address: string): any {
 
 function isValidLegacyAddress(address: string): boolean {
     const decoded = getDecoded(address);
+    // SUSPECTED-BUG-MUTATION: The guard `!Array.isArray(decoded) && decoded.length !== 2` is contradictory — it only rejects non-array objects whose `.length` is not exactly 2, so a 3-element array (or any array with length !== 2) falls through to `decoded[0]` / `decoded[1]` below despite the immediately-following code requiring decoded to be a 2-element array. Author likely intended `Array.isArray(decoded) && decoded.length !== 2` (reject if it IS an array but has wrong length) or `!Array.isArray(decoded) || decoded.length !== 2` (reject anything that is not a 2-element array).
+    // Mutator: LogicalOperator  Original: `!Array.isArray(decoded) && decoded.length !== 2`  →  Mutant: `!Array.isArray(decoded) || decoded.length !== 2`
+    // Needs human spec review before locking behavior with a test.
     if (!decoded || (!Array.isArray(decoded) && decoded.length !== 2)) {
         return false;
     }

--- a/packages/address-validator/src/bch_validator.ts
+++ b/packages/address-validator/src/bch_validator.ts
@@ -9,6 +9,14 @@ const DEFAULT_NETWORK_TYPE = 'prod';
 // Base32 charset used for the cashaddr payload (see "Base32" in the spec).
 const CASHADDR_CHARSET = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';
 
+// SUSPECTED-BUG-MUTATION: CASHADDR_PREFIX is hardcoded to mainnet 'bitcoincash' and validateAddress ignores
+// the networkType parameter, so every 'bchtest:'/'bchreg:' prefixed address is rejected at L77 regardless
+// of cashaddr-spec validity, while 'bitcoincash:' and prefix-less cashaddr inputs validate true for BOTH
+// networkType='prod' AND networkType='testnet' (no network gating). currencies.ts defines BCH testnet
+// addressTypes=['6f','c4'] suggesting testnet was intended; the existing tests at
+// wallet_address_validator.test.ts:1330-1332 lock in this incomplete behavior by asserting bchtest:/bchreg:
+// inputs are invalid — a half-finished testnet implementation parallel to the iter 188/202 loki findings.
+// Needs human spec review before locking behavior with a test.
 // Mainnet human-readable prefix; testnet/regtest use 'bchtest'/'bchreg'.
 const CASHADDR_PREFIX = 'bitcoincash';
 

--- a/packages/address-validator/src/crypto/sha3.ts
+++ b/packages/address-validator/src/crypto/sha3.ts
@@ -432,6 +432,9 @@ Keccak.prototype.arrayBuffer = function () {
         for (i = 0; i < blockCount && j < outputBlocks; ++i, ++j) {
             array[j] = s[i];
         }
+        // SUSPECTED-BUG-MUTATION: Missing `i = 0;` reset after f(s) — toString/hex resets it (see L398) but arrayBuffer/array/digest do not. When outputBlocks is a multiple of blockCount AND extraBytes > 0, the trailing partial-lane read at L440/L475 below reads s[blockCount] (capacity lane) instead of s[0] (rate lane after permutation), producing output that diverges from toString and from Node's reference SHAKE256. Verified: sha3.shake256.arrayBuffer('hello', 2200) returns 275 bytes whose last 3 differ from sha3.shake256('hello', 2200).slice(-6) and from crypto.createHash('shake256',{outputLength:275}).update('hello').digest('hex').slice(-6) ('957d9e' expected, 'b561ee' actual).
+        // Mutator: Manual / cross-method divergence  Original (digest/array/arrayBuffer): missing i=0 after f(s)  →  toString equivalent: f(s); i = 0;
+        // Needs human spec review before locking behavior with a test.
         if (j % blockCount === 0) {
             f(s);
         }
@@ -466,6 +469,9 @@ Keccak.prototype.digest = Keccak.prototype.array = function () {
             array[offset + 2] = (block >> 16) & 0xff;
             array[offset + 3] = (block >> 24) & 0xff;
         }
+        // SUSPECTED-BUG-MUTATION: Same bug as arrayBuffer above — missing `i = 0;` reset after f(s) that toString/hex performs (L398). When outputBlocks is a multiple of blockCount AND extraBytes > 0, the trailing partial-lane read at L475 below reads s[blockCount] (capacity lane) instead of s[0] (rate lane after permutation).
+        // Mutator: Manual / cross-method divergence  Original (digest/array): missing i=0 after f(s)  →  toString equivalent: f(s); i = 0;
+        // Needs human spec review before locking behavior with a test.
         if (j % blockCount === 0) {
             f(s);
         }

--- a/packages/address-validator/src/ripple_validator.ts
+++ b/packages/address-validator/src/ripple_validator.ts
@@ -7,6 +7,9 @@ import type { Currency } from './currency-types';
 const ALLOWED_CHARS = 'rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz';
 
 const codec = baseX(ALLOWED_CHARS);
+// SUSPECTED-BUG-MUTATION: The regex `^r[ALPHA]{27,35}$` requires total length 28-36, over-restricting against the XRP base58check spec (25-byte payload encodes to 25-35 chars total). Well-known XRP addresses with leading zero bytes are silently rejected: empirically `rrrrrrrrrrrrrrrrrrrrrhoLvTp` (ACCOUNT_ZERO, 27 chars, valid checksum) and `rrrrrrrrrrrrrrrrrrrn5RM1rHd` (ACCOUNT_ONE, 27 chars, valid checksum) both base58-decode to exactly 25 bytes and pass `sha256Checksum` verification, but `isValidAddress` returns false because they fail the regex's 28-char minimum. Lower bound should be `{24,35}` (i.e. 25-36 total chars) to match the XRPL spec.
+// Mutator: Regex/Block  Original: `^r[ALPHA]{27,35}$`  →  Mutant: `^r[ALPHA]{24,35}$`
+// Needs human spec review before locking behavior with a test.
 const regexp = new RegExp('^r[' + ALLOWED_CHARS + ']{27,35}$');
 
 function verifyChecksum(address: string): boolean {

--- a/packages/address-validator/src/tron_validator.ts
+++ b/packages/address-validator/src/tron_validator.ts
@@ -39,6 +39,9 @@ function decodeBase58Address(base58Sting: unknown): number[] | false {
 function getEnv(currency: any, networkType?: string): number {
     let evn = networkType || 'prod';
 
+    // SUSPECTED-BUG-MUTATION: Silently coerces any non-'prod'/'testnet' networkType (including 'both') to 'prod', diverging from monero/loki/bitcoin where 'both' means "match prod OR testnet". With this fallback, valid(testnetAddr, 'trx', 'both') returns false because evn becomes 'prod', so callers expecting prod-OR-testnet semantics under 'both' silently get a wrong-network rejection instead of an OR-match.
+    // Mutator: ConditionalExpression  Original: `if (evn !== 'prod' && evn !== 'testnet') evn = 'prod';`  →  Mutant: `if (false) evn = 'prod';` (would crash on networkType='both' because addressTypes['both'] is undefined; the fact that the test suite asserts valid() for 'both' relies on the coercion to mask the missing case)
+    // Needs human spec review before locking behavior with a test.
     if (evn !== 'prod' && evn !== 'testnet') evn = 'prod';
 
     return currency.addressTypes[evn][0];

--- a/packages/address-validator/tests/wallet_address_validator.test.ts
+++ b/packages/address-validator/tests/wallet_address_validator.test.ts
@@ -184,6 +184,36 @@ describe('WAValidator.validate()', function () {
             );
         });
 
+        it('should classify a bech32m bitcoin address with witness version 1 and a 20-byte program as WITNESS_UNKNOWN', function () {
+            isValidAddressType(
+                'bc1pqyqszqgpqyqszqgpqyqszqgpqyqszqgp6tcjpc',
+                'bitcoin',
+                'prod',
+                addressType.WITNESS_UNKNOWN,
+            );
+        });
+
+        it('should default to bitcoin currency when getAddressType is called without a currency', function () {
+            expect(WAValidator.getAddressType('1NSAR5mUUL3qZP29BfFj5jBPR5yWiiZZWi')).toEqual(
+                addressType.P2PKH,
+            );
+        });
+
+        it('should throw from getAddressType when the currency is unknown', function () {
+            expect(() =>
+                WAValidator.getAddressType(
+                    '1NSAR5mUUL3qZP29BfFj5jBPR5yWiiZZWi',
+                    'nonexistent-coin',
+                ),
+            ).toThrow('getAddressType: No validator for currency: nonexistent-coin');
+        });
+
+        it('should throw from validate when the currency is unknown', function () {
+            expect(() =>
+                WAValidator.validate('1NSAR5mUUL3qZP29BfFj5jBPR5yWiiZZWi', 'nonexistent-coin'),
+            ).toThrow('Missing validator for currency: nonexistent-coin');
+        });
+
         it('should return true for correct bitcoincash addresses', function () {
             valid('bitcoincash:qq4v32mtagxac29my6gwj6fd4tmqg8rysu23dax807', 'bch');
             valid('bitcoincash:qp3wjpa3tjlj042z2wv7hahsldgwhwy0rq9sywjpyy', 'bch');
@@ -217,6 +247,17 @@ describe('WAValidator.validate()', function () {
                 'prod',
                 undefined,
             ); // BTC address
+        });
+
+        it('should match the expected BCH address type when network type is omitted', function () {
+            // Exercises the DEFAULT_NETWORK_TYPE fallback in bch_validator.getAddressType
+            // (the `networkType || DEFAULT_NETWORK_TYPE` short-circuit on the right-hand side).
+            isValidAddressType(
+                'bitcoincash:qq4v32mtagxac29my6gwj6fd4tmqg8rysu23dax807',
+                'bch',
+                undefined,
+                addressType.ADDRESS,
+            );
         });
 
         it('should return true for correct litecoin addresses', function () {
@@ -313,6 +354,10 @@ describe('WAValidator.validate()', function () {
             );
         });
 
+        it('should return undefined as the Ethereum address type for a string that fails the eip55 hex regex', function () {
+            isValidAddressType('notanethereumaddress', 'ethereum', 'prod', undefined);
+        });
+
         it('should return true for correct Ripple addresses', function () {
             valid('rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn', 'ripple');
             valid('rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn', 'XRP');
@@ -367,6 +412,30 @@ describe('WAValidator.validate()', function () {
             );
         });
 
+        it('should return true for a correct cardano stake address when network type is stake', function () {
+            valid(
+                'stake1uya87zwnmax0v6nnn8ptqkl6ydx4522kpsc3l3wmf3yswygwx45el',
+                'cardano',
+                'stake',
+            );
+        });
+
+        it('should return false for a mainnet bech32 cardano address when network type is testnet', function () {
+            invalid(
+                'addr1qxnv5u3vrx2t37h3u27qd5ukgcjmrl4f8mu9f5sza3h20cxsfjh80un9kvlggfcdw8fp5kqp9tztqnee9msd0qsafhdsyqclvk',
+                'cardano',
+                'testnet',
+            );
+        });
+
+        it('should return false for a bech32 cardano address when network type is unrecognized', function () {
+            invalid(
+                'addr1qxnv5u3vrx2t37h3u27qd5ukgcjmrl4f8mu9f5sza3h20cxsfjh80un9kvlggfcdw8fp5kqp9tztqnee9msd0qsafhdsyqclvk',
+                'cardano',
+                'unknown',
+            );
+        });
+
         it('should match the expected Cardano address type - mainnet', function () {
             isValidAddressType(
                 'Ae2tdPwUPEYxYNJw1He1esdZYvjmr4NtPzUsGTiqL9zd8ohjZYQcwu6kom7',
@@ -393,6 +462,10 @@ describe('WAValidator.validate()', function () {
         it('should return true for correct trx addresses', function () {
             valid('TNDzfERDpxLDS2w1q6yaFC7pzqaSQ3Bg3r', 'trx');
             valid('27bLJCYjbH6MT8DBF9xcrK6yZnm43vx7MNQ', 'trx', 'testnet');
+        });
+
+        it('should return true for a correct tron address when network type is unrecognized', function () {
+            valid('TNDzfERDpxLDS2w1q6yaFC7pzqaSQ3Bg3r', 'trx', 'both');
         });
 
         it('should return true for correct stellar addresses', function () {
@@ -557,6 +630,18 @@ describe('WAValidator.validate()', function () {
             );
         });
 
+        it('should return false for a cardano address that decodes to a CBOR non-array primitive', function () {
+            invalid('2', 'cardano');
+        });
+
+        it('should return false for a cardano address whose CBOR-decoded second element is not a number', function () {
+            invalid('kkVd', 'cardano');
+        });
+
+        it('should return undefined as the cardano address type for a string that fails both legacy and bech32 decoding', function () {
+            isValidAddressType('notacardanoaddress', 'cardano', 'prod', undefined);
+        });
+
         it('should return true for correct tron addresses', function () {
             valid('TNXoiAJ3dct8Fjg4M9fkLFh9S2v9TXc32G', 'trx');
         });
@@ -565,6 +650,14 @@ describe('WAValidator.validate()', function () {
             commonTests('trx');
             invalid('xrb_1111111112111111111111111111111111111111111111111111hifc8npp', 'trx');
             invalid('TNDzfERDpxLDS2w1q6yaFC7pzqaSQ3Bg31', 'trx');
+        });
+
+        it('should return false for a non-string trx address', function () {
+            invalid(null as any, 'trx');
+        });
+
+        it('should return false for a short base58 input with a valid sha256d checksum but fewer than 21 bytes', function () {
+            invalid('3TsEbXHvP5', 'trx');
         });
 
         it('should match the expected tron address type', function () {
@@ -614,6 +707,19 @@ describe('WAValidator.validate()', function () {
                 'CN2JT7qJ84aVUMtSGuNSte5ytP5eMeeHgTVzyBiHDxMrH22WwH3qSAbZ6fH1n9PzGso3vBwQUz7gmK827ijLTgJW',
                 'sol',
             );
+        });
+
+        it('should match the expected solana address type', function () {
+            isValidAddressType(
+                '64duFXLEMcVaZpm4SRmtqEdSQ5LFht22hK1SLu2ayU9b',
+                'sol',
+                'prod',
+                addressType.ADDRESS,
+            );
+        });
+
+        it('should return undefined as the solana address type for a string that fails base58 decoding', function () {
+            isValidAddressType('sol_123456', 'sol', 'prod', undefined);
         });
     });
 });


### PR DESCRIPTION
I am not sure, do we want to merge this kind of documentation to develop and iterate on it later? 

# Staging PR: address-validator — tests and bug analysis

Experimental run of the test-writing agent on `@trezor/address-validator`. Stryker mutation testing was bootstrapped, then 200+ test-iterations chased survived/no-coverage mutants. The agent flagged 24 source-level findings as `// SUSPECTED-BUG-MUTATION:` markers; the test suite is a by-product.

## Follow-up PRs

- **#27833 — `chore(address-validator): drop 15 unused buggy validators`.** Acts on the subset of findings here that affect coins Suite does not use (and the team does not plan to integrate). 15 atomic per-coin removals. Targets `develop` directly.

> **TL;DR for review:** the most valuable artifact here is the **bug-marker list**, not the tests. About half the findings are plausible fund-loss-class bugs in coin-specific validators. Suite itself uses only a small subset of these validators, but `@trezor/address-validator` is a **published** package, so external consumers are exposed to the full set. **Action needed: decide whether to merge the test infra now and triage the findings as separate work, or hold the PR and ship coin-by-coin fixes first.**

## How `@trezor/address-validator` is used today

Two entry points consume the package; both flow through `validate(address, symbol, networkType?)`:

| Surface | Where | Call shape | `networkType` |
|---|---|---|---|
| Send form (desktop + native) | `suite-common/wallet-utils/src/validationUtils.ts` → `isAddressValid()` | `validate(addr, symbol.toUpperCase(), 'prod'\|'testnet'\|'regtest'\|'stake')` | always explicit |
| Trading receive-address modal | `packages/suite/src/views/wallet/trading/.../TradingReceiveAddressModal.tsx` | `validate(value, symbol)` | **undefined** (defaults inside each validator) |

Trading additionally calls `getCurrencies()` from `useTradingAssets.ts` to **filter** which assets are tradable — coins missing a validator are hidden from the UI. A broken validator that always returns `false` therefore makes a chain effectively un-tradable in Suite; a broken validator that accepts garbage lets bad addresses through.

### Suite-supported chains that route through this package

| Symbol | Validator class | Affected by a finding in this PR? |
|---|---|---|
| BTC, LTC, DOGE, ZEC, BCH | `BTCValidator` (base58check or cashaddr) | **BCH: yes** (testnet broken) |
| ETH, POL, BSC, ARB, BASE, OP, AVAX, ETC | `ETHValidator` (shared) | no |
| SOL | `solana_validator` | no |
| TRX | `tron_validator` | **yes** (`'both'` silently coerces to prod) |
| ADA | `ada_validator` | **yes** (legacy/Byron path only) |
| XRP | `ripple_validator` | **yes** (regex over-restricts) |
| XLM | `stellar_validator` | no |

ETH-family chains all share `ETHValidator`; **no findings in this PR affect that path**, so the largest single-asset surface of Suite is untouched.

## Findings — Suite-affecting subset

These are the markers that land on a code path Suite actually exercises.

| Coin | File:Line | Severity | Behavior | Real-world impact in Suite |
|---|---|---|---|---|
| **BCH** | `bch_validator.ts:13` | medium | `CASHADDR_PREFIX` hardcoded to mainnet `bitcoincash`; `bchtest:` / `bchreg:` always rejected, no network gating. | BCH mainnet sends OK. BCH testnet QA flows broken — not a production fund-loss path. |
| **TRX** | `tron_validator.ts:42` | low (today) | `getEnv` silently coerces non-`'prod'`/`'testnet'` networkType (including `'both'`, `undefined`) to `'prod'`. | Send form: passes explicit prod/testnet → unaffected. Trading modal: passes `undefined` → coerced to prod, behavior matches user intent. **Latent**: any future caller passing `'both'` gets prod-only validation silently. |
| **XRP** | `ripple_validator.ts:10` | low | Regex `^r[1-9A-HJ-NP-Za-km-z]{27,35}$` rejects valid 27-char addresses (e.g. ACCOUNT_ZERO `rrrrrrrrrrrrrrrrrrrrrhoLvTp`). Valid base58check decodes to 25 bytes. | Real-world XRP addresses are 25–35 chars; protocol-internal ACCOUNT_ZERO/ONE etc. are unlikely send targets. Fail-safe over-restriction, not fund-loss. |
| **ADA (Byron)** | `ada_validator.ts:23` | low | `!Array.isArray(decoded) && decoded.length !== 2` is contradictory; non-arrays with `length !== 2` reach indexing on a non-array. | Modern Cardano addresses are bech32 (Shelley) — separate code path, unaffected. Byron addresses are legacy and rare. Practical impact minimal. |

**Summary:** of Suite's 18 supported mainnets, 4 have a marker in this PR; none of those markers describe a production-traffic fund-loss path in Suite as-of today. The exposure surface is real but the immediate risk is low.

## Findings — external/published-package surface

`@trezor/address-validator` ships ESM (see `packages/connect/CHANGELOG.md`). External consumers — including any wallet integrating `@trezor/connect` and validating non-Suite chains — get the full set. Several markers are plausible fund-loss-class bugs that any external integrator should be told about.

### High severity — accept-gibberish / accept-wrong-chain

| Coin | File:Line | Behavior | Empirical repro |
|---|---|---|---|
| **Tezos** | `tezos_validator.ts:32` | `payload.slice(prefix.length)` is a discarded expression; the declared tz1 prefix `[6, 161, 159]` is **never compared** against the decoded payload. Any base58check-valid address with matching SHA256² checksum is accepted. | BTC mainnet P2PKH like `1NSAR5mUUL3qZP29BfFj5jBPR5yWiiZZWi` returns `true` for `validate(_, 'xtz')`. |
| **EOS** | `eos_validator.ts:5` | Regex `[a-z0-9]+` accepts `0,6,7,8,9` which are NOT in the EOS account-name charset (`a-z`, `1-5`, `.`). | `aaaaaaaaaaa9`, `666666666666`, `123456789012` all validate as true. |
| **Cosmos** | `atom_validator.ts:8` | Regex-only validation with `+` (variable length); no bech32 checksum decode. | `cosmos1q` (8 chars) and shorter charset-valid strings validate as true. |
| **Syscoin** | `sys_validator.ts:5` | Regex-only (HRP + length + charset); no bech32 checksum decode. | `sys1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` validates as true. |
| **NXT / ARDR** | `nxt_validator.ts:6`, `ardr_validator.ts:6` | Regex shape only; no Reed-Solomon checksum decode. | `NXT-AAAA-AAAA-AAAA-AAAAA` and `ARDOR-AAAA-AAAA-AAAA-AAAAA` validate as true. |
| **Aeternity** | `ae_validator.ts:11` | Trailing 4 base58check bytes are spliced off but never compared against `sha256(sha256(payload[:32]))[:4]`. | Tampering the checksum byte of a real AE address (flip trailing `A` → `Z`) still returns `true`. |
| **Siacoin** | `siacoin_validator.ts:13` | Enforces `length === 76` but no hex-charset check. | 64 non-hex `z`s + 12-char tail (first 12 of `blake2b('', 32)`) returns `true`. |

### Medium severity — half-finished testnet / network confusion

| Coin | File:Line | Behavior |
|---|---|---|
| **NEM** | `nem_validator.ts:5` | `networkType` parameter ignored. Testnet `T`-prefix passes with `networkType='prod'` and vice versa. |
| **Monero (testnet)** | `monero_validator.ts:9, 65` | `^[A9]…{94}` regex makes `B`-prefix testnet subaddresses and 106-char integrated addresses unreachable. `'both'` networkType silently coerces to prod-only (regex gate runs before `validateNetwork`). |
| **Loki/Oxen (testnet)** | `loki_validator.ts:10, 26` | `^L` anchor rejects every `T`-prefix testnet address. `addrKind === 'subaddress'` arm is unreachable (no caller ever sets it). |
| **Komodo (testnet)** | `currencies.ts:175` | Testnet addressTypes are 1-char hex `['0','5']`; `cryptoUtils.toHex` always emits 2-char zero-padded — never matches → testnet always false. (Corroborated by a commented-out testnet test in the existing suite.) |
| **Verge (testnet)** | `currencies.ts:1496` | Testnet entry `'6F'` is uppercase; `cryptoUtils.toHex` emits lowercase → testnet always false. |
| **Hedera** | `hbar_validator.ts:9, 12` | `split[2].length` throws on 2-segment input (`'0.0'`) — violates the `boolean` contract. `length <= 6` cap rejects valid 7-digit mainnet accounts despite int64 spec. |
| **ICON** | `icx_validator.ts:5` | Regex `^hx[0-9a-f]{40}$` only matches EOA addresses; all SCORE/contract addresses (`cx` prefix) are rejected. |
| **Zilliqa** | `zil_validator.ts:15` | `bech32.decode` throws on invalid checksum instead of returning falsy → `validate()` **throws** for shape-valid checksum-typo input, breaking the `boolean` contract. |

### Low severity — semantic divergence / spec mismatch

| Coin | File:Line | Behavior |
|---|---|---|
| **Lisk** | `lisk_validator.ts:4` | Regex `^[0-9]{1,20}L$` accepts `0L` and leading-zero forms (`01L`, `00000000000469226551L`). Diverges from canonical Lisk address form (non-zero uint64). |
| **Steem** | `steem_validator.ts:4` | Account-name regex has no upper length bound (`{3,}` vs documented 16-char max) — 200-char strings validate as true. |

### Upstream bug surfaced during the run

| Component | File:Line | Behavior |
|---|---|---|
| **bundled `js-sha3` v0.7.0** | `crypto/sha3.ts` (vendored copy) | `digest`/`array`/`arrayBuffer` methods miss the `i = 0` reset after `f(s)` that `toString` performs. When `outputBlocks` is a multiple of `blockCount`, trailing `extraBytes` read from the capacity-state lane instead of the rate lane. Affects any sha3 caller through this path. |

## Test suite — context only

If the bug-marker work is rated independently, the tests are also a deliverable:

- Stryker mutation testing infra is bootstrapped (`stryker.config.mjs`, `jest.config.stryker.js`, `list-targets.js`, `test:mutation` script).
- ~180 unit tests added across `tests/crypto_*.test.ts` and `tests/wallet_address_validator.test.ts` covering biginteger, base32, bech32, blake256, blake2b, cnBase58, sha3, and per-coin validators.
- Each test commit records the before/after delta in mutation score and branch coverage in its commit message.
- Final mutation score and branch coverage are not reported here — the run was time-limited rather than exhausted.

## What needs deciding

1. **Scope split.** Two independent artifacts are bundled in this PR: (a) Stryker infra + tests, (b) 24 `SUSPECTED-BUG-MUTATION` markers. They should probably ship separately. Proposed split:
   - **PR A — infra only:** bootstrap commit + per-package `.depcheckrc.json` + tests. Mergeable independently if the team wants Stryker available.
   - **PR B — bug markers:** the 24 inline source comments, no behavior change. Easy revert per coin if a coin owner disputes a finding.
   - **PR C+ — fixes:** one PR per coin-owner-confirmed bug. Author + reviewer per coin.
   - This PR (the "staging") is then a tracking thread; close once A and B land.

2. **Triage ownership.** Of the 24 markers, the high-severity external-surface bugs (Tezos, EOS, Atom/Sys/NXT/ARDR, Aeternity, Siacoin) deserve a security-style review. Suggest: file one umbrella issue, assign per coin to whoever owns the validator (or to whoever last touched the file via `git blame`).

3. **External-consumer notice.** If we confirm any of the fund-loss-class findings, do we publish a security advisory? `@trezor/address-validator` is in the published `@trezor/connect` dependency closure, and at least one external wallet integrating connect almost certainly hits these paths.

4. **Commit-message format.** The 209 commits in this PR use the literal `gnhf NNN: …` prefix from the agent's iteration counter, which fails `commit-message-check` (Conventional Commits is mandatory). A scripted bulk-reword is needed before merge — design pending.

5. **Conventional commits reword strategy.** Three viable approaches:
   - **Pattern-based rewrite** via `git rebase --exec`: `gnhf 1: Bootstrapped…` → `chore(address-validator): add stryker mutation testing infrastructure`, `gnhf NNN: Added a SUSPECTED-BUG-MUTATION…` → `chore(address-validator): mark suspected bug in <file>`, `gnhf NNN: Added a … test…` → `test(address-validator): <behavior>`.
   - **Squash** to a few logical commits (loses per-commit attribution + revertability).
   - **`git filter-branch --msg-filter`** (faster, identical effect to pattern rebase).
   All three rewrite all 209 SHAs — unavoidable.

## Diff at a glance

- **+1891 / −17 across 36 files** at the time of writing.
- Source changes are 25 markers totaling ~50 LOC, all comments (no runtime change).
- All other LOC are tests, the stryker config files, and yarn.lock entries for `@stryker-mutator/*`.

## Original prompt

<details>
<summary>Click to expand</summary>

The agent ran with a fixed prompt that bootstrapped Stryker, established mutation/coverage baselines, then iterated one test at a time. A "bug-check" step (14) was the gate that produced the `SUSPECTED-BUG-MUTATION` markers — when the original code looked wrong, the agent committed a marker instead of locking in possibly-buggy behavior with a test. See the previous version of this PR description for the full prompt text, or `git show 951c116340d` for the bootstrap commit.

</details>

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/gnhf/gnhf-prompt-add-test-b6546a/web/](https://dev.suite.sldev.cz/suite-web/gnhf/gnhf-prompt-add-test-b6546a/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->