### PR TITLE
feat(suite): Variable decimal places in crypto amounts (PoC)

### DIFF
--- a/packages/components/src/constants/keyboardEvents.ts
+++ b/packages/components/src/constants/keyboardEvents.ts
@@ -6,6 +6,7 @@ export enum KEYBOARD_CODE {
     ARROW_RIGHT = 'ArrowRight',
     TAB = 'Tab',
     COMMA = 'Comma',
+    KEY_A = 'KeyA',
     KEY_P = 'KeyP',
     KEY_D = 'KeyD',
 

--- a/packages/suite-data/files/translations/en-US.json
+++ b/packages/suite-data/files/translations/en-US.json
@@ -474,6 +474,8 @@
   "TR_BRIDGE_REQUESTED_DESCRIPTION": "Another app requested Trezor Suite to connect with your Trezor device. Keep Trezor Suite running in the background and try the action again in the other app.",
   "TR_BRIDGE_TIP_AUTOSTART": "Tip: Enable Trezor Suite to start automatically and run in the background for smoother interaction with third-party apps.",
   "TR_BTC_UNITS": "Bitcoin units",
+  "TR_FIAT_BASED_CRYPTO_DECIMALS": "Fiat-based crypto decimals",
+  "TR_FIAT_BASED_CRYPTO_DECIMALS_DESCRIPTION": "Shorten crypto amounts so that the smallest displayed unit is roughly worth one unit of your selected base currency. Disable to always show full precision.",
   "TR_BUG": "Bug",
   "TR_BUMP_FEE": "Speed up",
   "TR_BUMP_FEE_DISABLED_TOOLTIP": "To speed up your transactions, increase the fee on the oldest pending transaction in the queue (by nonce), as transactions must be confirmed in order. If you want to speed up this transaction specifically, open its detail and use the \"Speed up\" option. <a>Learn more</a>",

--- a/packages/suite/src/components/earn/dashboard/common/EarnAccountCellDetails.tsx
+++ b/packages/suite/src/components/earn/dashboard/common/EarnAccountCellDetails.tsx
@@ -64,6 +64,7 @@ export const EarnAccountCellDetails = ({
                         <FormattedCryptoAmount
                             value={tokenBalance.value}
                             symbol={tokenBalance.symbol}
+                            networkSymbol={networkSymbol}
                             contractAddress={tokenBalance.contractAddress}
                             isBalance
                         />

--- a/packages/suite/src/components/earn/yield/common/YieldTokenValue.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldTokenValue.tsx
@@ -30,7 +30,12 @@ export const YieldTokenValue = ({ token, amount }: YieldTokenValueProps) => {
                 isBordered={false}
             />
             <Text typographyStyle="body-md-strong">
-                <FormattedCryptoAmount value={roundedAmount} symbol={token.symbol} />
+                <FormattedCryptoAmount
+                    value={roundedAmount}
+                    symbol={token.symbol}
+                    networkSymbol={token.networkSymbol}
+                    contractAddress={token.contractAddress}
+                />
             </Text>
         </Row>
     );

--- a/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
+++ b/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
@@ -9,9 +9,13 @@ import {
     getNetworkOptional,
 } from '@suite-common/wallet-config';
 import { LOW_BALANCE_THRESHOLD } from '@suite-common/wallet-constants';
+import { selectBaseCurrency, selectFiatRatesByFiatRateKey } from '@suite-common/wallet-core';
+import { type TokenAddress } from '@suite-common/wallet-types';
 import {
     type AmountUnit,
     formatCoinBalance,
+    formatCoinBalanceByFiatRate,
+    getFiatRateKey,
     localizeNumber,
     networkAmountToSmallestUnit,
 } from '@suite-common/wallet-utils';
@@ -59,8 +63,27 @@ export const FormattedCryptoAmount = ({
     'data-testid': dataTest,
 }: FormattedCryptoAmountProps) => {
     const locale = useSelector(selectLanguage);
+    const baseCurrencyCode = useSelector(selectBaseCurrency);
 
     const { areSatsDisplayed } = useBitcoinAmountUnit();
+
+    const lowerCaseSymbol = symbol?.toLowerCase();
+    const {
+        features: networkFeatures,
+        testnet: isTestnet,
+        symbol: networkSymbol,
+    } = getNetworkOptional(lowerCaseSymbol) ?? {};
+
+    const currentRate = useSelector(state => {
+        if (!networkSymbol) return undefined;
+        const key = getFiatRateKey(
+            networkSymbol,
+            baseCurrencyCode,
+            (contractAddress ?? undefined) as TokenAddress | undefined,
+        );
+
+        return selectFiatRatesByFiatRateKey(state, key);
+    });
 
     const isAmountLow = useMemo(() => {
         if (!value || !showApproximation) return false;
@@ -72,13 +95,6 @@ export const FormattedCryptoAmount = ({
     if (!value) {
         return null;
     }
-
-    const lowerCaseSymbol = symbol?.toLowerCase();
-    const {
-        features: networkFeatures,
-        testnet: isTestnet,
-        symbol: networkSymbol,
-    } = getNetworkOptional(lowerCaseSymbol) ?? {};
 
     const areSatsSupported = !!networkFeatures?.includes('amount-unit');
 
@@ -94,15 +110,19 @@ export const FormattedCryptoAmount = ({
         formattedSymbol = isTestnet ? `sat ${formattedSymbol}` : 'sat';
     }
 
-    // format truncation + locale (used for balances) or just locale
-    if (isBalance && !isAmountLow) {
+    // Dynamic decimals based on fiat rate — skipped in sats mode (already integer units).
+    // Falls back to the existing formatters when no rate is available.
+    const fiatRate = !isSatoshis ? currentRate?.rate : undefined;
+
+    if (isAmountLow) {
+        formattedValue = `< ${LOW_BALANCE_THRESHOLD}`;
+    } else if (fiatRate !== undefined) {
+        formattedValue = formatCoinBalanceByFiatRate(String(formattedValue), locale, fiatRate);
+    } else if (isBalance) {
         formattedValue = formatCoinBalance(String(formattedValue), locale);
     } else {
         formattedValue = localizeNumber(formattedValue, locale);
     }
-
-    // prefix balance with < if it's below threshold
-    formattedValue = isAmountLow ? `< ${LOW_BALANCE_THRESHOLD}` : formattedValue;
 
     // output as a string, mostly for compatibility with graphs
     if (isRawString) {

--- a/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
+++ b/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
@@ -4,6 +4,7 @@ import { selectLanguage } from '@suite/settings';
 import { isSignValuePositive } from '@suite-common/formatters';
 import { type SignValue } from '@suite-common/suite-types';
 import {
+    type NetworkSymbol,
     type NetworkSymbolExtended,
     getDisplaySymbol,
     getNetworkOptional,
@@ -37,6 +38,10 @@ import { RedactNumericalValue } from './RedactNumericalValue';
 export interface FormattedCryptoAmountProps {
     value?: string | number | AmountUnit; // Todo: remove `string | number`, its for Back Compatibility only
     symbol?: NetworkSymbolExtended;
+    // Override for fiat-rate lookup when `symbol` carries a token ticker (e.g. "USDC")
+    // instead of a NetworkSymbol — pass the host chain (e.g. "eth") to enable rate-based
+    // decimal formatting for tokens.
+    networkSymbol?: NetworkSymbol;
     contractAddress?: string | null;
     isBalance?: boolean;
     showApproximation?: boolean;
@@ -55,6 +60,7 @@ export interface FormattedCryptoAmountProps {
 export const FormattedCryptoAmount = ({
     value, // expects a value in full units (BTC not sats)
     symbol,
+    networkSymbol: networkSymbolOverride,
     contractAddress, // include contractAddress whenever the symbol is an token
     isBalance,
     showApproximation = false,
@@ -76,8 +82,12 @@ export const FormattedCryptoAmount = ({
     const {
         features: networkFeatures,
         testnet: isTestnet,
-        symbol: networkSymbol,
+        symbol: networkSymbolFromConfig,
     } = getNetworkOptional(lowerCaseSymbol) ?? {};
+
+    // Tokens carry a ticker in `symbol` (e.g. "USDC"); fall back to the explicit override
+    // so fiat-rate lookup still resolves the host chain.
+    const networkSymbol = networkSymbolFromConfig ?? networkSymbolOverride;
 
     const currentRate = useSelector(state => {
         if (!networkSymbol) return undefined;

--- a/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
+++ b/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
@@ -9,7 +9,11 @@ import {
     getNetworkOptional,
 } from '@suite-common/wallet-config';
 import { LOW_BALANCE_THRESHOLD } from '@suite-common/wallet-constants';
-import { selectBaseCurrency, selectFiatRatesByFiatRateKey } from '@suite-common/wallet-core';
+import {
+    selectBaseCurrency,
+    selectFiatRatesByFiatRateKey,
+    selectUseFiatBasedCryptoDecimals,
+} from '@suite-common/wallet-core';
 import { type TokenAddress } from '@suite-common/wallet-types';
 import {
     type AmountUnit,
@@ -64,6 +68,7 @@ export const FormattedCryptoAmount = ({
 }: FormattedCryptoAmountProps) => {
     const locale = useSelector(selectLanguage);
     const baseCurrencyCode = useSelector(selectBaseCurrency);
+    const useFiatBasedDecimals = useSelector(selectUseFiatBasedCryptoDecimals);
 
     const { areSatsDisplayed } = useBitcoinAmountUnit();
 
@@ -110,9 +115,9 @@ export const FormattedCryptoAmount = ({
         formattedSymbol = isTestnet ? `sat ${formattedSymbol}` : 'sat';
     }
 
-    // Dynamic decimals based on fiat rate — skipped in sats mode (already integer units).
-    // Falls back to the existing formatters when no rate is available.
-    const fiatRate = !isSatoshis ? currentRate?.rate : undefined;
+    // Dynamic decimals based on fiat rate — skipped in sats mode (already integer units)
+    // and when the user disabled the feature in settings.
+    const fiatRate = useFiatBasedDecimals && !isSatoshis ? currentRate?.rate : undefined;
 
     if (isAmountLow) {
         formattedValue = `< ${LOW_BALANCE_THRESHOLD}`;

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowToken/AssetAmount.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowToken/AssetAmount.tsx
@@ -1,5 +1,6 @@
 import { Translation } from '@suite/intl';
 import { useFormatters } from '@suite-common/formatters';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { selectBaseCurrency } from '@suite-common/wallet-core';
 import { type BaseCurrencyAmount } from '@suite-common/wallet-types';
 import { Column, Text } from '@trezor/components';
@@ -9,6 +10,7 @@ import { useSelector } from 'src/hooks/suite';
 
 export type AssetAmountProps = {
     symbol: string;
+    networkSymbol?: NetworkSymbol;
     amount: string;
     contractAddress: string;
     fiatAmount?: BaseCurrencyAmount;
@@ -18,6 +20,7 @@ export type AssetAmountProps = {
 export function AssetAmount({
     amount,
     symbol,
+    networkSymbol,
     fiatAmount,
     contractAddress,
     fiatFallackText = false,
@@ -31,6 +34,7 @@ export function AssetAmount({
                 <FormattedCryptoAmount
                     value={amount}
                     symbol={symbol}
+                    networkSymbol={networkSymbol}
                     contractAddress={contractAddress}
                     isBalance
                 />

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowToken/AssetRowToken.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowToken/AssetRowToken.tsx
@@ -49,6 +49,7 @@ export function AssetRowToken({
             {token.balance && (
                 <AssetAmount
                     symbol={token.symbol!}
+                    networkSymbol={account.symbol}
                     fiatAmount={token.fiatRate ? asBaseCurrencyAmount(token.fiatValue) : undefined}
                     contractAddress={token.contract}
                     amount={token.balance}

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/AppShortcuts.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/AppShortcuts.tsx
@@ -2,7 +2,7 @@ import { useEvent } from 'react-use';
 
 import { closeModalApp, goto } from '@suite/router';
 import { selectSelectedDevice } from '@suite-common/device';
-import { startDiscoveryThunk } from '@suite-common/wallet-core';
+import { startDiscoveryThunk, toggleUseFiatBasedCryptoDecimals } from '@suite-common/wallet-core';
 import { KEYBOARD_CODE } from '@trezor/components';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -17,8 +17,14 @@ export const AppShortcuts = () => {
         discoveryStatus !== undefined && discoveryStatus.status === 'loading';
 
     useEvent('keydown', e => {
-        const { altKey, metaKey } = e;
+        const { altKey, metaKey, shiftKey } = e;
         const isDeviceSelected = selectedDevice !== undefined;
+
+        // press Shift + Alt/Option + A to toggle fiat-based crypto decimals
+        if (shiftKey && altKey && e.code === KEYBOARD_CODE.KEY_A) {
+            dispatch(toggleUseFiatBasedCryptoDecimals());
+            e.preventDefault();
+        }
         // press ALT + P to show PassphraseModal
         if (
             selectedDevice?.connected &&

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseModal.tsx
@@ -81,7 +81,6 @@ export const PassphraseModal = ({ device }: { device: TrezorDevice }) => {
     const offerPassphraseOnDevice = useSelector(selectHasDevicePassphraseEntryCapability);
 
     if (!device || !discovery || !discovery.isAddingHiddenWallet) return null;
-
     switch (discovery.status) {
         case 'progress':
             return <DiscoveryLoader />;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AmountDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AmountDetails.tsx
@@ -206,6 +206,7 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                                     <Text intent="neutral">
                                         <AmountComponent
                                             transfer={transfer}
+                                            networkSymbol={selectedAccount.account?.symbol}
                                             withLink={true}
                                             withSign={true}
                                             alignMultitoken="flex-start"

--- a/packages/suite/src/components/wallet/AmountComponent.tsx
+++ b/packages/suite/src/components/wallet/AmountComponent.tsx
@@ -1,3 +1,4 @@
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import {
     convertAmountSubunitsToUnits,
     getTxOperation,
@@ -11,6 +12,7 @@ import { FormattedNftAmount } from 'src/components/suite/FormattedNftAmount';
 
 type AmountComponentProps = {
     transfer: TokenTransfer;
+    networkSymbol?: NetworkSymbol;
     withLink?: boolean;
     withSign?: boolean;
     signGrayscale?: boolean;
@@ -20,6 +22,7 @@ type AmountComponentProps = {
 
 export const AmountComponent = ({
     transfer,
+    networkSymbol,
     withLink = false,
     withSign = false,
     signGrayscale,
@@ -46,6 +49,7 @@ export const AmountComponent = ({
             <FormattedCryptoAmount
                 value={convertAmountSubunitsToUnits(transfer.amount, transfer.decimals)}
                 symbol={transfer.symbol}
+                networkSymbol={networkSymbol}
                 contractAddress={transfer.contract}
                 signValue={operation}
                 signGrayscale={signGrayscale}

--- a/packages/suite/src/components/wallet/TokenBalance.tsx
+++ b/packages/suite/src/components/wallet/TokenBalance.tsx
@@ -1,4 +1,5 @@
 import { useFormatters } from '@suite-common/formatters';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { selectBaseCurrency } from '@suite-common/wallet-core';
 import { Column, Text } from '@trezor/components';
 import { type AssetProps } from '@trezor/product-components';
@@ -8,10 +9,11 @@ import { useSelector } from 'src/hooks/suite';
 
 export interface TokenBalanceProps {
     contractAddress: string;
+    networkSymbol?: NetworkSymbol;
     tokenBalance: NonNullable<AssetProps['tokenBalance']>;
 }
 
-export function TokenBalance({ contractAddress, tokenBalance }: TokenBalanceProps) {
+export function TokenBalance({ contractAddress, networkSymbol, tokenBalance }: TokenBalanceProps) {
     const { BaseCurrencyAmountFormatter } = useFormatters();
     const fiatCurrency = useSelector(selectBaseCurrency);
 
@@ -20,6 +22,7 @@ export function TokenBalance({ contractAddress, tokenBalance }: TokenBalanceProp
             <FormattedCryptoAmount
                 value={tokenBalance.baseAmount}
                 symbol={tokenBalance.baseSymbol}
+                networkSymbol={networkSymbol}
                 contractAddress={contractAddress}
             />
             {tokenBalance.fiatAmount && (

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
@@ -121,6 +121,7 @@ export const TransactionTarget = ({
                 return (
                     <AmountComponent
                         transfer={payload}
+                        networkSymbol={transaction.symbol}
                         withLink={false}
                         withSign
                         signGrayscale

--- a/packages/suite/src/views/settings/SettingsGeneral/FiatBasedCryptoDecimals.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/FiatBasedCryptoDecimals.tsx
@@ -1,0 +1,43 @@
+import { Translation } from '@suite/intl';
+import { Anchor, SettingsAnchor } from '@suite/router';
+import {
+    selectUseFiatBasedCryptoDecimals,
+    setUseFiatBasedCryptoDecimals,
+} from '@suite-common/wallet-core';
+import { Switch } from '@trezor/components';
+import { ActionColumn, SectionItem, TextColumn } from '@trezor/product-components';
+
+import { useDispatch, useSelector } from 'src/hooks/suite';
+
+export const FiatBasedCryptoDecimals = () => {
+    const dispatch = useDispatch();
+    const isEnabled = useSelector(selectUseFiatBasedCryptoDecimals);
+
+    const handleChange = () => {
+        dispatch(setUseFiatBasedCryptoDecimals(!isEnabled));
+    };
+
+    return (
+        <Anchor anchorId={SettingsAnchor.FiatBasedCryptoDecimals}>
+            {({ anchorId, anchorRef, shouldHighlight }) => (
+                <SectionItem
+                    data-testid={anchorId}
+                    ref={anchorRef}
+                    shouldHighlight={shouldHighlight}
+                >
+                    <TextColumn
+                        title={<Translation id="TR_FIAT_BASED_CRYPTO_DECIMALS" />}
+                        description={<Translation id="TR_FIAT_BASED_CRYPTO_DECIMALS_DESCRIPTION" />}
+                    />
+                    <ActionColumn>
+                        <Switch
+                            isChecked={isEnabled}
+                            onChange={handleChange}
+                            data-testid="@settings/fiat-based-crypto-decimals-switch"
+                        />
+                    </ActionColumn>
+                </SectionItem>
+            )}
+        </Anchor>
+    );
+};

--- a/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
@@ -34,6 +34,7 @@ import { DisconnectLabelingProvider } from './DisconnectLabelingProvider';
 import { DustPhishing } from './DustPhishing';
 import { EarlyAccess } from './EarlyAccess';
 import { Experimental } from './Experimental';
+import { FiatBasedCryptoDecimals } from './FiatBasedCryptoDecimals';
 import { Language } from './Language';
 import { LegacyLabelingMigration } from './LegacyLabelingMigration';
 import { McpServer } from './McpServer';
@@ -117,6 +118,7 @@ export const SettingsGeneral = () => {
                 <Language />
                 <BaseCurrency />
                 {hasBitcoinNetworks && <BitcoinAmountUnit />}
+                <FiatBasedCryptoDecimals />
             </SettingsSection>
 
             <SettingsSection

--- a/packages/suite/src/views/wallet/send/Outputs/TokenSelect/SelectTokenAssetModal/SelectTokenAssetModal.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/TokenSelect/SelectTokenAssetModal/SelectTokenAssetModal.tsx
@@ -146,6 +146,7 @@ export function SelectTokenAssetModal({
                 option.tokenBalance && option.contractAddress ? (
                     <TokenBalance
                         contractAddress={option.contractAddress}
+                        networkSymbol={account.symbol}
                         tokenBalance={option.tokenBalance}
                     />
                 ) : null

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
@@ -93,6 +93,7 @@ export const TokenRow = ({
                                 data-testid={`@token-row/${token.name}/crypto-amount`}
                                 value={token.balance}
                                 symbol={token.symbol}
+                                networkSymbol={network.symbol}
                                 contractAddress={token.contract}
                             />
                         </Text>

--- a/suite-common/wallet-core/src/settings/walletSettingsActions.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsActions.ts
@@ -84,6 +84,8 @@ export type WalletSettingsAction =
     | ReturnType<typeof setMevProtection>
     | ReturnType<typeof setNetworkReserve>
     | ReturnType<typeof setAddressDisplayType>
+    | ReturnType<typeof setUseFiatBasedCryptoDecimals>
+    | ReturnType<typeof toggleUseFiatBasedCryptoDecimals>
     | ChangeCoinVisibilityAction
     | SetHideBalanceAction
     | SetBitcoinAmountUnitsAction;

--- a/suite-common/wallet-core/src/settings/walletSettingsActions.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsActions.ts
@@ -49,6 +49,15 @@ export const setAddressDisplayType = createAction(
     (value: AddressDisplayOptions) => ({ payload: value }),
 );
 
+export const setUseFiatBasedCryptoDecimals = createAction(
+    WALLET_SETTINGS.SET_USE_FIAT_BASED_CRYPTO_DECIMALS,
+    (enabled: boolean) => ({ payload: enabled }),
+);
+
+export const toggleUseFiatBasedCryptoDecimals = createAction(
+    WALLET_SETTINGS.TOGGLE_USE_FIAT_BASED_CRYPTO_DECIMALS,
+);
+
 export type ChangeCoinVisibilityAction = {
     type: typeof WALLET_SETTINGS.CHANGE_COIN_VISIBILITY;
     payload: {

--- a/suite-common/wallet-core/src/settings/walletSettingsConstants.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsConstants.ts
@@ -10,6 +10,9 @@ const SET_MEV_PROTECTION = '@wallet-settings/set-mev-protection';
 const SET_NETWORK_RESERVE = '@wallet-settings/set-network-reserve';
 const SET_AUTO_EJECT = '@wallet-settings/set-auto-eject';
 const SET_ADDRESS_DISPLAY_TYPE = '@wallet-settings/set-address-display-type';
+const SET_USE_FIAT_BASED_CRYPTO_DECIMALS = '@wallet-settings/set-use-fiat-based-crypto-decimals';
+const TOGGLE_USE_FIAT_BASED_CRYPTO_DECIMALS =
+    '@wallet-settings/toggle-use-fiat-based-crypto-decimals';
 
 export const WALLET_SETTINGS = {
     SET_BASE_CURRENCY,
@@ -24,4 +27,6 @@ export const WALLET_SETTINGS = {
     SET_NETWORK_RESERVE,
     SET_AUTO_EJECT,
     SET_ADDRESS_DISPLAY_TYPE,
+    SET_USE_FIAT_BASED_CRYPTO_DECIMALS,
+    TOGGLE_USE_FIAT_BASED_CRYPTO_DECIMALS,
 } as const;

--- a/suite-common/wallet-core/src/settings/walletSettingsReducer.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsReducer.ts
@@ -39,6 +39,7 @@ const initialState: WalletSettingsState = {
     networkReserve: true,
     isAutoEjectEnabled: false,
     addressDisplayType: AddressDisplayOptions.CHUNKED,
+    useFiatBasedCryptoDecimals: true,
 };
 export const initialWalletSettingsState: WalletSettingsState = initialState;
 
@@ -52,6 +53,7 @@ export const walletSettingsPersistedWhitelist: Array<keyof WalletSettingsState> 
     'networkReserve',
     'isAutoEjectEnabled',
     'addressDisplayType',
+    'useFiatBasedCryptoDecimals',
 ];
 
 export const prepareWalletSettingsReducer = createReducerWithExtraDeps(
@@ -113,6 +115,18 @@ export const prepareWalletSettingsReducer = createReducerWithExtraDeps(
                 state.addressDisplayType = action.payload;
             },
         );
+        builder.addCase(
+            WALLET_SETTINGS.SET_USE_FIAT_BASED_CRYPTO_DECIMALS,
+            (
+                state,
+                action: ReturnType<typeof walletSettingsActions.setUseFiatBasedCryptoDecimals>,
+            ) => {
+                state.useFiatBasedCryptoDecimals = action.payload;
+            },
+        );
+        builder.addCase(WALLET_SETTINGS.TOGGLE_USE_FIAT_BASED_CRYPTO_DECIMALS, state => {
+            state.useFiatBasedCryptoDecimals = !state.useFiatBasedCryptoDecimals;
+        });
     },
 );
 
@@ -192,3 +206,6 @@ export const selectIsDustPhishingThresholdSettingsVisible = createMemoizedSelect
 
 export const selectAddressDisplayType = (state: WalletSettingsRootState) =>
     state.wallet.settings.addressDisplayType;
+
+export const selectUseFiatBasedCryptoDecimals = (state: WalletSettingsRootState) =>
+    state.wallet.settings.useFiatBasedCryptoDecimals;

--- a/suite-common/wallet-types/src/settings.ts
+++ b/suite-common/wallet-types/src/settings.ts
@@ -27,4 +27,5 @@ export interface WalletSettings {
     networkReserve: boolean;
     isAutoEjectEnabled: boolean;
     addressDisplayType: AddressDisplayOptions;
+    useFiatBasedCryptoDecimals: boolean;
 }

--- a/suite-common/wallet-utils/src/__tests__/balanceUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/balanceUtils.test.ts
@@ -20,17 +20,17 @@ test('formatBalanceUtils', () => {
     expect(formatCoinBalance('200000')).toEqual('200,000');
     expect(formatCoinBalance('2000000')).toEqual('2,000,000');
     expect(formatCoinBalance('2900000')).toEqual('2,900,000');
-    expect(formatCoinBalance('0099999999.999999999999')).toEqual('99,999,999.9…');
+    expect(formatCoinBalance('0099999999.999999999999')).toEqual('99,999,999.9');
     expect(formatCoinBalance('0.12345678')).toEqual('0.12345678');
-    expect(formatCoinBalance('10.12345678')).toEqual('10.1234567…');
+    expect(formatCoinBalance('10.12345678')).toEqual('10.1234567');
     expect(formatCoinBalance('10000.123', 'cs-CZ')).toEqual('10\xa0000,123');
     expect(formatCoinBalance('10000.123', 'es-ES')).toEqual('10.000,123');
     expect(formatCoinBalance('10000.123', 'ru-RU')).toEqual('10\xa0000,123');
 });
 
 test('formatCoinBalanceByFiatRate', () => {
-    // Zero / invalid inputs
-    expect(formatCoinBalanceByFiatRate('0', 'en-US', 60000)).toEqual('0');
+    // Zero / invalid inputs (zero is padded to min decimals)
+    expect(formatCoinBalanceByFiatRate('0', 'en-US', 60000)).toEqual('0.00');
     expect(formatCoinBalanceByFiatRate('not-a-number', 'en-US', 60000)).toEqual('0');
 
     // Missing / invalid rate falls back to formatCoinBalance
@@ -39,28 +39,28 @@ test('formatCoinBalanceByFiatRate', () => {
     expect(formatCoinBalanceByFiatRate('1.23456789', 'en-US', -5)).toEqual('1.23456789');
 
     // BTC @ $60k → 5 decimals
-    expect(formatCoinBalanceByFiatRate('0.12345678', 'en-US', 60000)).toEqual('0.12345…');
-    expect(formatCoinBalanceByFiatRate('1.5', 'en-US', 60000)).toEqual('1.5');
+    expect(formatCoinBalanceByFiatRate('0.12345678', 'en-US', 60000)).toEqual('0.12345');
+    expect(formatCoinBalanceByFiatRate('1.5', 'en-US', 60000)).toEqual('1.50');
 
     // ETH @ $3k → 4 decimals
-    expect(formatCoinBalanceByFiatRate('1.23456789', 'en-US', 3000)).toEqual('1.2345…');
-    expect(formatCoinBalanceByFiatRate('1.5', 'en-US', 3000)).toEqual('1.5');
+    expect(formatCoinBalanceByFiatRate('1.23456789', 'en-US', 3000)).toEqual('1.2345');
+    expect(formatCoinBalanceByFiatRate('1.5', 'en-US', 3000)).toEqual('1.50');
 
     // SOL @ $150 → 3 decimals
-    expect(formatCoinBalanceByFiatRate('1.23456789', 'en-US', 150)).toEqual('1.234…');
+    expect(formatCoinBalanceByFiatRate('1.23456789', 'en-US', 150)).toEqual('1.234');
 
-    // ADA @ $0.50 → 0 decimals
-    expect(formatCoinBalanceByFiatRate('123.456', 'en-US', 0.5)).toEqual('123…');
+    // ADA @ $0.50 → 2 decimals (min)
+    expect(formatCoinBalanceByFiatRate('123.456', 'en-US', 0.5)).toEqual('123.45');
 
-    // DOGE @ $0.10 → 0 decimals
-    expect(formatCoinBalanceByFiatRate('1234.5', 'en-US', 0.1)).toEqual('1,234…');
+    // DOGE @ $0.10 → 2 decimals (min)
+    expect(formatCoinBalanceByFiatRate('1234.5', 'en-US', 0.1)).toEqual('1,234.50');
 
-    // SHIB @ $0.00002 → 0 decimals
-    expect(formatCoinBalanceByFiatRate('50000', 'en-US', 0.00002)).toEqual('50,000');
+    // SHIB @ $0.00002 → 2 decimals (min)
+    expect(formatCoinBalanceByFiatRate('50000', 'en-US', 0.00002)).toEqual('50,000.00');
 
     // Sub-decimal dust on a high-priced coin → surface "< x" hint
     expect(formatCoinBalanceByFiatRate('0.000001', 'en-US', 60000)).toEqual('< 0.00001');
-    expect(formatCoinBalanceByFiatRate('0.5', 'en-US', 0.1)).toEqual('< 1');
+    expect(formatCoinBalanceByFiatRate('0.001', 'en-US', 0.1)).toEqual('< 0.01');
 
     // Locale propagation
     expect(formatCoinBalanceByFiatRate('1234.5678', 'cs-CZ', 3000)).toEqual('1\xa0234,5678');

--- a/suite-common/wallet-utils/src/__tests__/balanceUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/balanceUtils.test.ts
@@ -1,4 +1,4 @@
-import { formatCoinBalance } from '../balanceUtils';
+import { formatCoinBalance, formatCoinBalanceByFiatRate } from '../balanceUtils';
 
 test('formatBalanceUtils', () => {
     // @ts-expect-error
@@ -26,4 +26,42 @@ test('formatBalanceUtils', () => {
     expect(formatCoinBalance('10000.123', 'cs-CZ')).toEqual('10\xa0000,123');
     expect(formatCoinBalance('10000.123', 'es-ES')).toEqual('10.000,123');
     expect(formatCoinBalance('10000.123', 'ru-RU')).toEqual('10\xa0000,123');
+});
+
+test('formatCoinBalanceByFiatRate', () => {
+    // Zero / invalid inputs
+    expect(formatCoinBalanceByFiatRate('0', 'en-US', 60000)).toEqual('0');
+    expect(formatCoinBalanceByFiatRate('not-a-number', 'en-US', 60000)).toEqual('0');
+
+    // Missing / invalid rate falls back to formatCoinBalance
+    expect(formatCoinBalanceByFiatRate('1.23456789', 'en-US', undefined)).toEqual('1.23456789');
+    expect(formatCoinBalanceByFiatRate('1.23456789', 'en-US', 0)).toEqual('1.23456789');
+    expect(formatCoinBalanceByFiatRate('1.23456789', 'en-US', -5)).toEqual('1.23456789');
+
+    // BTC @ $60k → 5 decimals
+    expect(formatCoinBalanceByFiatRate('0.12345678', 'en-US', 60000)).toEqual('0.12345…');
+    expect(formatCoinBalanceByFiatRate('1.5', 'en-US', 60000)).toEqual('1.5');
+
+    // ETH @ $3k → 4 decimals
+    expect(formatCoinBalanceByFiatRate('1.23456789', 'en-US', 3000)).toEqual('1.2345…');
+    expect(formatCoinBalanceByFiatRate('1.5', 'en-US', 3000)).toEqual('1.5');
+
+    // SOL @ $150 → 3 decimals
+    expect(formatCoinBalanceByFiatRate('1.23456789', 'en-US', 150)).toEqual('1.234…');
+
+    // ADA @ $0.50 → 0 decimals
+    expect(formatCoinBalanceByFiatRate('123.456', 'en-US', 0.5)).toEqual('123…');
+
+    // DOGE @ $0.10 → 0 decimals
+    expect(formatCoinBalanceByFiatRate('1234.5', 'en-US', 0.1)).toEqual('1,234…');
+
+    // SHIB @ $0.00002 → 0 decimals
+    expect(formatCoinBalanceByFiatRate('50000', 'en-US', 0.00002)).toEqual('50,000');
+
+    // Sub-decimal dust on a high-priced coin → surface "< x" hint
+    expect(formatCoinBalanceByFiatRate('0.000001', 'en-US', 60000)).toEqual('< 0.00001');
+    expect(formatCoinBalanceByFiatRate('0.5', 'en-US', 0.1)).toEqual('< 1');
+
+    // Locale propagation
+    expect(formatCoinBalanceByFiatRate('1234.5678', 'cs-CZ', 3000)).toEqual('1\xa0234,5678');
 });

--- a/suite-common/wallet-utils/src/balanceUtils.ts
+++ b/suite-common/wallet-utils/src/balanceUtils.ts
@@ -44,8 +44,11 @@ export const formatCoinBalance = (value: string, locale: Locale = 'en-US') => {
     return localizeNumber(balanceBig, locale);
 };
 
+const MIN_FIAT_BASED_DECIMALS = 2;
+
 // Targets a smallest displayed unit of ≈ $1: decimals = ceil(log10(fiatRate)).
-// BTC @ $60k → 5 decimals (0.00001 BTC ≈ $0.60); DOGE @ $0.10 → 0 decimals.
+// Always shows at least 2 decimal places to match fiat formatting conventions.
+// BTC @ $60k → 5 decimals (0.00001 BTC ≈ $0.60); DOGE @ $0.10 → 2 decimals.
 export const formatCoinBalanceByFiatRate = (
     value: string,
     locale: Locale = 'en-US',
@@ -53,13 +56,14 @@ export const formatCoinBalanceByFiatRate = (
 ) => {
     const balanceBig = new BigNumber(value);
 
-    if (balanceBig.isZero() || balanceBig.isNaN()) return '0';
+    if (balanceBig.isNaN()) return '0';
+    if (balanceBig.isZero()) return localizeNumber(balanceBig, locale, MIN_FIAT_BASED_DECIMALS);
 
     if (fiatRate === undefined || !Number.isFinite(fiatRate) || fiatRate <= 0) {
         return formatCoinBalance(value, locale);
     }
 
-    const decimals = Math.max(0, Math.ceil(Math.log10(fiatRate)));
+    const decimals = Math.max(MIN_FIAT_BASED_DECIMALS, Math.ceil(Math.log10(fiatRate)));
 
     const parts = balanceBig.abs().toFixed().split('.');
     const fractionalLength = parts.length > 1 ? parts[1].length : 0;
@@ -68,12 +72,12 @@ export const formatCoinBalanceByFiatRate = (
     const fixedBalance = balanceBig.toFixed(decimals, 1); // ROUND_DOWN
     const fixedBalanceBig = new BigNumber(fixedBalance);
 
-    // Non-zero original got truncated to zero — surface a dust hint instead of "0"
+    // Non-zero original got truncated to zero — surface a dust hint instead of "0.00"
     if (fixedBalanceBig.isZero() && balanceBig.isGreaterThan(0)) {
-        return decimals > 0 ? `< 0.${'0'.repeat(decimals - 1)}1` : '< 1';
+        return `< 0.${'0'.repeat(decimals - 1)}1`;
     }
 
-    const localizedBalance = localizeNumber(fixedBalanceBig, locale);
+    const localizedBalance = localizeNumber(fixedBalanceBig, locale, MIN_FIAT_BASED_DECIMALS);
 
     return isTruncated ? `${localizedBalance}` : localizedBalance;
 };

--- a/suite-common/wallet-utils/src/balanceUtils.ts
+++ b/suite-common/wallet-utils/src/balanceUtils.ts
@@ -38,8 +38,42 @@ export const formatCoinBalance = (value: string, locale: Locale = 'en-US') => {
 
         const localizedBalance = localizeNumber(fixedBalanceBig, locale);
 
-        return isTruncated ? `${localizedBalance}…` : localizedBalance;
+        return isTruncated ? `${localizedBalance}` : localizedBalance;
     }
 
     return localizeNumber(balanceBig, locale);
+};
+
+// Targets a smallest displayed unit of ≈ $1: decimals = ceil(log10(fiatRate)).
+// BTC @ $60k → 5 decimals (0.00001 BTC ≈ $0.60); DOGE @ $0.10 → 0 decimals.
+export const formatCoinBalanceByFiatRate = (
+    value: string,
+    locale: Locale = 'en-US',
+    fiatRate?: number,
+) => {
+    const balanceBig = new BigNumber(value);
+
+    if (balanceBig.isZero() || balanceBig.isNaN()) return '0';
+
+    if (fiatRate === undefined || !Number.isFinite(fiatRate) || fiatRate <= 0) {
+        return formatCoinBalance(value, locale);
+    }
+
+    const decimals = Math.max(0, Math.ceil(Math.log10(fiatRate)));
+
+    const parts = balanceBig.abs().toFixed().split('.');
+    const fractionalLength = parts.length > 1 ? parts[1].length : 0;
+    const isTruncated = fractionalLength > decimals;
+
+    const fixedBalance = balanceBig.toFixed(decimals, 1); // ROUND_DOWN
+    const fixedBalanceBig = new BigNumber(fixedBalance);
+
+    // Non-zero original got truncated to zero — surface a dust hint instead of "0"
+    if (fixedBalanceBig.isZero() && balanceBig.isGreaterThan(0)) {
+        return decimals > 0 ? `< 0.${'0'.repeat(decimals - 1)}1` : '< 1';
+    }
+
+    const localizedBalance = localizeNumber(fixedBalanceBig, locale);
+
+    return isTruncated ? `${localizedBalance}` : localizedBalance;
 };

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -8423,6 +8423,15 @@ export const messages = defineMessages({
         id: 'TR_BTC_UNITS',
         defaultMessage: 'Bitcoin units',
     },
+    TR_FIAT_BASED_CRYPTO_DECIMALS: {
+        id: 'TR_FIAT_BASED_CRYPTO_DECIMALS',
+        defaultMessage: 'Fiat-based crypto decimals',
+    },
+    TR_FIAT_BASED_CRYPTO_DECIMALS_DESCRIPTION: {
+        id: 'TR_FIAT_BASED_CRYPTO_DECIMALS_DESCRIPTION',
+        defaultMessage:
+            'Shorten crypto amounts so that the smallest displayed unit is roughly worth one unit of your selected base currency. Disable to always show full precision.',
+    },
     TR_FAILED: {
         id: 'TR_FAILED',
         defaultMessage: 'Failed',

--- a/suite/router/src/anchors.ts
+++ b/suite/router/src/anchors.ts
@@ -17,6 +17,7 @@ export const SettingsAnchor = {
     Language: '@general-settings/language',
     Fiat: '@general-settings/fiat',
     BitcoinAmountUnit: '@general-settings/btc-amount-unit',
+    FiatBasedCryptoDecimals: '@general-settings/fiat-based-crypto-decimals',
     Labeling: '@general-settings/labeling',
     LabelingServers: '@general-settings/labeling-servers',
     LabelingDisconnect: '@general-settings/labeling-disconnect',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`SHIFT + ALT + A` to switch

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


https://github.com/user-attachments/assets/b2e85058-9ceb-42c6-81e3-bcb1cba3cf34



<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes span three functional areas: crypto amount display formatting (FormattedCryptoAmount.tsx), balance computation utilities (balanceUtils.ts with its unit test), and the passphrase entry modal (PassphraseModal.tsx). All three changed source files map broadly to 121 tests each, indicating they are global/shared components. The highest risk is in balance display and passphrase entry flows. Testing should focus on tests that directly assert balance values, crypto amount formatting, and passphrase modal interactions rather than tests that merely transitively import these components.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite/src/components/suite/FormattedCryptoAmount.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseModal.tsx`
- `suite-common/wallet-utils/src/__tests__/balanceUtils.test.ts`
- `suite-common/wallet-utils/src/balanceUtils.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — This test directly exercises balance display formatting (hiding/revealing balances with '###' placeholders and actual values like '$0.00'). Changes to FormattedCryptoAmount.tsx and balanceUtils.ts could directly affect how balances are rendered and formatted in discreet mode, causing visible regressions in the portfolio, asset cards, and wallet values.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — This test verifies that account balances are displayed with correct non-zero values after receiving BTC, including handling of ellipsis truncation for long balance strings. Changes to FormattedCryptoAmount.tsx (which renders crypto amounts) and balanceUtils.ts (which computes balances) directly affect this test's core assertions about balance display correctness.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/general/wallet-discovery.test.ts` — This test asserts that a BTC balance is visible after discovering a standard wallet. The balance display relies on FormattedCryptoAmount and balanceUtils, so changes to these could affect whether the balance renders correctly after discovery.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — This test exercises the passphrase modal flow extensively — adding hidden wallets, entering/confirming passphrases, handling mismatches, and toggling visibility. Changes to PassphraseModal.tsx directly affect this test's core user flow for passphrase entry and confirmation.
- `suite/e2e/tests/passphrase/passphrase-cancel.test.ts` — This test covers cancelling the passphrase entry flow after filling in a passphrase and confirming on the device prompt. Changes to PassphraseModal.tsx could affect the modal's cancel/close behavior.
- `suite/e2e/tests/passphrase/passphrase-duplicate.test.ts` — This test verifies duplicate passphrase detection when creating hidden wallets, which involves the PassphraseModal for passphrase entry. Changes to PassphraseModal.tsx could affect the duplicate detection flow and warning display.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — This test verifies that after device reconnection, the passphrase prompt re-appears and the user must re-enter the passphrase. Changes to PassphraseModal.tsx could affect the re-prompting behavior and passphrase caching logic.
- `suite/e2e/tests/dashboard/assets.test.ts` — This test verifies asset contents in both grid and table views after enabling coins. The asset display includes formatted crypto amounts and balance calculations that depend on FormattedCryptoAmount and balanceUtils.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/passphrase/passphrase-numbering.test.ts` — This test focuses on wallet numbering/labeling when adding multiple passphrase wallets. While it uses the passphrase modal flow, its core assertions are about numbering labels rather than the modal's input behavior, so it's less directly affected by PassphraseModal changes.
- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts` — This test involves adding a hidden wallet via passphrase (which uses PassphraseModal) and then verifying Cardano receive addresses. The passphrase entry step could be affected by PassphraseModal changes.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/wallet-utils/src/__tests__/balanceUtils.test.ts`

_Updated: 2026-05-15T06:08:15.430Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=variable-decimal-places-in-crypto-amounts&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=variable-decimal-places-in-crypto-amounts&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=variable-decimal-places-in-crypto-amounts&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-15T13:19:14.538Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-15T13:17:42.578Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/variable-decimal-places-in-crypto-amounts/web/](https://dev.suite.sldev.cz/suite-web/variable-decimal-places-in-crypto-amounts/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->