### PR TITLE
fix(suite-native): fix hidden token balance showing native coin balance

### DIFF
--- a/suite-native/module-accounts-management/src/components/TransactionListHeader.tsx
+++ b/suite-native/module-accounts-management/src/components/TransactionListHeader.tsx
@@ -69,6 +69,10 @@ const TransactionListHeaderContent = ({
             selectIsUnrecognizedToken(state, accountKey, tokenContract),
     );
 
+    const token = useSelector((state: TokensRootState) =>
+        selectAccountTokenInfo(state, accountKey, tokenContract),
+    );
+
     if (!account) return null;
 
     const isGraphDisplayed = hasAccountTransactions && !isTestnetAccount && !isUnrecognizedToken;
@@ -77,9 +81,20 @@ const TransactionListHeaderContent = ({
         return <AccountDetailGraph accountKey={accountKey} tokenContract={tokenContract} />;
     }
 
-    if (isTestnetAccount || isUnrecognizedToken) {
+    if (isTestnetAccount) {
         return (
             <AccountDetailCryptoValue value={account.formattedBalance} symbol={account.symbol} />
+        );
+    }
+    if (token && isUnrecognizedToken) {
+        const { balance = '0', symbol: tokenSymbol } = token;
+
+        return (
+            <AccountDetailCryptoValue
+                value={balance}
+                symbol={account.symbol}
+                tokenSymbol={tokenSymbol}
+            />
         );
     }
 


### PR DESCRIPTION
## Description

When viewing unrecognized (hidden) token details, the header was showing the network's native coin balance instead of the token's own balance. This was caused by a shared condition \`if (isTestnetAccount || isUnrecognizedToken)\` in \`TransactionListHeaderContent\` that always rendered \`account.formattedBalance\`.

The fix splits this into two separate conditions:
- Testnet accounts → show native coin balance (unchanged)
- Unrecognized tokens → show the token's own balance and symbol

## Notes for QA

1. Add a wallet with ERC-20 or other tokens
2. Open the hidden token's detail view — balance should show the **token** balance, not the ETH/network balance

## Related Issue

Resolve #27773

## Screenshots:
<img width="397" height="340" alt="Screenshot 2026-05-15 at 09 58 36" src="https://github.com/user-attachments/assets/9ea9a930-a5be-4da8-a295-4220fa9a86ac" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-native-hidden-token-balance-display&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->