### PR TITLE
refactor(suite): update ConfirmActionModal and PassphraseOnDeviceModal

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ConfirmActionModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ConfirmActionModal.tsx
@@ -2,23 +2,19 @@ import { useIntl } from 'react-intl';
 
 import { Translation, type TranslationKey, messages } from '@suite/intl';
 import { type TrezorDevice } from '@suite-common/suite-types';
-import { getDeviceInternalModel } from '@suite-common/suite-utils';
 import { Column, H2, Modal } from '@trezor/components';
 import TrezorConnect from '@trezor/connect';
-import { getDeviceColorVariant } from '@trezor/device-utils';
-import { ConfirmOnDevicePill } from '@trezor/product-components';
-import { spacings } from '@trezor/theme';
 
 import { ConnectModalBackdrop } from 'src/components/suite/ConnectModalBackdrop';
 import { DeviceConfirmImage } from 'src/components/suite/DeviceConfirmImage';
 
-interface ConfirmActionProps {
+type ConfirmActionProps = {
     cancelable?: boolean;
     device: TrezorDevice;
     title?: TranslationKey;
     onCancel?: () => void;
     enableBackdropClick?: boolean;
-}
+};
 
 export const ConfirmActionModal = ({
     title,
@@ -42,19 +38,10 @@ export const ConfirmActionModal = ({
             data-testid="@suite/modal/confirm-action-on-device"
             canSwitchDevice
         >
-            <ConfirmOnDevicePill
-                title={<Translation id="TR_CONFIRM_ON_TREZOR" />}
-                deviceModelInternal={getDeviceInternalModel(device)}
-                deviceUnitColor={getDeviceColorVariant(device)}
-                onCancel={cancelable ? handleCancel : undefined}
-            />
-            <Modal.ModalBase width={400}>
-                <Column alignItems="center" gap={16}>
+            <Modal.ModalBase width={400} onCancel={cancelable ? handleCancel : undefined}>
+                <Column alignItems="center" gap={16} padding={{ horizontal: 10, bottom: 24 }}>
                     <DeviceConfirmImage device={device} />
-                    <H2
-                        align="center"
-                        margin={{ left: spacings.md, right: spacings.md, bottom: spacings.md }}
-                    >
+                    <H2 align="center" textWrap="pretty">
                         <Translation id={title ?? 'TR_CONFIRM_ACTION_ON_YOUR'} />
                     </H2>
                 </Column>

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseOnDeviceModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseOnDeviceModal.tsx
@@ -1,27 +1,18 @@
 import { useIntl } from 'react-intl';
 
-import styled from 'styled-components';
-
 import { Translation, messages } from '@suite/intl';
 import { selectSelectedDeviceLabelOrName } from '@suite-common/device';
 import { selectIsDiscoveryStatusConfirmEmptyPassphrase } from '@suite-common/wallet-core';
-import { H2, Modal, Paragraph } from '@trezor/components';
+import { Column, H2, Modal, Note } from '@trezor/components';
 import TrezorConnect from '@trezor/connect';
-import { ConfirmOnDevicePill } from '@trezor/product-components';
-import { spacings } from '@trezor/theme';
 
 import { DeviceConfirmImage } from 'src/components/suite/DeviceConfirmImage';
 import { useSelector } from 'src/hooks/suite';
 import type { TrezorDevice } from 'src/types/suite';
 
-const ImageWrapper = styled.div`
-    display: flex;
-    justify-content: center;
-`;
-
-interface PassphraseOnDeviceModalProps {
+type PassphraseOnDeviceModalProps = {
     device: TrezorDevice;
-}
+};
 
 /**
  * Modal used with T2T1 with legacy firmware as result of 'ButtonRequest_PassphraseType' where passphrase source is requested on device
@@ -35,19 +26,10 @@ export const PassphraseOnDeviceModal = ({ device }: PassphraseOnDeviceModalProps
     const onCancel = () => TrezorConnect.cancel(intl.formatMessage(messages.TR_CANCELLED));
 
     return (
-        <Modal.Backdrop onClick={onCancel}>
-            <ConfirmOnDevicePill
-                title={<Translation id="TR_CONFIRM_ON_TREZOR" />}
-                deviceModelInternal={device?.features?.internal_model}
-                deviceUnitColor={device?.features?.unit_color}
-                onCancel={onCancel}
-            />
-            <Modal.ModalBase width={400} data-testid="@modal/enter-passphrase-on-device">
-                <ImageWrapper>
-                    <DeviceConfirmImage device={device} />
-                </ImageWrapper>
-
-                <H2 align="center">
+        <Modal width={400} data-testid="@modal/enter-passphrase-on-device" onCancel={onCancel}>
+            <Column alignItems="center" gap={16} padding={{ horizontal: 10, bottom: 24 }}>
+                <DeviceConfirmImage device={device} />
+                <H2 align="center" textWrap="pretty">
                     <Translation
                         id={
                             confirmEmptyPassphrase
@@ -57,14 +39,7 @@ export const PassphraseOnDeviceModal = ({ device }: PassphraseOnDeviceModalProps
                         values={{ deviceLabel }}
                     />
                 </H2>
-
-                <Paragraph
-                    align="center"
-                    typographyStyle="body-xs"
-                    intent="neutral"
-                    priority="secondary"
-                    margin={{ top: spacings.md }}
-                >
+                <Note>
                     <Translation
                         id={
                             confirmEmptyPassphrase
@@ -72,8 +47,8 @@ export const PassphraseOnDeviceModal = ({ device }: PassphraseOnDeviceModalProps
                                 : 'TR_PASSPHRASE_CASE_SENSITIVE'
                         }
                     />
-                </Paragraph>
-            </Modal.ModalBase>
-        </Modal.Backdrop>
+                </Note>
+            </Column>
+        </Modal>
     );
 };


### PR DESCRIPTION
## Notes for QA

Updated layout in modals requesting device action and removing superfluous confirm pill

## Screenshots:

### Before
<img width="966" height="1180" alt="image" src="https://github.com/user-attachments/assets/b4e0114c-a87e-4904-aa55-a27c88f09fc2" />

### After
<img width="914" height="1266" alt="image" src="https://github.com/user-attachments/assets/904df1a0-6ca7-4f54-8082-e2c78ab343e5" />


<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect two device context modal components: ConfirmActionModal (the generic device confirmation prompt) and PassphraseOnDeviceModal (the passphrase-on-device entry modal). Both map to 121 tests each, indicating they are broadly shared UI components. The highest risk is in passphrase-related flows where both modals are directly exercised, followed by any flow requiring device confirmation (backup, receive, public keys). The recommended strategy focuses on passphrase tests as highest priority since both changed files are involved, with selected device-confirmation-heavy tests at medium priority.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ConfirmActionModal.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseOnDeviceModal.tsx`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/passphrase/passphrase.test.ts` — PassphraseOnDeviceModal.tsx is directly part of the passphrase device interaction flow. This test exercises adding hidden wallets with passphrases, confirming on device, and handling passphrase mismatches — all flows that would render the PassphraseOnDeviceModal when passphrase is entered on device.
- `suite/e2e/tests/passphrase/passphrase-cancel.test.ts` — This test directly exercises the passphrase entry and cancellation flow with device confirmation prompts, which involves the PassphraseOnDeviceModal and ConfirmActionModal components.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — Tests passphrase wallet reconnection requiring re-entry of passphrase on device after disconnect — directly exercises the PassphraseOnDeviceModal flow and device confirmation prompts (ConfirmActionModal).

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts` — Tests passphrase-protected hidden wallet creation and address verification on Cardano, which involves the PassphraseOnDeviceModal for passphrase entry and ConfirmActionModal for device address confirmation.
- `suite/e2e/tests/passphrase/passphrase-duplicate.test.ts` — Tests duplicate passphrase detection when adding hidden wallets, which involves the passphrase entry modal flow. Changes to PassphraseOnDeviceModal could affect the duplicate detection UX.
- `suite/e2e/tests/settings/passphrase.test.ts` — Tests enabling passphrase protection via device settings with a confirm-on-device prompt. The ConfirmActionModal is directly involved in rendering the device confirmation prompt shown during this flow.
- `suite/e2e/tests/backup/t2t1-success.test.ts` — The backup flow requires multiple device confirmations (confirm-on-device prompts) which are rendered by ConfirmActionModal. Changes to this modal could break the backup confirmation UX.
- `suite/e2e/tests/wallet/receive.test.ts` — Receive address flow requires device confirmation prompts (ConfirmActionModal) to verify the address on the hardware device. This is a core user-facing flow where the confirm action modal is exercised.
- `suite/e2e/tests/wallet/public-keys.test.ts` — Showing and confirming public keys requires a device prompt rendered by ConfirmActionModal. The test explicitly verifies the device prompt output value and confirmation flow.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/settings/safety-checks.test.ts` — Safety checks changes require device confirmation prompts (ConfirmActionModal) when applying the new setting. A regression in the confirm-on-device modal could block this flow.
- `suite/e2e/tests/passphrase/passphrase-numbering.test.ts` — Tests adding multiple passphrase wallets which involves the passphrase entry flow. While focused on numbering logic, the PassphraseOnDeviceModal is exercised during wallet creation.

</details>

_Updated: 2026-05-14T12:57:57.776Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/confirm-on-device-modals&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/confirm-on-device-modals&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-14T13:02:45.831Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-14T13:01:25.886Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/confirm-on-device-modals/web/](https://dev.suite.sldev.cz/suite-web/refactor/confirm-on-device-modals/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->