### PR TITLE
fix(connect-common): narrow protocol pkg runtime import

### DIFF
--- a/packages/connect-common/src/types/index.ts
+++ b/packages/connect-common/src/types/index.ts
@@ -80,5 +80,6 @@ export type {
     AccountBalanceHistory as BlockchainAccountBalanceHistory,
 } from '@trezor/blockchain-link';
 
-export { ThpPairingMethod } from '@trezor/protocol';
+// direct targeted import, we need to avoid protocol barrel file (#27772)
+export { ThpPairingMethod } from '@trezor/protocol/src/protocol-thp/messages';
 export type { MessagesSchema as PROTO } from '@trezor/protobuf';


### PR DESCRIPTION
## Description

We can't directly import from `@trezor/protocol` index in `@trezor/connect-common` runtime, it pulls in too much. 
Then it doesn't work with plain Expo, for example due to missing crypto polyfill. 

<img width="946" height="522" alt="Screenshot 2026-05-14 at 17 02 39" src="https://github.com/user-attachments/assets/ada7517a-6872-4f4f-aff5-e8902b638d40" />

## Notes for QA

Nothing to test, code only change

## Related Issue

Related to #27414

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/connect-common-protocol-import/web/](https://dev.suite.sldev.cz/suite-web/fix/connect-common-protocol-import/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/connect-common-protocol-import&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-14T15:11:18.240Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->