### PR TITLE
style(suite): Update description formatting in hero messages

### DIFF
--- a/packages/suite/src/views/dashboard/PortfolioCard/EmptyWallet.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/EmptyWallet.tsx
@@ -5,7 +5,7 @@ import { Translation } from '@suite/intl';
 import { goto } from '@suite/router';
 import { selectHasBitcoinOnlyFirmware } from '@suite-common/device';
 import { selectEnabledNetworks } from '@suite-common/wallet-core';
-import { Box, Button, Column, H3, Illustration, Paragraph, Row, Text } from '@trezor/components';
+import { Box, Button, Column, H3, Illustration, Paragraph, Row } from '@trezor/components';
 import { NetworkIconSet } from '@trezor/product-components';
 import { borders } from '@trezor/theme';
 
@@ -50,9 +50,15 @@ export const EmptyWallet = () => {
             <H3 margin={{ top: 16 }}>
                 <Translation id="TR_YOUR_WALLET_IS_READY_WHAT" />
             </H3>
-            <Text intent="neutral" priority="secondary" typographyStyle="body-sm">
+            <Paragraph
+                intent="neutral"
+                priority="secondary"
+                typographyStyle="body-sm"
+                maxWidth={500}
+                align="center"
+            >
                 <Translation id="TR_DASHBOARD_EMPTY_WALLET_DESC" />
-            </Text>
+            </Paragraph>
             {enabledNetworks.length > 0 && !isBitcoinOnlyFirmware && (
                 <RoundedBorder>
                     <Row gap={8} flexWrap="wrap">

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardException.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardException.tsx
@@ -14,8 +14,8 @@ import {
     IconCircle,
     type IconName,
     Illustration,
+    Paragraph,
     Row,
-    Text,
 } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
@@ -53,18 +53,20 @@ const Container = ({ title, description, cta, dataTestBase, image }: ContainerPr
                 <Translation id={title} />
             </H3>
             {description && (
-                <Text
+                <Paragraph
                     data-testid={`@exception/${dataTestBase}/description`}
                     intent="neutral"
                     priority="secondary"
                     typographyStyle="body-sm"
+                    maxWidth={500}
+                    align="center"
                 >
                     {typeof description === 'string' ? (
                         <Translation id={description} />
                     ) : (
                         description
                     )}
-                </Text>
+                </Paragraph>
             )}
             <Row gap={spacings.sm} margin={{ top: spacings.md }}>
                 {actions.map(a => (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
changed formatting for descriptions:
- max width 500px
- align center

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

before

<img width="870" height="617" alt="image" src="https://github.com/user-attachments/assets/b0d14809-80a0-4416-adc3-8c5a93e52aec" />


after

<img width="1024" height="645" alt="image" src="https://github.com/user-attachments/assets/095068ad-21e2-45d5-88e6-542325b89aa1" />


<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect two dashboard PortfolioCard sub-components: EmptyWallet.tsx (shown when no coins are enabled or wallet is empty) and PortfolioCardException.tsx (shown when discovery fails or errors occur). Both files map to 99 tests via transitive imports, indicating they are part of a broadly-imported dashboard view. The risk is moderate and localized to dashboard rendering states. Testing should focus on tests that specifically exercise dashboard empty states, discovery failure states, and portfolio card rendering rather than the dozens of tests that merely transit through the dashboard.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/views/dashboard/PortfolioCard/EmptyWallet.tsx`
- `packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardException.tsx`

</details>

**Recommended tests (6)**

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — This test exercises the dashboard page including the assets section. EmptyWallet.tsx is part of the PortfolioCard on the dashboard, and this test navigates through the dashboard with network enabling and asset activation flows where the empty wallet state or portfolio card exception could be rendered.
- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — This test operates on the dashboard page and interacts with portfolio balance display, which is rendered by the PortfolioCard containing both EmptyWallet and PortfolioCardException components. Changes to these components could affect the dashboard layout or balance display behavior.
- `suite/e2e/tests/settings/coins.test.ts` — This test verifies the dashboard empty state when no coins are enabled, checking for specific translation keys like 'TR_YOUR_WALLET_IS_READY_WHAT' and 'TR_DASHBOARD_ACTIVATE_ASSETS_DESC'. The EmptyWallet component is the likely source of this empty dashboard state, making this test directly relevant to changes in EmptyWallet.tsx.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — This test exercises wallet discovery from the dashboard, which involves the PortfolioCard area. During discovery or when accounts are empty, EmptyWallet or PortfolioCardException could be rendered depending on wallet state.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts` — This test specifically asserts that '@exception/discovery-failed/description' is visible on the dashboard when offline, which is the exact error state rendered by PortfolioCardException.tsx. Changes to that component directly affect this test's assertions.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test verifies discovery error states on account pages when using wrong backend URLs (TR_ACCOUNT_EXCEPTION_DISCOVERY_ERROR). While the exception component tested is at the account level rather than dashboard, PortfolioCardException changes could share patterns with discovery error rendering.

</details>

_Updated: 2026-05-15T09:40:47.802Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=update-description-formatting-in-hero-messages&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=update-description-formatting-in-hero-messages&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-15T09:45:42.625Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-15T09:44:18.310Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/update-description-formatting-in-hero-messages/web/](https://dev.suite.sldev.cz/suite-web/update-description-formatting-in-hero-messages/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->