### PR TITLE
fix(suite): make message system debug lists scrollable

### DIFF
--- a/packages/node-utils/src/validateJsonSchema.ts
+++ b/packages/node-utils/src/validateJsonSchema.ts
@@ -1,5 +1,11 @@
 import Ajv from 'ajv';
 
+const getDuplicateIds = (ids: string[]) => {
+    const seenIds = new Set<string>();
+
+    return [...new Set(ids.filter(id => seenIds.size === seenIds.add(id).size))];
+};
+
 // checks that a config meets the criteria specified by the schema
 export const validateJsonSchema = (config: string, schema: string) => {
     const ajv = new Ajv();
@@ -42,6 +48,30 @@ export const validateJsonSchema = (config: string, schema: string) => {
         const details = invalidExperiments.map(exp => `id=${exp.id}, sum=${exp.sum}`).join('; ');
         throw new Error(
             `Config is invalid: percentages must sum to 100. Failed experiments: ${details}`,
+        );
+    }
+
+    const duplicateMessageIds = getDuplicateIds(
+        (parsedConfig as { actions?: unknown[] }).actions
+            ?.map((action: any) => action?.message?.id)
+            .filter((id): id is string => typeof id === 'string') ?? [],
+    );
+
+    if (duplicateMessageIds.length > 0) {
+        throw new Error(
+            `Config is invalid: message ids must be unique. Duplicate ids: ${duplicateMessageIds.join(', ')}`,
+        );
+    }
+
+    const duplicateExperimentIds = getDuplicateIds(
+        (parsedConfig as { experiments?: unknown[] }).experiments
+            ?.map((experiment: any) => experiment?.experiment?.id)
+            .filter((id): id is string => typeof id === 'string') ?? [],
+    );
+
+    if (duplicateExperimentIds.length > 0) {
+        throw new Error(
+            `Config is invalid: experiment ids must be unique. Duplicate ids: ${duplicateExperimentIds.join(', ')}`,
         );
     }
 };

--- a/packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemExperiment/MessageSystemExperimentToolbar.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemExperiment/MessageSystemExperimentToolbar.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { Fragment, useRef } from 'react';
 
 import styled from 'styled-components';
 
@@ -7,6 +7,7 @@ import { type Condition } from '@suite-common/suite-types';
 import {
     Button,
     Card,
+    Grid,
     IconButton,
     Menu,
     Popover,
@@ -14,27 +15,13 @@ import {
     Row,
     Text,
 } from '@trezor/components';
-import { spacings, spacingsPx, zIndices } from '@trezor/theme';
+import { spacings, zIndices } from '@trezor/theme';
 
 import { MessageSystemManual } from '../MessageSystemManual';
 
 const ScrollContainer = styled.div`
     overflow-y: auto;
     max-height: 90vh;
-`;
-
-const StyledList = styled.div`
-    display: grid;
-    grid-template-columns: repeat(2, max-content);
-    gap: ${spacingsPx.xxxs} ${spacingsPx.md};
-
-    font-variant-numeric: tabular-nums;
-`;
-
-const StyledItem = styled.div`
-    display: grid;
-    grid-column: 1 / -1;
-    grid-template-columns: subgrid;
 `;
 
 type MessageSystemExperimentToolbarProps = {
@@ -95,15 +82,16 @@ export const MessageSystemExperimentToolbar = ({
                 <Popover
                     content={
                         <Card>
-                            <StyledList>
+                            <Grid columns="repeat(2, max-content)" rowGap={4} columnGap={16}>
                                 {Object.entries(EXPERIMENT_MAP)
                                     .sort((a, b) => a[0].localeCompare(b[0]))
                                     .map(([key, name]) => (
-                                        <StyledItem key={key}>
-                                            <strong>{name}</strong> {key}
-                                        </StyledItem>
+                                        <Fragment key={key}>
+                                            <strong>{name}</strong>
+                                            <span>{key}</span>
+                                        </Fragment>
                                     ))}
-                            </StyledList>
+                            </Grid>
                         </Card>
                     }
                     zIndex={zIndices.tooltip}

--- a/packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemManager/MessageSystemManager.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemManager/MessageSystemManager.tsx
@@ -67,7 +67,6 @@ export const MessageSystemManager = ({ actions, onCloseModal }: MessageSystemMan
             onCancel={onCloseModal}
             heading={`Messages (${allValidMessages.length} active of ${actions.length})`}
             bottomContent={<MessageSystemFormMessage />}
-            isBackdropCancelable={false}
         >
             <Column gap={spacings.sm}>
                 <MessageSystemManagerFilters

--- a/packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemManager/MessageSystemManagerToolbar.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemManager/MessageSystemManagerToolbar.tsx
@@ -8,13 +8,13 @@ import {
     Button,
     ButtonGroup,
     Card,
+    Column,
     IconButton,
     Menu,
     Popover,
     type PopoverRef,
     Row,
     Text,
-    Tooltip,
 } from '@trezor/components';
 import { spacings, zIndices } from '@trezor/theme';
 
@@ -81,16 +81,21 @@ export const MessageSystemManagerToolbar = ({
                 </Popover>
             </Row>
             <Row gap={spacings.xs}>
-                <Tooltip
+                <Popover
                     content={
-                        <div>
-                            {Object.values(CONTEXT_PATTERNS)
-                                .sort((a, b) => a.pattern.localeCompare(b.pattern))
-                                .map(pattern => (
-                                    <div key={pattern.pattern}>{pattern.pattern}</div>
-                                ))}
-                        </div>
+                        <Card>
+                            <ScrollContainer>
+                                <Column gap={4}>
+                                    {Object.values(CONTEXT_PATTERNS)
+                                        .sort((a, b) => a.pattern.localeCompare(b.pattern))
+                                        .map(pattern => (
+                                            <div key={pattern.pattern}>{pattern.pattern}</div>
+                                        ))}
+                                </Column>
+                            </ScrollContainer>
+                        </Card>
                     }
+                    zIndex={zIndices.tooltip}
                 >
                     <Button
                         size="small"
@@ -100,21 +105,26 @@ export const MessageSystemManagerToolbar = ({
                     >
                         Context patterns
                     </Button>
-                </Tooltip>
+                </Popover>
 
-                <Tooltip
+                <Popover
                     content={
-                        <div>
-                            {FEATURE_LIST.map(feature => (
-                                <div key={feature}>{feature}</div>
-                            ))}
-                        </div>
+                        <Card>
+                            <ScrollContainer>
+                                <Column gap={4}>
+                                    {FEATURE_LIST.map(feature => (
+                                        <div key={feature}>{feature}</div>
+                                    ))}
+                                </Column>
+                            </ScrollContainer>
+                        </Card>
                     }
+                    zIndex={zIndices.tooltip}
                 >
                     <Button size="small" iconLeft="checkFat" intent="neutral" priority="secondary">
                         Feature list
                     </Button>
-                </Tooltip>
+                </Popover>
 
                 <Popover
                     content={

--- a/suite-common/message-system/schema/config.schema.v1.json
+++ b/suite-common/message-system/schema/config.schema.v1.json
@@ -45,7 +45,8 @@
                         ],
                         "properties": {
                             "id": {
-                                "type": "string"
+                                "type": "string",
+                                "minLength": 1
                             },
                             "priority": {
                                 "type": "integer",
@@ -225,7 +226,8 @@
                         "required": ["id", "groups"],
                         "properties": {
                             "id": {
-                                "type": "string"
+                                "type": "string",
+                                "minLength": 1
                             },
                             "groups": {
                                 "type": "array",


### PR DESCRIPTION
## Description

Fixes the Message System debug toolbar so long feature/context lists no longer overflow the screen.

- Changes Message Manager `Feature list` and `Context patterns` from hover tooltips to clickable popovers with internal scrolling.
- Refactors the Experiments `Experiment map` popover to use the shared `Grid` component instead of local styled grid wrappers.
- Allows closing the Message Manager modal by clicking the backdrop, matching the Experiments modal behavior.
- Tightens message-system config validation so message and experiment IDs cannot be empty and duplicate IDs are rejected.


## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27367

## Screenshots:

<img width="1075" height="891" alt="image" src="https://github.com/user-attachments/assets/07933508-c5c6-46cb-b6d0-3a58d8b6a075" />

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies Message System debug UI components (MessageSystemManager, MessageSystemManagerToolbar, MessageSystemExperimentToolbar), the message system JSON schema, and a node-utils JSON schema validator. The highest risk is to the promo banner debug functionality which is directly tested by the promo-banner-events test. The remaining statically mapped tests (metadata/suite-sync tests) appear to be transitively linked through shared debug settings view imports rather than exercising the changed message system functionality directly. The schema and validator changes have no direct E2E test coverage.

<details><summary><b>Changed files (5)</b></summary>

- `packages/node-utils/src/validateJsonSchema.ts`
- `packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemExperiment/MessageSystemExperimentToolbar.tsx`
- `packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemManager/MessageSystemManager.tsx`
- `packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemManager/MessageSystemManagerToolbar.tsx`
- `suite-common/message-system/schema/config.schema.v1.json`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/analytics/promo-banner-events.test.ts` — This test directly exercises the debug settings tab's banner injection functionality (settingsPage.debugTab.addBanner), which is implemented by the changed MessageSystemManager and MessageSystemManagerToolbar components. Changes to these components could break the ability to add promo banners via debug settings.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts` — This test is statically mapped to the changed debug settings components but its actual behavior focuses on metadata label migration from Dropbox to Suite Sync. The connection is likely through a transitive import of the SettingsDebug view rather than direct functional dependency. Including at low priority as a safety net.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/node-utils/src/validateJsonSchema.ts`
- `suite-common/message-system/schema/config.schema.v1.json`

_Updated: 2026-05-14T18:15:54.070Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/message-system-debug-tools&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/message-system-debug-tools&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/message-system-debug-tools&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/message-system-debug-tools/web/](https://dev.suite.sldev.cz/suite-web/fix/message-system-debug-tools/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-14T18:20:51.415Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-14T18:19:37.121Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->