### PR TITLE
fix(suite): allow earn dashboard preview without device

### DIFF
--- a/packages/components/src/components/Card/Card.tsx
+++ b/packages/components/src/components/Card/Card.tsx
@@ -48,6 +48,7 @@ const Container = styled.section<ContainerProps & TransientAllowedFrameProps>`
     flex-direction: column;
     width: 100%;
     border-radius: ${borders.radii.md};
+    overflow: hidden;
     cursor: ${({ $isClickable }) => ($isClickable ? 'pointer' : 'default')};
     transition:
         background 0.5s,

--- a/packages/suite/src/components/earn/yield/claim/YieldClaimPageHeader.tsx
+++ b/packages/suite/src/components/earn/yield/claim/YieldClaimPageHeader.tsx
@@ -3,6 +3,7 @@ import { Translation } from '@suite/intl';
 import { goto } from '@suite/router';
 import { type Account } from '@suite-common/wallet-types';
 import { IconButton, Row } from '@trezor/components';
+import { CoinLogo } from '@trezor/product-components';
 
 import { AccountLabel } from 'src/components/suite/AccountLabel';
 import { PageHeader } from 'src/components/suite/layouts/SuiteLayout';
@@ -44,11 +45,14 @@ export const YieldClaimPageHeader = ({ account }: YieldClaimPageHeaderProps) => 
                     data-testid="@account-subpage/back"
                 />
                 {account ? (
-                    <AccountLabel
-                        account={account}
-                        typographyStyle="headline-md"
-                        rowProps={{ flex: '1', overflow: 'hidden' }}
-                    />
+                    <Row gap={12} alignItems="center" flex="1" overflow="hidden">
+                        <CoinLogo symbol={account.symbol} type="token" size={32} />
+                        <AccountLabel
+                            account={account}
+                            typographyStyle="headline-md"
+                            rowProps={{ flex: '1', overflow: 'hidden' }}
+                        />
+                    </Row>
                 ) : (
                     <BasicName>
                         <Translation id="TR_EARN" />

--- a/packages/suite/src/utils/suite/prerequisites.ts
+++ b/packages/suite/src/utils/suite/prerequisites.ts
@@ -125,6 +125,11 @@ export const isPrerequisiteGloballyExcluded = ({
     prerequisite,
 }: IsPrerequisiteExcluded): boolean => {
     if (prerequisite === null) return true;
+
+    if (router.app === 'earn') {
+        return true;
+    }
+
     if (router.app === 'settings') {
         return !settingsAppActivePrerequisites.includes(prerequisite);
     }


### PR DESCRIPTION
## Description

- Allow `/earn` dashboard to render when the device is disconnected.
- Restore card overflow clipping for rounded table corners.
- Add missing network icon to the **Earn** claim header.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27792
Resolve https://github.com/trezor/trezor-suite/issues/27796
Resolve https://github.com/trezor/trezor-suite/issues/27800

## Screenshots:

<img width="1129" height="761" alt="image" src="https://github.com/user-attachments/assets/7046f450-fb37-425a-afde-ea52e5a886e7" />

<img width="475" height="239" alt="image" src="https://github.com/user-attachments/assets/979dc6d8-abb7-4bb6-9e7d-c1d6d744a821" />

<img width="1003" height="557" alt="image" src="https://github.com/user-attachments/assets/cae7b61c-49cb-45a5-b56d-882a6ee6ddc1" />

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies three files: a shared Card component (very broad, 121 tests), a prerequisites utility (very broad, 121 tests), and a YieldClaimPageHeader component (no static coverage). The Card and prerequisites changes are extremely broad dependencies — without knowing the specific nature of the changes, running all 121 mapped tests would be wasteful. The YieldClaimPageHeader is a focused earn/yield claim component best covered by staking claim tests. The recommended strategy is to run the ADA claim test (most directly relevant to yield claim UI) and medium-priority unstake tests that include claim flows, while relying on unit tests for the Card component and prerequisites utility given their broad usage.

<details><summary><b>Changed files (3)</b></summary>

- `packages/components/src/components/Card/Card.tsx`
- `packages/suite/src/components/earn/yield/claim/YieldClaimPageHeader.tsx`
- `packages/suite/src/utils/suite/prerequisites.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — YieldClaimPageHeader.tsx is a component specifically for the yield/claim flow. The ADA claim test directly exercises the claim rewards flow which would render claim-related page headers. This is the most directly relevant test for the YieldClaimPageHeader change.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/staking/eth/unstake.test.ts` — The ETH unstake test includes a claim flow (claiming unstaked ETH) which likely renders yield claim UI components including the YieldClaimPageHeader. This test exercises a related but distinct claim path.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — The SOL unstake test includes a claim step where the user claims unstaked SOL, which may render yield claim page headers. It exercises the claim flow on a different network.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/components/src/components/Card/Card.tsx`
- `packages/suite/src/utils/suite/prerequisites.ts`

_Updated: 2026-05-15T11:32:19.407Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/earn-preview-and-claim-ui&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/earn-preview-and-claim-ui&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/earn-preview-and-claim-ui/web/](https://dev.suite.sldev.cz/suite-web/fix/earn-preview-and-claim-ui/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-15T12:24:33.914Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-15T11:36:07.568Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->