### PR TITLE
Correct path to coins packages

### DIFF
--- a/scripts/ci/check-version.js
+++ b/scripts/ci/check-version.js
@@ -19,7 +19,11 @@ if (!['latest', 'beta', 'alpha'].includes(distTag)) {
 }
 
 const ROOT = path.join(import.meta.dirname, '..', '..');
-const PACKAGE_PATH = path.join(ROOT, 'packages', packageName);
+const PACKAGE_PATH = path.join(
+    ROOT,
+    packageName.startsWith('coins-') ? 'coins' : 'packages',
+    packageName,
+);
 
 // read package version
 const packageJSONRaw = fs.readFileSync(path.join(PACKAGE_PATH, 'package.json'), {
@@ -35,7 +39,7 @@ const npmInfoRaw = child_process.spawnSync('npm', ['view', '--json'], {
 }).stdout;
 
 const npmInfo = JSON.parse(npmInfoRaw);
-if (npmInfo && npmInfo.error && npmInfo.error.code === 'E404') {
+if (npmInfo?.error?.[packageJSON.name]?.code === 'E404') {
     // exit 0, its ok, we probably did not publish it yet
     process.exit(0);
 }

--- a/scripts/ci/connect-bump-versions.ts
+++ b/scripts/ci/connect-bump-versions.ts
@@ -8,6 +8,7 @@ import {
     exec,
     commit,
     comment,
+    getTrezorPackageDir,
 } from './helpers';
 
 const readFile = promisify(fs.readFile);
@@ -151,7 +152,7 @@ const bumpConnect = async () => {
         console.log('allUniquePackagesToUpdate', allUniquePackagesToUpdate);
 
         for (const packageName of allUniquePackagesToUpdate) {
-            const PACKAGE_PATH = path.join(ROOT, 'packages', packageName);
+            const PACKAGE_PATH = getTrezorPackageDir(packageName);
             const PACKAGE_JSON_PATH = path.join(PACKAGE_PATH, 'package.json');
 
             // This uses dependency version-bump-prompt.
@@ -197,7 +198,7 @@ const bumpConnect = async () => {
             });
         }
 
-        const CONNECT_PACKAGE_PATH = path.join(ROOT, 'packages', 'connect');
+        const CONNECT_PACKAGE_PATH = getTrezorPackageDir('connect');
         const CONNECT_PACKAGE_JSON_PATH = path.join(CONNECT_PACKAGE_PATH, 'package.json');
         const CONNECT_CHANGELOG_PATH = path.join(CONNECT_PACKAGE_PATH, 'CHANGELOG.md');
 

--- a/scripts/ci/get-connect-dependencies-to-release.ts
+++ b/scripts/ci/get-connect-dependencies-to-release.ts
@@ -6,17 +6,15 @@ import util from 'node:util';
 import path from 'node:path';
 import semver from 'semver';
 
-import { getNpmRemoteGreatestVersion } from './helpers';
+import { getNpmRemoteGreatestVersion, getTrezorPackageDir } from './helpers';
 
 const readFile = util.promisify(fs.readFile);
-
-const ROOT = path.join(import.meta.dirname, '..', '..');
 
 const nonReleaseDependencies: string[] = [];
 
 const checkNonReleasedDependencies = async (packageName: string) => {
     const rawPackageJSON = await readFile(
-        path.join(ROOT, 'packages', packageName, 'package.json'),
+        path.join(getTrezorPackageDir(packageName), 'package.json'),
         'utf-8',
     );
 

--- a/scripts/ci/helpers.ts
+++ b/scripts/ci/helpers.ts
@@ -46,7 +46,7 @@ export const getPackageDependencies = async (
     console.info('-------------------------------------------------------------------------');
     console.info(`Getting @trezor dependencies of package ${packageNameWithoutTrezorPrefix}`);
 
-    const trezorDependencies = await getTrezorDependencies(ROOT, packageNameWithoutTrezorPrefix);
+    const trezorDependencies = await getTrezorDependencies(packageNameWithoutTrezorPrefix);
     console.info(`Trezor dependencies: ${trezorDependencies.join(', ')}`);
 
     // eslint-disable-next-line no-restricted-syntax
@@ -125,7 +125,7 @@ export const comment = async ({ prNumber, body }: { prNumber: string; body: stri
 };
 
 export const getLocalVersion = (packageName: string) => {
-    const packageJsonPath = path.join(ROOT, 'packages', packageName, 'package.json');
+    const packageJsonPath = path.join(getTrezorPackageDir(packageName), 'package.json');
     if (!fs.existsSync(packageJsonPath)) {
         throw new Error(`package.json not found for package: ${packageName}`);
     }
@@ -133,17 +133,12 @@ export const getLocalVersion = (packageName: string) => {
     return packageJson.version;
 };
 
-export const getTrezorPackagesDir = (pkg: string) =>
-    pkg.startsWith('coins-') ? 'coins' : 'packages';
+export const getTrezorPackageDir = (packageName: string) =>
+    path.join(ROOT, packageName.startsWith('coins-') ? 'coins' : 'packages', packageName);
 
-export const getTrezorDependencies = async (
-    rootDir: string,
-    packageNameWithoutTrezorPrefix: string,
-) => {
+export const getTrezorDependencies = async (packageNameWithoutTrezorPrefix: string) => {
     const packageJsonPath = path.join(
-        rootDir,
-        getTrezorPackagesDir(packageNameWithoutTrezorPrefix),
-        packageNameWithoutTrezorPrefix,
+        getTrezorPackageDir(packageNameWithoutTrezorPrefix),
         'package.json',
     );
     const packageJsonContent = await fs.promises.readFile(packageJsonPath, 'utf-8');

--- a/scripts/ci/pack-packages.ts
+++ b/scripts/ci/pack-packages.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import util from 'node:util';
 
-import { exec, getPackageDependencies, getTrezorPackagesDir } from './helpers';
+import { exec, getPackageDependencies, getTrezorPackageDir } from './helpers';
 
 const mkdir = util.promisify(fs.mkdir);
 const existsDirectory = util.promisify(fs.exists);
@@ -53,7 +53,7 @@ const collectPublishTargets = (value: unknown): string[] => {
 };
 
 const validatePackagePublishTargets = async (pkg: string) => {
-    const packageDir = path.join(ROOT_DIR, getTrezorPackagesDir(pkg), pkg);
+    const packageDir = getTrezorPackageDir(pkg);
     const packageJsonPath = path.join(packageDir, 'package.json');
     const rawPackageJson = await fs.promises.readFile(packageJsonPath, 'utf8');
     const packageJson = JSON.parse(rawPackageJson);
@@ -140,7 +140,7 @@ const buildAllPackages = async () => {
     } = { success: [], failed: [] };
 
     for (const pkg of PACKAGES) {
-        const pkgDir = path.join(ROOT_DIR, getTrezorPackagesDir(pkg), pkg);
+        const pkgDir = getTrezorPackageDir(pkg);
 
         if (!(await existsDirectory(pkgDir))) {
             console.error(`Package not found: ${pkg}`);


### PR DESCRIPTION
## Description

Fix paths in CI scripts so `@trezor/coins-*` packages are looked for in `/coins` dir instead of `/packages`.

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All five changed files are CI/build scripts (scripts/ci/*) that handle version checking, version bumping, dependency release resolution, helper utilities for CI, and package packing. These scripts are not part of the runtime application code and are not imported or referenced by any E2E test. They affect the build/release pipeline only, not the user-facing application behavior. No E2E tests are necessary for this change set as the risk of user-facing regression is effectively zero.

<details><summary><b>Changed files (5)</b></summary>

- `scripts/ci/check-version.js`
- `scripts/ci/connect-bump-versions.ts`
- `scripts/ci/get-connect-dependencies-to-release.ts`
- `scripts/ci/helpers.ts`
- `scripts/ci/pack-packages.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (5)**
- `scripts/ci/check-version.js`
- `scripts/ci/connect-bump-versions.ts`
- `scripts/ci/get-connect-dependencies-to-release.ts`
- `scripts/ci/helpers.ts`
- `scripts/ci/pack-packages.ts`

_Updated: 2026-05-14T12:43:54.648Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/ci-coins-package-path&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/ci-coins-package-path&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-14T12:49:07.741Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-14T12:48:00.053Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->