### PR TITLE
Fix/tx simulation fees validaiton

### DIFF
--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/CustomFee/CustomFeeEthereum.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/CustomFee/CustomFeeEthereum.tsx
@@ -29,6 +29,7 @@ export const CustomFeeEthereum = ({
     const locale = useSelector(selectLanguage);
 
     const { control, getValues, setValue, trigger, watch } = useFormContext<FormState>();
+
     const { errors } = useFormState<FormState>();
 
     const { maxFee, minFee, levels, minPriorityFee } = feeInfo;
@@ -38,14 +39,9 @@ export const CustomFeeEthereum = ({
     const customMaxPriorityFeePerGas = watch(MAX_PRIORITY_FEE_PER_GAS);
 
     useEffect(() => {
-        trigger?.(MAX_PRIORITY_FEE_PER_GAS);
-    }, [customMaxFeePerGas, trigger]);
-
-    useEffect(() => {
-        trigger?.(MAX_FEE_PER_GAS);
-    }, [customMaxPriorityFeePerGas, trigger]);
-
-    const recommendedMaxFeePerGas = levels.find(level => level.label === 'normal')?.maxFeePerGas;
+        trigger(MAX_FEE_PER_GAS);
+        trigger(MAX_PRIORITY_FEE_PER_GAS);
+    }, [customMaxPriorityFeePerGas, customMaxFeePerGas, trigger]);
 
     const gasLimitRules = {
         required: translationString('GAS_LIMIT_IS_NOT_SET'),
@@ -127,12 +123,13 @@ export const CustomFeeEthereum = ({
         },
     };
 
+    const recommendedMaxFeePerGas = levels.find(level => level.label === 'normal')?.maxFeePerGas;
     const maxFeePerGasValidationProps = {
-        onClick: () =>
-            recommendedMaxFeePerGas &&
-            setValue(MAX_FEE_PER_GAS, recommendedMaxFeePerGas, {
-                shouldValidate: true,
-            }),
+        onClick: () => {
+            if (!recommendedMaxFeePerGas) return;
+
+            setValue(MAX_FEE_PER_GAS, recommendedMaxFeePerGas, { shouldValidate: true });
+        },
         text: translationString('CUSTOM_FEE_USE_RECOMMENDED'),
     };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Make sure `maxPriorityFeePerGas` and `maxFeePerGas` fields don't have stale validation errors.

<!--- Describe your changes in detail -->
Before:

https://github.com/user-attachments/assets/f814a0b9-daca-420f-b478-085b8a64e4e7

After:

https://github.com/user-attachments/assets/55548387-a559-4348-9192-97b1b57270e0

## Related Issue

Resolve #27692


<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect two EVM-specific fee-related files: the CustomFeeEthereum UI component and the useEvmTxSimulationFeesForm hook. The primary risk is in Ethereum/EVM send, sell, swap, and staking flows where custom gas fees are configured and displayed. The CustomFeeEthereum.tsx file maps to 121 tests via broad transitive imports, but only tests that directly exercise Ethereum custom fee settings are relevant. Priority testing should focus on ETH send/swap/sell flows that explicitly set and verify custom gas parameters.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/components/tx-simulation/common/hooks/useEvmTxSimulationFeesForm.ts`
- `packages/suite/src/components/wallet/Fees/CollapsibleFees/CustomFee/CustomFeeEthereum.tsx`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/wallet/send-eth.test.ts` — CustomFeeEthereum.tsx is the Ethereum custom fee component used in send flows. This test directly exercises custom Ethereum gas fee settings (gas limit, max fee per gas, max priority fee per gas) during an ETH send transaction, which is the primary UI that CustomFeeEthereum renders.
- `suite/e2e/tests/wallet/send-base.test.ts` — This test sets custom Ethereum fees (gas limit, max fee per gas, max priority fee per gas) on the Base network, which is an EVM chain using the same CustomFeeEthereum component. It directly validates the custom fee UI behavior changed in CustomFeeEthereum.tsx.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — This test explicitly sets custom Ethereum gas fees (gas limit, max fee per gas, max priority fee per gas) during a sell flow, directly exercising the CustomFeeEthereum component and the fee form logic potentially connected to useEvmTxSimulationFeesForm.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — This test configures custom Ethereum fee parameters (gas limit, max fee per gas, max priority fee per gas) during a swap flow and verifies them on the device display. It directly exercises CustomFeeEthereum.tsx and related fee calculation logic.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — While this test uses custom fee settings for Bitcoin (not Ethereum), the fee UI shares the CollapsibleFees infrastructure. Changes to CustomFeeEthereum.tsx could have side effects on the shared fee component structure, though the Bitcoin fee path is separate.
- `suite/e2e/tests/staking/staking-form.test.ts` — The staking form test exercises ETH staking input validation and amount entry. The useEvmTxSimulationFeesForm hook likely integrates with EVM transaction simulation in staking contexts, and this test validates the ETH staking form behavior including fee-related interactions.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test performs a full ETH staking transaction including fee display and device confirmation. The useEvmTxSimulationFeesForm hook may be involved in the EVM transaction simulation during staking, and fee amounts are verified in assertions.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — This test sells an ERC-20 token (USDC) and verifies device prompt shows correct crypto amount and fee. It exercises the Ethereum send/fee flow which involves CustomFeeEthereum and potentially useEvmTxSimulationFeesForm.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/components/tx-simulation/common/hooks/useEvmTxSimulationFeesForm.ts`

_Updated: 2026-05-14T13:53:36.668Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/tx-simulation-fees-validaiton/web/](https://dev.suite.sldev.cz/suite-web/fix/tx-simulation-fees-validaiton/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-14T13:58:52.848Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-14T13:56:59.765Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/tx-simulation-fees-validaiton&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->