### PR TITLE
fix(suite): Fix empty wallet skeleton

### DIFF
--- a/packages/suite/src/views/dashboard/PortfolioCard/EmptyWalletSkeleton.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/EmptyWalletSkeleton.tsx
@@ -1,4 +1,4 @@
-import { Column, Row, SkeletonCircle, SkeletonRectangle } from '@trezor/components';
+import { Column, SkeletonCircle, SkeletonRectangle } from '@trezor/components';
 
 import { useLoadingSkeleton } from 'src/hooks/suite';
 
@@ -6,24 +6,10 @@ export const EmptyWalletSkeleton = () => {
     const { shouldAnimate } = useLoadingSkeleton();
 
     return (
-        <Column gap={4} data-testid="@dashboard/empty-wallet-skeleton" alignItems="center">
+        <Column gap={24} data-testid="@dashboard/empty-wallet-skeleton" alignItems="center">
             <SkeletonCircle size={96} animate={shouldAnimate} />
-            <SkeletonRectangle width={180} height={20} animate={shouldAnimate} borderRadius={6} />
-            <SkeletonRectangle width={280} height={14} animate={shouldAnimate} borderRadius={4} />
-            <Row gap={12} margin={{ top: 24 }}>
-                <SkeletonRectangle
-                    width={120}
-                    height={44}
-                    animate={shouldAnimate}
-                    borderRadius={12}
-                />
-                <SkeletonRectangle
-                    width={120}
-                    height={44}
-                    animate={shouldAnimate}
-                    borderRadius={12}
-                />
-            </Row>
+            <SkeletonRectangle width={180} height={32} animate={shouldAnimate} borderRadius={4} />
+            <SkeletonRectangle width={280} height={28} animate={shouldAnimate} borderRadius={4} />
         </Column>
     );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

should be now according to figma: https://www.figma.com/design/wadmlRm45Xnt4lQRwaJiKZ/Assets--Final-?node-id=2698-26711&t=ZDz6WGUJyEsN4aRO-0

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

before

<img width="1512" height="982" alt="Screenshot 2026-05-15 at 6 06 22" src="https://github.com/user-attachments/assets/69a82aad-5305-48ec-984a-ca76dd19d335" />

after


<img width="807" height="685" alt="Screenshot 2026-05-15 at 7 08 59" src="https://github.com/user-attachments/assets/fa33111d-883a-4c7d-b8ab-297af7dd7ab2" />

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is limited to a single UI skeleton component (EmptyWalletSkeleton) within the dashboard PortfolioCard. This is a low-risk, visual-only change with no static test coverage mapping. The component is most likely rendered when the wallet has no accounts or during loading states on the dashboard. Testing should focus on dashboard tests that exercise empty/loading wallet states to verify the skeleton renders correctly without breaking layout.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/views/dashboard/PortfolioCard/EmptyWalletSkeleton.tsx`

</details>

**Recommended tests (3)**

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `../../suite/e2e/tests/dashboard/assets.test.ts` — EmptyWalletSkeleton is a component within the PortfolioCard on the dashboard view. The assets test exercises the dashboard page including asset display and interaction, which shares the same dashboard view where the PortfolioCard (and its empty state skeleton) renders.
- `../../suite/e2e/tests/settings/coins.test.ts` — This test validates the dashboard empty state when no coins are enabled (discoveryEmptyHeader, discoveryEmptyDesc, discoveryEmptyPrimaryButton), which is precisely when an EmptyWalletSkeleton component would be rendered in the PortfolioCard area. Changes to the skeleton could affect the empty wallet dashboard appearance.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `../../suite/e2e/tests/dashboard/discreet-mode.test.ts` — This test interacts with the dashboard portfolio area (portfolioFiatAmount, hideBalanceButton) which is part of the PortfolioCard where EmptyWalletSkeleton lives. While the test focuses on non-empty balance states, a regression in the PortfolioCard component tree could surface here.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/views/dashboard/PortfolioCard/EmptyWalletSkeleton.tsx`

_Updated: 2026-05-15T05:10:03.285Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-empty-wallet-skeleton&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-empty-wallet-skeleton&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-15T05:15:11.482Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-15T05:13:32.091Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-empty-wallet-skeleton/web/](https://dev.suite.sldev.cz/suite-web/fix-empty-wallet-skeleton/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->