### PR TITLE
Cancel by callId

### DIFF
--- a/packages/connect-common/src/events/call.ts
+++ b/packages/connect-common/src/events/call.ts
@@ -64,7 +64,7 @@ export interface CoreCallMessage {
 
 export interface CoreCallCancelMessage {
     type: typeof CORE_CALL_CANCEL;
-    payload: { reason?: string } | null;
+    payload: { reason?: string; callId?: string } | null;
 }
 
 export const RESPONSE_EVENT = 'RESPONSE_EVENT';

--- a/packages/connect-common/src/events/popup.ts
+++ b/packages/connect-common/src/events/popup.ts
@@ -40,7 +40,7 @@ export interface PopupHandshake {
 
 export interface PopupClosedMessage {
     type: typeof POPUP.CLOSED;
-    payload: { error: any } | null;
+    payload: { error?: any; callId?: string } | null;
 }
 
 export interface PopupCloseWindow {

--- a/packages/connect-common/src/impl/dynamic.ts
+++ b/packages/connect-common/src/impl/dynamic.ts
@@ -7,6 +7,7 @@ import type { ConnectFactoryDependencies } from '../factory';
 import type { ConnectSettings } from '../types';
 import type { UpdateConnectSettings } from '../types/api/updateConnectSettings';
 import { ConnectEmitter } from '../types/emitter';
+import { type CancelParams } from '../utils/cancelParams';
 
 export type ConnectImplSettings = {
     manifest: NonNullable<ConnectSettings['manifest']>;
@@ -152,8 +153,8 @@ export class TrezorConnectDynamic implements ConnectFactoryDependencies<Record<n
         }
     }
 
-    public cancel(error?: string) {
-        return this.getTarget().cancel(error);
+    public cancel(params?: CancelParams) {
+        return this.getTarget().cancel(params);
     }
 
     public dispose() {

--- a/packages/connect-common/src/types/api/__tests__/index.ts
+++ b/packages/connect-common/src/types/api/__tests__/index.ts
@@ -16,6 +16,12 @@ export const init = async (api: TrezorConnect) => {
     }
 
     api.dispose();
+    // callId must be a UUID v4 (validated when the method is invoked via AbstractMethod).
+    const exampleCallId = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
     api.cancel();
+    api.cancel({ reason: 'Interruption error' });
+    api.cancel({ callId: exampleCallId });
+    api.cancel({ reason: 'Interruption error', callId: exampleCallId });
+    // Backward-compatible string form (legacy API).
     api.cancel('Interruption error');
 };

--- a/packages/connect-common/src/types/api/cancel.ts
+++ b/packages/connect-common/src/types/api/cancel.ts
@@ -1,1 +1,1 @@
-export declare function cancel(params?: string): void;
+export declare function cancel(params?: string | { reason?: string; callId?: string }): void;

--- a/packages/connect-common/src/utils/__tests__/cancelParams.test.ts
+++ b/packages/connect-common/src/utils/__tests__/cancelParams.test.ts
@@ -1,0 +1,25 @@
+import { normalizeCancelParams } from '../cancelParams';
+
+describe('utils/cancelParams', () => {
+    describe('normalizeCancelParams', () => {
+        it('returns empty object when params is undefined', () => {
+            expect(normalizeCancelParams()).toEqual({});
+            expect(normalizeCancelParams(undefined)).toEqual({});
+        });
+
+        it('returns the object as-is when params is an object', () => {
+            expect(normalizeCancelParams({})).toEqual({});
+            expect(normalizeCancelParams({ reason: 'foo' })).toEqual({ reason: 'foo' });
+            expect(normalizeCancelParams({ callId: 'abc' })).toEqual({ callId: 'abc' });
+            expect(normalizeCancelParams({ reason: 'foo', callId: 'abc' })).toEqual({
+                reason: 'foo',
+                callId: 'abc',
+            });
+        });
+
+        it('wraps a string into { reason } for backward compatibility', () => {
+            expect(normalizeCancelParams('cancelled')).toEqual({ reason: 'cancelled' });
+            expect(normalizeCancelParams('')).toEqual({ reason: '' });
+        });
+    });
+});

--- a/packages/connect-common/src/utils/cancelParams.ts
+++ b/packages/connect-common/src/utils/cancelParams.ts
@@ -1,0 +1,13 @@
+// The string form is supported for backward compatibility with older API
+// versions where `cancel(reason)` accepted a single reason string.
+export type CancelParams = string | { reason?: string; callId?: string };
+
+export const normalizeCancelParams = (
+    params?: CancelParams,
+): { reason?: string; callId?: string } => {
+    if (typeof params === 'string') {
+        return { reason: params };
+    }
+
+    return params ?? {};
+};

--- a/packages/connect-mobile/src/index.ts
+++ b/packages/connect-mobile/src/index.ts
@@ -111,8 +111,8 @@ export class TrezorConnectDeeplink implements ConnectFactoryDependencies<Connect
         throw ERRORS.TypedError('Method_InvalidPackage');
     }
 
-    public cancel(error?: string) {
-        this.resolveMessagePromises({ success: false, error });
+    public cancel(params?: { reason?: string; callId?: string }) {
+        this.resolveMessagePromises({ success: false, error: params?.reason });
     }
 
     public dispose() {

--- a/packages/connect-mobile/src/index.ts
+++ b/packages/connect-mobile/src/index.ts
@@ -9,6 +9,10 @@ import { createErrorMessage } from '@trezor/connect-common/src/events';
 import { type ConnectFactoryDependencies, factory } from '@trezor/connect-common/src/factory';
 import { type Manifest, type UpdateConnectSettings } from '@trezor/connect-common/src/types';
 import { ConnectEmitter } from '@trezor/connect-common/src/types/emitter';
+import {
+    type CancelParams,
+    normalizeCancelParams,
+} from '@trezor/connect-common/src/utils/cancelParams';
 import { createDeferredManager, removeTrailingSlashes } from '@trezor/utils';
 
 type BuildUrlParams = {
@@ -111,8 +115,9 @@ export class TrezorConnectDeeplink implements ConnectFactoryDependencies<Connect
         throw ERRORS.TypedError('Method_InvalidPackage');
     }
 
-    public cancel(params?: { reason?: string; callId?: string }) {
-        this.resolveMessagePromises({ success: false, error: params?.reason });
+    public cancel(params?: CancelParams) {
+        const { reason } = normalizeCancelParams(params);
+        this.resolveMessagePromises({ success: false, error: reason });
     }
 
     public dispose() {

--- a/packages/connect-web/src/impl/core-in-suite-desktop.ts
+++ b/packages/connect-web/src/impl/core-in-suite-desktop.ts
@@ -8,6 +8,10 @@ import {
 } from '@trezor/connect-common/src/events';
 import type { ConnectImpl, ConnectImplSettings } from '@trezor/connect-common/src/impl/dynamic';
 import type { Manifest } from '@trezor/connect-common/src/types/settings';
+import {
+    type CancelParams,
+    normalizeCancelParams,
+} from '@trezor/connect-common/src/utils/cancelParams';
 import { WebsocketClient, WebsocketError } from '@trezor/websocket-client';
 
 /**
@@ -31,10 +35,11 @@ export class CoreInSuiteDesktop implements ConnectImpl {
         return Promise.resolve(undefined);
     }
 
-    public cancel(reason?: string) {
+    public cancel(params?: CancelParams) {
+        const { reason, callId } = normalizeCancelParams(params);
         this.ws.sendMessage({
             type: CORE_CALL_CANCEL,
-            payload: reason ? { reason } : null,
+            payload: reason || callId ? { reason, callId } : null,
         });
     }
 

--- a/packages/connect-web/src/impl/core-in-suite-web.ts
+++ b/packages/connect-web/src/impl/core-in-suite-web.ts
@@ -7,6 +7,10 @@ import {
     createErrorMessage,
 } from '@trezor/connect-common/src/events';
 import type { ConnectImpl, ConnectImplSettings } from '@trezor/connect-common/src/impl/dynamic';
+import {
+    type CancelParams,
+    normalizeCancelParams,
+} from '@trezor/connect-common/src/utils/cancelParams';
 import { type Log, initLog } from '@trezor/connect-common/src/utils/debug';
 
 import { getEnv } from '../connectSettings';
@@ -32,8 +36,9 @@ export class CoreInSuiteWeb implements ConnectImpl {
         return Promise.resolve(undefined);
     }
 
-    public cancel(reason?: string) {
-        this.logger.debug('cancel', reason);
+    public cancel(params?: CancelParams) {
+        const { reason, callId } = normalizeCancelParams(params);
+        this.logger.debug('cancel', reason, callId);
 
         // Flush any pending outgoing messages so that the cancel is not
         // delayed behind queued sends (relevant for the webextension
@@ -42,7 +47,7 @@ export class CoreInSuiteWeb implements ConnectImpl {
         this._popupManager?.channel?.postMessage(
             {
                 type: CORE_CALL_CANCEL,
-                payload: reason ? { reason } : null,
+                payload: reason || callId ? { reason, callId } : null,
             },
             { usePromise: false },
         );

--- a/packages/connect-webextension/src/index.ts
+++ b/packages/connect-webextension/src/index.ts
@@ -37,6 +37,7 @@ const initProxyChannel = () => {
         reason?: string;
         // We need `error` field for backward compatibility, for connect10 with older clients.
         error?: string;
+        callId?: string;
     }>({
         name: 'trezor-connect-proxy',
         channel: {
@@ -56,12 +57,12 @@ const initProxyChannel = () => {
         // Handle cancel before the payload guard — cancel messages may
         // carry no meaningful payload.
         if (type === POPUP.CLOSED) {
-            TrezorConnect.cancel(payload?.error);
+            TrezorConnect.cancel({ reason: payload?.error, callId: payload?.callId });
 
             return;
         }
         if (type === CORE_CALL_CANCEL) {
-            TrezorConnect.cancel(payload?.reason);
+            TrezorConnect.cancel({ reason: payload?.reason, callId: payload?.callId });
 
             return;
         }

--- a/packages/connect-webextension/src/proxy/index.ts
+++ b/packages/connect-webextension/src/proxy/index.ts
@@ -11,6 +11,10 @@ import { type ConnectDynamicSettings } from '@trezor/connect-common/src/impl/dyn
 import { WindowServiceWorkerChannel } from '@trezor/connect-common/src/messageChannel/window-serviceworker';
 import type { UpdateConnectSettings } from '@trezor/connect-common/src/types';
 import { ConnectEmitter } from '@trezor/connect-common/src/types/emitter';
+import {
+    type CancelParams,
+    normalizeCancelParams,
+} from '@trezor/connect-common/src/utils/cancelParams';
 
 const eventEmitter = new ConnectEmitter();
 let _channel: any;
@@ -21,8 +25,9 @@ const dispose = () => {
     return Promise.resolve(undefined);
 };
 
-const cancel = (reason?: string) => {
+const cancel = (params?: CancelParams) => {
     if (_channel) {
+        const { reason } = normalizeCancelParams(params);
         _channel.postMessage(
             {
                 type: CORE_CALL_CANCEL,

--- a/packages/connect-webextension/src/proxy/index.ts
+++ b/packages/connect-webextension/src/proxy/index.ts
@@ -27,11 +27,11 @@ const dispose = () => {
 
 const cancel = (params?: CancelParams) => {
     if (_channel) {
-        const { reason } = normalizeCancelParams(params);
+        const { reason, callId } = normalizeCancelParams(params);
         _channel.postMessage(
             {
                 type: CORE_CALL_CANCEL,
-                payload: reason ? { reason } : null,
+                payload: reason || callId ? { reason, callId } : null,
             },
             { usePromise: false },
         );

--- a/packages/connect/e2e/tests/device/cancel.test.ts
+++ b/packages/connect/e2e/tests/device/cancel.test.ts
@@ -1,5 +1,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import TrezorConnect from '@trezor/connect';
+import type { TrezorUserEnvLinkClass } from '@trezor/trezor-user-env-link';
 import { Model } from '@trezor/trezor-user-env-link';
 
 import { conditionalTest, getController, initTrezorConnect, setup } from '../../common.setup';
@@ -39,6 +40,51 @@ const assertGetAddressWorks = async () => {
         success: true,
         payload: { address: 'tb1qkvwu9g3k2pdxewfqr7syz89r3gj557l3uuf9r9' },
     });
+};
+
+const runCancelScenario = async (
+    controller: TrezorUserEnvLinkClass,
+    buildCancelParams: (callIdA: string) => { reason?: string; callId?: string } | undefined,
+    expectCallBSuccess: boolean,
+) => {
+    await setup(controller, {
+        mnemonic: 'mnemonic_all',
+        passphrase_protection: true,
+    });
+    await initTrezorConnect(controller);
+
+    // Let call A run to completion so its callId is no longer in callMethods
+    const callIdA = crypto.randomUUID();
+    TrezorConnect.on('ui-request_passphrase', passphraseHandler(''));
+    const responseA = await TrezorConnect.getAddress({
+        path: "m/84'/1'/0'/0/0",
+        coin: 'regtest',
+        showOnTrezor: true,
+        callId: callIdA,
+    });
+
+    expect(responseA.success).toBeTruthy();
+
+    const callB = TrezorConnect.getAddress({
+        path: "m/84'/1'/0'/0/0",
+        coin: 'regtest',
+        showOnTrezor: true,
+    });
+
+    await new Promise<void>(resolve => {
+        const handler = (event: any) => {
+            if (event.code === 'ButtonRequest_Address') {
+                TrezorConnect.off('button', handler);
+                resolve();
+            }
+        };
+        TrezorConnect.on('button', handler);
+    });
+
+    TrezorConnect.cancel(buildCancelParams(callIdA));
+
+    const responseB = await callB;
+    expect(responseB.success).toEqual(expectCallBSuccess);
 };
 
 describe('TrezorConnect.cancel', () => {
@@ -181,6 +227,14 @@ describe('TrezorConnect.cancel', () => {
 
         // After a targeted cancel the device should still be usable
         await assertGetAddressWorks();
+    });
+
+    it('Cancel without callId aborts the current call even after a prior callId', async () => {
+        await runCancelScenario(controller, () => undefined, false);
+    });
+
+    it('Stale callId cancel does not cancel other methods', async () => {
+        await runCancelScenario(controller, callIdA => ({ callId: callIdA }), true);
     });
 
     conditionalTest(['2'], 'Pin request - Cancel', async () => {

--- a/packages/connect/e2e/tests/device/cancel.test.ts
+++ b/packages/connect/e2e/tests/device/cancel.test.ts
@@ -81,7 +81,7 @@ describe('TrezorConnect.cancel', () => {
             });
         });
 
-        TrezorConnect.cancel('Cancel reason');
+        TrezorConnect.cancel({ reason: 'Cancel reason' });
 
         const response = await getAddressCall;
 
@@ -118,7 +118,7 @@ describe('TrezorConnect.cancel', () => {
         // TODO: model T is happy with 1ms, model one needs more (1000 worked)
         await new Promise(resolve => setTimeout(resolve, 1000));
 
-        TrezorConnect.cancel('Cancel reason');
+        TrezorConnect.cancel({ reason: 'Cancel reason' });
 
         const response = await getAddressCall;
 
@@ -152,6 +152,34 @@ describe('TrezorConnect.cancel', () => {
 
         expect(response.success).toEqual(false);
 
+        await assertGetAddressWorks();
+    });
+
+    it('Passphrase request - Cancel by callId', async () => {
+        await setup(controller, {
+            mnemonic: 'mnemonic_all',
+            passphrase_protection: true,
+        });
+        await initTrezorConnect(controller);
+
+        const callId = crypto.randomUUID();
+        const callA = TrezorConnect.getAddress({
+            path: "m/84'/1'/0'/0/0",
+            coin: 'regtest',
+            showOnTrezor: false,
+            callId,
+        });
+
+        // Wait for passphrase prompt then cancel only this call by its callId
+        await new Promise<void>(resolve => {
+            TrezorConnect.on('ui-request_passphrase', () => resolve());
+        });
+        TrezorConnect.cancel({ callId });
+
+        const responseA = await callA;
+        expect(responseA.success).toEqual(false);
+
+        // After a targeted cancel the device should still be usable
         await assertGetAddressWorks();
     });
 

--- a/packages/connect/e2e/tests/device/discoverAccounts.test.ts
+++ b/packages/connect/e2e/tests/device/discoverAccounts.test.ts
@@ -71,7 +71,7 @@ describe(`TrezorConnect.discoverAccounts`, () => {
         TrezorConnect.on(UI_REQUEST.BUNDLE_PROGRESS, onBundleProgress);
         /*
         new Promise(resolve => setTimeout(resolve, 600)).then(() =>
-            TrezorConnect.cancel('CANCELLED'),
+            TrezorConnect.cancel({ reason: 'CANCELLED' }),
         );
         */
 

--- a/packages/connect/e2e/tests/device/thpPairing.test.ts
+++ b/packages/connect/e2e/tests/device/thpPairing.test.ts
@@ -178,7 +178,7 @@ describe('THP pairing', () => {
     const cancelOnHost = async () => {
         // events are emitted before ButtonAck is sent to device
         await new Promise(resolve => setTimeout(resolve, 10));
-        TrezorConnect.cancel(CANCEL_ERR);
+        TrezorConnect.cancel({ reason: CANCEL_ERR });
     };
     const buttonRequestHandler =
         (cancelOnButtonRequestName?: string) => (br: { name?: string }) => {

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -667,12 +667,34 @@ const registerDeviceEvents =
         device.on(DEVICE.THP_PAIRING_STATUS_CHANGED, onThpPhaseChangedHandler(device, context));
     };
 
-// Shared cancel/interrupt routine. The caller decides which TrezorError to use,
-// which determines whether the consumer sees Method_Interrupted (popup closed)
-// or Method_Cancel (explicit cancel() call).
-const abortRunningCall = (context: CoreContext, error: TrezorError) => {
+// When `callId` is provided, the abort is scoped to the single method whose
+// AbstractMethod.callId matches. Other in-flight methods, devices and UI
+// promises remain untouched. When `callId` is undefined, all in-flight work
+// is aborted (legacy behavior).
+const abortRunningCall = (context: CoreContext, error: TrezorError, callId?: string) => {
     const { uiPromises, deviceList, callMethods, resetWaitForFirstMethod, sendCoreMessage } =
         context;
+
+    if (callId) {
+        const method = callMethods.find(m => m.callId === callId);
+        if (!method) {
+            return;
+        }
+
+        if (method.device?.isUsedHere()) {
+            // Aborting the device session causes device.run to reject which
+            // propagates through the onCallDevice try/catch block and emits
+            // the response for this method only.
+            method.device.interrupt(error);
+        } else {
+            // Method has not acquired a device yet. Respond directly and
+            // let sendCoreMessage's RESPONSE_EVENT handler prune callMethods.
+            sendCoreMessage(createResponseMessage(method.responseID, false, { error }));
+        }
+
+        return;
+    }
+
     // Device was already acquired. Try to interrupt running action which will throw error from onCall try/catch block
     if (deviceList.isConnected() && deviceList.getDeviceCount() > 0) {
         deviceList.getAllDevices().forEach(d => {
@@ -702,8 +724,8 @@ const onPopupClosed = (context: CoreContext) => {
 };
 
 // Handle an explicit cancel() call (always produces Method_Cancel)
-const onCallCancel = (context: CoreContext, reason?: string) => {
-    abortRunningCall(context, ERRORS.TypedError('Method_Cancel', reason));
+const onCallCancel = (context: CoreContext, reason?: string, callId?: string) => {
+    abortRunningCall(context, ERRORS.TypedError('Method_Cancel', reason), callId);
 };
 
 const initDeviceList = (context: CoreContext) => {
@@ -802,7 +824,11 @@ export class Core extends EventEmitter {
                 break;
 
             case CORE_CALL_CANCEL:
-                onCallCancel(this.getCoreContext(), message.payload?.reason);
+                onCallCancel(
+                    this.getCoreContext(),
+                    message.payload?.reason,
+                    message.payload?.callId,
+                );
                 break;
 
             case TRANSPORT.DISABLE_WEBUSB: {

--- a/packages/connect/src/impl/core-in-module.ts
+++ b/packages/connect/src/impl/core-in-module.ts
@@ -23,6 +23,10 @@ import type {
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { parseConnectSettings } from '@trezor/connect-common/src/data/connectSettings';
 import { ConnectEmitter } from '@trezor/connect-common/src/types/emitter';
+import {
+    type CancelParams,
+    normalizeCancelParams,
+} from '@trezor/connect-common/src/utils/cancelParams';
 import { initLog } from '@trezor/connect-common/src/utils/debug';
 import { TRANSPORT } from '@trezor/transport-common';
 import { cloneObject, createDeferredManager } from '@trezor/utils';
@@ -177,8 +181,12 @@ export abstract class CoreInModule implements ConnectFactoryDependencies<Connect
         this.handleCoreMessage(response);
     }
 
-    public cancel(reason?: string) {
-        this.handleCoreMessage({ type: CORE_CALL_CANCEL, payload: reason ? { reason } : null });
+    public cancel(params?: CancelParams) {
+        const { reason, callId } = normalizeCancelParams(params);
+        this.handleCoreMessage({
+            type: CORE_CALL_CANCEL,
+            payload: reason || callId ? { reason, callId } : null,
+        });
     }
 
     public dispose() {

--- a/packages/suite-desktop-api/src/messages.ts
+++ b/packages/suite-desktop-api/src/messages.ts
@@ -158,6 +158,7 @@ export type ConnectPopupCall = {
 
 export type ConnectPopupCancel = {
     error?: string;
+    callId?: string;
 };
 
 export type ConnectPopupResponse = {

--- a/packages/suite-desktop-core/src/libs/connect-ws.ts
+++ b/packages/suite-desktop-core/src/libs/connect-ws.ts
@@ -148,10 +148,12 @@ export const exposeConnectWs = ({
             } else if (message.type === POPUP.CLOSED) {
                 mainWindowProxy.getInstance()?.webContents.send('connect-popup/cancel', {
                     error: message.payload?.error,
+                    callId: message.payload?.callId,
                 });
             } else if (message.type === CORE_CALL_CANCEL) {
                 mainWindowProxy.getInstance()?.webContents.send('connect-popup/cancel', {
                     error: message.payload?.reason,
+                    callId: message.payload?.callId,
                 });
             } else if (message.type === CORE_CALL) {
                 if (!processOnPort) {

--- a/packages/suite/src/actions/wallet/send/replaceByFeeErrorThunk.ts
+++ b/packages/suite/src/actions/wallet/send/replaceByFeeErrorThunk.ts
@@ -9,7 +9,7 @@ export const RBF_ERROR_ALREADY_MINED = 'replace-by-fee-error-transaction-already
 export const replaceByFeeErrorThunk = createThunk(
     `${MODULE_PREFIX}/replaceByFeeErrorThunk`,
     (_, { dispatch }) => {
-        TrezorConnect.cancel(RBF_ERROR_ALREADY_MINED);
+        TrezorConnect.cancel({ reason: RBF_ERROR_ALREADY_MINED });
 
         dispatch(
             openModal({

--- a/packages/suite/src/actions/wallet/stablecoin-yield/cancelSignYieldTx.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/cancelSignYieldTx.ts
@@ -9,7 +9,7 @@ export const cancelSignYieldTx = createThunk(
         const { serializedTx } = selectStablecoinYieldTxReview(getState());
 
         if (!serializedTx) {
-            TrezorConnect.cancel('tx-cancelled');
+            TrezorConnect.cancel({ reason: 'tx-cancelled' });
         }
 
         dispatch(closeModal());

--- a/packages/suite/src/actions/wallet/stakeActions.ts
+++ b/packages/suite/src/actions/wallet/stakeActions.ts
@@ -65,7 +65,7 @@ export const cancelSignTx =
         dispatch(stakeActions.requestPushTransaction());
         // if transaction is not signed yet interrupt signing in TrezorConnect
         if (!serializedTx) {
-            TrezorConnect.cancel('tx-cancelled');
+            TrezorConnect.cancel({ reason: 'tx-cancelled' });
 
             return;
         }

--- a/packages/suite/src/components/onboarding/ThpPairingStep/ThpCodeEntryStep.tsx
+++ b/packages/suite/src/components/onboarding/ThpPairingStep/ThpCodeEntryStep.tsx
@@ -12,7 +12,7 @@ export const ThpCodeEntryStep = () => {
     const intl = useIntl();
 
     const abort = useCallback(
-        () => TrezorConnect.cancel(intl.formatMessage(messages.TR_CANCELLED)),
+        () => TrezorConnect.cancel({ reason: intl.formatMessage(messages.TR_CANCELLED) }),
         [intl],
     );
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ConfirmActionModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ConfirmActionModal.tsx
@@ -32,7 +32,7 @@ export const ConfirmActionModal = ({
         if (!cancelable) {
             return;
         }
-        TrezorConnect.cancel(intl.formatMessage(messages.TR_CANCELLED));
+        TrezorConnect.cancel({ reason: intl.formatMessage(messages.TR_CANCELLED) });
         onCancel?.();
     };
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ConfirmPassphraseBeforeAction.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ConfirmPassphraseBeforeAction.tsx
@@ -25,7 +25,7 @@ export const ConfirmPassphraseBeforeAction = () => {
     const intl = useIntl();
 
     const onEnterPassphraseDialogCancel = () =>
-        TrezorConnect.cancel(intl.formatMessage(messages.TR_CANCELLED));
+        TrezorConnect.cancel({ reason: intl.formatMessage(messages.TR_CANCELLED) });
 
     const onSubmit = useCallback(
         (value: string, passphraseOnDevice?: boolean) => {

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/DeviceContextModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/DeviceContextModal.tsx
@@ -28,7 +28,7 @@ export const DeviceContextModal = ({
     const selectedAccount = useSelector(selectSelectedAccount);
 
     if (!device) return null;
-    const abort = () => TrezorConnect.cancel(intl.formatMessage(messages.TR_CANCELLED));
+    const abort = () => TrezorConnect.cancel({ reason: intl.formatMessage(messages.TR_CANCELLED) });
 
     switch (windowType) {
         // T1B1 firmware

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseOnDeviceModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseOnDeviceModal.tsx
@@ -32,7 +32,8 @@ export const PassphraseOnDeviceModal = ({ device }: PassphraseOnDeviceModalProps
     const confirmEmptyPassphrase = useSelector(selectIsDiscoveryStatusConfirmEmptyPassphrase);
     const deviceLabel = useSelector(selectSelectedDeviceLabelOrName);
 
-    const onCancel = () => TrezorConnect.cancel(intl.formatMessage(messages.TR_CANCELLED));
+    const onCancel = () =>
+        TrezorConnect.cancel({ reason: intl.formatMessage(messages.TR_CANCELLED) });
 
     return (
         <Modal.Backdrop onClick={onCancel}>

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBody.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBody.tsx
@@ -78,7 +78,7 @@ export const TransactionReviewModalBody = ({
             if (mounted && !isSending) {
                 setHasTxReviewExpired(true);
                 dispatch(preserveModalOnTxTimeout());
-                TrezorConnect.cancel('tx-timeout');
+                TrezorConnect.cancel({ reason: 'tx-timeout' });
             }
         }, timeLeft);
 
@@ -108,7 +108,7 @@ export const TransactionReviewModalBody = ({
         (cancel: boolean) => {
             if (cancel && !serializedTx && !isSending) {
                 dispatch(preserveModalOnTxTimeout());
-                TrezorConnect.cancel('tx-timeout');
+                TrezorConnect.cancel({ reason: 'tx-timeout' });
             }
 
             setHasTxReviewExpired(false);

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/MultiShareBackupModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/MultiShareBackupModal.tsx
@@ -59,7 +59,7 @@ export const MultiShareBackupModal = ({ onCancel }: MultiShareBackupModalProps) 
     };
 
     const closeWithCancelOnDevice = () => {
-        TrezorConnect.cancel('cancel');
+        TrezorConnect.cancel({ reason: 'cancel' });
         handleCancel();
     };
 

--- a/packages/suite/src/support/suite/useConnectPopup.tsx
+++ b/packages/suite/src/support/suite/useConnectPopup.tsx
@@ -32,8 +32,8 @@ export type ConnectPopupMessage =
           version: string;
       }
     | { type: typeof CORE_CALL; id: string; payload: { method: string; [key: string]: unknown } }
-    | { type: typeof POPUP.CLOSED; payload?: { error?: string } | null }
-    | { type: typeof CORE_CALL_CANCEL; payload?: { reason?: string } | null };
+    | { type: typeof POPUP.CLOSED; payload?: { error?: string; callId?: string } | null }
+    | { type: typeof CORE_CALL_CANCEL; payload?: { reason?: string; callId?: string } | null };
 
 /** Outgoing message shape. */
 export type ConnectPopupOutgoingMessage = Record<string, unknown> & { type: string };
@@ -122,9 +122,19 @@ export const useConnectPopup = (
 
                 setResponseSent(true);
             } else if (event.type === POPUP.CLOSED) {
-                dispatch(connectPopupCancelThunk({ error: event.payload?.error }));
+                dispatch(
+                    connectPopupCancelThunk({
+                        error: event.payload?.error,
+                        callId: event.payload?.callId,
+                    }),
+                );
             } else if (event.type === CORE_CALL_CANCEL) {
-                dispatch(connectPopupCancelThunk({ error: event.payload?.reason }));
+                dispatch(
+                    connectPopupCancelThunk({
+                        error: event.payload?.reason,
+                        callId: event.payload?.callId,
+                    }),
+                );
             }
         };
 

--- a/packages/suite/src/support/suite/useConnectPopupModals.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupModals.tsx
@@ -113,7 +113,7 @@ export const useConnectPopupModals = () => {
             }
             case 'switch-device': {
                 if (modalContext !== MODAL_CONTEXT_NONE && !isInDiscoveryFlow) {
-                    TrezorConnect.cancel('switching-device');
+                    TrezorConnect.cancel({ reason: 'switching-device' });
                     dispatch(removePreserveModal());
                     dispatch(cancelModal());
                     dispatch(

--- a/packages/suite/src/views/onboarding/steps/DeviceTutorialStep.tsx
+++ b/packages/suite/src/views/onboarding/steps/DeviceTutorialStep.tsx
@@ -21,7 +21,8 @@ export const DeviceTutorialStep = () => {
         dispatch(beginOnboardingTutorial());
     }, [dispatch]);
 
-    const handleSkipClick = () => TrezorConnect.cancel(intl.formatMessage(messages.TR_CANCELLED));
+    const handleSkipClick = () =>
+        TrezorConnect.cancel({ reason: intl.formatMessage(messages.TR_CANCELLED) });
 
     return (
         <OnboardingCard

--- a/packages/suite/src/views/recovery/index.tsx
+++ b/packages/suite/src/views/recovery/index.tsx
@@ -61,7 +61,7 @@ export const Recovery = ({ onCancel }: ForegroundAppProps) => {
 
     const handleClose = () => {
         if (['in-progress', 'waiting-for-confirmation'].includes(recovery.status)) {
-            TrezorConnect.cancel(intl.formatMessage(messages.TR_CANCELLED));
+            TrezorConnect.cancel({ reason: intl.formatMessage(messages.TR_CANCELLED) });
         } else {
             onCancel();
         }

--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -376,7 +376,7 @@ export const connectPopupCancelThunk = createThunk<void, { error?: string }>(
     `${CONNECT_POPUP_MODULE}/cancelThunk`,
     ({ error }, { dispatch }) => {
         getPermissionDeferred().reject(TypedError('Method_Cancel'));
-        TrezorConnect.cancel(error);
+        TrezorConnect.cancel({ reason: error });
         // todo: probably not needed to call explicitly anymore
         dispatch(deviceActions.removeButtonRequests({}));
 

--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -372,11 +372,11 @@ export const connectPopupVerifyAddressThunk = createThunk<void, { index: number 
     },
 );
 
-export const connectPopupCancelThunk = createThunk<void, { error?: string }>(
+export const connectPopupCancelThunk = createThunk<void, { error?: string; callId?: string }>(
     `${CONNECT_POPUP_MODULE}/cancelThunk`,
-    ({ error }, { dispatch }) => {
+    ({ error, callId }, { dispatch }) => {
         getPermissionDeferred().reject(TypedError('Method_Cancel'));
-        TrezorConnect.cancel({ reason: error });
+        TrezorConnect.cancel({ reason: error, callId });
         // todo: probably not needed to call explicitly anymore
         dispatch(deviceActions.removeButtonRequests({}));
 

--- a/suite-common/device/src/usePinHook.ts
+++ b/suite-common/device/src/usePinHook.ts
@@ -21,8 +21,8 @@ export const usePin = (buttonRequests: ButtonRequest[], requestId?: string) => {
 
     const cancel = () =>
         isSettingNewWipeCode
-            ? TrezorConnect.cancel('wipe-cancelled')
-            : TrezorConnect.cancel('pin-cancelled');
+            ? TrezorConnect.cancel({ reason: 'wipe-cancelled' })
+            : TrezorConnect.cancel({ reason: 'pin-cancelled' });
 
     const handlePinSubmit = () => {
         setSubmitted(true);

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -341,7 +341,7 @@ export const cancelDiscoveryThunk = createThunk(
     `${DISCOVERY_MODULE_PREFIX}/cancel`,
     (device: TrezorDevice, { dispatch }) => {
         // cancel with a custom error code so we can distinguish it from device cancellation
-        TrezorConnect.cancel(USER_UI_CANCEL_CODE);
+        TrezorConnect.cancel({ reason: USER_UI_CANCEL_CODE });
 
         dispatch(discoveryActions.updateDiscovery({ status: 'cancelled' }, device.path));
     },

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -236,7 +236,7 @@ export const cancelSignSendFormTransactionThunk = createThunk(
         dispatch(sendFormActions.discardTransaction());
         // if transaction is not signed yet interrupt signing in TrezorConnect
         if (!serializedTx) {
-            TrezorConnect.cancel('tx-cancelled');
+            TrezorConnect.cancel({ reason: 'tx-cancelled' });
 
             return;
         }

--- a/suite-native/device-authorization/src/components/ConnectDeviceScreenHeader.tsx
+++ b/suite-native/device-authorization/src/components/ConnectDeviceScreenHeader.tsx
@@ -70,7 +70,7 @@ export const ConnectDeviceScreenHeader = ({
             }
         } else {
             if (hasDeviceRequestedPin || isAddingHiddenWallet) {
-                TrezorConnect.cancel('pin-cancelled');
+                TrezorConnect.cancel({ reason: 'pin-cancelled' });
             }
 
             if (onCancel) {

--- a/suite/onboarding-components/src/OnboardingCard.tsx
+++ b/suite/onboarding-components/src/OnboardingCard.tsx
@@ -97,9 +97,9 @@ export const OnboardingCard = ({
                             onCancel={
                                 isActionAbortable
                                     ? () =>
-                                          TrezorConnect.cancel(
-                                              intl.formatMessage(messages.TR_CANCELLED),
-                                          )
+                                          TrezorConnect.cancel({
+                                              reason: intl.formatMessage(messages.TR_CANCELLED),
+                                          })
                                     : undefined
                             }
                         />

--- a/suite/thp/src/connection/ThpPairingPinEntryModal.tsx
+++ b/suite/thp/src/connection/ThpPairingPinEntryModal.tsx
@@ -10,7 +10,7 @@ export const ThpPairingPinEntryModal = () => {
     const intl = useIntl();
 
     const onCancel = () => {
-        TrezorConnect.cancel(intl.formatMessage(messages.TR_CANCELLED));
+        TrezorConnect.cancel({ reason: intl.formatMessage(messages.TR_CANCELLED) });
     };
 
     return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Since now we have `callId` for methods that are linking different events when they are trigger because some method was called, we can use that `callId` to cancel the method so we have a cleaner way of canceling a method. The previous behavior of canceling everything still applies when no `callId` is provided.

We do not have the option of concurrent methods in connect for now, but this is still useful since it creates a more reliable cancel management, like the case below:

1. Client sends method A (gets callId: "abc")
2. Method A completes, client immediately sends method B (gets callId: "xyz")
3. Client sends cancel({ callId: "abc" }) — but method A is already done. With the new changes method B should be safe.

That case is cover in tests 06b95e3129593bbb3102f5bbc1bd634ee09b762e with one test case that it does not use `callId` and then it cancels the call B and with callId  it does not cancel call B.

## Notes for QA

Test that when canceling some connect method it all is working as expected.

## Related Issue

Related https://github.com/trezor/trezor-suite/issues/27083

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=cancel-by-callId&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=cancel-by-callId&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=cancel-by-callId&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-15T11:10:10.620Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-15T11:09:02.491Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/cancel-by-callId/web/](https://dev.suite.sldev.cz/suite-web/cancel-by-callId/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->