### PR TITLE
Mobile Trade: My Assets picker search

### DIFF
--- a/suite-common/trading/src/hooks/__tests__/useSectionDataFilter.test.ts
+++ b/suite-common/trading/src/hooks/__tests__/useSectionDataFilter.test.ts
@@ -1,0 +1,174 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { useSectionDataFilter } from '../useSectionDataFilter';
+
+type ItemShape = {
+    id: string;
+    name: string;
+};
+
+type SectionShape = {
+    key: string;
+    label: string;
+    data: ItemShape[];
+};
+
+const rawSections: SectionShape[] = [
+    {
+        key: 'section_a',
+        label: 'Section A',
+        data: [
+            { id: '1', name: 'Apple' },
+            { id: '2', name: 'Avocado' },
+        ],
+    },
+    {
+        key: 'section_b',
+        label: 'Section B',
+        data: [
+            { id: '3', name: 'Banana' },
+            { id: '4', name: 'Blueberry' },
+        ],
+    },
+];
+
+const filterCallback = (item: ItemShape, filterValue: string) =>
+    item.name.toLowerCase().includes(filterValue.toLowerCase());
+
+describe('useSectionDataFilter', () => {
+    const renderFilter = () => renderHook(() => useSectionDataFilter(rawSections, filterCallback));
+
+    it('should return the original sections reference when no filter is applied', () => {
+        const { result } = renderFilter();
+
+        expect(result.current.filteredSections).toBe(rawSections);
+    });
+
+    it('should filter items within sections based on filter value', () => {
+        const { result } = renderFilter();
+
+        act(() => {
+            result.current.setFilterValue('Apple');
+        });
+
+        expect(result.current.filteredSections).toHaveLength(1);
+        expect(result.current.filteredSections[0].key).toBe('section_a');
+        expect(result.current.filteredSections[0].data).toHaveLength(1);
+        expect(result.current.filteredSections[0].data[0].name).toBe('Apple');
+    });
+
+    it('should keep items from multiple sections when both have matches', () => {
+        const { result } = renderFilter();
+
+        act(() => {
+            result.current.setFilterValue('e');
+        });
+
+        expect(result.current.filteredSections).toHaveLength(2);
+    });
+
+    it('should preserve extra section properties after filtering', () => {
+        const { result } = renderFilter();
+
+        act(() => {
+            result.current.setFilterValue('Apple');
+        });
+
+        expect(result.current.filteredSections[0].label).toBe('Section A');
+    });
+
+    it('should remove sections with no matching items', () => {
+        const { result } = renderFilter();
+
+        act(() => {
+            result.current.setFilterValue('Banana');
+        });
+
+        expect(result.current.filteredSections).toHaveLength(1);
+        expect(result.current.filteredSections[0].key).toBe('section_b');
+    });
+
+    it('should return empty array when no items match', () => {
+        const { result } = renderFilter();
+
+        act(() => {
+            result.current.setFilterValue('NonExistent');
+        });
+
+        expect(result.current.filteredSections).toHaveLength(0);
+    });
+
+    it('should return empty string as filter value by default', () => {
+        const { result } = renderFilter();
+
+        expect(result.current.filterValue).toBe('');
+    });
+
+    it('should return the current filter value', () => {
+        const { result } = renderFilter();
+
+        act(() => {
+            result.current.setFilterValue('Apple');
+        });
+
+        expect(result.current.filterValue).toBe('Apple');
+    });
+
+    describe('with sortSectionItemsCallback', () => {
+        const sortSectionItemsCallback = (a: ItemShape, b: ItemShape) =>
+            -a.name.localeCompare(b.name);
+
+        const renderFilterWithSort = () =>
+            renderHook(() =>
+                useSectionDataFilter(rawSections, filterCallback, sortSectionItemsCallback),
+            );
+
+        it('should sort items within each section when filter is active', () => {
+            const { result } = renderFilterWithSort();
+
+            act(() => {
+                result.current.setFilterValue('a');
+            });
+
+            expect(result.current.filteredSections[0].data.map(i => i.name)).toEqual([
+                'Avocado',
+                'Apple',
+            ]);
+        });
+
+        it('should not sort when filter is not active', () => {
+            const { result } = renderFilterWithSort();
+
+            expect(result.current.filteredSections).toBe(rawSections);
+        });
+    });
+
+    describe('with sortSectionsCallback', () => {
+        const sortSectionsCallback = (a: SectionShape, b: SectionShape) =>
+            -a.key.localeCompare(b.key);
+
+        const renderFilterWithSectionSort = () =>
+            renderHook(() =>
+                useSectionDataFilter(rawSections, filterCallback, undefined, sortSectionsCallback),
+            );
+
+        it('should sort sections when filter is active', () => {
+            const { result } = renderFilterWithSectionSort();
+
+            act(() => {
+                result.current.setFilterValue('a');
+            });
+
+            expect(result.current.filteredSections.map(s => s.key)).toEqual([
+                'section_b',
+                'section_a',
+            ]);
+        });
+
+        it('should not sort sections when filter is not active', () => {
+            const { result } = renderFilterWithSectionSort();
+
+            expect(result.current.filteredSections).toBe(rawSections);
+        });
+    });
+});

--- a/suite-common/trading/src/hooks/useSectionDataFilter.ts
+++ b/suite-common/trading/src/hooks/useSectionDataFilter.ts
@@ -1,0 +1,40 @@
+import { useMemo, useState } from 'react';
+
+export const useSectionDataFilter = <T, S extends { data: T[] }>(
+    rawSections: S[],
+    filterCallback: (item: T, filterValue: string) => boolean,
+    sortSectionItemsCallback?: (a: T, b: T, filterValue: string) => number,
+    sortSectionsCallback?: (a: S, b: S, filterValue: string) => number,
+): {
+    filteredSections: S[];
+    filterValue: string;
+    setFilterValue: (value: string) => void;
+} => {
+    const [filterValue, setFilterValue] = useState('');
+
+    const filteredSections = useMemo(() => {
+        if (!filterValue) {
+            return rawSections;
+        }
+
+        const sections = rawSections
+            .map(section => {
+                const data = section.data.filter(item => filterCallback(item, filterValue));
+
+                if (sortSectionItemsCallback) {
+                    data.sort((a, b) => sortSectionItemsCallback(a, b, filterValue));
+                }
+
+                return { ...section, data };
+            })
+            .filter(section => section.data.length > 0) as S[];
+
+        if (sortSectionsCallback) {
+            sections.sort((a, b) => sortSectionsCallback(a, b, filterValue));
+        }
+
+        return sections;
+    }, [rawSections, filterValue, filterCallback, sortSectionItemsCallback, sortSectionsCallback]);
+
+    return { filteredSections, filterValue, setFilterValue };
+};

--- a/suite-common/trading/src/index.ts
+++ b/suite-common/trading/src/index.ts
@@ -5,6 +5,7 @@ export * from './currency';
 export * from './hooks/useTradingAssets';
 export * from './hooks/useTradingUtils';
 export * from './hooks/useListDataFilter';
+export * from './hooks/useSectionDataFilter';
 export * from './hooks/useCountryFilteredData';
 export * from './hooks/useCountrySubdivisionFilteredData';
 export * from './hooks/useProviderMetadataChangeEffect';

--- a/suite-native/app/e2e/pageObjects/trading/TradingFormActions.ts
+++ b/suite-native/app/e2e/pageObjects/trading/TradingFormActions.ts
@@ -11,6 +11,10 @@ export abstract class TradingFormActions extends TradingActions {
         return this.getElementById('receive-asset-sheet/header/search-input');
     }
 
+    getSearchSendCryptoElement() {
+        return this.getElementById('send-asset-sheet/header/search-input');
+    }
+
     getSearchFiatElement() {
         return this.getElementById('fiat-search-input');
     }
@@ -162,13 +166,33 @@ export abstract class TradingFormActions extends TradingActions {
             .withTimeout(this.SHORT_TIMEOUT);
     }
 
-    async selectSendAsset(asset: string) {
-        await this.getElementById('asset-send-button').tap();
+    async selectSendAsset(asset: string, network?: string, searchString?: string) {
+        const sendAssetButton = this.getElementById('asset-send-button');
+        await waitForVisible(sendAssetButton, { timeout: this.SHORT_TIMEOUT });
+        await sendAssetButton.tap();
+
         await this.expectSheetHeaderTitle('Your assets');
 
-        await element(by.text(asset)).atIndex(0).tap();
+        const searchSendCryptoInput = this.getSearchSendCryptoElement();
+        await searchSendCryptoInput.tap();
+        await wait(this.BOTTOM_SHEET_ANIMATION_DURATION);
+        const searchForStr = searchString ?? asset;
+        await searchSendCryptoInput.replaceText(searchForStr.slice(0, -1));
 
-        await detoxExpect(this.getElementById('asset-send-button/symbol')).toHaveText(asset);
+        if (network) {
+            const networkFilterTab = element(
+                by.text(network).withAncestor(by.id(this.getTestId('send-asset-sheet/header'))),
+            );
+            await waitForVisible(networkFilterTab);
+            await networkFilterTab.tap();
+        }
+
+        await waitForVisible(by.text(asset));
+        await element(by.text(asset)).tap();
+
+        await waitFor(this.getElementById('asset-send-button/symbol'))
+            .toHaveText(asset)
+            .withTimeout(this.SHORT_TIMEOUT);
     }
 
     async confirmTradingForm() {

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2947,6 +2947,7 @@ export const messages = {
             emptyTitle: 'Coin not found',
             emptyDescription: 'Check the spelling or browse the list to select an option.',
             searchInputPlaceholder: 'Search tokens or address',
+            allFilterTabTitle: 'All',
         },
         accountScreen: {
             accountEmpty: {
@@ -3162,6 +3163,7 @@ export const messages = {
         },
         myAssetSheet: {
             title: 'Your assets',
+            searchInputPlaceholder: 'Search assets',
             emptyTitle: 'No assets found',
             emptyDescription: 'You do not have any assets available for this operation.',
             noPair: {

--- a/suite-native/module-trading/src/components/exchange/send/ExchangeSendAssetPicker.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/ExchangeSendAssetPicker.tsx
@@ -14,6 +14,7 @@ import { MyAssetSheet } from '../../general/MyAssetSheet/MyAssetSheet';
 import { SelectTradeableAssetButton } from '../../general/SelectTradeableAssetButton';
 
 const ASSET_PICKER_TEST_ID = '@trading/exchange/asset-send-button';
+const ASSET_SHEET_TEST_ID = '@trading/exchange/send-asset-sheet';
 
 export const ExchangeSendAssetPicker = () => {
     const dispatch = useDispatch();
@@ -60,6 +61,7 @@ export const ExchangeSendAssetPicker = () => {
                 isVisible={isSheetVisible}
                 onClose={hideSheet}
                 onAssetSelect={onAssetSelect}
+                testID={ASSET_SHEET_TEST_ID}
             />
         </>
     );

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetFilterTabs.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetFilterTabs.tsx
@@ -12,12 +12,13 @@ type MyAssetFilterTabsProps = {
     availableNetworks: NetworkSymbol[];
 };
 
-export const MyAssetFilterTabs = ({
-    visible,
+const keyExtractor = (item: FilterItem<NetworkSymbol | undefined>) => item.value ?? 'undefined';
+
+const MyAssetFilterTabsContent = ({
     animationDuration,
     onSelectedNetworkFilter,
     availableNetworks,
-}: MyAssetFilterTabsProps) => {
+}: Omit<MyAssetFilterTabsProps, 'visible'>) => {
     const [selectedValue, setSelectedValue] = useState<NetworkSymbol | undefined>(undefined);
 
     const { translate } = useTranslate();
@@ -27,7 +28,6 @@ export const MyAssetFilterTabs = ({
         onSelectedNetworkFilter(value);
     };
 
-    // Clear network filter on unmounting filter tabs
     useEffect(() => () => onSelectedNetworkFilter(undefined), [onSelectedNetworkFilter]);
 
     const filterItems: FilterItem<NetworkSymbol | undefined>[] = useMemo(
@@ -44,12 +44,6 @@ export const MyAssetFilterTabs = ({
         [availableNetworks, translate],
     );
 
-    const keyExtractor = (item: FilterItem<NetworkSymbol | undefined>) => item.value ?? 'undefined';
-
-    if (!visible) {
-        return null;
-    }
-
     return (
         <Animated.View
             entering={FadeIn.duration(animationDuration)}
@@ -63,4 +57,12 @@ export const MyAssetFilterTabs = ({
             />
         </Animated.View>
     );
+};
+
+export const MyAssetFilterTabs = ({ visible, ...rest }: MyAssetFilterTabsProps) => {
+    if (!visible) {
+        return null;
+    }
+
+    return <MyAssetFilterTabsContent {...rest} />;
 };

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetFilterTabs.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetFilterTabs.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useMemo, useState } from 'react';
+import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
+
+import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { useTranslate } from '@suite-native/intl';
+import { type FilterItem, FilterTabs } from '@suite-native/trading-atoms';
+
+type MyAssetFilterTabsProps = {
+    visible: boolean;
+    animationDuration: number;
+    onSelectedNetworkFilter: (symbol: NetworkSymbol | undefined) => void;
+    availableNetworks: NetworkSymbol[];
+};
+
+export const MyAssetFilterTabs = ({
+    visible,
+    animationDuration,
+    onSelectedNetworkFilter,
+    availableNetworks,
+}: MyAssetFilterTabsProps) => {
+    const [selectedValue, setSelectedValue] = useState<NetworkSymbol | undefined>(undefined);
+
+    const { translate } = useTranslate();
+
+    const onFilterChange = (value: NetworkSymbol | undefined) => {
+        setSelectedValue(value);
+        onSelectedNetworkFilter(value);
+    };
+
+    // Clear network filter on unmounting filter tabs
+    useEffect(() => () => onSelectedNetworkFilter(undefined), [onSelectedNetworkFilter]);
+
+    const filterItems: FilterItem<NetworkSymbol | undefined>[] = useMemo(
+        () => [
+            {
+                label: translate('moduleTrading.tradeableAssetsSheet.allFilterTabTitle'),
+                value: undefined,
+            },
+            ...availableNetworks.map(symbol => ({
+                label: getNetwork(symbol).name,
+                value: symbol,
+            })),
+        ],
+        [availableNetworks, translate],
+    );
+
+    const keyExtractor = (item: FilterItem<NetworkSymbol | undefined>) => item.value ?? 'undefined';
+
+    if (!visible) {
+        return null;
+    }
+
+    return (
+        <Animated.View
+            entering={FadeIn.duration(animationDuration)}
+            exiting={FadeOut.duration(animationDuration)}
+        >
+            <FilterTabs
+                items={filterItems}
+                onChange={onFilterChange}
+                keyExtractor={keyExtractor}
+                value={selectedValue}
+            />
+        </Animated.View>
+    );
+};

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetFilterTabs.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetFilterTabs.tsx
@@ -6,7 +6,7 @@ import { useTranslate } from '@suite-native/intl';
 import { type FilterItem, FilterTabs } from '@suite-native/trading-atoms';
 
 type MyAssetFilterTabsProps = {
-    visible: boolean;
+    isVisible: boolean;
     animationDuration: number;
     onSelectedNetworkFilter: (symbol: NetworkSymbol | undefined) => void;
     availableNetworks: NetworkSymbol[];
@@ -18,7 +18,7 @@ const MyAssetFilterTabsContent = ({
     animationDuration,
     onSelectedNetworkFilter,
     availableNetworks,
-}: Omit<MyAssetFilterTabsProps, 'visible'>) => {
+}: Omit<MyAssetFilterTabsProps, 'isVisible'>) => {
     const [selectedValue, setSelectedValue] = useState<NetworkSymbol | undefined>(undefined);
 
     const { translate } = useTranslate();
@@ -59,8 +59,8 @@ const MyAssetFilterTabsContent = ({
     );
 };
 
-export const MyAssetFilterTabs = ({ visible, ...rest }: MyAssetFilterTabsProps) => {
-    if (!visible) {
+export const MyAssetFilterTabs = ({ isVisible, ...rest }: MyAssetFilterTabsProps) => {
+    if (!isVisible) {
         return null;
     }
 

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetSheet.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetSheet.tsx
@@ -22,6 +22,7 @@ export type MyAssetSheetProps = {
     isVisible: boolean;
     onClose: (shouldHideKeyboard?: boolean) => void;
     onAssetSelect: MyAssetListItemProps['onPress'];
+    testID?: string;
 };
 
 const keyExtractor = (asset: MyAssetRow, sectionData: Account) =>
@@ -39,7 +40,7 @@ const renderItem = (
     );
 
 export const MyAssetSheet = memo(
-    ({ tradingType, isVisible, onClose, onAssetSelect }: MyAssetSheetProps) => {
+    ({ tradingType, isVisible, onClose, onAssetSelect, testID }: MyAssetSheetProps) => {
         const onAssetSelectCallback = (asset: TradeableAsset, account: Account) => {
             onAssetSelect(asset, account);
             onClose(false);
@@ -57,6 +58,8 @@ export const MyAssetSheet = memo(
             filterValue,
         } = useMyAssetsFilteredData(myAssets);
 
+        const headerTestID = testID ? `${testID}/header` : undefined;
+
         const renderHandle = useCallback(
             () => (
                 <MyAssetSheetHeader
@@ -64,9 +67,10 @@ export const MyAssetSheet = memo(
                     onFilterChange={setFilterValue}
                     onSelectedNetworkFilter={setFilterSymbol}
                     availableNetworks={availableNetworks}
+                    testID={headerTestID}
                 />
             ),
-            [onClose, setFilterValue, setFilterSymbol, availableNetworks],
+            [onClose, setFilterValue, setFilterSymbol, availableNetworks, headerTestID],
         );
 
         return (

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetSheet.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetSheet.tsx
@@ -1,9 +1,8 @@
-import { memo } from 'react';
+import { memo, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 
 import { type TradingType } from '@suite-common/trading';
 import { type Account } from '@suite-common/wallet-types';
-import { Translation } from '@suite-native/intl';
 import { BottomSheetSectionList } from '@suite-native/trading-atoms';
 import {
     type CombinedSelectorsRootState,
@@ -14,8 +13,9 @@ import { type MyAssetRow, type TradeableAsset } from '@suite-native/trading-type
 import { MyAssetListEmptyComponent } from './MyAssetListEmptyComponent';
 import { MyAssetListItem, type MyAssetListItemProps } from './MyAssetListItem';
 import { MyAssetListSectionHeader } from './MyAssetListSectionHeader';
-import { SimpleSheetHeader } from '../SimpleSheetHeader';
+import { MyAssetSheetHeader } from './MyAssetSheetHeader';
 import { MyAssetsDisabledListItem } from './MyAssetsDisabledListItem';
+import { useMyAssetsFilteredData } from '../../../hooks/general/useMyAssetsFilteredData';
 
 export type MyAssetSheetProps = {
     tradingType: TradingType;
@@ -49,11 +49,24 @@ export const MyAssetSheet = memo(
             selectAccountsWithTokensToSellSectionCondensedListByTradingType(state, tradingType),
         );
 
-        const renderHandle = () => (
-            <SimpleSheetHeader
-                onClose={onClose}
-                title={<Translation id="moduleTrading.myAssetSheet.title" />}
-            />
+        const {
+            filteredSections,
+            setFilterValue,
+            setFilterSymbol,
+            availableNetworks,
+            filterValue,
+        } = useMyAssetsFilteredData(myAssets);
+
+        const renderHandle = useCallback(
+            () => (
+                <MyAssetSheetHeader
+                    onClose={onClose}
+                    onFilterChange={setFilterValue}
+                    onSelectedNetworkFilter={setFilterSymbol}
+                    availableNetworks={availableNetworks}
+                />
+            ),
+            [onClose, setFilterValue, setFilterSymbol, availableNetworks],
         );
 
         return (
@@ -62,11 +75,11 @@ export const MyAssetSheet = memo(
                 onClose={onClose}
                 ListEmptyComponent={<MyAssetListEmptyComponent />}
                 handleComponent={renderHandle}
-                data={myAssets}
+                data={filteredSections}
                 keyExtractor={keyExtractor}
                 renderItem={(asset, config) => renderItem(asset, config, onAssetSelectCallback)}
                 renderSectionHeader={(_label, config) => {
-                    const sectionIndex = myAssets.findIndex(
+                    const sectionIndex = filteredSections.findIndex(
                         section => section.sectionData.key === config.sectionData.key,
                     );
 
@@ -77,6 +90,7 @@ export const MyAssetSheet = memo(
                         />
                     );
                 }}
+                flashListKey={filterValue}
             />
         );
     },

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetSheetHeader.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetSheetHeader.tsx
@@ -46,6 +46,7 @@ export const MyAssetSheetHeader = ({
             style={applyStyle(wrapperStyle)}
             searchInputTestId={searchInputTestId}
             searchInputPlaceholder={translate('moduleTrading.myAssetSheet.searchInputPlaceholder')}
+            autoCorrect={false}
         >
             <Animated.View
                 layout={LinearTransition.duration(FOCUS_ANIMATION_DURATION)}

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetSheetHeader.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetSheetHeader.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import Animated, { LinearTransition } from 'react-native-reanimated';
+
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { Translation, useTranslate } from '@suite-native/intl';
+import {
+    FOCUS_ANIMATION_DURATION,
+    SEARCHABLE_SHEET_HEADER_DEFAULT_HEIGHT,
+    SearchableSheetHeader,
+} from '@suite-native/trading-atoms';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+
+import { MyAssetFilterTabs } from './MyAssetFilterTabs';
+
+type MyAssetSheetHeaderProps = {
+    onClose: () => void;
+    onFilterChange: (value: string) => void;
+    onSelectedNetworkFilter: (symbol: NetworkSymbol | undefined) => void;
+    availableNetworks: NetworkSymbol[];
+};
+
+const wrapperStyle = prepareNativeStyle(() => ({
+    height: SEARCHABLE_SHEET_HEADER_DEFAULT_HEIGHT,
+}));
+
+export const MyAssetSheetHeader = ({
+    onClose,
+    onFilterChange,
+    onSelectedNetworkFilter,
+    availableNetworks,
+}: MyAssetSheetHeaderProps) => {
+    const { applyStyle } = useNativeStyles();
+    const { translate } = useTranslate();
+    const [isFilterActive, setIsFilterActive] = useState(false);
+
+    return (
+        <SearchableSheetHeader
+            onClose={onClose}
+            title={<Translation id="moduleTrading.myAssetSheet.title" />}
+            onFilterFocusChange={setIsFilterActive}
+            onFilterChange={onFilterChange}
+            style={applyStyle(wrapperStyle)}
+            searchInputPlaceholder={translate('moduleTrading.myAssetSheet.searchInputPlaceholder')}
+        >
+            <Animated.View layout={LinearTransition.duration(FOCUS_ANIMATION_DURATION)}>
+                <MyAssetFilterTabs
+                    visible={isFilterActive}
+                    animationDuration={FOCUS_ANIMATION_DURATION}
+                    onSelectedNetworkFilter={onSelectedNetworkFilter}
+                    availableNetworks={availableNetworks}
+                />
+            </Animated.View>
+        </SearchableSheetHeader>
+    );
+};

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetSheetHeader.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetSheetHeader.tsx
@@ -17,6 +17,7 @@ type MyAssetSheetHeaderProps = {
     onFilterChange: (value: string) => void;
     onSelectedNetworkFilter: (symbol: NetworkSymbol | undefined) => void;
     availableNetworks: NetworkSymbol[];
+    testID?: string;
 };
 
 const wrapperStyle = prepareNativeStyle(() => ({
@@ -28,10 +29,13 @@ export const MyAssetSheetHeader = ({
     onFilterChange,
     onSelectedNetworkFilter,
     availableNetworks,
+    testID,
 }: MyAssetSheetHeaderProps) => {
     const { applyStyle } = useNativeStyles();
     const { translate } = useTranslate();
     const [isFilterActive, setIsFilterActive] = useState(false);
+
+    const searchInputTestId = testID ? `${testID}/search-input` : undefined;
 
     return (
         <SearchableSheetHeader
@@ -40,9 +44,13 @@ export const MyAssetSheetHeader = ({
             onFilterFocusChange={setIsFilterActive}
             onFilterChange={onFilterChange}
             style={applyStyle(wrapperStyle)}
+            searchInputTestId={searchInputTestId}
             searchInputPlaceholder={translate('moduleTrading.myAssetSheet.searchInputPlaceholder')}
         >
-            <Animated.View layout={LinearTransition.duration(FOCUS_ANIMATION_DURATION)}>
+            <Animated.View
+                layout={LinearTransition.duration(FOCUS_ANIMATION_DURATION)}
+                testID={testID}
+            >
                 <MyAssetFilterTabs
                     visible={isFilterActive}
                     animationDuration={FOCUS_ANIMATION_DURATION}

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetSheetHeader.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetSheetHeader.tsx
@@ -53,7 +53,7 @@ export const MyAssetSheetHeader = ({
                 testID={testID}
             >
                 <MyAssetFilterTabs
-                    visible={isFilterActive}
+                    isVisible={isFilterActive}
                     animationDuration={FOCUS_ANIMATION_DURATION}
                     onSelectedNetworkFilter={onSelectedNetworkFilter}
                     availableNetworks={availableNetworks}

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetFilterTabs.test.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetFilterTabs.test.tsx
@@ -65,4 +65,20 @@ describe('MyAssetFilterTabs', () => {
 
         expect(onSelectedNetworkFilter).toHaveBeenCalledWith(undefined);
     });
+
+    it('should call onSelectedNetworkFilter with undefined when hidden', () => {
+        const onSelectedNetworkFilter = jest.fn();
+        const { rerender } = renderComponent(onSelectedNetworkFilter);
+
+        rerender(
+            <MyAssetFilterTabs
+                visible={false}
+                animationDuration={300}
+                onSelectedNetworkFilter={onSelectedNetworkFilter}
+                availableNetworks={availableNetworks}
+            />,
+        );
+
+        expect(onSelectedNetworkFilter).toHaveBeenCalledWith(undefined);
+    });
 });

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetFilterTabs.test.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetFilterTabs.test.tsx
@@ -9,7 +9,7 @@ describe('MyAssetFilterTabs', () => {
     const renderComponent = (onSelectedNetworkFilter = jest.fn()) =>
         renderWithStoreProvider(
             <MyAssetFilterTabs
-                visible={true}
+                isVisible={true}
                 animationDuration={300}
                 onSelectedNetworkFilter={onSelectedNetworkFilter}
                 availableNetworks={availableNetworks}
@@ -27,7 +27,7 @@ describe('MyAssetFilterTabs', () => {
     it('should not render anything when visible is false', () => {
         const { queryByText } = renderWithStoreProvider(
             <MyAssetFilterTabs
-                visible={false}
+                isVisible={false}
                 animationDuration={300}
                 onSelectedNetworkFilter={jest.fn()}
                 availableNetworks={availableNetworks}
@@ -72,7 +72,7 @@ describe('MyAssetFilterTabs', () => {
 
         rerender(
             <MyAssetFilterTabs
-                visible={false}
+                isVisible={false}
                 animationDuration={300}
                 onSelectedNetworkFilter={onSelectedNetworkFilter}
                 availableNetworks={availableNetworks}

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetFilterTabs.test.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetFilterTabs.test.tsx
@@ -1,0 +1,68 @@
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { fireEvent, renderWithStoreProvider } from '@suite-native/test-utils-store';
+
+import { MyAssetFilterTabs } from '../MyAssetFilterTabs';
+
+const availableNetworks: NetworkSymbol[] = ['btc', 'eth'];
+
+describe('MyAssetFilterTabs', () => {
+    const renderComponent = (onSelectedNetworkFilter = jest.fn()) =>
+        renderWithStoreProvider(
+            <MyAssetFilterTabs
+                visible={true}
+                animationDuration={300}
+                onSelectedNetworkFilter={onSelectedNetworkFilter}
+                availableNetworks={availableNetworks}
+            />,
+        );
+
+    it('should render "All" tab and one tab per available network', () => {
+        const { getByText } = renderComponent();
+
+        expect(getByText('All')).toBeTruthy();
+        expect(getByText('Bitcoin')).toBeTruthy();
+        expect(getByText('Ethereum')).toBeTruthy();
+    });
+
+    it('should not render anything when visible is false', () => {
+        const { queryByText } = renderWithStoreProvider(
+            <MyAssetFilterTabs
+                visible={false}
+                animationDuration={300}
+                onSelectedNetworkFilter={jest.fn()}
+                availableNetworks={availableNetworks}
+            />,
+        );
+
+        expect(queryByText('All')).toBeNull();
+        expect(queryByText('Bitcoin')).toBeNull();
+        expect(queryByText('Ethereum')).toBeNull();
+    });
+
+    it('should call onSelectedNetworkFilter with undefined when "All" tab is pressed', () => {
+        const onSelectedNetworkFilter = jest.fn();
+        const { getByText } = renderComponent(onSelectedNetworkFilter);
+
+        fireEvent.press(getByText('All'));
+
+        expect(onSelectedNetworkFilter).toHaveBeenCalledWith(undefined);
+    });
+
+    it('should call onSelectedNetworkFilter with network symbol when a network tab is pressed', () => {
+        const onSelectedNetworkFilter = jest.fn();
+        const { getByText } = renderComponent(onSelectedNetworkFilter);
+
+        fireEvent.press(getByText('Bitcoin'));
+
+        expect(onSelectedNetworkFilter).toHaveBeenCalledWith('btc');
+    });
+
+    it('should call onSelectedNetworkFilter with undefined when unmounted', () => {
+        const onSelectedNetworkFilter = jest.fn();
+        const { unmount } = renderComponent(onSelectedNetworkFilter);
+
+        unmount();
+
+        expect(onSelectedNetworkFilter).toHaveBeenCalledWith(undefined);
+    });
+});

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetSheetHeader.test.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetSheetHeader.test.tsx
@@ -1,0 +1,84 @@
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { fireEvent, renderWithStoreProvider } from '@suite-native/test-utils-store';
+
+import { MyAssetSheetHeader } from '../MyAssetSheetHeader';
+
+jest.mock('@trezor/react-utils', () => ({
+    ...jest.requireActual('@trezor/react-utils'),
+    useDebounce: () => (fn: () => unknown) => fn(),
+}));
+
+describe('MyAssetSheetHeader', () => {
+    const renderComponent = ({
+        onClose = jest.fn(),
+        onFilterChange = jest.fn(),
+        onSelectedNetworkFilter = jest.fn(),
+        availableNetworks = ['btc', 'eth'] as NetworkSymbol[],
+    } = {}) =>
+        renderWithStoreProvider(
+            <MyAssetSheetHeader
+                onClose={onClose}
+                onFilterChange={onFilterChange}
+                onSelectedNetworkFilter={onSelectedNetworkFilter}
+                availableNetworks={availableNetworks}
+            />,
+        );
+
+    it('should display title and hide filter tabs by default', () => {
+        const { getByText, queryByText } = renderComponent();
+
+        expect(getByText('Your assets')).toBeTruthy();
+        expect(queryByText('All')).toBeNull();
+    });
+
+    it('should show filter tabs after focusing the search input', () => {
+        const { getByPlaceholderText, getByText, queryByText } = renderComponent();
+
+        fireEvent(getByPlaceholderText(/Search/), 'focus');
+
+        expect(getByText('All')).toBeTruthy();
+        expect(queryByText('Your assets')).toBeNull();
+    });
+
+    it('should display cancel button after focusing the search input', () => {
+        const { getByPlaceholderText, getByText } = renderComponent();
+
+        fireEvent(getByPlaceholderText(/Search/), 'focus');
+
+        expect(getByText('Cancel')).toBeTruthy();
+    });
+
+    it('should not display cancel button by default', () => {
+        const { queryByText } = renderComponent();
+
+        expect(queryByText('Cancel')).toBeNull();
+    });
+
+    it('should call onClose when close button is pressed', () => {
+        const onClose = jest.fn();
+        const { getByLabelText } = renderComponent({ onClose });
+
+        fireEvent.press(getByLabelText('Close'));
+
+        expect(onClose).toHaveBeenCalled();
+    });
+
+    it('should call onFilterChange when search text changes', () => {
+        const onFilterChange = jest.fn();
+        const { getByPlaceholderText } = renderComponent({ onFilterChange });
+
+        fireEvent.changeText(getByPlaceholderText(/Search/), 'Bitcoin');
+
+        expect(onFilterChange).toHaveBeenCalledWith('Bitcoin');
+    });
+
+    it('should call onSelectedNetworkFilter when a network tab is selected', () => {
+        const onSelectedNetworkFilter = jest.fn();
+        const { getByPlaceholderText, getByText } = renderComponent({ onSelectedNetworkFilter });
+
+        fireEvent(getByPlaceholderText(/Search/), 'focus');
+        fireEvent.press(getByText('Bitcoin'));
+
+        expect(onSelectedNetworkFilter).toHaveBeenCalledWith('btc');
+    });
+});

--- a/suite-native/module-trading/src/components/general/TradeableAssetSheet/TradeableAssetFilterTabs.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetSheet/TradeableAssetFilterTabs.tsx
@@ -13,11 +13,12 @@ type TradeableAssetsFilterTabsProps = {
     onSelectedNetworkFilter: (symbol: NetworkSymbol | undefined) => void;
 };
 
-export const TradeableAssetFilterTabs = ({
-    visible,
+const keyExtractor = (item: FilterItem<NetworkSymbol | undefined>) => item.value ?? 'undefined';
+
+const TradeableAssetFilterTabsContent = ({
     animationDuration,
     onSelectedNetworkFilter,
-}: TradeableAssetsFilterTabsProps) => {
+}: Omit<TradeableAssetsFilterTabsProps, 'visible'>) => {
     const networks = useSelector(selectDiscoverySupportedNetworks);
 
     const [selectedValue, setSelectedValue] = useState<NetworkSymbol | undefined>(undefined);
@@ -43,12 +44,6 @@ export const TradeableAssetFilterTabs = ({
         [networks, translate],
     );
 
-    const keyExtractor = (item: FilterItem<NetworkSymbol | undefined>) => item.value ?? 'undefined';
-
-    if (!visible) {
-        return null;
-    }
-
     return (
         <Animated.View
             entering={FadeIn.duration(animationDuration)}
@@ -62,4 +57,12 @@ export const TradeableAssetFilterTabs = ({
             />
         </Animated.View>
     );
+};
+
+export const TradeableAssetFilterTabs = ({ visible, ...rest }: TradeableAssetsFilterTabsProps) => {
+    if (!visible) {
+        return null;
+    }
+
+    return <TradeableAssetFilterTabsContent {...rest} />;
 };

--- a/suite-native/module-trading/src/components/general/TradeableAssetSheet/TradeableAssetFilterTabs.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetSheet/TradeableAssetFilterTabs.tsx
@@ -8,7 +8,7 @@ import { useTranslate } from '@suite-native/intl';
 import { type FilterItem, FilterTabs } from '@suite-native/trading-atoms';
 
 type TradeableAssetsFilterTabsProps = {
-    visible: boolean;
+    isVisible: boolean;
     animationDuration: number;
     onSelectedNetworkFilter: (symbol: NetworkSymbol | undefined) => void;
 };
@@ -18,7 +18,7 @@ const keyExtractor = (item: FilterItem<NetworkSymbol | undefined>) => item.value
 const TradeableAssetFilterTabsContent = ({
     animationDuration,
     onSelectedNetworkFilter,
-}: Omit<TradeableAssetsFilterTabsProps, 'visible'>) => {
+}: Omit<TradeableAssetsFilterTabsProps, 'isVisible'>) => {
     const networks = useSelector(selectDiscoverySupportedNetworks);
 
     const [selectedValue, setSelectedValue] = useState<NetworkSymbol | undefined>(undefined);
@@ -59,8 +59,11 @@ const TradeableAssetFilterTabsContent = ({
     );
 };
 
-export const TradeableAssetFilterTabs = ({ visible, ...rest }: TradeableAssetsFilterTabsProps) => {
-    if (!visible) {
+export const TradeableAssetFilterTabs = ({
+    isVisible,
+    ...rest
+}: TradeableAssetsFilterTabsProps) => {
+    if (!isVisible) {
         return null;
     }
 

--- a/suite-native/module-trading/src/components/general/TradeableAssetSheet/TradeableAssetFilterTabs.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetSheet/TradeableAssetFilterTabs.tsx
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux';
 
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { selectDiscoverySupportedNetworks } from '@suite-native/discovery';
+import { useTranslate } from '@suite-native/intl';
 import { type FilterItem, FilterTabs } from '@suite-native/trading-atoms';
 
 type TradeableAssetsFilterTabsProps = {
@@ -21,6 +22,8 @@ export const TradeableAssetFilterTabs = ({
 
     const [selectedValue, setSelectedValue] = useState<NetworkSymbol | undefined>(undefined);
 
+    const { translate } = useTranslate();
+
     const onFilterChange = (value: NetworkSymbol | undefined) => {
         setSelectedValue(value);
         onSelectedNetworkFilter(value);
@@ -31,10 +34,13 @@ export const TradeableAssetFilterTabs = ({
 
     const filterItems: FilterItem<NetworkSymbol | undefined>[] = useMemo(
         () => [
-            { label: 'All', value: undefined },
+            {
+                label: translate('moduleTrading.tradeableAssetsSheet.allFilterTabTitle'),
+                value: undefined,
+            },
             ...networks.map(n => ({ label: n.name, value: n.symbol })),
         ],
-        [networks],
+        [networks, translate],
     );
 
     const keyExtractor = (item: FilterItem<NetworkSymbol | undefined>) => item.value ?? 'undefined';

--- a/suite-native/module-trading/src/components/general/TradeableAssetSheet/TradeableAssetSheetHeader.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetSheet/TradeableAssetSheetHeader.tsx
@@ -54,7 +54,7 @@ export const TradeableAssetSheetHeader = ({
                 testID={testID}
             >
                 <TradeableAssetFilterTabs
-                    visible={isFilterActive}
+                    isVisible={isFilterActive}
                     animationDuration={FOCUS_ANIMATION_DURATION}
                     onSelectedNetworkFilter={onSelectedNetworkFilter}
                 />

--- a/suite-native/module-trading/src/components/general/TradeableAssetSheet/TradeableAssetSheetHeader.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetSheet/TradeableAssetSheetHeader.tsx
@@ -47,6 +47,7 @@ export const TradeableAssetSheetHeader = ({
             searchInputPlaceholder={translate(
                 'moduleTrading.tradeableAssetsSheet.searchInputPlaceholder',
             )}
+            autoCorrect={false}
         >
             <Animated.View
                 layout={LinearTransition.duration(FOCUS_ANIMATION_DURATION)}

--- a/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/TradeableAssetFilterTabs.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/TradeableAssetFilterTabs.test.tsx
@@ -25,7 +25,7 @@ describe('TradeableAssetFilterTabs', () => {
     const renderComponent = (onSelectedNetworkFilter = jest.fn()) =>
         renderWithStoreProvider(
             <TradeableAssetFilterTabs
-                visible={true}
+                isVisible={true}
                 animationDuration={300}
                 onSelectedNetworkFilter={onSelectedNetworkFilter}
             />,
@@ -42,7 +42,7 @@ describe('TradeableAssetFilterTabs', () => {
     it('should not render anything when visible is false', () => {
         const { queryByText } = renderWithStoreProvider(
             <TradeableAssetFilterTabs
-                visible={false}
+                isVisible={false}
                 animationDuration={300}
                 onSelectedNetworkFilter={jest.fn()}
             />,
@@ -77,7 +77,7 @@ describe('TradeableAssetFilterTabs', () => {
 
         rerender(
             <TradeableAssetFilterTabs
-                visible={false}
+                isVisible={false}
                 animationDuration={300}
                 onSelectedNetworkFilter={onSelectedNetworkFilter}
             />,

--- a/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/TradeableAssetFilterTabs.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/TradeableAssetFilterTabs.test.tsx
@@ -70,4 +70,19 @@ describe('TradeableAssetFilterTabs', () => {
 
         expect(onSelectedNetworkFilter).toHaveBeenCalledWith('btc');
     });
+
+    it('should call onSelectedNetworkFilter with undefined when hidden', () => {
+        const onSelectedNetworkFilter = jest.fn();
+        const { rerender } = renderComponent(onSelectedNetworkFilter);
+
+        rerender(
+            <TradeableAssetFilterTabs
+                visible={false}
+                animationDuration={300}
+                onSelectedNetworkFilter={onSelectedNetworkFilter}
+            />,
+        );
+
+        expect(onSelectedNetworkFilter).toHaveBeenCalledWith(undefined);
+    });
 });

--- a/suite-native/module-trading/src/components/general/__tests__/FilterTabs.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/FilterTabs.test.tsx
@@ -1,9 +1,13 @@
+import { getTranslation } from '@suite-native/intl';
 import { fireEvent, renderWithStoreProvider, within } from '@suite-native/test-utils-store';
 import { type FilterItem, FilterTabs } from '@suite-native/trading-atoms';
 
 describe('FilterTabs', () => {
     const items: FilterItem<string>[] = [
-        { label: 'All', value: 'all' },
+        {
+            label: getTranslation('moduleTrading.tradeableAssetsSheet.allFilterTabTitle'),
+            value: 'all',
+        },
         { label: 'Bitcoin', value: 'btc' },
         { label: 'Ethereum', value: 'eth' },
     ];
@@ -25,7 +29,9 @@ describe('FilterTabs', () => {
     it('should render all filter tabs', () => {
         const { getByText } = renderComponent();
 
-        expect(getByText('All')).toBeTruthy();
+        expect(
+            getByText(getTranslation('moduleTrading.tradeableAssetsSheet.allFilterTabTitle')),
+        ).toBeTruthy();
         expect(getByText('Bitcoin')).toBeTruthy();
         expect(getByText('Ethereum')).toBeTruthy();
     });
@@ -47,8 +53,15 @@ describe('FilterTabs', () => {
         const activeTab = getByRole('tab', { selected: true });
         expect(within(activeTab).getByText('Bitcoin')).toBeTruthy();
 
-        const inactiveTab = getByRole('tab', { selected: false, name: 'All' });
-        expect(within(inactiveTab).getByText('All')).toBeTruthy();
+        const inactiveTab = getByRole('tab', {
+            selected: false,
+            name: getTranslation('moduleTrading.tradeableAssetsSheet.allFilterTabTitle'),
+        });
+        expect(
+            within(inactiveTab).getByText(
+                getTranslation('moduleTrading.tradeableAssetsSheet.allFilterTabTitle'),
+            ),
+        ).toBeTruthy();
     });
 
     it('should use custom keyExtractor if provided', () => {

--- a/suite-native/module-trading/src/components/sell/send/SellSendAssetPicker.tsx
+++ b/suite-native/module-trading/src/components/sell/send/SellSendAssetPicker.tsx
@@ -14,6 +14,7 @@ import { MyAssetSheet } from '../../general/MyAssetSheet/MyAssetSheet';
 import { SelectTradeableAssetButton } from '../../general/SelectTradeableAssetButton';
 
 const ASSET_PICKER_TEST_ID = '@trading/sell/asset-send-button';
+const ASSET_SHEET_TEST_ID = '@trading/sell/send-asset-sheet';
 
 export const SellSendAssetPicker = () => {
     const dispatch = useDispatch();
@@ -60,6 +61,7 @@ export const SellSendAssetPicker = () => {
                 isVisible={isSheetVisible}
                 onClose={hideSheet}
                 onAssetSelect={onAssetSelect}
+                testID={ASSET_SHEET_TEST_ID}
             />
         </>
     );

--- a/suite-native/module-trading/src/hooks/general/__tests__/useMyAssetsFilteredData.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useMyAssetsFilteredData.test.ts
@@ -1,0 +1,248 @@
+import type { CryptoId } from 'invity-api';
+
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { type TokenSymbol } from '@suite-common/wallet-types';
+import { asBaseCurrencyAmount } from '@suite-common/wallet-types';
+import { act, renderHook } from '@suite-native/test-utils';
+import { btc1NormalAccount, eth1NormalAccount } from '@suite-native/trading-fixtures';
+import {
+    type MyAssetRow,
+    type MyAssetTradeable,
+    type MyAssetsDisabled,
+} from '@suite-native/trading-types';
+import { BigNumber } from '@trezor/utils';
+
+import { useMyAssetsFilteredData } from '../useMyAssetsFilteredData';
+
+const btcAsset: MyAssetTradeable = {
+    name: 'Bitcoin',
+    symbol: 'btc' as NetworkSymbol,
+    cryptoId: 'bitcoin' as CryptoId,
+    balance: '1.0',
+    fiatBalance: asBaseCurrencyAmount(new BigNumber(50000)),
+    isEnabled: true,
+};
+
+const ethAsset: MyAssetTradeable = {
+    name: 'Ethereum',
+    symbol: 'eth' as NetworkSymbol,
+    cryptoId: 'ethereum' as CryptoId,
+    balance: '2.0',
+    fiatBalance: asBaseCurrencyAmount(new BigNumber(5000)),
+    isEnabled: true,
+};
+
+const usdcAsset: MyAssetTradeable = {
+    name: 'USD Coin',
+    symbol: 'eth' as NetworkSymbol,
+    tokenSymbol: 'usdc' as TokenSymbol,
+    cryptoId: 'usd-coin' as CryptoId,
+    balance: '100.0',
+    fiatBalance: asBaseCurrencyAmount(new BigNumber(100)),
+    isEnabled: true,
+};
+
+const disabledRow: MyAssetsDisabled = {
+    name: 'non-tradeable-assets',
+    count: 2,
+    isEnabled: false,
+};
+
+const btcSection = {
+    key: 'section_btc',
+    label: 'BTC Account #1',
+    sectionData: btc1NormalAccount,
+    data: [btcAsset] as MyAssetRow[],
+};
+
+const ethSection = {
+    key: 'section_eth',
+    label: 'ETH Account #1',
+    sectionData: eth1NormalAccount,
+    data: [ethAsset, usdcAsset, disabledRow] as MyAssetRow[],
+};
+
+const mockSections = [btcSection, ethSection];
+
+describe('useMyAssetsFilteredData', () => {
+    const renderFilter = () => renderHook(() => useMyAssetsFilteredData(mockSections));
+
+    it('should return all sections unchanged when no filter is applied', () => {
+        const { result } = renderFilter();
+
+        expect(result.current.filteredSections).toBe(mockSections);
+    });
+
+    it('should filter assets by network symbol', () => {
+        const { result } = renderFilter();
+
+        act(() => {
+            result.current.setFilterSymbol('btc' as NetworkSymbol);
+        });
+
+        expect(result.current.filteredSections).toHaveLength(1);
+        expect(result.current.filteredSections[0].data).toHaveLength(1);
+        expect(result.current.filteredSections[0].data[0]).toBe(btcAsset);
+    });
+
+    it('should filter assets by text search on name', () => {
+        const { result } = renderFilter();
+
+        act(() => {
+            result.current.setFilterValue('Bitcoin');
+        });
+
+        expect(result.current.filteredSections).toHaveLength(1);
+        expect(result.current.filteredSections[0].data).toHaveLength(1);
+        expect(result.current.filteredSections[0].data[0]).toBe(btcAsset);
+    });
+
+    it('should filter assets by text search on symbol', () => {
+        const { result } = renderFilter();
+
+        act(() => {
+            result.current.setFilterValue('eth');
+        });
+
+        // ethAsset.symbol = 'eth', usdcAsset.symbol = 'eth'
+        expect(result.current.filteredSections).toHaveLength(1);
+        expect(result.current.filteredSections[0].data).toHaveLength(2);
+    });
+
+    it('should filter assets by text search on tokenSymbol', () => {
+        const { result } = renderFilter();
+
+        act(() => {
+            result.current.setFilterValue('usdc');
+        });
+
+        expect(result.current.filteredSections).toHaveLength(1);
+        expect(result.current.filteredSections[0].data).toHaveLength(1);
+        expect(result.current.filteredSections[0].data[0]).toBe(usdcAsset);
+    });
+
+    it('should filter assets by text search on cryptoId', () => {
+        const { result } = renderFilter();
+
+        act(() => {
+            result.current.setFilterValue('usd-coin');
+        });
+
+        expect(result.current.filteredSections).toHaveLength(1);
+        expect(result.current.filteredSections[0].data).toHaveLength(1);
+        expect(result.current.filteredSections[0].data[0]).toBe(usdcAsset);
+    });
+
+    it('should be case-insensitive', () => {
+        const { result } = renderFilter();
+
+        act(() => {
+            result.current.setFilterValue('BITCOIN');
+        });
+
+        expect(result.current.filteredSections).toHaveLength(1);
+        expect(result.current.filteredSections[0].data[0]).toBe(btcAsset);
+    });
+
+    it('should remove sections with no matching assets', () => {
+        const { result } = renderFilter();
+
+        act(() => {
+            result.current.setFilterValue('NonExistentAsset');
+        });
+
+        expect(result.current.filteredSections).toHaveLength(0);
+    });
+
+    it('should hide disabled rows when text filter is active', () => {
+        const { result } = renderFilter();
+
+        act(() => {
+            result.current.setFilterValue('USD');
+        });
+
+        // Only usdcAsset in ethSection matches "USD"; disabled row should be hidden
+        expect(result.current.filteredSections).toHaveLength(1);
+        const ethSectionData = result.current.filteredSections[0].data;
+        expect(ethSectionData.every(item => item.isEnabled)).toBe(true);
+    });
+
+    it('should hide disabled rows when network filter is active', () => {
+        const { result } = renderFilter();
+
+        act(() => {
+            result.current.setFilterSymbol('eth' as NetworkSymbol);
+        });
+
+        const ethSectionData = result.current.filteredSections[0].data;
+        expect(ethSectionData.every(item => item.isEnabled)).toBe(true);
+    });
+
+    it('should show disabled rows when no filter is active', () => {
+        const { result } = renderFilter();
+
+        const ethSectionData = result.current.filteredSections[1].data;
+        expect(ethSectionData.some(item => !item.isEnabled)).toBe(true);
+    });
+
+    it('should combine network symbol filter with text search', () => {
+        const { result } = renderFilter();
+
+        act(() => {
+            result.current.setFilterSymbol('eth' as NetworkSymbol);
+            result.current.setFilterValue('usd');
+        });
+
+        expect(result.current.filteredSections).toHaveLength(1);
+        expect(result.current.filteredSections[0].data).toHaveLength(1);
+        expect(result.current.filteredSections[0].data[0]).toBe(usdcAsset);
+    });
+
+    it('should return correct availableNetworks from all enabled assets', () => {
+        const { result } = renderFilter();
+
+        expect(result.current.availableNetworks).toContain('btc');
+        expect(result.current.availableNetworks).toContain('eth');
+        // eth appears twice (ethAsset and usdcAsset) but should only be in list once
+        expect(result.current.availableNetworks.filter(n => n === 'eth')).toHaveLength(1);
+    });
+
+    describe('filterValue composite key', () => {
+        it('should have correct value with no filter applied', () => {
+            const { result } = renderFilter();
+
+            expect(result.current.filterValue).toBe('Network:all;Search:');
+        });
+
+        it('should reflect search text in filterValue', () => {
+            const { result } = renderFilter();
+
+            act(() => {
+                result.current.setFilterValue('Bitcoin');
+            });
+
+            expect(result.current.filterValue).toBe('Network:all;Search:Bitcoin');
+        });
+
+        it('should reflect network symbol in filterValue', () => {
+            const { result } = renderFilter();
+
+            act(() => {
+                result.current.setFilterSymbol('eth' as NetworkSymbol);
+            });
+
+            expect(result.current.filterValue).toBe('Network:eth;Search:');
+        });
+
+        it('should reflect both search text and network symbol in filterValue', () => {
+            const { result } = renderFilter();
+
+            act(() => {
+                result.current.setFilterValue('usd');
+                result.current.setFilterSymbol('eth' as NetworkSymbol);
+            });
+
+            expect(result.current.filterValue).toBe('Network:eth;Search:usd');
+        });
+    });
+});

--- a/suite-native/module-trading/src/hooks/general/__tests__/useMyAssetsFilteredData.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useMyAssetsFilteredData.test.ts
@@ -207,6 +207,139 @@ describe('useMyAssetsFilteredData', () => {
         expect(result.current.availableNetworks.filter(n => n === 'eth')).toHaveLength(1);
     });
 
+    describe('sort order', () => {
+        const ethNameServiceAsset: MyAssetTradeable = {
+            name: 'Ethereum Name Service',
+            symbol: 'eth' as NetworkSymbol,
+            tokenSymbol: 'ens' as TokenSymbol,
+            cryptoId: 'ethereum-name-service' as CryptoId,
+            balance: '5.0',
+            fiatBalance: asBaseCurrencyAmount(new BigNumber(50)),
+            isEnabled: true,
+        };
+
+        const mixedSection = {
+            key: 'section_mixed',
+            label: 'Mixed Account',
+            sectionData: eth1NormalAccount,
+            // Input order: ethNameServiceAsset first, then ethAsset
+            data: [ethNameServiceAsset, ethAsset] as MyAssetRow[],
+        };
+
+        const renderMixedFilter = () => renderHook(() => useMyAssetsFilteredData([mixedSection]));
+
+        it('should rank exact symbol match before name-startsWith', () => {
+            // ethAsset: tokenSymbol=undefined, symbol='eth' → exact symbol match → weight 1
+            // ethNameServiceAsset: tokenSymbol='ens', name='Ethereum Name Service' → name startsWith 'eth' → weight 2
+            const { result } = renderMixedFilter();
+
+            act(() => {
+                result.current.setFilterValue('eth');
+            });
+
+            const { data } = result.current.filteredSections[0];
+            expect(data[0]).toBe(ethAsset);
+            expect(data[1]).toBe(ethNameServiceAsset);
+        });
+
+        it('should rank exact name match before exact symbol match', () => {
+            // ethAsset: name='Ethereum' exact match → weight 0
+            // ethNameServiceAsset: tokenSymbol='ens', name='Ethereum Name Service' → name startsWith → weight 2
+            const { result } = renderMixedFilter();
+
+            act(() => {
+                result.current.setFilterValue('ethereum');
+            });
+
+            const { data } = result.current.filteredSections[0];
+            expect(data[0]).toBe(ethAsset);
+        });
+
+        it('should rank name-startsWith before name-includes', () => {
+            // ethAsset: name='Ethereum' startsWith 'ether' → weight 2
+            // ethNameServiceAsset: name='Ethereum Name Service' startsWith 'ether' → weight 2 (tie, original order kept)
+            // Using 'name' query to get name-includes case
+            const nameIncludesAsset: MyAssetTradeable = {
+                name: 'Wrapped Ether',
+                symbol: 'eth' as NetworkSymbol,
+                tokenSymbol: 'weth' as TokenSymbol,
+                cryptoId: 'weth' as CryptoId,
+                balance: '1.0',
+                fiatBalance: asBaseCurrencyAmount(new BigNumber(3000)),
+                isEnabled: true,
+            };
+
+            const { result } = renderHook(() =>
+                useMyAssetsFilteredData([
+                    {
+                        key: 'section_sort',
+                        label: 'Sort Test',
+                        sectionData: eth1NormalAccount,
+                        data: [nameIncludesAsset, ethAsset] as MyAssetRow[],
+                    },
+                ]),
+            );
+
+            act(() => {
+                result.current.setFilterValue('ether');
+            });
+
+            const { data } = result.current.filteredSections[0];
+            // ethAsset: name='Ethereum' startsWith 'ether' → weight 2
+            // nameIncludesAsset: name='Wrapped Ether' includes 'ether' → weight 4
+            expect(data[0]).toBe(ethAsset);
+            expect(data[1]).toBe(nameIncludesAsset);
+        });
+
+        it('should rank name-includes before symbol-startsWith', () => {
+            // btcAsset: name='Bitcoin' includes 'itc' → weight 4
+            // asset with tokenSymbol startsWith 'itc': weight 3 → should rank before btcAsset
+            const itcTokenAsset: MyAssetTradeable = {
+                name: 'Some Token',
+                symbol: 'eth' as NetworkSymbol,
+                tokenSymbol: 'itcx' as TokenSymbol,
+                cryptoId: 'itcx-token' as CryptoId,
+                balance: '1.0',
+                fiatBalance: asBaseCurrencyAmount(new BigNumber(10)),
+                isEnabled: true,
+            };
+
+            const { result } = renderHook(() =>
+                useMyAssetsFilteredData([
+                    {
+                        key: 'section_sort',
+                        label: 'Sort Test',
+                        sectionData: eth1NormalAccount,
+                        data: [btcAsset, itcTokenAsset] as MyAssetRow[],
+                    },
+                ]),
+            );
+
+            act(() => {
+                result.current.setFilterValue('itc');
+            });
+
+            const { data } = result.current.filteredSections[0];
+            // itcTokenAsset: tokenSymbol='itcx' startsWith 'itc' → weight 3
+            // btcAsset: name='Bitcoin' includes 'itc' → weight 4
+            expect(data[0]).toBe(itcTokenAsset);
+            expect(data[1]).toBe(btcAsset);
+        });
+
+        it('should preserve original order for items with equal weight', () => {
+            // Both assets have name startsWith 'e' → weight 2, original order kept
+            const { result } = renderMixedFilter();
+
+            act(() => {
+                result.current.setFilterValue('e');
+            });
+
+            const { data } = result.current.filteredSections[0];
+            expect(data[0]).toBe(ethNameServiceAsset);
+            expect(data[1]).toBe(ethAsset);
+        });
+    });
+
     describe('filterValue composite key', () => {
         it('should have correct value with no filter applied', () => {
             const { result } = renderFilter();

--- a/suite-native/module-trading/src/hooks/general/useMyAssetsFilteredData.ts
+++ b/suite-native/module-trading/src/hooks/general/useMyAssetsFilteredData.ts
@@ -23,6 +23,28 @@ const filterCallback = (item: MyAssetRow, filterValue: string): boolean => {
     );
 };
 
+const getSortWeight = (asset: MyAssetTradeable, query: string): number => {
+    const name = normalizeForSearch(asset.name);
+    const symbol = normalizeForSearch(asset.tokenSymbol ?? asset.symbol);
+
+    if (name === query) return 0;
+    if (symbol === query) return 1;
+    if (name.startsWith(query)) return 2;
+    if (symbol.startsWith(query)) return 3;
+    if (name.includes(query)) return 4;
+    if (symbol.includes(query)) return 5;
+
+    return 6;
+};
+
+const sortSectionItemsCallback = (a: MyAssetRow, b: MyAssetRow, filterValue: string): number => {
+    const query = normalizeForSearch(filterValue);
+
+    return (
+        getSortWeight(a as MyAssetTradeable, query) - getSortWeight(b as MyAssetTradeable, query)
+    );
+};
+
 export const useMyAssetsFilteredData = (sections: SectionListData<MyAssetRow, Account>) => {
     const [filterSymbol, setFilterSymbol] = useState<NetworkSymbol | undefined>(undefined);
 
@@ -43,7 +65,7 @@ export const useMyAssetsFilteredData = (sections: SectionListData<MyAssetRow, Ac
         filteredSections,
         filterValue: searchText,
         setFilterValue,
-    } = useSectionDataFilter(sectionsForTextFilter, filterCallback);
+    } = useSectionDataFilter(sectionsForTextFilter, filterCallback, sortSectionItemsCallback);
 
     const availableNetworks = useMemo(
         () =>

--- a/suite-native/module-trading/src/hooks/general/useMyAssetsFilteredData.ts
+++ b/suite-native/module-trading/src/hooks/general/useMyAssetsFilteredData.ts
@@ -1,0 +1,65 @@
+import { useMemo, useState } from 'react';
+
+import { normalizeForSearch } from '@suite-common/suite-utils';
+import { useSectionDataFilter } from '@suite-common/trading';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { type Account } from '@suite-common/wallet-types';
+import { type SectionListData } from '@suite-native/trading-atoms';
+import { type MyAssetRow, type MyAssetTradeable } from '@suite-native/trading-types';
+
+const filterCallback = (item: MyAssetRow, filterValue: string): boolean => {
+    if (!item.isEnabled) {
+        return false;
+    }
+
+    const normalized = normalizeForSearch(filterValue);
+    const asset = item as MyAssetTradeable;
+
+    return (
+        normalizeForSearch(asset.name).includes(normalized) ||
+        normalizeForSearch(asset.symbol).includes(normalized) ||
+        (asset.tokenSymbol != null && normalizeForSearch(asset.tokenSymbol).includes(normalized)) ||
+        (asset.cryptoId != null && normalizeForSearch(asset.cryptoId).includes(normalized))
+    );
+};
+
+export const useMyAssetsFilteredData = (sections: SectionListData<MyAssetRow, Account>) => {
+    const [filterSymbol, setFilterSymbol] = useState<NetworkSymbol | undefined>(undefined);
+
+    const sectionsForTextFilter = useMemo(() => {
+        if (!filterSymbol) {
+            return sections;
+        }
+
+        return sections
+            .map(section => ({
+                ...section,
+                data: section.data.filter(item => item.isEnabled && item.symbol === filterSymbol),
+            }))
+            .filter(section => section.data.length > 0);
+    }, [sections, filterSymbol]);
+
+    const {
+        filteredSections,
+        filterValue: searchText,
+        setFilterValue,
+    } = useSectionDataFilter(sectionsForTextFilter, filterCallback);
+
+    const availableNetworks = useMemo(
+        () =>
+            Array.from(
+                new Set(
+                    sections.flatMap(section =>
+                        section.data
+                            .filter(item => item.isEnabled)
+                            .map(item => (item as MyAssetTradeable).symbol),
+                    ),
+                ),
+            ),
+        [sections],
+    );
+
+    const filterValue = `Network:${filterSymbol ?? 'all'};Search:${searchText}`;
+
+    return { filteredSections, setFilterValue, setFilterSymbol, availableNetworks, filterValue };
+};

--- a/suite-native/trading-atoms/package.json
+++ b/suite-native/trading-atoms/package.json
@@ -27,6 +27,7 @@
         "@trezor/styles-native": "workspace:*",
         "@trezor/theme": "workspace:*",
         "@trezor/type-utils": "workspace:*",
+        "@trezor/utils": "workspace:*",
         "react": "19.2.4",
         "react-native": "0.83.2",
         "react-native-gesture-handler": "2.31.1",

--- a/suite-native/trading-atoms/src/components/FilterTabs.tsx
+++ b/suite-native/trading-atoms/src/components/FilterTabs.tsx
@@ -1,8 +1,9 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { FlatList } from 'react-native-gesture-handler';
 
 import { Button } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+import { noop } from '@trezor/utils';
 
 export type FilterItem<T = any> = {
     label: string;
@@ -45,12 +46,30 @@ export const FilterTabs = <T,>({
     value,
     keyExtractor = (item: FilterItem<T>) => String(item.value),
 }: FilterTabsProps<T>) => {
+    const listRef = useRef<FlatList>(null);
     const { applyStyle } = useNativeStyles();
 
     const defaultKeyExtractor = useMemo(
         () => (item: FilterItem<T>) => keyExtractor(item),
         [keyExtractor],
     );
+
+    const activeTabIndex = useMemo(
+        () => items.findIndex(item => item.value === value),
+        [items, value],
+    );
+
+    useEffect(() => {
+        if (activeTabIndex < 0) {
+            return;
+        }
+
+        listRef.current?.scrollToIndex({
+            index: activeTabIndex,
+            animated: true,
+            viewPosition: 0.5,
+        });
+    }, [activeTabIndex]);
 
     const renderFilterTab = ({ item }: { item: FilterItem<T> }) => (
         <FilterTab active={value === item.value} onPress={() => onChange(item.value)}>
@@ -60,6 +79,7 @@ export const FilterTabs = <T,>({
 
     return (
         <FlatList
+            ref={listRef}
             horizontal
             showsHorizontalScrollIndicator={false}
             accessible={true}
@@ -69,6 +89,7 @@ export const FilterTabs = <T,>({
             accessibilityRole="tablist"
             renderItem={renderFilterTab}
             keyboardShouldPersistTaps="always"
+            onScrollToIndexFailed={noop}
         />
     );
 };

--- a/suite-native/trading-atoms/src/components/SearchableSheetHeader.tsx
+++ b/suite-native/trading-atoms/src/components/SearchableSheetHeader.tsx
@@ -21,6 +21,7 @@ export type SearchableSheetHeaderProps = {
     filterValue?: string;
     searchInputPlaceholder?: string;
     searchInputTestId?: string;
+    autoCorrect?: boolean;
 };
 
 export const SEARCHABLE_SHEET_HEADER_DEFAULT_HEIGHT = 160 as const;
@@ -45,6 +46,7 @@ export const SearchableSheetHeader = ({
     filterValue,
     searchInputTestId,
     searchInputPlaceholder,
+    autoCorrect,
 }: SearchableSheetHeaderProps) => {
     const { applyStyle } = useNativeStyles();
     const { translate } = useTranslate();
@@ -88,6 +90,7 @@ export const SearchableSheetHeader = ({
                     value={filterValue}
                     placeholder={searchInputPlaceholder}
                     testId={searchInputTestId}
+                    autoCorrect={autoCorrect}
                 />
             </Animated.View>
             {children}

--- a/suite-native/trading-atoms/tsconfig.json
+++ b/suite-native/trading-atoms/tsconfig.json
@@ -21,6 +21,7 @@
         },
         { "path": "../../packages/theme" },
         { "path": "../../packages/type-utils" },
+        { "path": "../../packages/utils" },
         { "path": "../../suite-common/device" },
         {
             "path": "../../suite-common/message-system"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13871,6 +13871,7 @@ __metadata:
     "@trezor/styles-native": "workspace:*"
     "@trezor/theme": "workspace:*"
     "@trezor/type-utils": "workspace:*"
+    "@trezor/utils": "workspace:*"
     "@types/invity-api": "npm:^1.1.15"
     react: "npm:19.2.4"
     react-native: "npm:0.83.2"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Introduces possibility to filter my tradeable assets in Sell and Swap.

## Description

- Introduced `useSectionDataFilter` hook to common
- Added Search bar with Network Search tabs to My assets bottom sheet.
  - Allows to search by name, symbol, tokenSymbol and cryptoId 
- Sorted results should be in this order:
  1. Exact match on name
  2. Exact match on token symbol
  3. Name starts with searched string
  4. Symbol starts with searched string
  5. Name contains searched string
  6. Symbol contains searched string
  7. rest
- Sections are currently always in same order. Only sections with zero matches are hidden.
<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #27721


## Screenshots:

https://github.com/user-attachments/assets/c378ccd5-d3a4-43a9-8de8-81578258f2ec


<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/27721-from-asset-picker-does-not-have-search/web/](https://dev.suite.sldev.cz/suite-web/27721-from-asset-picker-does-not-have-search/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=27721-from-asset-picker-does-not-have-search&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=27721-from-asset-picker-does-not-have-search&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=27721-from-asset-picker-does-not-have-search&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect webextension -> Suite Web > call cancelled from calling application | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-15T15:30:01.174Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-15T10:05:32.267Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->