### PR TITLE
feat(suite): Add tooltip to eject icon button

### DIFF
--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
@@ -21,6 +21,7 @@ import {
     Icon,
     IconButton,
     Row,
+    TOOLTIP_DELAY_LONG,
     Text,
     Tooltip,
 } from '@trezor/components';
@@ -205,21 +206,34 @@ export const WalletInstance = ({
                                 )}
                             </Text>
                             <Collapsible.Toggle>
-                                <IconButton
-                                    data-testid={
-                                        isEjecting
-                                            ? `@switch-device/cancelEject`
-                                            : `${dataTestBase}/eject-button`
+                                <Tooltip
+                                    delayShow={TOOLTIP_DELAY_LONG}
+                                    content={
+                                        <Translation
+                                            id={
+                                                isEjecting
+                                                    ? 'TR_CANCEL'
+                                                    : 'TR_SWITCH_DEVICE_EJECT_TOOLTIP'
+                                            }
+                                        />
                                     }
-                                    icon={isEjecting ? 'x' : 'eject'}
-                                    size="small"
-                                    intent="neutral"
-                                    priority="secondary"
-                                    onClick={e => {
-                                        e.stopPropagation();
-                                        setIsEjecting(prev => !prev);
-                                    }}
-                                />
+                                >
+                                    <IconButton
+                                        data-testid={
+                                            isEjecting
+                                                ? `@switch-device/cancelEject`
+                                                : `${dataTestBase}/eject-button`
+                                        }
+                                        icon={isEjecting ? 'x' : 'eject'}
+                                        size="small"
+                                        intent="neutral"
+                                        priority="secondary"
+                                        onClick={e => {
+                                            e.stopPropagation();
+                                            setIsEjecting(prev => !prev);
+                                        }}
+                                    />
+                                </Tooltip>
                             </Collapsible.Toggle>
                         </Row>
 

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10634,6 +10634,10 @@ export const messages = defineMessages({
         id: 'TR_SWITCH_DEVICE_EJECT_CONFIRMATION_CANCEL_BUTTON',
         defaultMessage: 'Cancel',
     },
+    TR_SWITCH_DEVICE_EJECT_TOOLTIP: {
+        id: 'TR_SWITCH_DEVICE_EJECT_TOOLTIP',
+        defaultMessage: 'Eject wallet',
+    },
     TR_DO_NOT_SHOW_AGAIN: {
         id: 'TR_DO_NOT_SHOW_AGAIN',
         defaultMessage: "Don't show again",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

in wallet swithcer it was unclear what this icon button does (eject wallet)

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<img width="407" height="332" alt="image" src="https://github.com/user-attachments/assets/bee048b1-f970-4361-bf19-bce05e1479fb" />


<img width="415" height="492" alt="image" src="https://github.com/user-attachments/assets/c2050543-4ba0-48b7-b060-acae5fdfb874" />


<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes involve WalletInstance.tsx (a component in the SwitchDevice/DeviceItem view) and messages.ts (the global i18n messages file). WalletInstance.tsx is rendered in the device switcher panel and maps to 121 tests via static analysis, indicating it's a widely-imported component. The highest-risk tests are those that directly interact with the device switcher UI — checking wallet labels, adding/ejecting wallets, and verifying wallet numbering. The messages.ts file has no static test coverage data, but since it's the global translation source, any test checking translated text could be affected; however, without knowing which specific keys changed, only tests that heavily rely on device-switcher-related translations are prioritized.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (11)**

<details><summary>🟡 <b>Medium priority (9)</b></summary>

- `suite/e2e/tests/analytics/toggle.test.ts` — This test opens the device switcher (dashboardPage.openDeviceSwitcher), which renders the SwitchDevice view containing WalletInstance components. Changes to WalletInstance.tsx could affect how wallet items appear in the device switcher, and changes to messages.ts could affect translated text shown during the analytics toggle flow.
- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — This test opens the device switcher and checks walletAtIndexFiatAmount, which directly renders WalletInstance components. Changes to WalletInstance.tsx could affect the fiat amount display or discreet mode behavior in the device switcher wallet list.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — This test uses the device switcher to eject a wallet and add a standard wallet, directly exercising the SwitchDevice UI where WalletInstance is rendered. Changes to WalletInstance could affect wallet listing, ejection, or adding flows.
- `suite/e2e/tests/passphrase/passphrase-numbering.test.ts` — This test heavily exercises the device switcher with wallet labels (TR_NO_PASSPHRASE_WALLET, TR_PASSPHRASE_WALLET), adding/ejecting wallets, and checking wallet numbering at specific indices — all of which render WalletInstance components. Changes to WalletInstance.tsx or messages.ts translation keys could break numbering or label display.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — This test interacts with the device switcher to add hidden wallets, checks wallet labels (TR_PASSPHRASE_WALLET), and verifies walletAtIndex content — all exercising WalletInstance rendering. Changes to WalletInstance.tsx or translation strings in messages.ts could affect passphrase wallet display.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — This test checks that after device reconnection, walletAtIndex(1) contains TR_PASSPHRASE_WALLET translation, directly rendering WalletInstance in the device switcher. Changes to WalletInstance.tsx or messages.ts could affect reconnection wallet display.
- `suite/e2e/tests/passphrase/passphrase-duplicate.test.ts` — This test creates hidden wallets through the device switcher and checks duplicate passphrase warnings (TR_WALLET_DUPLICATE_TITLE, TR_WALLET_DUPLICATE_DESC). The WalletInstance component is rendered in the device switcher, and messages.ts may contain the translation keys for these warnings.
- `suite/e2e/tests/metadata/legacy/wallet-metadata.test.ts` — This test edits wallet labels in the device switcher (wallet.clickEditLabel, wallet.walletLabel) which directly renders WalletInstance components. Changes to WalletInstance.tsx could affect how wallet labels are displayed or edited in the switcher.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test checks device status on the switch device panel (deviceStatusOnSwitchDevice, walletAtIndex) which renders WalletInstance. Changes to WalletInstance.tsx could affect how session status or wallet items are displayed in the device switcher.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/backup/t2t1-misc.test.ts` — This test uses the device switcher (walletAtIndex) during the backup flow for a remembered device scenario. WalletInstance changes could affect how the wallet appears in the switcher, though the primary focus is backup functionality.
- `suite/e2e/tests/settings/autodetect.test.ts` — This test verifies autodetected language and theme on the onboarding analytics heading, which uses translations from messages.ts. If translation keys referenced in the analytics section heading were modified, this test would catch regressions.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/intl/src/messages.ts`

_Updated: 2026-05-15T05:42:37.579Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=add-tooltip-to-eject&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=add-tooltip-to-eject&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-15T05:47:30.952Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-15T05:45:38.805Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/add-tooltip-to-eject/web/](https://dev.suite.sldev.cz/suite-web/add-tooltip-to-eject/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->