### PR TITLE
feat(ci): use socket firewall free in CI

### DIFF
--- a/.github/actions/minimal-yarn-install/action.yml
+++ b/.github/actions/minimal-yarn-install/action.yml
@@ -34,6 +34,11 @@ runs:
       run: |
         echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
 
+    - name: Install Socket Firewall
+      uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+      with:
+        mode: firewall-free
+
     - name: Install dependencies using Yarn
       shell: bash
-      run: yarn --immutable
+      run: sfw --silent yarn --immutable

--- a/.github/actions/release-connect-npm/action.yml
+++ b/.github/actions/release-connect-npm/action.yml
@@ -56,9 +56,14 @@ runs:
         node-version-file: ".nvmrc"
         cache: yarn
 
+    - name: Install Socket Firewall
+      uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+      with:
+        mode: firewall-free
+
     - name: Install dependencies
       shell: bash
-      run: yarn install --immutable
+      run: sfw --silent yarn install --immutable
 
     - name: Check version
       shell: bash

--- a/.github/actions/release-connect/action.yml
+++ b/.github/actions/release-connect/action.yml
@@ -63,11 +63,16 @@ runs:
         node-version-file: ".nvmrc"
         cache: yarn
 
+    - name: Install Socket Firewall
+      uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+      with:
+        mode: firewall-free
+
     - name: Install dependencies
       shell: bash
       run: |
         echo -e "\nenableScripts: false" >> .yarnrc.yml
-        yarn install --immutable # focus install is not used here to make sure that all global patches are applied for the release.
+        sfw --silent yarn install --immutable # focus install is not used here to make sure that all global patches are applied for the release.
 
     - name: Build connect-explorer-theme
       shell: bash

--- a/.github/workflows/bot-crowdin-sync.yml
+++ b/.github/workflows/bot-crowdin-sync.yml
@@ -37,8 +37,12 @@ jobs:
       - name: Set current timestamp as env variable
         run: echo "NOW=$(date +'%s')" >> $GITHUB_ENV
 
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install dependencies
-        run: yarn install
+        run: sfw --silent yarn install
 
       - name: Set source branch
         run: echo "SOURCE_BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV

--- a/.github/workflows/build-analytics-docs.yml
+++ b/.github/workflows/build-analytics-docs.yml
@@ -36,11 +36,15 @@ jobs:
           node-version-file: ".nvmrc"
           cache: yarn
 
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install dependencies
         run: |
           echo -e "\nenableScripts: false" >> .yarnrc.yml
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          yarn workspaces focus @trezor/analytics-docs
+          sfw --silent yarn workspaces focus @trezor/analytics-docs
 
       - name: Build analytics-docs
         env:

--- a/.github/workflows/build-desktop-apps.yml
+++ b/.github/workflows/build-desktop-apps.yml
@@ -41,9 +41,13 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version-file: ".nvmrc"
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install deps and build libs
         run: |
-          yarn install --immutable
+          sfw --silent yarn install --immutable
           yarn message-system-sign-config
           yarn workspace @trezor/suite-data build:lib
           yarn workspace @trezor/transport-bridge build:lib
@@ -88,9 +92,13 @@ jobs:
           key: renderer-bundle-${{ github.sha }}
           fail-on-cache-miss: true
 
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install deps and build libs
         run: |
-          yarn install --immutable
+          sfw --silent yarn install --immutable
           yarn message-system-sign-config
           yarn workspace @trezor/suite-data build:lib
           yarn workspace @trezor/transport-bridge build:lib
@@ -143,9 +151,13 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install deps and build libs
         run: |
-          yarn install --immutable
+          sfw --silent yarn install --immutable
           yarn message-system-sign-config
 
       - name: Build libs

--- a/.github/workflows/build-llm-test-analysis-nightly.yml
+++ b/.github/workflows/build-llm-test-analysis-nightly.yml
@@ -44,9 +44,13 @@ jobs:
           key: node_modules-${{ hashFiles('yarn.lock') }}
           restore-keys: node_modules-
 
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install dependencies
         shell: bash
-        run: yarn workspaces focus @trezor/e2e-utils
+        run: sfw --silent yarn workspaces focus @trezor/e2e-utils
 
       - name: Download existing LLM analysis cache from S3
         run: |

--- a/.github/workflows/build-node-bridge.yml
+++ b/.github/workflows/build-node-bridge.yml
@@ -31,9 +31,13 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install deps and build libs
         run: |
-          yarn install --immutable
+          sfw --silent yarn install --immutable
 
       - name: Build bin.js file
         run: |

--- a/.github/workflows/build-storybook-native.yml
+++ b/.github/workflows/build-storybook-native.yml
@@ -44,11 +44,15 @@ jobs:
           path: node_modules
           key: node_modules/${{ github.ref }}/${{github.run_id}}
 
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install Yarn dependencies
         run: |
           echo -e "\nenableScripts: false" >> .yarnrc.yml
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          yarn install
+          sfw --silent yarn install
 
       - name: Build storybook
         working-directory: ./suite-native/storybook

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -31,12 +31,16 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: yarn
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install dependencies
         run: |
           echo -e "\nenableScripts: false" >> .yarnrc.yml
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          yarn workspaces focus @trezor/components
-          yarn workspaces focus @trezor/product-components
+          sfw --silent yarn workspaces focus @trezor/components
+          sfw --silent yarn workspaces focus @trezor/product-components
 
       - name: Build storybook
         env:

--- a/.github/workflows/build-suite-desktop-e2e.yml
+++ b/.github/workflows/build-suite-desktop-e2e.yml
@@ -26,10 +26,14 @@ jobs:
           key: node_modules-${{ hashFiles('yarn.lock') }}
           restore-keys: node_modules-
 
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install dependencies, build libs
         shell: bash
         run: |
-          yarn workspaces focus @trezor/suite-desktop @trezor/suite-desktop-core @trezor/suite-build @trezor/suite @trezor/suite-data @trezor/transport-bridge @suite-common/message-system
+          sfw --silent yarn workspaces focus @trezor/suite-desktop @trezor/suite-desktop-core @trezor/suite-build @trezor/suite @trezor/suite-data @trezor/transport-bridge @suite-common/message-system
           yarn message-system-sign-config
           yarn workspace @trezor/suite-data build:lib
           yarn workspace @trezor/transport-bridge build:lib

--- a/.github/workflows/build-suite-native-adhoc.yml
+++ b/.github/workflows/build-suite-native-adhoc.yml
@@ -38,9 +38,13 @@ jobs:
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN_DEVELOP }}
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install libs
         run: |
-          yarn workspaces focus @suite-native/app
+          sfw --silent yarn workspaces focus @suite-native/app
       - name: Trigger adhoc build Android
         working-directory: suite-native/app
         if: ${{ github.event.inputs.PLATFORM == 'android' || github.event.inputs.PLATFORM == 'all' }}

--- a/.github/workflows/build-suite-native-preview.yml
+++ b/.github/workflows/build-suite-native-preview.yml
@@ -48,9 +48,13 @@ jobs:
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN_DEVELOP }}
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install libs
         run: |
-          yarn workspaces focus @suite-native/app
+          sfw --silent yarn workspaces focus @suite-native/app
 
       - name: Check runtimeVersion builds
         run: |

--- a/.github/workflows/build-suite-web-e2e.yml
+++ b/.github/workflows/build-suite-web-e2e.yml
@@ -47,12 +47,16 @@ jobs:
           key: node_modules-${{ hashFiles('yarn.lock') }}
           restore-keys: node_modules-
 
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install dependencies
         shell: bash
         run: |
           echo -e "\nenableScripts: false" >> .yarnrc.yml
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          yarn workspaces focus @trezor/suite-web @trezor/suite-data @trezor/suite-build
+          sfw --silent yarn workspaces focus @trezor/suite-web @trezor/suite-data @trezor/suite-build
 
       - name: Build Suite Web
         shell: bash

--- a/.github/workflows/build-suite-web.yml
+++ b/.github/workflows/build-suite-web.yml
@@ -57,11 +57,15 @@ jobs:
           node-version-file: ".nvmrc"
           cache: yarn
 
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install dependencies
         run: |
           echo -e "\nenableScripts: false" >> .yarnrc.yml
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          yarn workspaces focus @trezor/suite-web @trezor/suite-data @trezor/suite-build
+          sfw --silent yarn workspaces focus @trezor/suite-web @trezor/suite-data @trezor/suite-build
 
       - name: Build suite-web
         env:

--- a/.github/workflows/check-code-validation.yml
+++ b/.github/workflows/check-code-validation.yml
@@ -24,6 +24,10 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version-file: ".nvmrc"
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
@@ -37,7 +41,7 @@ jobs:
       # We can skip the build for all dependencies, even for those whitelisted, because this process is used only to validate the yarn.lock file and populate the cache.
       - name: Install deps
         run: |
-          yarn --immutable --mode=skip-build
+          sfw --silent yarn --immutable --mode=skip-build
 
   type-check:
     name: Type Checking
@@ -165,8 +169,12 @@ jobs:
         run: yarn verify-project-references
       - name: Detect unused dependencies
         run: yarn depcheck
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Yarn Dedupe check
-        run: yarn dedupe --check
+        run: sfw --silent yarn dedupe --check
       - name: Check dependency domain lists
         run: ./scripts/ci/list-missing-dependencies.sh
       - name: Verify Workspace Resolutions

--- a/.github/workflows/check-test-health-nightly.yml
+++ b/.github/workflows/check-test-health-nightly.yml
@@ -35,9 +35,13 @@ jobs:
           key: node_modules-${{ hashFiles('yarn.lock') }}
           restore-keys: node_modules-
 
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install dependencies
         shell: bash
-        run: yarn workspaces focus @trezor/e2e-utils
+        run: sfw --silent yarn workspaces focus @trezor/e2e-utils
 
       - name: Check test health and manage quarantine
         env:

--- a/.github/workflows/check-test-health.yml
+++ b/.github/workflows/check-test-health.yml
@@ -47,9 +47,13 @@ jobs:
           key: node_modules-${{ hashFiles('yarn.lock') }}
           restore-keys: node_modules-
 
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install dependencies
         shell: bash
-        run: yarn workspaces focus @trezor/e2e-utils
+        run: sfw --silent yarn workspaces focus @trezor/e2e-utils
 
       - name: Check test health and manage quarantine
         env:

--- a/.github/workflows/chore-purge-android-e2e-build.yml
+++ b/.github/workflows/chore-purge-android-e2e-build.yml
@@ -33,11 +33,15 @@ jobs:
           path: node_modules
           key: node_modules/${{ github.ref }}/${{github.run_id}}
 
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install Yarn dependencies
         run: |
           echo -e "\nenableScripts: false" >> .yarnrc.yml
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          yarn install
+          sfw --silent yarn install
 
       - name: Prebuild native expo project
         working-directory: ./suite-native/app

--- a/.github/workflows/release-connect-bump-versions.yml
+++ b/.github/workflows/release-connect-bump-versions.yml
@@ -43,8 +43,12 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install dependencies
-        run: yarn install
+        run: sfw --silent yarn install
 
       # The script connect-bump-versions.ts needs to build packages so dependencies are required.
       - name: Build dependencies

--- a/.github/workflows/release-connect-npm.yml
+++ b/.github/workflows/release-connect-npm.yml
@@ -56,8 +56,12 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install dependencies
-        run: yarn install
+        run: sfw --silent yarn install
 
       - name: Get packages that need release
         id: set-packages-need-release

--- a/.github/workflows/release-suite-coin-icons.yml
+++ b/.github/workflows/release-suite-coin-icons.yml
@@ -27,9 +27,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Download crypto icons
         run: |
-          yarn install
+          sfw --silent yarn install
           cd suite-common/icons
           yarn download-crypto-icons
 

--- a/.github/workflows/release-suite-definitions.yml
+++ b/.github/workflows/release-suite-definitions.yml
@@ -37,10 +37,14 @@ jobs:
           role-to-assume: ${{ github.event.inputs.environment == 'develop-definitions' && 'arn:aws:iam::538326561891:role/gh_actions_suite_develop_definitions' || 'arn:aws:iam::538326561891:role/gh_actions_suite_production_definitions' }}
           aws-region: ${{ env.AWS_REGION }}
 
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Build and sign ${{ github.event.inputs.environment }} token-definitions
         if: ${{ github.event.inputs.environment == 'develop-definitions' && github.ref == 'refs/heads/develop' }}
         run: |
-          yarn install
+          sfw --silent yarn install
           cd suite-common/token-definitions
 
           yarn nfts simple ethereum polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche
@@ -53,7 +57,7 @@ jobs:
           IS_CODESIGN_BUILD: "true"
           JWS_PRIVATE_KEY_ENV: ${{ secrets.JWS_PRIVATE_KEY_ENV }}
         run: |
-          yarn install
+          sfw --silent yarn install
           cd suite-common/token-definitions
 
           yarn nfts simple ethereum polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche

--- a/.github/workflows/release-suite-desktop-web-staging.yml
+++ b/.github/workflows/release-suite-desktop-web-staging.yml
@@ -62,9 +62,13 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install deps and build libs
         run: |
-          yarn install --immutable
+          sfw --silent yarn install --immutable
           yarn message-system-sign-config
           yarn workspace @trezor/suite-data build:lib
           yarn workspace @trezor/transport-bridge build:lib
@@ -184,11 +188,15 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: yarn
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install dependencies
         run: |
           echo -e "\nenableScripts: false" >> .yarnrc.yml
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          yarn install --immutable # focus install is not used here to make sure that all global patches are applied for the release.
+          sfw --silent yarn install --immutable # focus install is not used here to make sure that all global patches are applied for the release.
 
       - name: Build suite-web
         env:
@@ -238,9 +246,13 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install deps and build libs
         run: |
-          yarn install --immutable
+          sfw --silent yarn install --immutable
           yarn message-system-sign-config
           yarn workspace @trezor/suite-data build:lib
           yarn workspace @trezor/transport-bridge build:lib

--- a/.github/workflows/release-suite-message-system-config.yml
+++ b/.github/workflows/release-suite-message-system-config.yml
@@ -31,12 +31,16 @@ jobs:
           role-to-assume: ${{ env.ROLE_TO_ASSUME  }}
           aws-region: ${{ env.AWS_REGION }}
 
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Build and sign ${{ env.RELEASE_ENV }} message-system config file
         env:
           IS_CODESIGN_BUILD: ${{ env.RELEASE_ENV == 'production' && 'true' || 'false' }}
           JWS_PRIVATE_KEY_ENV: ${{ secrets.JWS_PRIVATE_KEY_ENV }}
         run: |
-          yarn install
+          sfw --silent yarn install
           yarn message-system-sign-config
 
       - name: Upload ${{ env.RELEASE_ENV }}  message-system config file

--- a/.github/workflows/release-suite-native-develop.yml
+++ b/.github/workflows/release-suite-native-develop.yml
@@ -33,9 +33,13 @@ jobs:
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install libs
         run: |
-          yarn workspaces focus @suite-native/app
+          sfw --silent yarn workspaces focus @suite-native/app
       - name: Build on EAS Android
         run: eas build
           --platform android

--- a/.github/workflows/release-suite-native-production.yml
+++ b/.github/workflows/release-suite-native-production.yml
@@ -40,9 +40,13 @@ jobs:
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install libs
         run: |
-          yarn workspaces focus @suite-native/app
+          sfw --silent yarn workspaces focus @suite-native/app
       - name: Build on EAS iOS
         run: eas build
           --platform ios
@@ -69,9 +73,13 @@ jobs:
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install libs
         run: |
-          yarn workspaces focus @suite-native/app
+          sfw --silent yarn workspaces focus @suite-native/app
       - name: Build on EAS Android
         run: eas build
           --platform android
@@ -104,9 +112,13 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::538326561891:role/gh_actions_mobile_prod_deploy
           aws-region: eu-central-1
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install libs
         run: |
-          yarn workspaces focus @suite-native/app
+          sfw --silent yarn workspaces focus @suite-native/app
 
       - name: Get Suite version
         id: get_version

--- a/.github/workflows/template-connect-test-params.yml
+++ b/.github/workflows/template-connect-test-params.yml
@@ -63,12 +63,16 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: yarn
-      - run: yarn workspaces focus @trezor/connect
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
+      - run: sfw --silent yarn workspaces focus @trezor/connect
       - if: ${{ inputs.testEnv == 'web' }}
         run: |
           echo -e "\nenableScripts: false" >> .yarnrc.yml
-          yarn workspaces focus @trezor/connect-web
-          yarn && yarn build:libs
+          sfw --silent yarn workspaces focus @trezor/connect-web
+          sfw --silent yarn && yarn build:libs
       - name: Install Playwright chromium
         if: ${{ inputs.testEnv == 'web' }}
         run: yarn workspace @trezor/connect-web exec playwright install --with-deps chromium

--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -72,11 +72,15 @@ jobs:
           key: node_modules-${{ hashFiles('yarn.lock') }}
           restore-keys: node_modules-
 
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install Yarn dependencies
         run: |
           echo -e "\nenableScripts: false" >> .yarnrc.yml
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          yarn install
+          sfw --silent yarn install
 
       # Detox runtime may indirectly import the built config, and that would crash if message-system is not built
       - name: Sign message system config

--- a/.github/workflows/template-suite-native-prepare-test-app-android.yml
+++ b/.github/workflows/template-suite-native-prepare-test-app-android.yml
@@ -45,11 +45,15 @@ jobs:
           key: node_modules-${{ hashFiles('yarn.lock') }}
           restore-keys: node_modules-
 
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install Yarn dependencies
         run: |
           echo -e "\nenableScripts: false" >> .yarnrc.yml
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          yarn install
+          sfw --silent yarn install
 
       - name: Setup Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5

--- a/.github/workflows/template-suite-run-e2e.yml
+++ b/.github/workflows/template-suite-run-e2e.yml
@@ -144,10 +144,14 @@ jobs:
           rm -rf ${{ github.workspace }}/packages/connect-explorer/build-webextension
           mv ${{ github.workspace }}/artifact-download ${{ github.workspace }}/packages/connect-explorer/build-webextension
 
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install PW Dependencies
         shell: bash
         run: |
-          yarn workspaces focus @trezor/suite-e2e ${{ inputs.workspace-dependencies }}
+          sfw --silent yarn workspaces focus @trezor/suite-e2e ${{ inputs.workspace-dependencies }}
 
       - name: Install Playwright Browsers
         if: inputs.target == 'web' && steps.playwright-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/test-blockchain-link.yml
+++ b/.github/workflows/test-blockchain-link.yml
@@ -33,8 +33,12 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install dependencies
-        run: yarn --immutable
+        run: sfw --silent yarn --immutable
 
       - name: Build dependencies
         run: yarn build:libs

--- a/.github/workflows/test-connect-misc.yml
+++ b/.github/workflows/test-connect-misc.yml
@@ -71,8 +71,12 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install dependencies
-        run: yarn install
+        run: sfw --silent yarn install
 
       - name: Pack packages
         run: yarn tsx ./scripts/ci/pack-packages.ts
@@ -101,5 +105,9 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
-      - run: yarn install --immutable
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
+      - run: sfw --silent yarn install --immutable
       - run: yarn workspace @trezor/protobuf update:protobuf

--- a/.github/workflows/test-e2e-controller-pr.yml
+++ b/.github/workflows/test-e2e-controller-pr.yml
@@ -96,8 +96,12 @@ jobs:
           key: node_modules-${{ hashFiles('yarn.lock') }}
           restore-keys: node_modules-
 
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install dependencies
-        run: yarn workspaces focus @trezor/e2e-utils
+        run: sfw --silent yarn workspaces focus @trezor/e2e-utils
 
       - name: Run LLM test selector
         env:

--- a/.github/workflows/test-misc.yml
+++ b/.github/workflows/test-misc.yml
@@ -26,7 +26,11 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
-      - run: yarn install --immutable
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
+      - run: sfw --silent yarn install --immutable
       - run: yarn workspace @suite/intl translations:list-unused
 
   media-duplicates:
@@ -54,7 +58,11 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
-      - run: yarn install --immutable
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
+      - run: sfw --silent yarn install --immutable
       - run: ./scripts/circular-dependencies/check-circular-dependencies.sh
 
   test-unit:
@@ -71,7 +79,11 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
-      - run: yarn install --immutable
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
+      - run: sfw --silent yarn install --immutable
       - run: yarn message-system-sign-config
       - name: Unit Tests - Suite, Connect, Common
         run: yarn test:unit:all --exclude='@suite-native/*' -- --silent
@@ -90,6 +102,7 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
+      # sfw not working on windows runners
       - run: yarn install --immutable
       - run: yarn workspace @trezor/node-utils test:unit
 
@@ -105,7 +118,11 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
-      - run: yarn install --immutable
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
+      - run: sfw --silent yarn install --immutable
       - run: yarn generate-package @trezor/meow-package
       - run: rm -rf packages/meow-package
 
@@ -120,5 +137,9 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
-      - run: yarn install --immutable
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
+      - run: sfw --silent yarn install --immutable
       - run: yarn tsx ./packages/components/scripts/test-img-paths-exist.ts

--- a/.github/workflows/test-request-manager.yml
+++ b/.github/workflows/test-request-manager.yml
@@ -30,5 +30,9 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
-      - run: yarn install --immutable
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
+      - run: sfw --silent yarn install --immutable
       - run: yarn workspace @trezor/request-manager test:all

--- a/.github/workflows/test-suite-manual-release.yml
+++ b/.github/workflows/test-suite-manual-release.yml
@@ -46,11 +46,15 @@ jobs:
         run: |
           echo "release_build=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}-${GITHUB_SHA:0:7}" >> $GITHUB_ENV
 
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install PW Dependencies
         shell: bash
         run: |
           echo "Installing Playwright dependencies"
-          yarn workspaces focus @trezor/suite-e2e
+          sfw --silent yarn workspaces focus @trezor/suite-e2e
           # Playwright runtime may indirectly import the built config, and that would crash if message-system is not built
           yarn message-system-sign-config
 

--- a/.github/workflows/test-suite-native-e2e-ios.yml
+++ b/.github/workflows/test-suite-native-e2e-ios.yml
@@ -50,11 +50,15 @@ jobs:
           key: node_modules-${{ hashFiles('yarn.lock') }}
           restore-keys: node_modules-
 
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install Yarn dependencies
         run: |
           echo -e "\nenableScripts: false" >> .yarnrc.yml
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          yarn install
+          sfw --silent yarn install
 
       - name: Use latest stable Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
@@ -121,11 +125,15 @@ jobs:
           key: node_modules-${{ hashFiles('yarn.lock') }}
           restore-keys: node_modules-
 
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install Yarn dependencies
         run: |
           echo -e "\nenableScripts: false" >> .yarnrc.yml
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          yarn install
+          sfw --silent yarn install
 
       # Detox runtime may indirectly import the built config, and that would crash if message-system is not built
       - name: Sign message system config

--- a/.github/workflows/test-suite-native-e2e-manual-reporter.yml
+++ b/.github/workflows/test-suite-native-e2e-manual-reporter.yml
@@ -43,11 +43,15 @@ jobs:
           path: node_modules
           key: node_modules/${{ github.ref }}/${{github.run_id}}
 
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install Yarn dependencies
         run: |
           echo -e "\nenableScripts: false" >> .yarnrc.yml
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          yarn install
+          sfw --silent yarn install
 
       - name: Extract Release Build
         id: extract_branch

--- a/.github/workflows/test-suite-web-e2e-nightly.yml
+++ b/.github/workflows/test-suite-web-e2e-nightly.yml
@@ -108,8 +108,12 @@ jobs:
           node-version-file: ".nvmrc"
           cache: yarn
 
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install dependencies
-        run: yarn workspaces focus @trezor/e2e-utils
+        run: sfw --silent yarn workspaces focus @trezor/e2e-utils
 
       - name: Download per-test coverage map artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/.github/workflows/test-transport.yml
+++ b/.github/workflows/test-transport.yml
@@ -40,10 +40,14 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install dependencies
         run: |
           echo -e "\nenableScripts: false" >> .yarnrc.yml
-          yarn workspaces focus @trezor/transport-test
+          sfw --silent yarn workspaces focus @trezor/transport-test
 
       - name: Setup containers
         run: |
@@ -81,11 +85,15 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install dependencies
         shell: bash
         run: |
           echo -e "\nenableScripts: false" >> .yarnrc.yml
-          yarn workspaces focus @trezor/transport -A
+          sfw --silent yarn workspaces focus @trezor/transport -A
 
       - name: Build transport tester
         run: |

--- a/.github/workflows/test-trezor-user-env-link-e2e.yml
+++ b/.github/workflows/test-trezor-user-env-link-e2e.yml
@@ -32,11 +32,15 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: yarn
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
       - name: Install dependencies
         run: |
           echo -e "\nenableScripts: false" >> .yarnrc.yml
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          yarn workspaces focus @trezor/trezor-user-env-link
+          sfw --silent yarn workspaces focus @trezor/trezor-user-env-link
 
       - name: Run e2e tests
         run: |

--- a/.github/workflows/test-urls.yml
+++ b/.github/workflows/test-urls.yml
@@ -23,5 +23,9 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
-      - run: yarn install --immutable
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
+      - run: sfw --silent yarn install --immutable
       - run: yarn workspace @trezor/urls test:e2e


### PR DESCRIPTION
## Description

Wrap each and every yarn install in CI with `sfw`. to scan deps realtime while fetching and fail the CI if Socket firewall throws. This seems more appropriate than using socket dev CLI, see issue.

Sfw is installed using their official github action https://github.com/SocketDev/action (it directly downloads binary and adds it to PATH, which is simpler than doing it manually via `npm install -g`)

**TBD**
- maybe I should include only PR workflows, and not those that run scheduled or manual?
  - e.g. don't check nightlies, because `develop` is considered safe

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27696

## Screenshots:

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** No relevant source file changes detected against origin/develop.

_No test recommendations found._

_Updated: 2026-05-14T14:51:08.975Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=ci/sfw-cli-check&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=ci/sfw-cli-check&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=ci/sfw-cli-check&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-14T16:13:03.106Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-14T16:11:00.936Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/ci/sfw-cli-check/web/](https://dev.suite.sldev.cz/suite-web/ci/sfw-cli-check/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->