### PR TITLE
test(e2e-suite): fix db-migration flakiness in CI

### DIFF
--- a/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
+++ b/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
@@ -83,10 +83,23 @@ export class OnboardingPage {
     }
 
     @step()
-    async verifySuiteIsLoaded() {
-        await expect(this.welcomeBody, 'expect Suite to load in under 30s').toBeVisible({
-            timeout: 30_000,
-        });
+    async verifySuiteIsLoaded(options?: { timeout?: number }) {
+        const timeout = options?.timeout ?? 10_000;
+
+        const suiteLoaded = this.page
+            .locator('[data-testid^="@welcome"]')
+            .or(this.page.locator('[data-testid^="@suite-layout"]'))
+            .or(this.page.locator('[data-testid^="@onboarding"]'))
+            .first();
+
+        try {
+            await suiteLoaded.waitFor({ state: 'attached', timeout });
+        } catch {
+            await this.page.reload({ waitUntil: 'domcontentloaded', timeout });
+            await suiteLoaded.waitFor({ state: 'attached', timeout });
+        }
+
+        await expect(suiteLoaded).toBeVisible({ timeout });
     }
 
     @step()

--- a/suite/e2e/support/setup.ts
+++ b/suite/e2e/support/setup.ts
@@ -82,7 +82,7 @@ export const electronTeardown = async (
     await closePromise;
 };
 
-export const webSetup = async (browserContext: BrowserContext) => {
+export const webSetup = async (browserContext: BrowserContext, skipInitNavigation = false) => {
     await TrezorUserEnvLink.startBridge(BRIDGE_VERSION);
 
     // Need to allow this to be able to access bridge on localhost
@@ -98,7 +98,10 @@ export const webSetup = async (browserContext: BrowserContext) => {
     await page.context().addInitScript(() => {
         window.Playwright = true;
     });
-    await page.goto('./');
+
+    // Prevent the app from polluting IndexedDB before loading legacy versions.
+    if (!skipInitNavigation) await page.goto('./');
+
     await mockRemoteMessageSystem(page);
 
     return page;

--- a/suite/e2e/support/testExtends/suiteBaseFixture.ts
+++ b/suite/e2e/support/testExtends/suiteBaseFixture.ts
@@ -28,6 +28,7 @@ type SuiteBaseFixture = {
     trezorUserEnv: TrezorUserEnv;
     electronApp: ElectronApplication | undefined;
     page: Page;
+    skipInitNavigation: boolean;
     exceptionLogger: void;
     coverageMapCollector: void;
 };
@@ -51,6 +52,7 @@ const suiteBaseTest = currentsTest.extend<SuiteTestOptions & SuiteBaseFixture>({
     target: [PlaywrightTarget.Web, { option: true }],
     model: [undefined, { option: true }],
     firmwareVersion: [undefined, { option: true }],
+    skipInitNavigation: [false, { option: true }],
     startEmulator: true,
     setupEmulator: true,
     deviceSetup: {},

--- a/suite/e2e/tests/general/check-links.test.ts
+++ b/suite/e2e/tests/general/check-links.test.ts
@@ -4,10 +4,12 @@ import { routes } from '@suite/router-config';
 import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
 
 import { expect, test } from '../../support/fixtures';
+import { OnboardingPage } from '../../support/pageObjects/onboarding/onboardingPage';
 import { createTestAnnotation } from '../../support/reporters/annotations';
 
 async function getAllLinksFromAllPages(
     page: Page,
+    onboardingPage: OnboardingPage,
     testInfo: TestInfo,
     paths: Array<string>,
 ): Promise<Set<string>> {
@@ -19,25 +21,7 @@ async function getAllLinksFromAllPages(
 
             // Ensure the page is loaded by asserting the element is attached to the DOM.
             // For unknown reasons, this is the only available method to wait for the page to load.
-            const pageContent = page
-                .locator('[data-testid^="@welcome"]')
-                .or(page.locator('[data-testid^="@suite-layout"]'))
-                .or(page.locator('[data-testid^="@onboarding"]'))
-                .first();
-
-            try {
-                await pageContent.waitFor({ state: 'attached', timeout: 10_000 });
-            } catch {
-                await test.step(`Page element not found for ${path}, reloading...`, async () => {
-                    await page.reload({ waitUntil: 'domcontentloaded', timeout: 10_000 });
-                });
-            }
-
-            await expect(
-                pageContent,
-                `The page element for route "${path}" should be attached`,
-            ).toBeAttached();
-            await expect(page.getByTestId('@suite/bundle-loader')).toBeHidden();
+            await onboardingPage.verifySuiteIsLoaded();
 
             // Extract all hrefs in a single browser operation to reduce network latency in CI.
             const allHrefs = await page
@@ -94,7 +78,7 @@ test.describe('Check Links', { tag: ['@webOnly', '@nightlyOnly', '@T3T1'] }, () 
                 stream: TestStream.Foundation,
             }),
         },
-        async ({ page }, testInfo) => {
+        async ({ page, onboardingPage }, testInfo) => {
             let allUrls = new Set<string>();
 
             const urlsToCheck: string[] = [];
@@ -115,7 +99,7 @@ test.describe('Check Links', { tag: ['@webOnly', '@nightlyOnly', '@T3T1'] }, () 
 
                 // After onboarding, the URL is cleared to the base domain by the application's routing logic.
                 // We need to navigate back to the correct base URL for the test environment.
-                allUrls = await getAllLinksFromAllPages(page, testInfo, allPaths);
+                allUrls = await getAllLinksFromAllPages(page, onboardingPage, testInfo, allPaths);
             });
 
             await test.step('Filter known broken links', () => {

--- a/suite/e2e/tests/suite/db-locale-migration.test.ts
+++ b/suite/e2e/tests/suite/db-locale-migration.test.ts
@@ -16,6 +16,7 @@ test.describe(
     () => {
         test.use({
             deviceSetup: { passphrase_protection: true, mnemonic: 'mnemonic_all' },
+            skipInitNavigation: true,
         });
 
         test(

--- a/suite/e2e/tests/suite/db-migration.test.ts
+++ b/suite/e2e/tests/suite/db-migration.test.ts
@@ -20,6 +20,7 @@ test.describe(
     () => {
         test.use({
             deviceSetup: { passphrase_protection: true, mnemonic: 'mnemonic_all' },
+            skipInitNavigation: true,
             bypassCSP: true,
         });
 


### PR DESCRIPTION
## Description

1. Refined `verifySuiteIsLoaded`
 * Configurable Option: Add options object `({ timeout?: number })` as parameter with a 10-second default.
 * Active Recovery: Implemented an "intelligent wait" strategy. If the initial wait fails, it reloads the page and tries again. This actively recovers from transient browser hangs rather than just waiting passively.

2. `skipInitNavigation` Implementation
 * Configurable Option: Added `skipInitNavigation` to the base test fixture (defaulting to false). This allows individual tests to opt out of the automatic initial navigation.
 * Migration Support: In `webSetup` this flag prevents the app from immediately loading `page.goto('./')`. This is essential for Database Migration tests, allowing them to navigate to specific legacy URLs first without the current app version "polluting" the database state beforehand.




<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies three test files directly (check-links, db-locale-migration, db-migration) which must be run, plus three shared infrastructure files: the onboarding page object, the base test fixture, and the test setup module. The infrastructure changes affect virtually all tests that go through onboarding, but since these are broad utilities, only tests with the most direct onboarding-specific behavior are recommended at medium priority. The risk is moderate — infrastructure changes could cause widespread failures, but the small number of targeted test runs should catch regressions in core flows.

<details><summary><b>Changed files (6)</b></summary>

- `suite/e2e/support/pageObjects/onboarding/onboardingPage.ts`
- `suite/e2e/support/setup.ts`
- `suite/e2e/support/testExtends/suiteBaseFixture.ts`
- `suite/e2e/tests/general/check-links.test.ts`
- `suite/e2e/tests/suite/db-locale-migration.test.ts`
- `suite/e2e/tests/suite/db-migration.test.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `../../suite/e2e/tests/general/check-links.test.ts` — This test file was directly changed. It must be run to verify the modifications to the link-checking test itself work correctly.
- `../../suite/e2e/tests/suite/db-locale-migration.test.ts` — This test file was directly changed. It must be run to verify the database locale migration test modifications work correctly.
- `../../suite/e2e/tests/suite/db-migration.test.ts` — This test file was directly changed. It must be run to verify the database migration test modifications work correctly.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `../../suite/e2e/tests/onboarding/analytics-consent.test.ts` — The onboardingPage page object was changed, and this test directly uses onboardingPage for the analytics consent flow during onboarding. Changes to the page object could break the onboarding interactions in this test.
- `../../suite/e2e/tests/onboarding/firmware-check.test.ts` — This test directly uses onboardingPage (including disableNecessaryFirmwareChecks and firmware sub-component) which was changed. It also relies on the test fixtures/setup infrastructure.
- `../../suite/e2e/tests/suite/initial-run.test.ts` — This test heavily exercises onboardingPage (completeOnboarding, verifySuiteIsLoaded, enterTHPPairingCode, optionallyDismissFwHashCheckError) and the analytics section during initial run. Changes to the onboarding page object and base fixtures could break this flow.
- `../../suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts` — This test uses onboardingPage extensively (firmware, tutorial, backup, pin, seed type selection) and relies on the base fixture and setup. Changes to the onboarding page object directly affect this wallet creation flow.
- `../../suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts` — This test uses onboardingPage extensively for the T3W1 wallet creation flow including firmware, THP pairing, tutorial, backup, and PIN setup. Changes to the onboarding page object could break any of these steps.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `../../suite/e2e/tests/analytics/events.test.ts` — This test uses completeOnboarding from the changed onboardingPage and relies on the base fixture/setup infrastructure. The onboarding flow is a critical prerequisite for this analytics test, so changes could cause setup failures.
- `../../suite/e2e/tests/settings/autodetect.test.ts` — This test uses onboardingPage.optionallyDismissFwHashCheckError which is part of the changed page object. It tests autodetect behavior on the onboarding analytics page.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite/e2e/support/setup.ts`
- `suite/e2e/support/testExtends/suiteBaseFixture.ts`

_Updated: 2026-05-14T14:30:09.712Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/fix-db-migration-flakiness&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/fix-db-migration-flakiness&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-14T14:35:39.937Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-14T14:33:16.245Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/fix-db-migration-flakiness/web/](https://dev.suite.sldev.cz/suite-web/test/fix-db-migration-flakiness/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->