### PR TITLE
fix(suite): connect silent mode remaining states

### DIFF
--- a/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
@@ -19,6 +19,7 @@ import TrezorConnect, {
     UI_REQUEST,
 } from '@trezor/connect';
 import { desktopApi } from '@trezor/suite-desktop-api';
+import { exhaustive } from '@trezor/type-utils';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useAnalytics } from 'src/support/useAnalytics';
@@ -177,17 +178,28 @@ export const useConnectPopupDesktop = () => {
     const [wasVisible, setWasVisible] = useState(false);
     useEffect(() => {
         const shouldFocus = (() => {
-            if (!popupCall) return false;
-            if (popupCall.state === 'permission-request') return true;
-            if (popupCall.state === 'address-confirmation') return true;
-            if (popupCall.state === 'ongoing' && popupCall.methodInfo.useUi) {
-                // Silent mode only focuses when the user has to type something
-                // into Suite (passphrase/PIN/word). Device-side confirmations
-                // and simple ongoing calls stay in the background.
-                return !isSilentMode || isUserInputModalOpen;
+            const state = popupCall?.state;
+            switch (state) {
+                case 'error':
+                case 'call-error':
+                case 'switch-device':
+                case 'permission-request':
+                case 'address-confirmation':
+                case 'tx-simulation':
+                    return true;
+                case 'ongoing': {
+                    // Silent mode only focuses when the user has to type something
+                    // into Suite (passphrase/PIN/word). Device-side confirmations
+                    // and simple ongoing calls stay in the background.
+                    return popupCall?.methodInfo?.useUi && (!isSilentMode || isUserInputModalOpen);
+                }
+                case 'finished':
+                case 'deeplink-callback':
+                case undefined:
+                    return false;
+                default:
+                    return exhaustive(state);
             }
-
-            return false;
         })();
 
         if (shouldFocus) {


### PR DESCRIPTION
## Description

Handle remaining states for Connect Popup silent mode

## Notes for QA

See issue

## Related Issue

Resolve  #27580

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to useConnectPopupDesktop.tsx, which manages the TrezorConnect popup lifecycle specifically for the desktop (Electron) Suite app. This hook controls how external TrezorConnect calls trigger permissions modals, device prompts, and popup focus behavior. The highest risk is to the trezor-connect E2E tests that directly exercise popup flows with coreMode 'suite-desktop'. No static coverage mapping exists for this file, so all recommendations are inferred from the LLM analysis of test behaviors and source hints.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/support/suite/useConnectPopupDesktop.tsx`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `../../suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — useConnectPopupDesktop.tsx directly handles Connect popup behavior for desktop. The connectPopupWeb test exercises the TrezorConnect popup flow including permissions, address confirmation, and popup lifecycle management. Changes to the connect popup hook could affect how popups are opened, managed, or closed.
- `../../suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — This test exercises TrezorConnect popup flows via webextension which share the same popup infrastructure that useConnectPopupDesktop manages. Changes to the desktop connect popup hook could affect how the Suite popup responds to external TrezorConnect calls.
- `../../suite/e2e/tests/trezor-connect/permissions.test.ts` — This test covers TrezorConnect permissions granting, remembering, and revoking — functionality that directly involves the connect popup flow managed by useConnectPopupDesktop. The source_hints reference connectPopup.permissions Redux state which the changed hook likely interacts with.
- `../../suite/e2e/tests/trezor-connect/silentMode.test.ts` — This test exercises silent mode for TrezorConnect calls including the connectPopup Redux slice (connectPopup.permissions state) and app/focus behavior — both directly managed by the useConnectPopupDesktop hook. Changes could affect whether Suite is brought to foreground during connect calls.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `../../suite/e2e/tests/trezor-connect/error.test.ts` — This test validates error handling when TrezorConnect is initialized with coreMode 'suite-desktop', which is the mode useConnectPopupDesktop supports. Changes to the popup hook could affect how errors are displayed in the connect popup flow.
- `../../suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts` — This test uses TrezorConnect with coreMode 'suite-desktop' and exercises the permissions modal flow that useConnectPopupDesktop orchestrates. Changes to the hook could affect how the sign message modal is displayed after permissions are granted.
- `../../suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — This test uses TrezorConnect with coreMode 'suite-desktop' and exercises the permissions and device confirmation flow. The useConnectPopupDesktop hook manages the popup lifecycle for these desktop connect calls.
- `../../suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — This test calls TrezorConnect.getAccountInfo with coreMode 'suite-desktop', triggering the connect permissions modal managed by the useConnectPopupDesktop hook. Changes could affect account selection flow after permission grant.
- `../../suite/e2e/tests/trezor-connect/getAddress.test.ts` — This test exercises TrezorConnect.getAddress with coreMode 'suite-desktop', including permissions modal, address confirmation, and device verification — all flows that pass through the desktop connect popup infrastructure managed by the changed hook.
- `../../suite/e2e/tests/trezor-connect/signTransaction.test.ts` — This test uses TrezorConnect.signTransaction with coreMode 'suite-desktop' and exercises the permissions confirmation and multi-step device prompt flow. The useConnectPopupDesktop hook manages the popup state for these desktop connect interactions.

</details>

_Updated: 2026-05-14T14:32:34.134Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/27580-silent-mode-disconnected&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/27580-silent-mode-disconnected&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-14T14:37:03.952Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-14T14:35:31.324Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/27580-silent-mode-disconnected/web/](https://dev.suite.sldev.cz/suite-web/fix/27580-silent-mode-disconnected/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->