### PR TITLE
feat(suite-native): add message system context for concierge

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/useTradingFormAccount.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingFormAccount.ts
@@ -2,10 +2,10 @@ import { useCallback, useEffect, useMemo } from 'react';
 
 import { type CryptoId } from 'invity-api';
 
-import { type TradingType } from '@suite-common/suite-types';
 import { selectTokenDefinitions } from '@suite-common/token-definitions';
 import {
     CONTRACT_ADDRESS_FOR_NATIVE_TOKEN,
+    type TradingType,
     parseCryptoId,
     selectTradingAccountKeyByTradeType,
     selectTradingPrefilledFromAccount,

--- a/suite-common/message-system/schema/config.schema.v1.json
+++ b/suite-common/message-system/schema/config.schema.v1.json
@@ -787,7 +787,7 @@
         },
         "tradingType": {
             "type": "string",
-            "enum": ["buy", "sell", "exchange"]
+            "enum": ["buy", "sell", "exchange", "concierge"]
         },
         "yieldFlowType": {
             "type": "string",

--- a/suite-common/message-system/src/__tests__/messageSystemTypes.test.ts
+++ b/suite-common/message-system/src/__tests__/messageSystemTypes.test.ts
@@ -1,3 +1,4 @@
+import { type TradingType } from '@suite-common/suite-types';
 import {
     type AccountType,
     type NetworkSymbol,
@@ -49,8 +50,8 @@ describe('Message system types', () => {
                 ['buy', 'trading.buy'],
                 ['sell', 'trading.sell'],
                 ['exchange', 'trading.exchange'],
-                // Todo: fix TradingType see: https://github.com/trezor/trezor-suite/pull/21265
-            ] as const satisfies ['buy' | 'sell' | 'exchange', string][])(
+                ['concierge', 'trading.concierge'],
+            ] as const satisfies [TradingType, string][])(
                 'getTrading(%s) → %s',
                 (type, expected) => {
                     expect(Context.getTrading(type)).toBe(expected);

--- a/suite-common/message-system/src/messageSystemConstants.ts
+++ b/suite-common/message-system/src/messageSystemConstants.ts
@@ -61,7 +61,7 @@ export const CONTEXT_PATTERNS = {
     },
     getTrading: {
         pattern: 'trading.{type}',
-        regex: /^trading\.(buy|sell|exchange)$/,
+        regex: /^trading\.(buy|sell|exchange|concierge)$/,
     },
     getEarnDashboard: {
         pattern: 'earn.dashboard.{type}',

--- a/suite-common/suite-types/src/messageSystem.ts
+++ b/suite-common/suite-types/src/messageSystem.ts
@@ -302,7 +302,7 @@ export type CTAAction = 'internal-link' | 'external-link';
  * This interface was referenced by `MessageSystem`'s JSON-Schema
  * via the `definition` "tradingType".
  */
-export type TradingType = 'buy' | 'sell' | 'exchange';
+export type TradingType = 'buy' | 'sell' | 'exchange' | 'concierge';
 /**
  * This interface was referenced by `MessageSystem`'s JSON-Schema
  * via the `definition` "yieldFlowType".

--- a/suite-native/module-trading/src/components/general/TradingTypeAwareContextMessage.tsx
+++ b/suite-native/module-trading/src/components/general/TradingTypeAwareContextMessage.tsx
@@ -9,9 +9,11 @@ export type TradingTypeAwareContextMessageProps = Omit<ContextMessageProps, 'con
 export const TradingTypeAwareContextMessage = (props: TradingTypeAwareContextMessageProps) => {
     const activeType = useSelector(selectActiveTradingType);
 
-    if (!activeType || activeType === 'concierge') {
+    if (!activeType) {
         return null;
     }
 
-    return <ContextMessage context={Context.getTrading(activeType)} {...props} />;
+    const context = Context.getTrading(activeType);
+
+    return <ContextMessage context={context} {...props} />;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Add new type for concierge context, to not extend the trading type 

## Notes for QA\

## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/27516


<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes consist of: (1) modifications to message-system types and constants, which are broadly imported across 121+ tests but are foundational type/constant definitions unlikely to cause runtime behavioral changes in any specific E2E test unless the message system rendering or filtering logic is directly affected; (2) a unit test file for messageSystemTypes which has no E2E coverage; and (3) a TradingTypeAwareContextMessage component in the native trading module which has no static E2E test coverage. The messageSystemTypes.ts and messageSystemConstants.ts files map to 121 tests, indicating they are global shared utilities. Without evidence that any specific test exercises message system type changes or constant changes in a way that would regress, no E2E tests are warranted at high or medium priority. The native trading component change is in suite-native, which is not covered by the suite desktop/web E2E tests at all. This is a low-risk change set from an E2E perspective.

<details><summary><b>Changed files (4)</b></summary>

- `suite-common/message-system/src/__tests__/messageSystemTypes.test.ts`
- `suite-common/message-system/src/messageSystemConstants.ts`
- `suite-common/message-system/src/messageSystemTypes.ts`
- `suite-native/module-trading/src/components/general/TradingTypeAwareContextMessage.tsx`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (2)**
- `suite-common/message-system/src/__tests__/messageSystemTypes.test.ts`
- `suite-native/module-trading/src/components/general/TradingTypeAwareContextMessage.tsx`

_Updated: 2026-05-15T06:09:15.763Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/27516-consierge-improvements/web/](https://dev.suite.sldev.cz/suite-web/feat/27516-consierge-improvements/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/27516-consierge-improvements&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/27516-consierge-improvements&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/27516-consierge-improvements&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-18T10:29:26.852Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-15T06:12:52.725Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->