### PR TITLE
chore(suite-desktop-core): remove dead code (batch)

### DIFF
--- a/packages/suite-desktop-core/src/libs/processes/BaseProcess.ts
+++ b/packages/suite-desktop-core/src/libs/processes/BaseProcess.ts
@@ -223,16 +223,6 @@ export abstract class BaseProcess {
         });
     }
 
-    /**
-     * Restart the process
-     * @param force Force the restart
-     */
-    async restart() {
-        this.logger.info(this.logTopic, 'Restarting');
-        await this.stop();
-        await this.start();
-    }
-
     private onError(err: Error) {
         this.logger.error(this.logTopic, err.message);
     }

--- a/packages/suite-desktop-core/src/libs/processes/BluetoothProcess.ts
+++ b/packages/suite-desktop-core/src/libs/processes/BluetoothProcess.ts
@@ -27,10 +27,6 @@ export class BluetoothProcess extends BaseProcess {
         return `http://localhost:${this.port}/`;
     }
 
-    getPort() {
-        return this.port;
-    }
-
     async status(): Promise<Status> {
         if (!this.process) {
             return {

--- a/packages/suite-desktop-core/src/libs/processes/TorExternalProcess.ts
+++ b/packages/suite-desktop-core/src/libs/processes/TorExternalProcess.ts
@@ -5,7 +5,6 @@ import { type Status } from './BaseProcess';
 export type TorProcessStatus = Status & { isBootstrapping?: boolean };
 
 export class TorExternalProcess {
-    isStopped = true;
     torController: TorControllerExternal;
     port: number;
     host: string;
@@ -35,12 +34,10 @@ export class TorExternalProcess {
     }
 
     public async start(): Promise<void> {
-        this.isStopped = false;
         await this.torController.waitUntilAlive();
     }
 
     public stop() {
         // We should not stop External Tor Process but ignore it.
-        this.isStopped = true;
     }
 }

--- a/packages/suite-desktop-core/src/libs/screen.ts
+++ b/packages/suite-desktop-core/src/libs/screen.ts
@@ -2,9 +2,9 @@ import { screen } from 'electron';
 
 export const MIN_WIDTH = 420;
 export const MIN_HEIGHT = 420;
-export const MAX_WIDTH = 1920;
-export const MAX_HEIGHT = 1080;
-export const WINDOW_SIZE_FACTOR = 0.8;
+const MAX_WIDTH = 1920;
+const MAX_HEIGHT = 1080;
+const WINDOW_SIZE_FACTOR = 0.8;
 
 export const getInitialWindowSize = () => {
     const { bounds } = screen.getPrimaryDisplay();

--- a/packages/suite-desktop-core/src/libs/thread-proxy.ts
+++ b/packages/suite-desktop-core/src/libs/thread-proxy.ts
@@ -92,10 +92,6 @@ export class ThreadProxy<_Target extends object> {
         this.lifecycle.on(event, listener);
     }
 
-    unwatch(event: LifecycleEvent) {
-        this.lifecycle.removeAllListeners(event);
-    }
-
     /** Removes all the listeners and kills the process (ignoring possible `keepAlive`) */
     dispose() {
         this.lifecycle.emit('disposed');

--- a/packages/suite-desktop-core/src/libs/utils.ts
+++ b/packages/suite-desktop-core/src/libs/utils.ts
@@ -1,20 +1,2 @@
-import net from 'net';
-
-export const isPortUsed = (port: number) =>
-    new Promise(resolve => {
-        const server = net.createServer();
-
-        server.once('error', () => {
-            resolve(true);
-        });
-
-        server.once('listening', () => {
-            server.close();
-            resolve(false);
-        });
-
-        server.listen(port);
-    });
-
 // Bool 2 Text
 export const b2t = (bool: boolean) => (bool ? 'Yes' : 'No');

--- a/packages/suite-desktop-core/src/threads/bridge.ts
+++ b/packages/suite-desktop-core/src/threads/bridge.ts
@@ -4,7 +4,7 @@ import { Logger } from '../libs/logger';
 import { createThread } from '../libs/thread';
 import { convertILoggerToLog } from '../utils/IloggerToLog';
 
-export interface TrezordNodeSettings {
+interface TrezordNodeSettings {
     port: number;
     api: 'usb' | 'udp';
 }


### PR DESCRIPTION
## Summary

Removes 7 pieces of dead code from `@trezor/suite-desktop-core`:

- `isPortUsed` helper (no callers)
- `BaseProcess.restart` method (no callers)
- `ThreadProxy.unwatch` method (no callers)
- Unnecessary `export` on screen size constants
- Write-only `TorExternalProcess.isStopped` property
- `BluetoothProcess.getPort` method (no callers)
- Unnecessary `export` on `TrezordNodeSettings` interface

Each commit is a single, narrowly-scoped removal — safe to review independently.

## Context

Part of the dead-code-removal series spun out of the staging PR #27551. Sibling PRs:

<!-- siblings-start -->
- #27753 — coinjoin
- #27754 — request-manager
- #27755 — ipc-proxy
<!-- siblings-end -->

## Test plan

- [ ] `yarn workspace @trezor/suite-desktop-core build:lib`
- [ ] CI typecheck / lint passes

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are concentrated in suite-desktop-core's process management infrastructure: BaseProcess (parent class for spawning child processes), BluetoothProcess and TorExternalProcess (specific process implementations), the bridge thread, screen utilities, thread-proxy, and general utils. The highest risk is to bridge spawning/lifecycle tests since threads/bridge.ts and BaseProcess.ts are directly exercised by the spawn-bridge tests. BluetoothProcess, TorExternalProcess, screen.ts, and thread-proxy.ts have no direct E2E test coverage. The recommended strategy is to run bridge lifecycle tests as mandatory and bridge-dependent recovery tests as secondary validation.

<details><summary><b>Changed files (7)</b></summary>

- `packages/suite-desktop-core/src/libs/processes/BaseProcess.ts`
- `packages/suite-desktop-core/src/libs/processes/BluetoothProcess.ts`
- `packages/suite-desktop-core/src/libs/processes/TorExternalProcess.ts`
- `packages/suite-desktop-core/src/libs/screen.ts`
- `packages/suite-desktop-core/src/libs/thread-proxy.ts`
- `packages/suite-desktop-core/src/libs/utils.ts`
- `packages/suite-desktop-core/src/threads/bridge.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `../../suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — This test directly exercises bridge process spawning, lifecycle management, and reconnection — all of which depend on BaseProcess (parent class for bridge process management), the bridge thread (threads/bridge.ts), and process utility functions (libs/utils.ts). Changes to these files could break bridge spawning, status detection, or restart behavior.
- `../../suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — This test validates bridge daemon mode spawning and lifecycle (daemon keeps bridge alive after UI closes). It directly depends on BaseProcess for process management, threads/bridge.ts for the bridge thread implementation, and libs/utils.ts for process utilities.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `../../suite/e2e/tests/suite/multiple-sessions.test.ts` — This test validates Bridge session management (session stealing, reclaiming). Changes to threads/bridge.ts and BaseProcess.ts could affect how the bridge handles concurrent sessions and transport layer behavior.
- `../../suite/e2e/tests/recovery/dry-run.test.ts` — This test stops and restarts the bridge mid-recovery to simulate device disconnection. Changes to bridge thread logic (threads/bridge.ts) and process management (BaseProcess.ts) could affect bridge stop/start reliability during this scenario.
- `../../suite/e2e/tests/recovery/t2t1-dry-run.test.ts` — Similar to the dry-run test, this T2T1-specific variant stops and restarts the bridge to simulate device disconnect during recovery. Bridge process changes could affect reconnection behavior.

</details>

⚠️ **Changes with no test coverage (4)**
- `packages/suite-desktop-core/src/libs/processes/BluetoothProcess.ts`
- `packages/suite-desktop-core/src/libs/processes/TorExternalProcess.ts`
- `packages/suite-desktop-core/src/libs/screen.ts`
- `packages/suite-desktop-core/src/libs/thread-proxy.ts`

_Updated: 2026-05-14T12:35:20.643Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-suite-desktop-core&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-suite-desktop-core&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-14T12:40:05.875Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-14T12:38:36.919Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-suite-desktop-core/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-suite-desktop-core/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->