### PR TITLE
fix(suite-native): check staking in the home assets navigation

### DIFF
--- a/suite-native/assets/src/components/AssetItem.tsx
+++ b/suite-native/assets/src/components/AssetItem.tsx
@@ -98,7 +98,7 @@ export const AssetItem = React.memo(({ cryptoCurrencySymbol }: AssetItemProps) =
         selectVisibleDeviceAccountsKeysByNetworkSymbol(state, cryptoCurrencySymbol),
     );
 
-    const accountsPerAsset = accountsKeysForNetworkSymbol.length;
+    const accountCount = accountsKeysForNetworkSymbol.length;
     const hasAnyTokensWithBalance = useSelector((state: TokensRootState) =>
         selectHasDeviceAnyTokensWithBalanceForNetwork(state, cryptoCurrencySymbol),
     );
@@ -107,15 +107,15 @@ export const AssetItem = React.memo(({ cryptoCurrencySymbol }: AssetItemProps) =
     );
 
     const handleAssetPress = () => {
-        if (accountsPerAsset === 1 && !hasAnyTokensWithBalance) {
-            navigation.navigate(RootStackRoutes.AccountDetail, {
-                accountKey: accountsKeysForNetworkSymbol[0],
-                closeActionType: 'back',
-            });
-        } else {
+        if (accountCount > 1 || hasAnyTokensWithBalance || hasAnyAccountsWithStaking) {
             navigation.navigate(AppTabsRoutes.AccountsStack, {
                 screen: AccountsStackRoutes.Accounts,
                 params: { networksFilter: [cryptoCurrencySymbol] },
+            });
+        } else {
+            navigation.navigate(RootStackRoutes.AccountDetail, {
+                accountKey: accountsKeysForNetworkSymbol[0],
+                closeActionType: 'back',
             });
         }
     };
@@ -131,7 +131,7 @@ export const AssetItem = React.memo(({ cryptoCurrencySymbol }: AssetItemProps) =
                         <Icon size="medium" color="contentSecondary" name="wallet" />
                     </Box>
                     <Text variant="body-sm" color="contentSecondary">
-                        {accountsPerAsset}
+                        {accountCount}
                     </Text>
                     {hasAnyAccountsWithStaking && (
                         <StakingBadge networkSymbol={cryptoCurrencySymbol} />

--- a/suite-native/assets/src/components/AssetItem.tsx
+++ b/suite-native/assets/src/components/AssetItem.tsx
@@ -24,10 +24,7 @@ import {
     type NativeStakingRootState,
     selectHasAnyDeviceAccountsWithStaking,
 } from '@suite-native/staking';
-import {
-    type TokensRootState,
-    selectHasDeviceAnyTokensWithBalanceForNetwork,
-} from '@suite-native/tokens';
+import { type TokensRootState, selectHasDeviceAnyTokensForNetwork } from '@suite-native/tokens';
 import { BigNumber } from '@trezor/utils';
 
 import {
@@ -99,15 +96,15 @@ export const AssetItem = React.memo(({ cryptoCurrencySymbol }: AssetItemProps) =
     );
 
     const accountCount = accountsKeysForNetworkSymbol.length;
-    const hasAnyTokensWithBalance = useSelector((state: TokensRootState) =>
-        selectHasDeviceAnyTokensWithBalanceForNetwork(state, cryptoCurrencySymbol),
+    const hasAnyTokens = useSelector((state: TokensRootState) =>
+        selectHasDeviceAnyTokensForNetwork(state, cryptoCurrencySymbol),
     );
     const hasAnyAccountsWithStaking = useSelector((state: NativeStakingRootState) =>
         selectHasAnyDeviceAccountsWithStaking(state, cryptoCurrencySymbol),
     );
 
     const handleAssetPress = () => {
-        if (accountCount > 1 || hasAnyTokensWithBalance || hasAnyAccountsWithStaking) {
+        if (accountCount > 1 || hasAnyTokens || hasAnyAccountsWithStaking) {
             navigation.navigate(AppTabsRoutes.AccountsStack, {
                 screen: AccountsStackRoutes.Accounts,
                 params: { networksFilter: [cryptoCurrencySymbol] },
@@ -136,7 +133,7 @@ export const AssetItem = React.memo(({ cryptoCurrencySymbol }: AssetItemProps) =
                     {hasAnyAccountsWithStaking && (
                         <StakingBadge networkSymbol={cryptoCurrencySymbol} />
                     )}
-                    {hasAnyTokensWithBalance && (
+                    {hasAnyTokens && (
                         <Badge size="small" label={<Translation id="generic.tokens" />} />
                     )}
                 </>

--- a/suite-native/tokens/src/tokensSelectors.ts
+++ b/suite-native/tokens/src/tokensSelectors.ts
@@ -1,13 +1,8 @@
 import { A, pipe } from '@mobily/ts-belt';
 
 import type { DeviceRootState } from '@suite-common/device';
-import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
-import {
-    type TokenDefinitionsRootState,
-    getSimpleCoinDefinitionsByNetwork,
-    isTokenDefinitionKnown,
-    selectTokenDefinitions,
-} from '@suite-common/token-definitions';
+import { createWeakMapSelector } from '@suite-common/redux-utils';
+import { type TokenDefinitionsRootState } from '@suite-common/token-definitions';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
@@ -24,7 +19,7 @@ import {
     type TokenInfoBranded,
     type TokenSymbol,
 } from '@suite-common/wallet-types';
-import { shouldUppercaseTokenSymbol } from '@suite-common/wallet-utils';
+import { isNftToken, shouldUppercaseTokenSymbol } from '@suite-common/wallet-utils';
 import { type TokenInfo, type TokenTransfer } from '@trezor/blockchain-link';
 
 import { type TypedTokenTransfer, type WalletAccountTransaction } from './types';
@@ -138,57 +133,7 @@ export const selectAccountStakeTypeTransactionsWithTokenTransfers = createMemoiz
         ) as WalletAccountTransaction[],
 );
 
-export const selectAccountKnownTokens = createMemoizedSelector(
-    [selectAccountByKey, selectTokenDefinitions],
-    (account, tokenDefinitions): TokenInfoBranded[] => {
-        if (!account || !isNetworkWithTokens(account.symbol)) {
-            return returnStableArrayIfEmpty<TokenInfoBranded>([]);
-        }
-
-        // For Stellar, show all tokens without filtering.
-        // Unlike EVM chains where tokens can be airdropped as spam, Stellar tokens (trustlines)
-        // require explicit user action to activate - users must sign a transaction to add each
-        // trustline. Therefore, all Stellar tokens on an account are intentionally added by the
-        // user and should be displayed, even if they're not in the token-definitions list.
-        if (account.networkType === 'stellar') {
-            return returnStableArrayIfEmpty(account.tokens ?? []) as TokenInfoBranded[];
-        }
-
-        const tokenDefinitionsForNetwork = getSimpleCoinDefinitionsByNetwork(
-            tokenDefinitions,
-            account.symbol,
-        );
-
-        const coinDefs = tokenDefinitions[account.symbol]?.coin;
-        const hiddenSet = new Set((coinDefs?.hide ?? []).map(c => c.toLowerCase()));
-        const shownSet = new Set((coinDefs?.show ?? []).map(c => c.toLowerCase()));
-
-        const knownTokens = (account.tokens ?? []).filter(
-            token =>
-                (isTokenDefinitionKnown(
-                    tokenDefinitionsForNetwork,
-                    account.symbol,
-                    token.contract,
-                ) ||
-                    shownSet.has(token.contract.toLowerCase())) &&
-                !hiddenSet.has(token.contract.toLowerCase()),
-        ) as TokenInfoBranded[];
-
-        return returnStableArrayIfEmpty(knownTokens);
-    },
-);
-
-export const selectAccountKnownTokensWithBalance = createMemoizedSelector(
-    [selectAccountKnownTokens],
-    tokens => tokens.filter(token => parseFloat(token?.balance ?? '0') > 0),
-);
-
-export const selectNumberOfAccountKnownTokensWithBalance = createMemoizedSelector(
-    [selectAccountKnownTokensWithBalance],
-    tokens => tokens.length,
-);
-
-export const selectHasDeviceAnyTokensWithBalanceForNetwork = (
+export const selectHasDeviceAnyTokensForNetwork = (
     state: TokensRootState,
     symbol: NetworkSymbol,
 ) => {
@@ -198,11 +143,7 @@ export const selectHasDeviceAnyTokensWithBalanceForNetwork = (
 
     const accounts = selectVisibleDeviceAccountsByNetworkSymbol(state, symbol);
 
-    return A.any(accounts, account => {
-        const count = selectNumberOfAccountKnownTokensWithBalance(state, account.key);
-
-        return count > 0;
-    });
+    return A.any(accounts, account => (account.tokens ?? []).some(token => !isNftToken(token)));
 };
 
 export const selectNetworkSymbolsOfAccountsWithTokensAllowed = createMemoizedSelector(


### PR DESCRIPTION
## Description

The navigation from the Home assets screen (AssetItem) was inconsistent with the My assets screen for networks with staking (e.g. Cardano). When an account had staking active but no active tokens, tapping the asset from the Home screen would navigate directly to account detail instead of the assets list.

Fixed by including `hasAnyAccountsWithStaking` in the navigation condition alongside `accountCount > 1` and `hasAnyTokensWithBalance`.

## Notes for QA

- Open Cardano (or another staking network) that has no tokens from the **Home** screen asset card — it should navigate to the accounts list (showing staking info), not directly to account detail.
- Verify the same network opened from **My assets** behaves identically.
- Non-staking, single-account networks should still navigate directly to account detail.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27786

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/check-staking-in-home-assets&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->