### PR TITLE
fix(suite-native): add abort signal to stop thunk from rewriting store

### DIFF
--- a/suite-common/trading/src/invityAPI.ts
+++ b/suite-common/trading/src/invityAPI.ts
@@ -246,12 +246,17 @@ class InvityAPI {
         }
     };
 
-    doExchangeTrade = async (tradeRequest: ConfirmExchangeTradeRequest): Promise<ExchangeTrade> => {
+    doExchangeTrade = async (
+        tradeRequest: ConfirmExchangeTradeRequest,
+        signal?: SignalType,
+    ): Promise<ExchangeTrade> => {
         try {
             const response: ExchangeTrade = await this.request(
                 this.EXCHANGE_DO_TRADE,
                 tradeRequest,
                 'POST',
+                undefined,
+                signal,
             );
 
             return response;

--- a/suite-common/trading/src/reducers/__tests__/tradingReducerExtended.test.ts
+++ b/suite-common/trading/src/reducers/__tests__/tradingReducerExtended.test.ts
@@ -6,6 +6,7 @@ import { type AccountKey } from '@suite-common/wallet-types';
 
 import { selectTradingMaxSlippagePercentage } from '../../selectors/settingsSelectors';
 import { buyThunks } from '../../thunks/buy';
+import { exchangeThunks } from '../../thunks/exchange';
 import { sellThunks } from '../../thunks/sell';
 import { getProviderMetadataFixture } from '../__fixtures__/providerMetadata';
 import { tradingFixtures } from '../__fixtures__/tradingReducer';
@@ -112,6 +113,46 @@ describe('Testing trading reducer', () => {
         );
         expect(store.getState().wallet.trading.info).toEqual(
             expect.objectContaining({ paymentMethods: [] }),
+        );
+    });
+
+    it('exchangeThunks.handleRequestThunk.rejected should clear quotes, amountLimits and set isLoading to false', () => {
+        const store = configureMockStore({
+            extra: {},
+            reducer: combineReducers({
+                wallet: combineReducers({
+                    trading: tradingReducer,
+                }),
+            }),
+            preloadedState: {
+                wallet: {
+                    trading: {
+                        ...initialState,
+                        exchange: {
+                            ...exchangeInitialState,
+                            isLoading: true,
+                            quotes: [{ orderId: '1' }],
+                            amountLimits: { min: 0, max: 100 },
+                            quotesRequest: {
+                                send: 'bitcoin',
+                                receive: 'ethereum',
+                                sendStringAmount: '1',
+                            },
+                        },
+                    },
+                },
+            },
+        });
+
+        store.dispatch({ type: exchangeThunks.handleRequestThunk.rejected.type });
+
+        expect(store.getState().wallet.trading.exchange).toEqual(
+            expect.objectContaining({
+                isLoading: false,
+                quotesRequest: undefined,
+                quotes: [],
+                amountLimits: undefined,
+            }),
         );
     });
 

--- a/suite-common/trading/src/reducers/tradingReducer.ts
+++ b/suite-common/trading/src/reducers/tradingReducer.ts
@@ -56,6 +56,12 @@ const tradingSlice = createSliceWithExtraDeps({
             .addCase(exchangeThunks.handleRequestThunk.fulfilled, state => {
                 state.exchange.isLoading = false;
             })
+            .addCase(exchangeThunks.handleRequestThunk.rejected, state => {
+                state.exchange.isLoading = false;
+                state.exchange.amountLimits = undefined;
+                state.exchange.quotes = [];
+                state.exchange.quotesRequest = undefined;
+            })
             .addCase(sellThunks.handleRequestThunk.pending, state => {
                 state.sell.isLoading = true;
                 state.info.paymentMethods = [];
@@ -80,6 +86,9 @@ const tradingSlice = createSliceWithExtraDeps({
                 state.exchange.isLoading = true;
             })
             .addCase(exchangeThunks.confirmTradeThunk.fulfilled, state => {
+                state.exchange.isLoading = false;
+            })
+            .addCase(exchangeThunks.confirmTradeThunk.rejected, state => {
                 state.exchange.isLoading = false;
             })
             .addMatcher(

--- a/suite-common/trading/src/thunks/exchange/__tests__/confirmExchangeTradeThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/confirmExchangeTradeThunk.test.ts
@@ -269,6 +269,49 @@ describe('confirmExchangeTradeThunk', () => {
         expect(!!response).toBeFalsy();
     });
 
+    it('should return undefined when request is aborted', async () => {
+        const {
+            store,
+            returnUrl,
+            receiveAddress,
+            account,
+            trade,
+            mockProcessResponseData,
+            mockNextStep,
+            mockTriggerAnalyticsTradeConfirmation,
+        } = getMocks();
+
+        invityAPI.doExchangeTrade = () =>
+            new Promise<ExchangeTrade>(resolve => {
+                resolve(undefined as unknown as ExchangeTrade);
+            });
+
+        const promise = store.dispatch(
+            exchangeThunks.confirmTradeThunk({
+                returnUrl,
+                receiveAddress,
+                account,
+                trade,
+                nextStep: mockNextStep,
+                triggerAnalyticsTradeConfirmation: mockTriggerAnalyticsTradeConfirmation,
+                processResponseData: mockProcessResponseData,
+            }),
+        );
+
+        promise.abort();
+
+        const action = await promise;
+
+        expect(exchangeThunks.confirmTradeThunk.rejected.match(action)).toBe(true);
+
+        if (!exchangeThunks.confirmTradeThunk.rejected.match(action)) {
+            throw new Error('Expected confirmTradeThunk to be rejected');
+        }
+
+        expect(action.meta.aborted).toBe(true);
+        expect(action.payload).toBeUndefined();
+    });
+
     describe('should return false from confirmation', () => {
         it.each([
             [

--- a/suite-common/trading/src/thunks/exchange/confirmExchangeTradeThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/confirmExchangeTradeThunk.ts
@@ -42,7 +42,7 @@ export const confirmExchangeTradeThunk = createThunk(
             processResponseData,
             nextStep,
         }: ConfirmExchangeTradeThunkProps,
-        { dispatch, getState },
+        { dispatch, getState, signal },
     ) => {
         triggerAnalyticsTradeConfirmation();
 
@@ -67,14 +67,21 @@ export const confirmExchangeTradeThunk = createThunk(
             }
         }
 
-        const response = await invityAPI.doExchangeTrade({
-            trade,
-            receiveAddress,
-            refundAddress,
-            extraField,
-            returnUrl,
-            approvalFlow,
-        });
+        const response = await invityAPI.doExchangeTrade(
+            {
+                trade,
+                receiveAddress,
+                refundAddress,
+                extraField,
+                returnUrl,
+                approvalFlow,
+            },
+            signal,
+        );
+
+        if (signal.aborted) {
+            return undefined;
+        }
 
         if (!response) {
             dispatch(

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeFlow.tsx
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeFlow.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
@@ -127,6 +127,10 @@ export const useExchangeFlow = ({ flowType }: UseExchangeFlowProps = {}) => {
         triggerAnalyticsTradeConfirmation: baseCommonFunctions?.triggerAnalyticsTradeConfirmation,
     });
 
+    const inFlightConfirmTradePromiseRef = useRef<{ abort: (reason?: string) => void } | null>(
+        null,
+    );
+
     // changing trade state and initial confirmation
     const confirmTrade = useCallback(
         async ({
@@ -149,7 +153,7 @@ export const useExchangeFlow = ({ flowType }: UseExchangeFlowProps = {}) => {
             const { returnUrl, triggerAnalyticsTradeConfirmation, processResponseData } =
                 commonFunctions;
 
-            return !!(await dispatch(
+            const promiseAction = dispatch(
                 exchangeThunks.confirmTradeThunk({
                     returnUrl,
                     receiveAddress,
@@ -161,14 +165,23 @@ export const useExchangeFlow = ({ flowType }: UseExchangeFlowProps = {}) => {
                     processResponseData,
                     nextStep,
                 }),
-            ).unwrap());
+            );
+            inFlightConfirmTradePromiseRef.current = promiseAction;
+
+            return !!(await promiseAction.unwrap());
         },
         [getCommonFunctions, sendAccount, dispatch],
     );
 
+    const abortConfirmTrade = useCallback(() => {
+        inFlightConfirmTradePromiseRef.current?.abort();
+        inFlightConfirmTradePromiseRef.current = null;
+    }, []);
+
     return {
         txnErrorString,
         confirmTrade,
+        abortConfirmTrade,
         composeRequest,
         fetchFeesAndCompose,
         signAndSendTransaction,

--- a/suite-native/module-trading/src/screens/TradingExchangePreviewScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingExchangePreviewScreen.tsx
@@ -58,7 +58,8 @@ const TradingExchangePreviewScreenContent = ({
 
     useSubscribeForSolanaBlockUpdates(fromAccount ?? null);
 
-    const { txnErrorString, confirmTrade, fetchFeesAndCompose } = useExchangeFlow();
+    const { txnErrorString, confirmTrade, abortConfirmTrade, fetchFeesAndCompose } =
+        useExchangeFlow();
 
     const [isConfirmationErrorRequested, setIsConfirmationErrorRequested] =
         useState<boolean>(false);
@@ -111,9 +112,10 @@ const TradingExchangePreviewScreenContent = ({
     // clear trading state on unmount
     useEffect(
         () => () => {
+            abortConfirmTrade();
             dispatch(clearTradingStateThunk());
         },
-        [dispatch],
+        [abortConfirmTrade, dispatch],
     );
 
     useEffect(() => {

--- a/suite-native/module-trading/src/screens/__tests__/TradingExchangePreviewScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingExchangePreviewScreen.test.tsx
@@ -63,10 +63,12 @@ const mockConfirmTrade = jest.fn().mockResolvedValue(Promise.resolve());
 const mockFetchFeesAndCompose = jest.fn();
 const mockSignAndSendTransaction = jest.fn();
 const mockResolveConsent = jest.fn();
+const mockAbortConfirmTrade = jest.fn();
 let mockTxnErrorString: string | null = null;
 
 jest.mock('../../hooks/exchange/useExchangeFlow', () => ({
     useExchangeFlow: () => ({
+        abortConfirmTrade: mockAbortConfirmTrade,
         confirmTrade: mockConfirmTrade,
         fetchFeesAndCompose: mockFetchFeesAndCompose,
         signAndSendTransaction: mockSignAndSendTransaction,
@@ -306,6 +308,29 @@ describe('TradingExchangePreviewScreen', () => {
                 action: 'visit',
             }),
         });
+    });
+
+    it('should abort confirm trade on unmount', () => {
+        const { result } = renderTradingExchangePreviewScreen();
+
+        expect(mockAbortConfirmTrade).not.toHaveBeenCalled();
+
+        result.unmount();
+        unmount = undefined;
+
+        expect(mockAbortConfirmTrade).toHaveBeenCalledTimes(1);
+    });
+
+    it('should clear trading state on unmount', () => {
+        const { result } = renderTradingExchangePreviewScreen();
+
+        expect(store.getState().wallet.trading.exchange.selectedQuote).toBeDefined();
+
+        result.unmount();
+        unmount = undefined;
+
+        expect(store.getState().wallet.trading.exchange.selectedQuote).toBeUndefined();
+        expect(store.getState().wallet.trading.sell.selectedQuote).toBeUndefined();
     });
 
     it('should report to analytics on Continue press', async () => {


### PR DESCRIPTION
* add abort signal to stop thunk from rewriting store 
* fix missing rejected handler to flip loading flag

## Notes for QA

## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/27726

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect the trading/exchange flow in both the common trading layer (reducer and exchange confirmation thunk) and the native mobile module (exchange flow hook and preview screen). The two suite-common files map to 121 tests each via broad transitive imports, but only the trading/swap E2E tests directly exercise the exchange confirmation and trading state management logic. The two suite-native files have zero static test coverage, representing the mobile exchange preview flow which has no desktop E2E counterpart. The recommended strategy focuses on swap/exchange-related tests that verify trade confirmation, state transitions, and transaction detail rendering.

<details><summary><b>Changed files (4)</b></summary>

- `suite-common/trading/src/reducers/tradingReducer.ts`
- `suite-common/trading/src/thunks/exchange/confirmExchangeTradeThunk.ts`
- `suite-native/module-trading/src/hooks/exchange/useExchangeFlow.tsx`
- `suite-native/module-trading/src/screens/TradingExchangePreviewScreen.tsx`

</details>

**Recommended tests (9)**

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/trading/swap-coins.test.ts` — This test exercises the full swap flow including trade confirmation, which shares infrastructure with the exchange confirmation flow changed in confirmExchangeTradeThunk.ts. The tradingReducer changes could affect swap state management visible in this test's Redux state assertions and toast notifications.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Tests the swap/exchange confirmation flow end-to-end including transaction detail status assertions (TR_EXCHANGE_DETAIL_SUCCESS_TITLE) and provider confirmation, which directly depend on exchange trade confirmation logic modified in confirmExchangeTradeThunk.ts and state managed by tradingReducer.ts.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Exercises swap/exchange trade confirmation and transaction detail status verification, which relies on the exchange confirmation thunk and trading reducer state transitions modified in this changeset.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Tests token-to-token swap flow with exchange detail success status and provider confirmation, exercising the exchange trade confirmation path changed in confirmExchangeTradeThunk.ts and trading state managed by tradingReducer.ts.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Tests swap trade confirmation with custom Bitcoin fees, including Redux state assertions on wallet.trading.composedTransactionInfo which is managed by the trading reducer. Changes to tradingReducer.ts could affect this state.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests swap trade confirmation with custom Ethereum fees and asserts wallet.trading.composedTransactionInfo Redux state from the trading reducer. Changes to tradingReducer.ts could break these state assertions.
- `suite/e2e/tests/trading/swap-history.test.ts` — Tests swap/exchange transaction history display including trade status labels and detail views. The trading reducer manages the state for these swap history entries, and changes could affect how trade records are stored and displayed.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — Tests navigation to swap/exchange forms from various entry points. While it doesn't test the confirmation flow directly, changes to tradingReducer.ts could affect the swap form's initial state loading behavior.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — Tests swap form behavior with disabled networks, which relies on trading state managed by tradingReducer.ts. A regression in initial swap state could prevent the form from loading correctly.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-native/module-trading/src/hooks/exchange/useExchangeFlow.tsx`
- `suite-native/module-trading/src/screens/TradingExchangePreviewScreen.tsx`

_Updated: 2026-05-14T12:37:07.319Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/27726-old-provider-is-retained-for-revocation-after-switching-providers&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/27726-old-provider-is-retained-for-revocation-after-switching-providers&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/27726-old-provider-is-retained-for-revocation-after-switching-providers&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-14T12:42:00.064Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-14T12:40:31.245Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/27726-old-provider-is-retained-for-revocation-after-switching-providers/web/](https://dev.suite.sldev.cz/suite-web/fix/27726-old-provider-is-retained-for-revocation-after-switching-providers/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->