### PR TITLE
chore(ipc-proxy): remove dead invoke plumbing

### DIFF
--- a/packages/ipc-proxy/src/proxy-generator.ts
+++ b/packages/ipc-proxy/src/proxy-generator.ts
@@ -47,10 +47,6 @@ const createIpcProxyApi = (ipcRenderer: IpcRenderer, validChannels: string[]): I
             ipcRenderer.send(`${channelName}/${instanceId}/request`, [responseEvent, method, args]);
         });
 
-    const invoke = (channelName: string, instanceId: string, method: string, args: any[]) =>
-        validateChannel(channelName) &&
-        ipcRenderer.invoke(`${channelName}/${instanceId}/invoke`, [method, ...args]);
-
     const setHandler = (
         channelName: string,
         instanceId: string,
@@ -80,7 +76,6 @@ const createIpcProxyApi = (ipcRenderer: IpcRenderer, validChannels: string[]): I
     return {
         create,
         request,
-        invoke,
         setHandler,
         clearHandler,
     };

--- a/packages/ipc-proxy/src/proxy-handler.ts
+++ b/packages/ipc-proxy/src/proxy-handler.ts
@@ -39,9 +39,8 @@ interface IpcMainEvents<Api> {
     '/request': [string, ...Parameters<ApiUnion<Api>>]; // responseEvent, methodName, ...params
 }
 
-interface IpcMainHandlers<Api> {
+interface IpcMainHandlers {
     '/create': [string, ...any[]]; // channelName, ...params of interface constructor
-    '/invoke': Parameters<ApiUnion<Api>>; // methodName, ...params
 }
 
 export interface ElectronIpcMainEvent {
@@ -56,9 +55,9 @@ interface ElectronIpcMain<Api> {
         listener: (event: ElectronIpcMainEvent, args: IpcMainEvents<Api>[K]) => void,
     ): any;
     on(channel: string, listener: (event: ElectronIpcMainInvokeEvent, ...args: any[]) => void): any; // just to type compatibility with original Electron.IpcMain
-    handle<K extends keyof IpcMainHandlers<Api>, Key extends string>(
+    handle<K extends keyof IpcMainHandlers, Key extends string>(
         channel: `${Key}${K}`,
-        listener: (event: ElectronIpcMainInvokeEvent, args: IpcMainHandlers<Api>[K]) => void,
+        listener: (event: ElectronIpcMainInvokeEvent, args: IpcMainHandlers[K]) => void,
     ): any;
     handle(
         channel: string,
@@ -137,14 +136,6 @@ export const createIpcProxyHandler = <Api extends EventEmitterApi>(
                 });
             }
         });
-
-        ipcMain.handle(`${instancePrefix}/invoke`, async (ipcEventInvoke, params) => {
-            validateIpcMessage({ ipcEvent: ipcEventInvoke });
-
-            const payload = await onRequest(...params);
-
-            return payload;
-        });
     });
 
     return () => {
@@ -156,7 +147,5 @@ export const createIpcProxyHandler = <Api extends EventEmitterApi>(
         });
 
         ipcMain.removeHandler(`${channel}/create`);
-        // ipcMain.removeHandler(`${instancePrefix}/invoke`); // TODO: filter unregistered to get instancePrefix
-        // TODO remove all invoke handlers
     };
 };

--- a/packages/ipc-proxy/src/proxy.ts
+++ b/packages/ipc-proxy/src/proxy.ts
@@ -22,11 +22,6 @@ const getIpcMethods = (ipcProxy: IpcProxyApi, channelName: string, instanceId: s
         (...args: any[]) =>
             ipcProxy.request(channelName, instanceId, method, args);
 
-    const invoke =
-        (method: string) =>
-        (...args: any[]) =>
-            ipcProxy.invoke(channelName, instanceId, method, args);
-
     const setOrClearHandler = (eventName: string) => {
         const eventListeners = listeners.filter(l => l.eventName === eventName);
         if (eventListeners.length) {
@@ -53,7 +48,6 @@ const getIpcMethods = (ipcProxy: IpcProxyApi, channelName: string, instanceId: s
     return {
         create,
         request,
-        invoke,
         addListener,
         removeListener,
     };

--- a/packages/ipc-proxy/src/types.ts
+++ b/packages/ipc-proxy/src/types.ts
@@ -13,7 +13,6 @@ export type IpcProxyGenerator<T> = (
 export type IpcProxyApi = {
     create: (channelName: string, instanceId: string, constructorParams: any) => Promise<any>;
     request: (channelName: string, instanceId: string, method: string, args: any[]) => Promise<any>;
-    invoke: (channelName: string, instanceId: string, method: string, args: any[]) => Promise<any>;
     setHandler: (channelName: string, instanceId: string, eventName: string, handler: any) => void;
     clearHandler: (channelName: string, instanceId: string, eventName: string) => void;
 };


### PR DESCRIPTION
## Summary

Removes the dead `invoke` plumbing from `@trezor/ipc-proxy`:

1. Drops the unused `invoke` closure from `getIpcMethods`
2. Removes the now-dead `invoke` plumbing across the IPC proxy (channel registration, types, IPC binding)

The two commits are sequential — the second depends on the first. Easiest to land together.

## Context

Part of the dead-code-removal series spun out of the staging PR #27551. Sibling PRs:

<!-- siblings-start -->
- #27752 — suite-desktop-core
- #27753 — coinjoin
- #27754 — request-manager
<!-- siblings-end -->

## Test plan

- [ ] `yarn workspace @trezor/ipc-proxy build:lib`
- [ ] `yarn workspace @trezor/ipc-proxy test:unit`
- [ ] Smoke-test suite-desktop locally (renderer ↔ main IPC still works)
- [ ] CI typecheck / lint passes

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are all in the `packages/ipc-proxy/src/` package, which provides IPC proxy infrastructure used broadly across the Suite application for inter-process communication. The single file with static coverage (`proxy.ts`) maps to 121 tests, indicating it is a foundational global utility. The other three changed files (`proxy-generator.ts`, `proxy-handler.ts`, `types.ts`) have no static test coverage at all. Since all 121 mapped tests only transitively depend on this IPC proxy layer and none of the LLM test analyses reference IPC proxy internals, proxy generation, or proxy handling as direct behavioral concerns, there is no specific evidence that any individual E2E test exercises the changed code paths directly. The IPC proxy changes represent infrastructure-level risk that would best be validated by unit/integration tests within the `ipc-proxy` package itself rather than E2E tests. No E2E tests are recommended at high or medium priority.

<details><summary><b>Changed files (4)</b></summary>

- `packages/ipc-proxy/src/proxy-generator.ts`
- `packages/ipc-proxy/src/proxy-handler.ts`
- `packages/ipc-proxy/src/proxy.ts`
- `packages/ipc-proxy/src/types.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (3)**
- `packages/ipc-proxy/src/proxy-generator.ts`
- `packages/ipc-proxy/src/proxy-handler.ts`
- `packages/ipc-proxy/src/types.ts`

_Updated: 2026-05-14T12:35:40.670Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-ipc-proxy&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-ipc-proxy&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-14T12:40:45.805Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-14T12:39:15.347Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-ipc-proxy/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-ipc-proxy/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->