### PR TITLE
feat(suite): Add ButtonGroup and tooltip to my assets view 

### DIFF
--- a/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
@@ -28,7 +28,17 @@ import {
     toFiatCurrency,
 } from '@suite-common/wallet-utils';
 import type { BaseCurrencyCode, TokenInfo } from '@trezor/blockchain-link-types';
-import { Button, Card, Icon, IconButton, LoadingContent, Row } from '@trezor/components';
+import {
+    Button,
+    ButtonGroup,
+    Card,
+    Icon,
+    IconButton,
+    LoadingContent,
+    Row,
+    TOOLTIP_DELAY_LONG,
+    Tooltip,
+} from '@trezor/components';
 import { spacingsPx, typography } from '@trezor/theme';
 import { type PartialRecord } from '@trezor/type-utils';
 import { BigNumber, typedObjectKeys } from '@trezor/utils';
@@ -204,22 +214,25 @@ export const AssetsView = () => {
                                 <Translation id="TR_ENABLE_MORE_COINS" />
                             </Button>
                         )}
-                        <Row gap={4}>
-                            <IconButton
-                                icon="rowsFilled"
-                                data-testid="@dashboard/assets/table-icon"
-                                onClick={setTable}
-                                intent={dashboardAssetsGridMode ? 'neutral' : 'brand'}
-                                priority="secondary"
-                            />
-                            <IconButton
-                                icon="gridNineFilled"
-                                data-testid="@dashboard/assets/grid-icon"
-                                onClick={setGrid}
-                                intent={dashboardAssetsGridMode ? 'brand' : 'neutral'}
-                                priority="secondary"
-                            />
-                        </Row>
+                        <Tooltip
+                            content={<Translation id="TR_MY_ASSETS_CHANGE_VIEW" />}
+                            delayShow={TOOLTIP_DELAY_LONG}
+                        >
+                            <ButtonGroup intent="neutral" priority="secondary">
+                                <IconButton
+                                    icon="rowsFilled"
+                                    data-testid="@dashboard/assets/table-icon"
+                                    onClick={setTable}
+                                    intent={dashboardAssetsGridMode ? 'neutral' : 'brand'}
+                                />
+                                <IconButton
+                                    icon="gridNineFilled"
+                                    data-testid="@dashboard/assets/grid-icon"
+                                    onClick={setGrid}
+                                    intent={dashboardAssetsGridMode ? 'brand' : 'neutral'}
+                                />
+                            </ButtonGroup>
+                        </Tooltip>
                     </Row>
                 )
             }

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -5793,6 +5793,10 @@ export const messages = defineMessages({
         id: 'TR_MY_ASSETS',
         defaultMessage: 'My assets',
     },
+    TR_MY_ASSETS_CHANGE_VIEW: {
+        defaultMessage: 'Change view',
+        id: 'TR_MY_ASSETS_CHANGE_VIEW',
+    },
     TR_ON: {
         id: 'TR_ON',
         defaultMessage: 'on',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

before

<img width="302" height="191" alt="image" src="https://github.com/user-attachments/assets/906cbae0-58f8-485d-ac08-28066651a02b" />


after

<img width="306" height="179" alt="image" src="https://github.com/user-attachments/assets/8521301d-2073-49cb-bdcb-c94f744eaf65" />



<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes touch two files: AssetsView.tsx (the dashboard assets view component) and messages.ts (the global internationalization messages file). AssetsView.tsx maps to 99 tests but most only transitively depend on it via the dashboard being a common landing page after onboarding. The highest risk is in tests that directly interact with the assets section UI (buy buttons, grid/table views, enable coins modal, discreet mode on asset amounts, staking from dashboard). Messages.ts has no static test coverage but is a broadly-used i18n file; only tests that explicitly assert specific translation key content are meaningfully affected. The recommended strategy focuses on the 2 dashboard-specific tests at high priority and 3 medium-priority tests that exercise specific AssetsView interactions or translation assertions.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — This test directly exercises the AssetsView component on the dashboard, testing buy actions in table/grid views and enabling new coins. Changes to AssetsView.tsx could break asset rendering, view toggling, or the 'Enable more coins' modal flow.
- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — This test verifies balance hiding/revealing across the dashboard including asset card and asset row fiat amounts, which are rendered by the AssetsView component. Changes to AssetsView.tsx could affect how discreet mode values are displayed in both card and table views.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/analytics/staking-events.test.ts` — This test navigates to staking from the dashboard assets section for ETH and ADA, directly interacting with stake buttons within the AssetsView. Changes to the AssetsView component could affect the staking navigation entry point from the dashboard.
- `suite/e2e/tests/settings/coins.test.ts` — This test verifies the dashboard empty state when no coins are enabled and the Activate Assets modal flow, which interacts with the AssetsView component's activateAssetsModalNetworkButton and activateAssetsModalSaveButton. Changes to AssetsView could affect the empty state display or asset activation modal.
- `suite/e2e/tests/settings/autodetect.test.ts` — This test verifies autodetection of language and theme using translation keys from messages.ts (specifically TR_ONBOARDING_DATA_COLLECTION_HEADING). Changes to messages.ts could alter translation strings or keys that this test asserts against.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/intl/src/messages.ts`

_Updated: 2026-05-15T06:32:01.658Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=add-tooltip-to-my-assets-view-change&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=add-tooltip-to-my-assets-view-change&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-15T06:40:34.007Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-15T06:39:13.549Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/add-tooltip-to-my-assets-view-change/web/](https://dev.suite.sldev.cz/suite-web/add-tooltip-to-my-assets-view-change/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->