### PR TITLE
fix(suite): block yield tx broadcast when balance can't cover fee

### DIFF
--- a/packages/suite/src/components/earn/yield/common/YieldActionStep.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldActionStep.tsx
@@ -31,7 +31,6 @@ export type YieldActionStepProps = {
     isDisabled?: boolean;
     isPending?: boolean;
     warning?: ReactNode;
-    networkFeeWarning?: ReactNode;
     pendingTransaction?: YieldPendingTransactionState;
     unitToggle?: YieldAmountCardUnitToggleProps;
     onMaxClick?: () => void;
@@ -46,7 +45,6 @@ export const YieldActionStep = ({
     isDisabled = false,
     isPending = false,
     warning,
-    networkFeeWarning,
     pendingTransaction,
     unitToggle,
     onMaxClick,
@@ -73,8 +71,6 @@ export const YieldActionStep = ({
                 warning={warning}
                 isDisabled={!!pendingTransaction}
             />
-
-            {networkFeeWarning}
 
             <Button
                 size="large"

--- a/packages/suite/src/components/earn/yield/common/YieldActionStepWarning.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldActionStepWarning.tsx
@@ -1,19 +1,15 @@
 import { Translation } from '@suite/intl';
 import { Banner, Button, Column, Text } from '@trezor/components';
 
-import { type YieldNetworkFeeWarning } from '../yieldFlowUtils';
-
 type YieldActionStepWarningProps = {
     isInsufficientFunds?: boolean;
     isApprovalInsufficient?: boolean;
-    networkFeeWarning?: YieldNetworkFeeWarning | null;
     onModifyApproval?: () => void;
 };
 
 export const YieldActionStepWarning = ({
     isInsufficientFunds = false,
     isApprovalInsufficient = false,
-    networkFeeWarning,
     onModifyApproval,
 }: YieldActionStepWarningProps) => {
     if (isApprovalInsufficient) {
@@ -44,36 +40,6 @@ export const YieldActionStepWarning = ({
                     <Text>
                         <Translation id="AMOUNT_IS_NOT_ENOUGH" />
                     </Text>
-                }
-            />
-        );
-    }
-
-    if (networkFeeWarning) {
-        return (
-            <Banner
-                intent="warning"
-                icon="warning"
-                description={
-                    <Column gap={4}>
-                        <Text>
-                            <Translation
-                                id="TR_EARN_YIELD_NETWORK_FEE_WARNING_TITLE"
-                                values={{
-                                    amount: networkFeeWarning.availableAmount,
-                                    networkDisplaySymbol: networkFeeWarning.networkDisplaySymbol,
-                                }}
-                            />
-                        </Text>
-                        <Text>
-                            <Translation
-                                id="TR_EARN_YIELD_NETWORK_FEE_WARNING_DESCRIPTION"
-                                values={{
-                                    networkDisplaySymbol: networkFeeWarning.networkDisplaySymbol,
-                                }}
-                            />
-                        </Text>
-                    </Column>
                 }
             />
         );

--- a/packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx
@@ -66,7 +66,6 @@ export type YieldApproveStepProps = {
     approvalAction: YieldApprovalAction;
     canRevokeAllowance: boolean;
     warning?: ReactNode;
-    networkFeeWarning?: ReactNode;
     pendingApproveTransaction?: YieldPendingTransactionState;
     onMaxClick?: () => void;
     onApprovalSubmit?: () => void;
@@ -87,7 +86,6 @@ export const YieldApproveStep = ({
     approvalAction,
     canRevokeAllowance,
     warning,
-    networkFeeWarning,
     pendingApproveTransaction,
     onMaxClick,
     onApprovalSubmit,
@@ -130,8 +128,6 @@ export const YieldApproveStep = ({
                         warning={warning}
                         isDisabled={!!pendingApproveTransaction}
                     />
-
-                    {networkFeeWarning}
 
                     <Button
                         size="large"

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -5,7 +5,6 @@ import { useDevice } from '@suite/device';
 import { type TranslationKey } from '@suite/intl';
 import { openModal } from '@suite/modal';
 import { type EarnParams } from '@suite/router';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import {
     type YieldActionFlowType,
     type YieldAllowanceStatus,
@@ -19,14 +18,12 @@ import {
     handleYieldApproveCancelThunk,
     handleYieldApproveSuccessTxidThunk,
     initYieldAllowanceThunk,
-    selectRawNetworkFeeInfo,
     selectStablecoinYieldSession,
     stablecoinYieldActions,
     submitYieldApproveThunk,
     submitYieldRevokeThunk,
 } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
-import { getConvertedOrDefaultFeeInfo } from '@suite-common/wallet-utils';
 import type { BulletListItemState } from '@trezor/components';
 import { useCurrentRef } from '@trezor/react-utils';
 
@@ -41,12 +38,9 @@ import { useResolvedYieldFlowData } from './useResolvedYieldFlowData';
 import { useYieldPendingTransactionTracking } from './useYieldPendingTransactionTracking';
 import {
     type YieldApprovalAction,
-    type YieldNetworkFeeWarning,
     getBulletListItemStates,
     getYieldApprovalAction,
-    getYieldEstimatedContractCallFee,
     getYieldModifyAmountInput,
-    getYieldNetworkFeeWarning,
     isAmountGreaterThan,
 } from '../yieldFlowUtils';
 
@@ -87,8 +81,6 @@ export type UseYieldFlowResult = {
     allowanceStatus: YieldAllowanceStatus;
     approvalAction: YieldApprovalAction;
     canRevokeAllowance: boolean;
-    approvalNetworkFeeWarning: YieldNetworkFeeWarning | null;
-    actionNetworkFeeWarning: YieldNetworkFeeWarning | null;
     isAmountEmpty: boolean;
     isAmountTooHigh: boolean;
     isAmountInvalidDecimals: boolean;
@@ -140,15 +132,6 @@ export const useYieldFlow = ({
             account,
             routeParams,
         });
-    const rawFeeInfo = useSelector(state => selectRawNetworkFeeInfo(state, account.symbol));
-    const feeInfo = useMemo(
-        () =>
-            getConvertedOrDefaultFeeInfo({
-                networkType: account.networkType,
-                feeInfo: rawFeeInfo,
-            }),
-        [account.networkType, rawFeeInfo],
-    );
     const allowanceFlowDataRef = useCurrentRef({ account, vault, token, receiptToken });
 
     const session = useSelector(state => selectStablecoinYieldSession(state, flowType, flowKey));
@@ -535,35 +518,6 @@ export const useYieldFlow = ({
             amount: liveAmount,
             threshold: session.approval.allowanceAmount ?? undefined,
         });
-    const networkFeeWarning = useMemo(() => {
-        if (account.networkType !== 'ethereum') {
-            return {
-                approvalNetworkFeeWarning: null,
-                actionNetworkFeeWarning: null,
-            };
-        }
-
-        const networkDisplaySymbol = getNetworkDisplaySymbol(account.symbol);
-        const estimatedContractCallFee = getYieldEstimatedContractCallFee(feeInfo);
-
-        if (!estimatedContractCallFee) {
-            return {
-                approvalNetworkFeeWarning: null,
-                actionNetworkFeeWarning: null,
-            };
-        }
-
-        const warning = getYieldNetworkFeeWarning({
-            availableBalance: account.availableBalance,
-            requiredFee: estimatedContractCallFee,
-            networkDisplaySymbol,
-        });
-
-        return {
-            approvalNetworkFeeWarning: flowType === 'deposit' ? warning : null,
-            actionNetworkFeeWarning: warning,
-        };
-    }, [account.availableBalance, account.networkType, account.symbol, feeInfo, flowType]);
 
     return {
         account,
@@ -590,8 +544,6 @@ export const useYieldFlow = ({
         allowanceStatus: session.approval.allowanceStatus,
         approvalAction,
         canRevokeAllowance,
-        approvalNetworkFeeWarning: networkFeeWarning.approvalNetworkFeeWarning,
-        actionNetworkFeeWarning: networkFeeWarning.actionNetworkFeeWarning,
         isAmountEmpty,
         isAmountTooHigh,
         isAmountInvalidDecimals,

--- a/packages/suite/src/components/earn/yield/supply/YieldSupplyForm.tsx
+++ b/packages/suite/src/components/earn/yield/supply/YieldSupplyForm.tsx
@@ -35,8 +35,6 @@ export const YieldSupplyForm = () => {
         allowanceStatus,
         approvalAction,
         canRevokeAllowance,
-        approvalNetworkFeeWarning,
-        actionNetworkFeeWarning,
         isAmountEmpty,
         isAmountTooHigh,
         isAmountInvalidDecimals,
@@ -226,14 +224,6 @@ export const YieldSupplyForm = () => {
                                                 />
                                             ) : undefined
                                         }
-                                        networkFeeWarning={
-                                            approveStepState === 'active' &&
-                                            approvalNetworkFeeWarning ? (
-                                                <YieldActionStepWarning
-                                                    networkFeeWarning={approvalNetworkFeeWarning}
-                                                />
-                                            ) : undefined
-                                        }
                                         isDisabled={
                                             isAmountEmpty ||
                                             isAmountTooHigh ||
@@ -272,13 +262,6 @@ export const YieldSupplyForm = () => {
                                                             isApprovalInsufficient
                                                         }
                                                         onModifyApproval={enterModifyApproval}
-                                                    />
-                                                ) : undefined
-                                            }
-                                            networkFeeWarning={
-                                                actionNetworkFeeWarning ? (
-                                                    <YieldActionStepWarning
-                                                        networkFeeWarning={actionNetworkFeeWarning}
                                                     />
                                                 ) : undefined
                                             }

--- a/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
+++ b/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
@@ -24,7 +24,6 @@ export const YieldWithdrawForm = () => {
         completedAmount,
         errorMessage,
         pendingTransaction,
-        actionNetworkFeeWarning,
         isAmountEmpty,
         isAmountTooHigh,
         isAmountInvalidDecimals,
@@ -125,13 +124,6 @@ export const YieldWithdrawForm = () => {
                             warning={
                                 !isAmountInvalidDecimals && isAmountTooHigh ? (
                                     <YieldActionStepWarning isInsufficientFunds={isAmountTooHigh} />
-                                ) : undefined
-                            }
-                            networkFeeWarning={
-                                actionNetworkFeeWarning ? (
-                                    <YieldActionStepWarning
-                                        networkFeeWarning={actionNetworkFeeWarning}
-                                    />
                                 ) : undefined
                             }
                             isDisabled={

--- a/packages/suite/src/components/earn/yield/yieldFlowUtils.ts
+++ b/packages/suite/src/components/earn/yield/yieldFlowUtils.ts
@@ -1,10 +1,5 @@
-import { fromWei, toWei } from 'web3-utils';
-
 import { tokenSupportsIncreasingAllowance } from '@suite-common/trading';
-import { ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT } from '@suite-common/wallet-constants';
 import { YIELD_FLOW_STEPS, type YieldFlowStepId } from '@suite-common/wallet-core';
-import { type FeeInfo } from '@suite-common/wallet-types';
-import { calculateTotalGasCost } from '@suite-common/wallet-utils';
 import type { BulletListItemState } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
 
@@ -29,47 +24,8 @@ type GetYieldApprovalActionParams = {
 
 export type YieldApprovalAction = 'approve' | 'continue' | 'increase' | 'revoke';
 
-export type YieldNetworkFeeWarning = {
-    availableAmount: string;
-    networkDisplaySymbol: string;
-};
-
 export const isAmountGreaterThan = ({ amount, threshold }: AmountComparisonParams): boolean =>
     !!amount && !!threshold && new BigNumber(amount).gt(threshold);
-
-type GetYieldNetworkFeeWarningParams = {
-    availableBalance: string;
-    requiredFee: BigNumber;
-    networkDisplaySymbol: string;
-};
-
-export const getYieldNetworkFeeWarning = ({
-    availableBalance,
-    requiredFee,
-    networkDisplaySymbol,
-}: GetYieldNetworkFeeWarningParams): YieldNetworkFeeWarning | null => {
-    if (requiredFee.isZero() || new BigNumber(availableBalance || '0').gte(requiredFee)) {
-        return null;
-    }
-
-    return {
-        availableAmount: fromWei(availableBalance || '0', 'ether'),
-        networkDisplaySymbol,
-    };
-};
-
-export const getYieldEstimatedContractCallFee = (feeInfo: FeeInfo): BigNumber | null => {
-    const feeLevel = feeInfo.levels.find(level => level.label === 'normal') ?? feeInfo.levels[0];
-    const gasPrice = feeLevel?.maxFeePerGas || feeLevel?.feePerUnit;
-
-    if (!gasPrice) {
-        return null;
-    }
-
-    return new BigNumber(
-        calculateTotalGasCost(toWei(gasPrice, 'gwei'), ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT),
-    );
-};
 
 export const getYieldApprovalAction = ({
     liveAmount,

--- a/packages/suite/src/components/tx-simulation/common/hooks/useEvmTxSimulationFeesForm.ts
+++ b/packages/suite/src/components/tx-simulation/common/hooks/useEvmTxSimulationFeesForm.ts
@@ -4,7 +4,11 @@ import { useForm } from 'react-hook-form';
 import { numberToHex, toWei } from 'web3-utils';
 
 import { type TxSimulationEVMResult } from '@suite-common/tx-simulation';
-import { type NetworkSymbol, type NetworkType } from '@suite-common/wallet-config';
+import {
+    type NetworkSymbol,
+    type NetworkType,
+    getNetworkDisplaySymbol,
+} from '@suite-common/wallet-config';
 import { ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT } from '@suite-common/wallet-constants';
 import { selectRawNetworkFeeInfo } from '@suite-common/wallet-core';
 import { type EvmSelectedFee } from '@suite-common/wallet-types';
@@ -16,12 +20,14 @@ import { useComposedLevelsPlaceholder } from 'src/hooks/wallet/form/useComposedL
 import { type FeesFormValues, useFees } from 'src/hooks/wallet/form/useFees';
 
 interface UseTxFeesFormProps {
+    accountBalance: string;
     networkType?: NetworkType;
     networkSymbol?: NetworkSymbol;
     defaultGasLimit?: string;
 }
 
 export function useEvmTxSimulationFeesForm({
+    accountBalance,
     networkType = 'ethereum',
     networkSymbol = 'eth',
     defaultGasLimit = ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT,
@@ -67,6 +73,18 @@ export function useEvmTxSimulationFeesForm({
         feePerUnit,
         maxFeePerGas,
     });
+
+    const composedLevelsError = useMemo(() => {
+        const selectedLevel = composedLevels[selectedFee || 'normal'];
+        const fee = selectedLevel?.type === 'final' ? selectedLevel.fee : undefined;
+
+        if (!fee || new BigNumber(fee).lte(accountBalance)) return undefined;
+
+        return {
+            id: 'AMOUNT_NOT_ENOUGH_CURRENCY_FEE',
+            values: { networkDisplaySymbol: getNetworkDisplaySymbol(networkSymbol) },
+        } as const;
+    }, [accountBalance, composedLevels, networkSymbol, selectedFee]);
 
     function handleTxSimulationResult({ simulation, gas_estimation }: TxSimulationEVMResult) {
         const newFeeLimit =
@@ -127,6 +145,7 @@ export function useEvmTxSimulationFeesForm({
         changeFeeLevel,
         feeInfo,
         composedLevels,
+        composedLevelsError,
         handleTxSimulationResult,
         getSelectedFee,
     };

--- a/packages/suite/src/components/tx-simulation/connect-popup/ConnectPopupTxSimulationModalInner.tsx
+++ b/packages/suite/src/components/tx-simulation/connect-popup/ConnectPopupTxSimulationModalInner.tsx
@@ -49,6 +49,7 @@ export function ConnectPopupTxSimulationModalInner({
         handleTxSimulationResult,
         getSelectedFee,
     } = useEvmTxSimulationFeesForm({
+        accountBalance: account.balance,
         networkType: account.networkType,
         networkSymbol: account.symbol,
         defaultGasLimit: areTxSimulationMethods(TX_METHODS_WITH_FEES, action)

--- a/packages/suite/src/components/tx-simulation/earn-stablecoin/EarnYieldTxSimulationModalInner.tsx
+++ b/packages/suite/src/components/tx-simulation/earn-stablecoin/EarnYieldTxSimulationModalInner.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { FormProvider } from 'react-hook-form';
 
+import { Translation } from '@suite/intl';
 import { type UserContextModalType } from '@suite/modal';
 import {
     TxSimulationError,
@@ -17,7 +18,7 @@ import {
     useTxSimulation,
 } from '@suite-common/tx-simulation';
 import { type Account, type TxSimulationAction } from '@suite-common/wallet-types';
-import { Column, Modal } from '@trezor/components';
+import { Banner, Column, Modal } from '@trezor/components';
 
 import { Fees } from 'src/components/wallet/Fees/Fees';
 
@@ -45,6 +46,7 @@ export function EarnYieldTxSimulationModalInner({
         changeFeeLevel,
         feeInfo,
         composedLevels,
+        composedLevelsError,
         handleTxSimulationResult,
         getSelectedFee,
     } = useEvmTxSimulationFeesForm({
@@ -53,6 +55,7 @@ export function EarnYieldTxSimulationModalInner({
         defaultGasLimit: areTxSimulationMethods(TX_METHODS_WITH_FEES, action)
             ? action.payload.transaction.gasLimit
             : undefined,
+        accountBalance: account.availableBalance,
     });
 
     const simulation = useTxSimulation(action, {
@@ -96,7 +99,8 @@ export function EarnYieldTxSimulationModalInner({
 
     const isConfirmDisabled = Boolean(
         txSimulationQuery.isLoading ||
-        (txSimulationQuery.data?.payload?.needsDisclaimer && !disclaimerAccepted),
+        (txSimulationQuery.data?.payload?.needsDisclaimer && !disclaimerAccepted) ||
+        composedLevelsError,
     );
 
     return (
@@ -149,6 +153,19 @@ export function EarnYieldTxSimulationModalInner({
                                     }
                                 />
                             </FormProvider>
+                        )}
+
+                        {composedLevelsError && (
+                            <Banner
+                                intent="critical"
+                                icon="warning"
+                                description={
+                                    <Translation
+                                        id={composedLevelsError.id}
+                                        values={composedLevelsError.values}
+                                    />
+                                }
+                            />
                         )}
                     </Column>
                 </Column>

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -9568,15 +9568,6 @@ export const messages = defineMessages({
         id: 'TR_EARN_YIELD_APPROVED_AMOUNT',
         defaultMessage: 'Approved amount',
     },
-    TR_EARN_YIELD_NETWORK_FEE_WARNING_TITLE: {
-        id: 'TR_EARN_YIELD_NETWORK_FEE_WARNING_TITLE',
-        defaultMessage: 'You only have {amount} {networkDisplaySymbol} available.',
-    },
-    TR_EARN_YIELD_NETWORK_FEE_WARNING_DESCRIPTION: {
-        id: 'TR_EARN_YIELD_NETWORK_FEE_WARNING_DESCRIPTION',
-        defaultMessage:
-            'This balance may not cover network fees. Consider adding more {networkDisplaySymbol} before you continue.',
-    },
     TR_EARN_YIELD_SUPPLY_COMPLETE: {
         id: 'TR_EARN_YIELD_SUPPLY_COMPLETE',
         defaultMessage: 'Deposit complete',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Yield withdraw/deposit/claim tx simulation modal now blocks confirm when the native balance can't cover the fee
- "Insufficient fee" warning is no longer shown in the forms themselves

## Notes for QA

## Related Issue

Resolve #27562

## Screenshots:

<img width="611" height="558" alt="image" src="https://github.com/user-attachments/assets/8ed3fac1-31c5-4bbc-86d0-a288bfb71d80" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/disable-tx-submit-with-low-balance&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/disable-tx-submit-with-low-balance&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-14T13:56:38.667Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-14T13:54:35.545Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/disable-tx-submit-with-low-balance/web/](https://dev.suite.sldev.cz/suite-web/fix/disable-tx-submit-with-low-balance/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->