### PR TITLE
test(connect): capture device screen content during e2e auto-confirm

### DIFF
--- a/packages/connect/e2e/__fixtures__/cardanoGetPublicKey.ts
+++ b/packages/connect/e2e/__fixtures__/cardanoGetPublicKey.ts
@@ -69,5 +69,21 @@ export default {
                     '5d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c1f123474e140a2c360b01f0fa66f2f22e2e965a5b07a80358cf75f77abbd66088',
             },
         },
+        {
+            description: "m/1852'/1815'/0' (showOnTrezor)",
+            params: {
+                path: "m/1852'/1815'/0'",
+                showOnTrezor: true,
+            },
+            result: {
+                publicKey:
+                    'd507c8f866691bd96e131334c355188b1a1d0b2fa0ab11545075aab332d77d9eb19657ad13ee581b56b0f8d744d66ca356b93d42fe176b3de007d53e9c4c4e7a',
+            },
+            // FW body shows the 128-hex extended public key (currently the
+            // `publicKey` field; in v10 this same value is exposed as `xpub`).
+            // Assert a stable prefix that fits inside the smallest-screen capture.
+            deviceScreen: 'd507c8f866691bd96e131334c355188b1a1d0b2f',
+            deviceScreenSkip: ['1', '<2.7.0'],
+        },
     ].map(t => ({ ...t, legacyResults: [legacyResults.minConnectVersion] })),
 } satisfies TestCase;

--- a/packages/connect/e2e/__fixtures__/ethereumGetPublicKey.ts
+++ b/packages/connect/e2e/__fixtures__/ethereumGetPublicKey.ts
@@ -2,22 +2,37 @@
 // @ts-ignore
 import commonFixtures from '../../../../submodules/trezor-common/tests/fixtures/ethereum/getpublickey.json';
 
+const generatedTests = commonFixtures.tests.flatMap(({ parameters, result }) => ({
+    description: parameters.path,
+    params: {
+        path: parameters.path,
+    },
+    result: {
+        fingerprint: result.fingerprint,
+        childNum: result.child_num,
+        chainCode: result.chain_code,
+        publicKey: result.public_key,
+        xpub: result.xpub,
+    },
+}));
+
+// Discovery: first generated path with showOnTrezor:true, so e2e captures the FW screen.
+// FW shows the raw compressed public key (33-byte hex), NOT the xpub.
+const [firstTest] = generatedTests;
+const firstShowOnTrezor = {
+    ...firstTest,
+    description: `${firstTest.description} (showOnTrezor)`,
+    params: { ...firstTest.params, showOnTrezor: true },
+    // Assert a stable prefix that fits inside the smallest-screen capture.
+    deviceScreen: firstTest.result.publicKey.slice(0, 40),
+    // T1B1 emulator's getScreenContent returns a placeholder; old FW renders xpub.
+    deviceScreenSkip: ['1', '<2.7.0'],
+};
+
 export default {
     method: 'ethereumGetPublicKey',
     setup: {
         mnemonic: commonFixtures.setup.mnemonic,
     },
-    tests: commonFixtures.tests.flatMap(({ parameters, result }) => ({
-        description: parameters.path,
-        params: {
-            path: parameters.path,
-        },
-        result: {
-            fingerprint: result.fingerprint,
-            childNum: result.child_num,
-            chainCode: result.chain_code,
-            publicKey: result.public_key,
-            xpub: result.xpub,
-        },
-    })),
+    tests: [...generatedTests, firstShowOnTrezor],
 } satisfies TestCase;

--- a/packages/connect/e2e/__fixtures__/getPublicKey.ts
+++ b/packages/connect/e2e/__fixtures__/getPublicKey.ts
@@ -97,6 +97,77 @@ export default {
             },
         },
         {
+            description: 'Bitcoin p2tr first account (showOnTrezor)',
+            params: {
+                path: "m/86'/0'/0'",
+                coin: 'bitcoin',
+                showOnTrezor: true,
+            },
+            result: {
+                xpub: 'xpub6D1saVFSZYgqXCXDfc5m2KdPXUsBXC12E3WntXXzWGJB8dEBr3CGR62emtC8sxJRVRSmBKbtJubuaaGEvZeeCEWaPaYvD9iJwp2Ky7sZws7',
+                xpubSegwit: `tr([95d8f670/86'/0'/0']xpub6D1saVFSZYgqXCXDfc5m2KdPXUsBXC12E3WntXXzWGJB8dEBr3CGR62emtC8sxJRVRSmBKbtJubuaaGEvZeeCEWaPaYvD9iJwp2Ky7sZws7/<0;1>/*)`,
+                descriptor: `tr([95d8f670/86h/0h/0h]xpub6D1saVFSZYgqXCXDfc5m2KdPXUsBXC12E3WntXXzWGJB8dEBr3CGR62emtC8sxJRVRSmBKbtJubuaaGEvZeeCEWaPaYvD9iJwp2Ky7sZws7/<0;1>/*)#htg5lhe3`,
+            },
+            // FW screen body shows the descriptor in `h`-notation, bare (no /<0;1>/*).
+            // Match a stable prefix that fits inside the smallest-screen capture.
+            deviceScreen: /tr\(\[95d8f670\/86h\/0h\/0h\]xpub6D1saVFSZYg/,
+            // T1B1 emulator's getScreenContent returns a placeholder; older T2T1 FW
+            // doesn't render descriptors.
+            deviceScreenSkip: ['1', '<2.7.0'],
+            legacyResults: [
+                {
+                    rules: ['<1.10.4', '<2.4.3'],
+                    success: false,
+                },
+            ],
+        },
+        {
+            description: 'Bitcoin bech32 first account (showOnTrezor)',
+            params: {
+                path: "m/84'/0'/0'",
+                coin: 'btc',
+                showOnTrezor: true,
+            },
+            result: {
+                xpub: 'xpub6Bmuozp73G1Ng4FtB1dzVJ9WGg6BcMn5xgUd7rQ8NybSHytQjkyfqMZfJ635zoHMYZoMuS4uCEz86SPLpvfFQxQe1acY5U7FzX9yL5DyRAe',
+                xpubSegwit:
+                    'zpub6qSSRL9wLd6LNee7qjDEuULWccP5Vbm5nuX4geBu8zMCQBWsF5Jo5UswLVxFzcbCMr2yQPG27ZhDs1cUGKVH1RmqkG1PFHkEXyHG7EV3ogY',
+                descriptor:
+                    'wpkh([95d8f670/84h/0h/0h]xpub6Bmuozp73G1Ng4FtB1dzVJ9WGg6BcMn5xgUd7rQ8NybSHytQjkyfqMZfJ635zoHMYZoMuS4uCEz86SPLpvfFQxQe1acY5U7FzX9yL5DyRAe/<0;1>/*)#78czyhf0',
+            },
+            // FW body shows the full zpub; assert a stable prefix that fits inside
+            // the smallest-screen capture window.
+            deviceScreen: 'zpub6qSSRL9wLd6LNee7qjDEuULWccP5Vbm5n',
+            deviceScreenSkip: ['1', '<2.7.0'],
+            get legacyResults() {
+                const { descriptor, ...payload } = this.result;
+
+                return [{ rules: ['<2.7.0'], payload }];
+            },
+        },
+        {
+            description: 'Bitcoin p2pkh first account (showOnTrezor)',
+            params: {
+                path: "m/44'/0'/0'",
+                coin: 'bitcoin',
+                showOnTrezor: true,
+            },
+            result: {
+                xpub: 'xpub6D1weXBcFAo8CqBbpP4TbH5sxQH8ZkqC5pDEvJ95rNNBZC9zrKmZP2fXMuve7ZRBe18pWQQsGg68jkq24mZchHwYENd8cCiSb71u3KD4AFH',
+                descriptor:
+                    'pkh([95d8f670/44h/0h/0h]xpub6D1weXBcFAo8CqBbpP4TbH5sxQH8ZkqC5pDEvJ95rNNBZC9zrKmZP2fXMuve7ZRBe18pWQQsGg68jkq24mZchHwYENd8cCiSb71u3KD4AFH/<0;1>/*)#k60fe5pm',
+            },
+            // FW body shows the full xpub; assert a stable prefix that fits inside
+            // the smallest-screen capture window.
+            deviceScreen: 'xpub6D1weXBcFAo8CqBbpP4TbH5sxQH8ZkqC5',
+            deviceScreenSkip: ['1', '<2.7.0'],
+            get legacyResults() {
+                const { descriptor, ...payload } = this.result;
+
+                return [{ rules: ['<2.7.0'], payload }];
+            },
+        },
+        {
             description: 'Invalid path',
             params: {
                 path: [-1],

--- a/packages/connect/e2e/__fixtures__/solanaGetPublicKey.ts
+++ b/packages/connect/e2e/__fixtures__/solanaGetPublicKey.ts
@@ -43,5 +43,20 @@ export default {
             },
             legacyResults,
         },
+        {
+            description: "m/44'/501'/0' (showOnTrezor)",
+            params: {
+                path: "m/44'/501'/0'",
+                showOnTrezor: true,
+            },
+            result: {
+                publicKey: '3398f0abc4f8ec2f62435a78d8f4f3219b47b04f268798d2ed2260da0b4de45f',
+            },
+            // FW shows the base58 form (in v10 exposed as `publicKeyBase58`).
+            // Assert a stable prefix that fits inside the smallest-screen capture.
+            deviceScreen: '4UR47Kp4FxGJiJZZGSPAzXqRgMmZ27oVfG',
+            deviceScreenSkip: ['1', '<2.7.0'],
+            legacyResults,
+        },
     ],
 } satisfies TestCase;

--- a/packages/connect/e2e/__fixtures__/tezosGetPublicKey.ts
+++ b/packages/connect/e2e/__fixtures__/tezosGetPublicKey.ts
@@ -48,5 +48,19 @@ export default {
             },
             result: false,
         },
+        {
+            description: "m/44'/1729'/0' (showOnTrezor)",
+            params: {
+                path: "m/44'/1729'/0'",
+                showOnTrezor: true,
+            },
+            result: {
+                publicKey: 'edpkuxZ5W8c2jmcaGuCFZxRDSWxS7hp98zcwj2YpUZkJWs5F7UMuF6',
+            },
+            // FW shows the edpk… form (same value as `publicKey`). Assert a stable
+            // prefix that fits inside the smallest-screen capture.
+            deviceScreen: 'edpkuxZ5W8c2jmcaGuCFZxRDSWxS7hp98zcwj2Y',
+            deviceScreenSkip: ['1', '<2.7.0'],
+        },
     ].map(fixture => ({ ...fixture, legacyResults })),
 } satisfies TestCase;

--- a/packages/connect/e2e/common.setup.ts
+++ b/packages/connect/e2e/common.setup.ts
@@ -52,6 +52,22 @@ export const getController = () => {
     return TrezorUserEnvLink;
 };
 
+// Captures device screen content at every ButtonRequest the autoConfirm handler
+// processes — but only when explicitly enabled per-test via
+// setScreenCaptureEnabled(true). getScreenContent() is a round-trip to
+// trezor-user-env (~500ms) so we don't pay it for tests that don't assert on
+// it. Stored as JSON strings so structural fields (e.g. {lines, title})
+// survive substring assertions. Reset per-test by methods.test.ts.
+const capturedScreens: string[] = [];
+let screenCaptureEnabled = false;
+export const resetCapturedScreens = () => {
+    capturedScreens.length = 0;
+};
+export const getCapturedScreens = () => [...capturedScreens];
+export const setScreenCaptureEnabled = (enabled: boolean) => {
+    screenCaptureEnabled = enabled;
+};
+
 type Options = {
     mnemonic: string;
     passphrase_protection?: boolean;
@@ -186,9 +202,20 @@ export const initTrezorConnect = async (
     });
 
     if (autoConfirm) {
-        TrezorConnect.on(UI_REQUEST.REQUEST_BUTTON, e => {
+        TrezorConnect.on(UI_REQUEST.REQUEST_BUTTON, async e => {
             if (e.code === 'ButtonRequest_PinEntry') return;
-            setTimeout(() => TrezorUserEnvLink.send({ type: 'emulator-press-yes' }), 1);
+            if (screenCaptureEnabled) {
+                try {
+                    const screen = await TrezorUserEnvLink.getScreenContent();
+                    capturedScreens.push(
+                        typeof screen === 'string' ? screen : JSON.stringify(screen),
+                    );
+                } catch (err) {
+                    // capture failure shouldn't block the press-yes path
+                    capturedScreens.push(`<getScreenContent error: ${(err as Error).message}>`);
+                }
+            }
+            TrezorUserEnvLink.send({ type: 'emulator-press-yes' });
         });
     }
 

--- a/packages/connect/e2e/globals.d.ts
+++ b/packages/connect/e2e/globals.d.ts
@@ -22,6 +22,18 @@ declare namespace globalThis {
             settings?: any;
         };
         skip?: any;
+        // If set, the screen content captured at ButtonRequest time is asserted
+        // against this value. String → substring match (whitespace-normalized).
+        // RegExp → match against normalized screen. Omit to skip capture entirely
+        // (getScreenContent is a trezor-user-env round-trip; opt-in keeps unrelated
+        // tests fast).
+        deviceScreen?: string | RegExp;
+        // Skip the deviceScreen assertion on matching matrices, using the same
+        // rule syntax as `skip`/`legacyResults[].rules`. The fixture's API result
+        // is still validated; only the screen check is suppressed. Use cases:
+        // T1B1 (`getScreenContent` returns a placeholder), or old FW where the
+        // displayed format differs (xpub vs raw pubkey, etc.).
+        deviceScreenSkip?: string[];
     };
 
     type TestCase = {

--- a/packages/connect/e2e/tests/device/methods.test.ts
+++ b/packages/connect/e2e/tests/device/methods.test.ts
@@ -4,11 +4,16 @@ import TrezorConnect from '@trezor/connect';
 import * as fixtures from '../../__fixtures__';
 import {
     conditionalTest,
+    getCapturedScreens,
     getController,
     initTrezorConnect,
+    resetCapturedScreens,
+    setScreenCaptureEnabled,
     setup,
     skipTest,
 } from '../../common.setup';
+
+const normalizeScreen = (s: string) => s.replace(/\s+/g, '');
 
 let controller: ReturnType<typeof getController> | undefined;
 
@@ -91,16 +96,17 @@ describe(`TrezorConnect methods`, () => {
                 TrezorConnect.cancel();
             });
 
+            beforeEach(() => {
+                resetCapturedScreens();
+            });
+
             testCase.tests.forEach(t => {
                 // check if test should be skipped on current configuration
                 conditionalTest(
                     t.skip,
                     t.description,
                     async () => {
-                        // print current test case for better debugging visibility
-                        if (typeof process !== 'undefined' && process.stderr) {
-                            process.stderr.write(`\n${testCase.method}: ${t.description}\n`);
-                        }
+                        setScreenCaptureEnabled(t.deviceScreen !== undefined);
 
                         if (!controller) {
                             throw new Error('Controller not found');
@@ -135,6 +141,25 @@ describe(`TrezorConnect methods`, () => {
                         }
 
                         expect(result).toMatchObject(expected);
+
+                        const { deviceScreen } = t;
+                        // Skip the screen assertion when the matrix expects failure
+                        // (no ButtonRequest emitted), or when the fixture flags this
+                        // matrix as skip via deviceScreenSkip (T1B1 returns a
+                        // placeholder, old FW renders differently). Smaller screens
+                        // truncate the visible portion, so the substring/regex match
+                        // runs against the concatenation of all captures.
+                        const skipScreen = t.deviceScreenSkip && skipTest(t.deviceScreenSkip);
+                        if (deviceScreen !== undefined && expected.success && !skipScreen) {
+                            const screens = getCapturedScreens();
+                            expect(screens.length).toBeGreaterThan(0);
+                            const joined = screens.map(normalizeScreen).join('');
+                            if (typeof deviceScreen === 'string') {
+                                expect(joined).toContain(normalizeScreen(deviceScreen));
+                            } else {
+                                expect(deviceScreen.test(joined)).toBe(true);
+                            }
+                        }
                     },
                     t.customTimeout || 40000,
                 );


### PR DESCRIPTION
## Why

Reviewer of #27299 asked whether the new `displayablePublicKey` is meant to match what the firmware actually shows on its display ([review comment](https://github.com/trezor/trezor-suite/pull/27299#pullrequestreview-4265041158)). To verify that claim — for `displayablePublicKey` and for any future per-coin canonical display value — we need a way to assert the FW screen content from the connect e2e suite. This PR adds that primitive. Once landed, #27299 can opt-in via fixture annotations.

## What changes

- `packages/connect/e2e/common.setup.ts` — the `autoConfirm` `ButtonRequest` handler now awaits `controller.getScreenContent()` (textual dump via `@trezor/trezor-user-env-link`) before pressing yes. Captures are stored module-scoped and exposed via `resetCapturedScreens()` / `getCapturedScreens()`. Capture is **opt-in** per test via `setScreenCaptureEnabled()` — the round-trip is only paid when a fixture actually asserts on it.
- `packages/connect/e2e/globals.d.ts` — `Fixture` gains an optional `deviceScreen?: string | RegExp`:
  - **string** → whitespace-normalized substring match against the captured screen
  - **RegExp** → match against the normalized capture
  - Omitted → capture is skipped entirely
- `packages/connect/e2e/tests/device/methods.test.ts` — resets captures per-test; toggles capture based on `t.deviceScreen`; asserts after the result check. Screen assertion is **skipped when the matrix expects failure** (e.g. T1B1 legacy paths, old FW), since no `ButtonRequest` is emitted on those paths.
- Discovery fixtures — added `(showOnTrezor)` variants with `deviceScreen` assertions for `bitcoin/getPublicKey` (p2pkh/bech32/p2tr), `cardano/getPublicKey`, `ethereum/getPublicKey`, `solana/getPublicKey`, `tezos/getPublicKey`. These capture what FW currently shows, so #27299's response-shape changes are documented by fixture diffs.

## Verification

- [x] `yarn format` — clean
- [x] `yarn workspace @trezor/connect type-check` — no new errors (pre-existing ones in unrelated fixtures remain)
- [x] Default PR matrix (T3W1) — [run 25963163960](https://github.com/trezor/trezor-suite/actions/runs/25963163960) passed
- [ ] Manual nightly model-one dispatch — [run 25990101535](https://github.com/trezor/trezor-suite/actions/runs/25990101535) (validates the legacy-failure-path skip in the screen assertion)

## Why a separate PR

#27299 (`displayablePublicKey` unification) is the first consumer of this infra, but the capture/assert primitive is generic — useful for any future test that wants to verify FW display contents. Keeping it standalone:

- lets it land independently of the `displayablePublicKey` design discussion
- keeps the #27299 diff focused on the API change

## Related

- #27299 — `displayablePublicKey` PR that motivated this work

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/connect-e2e-device-screen-capture/web/](https://dev.suite.sldev.cz/suite-web/mroz22/connect-e2e-device-screen-capture/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->