### PR TITLE
fix(suite): handle mac fullscreen when hiding connect popup

### DIFF
--- a/packages/suite-desktop-api/src/api.ts
+++ b/packages/suite-desktop-api/src/api.ts
@@ -134,6 +134,7 @@ export interface InvokeChannels {
         response: 'background-always' | 'background-now' | 'quit-always' | 'quit-now',
     ) => void;
     'app/is-visible': () => boolean;
+    'app/is-fullscreen': () => boolean;
     'tray/change-settings': (payload: TraySettings) => InvokeResult;
     'tray/get-settings': () => InvokeResult<TraySettings>;
     'connect-popup/enabled': () => boolean;
@@ -191,6 +192,7 @@ export type DesktopApi = {
     appAutoStartPopupAck: DesktopApiInvoke<'app/auto-start/popup-ack'>;
     appAutoStartPopupResponse: DesktopApiInvoke<'app/auto-start/popup-response'>;
     appIsVisible: DesktopApiInvoke<'app/is-visible'>;
+    appIsFullScreen: DesktopApiInvoke<'app/is-fullscreen'>;
     // Auto-updater
     checkForUpdates: DesktopApiSend<'update/check'>;
     downloadUpdate: DesktopApiSend<'update/download'>;

--- a/packages/suite-desktop-api/src/factory.ts
+++ b/packages/suite-desktop-api/src/factory.ts
@@ -54,6 +54,7 @@ export const factory = <R extends StrictIpcRenderer<any, IpcRendererEvent>>(
         appAutoStartPopupResponse: response =>
             ipcRenderer.invoke('app/auto-start/popup-response', response),
         appIsVisible: () => ipcRenderer.invoke('app/is-visible'),
+        appIsFullScreen: () => ipcRenderer.invoke('app/is-fullscreen'),
 
         // Auto-updater
         checkForUpdates: ({ isManual }) => {

--- a/packages/suite-desktop-core/src/modules/window-controls.ts
+++ b/packages/suite-desktop-core/src/modules/window-controls.ts
@@ -99,4 +99,8 @@ export const init: ModuleInit = ({ mainWindowProxy }) => {
     });
 
     ipcMain.handle('app/is-visible', () => mainWindowProxy?.getInstance()?.isVisible() ?? false);
+    ipcMain.handle(
+        'app/is-fullscreen',
+        () => mainWindowProxy?.getInstance()?.isFullScreen() ?? false,
+    );
 };

--- a/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
@@ -18,6 +18,7 @@ import TrezorConnect, {
     type CallMethodPayload,
     UI_REQUEST,
 } from '@trezor/connect';
+import { isMacOs } from '@trezor/env-utils';
 import { desktopApi } from '@trezor/suite-desktop-api';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -206,7 +207,11 @@ export const useConnectPopupDesktop = () => {
             // Only hide if we actually focused during this call, otherwise
             // we'd hide a window the user was using before the call started.
             if (currentlyOngoing && !wasVisible) {
-                desktopApi.appHide();
+                desktopApi.appIsFullScreen().then(isFullScreen => {
+                    if (isMacOs() && isFullScreen) return;
+
+                    desktopApi.appHide();
+                });
             }
             setCurrentlyOngoing(false);
         }


### PR DESCRIPTION
## Description

When ending Connect Popup flow, check if fullscreen is enabled on macOS before hiding window, to prevent empty screen. 

## Related Issue

Resolve #27436

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes span the desktop API layer (api.ts, factory.ts), Electron window controls module, and the connect popup desktop hook. The highest risk is in the TrezorConnect desktop integration tests since they directly use coreMode 'suite-desktop' which depends on both the desktop API factory and the connect popup hook. The window-controls module change poses moderate risk to Electron-specific tests (bridge/spawn tests). The suite-desktop-api factory.ts maps to 121 tests but is a broad dependency — only tests that specifically exercise the desktop API or TrezorConnect desktop integration should be prioritized.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite-desktop-api/src/api.ts`
- `packages/suite-desktop-api/src/factory.ts`
- `packages/suite-desktop-core/src/modules/window-controls.ts`
- `packages/suite/src/support/suite/useConnectPopupDesktop.tsx`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (10)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — useConnectPopupDesktop.tsx directly implements the connect popup behavior for desktop. The connectPopupWeb test exercises TrezorConnect popup flows including permissions, address confirmation, and cancellation - the web variant of connect popup functionality that shares infrastructure with the desktop connect popup hook.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — This test exercises the TrezorConnect popup flow via webextension which shares the same connect popup infrastructure as useConnectPopupDesktop. Changes to the desktop popup hook could affect the shared connect popup permission and address confirmation flows.
- `suite/e2e/tests/trezor-connect/error.test.ts` — This test directly uses TrezorConnect with coreMode 'suite-desktop', which exercises the desktop API and connect popup integration. Changes to suite-desktop-api's api.ts and factory.ts directly affect how TrezorConnect initializes in desktop mode.
- `suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts` — This test uses TrezorConnect with coreMode 'suite-desktop' and exercises the connect permissions modal flow, directly testing the desktop API layer (api.ts, factory.ts) and the connect popup integration that useConnectPopupDesktop manages.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Exercises TrezorConnect.ethereumSignTransaction with coreMode 'suite-desktop', directly relying on the desktop API factory and connect popup infrastructure that were changed.
- `suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — Uses TrezorConnect.getAccountInfo with coreMode 'suite-desktop', testing the desktop API integration and connect permissions modal. Directly exercises the changed desktop API layer.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Tests TrezorConnect.getAddress with coreMode 'suite-desktop', including address verification on device. Directly relies on the desktop API and connect popup flow affected by the changes.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Tests TrezorConnect permission granting/remembering/forgetting with coreMode 'suite-desktop'. The connect popup permissions flow is managed by useConnectPopupDesktop and relies on the desktop API.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — Tests TrezorConnect.signTransaction with coreMode 'suite-desktop', including multi-step device confirmation. Directly uses the desktop API layer and connect popup flow.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — Tests TrezorConnect silent mode with coreMode 'suite-desktop', involving app/focus IPC events and the connectPopup Redux slice. Directly exercises desktop API (desktopApi/contextBridge) and connect popup behavior changed in useConnectPopupDesktop.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — Tests Electron app lifecycle including bridge spawning, window title verification, and app initialization. The window-controls module and desktop API factory are part of the Electron main process infrastructure this test exercises.
- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — Tests Electron app in daemon mode with bridge process management. The window-controls module affects Electron window lifecycle which this test depends on (Suite UI launching, window title, closing).

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite-desktop-core/src/modules/window-controls.ts`

_Updated: 2026-05-14T14:16:38.133Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/27436-connect-popup-mac-fullscreen&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/27436-connect-popup-mac-fullscreen&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-14T14:21:20.368Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-14T14:19:36.787Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/27436-connect-popup-mac-fullscreen/web/](https://dev.suite.sldev.cz/suite-web/fix/27436-connect-popup-mac-fullscreen/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->