### PR TITLE
feat(suite-native): always show connected/remembered devices in device switcher

### DIFF
--- a/suite-common/device/src/deviceSelectors.ts
+++ b/suite-common/device/src/deviceSelectors.ts
@@ -59,6 +59,11 @@ export const selectDevicesCount = (state: DeviceRootState) => state.device?.devi
 
 export const selectSelectedDevice = (state: DeviceRootState) => state.device.selectedDevice;
 
+export const selectIsAnyDeviceSelected = createMemoizedSelector(
+    [selectSelectedDevice],
+    device => !!device,
+);
+
 export const selectPersistentDeviceData = (state: DeviceRootState) =>
     state.device.persistentDeviceData;
 

--- a/suite-native/device-manager/package.json
+++ b/suite-native/device-manager/package.json
@@ -18,6 +18,7 @@
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/suite-sync": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
+        "@suite-common/suite-utils": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-types": "workspace:^",
         "@suite-common/wallet-utils": "workspace:*",

--- a/suite-native/device-manager/src/components/BootloaderModeItemContent.tsx
+++ b/suite-native/device-manager/src/components/BootloaderModeItemContent.tsx
@@ -1,6 +1,6 @@
 import { useSelector } from 'react-redux';
 
-import { selectSelectedDevice } from '@suite-common/device';
+import { selectDeviceModel, selectDeviceName } from '@suite-common/device';
 import { Box, HStack, Text } from '@suite-native/atoms';
 import { useNativeStyles } from '@trezor/styles-native';
 
@@ -16,15 +16,16 @@ import { headerStyle } from './DeviceItem/SimpleDeviceItemContent';
 export const BootloaderModeItemContent = () => {
     const { applyStyle } = useNativeStyles();
 
-    const device = useSelector(selectSelectedDevice);
+    const deviceModel = useSelector(selectDeviceModel);
+    const deviceName = useSelector(selectDeviceName);
 
-    if (!device) return null;
+    if (!deviceModel) return null;
 
     return (
         <HStack
             style={applyStyle(contentWrapperStyle, { height: DEVICE_SWITCHER_ITEM_CONTENT_HEIGHT })}
         >
-            <DeviceItemIcon deviceId={null} />
+            <DeviceItemIcon deviceModel={deviceModel} />
             <Box style={applyStyle(itemStyle, { isCompact: true })}>
                 <Text
                     variant="body-md-strong"
@@ -32,7 +33,7 @@ export const BootloaderModeItemContent = () => {
                     numberOfLines={1}
                     style={applyStyle(headerStyle)}
                 >
-                    {device.name}
+                    {deviceName}
                 </Text>
                 <Box>
                     <DeviceConnectionStatus isConnected={false} isDeviceInBootloaderMode={true} />

--- a/suite-native/device-manager/src/components/DeviceItem/DeviceItemContent.tsx
+++ b/suite-native/device-manager/src/components/DeviceItem/DeviceItemContent.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useSelector } from 'react-redux';
 
 import {
     type DeviceRootState,
@@ -10,7 +9,7 @@ import {
 } from '@suite-common/device';
 import { useSelectorDeepComparison } from '@suite-common/redux-utils';
 import { type TrezorDevice } from '@suite-common/suite-types';
-import { selectHasOnlyEmptyPortfolioTracker } from '@suite-common/wallet-core';
+import { getDeviceInternalModel } from '@suite-common/suite-utils';
 import { ACCESSIBILITY_FONTSIZE_MULTIPLIER, Box, HStack } from '@suite-native/atoms';
 import { selectShouldFactoryResetBeVisible } from '@suite-native/device';
 import { Translation, useTranslate } from '@suite-native/intl';
@@ -72,6 +71,7 @@ export const DeviceItemContent = React.memo(
             return {
                 id: d.id,
                 name: d.name,
+                model: getDeviceInternalModel(d),
                 isConnected: d.connected,
                 label: selectDeviceLabelOrNameById(state, d.id),
                 walletNumber: d.walletNumber,
@@ -79,7 +79,6 @@ export const DeviceItemContent = React.memo(
                 useEmptyPassphrase: d.useEmptyPassphrase,
             };
         });
-        const hasOnlyEmptyPortfolioTracker = useSelector(selectHasOnlyEmptyPortfolioTracker);
 
         const isPortfolioTrackerDevice = device?.id === PORTFOLIO_TRACKER_DEVICE_ID;
 
@@ -109,7 +108,7 @@ export const DeviceItemContent = React.memo(
                         : DEVICE_SWITCHER_ITEM_CONTENT_HEIGHT_LARGE,
                 })}
             >
-                <DeviceItemIcon deviceId={hasOnlyEmptyPortfolioTracker ? undefined : device.id} />
+                <DeviceItemIcon deviceId={device.id} deviceModel={device.model} />
                 <Box style={applyStyle(itemStyle, { isCompact })}>
                     {variant === 'simple' ? (
                         <SimpleDeviceItemContent

--- a/suite-native/device-manager/src/components/DeviceItem/DeviceItemContent.tsx
+++ b/suite-native/device-manager/src/components/DeviceItem/DeviceItemContent.tsx
@@ -28,7 +28,7 @@ const DEVICE_SWITCHER_ITEM_CONTENT_HEIGHT_LARGE = 56;
 export type DeviceItemContentVariant = 'simple' | 'walletDetail';
 
 export type DeviceItemContentProps = {
-    deviceState: TrezorDevice['state'] | undefined;
+    deviceState?: TrezorDevice['state'];
     headerTextVariant?: NativeTypographyStyle;
     variant?: DeviceItemContentVariant;
     isCompact?: boolean;
@@ -62,23 +62,10 @@ export const DeviceItemContent = React.memo(
     }: DeviceItemContentProps) => {
         const { translate } = useTranslate();
         const { applyStyle } = useNativeStyles();
-        const shouldFactoryResetBeVisible = useSelector(selectShouldFactoryResetBeVisible);
-        const selectedDevice = useSelector(selectSelectedDevice);
 
         const device = useSelectorDeepComparison((state: DeviceRootState) => {
             // select only what is needed to avoid unnecessary rerenders
-            const d = selectDeviceByState(state, deviceState);
-
-            if (!d && shouldFactoryResetBeVisible)
-                return {
-                    id: 'bootloader_device',
-                    name: selectedDevice?.name,
-                    label: selectedDevice?.label,
-                    walletNumber: 1,
-                    isConnected: true,
-                    isDeviceInBootloaderMode: true,
-                    useEmptyPassphrase: selectedDevice?.useEmptyPassphrase,
-                };
+            const d = selectDeviceByState(state, deviceState) ?? selectSelectedDevice(state);
 
             if (!d) return null;
 
@@ -88,7 +75,7 @@ export const DeviceItemContent = React.memo(
                 isConnected: d.connected,
                 label: selectDeviceLabelOrNameById(state, d.id),
                 walletNumber: d.walletNumber,
-                isDeviceInBootloaderMode: false,
+                isDeviceInBootloaderMode: !state && selectShouldFactoryResetBeVisible(state),
                 useEmptyPassphrase: d.useEmptyPassphrase,
             };
         });

--- a/suite-native/device-manager/src/components/DeviceItem/DeviceItemIcon.tsx
+++ b/suite-native/device-manager/src/components/DeviceItem/DeviceItemIcon.tsx
@@ -1,30 +1,33 @@
 import { useSelector } from 'react-redux';
 
-import {
-    type DeviceRootState,
-    PORTFOLIO_TRACKER_DEVICE_ID,
-    selectDeviceModelById,
-} from '@suite-common/device';
+import { PORTFOLIO_TRACKER_DEVICE_ID } from '@suite-common/device';
 import { type TrezorDevice } from '@suite-common/suite-types';
+import { selectHasOnlyEmptyPortfolioTracker } from '@suite-common/wallet-core';
 import { DeviceModelIcon, Icon, type IconSize } from '@suite-native/icons';
+import { type DeviceModelInternal } from '@trezor/device-utils';
 
 type DeviceItemIconProps = {
     deviceId?: TrezorDevice['id'];
+    deviceModel?: DeviceModelInternal;
     iconSize?: IconSize | number;
 };
 
 const ICON_SIZE = 28;
 
-export const DeviceItemIcon = ({ deviceId, iconSize = ICON_SIZE }: DeviceItemIconProps) => {
-    const deviceModel = useSelector((state: DeviceRootState) =>
-        selectDeviceModelById(state, deviceId),
-    );
+export const DeviceItemIcon = ({
+    deviceId,
+    deviceModel,
+    iconSize = ICON_SIZE,
+}: DeviceItemIconProps) => {
+    const hasOnlyEmptyPortfolioTracker = useSelector(selectHasOnlyEmptyPortfolioTracker);
 
-    if (deviceId === PORTFOLIO_TRACKER_DEVICE_ID) {
-        return <Icon name="database" color="contentPrimary" size={iconSize} />;
-    }
-    if (deviceModel !== null) {
-        return <DeviceModelIcon deviceModel={deviceModel} size={iconSize} />;
+    if (!hasOnlyEmptyPortfolioTracker) {
+        if (deviceId === PORTFOLIO_TRACKER_DEVICE_ID) {
+            return <Icon name="database" color="contentPrimary" size={iconSize} />;
+        }
+        if (deviceModel) {
+            return <DeviceModelIcon deviceModel={deviceModel} size={iconSize} />;
+        }
     }
 
     return <Icon name="trezorLogo" color="contentPrimary" size={iconSize} />;

--- a/suite-native/device-manager/src/components/DeviceList.tsx
+++ b/suite-native/device-manager/src/components/DeviceList.tsx
@@ -10,7 +10,6 @@ import { DeviceItem } from './DeviceItem/DeviceItem';
 import { MANAGER_MODAL_BOTTOM_RADIUS } from './DeviceManagerModal';
 
 type DeviceListProps = {
-    isVisible: boolean;
     onSelectDevice: (device: TrezorDevice) => void;
 };
 

--- a/suite-native/device-manager/src/components/DeviceManagerContent.tsx
+++ b/suite-native/device-manager/src/components/DeviceManagerContent.tsx
@@ -133,12 +133,7 @@ export const DeviceManagerContent = () => {
                 layout={LinearTransition}
             >
                 <VStack spacing="sp24">
-                    {isDeviceListVisible && (
-                        <DeviceList
-                            isVisible={isChangeDeviceRequested || isPortfolioTrackerDevice}
-                            onSelectDevice={handleSelectDevice}
-                        />
-                    )}
+                    {isDeviceListVisible && <DeviceList onSelectDevice={handleSelectDevice} />}
                     {!isPortfolioTrackerDevice && !shouldFactoryResetBeVisible && (
                         <AnimatedVStack
                             layout={LinearTransition}

--- a/suite-native/device-manager/src/components/DeviceManagerModal.tsx
+++ b/suite-native/device-manager/src/components/DeviceManagerModal.tsx
@@ -2,11 +2,8 @@ import { type ReactNode } from 'react';
 import { Dimensions, type GestureResponderEvent, Modal, Pressable, StatusBar } from 'react-native';
 import Animated, { FadeIn, LinearTransition, SlideInUp } from 'react-native-reanimated';
 import { type EdgeInsets, useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useSelector } from 'react-redux';
 
-import { selectDeviceState } from '@suite-common/device';
 import { Box, HStack, ScreenHeaderWrapper } from '@suite-native/atoms';
-import { selectShouldFactoryResetBeVisible } from '@suite-native/device';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 import { nativeBorders } from '@trezor/theme';
 
@@ -68,8 +65,6 @@ export const DeviceManagerModal = ({
     footer,
 }: DeviceManagerModalProps) => {
     const { applyStyle } = useNativeStyles();
-    const deviceState = useSelector(selectDeviceState);
-    const shouldFactoryResetBeVisible = useSelector(selectShouldFactoryResetBeVisible);
 
     const insets = useSafeAreaInsets();
 
@@ -114,15 +109,12 @@ export const DeviceManagerModal = ({
                                         spacing="sp16"
                                         flex={1}
                                     >
-                                        {(deviceState || shouldFactoryResetBeVisible) && (
-                                            <Box flexShrink={1}>
-                                                <DeviceItemContent
-                                                    deviceState={deviceState ?? undefined}
-                                                    headerTextVariant="headline-sm"
-                                                    isCompact={false}
-                                                />
-                                            </Box>
-                                        )}
+                                        <Box flexShrink={1}>
+                                            <DeviceItemContent
+                                                headerTextVariant="headline-sm"
+                                                isCompact={false}
+                                            />
+                                        </Box>
                                         {customSwitchRightView}
                                     </HStack>
                                 </ScreenHeaderWrapper>

--- a/suite-native/device-manager/src/components/DeviceSwitchContent.tsx
+++ b/suite-native/device-manager/src/components/DeviceSwitchContent.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 
-import { selectDeviceState, selectNumberOfDeviceInstances } from '@suite-common/device';
+import { selectIsAnyDeviceSelected, selectNumberOfDeviceInstances } from '@suite-common/device';
+import { selectHasOnlyEmptyPortfolioTracker } from '@suite-common/wallet-core';
 import { HStack, Text } from '@suite-native/atoms';
 import { selectShouldFactoryResetBeVisible } from '@suite-native/device';
 import { Translation } from '@suite-native/intl';
@@ -11,18 +12,20 @@ import { DeviceItemContent } from './DeviceItem/DeviceItemContent';
 import { DeviceItemIcon } from './DeviceItem/DeviceItemIcon';
 
 export const DeviceSwitchContent = () => {
-    const deviceState = useSelector(selectDeviceState);
-    const numberOfDevices = useSelector(selectNumberOfDeviceInstances);
+    const isAnyDeviceSelected = useSelector(selectIsAnyDeviceSelected);
+    const hasOnlyEmptyPortfolioTracker = useSelector(selectHasOnlyEmptyPortfolioTracker);
     const shouldFactoryResetBeVisible = useSelector(selectShouldFactoryResetBeVisible);
+    const numberOfDeviceInstances = useSelector(selectNumberOfDeviceInstances);
 
-    if (deviceState) {
+    // Portfolio tracker device is not selected until Connect is initialized.
+    if (!isAnyDeviceSelected || hasOnlyEmptyPortfolioTracker) {
         return (
-            <DeviceItemContent
-                deviceState={deviceState ?? undefined}
-                headerTextVariant="body-md-strong"
-                variant={numberOfDevices > 1 ? 'walletDetail' : 'simple'}
-                isSubHeaderForceHidden={true}
-            />
+            <HStack alignItems="center">
+                <DeviceItemIcon />
+                <Text variant="body-md-strong">
+                    <Translation id="deviceManager.defaultHeader" />
+                </Text>
+            </HStack>
         );
     }
 
@@ -31,11 +34,10 @@ export const DeviceSwitchContent = () => {
     }
 
     return (
-        <HStack alignItems="center">
-            <DeviceItemIcon />
-            <Text variant="body-md-strong">
-                <Translation id="deviceManager.defaultHeader" />
-            </Text>
-        </HStack>
+        <DeviceItemContent
+            headerTextVariant="body-md-strong"
+            variant={numberOfDeviceInstances > 1 ? 'walletDetail' : 'simple'}
+            isSubHeaderForceHidden={true}
+        />
     );
 };

--- a/suite-native/device-manager/tsconfig.json
+++ b/suite-native/device-manager/tsconfig.json
@@ -13,6 +13,9 @@
             "path": "../../suite-common/suite-types"
         },
         {
+            "path": "../../suite-common/suite-utils"
+        },
+        {
             "path": "../../suite-common/wallet-core"
         },
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11967,6 +11967,7 @@ __metadata:
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/suite-sync": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
+    "@suite-common/suite-utils": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-types": "workspace:^"
     "@suite-common/wallet-utils": "workspace:*"


### PR DESCRIPTION
- Default device switch content shown only during Connect init and for empty portfolio tracker.
- `DeviceItemContent` simplified and `deviceState` made optional.
- `DeviceManagerModal` includes `DeviceItemContent` unconditionally.
- Correct device icons are shown.
- Unused code removed.

## Notes for QA

Please test as many scenarios as possible. Device after factory reset, device with FW, soft-locked device, thp-locked device, ...

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set modifies device selectors (a broadly-used shared utility with 121 test mappings) and three React Native device manager components. The device selectors change poses moderate risk since it affects how devices/wallets are resolved across the app, particularly in device switcher flows. The three suite-native components have zero E2E test coverage as they are mobile-native components not exercised by the Playwright desktop/web test suite. Testing should focus on flows that directly exercise the device switcher UI where device selector state is most visibly consumed.

<details><summary><b>Changed files (4)</b></summary>

- `suite-common/device/src/deviceSelectors.ts`
- `suite-native/device-manager/src/components/DeviceItem/DeviceItemContent.tsx`
- `suite-native/device-manager/src/components/DeviceManagerModal.tsx`
- `suite-native/device-manager/src/components/DeviceSwitchContent.tsx`

</details>

**Recommended tests (7)**

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/general/wallet-discovery.test.ts` — This test exercises the device switcher flow (eject wallet, add standard wallet) which relies on device selectors from deviceSelectors.ts. Changes to device selectors could affect how wallets are listed and switched in the device switcher UI.
- `suite/e2e/tests/analytics/toggle.test.ts` — This test explicitly opens the device switcher (dashboardPage.openDeviceSwitcher) and verifies analytics events are fired. Changes to deviceSelectors.ts could affect how device state is resolved when the device switcher is opened, impacting the analytics event flow.
- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — This test interacts with the device switcher (deviceSwitchingOpenButton, walletAtIndexFiatAmount) to verify discreet mode on wallet values. Device selector changes could affect how wallet data is resolved and displayed in the switcher.
- `suite/e2e/tests/passphrase/passphrase-numbering.test.ts` — This test heavily exercises the device switcher for adding, ejecting, and numbering passphrase wallets (walletAtIndex assertions). Device selector changes directly impact how devices and wallets are enumerated and displayed in the switcher.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — This test adds hidden wallets via the device switcher, switches between them, and verifies wallet labels. Device selectors are used to determine which device/wallet is selected and how they are listed.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test validates device session status (TR_USE_HERE, TR_CONNECTED) in the device switching panel and wallet listing. Device selectors are central to resolving device connection state displayed in the switcher.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/backup/t2t1-misc.test.ts` — This test uses the device switcher to select a remembered wallet at index 0 after ejecting a wallet. Device selector changes could affect how the device switcher resolves and displays wallet state for remembered devices.

</details>

⚠️ **Changes with no test coverage (3)**
- `suite-native/device-manager/src/components/DeviceItem/DeviceItemContent.tsx`
- `suite-native/device-manager/src/components/DeviceManagerModal.tsx`
- `suite-native/device-manager/src/components/DeviceSwitchContent.tsx`

_Updated: 2026-05-14T14:45:24.207Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/native/device-switch-content/web/](https://dev.suite.sldev.cz/suite-web/fix/native/device-switch-content/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/device-switch-content&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/device-switch-content&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/device-switch-content&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-14T14:50:11.185Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-14T14:48:49.939Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->