### PR TITLE
chore(request-manager): remove dead code (batch)

### DIFF
--- a/packages/request-manager/src/controllerExternal.ts
+++ b/packages/request-manager/src/controllerExternal.ts
@@ -48,10 +48,6 @@ export class TorControllerExternal extends EventEmitter {
         this.options.port = port;
     }
 
-    public getTorConfiguration() {
-        return '';
-    }
-
     public async waitUntilAlive() {
         this.startBootstrap();
 

--- a/packages/request-manager/src/events/bootstrap.ts
+++ b/packages/request-manager/src/events/bootstrap.ts
@@ -32,4 +32,3 @@ export const bootstrapParser = (message: string): BootstrapEvent[] => {
 export const BOOTSTRAP_EVENT_PROGRESS = {
     Done: '100',
 } as const;
-export type BootstrapEventProgress = keyof typeof BOOTSTRAP_EVENT_PROGRESS;

--- a/packages/request-manager/src/torControlPort.ts
+++ b/packages/request-manager/src/torControlPort.ts
@@ -29,7 +29,6 @@ export class TorControlPort {
     options: TorConnectionOptions;
     socket: Socket;
     isSocketConnected = false;
-    isCircuitDone = false;
     clientNonce = '';
 
     onMessageReceived: (message: string) => void;


### PR DESCRIPTION
## Summary

Removes 3 pieces of dead code from `@trezor/request-manager`:

- `TorControllerExternal.getTorConfiguration` method (no callers)
- Write-only `TorControlPort.isCircuitDone` property
- Unused `BootstrapEventProgress` type

Each commit is a single, narrowly-scoped removal — safe to review independently.

## Context

Part of the dead-code-removal series spun out of the staging PR #27551. Sibling PRs:

<!-- siblings-start -->
- #27752 — suite-desktop-core
- #27753 — coinjoin
- #27755 — ipc-proxy
<!-- siblings-end -->

## Test plan

- [ ] `yarn workspace @trezor/request-manager build:lib`
- [ ] CI typecheck / lint passes

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are concentrated in the request-manager package, specifically in Tor control port handling (torControlPort.ts), external connection controller logic (controllerExternal.ts), and bootstrap events (events/bootstrap.ts). These are infrastructure-level changes affecting network transport and Tor proxy functionality. The highest risk is to bridge/transport lifecycle tests. There is no static test coverage mapping for any of the changed files, so all recommendations are inferred from LLM analysis of test behaviors and source hints. The changes are relatively low-level and may not have direct E2E test coverage for the Tor-specific codepaths.

<details><summary><b>Changed files (3)</b></summary>

- `packages/request-manager/src/controllerExternal.ts`
- `packages/request-manager/src/events/bootstrap.ts`
- `packages/request-manager/src/torControlPort.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `../../suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — The changed files include controllerExternal.ts and torControlPort.ts in the request-manager package, which directly relate to Tor and bridge/transport infrastructure. This test exercises bridge spawning, lifecycle management, and device reconnection after bridge restart — all of which could be affected by changes to how external connections and Tor control ports are managed.
- `../../suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — This test validates bridge daemon mode spawning and lifecycle, which is closely related to the transport/connection infrastructure modified in controllerExternal.ts and torControlPort.ts. Changes to Tor control port handling or external controller logic could affect how the bridge daemon process is managed.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `../../suite/e2e/tests/suite/multiple-sessions.test.ts` — This test covers Bridge session management (session stealing, reclaiming sessions across tabs). The controllerExternal.ts changes could affect how external transport connections are established and maintained, which underpins the session acquire/enumerate flow tested here.
- `../../suite/e2e/tests/analytics/events.test.ts` — The bootstrap events file was changed. The analytics events test checks SuiteReady event properties including 'tor false', suggesting the analytics system captures Tor status. Changes to the bootstrap event system in request-manager could affect how Tor-related state is reported in analytics events.
- `../../suite/e2e/tests/settings/coins-custom-backend.test.ts` — Custom backend configuration involves external network connections that may route through the request-manager's controllerExternal. Changes to how external connections are managed could affect the ability to connect to custom blockbook backends, which this test validates including error handling for wrong backends.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/request-manager/src/controllerExternal.ts`
- `packages/request-manager/src/events/bootstrap.ts`
- `packages/request-manager/src/torControlPort.ts`

_Updated: 2026-05-14T12:35:30.472Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-request-manager/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-request-manager/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-request-manager&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-request-manager&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-14T12:40:47.391Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-14T12:39:05.905Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->