### PR TITLE
Mobile Trade: update ExchangeFormQuoteDebugView and isMaxAllowance

### DIFF
--- a/suite-common/wallet-utils/src/__tests__/bigNumberUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/bigNumberUtils.test.ts
@@ -21,9 +21,10 @@ describe('BigNumber utils', () => {
 
         it('returns false for non-max values', () => {
             expect(isMaxAllowance('0')).toBe(false);
+            // this number is one order smaller than max
             expect(
                 isMaxAllowance(
-                    '115792089237316195423570985008687907853269984665640564039457584007913129639934',
+                    '15792089237316195423570985008687907853269984665640564039457584007913129639934',
                 ),
             ).toBe(false);
         });

--- a/suite-common/wallet-utils/src/bigNumberUtils.ts
+++ b/suite-common/wallet-utils/src/bigNumberUtils.ts
@@ -50,9 +50,10 @@ export const isMaxAllowance = (value: string | undefined): boolean => {
     }
 
     const allowance = new BigNumber(value);
+    const maxAllowance = new BigNumber(UINT256_MAX).dividedBy(2).integerValue();
 
     // Some callers pass the raw allowance value in base units.
-    if (allowance.eq(UINT256_MAX)) {
+    if (allowance.gte(maxAllowance)) {
         return true;
     }
 
@@ -63,5 +64,5 @@ export const isMaxAllowance = (value: string | undefined): boolean => {
     }
 
     // Some DEX quote fields pass the same value formatted with token decimals.
-    return allowance.shiftedBy(fractionalPart.length).eq(UINT256_MAX);
+    return allowance.shiftedBy(fractionalPart.length).gte(maxAllowance);
 };

--- a/suite-native/module-trading/package.json
+++ b/suite-native/module-trading/package.json
@@ -90,6 +90,7 @@
         "react-redux": "9.2.0"
     },
     "devDependencies": {
+        "@suite-common/suite-constants": "workspace:*",
         "@suite-common/test-utils": "workspace:*",
         "@suite-native/bluetooth": "workspace:*",
         "@suite-native/settings": "workspace:*",

--- a/suite-native/module-trading/src/components/exchange/ExchangeFormQuoteDebugView.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeFormQuoteDebugView.tsx
@@ -1,4 +1,5 @@
 import { getApprovalStatus } from '@suite-common/trading';
+import { isMaxAllowance } from '@suite-common/wallet-utils';
 import { HStack, Text } from '@suite-native/atoms';
 import { DebugModeView } from '@suite-native/trading-debug';
 
@@ -8,6 +9,13 @@ export const ExchangeFormQuoteDebugView = () => {
     const { watch } = useExchangeFormContext();
     const quote = watch('quote');
     const approvalStatus = getApprovalStatus(quote);
+
+    let preapproved = 'not defined';
+    if (quote?.preapprovedStringAmount) {
+        preapproved = isMaxAllowance(quote.preapprovedStringAmount)
+            ? 'unlimited'
+            : quote.preapprovedStringAmount;
+    }
 
     return (
         <DebugModeView>
@@ -20,7 +28,7 @@ export const ExchangeFormQuoteDebugView = () => {
             <HStack>
                 <Text variant="body-xs">Pre-approved</Text>
                 <Text variant="body-xs" color="contentSecondary">
-                    {quote?.preapprovedStringAmount ?? 'not defined'}
+                    {preapproved}
                 </Text>
             </HStack>
         </DebugModeView>

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeFormQuoteDebugView.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeFormQuoteDebugView.test.tsx
@@ -1,5 +1,6 @@
 import type { CryptoId, ExchangeTrade } from 'invity-api';
 
+import { UINT256_MAX } from '@suite-common/suite-constants';
 import { renderWithBasicProvider, screen } from '@suite-native/test-utils';
 
 import { ExchangeFormQuoteDebugView } from '../ExchangeFormQuoteDebugView';
@@ -91,5 +92,38 @@ describe('ExchangeFormQuoteDebugView', () => {
         renderDebugView();
 
         expect(screen.getByText('needs_approval')).toBeOnTheScreen();
+    });
+
+    it('should display "unlimited" for pre-approved amount when preapprovedStringAmount is max uint256', () => {
+        mockDebugMode = true;
+        mockQuote = {
+            send: 'ethereum--0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as CryptoId,
+            receive: 'bitcoin' as CryptoId,
+            exchange: 'invity',
+            isDex: true,
+            preapprovedStringAmount: UINT256_MAX,
+        };
+
+        renderDebugView();
+
+        expect(screen.getByText('Pre-approved')).toBeOnTheScreen();
+        expect(screen.getByText('unlimited')).toBeOnTheScreen();
+    });
+
+    it('should display the specific amount for pre-approved amount when preapprovedStringAmount is not max uint256', () => {
+        mockDebugMode = true;
+        const specificAmount = '1000000000000000000';
+        mockQuote = {
+            send: 'ethereum--0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as CryptoId,
+            receive: 'bitcoin' as CryptoId,
+            exchange: 'invity',
+            isDex: true,
+            preapprovedStringAmount: specificAmount,
+        };
+
+        renderDebugView();
+
+        expect(screen.getByText('Pre-approved')).toBeOnTheScreen();
+        expect(screen.getByText(specificAmount)).toBeOnTheScreen();
     });
 });

--- a/suite-native/module-trading/tsconfig.json
+++ b/suite-native/module-trading/tsconfig.json
@@ -94,6 +94,9 @@
         { "path": "../../packages/urls" },
         { "path": "../../packages/utils" },
         {
+            "path": "../../suite-common/suite-constants"
+        },
+        {
             "path": "../../suite-common/test-utils"
         },
         { "path": "../bluetooth" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -13256,6 +13256,7 @@ __metadata:
     "@suite-common/message-system": "workspace:*"
     "@suite-common/mev": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
+    "@suite-common/suite-constants": "workspace:*"
     "@suite-common/suite-sync": "workspace:*"
     "@suite-common/suite-utils": "workspace:*"
     "@suite-common/test-utils": "workspace:*"


### PR DESCRIPTION
- Update ExchangeFormQuoteDebugView to display pre-approved amount as 'unlimited' for max allowance.
- Update logic for "recognizing" unlimited allowance to be in par with `isAllowanceUnlimited`.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

- Test that unlimited allowance is correctly displayed for "all" assets

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->


## Screenshots:
<img width="369" height="71" alt="Screenshot 2026-05-14 at 17 18 55" src="https://github.com/user-attachments/assets/8bca3430-e5ec-4d39-b959-2e4518c4aaa0" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/display-unlimited-in-debug-view&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/display-unlimited-in-debug-view&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/display-unlimited-in-debug-view&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-14T15:48:23.322Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-14T15:46:56.001Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/display-unlimited-in-debug-view/web/](https://dev.suite.sldev.cz/suite-web/chore/display-unlimited-in-debug-view/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->