### PR TITLE
feat(suite): Add tooltip for NetworkIconSet

### DIFF
--- a/packages/product-components/src/components/NetworkIconSet/NetworkIconSet.tsx
+++ b/packages/product-components/src/components/NetworkIconSet/NetworkIconSet.tsx
@@ -1,12 +1,14 @@
 import { useMemo } from 'react';
 
-import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { Tooltip } from '@trezor/components';
 
 import { CoinLogo } from '../CoinLogo/CoinLogo';
 import { type CommonIconSetProps, IconSetBase, IconWrapper } from '../IconSet/IconSetBase';
 
 export type NetworkIconSetProps = CommonIconSetProps & {
     networks: NetworkSymbol[];
+    hasTooltip?: boolean;
 };
 
 export const NetworkIconSet = ({
@@ -17,6 +19,7 @@ export const NetworkIconSet = ({
     isCountVisible = false,
     isCentered = false,
     isReversed = true,
+    hasTooltip = false,
 }: NetworkIconSetProps) => {
     const { length } = networks;
 
@@ -26,10 +29,12 @@ export const NetworkIconSet = ({
 
         return visibleNetworks.map(network => (
             <IconWrapper key={network} $size={size} $gap={gap} $length={length}>
-                <CoinLogo size={size} symbol={network} />
+                <Tooltip content={getNetwork(network).name} isActive={hasTooltip}>
+                    <CoinLogo size={size} symbol={network} />
+                </Tooltip>
             </IconWrapper>
         ));
-    }, [networks, maxVisibleIcons, size, gap, length]);
+    }, [networks, maxVisibleIcons, size, gap, length, hasTooltip]);
 
     return (
         <IconSetBase

--- a/packages/suite/src/views/dashboard/PortfolioCard/EmptyWallet.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/EmptyWallet.tsx
@@ -71,6 +71,7 @@ export const EmptyWallet = () => {
                                 size={20}
                                 gap={16}
                                 maxVisibleIcons={null}
+                                hasTooltip
                             />
                         </Box>
                     </Row>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<img width="528" height="478" alt="image" src="https://github.com/user-attachments/assets/6e48860f-7a36-44b0-86db-3229146eb067" />


<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies two UI components: the NetworkIconSet (a product-components shared icon component) and the EmptyWallet view within the dashboard PortfolioCard. The EmptyWallet component maps to 99 tests, indicating it is a broadly imported dependency — most of those tests merely pass through the dashboard during setup and are unlikely to be affected. The NetworkIconSet has no static test coverage. The highest risk is in tests that directly assert on the dashboard empty state or asset display. The recommended strategy is to run the small set of dashboard-focused tests that explicitly verify empty wallet state and asset rendering.

<details><summary><b>Changed files (2)</b></summary>

- `packages/product-components/src/components/NetworkIconSet/NetworkIconSet.tsx`
- `packages/suite/src/views/dashboard/PortfolioCard/EmptyWallet.tsx`

</details>

**Recommended tests (3)**

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — EmptyWallet.tsx is part of the dashboard PortfolioCard, and this test exercises the dashboard Assets section including enabling coins and viewing asset contents. Changes to the empty wallet state rendering could affect what's displayed when no assets are enabled.
- `suite/e2e/tests/settings/coins.test.ts` — This test explicitly verifies the dashboard empty state messages (TR_YOUR_WALLET_IS_READY_WHAT, TR_DASHBOARD_ACTIVATE_ASSETS_DESC, TR_DASHBOARD_GET_STARTED) when no coins are enabled, which directly exercises the EmptyWallet component's rendering path.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — This test operates on the dashboard with portfolio values and balance displays. While it primarily tests discreet mode toggle behavior, it renders the dashboard PortfolioCard area where EmptyWallet lives, so a rendering regression could surface here.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/product-components/src/components/NetworkIconSet/NetworkIconSet.tsx`

_Updated: 2026-05-15T13:07:40.423Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=add-tooltip-for-networks-icon-set&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=add-tooltip-for-networks-icon-set&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-15T13:12:57.772Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-15T13:11:36.779Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/add-tooltip-for-networks-icon-set/web/](https://dev.suite.sldev.cz/suite-web/add-tooltip-for-networks-icon-set/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->