### PR TITLE
fix(suite): gix SecurityCheck tooltip

### DIFF
--- a/packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/SecurityCheck.tsx
+++ b/packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/SecurityCheck.tsx
@@ -42,7 +42,7 @@ import { SecurityCheckLayout } from 'src/components/suite/SecurityCheck/Security
 import { ContactSupport } from 'src/components/suite/SecurityCheck/deviceCompromisedCtas';
 import { useDispatch, useLayoutSize, useOnboarding, useSelector } from 'src/hooks/suite';
 import { selectIsOnboardingActive } from 'src/reducers/onboarding/onboardingReducer';
-import { ContentFlex } from 'src/support/suite/ContentFlex';
+import { ContentFlex, useIsContentBelowBreakpoint } from 'src/support/suite/ContentFlex';
 import { useAnalytics } from 'src/support/useAnalytics';
 
 import { SecurityChecklist } from './SecurityChecklist';
@@ -116,6 +116,7 @@ const SecurityCheckContent = ({
     const { isBelowTablet } = useLayoutSize();
     const recoveryStatus = useSelector(selectRecoveryStatus);
     const device = useSelector(selectSelectedDevice);
+    const isVerticalLayout = useIsContentBelowBreakpoint(breakpoints.tablet);
     const deviceId = device?.id;
     const deviceModel = device?.features?.internal_model || DeviceModelInternal.UNKNOWN;
     const isOnboardingActive = useSelector(selectIsOnboardingActive);
@@ -261,7 +262,8 @@ const SecurityCheckContent = ({
                                 <Translation id="TR_TAKES_N_MINUTES" />
                             </Note>
                         }
-                        width="100%"
+                        placement="bottom"
+                        width={isVerticalLayout ? '100%' : undefined}
                     >
                         <SecurityCheckButton
                             onClick={handleSetupButtonClick}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

before

<img width="662" height="328" alt="image" src="https://github.com/user-attachments/assets/23ae4c7f-dfa0-4bd8-b5ef-21f379486732" />


after

<img width="680" height="285" alt="Screenshot 2026-05-14 at 14 54 52" src="https://github.com/user-attachments/assets/3cb51cc3-f94d-4472-845f-afa22822b5ad" />
<img width="1006" height="582" alt="Screenshot 2026-05-14 at 14 54 33" src="https://github.com/user-attachments/assets/47a53115-815a-4d29-a8d4-6066b7396227" />

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to SecurityCheck.tsx within the DeviceAuthenticityStep of the onboarding flow. This component is rendered during device authenticity verification when setting up a new device. The highest risk is to onboarding wallet creation tests that explicitly pass through the authenticity check step (T3T1 and T3W1 create-wallet tests). The file maps to 121 tests via static analysis, but the vast majority only transitively import it through the onboarding flow completion helper — only tests that directly exercise the authenticity/security check step during onboarding are meaningfully affected.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/SecurityCheck.tsx`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts` — This test directly exercises the onboarding wallet creation flow on T3T1 which includes the authenticity check step. The changed file SecurityCheck.tsx is part of the DeviceAuthenticityStep, which is the device authenticity verification during onboarding. This test explicitly passes through the authenticity check (passDeviceAuthenticityCheck).
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts` — This test creates a wallet on T3T1 during offline onboarding and explicitly completes the authenticity check step. Changes to SecurityCheck.tsx directly affect the device authenticity verification flow exercised in this test.
- `suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts` — This test exercises the full onboarding wallet creation flow on T3W1, which includes firmware hash check dismissal and device authenticity steps. The SecurityCheck.tsx component is part of the authenticity verification that this test passes through.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/suite/initial-run.test.ts` — This test validates the full initial onboarding run persistence, including optionally dismissing firmware hash check errors and completing onboarding. The SecurityCheck component may be rendered during the authenticity/firmware check steps of the onboarding flow.
- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — This test completes the full onboarding flow including disabling the authenticity check (disableAuthenticityCheck referenced in source_hints for analytics toggle test). Changes to SecurityCheck.tsx could affect the authenticity check step that this test interacts with during onboarding.
- `suite/e2e/tests/onboarding/firmware-check.test.ts` — This test validates firmware readiness detection during onboarding after disabling necessary firmware checks. The SecurityCheck component is part of the DeviceAuthenticityStep which is closely related to firmware verification in the onboarding flow.

</details>

_Updated: 2026-05-14T12:59:18.524Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-security-check-tooltip&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-security-check-tooltip&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-14T13:03:39.246Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-14T13:02:22.503Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-security-check-tooltip/web/](https://dev.suite.sldev.cz/suite-web/fix-security-check-tooltip/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->