### PR TITLE
fix(suite-desktop): more robust autorestart on linux

### DIFF
--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -54,6 +54,9 @@ type CreateMainWindowParams = {
     cspNonce: string;
 };
 
+const isMainWindowUsable = (mainWindow: BrowserWindow | undefined): mainWindow is BrowserWindow =>
+    !!mainWindow && !mainWindow.isDestroyed();
+
 const createMainWindow = ({ winBounds, cspNonce, store }: CreateMainWindowParams) => {
     const darkTheme =
         store.getThemeSettings() === 'dark' ||
@@ -350,18 +353,21 @@ const init = async () => {
 
         const mainWindow = mainWindowProxy.getInstance();
         const windowExists =
-            mainWindow &&
-            !mainWindow.isDestroyed() &&
+            isMainWindowUsable(mainWindow) &&
             mainWindow.isClosable() &&
             (!isMacOs() || !app.isHidden());
         logger.info('main', `Before quit, window exists: ${windowExists}`);
 
         if (windowExists) {
             const continued = await promptForAutoStartBeforeQuit(mainWindow, store);
+
+            // Immediately hide the main window for the better closing UX.
+            // For daemon mode, it doesn't matter.
             logger.info('main', 'Hiding main window');
-            // NOTE: immediatly hide the main window for the better closing UX
-            // for daemon mode, it doesn't matter
-            mainWindow?.hide();
+            // Check again after async/await call.
+            if (isMainWindowUsable(mainWindow)) {
+                mainWindow.hide();
+            }
             if (!continued) return;
         }
 
@@ -374,7 +380,9 @@ const init = async () => {
             // Prevent quitting app when in daemon mode, unless the UI is already closed
             logger.info('main', 'Preventing app quit in daemon mode');
             app.dock?.hide();
-            mainWindow?.close();
+            if (isMainWindowUsable(mainWindow)) {
+                mainWindow.close();
+            }
 
             return;
         }
@@ -389,7 +397,9 @@ const init = async () => {
 
         // global cleanup
         logger.info('modules', 'All modules quit, exiting');
-        mainWindow?.removeAllListeners();
+        if (isMainWindowUsable(mainWindow)) {
+            mainWindow.removeAllListeners();
+        }
         logger.exit();
 
         await resolveAfter(1000);

--- a/packages/suite-desktop-core/src/modules/auto-start.ts
+++ b/packages/suite-desktop-core/src/modules/auto-start.ts
@@ -15,6 +15,9 @@ import type { ModuleInit } from './module';
 
 export const SERVICE_NAME = 'auto-start';
 
+const canUseWindowForAutoStartPrompt = (mainWindow: BrowserWindow) =>
+    !mainWindow.isDestroyed() && !mainWindow.webContents.isDestroyed();
+
 // Linux autostart desktop file
 const getLinuxExecutable = () => {
     if (process.env.container) {
@@ -90,7 +93,8 @@ export const promptForAutoStartBeforeQuit = async (mainWindow: BrowserWindow, st
     if (
         isAutoStartEnabled() ||
         store.getConnectSettings().autoStartDontAskAgain ||
-        !store.getConnectSettings().hasUsedConnectWs
+        !store.getConnectSettings().hasUsedConnectWs ||
+        !canUseWindowForAutoStartPrompt(mainWindow)
     ) {
         return true;
     }
@@ -110,7 +114,16 @@ export const promptForAutoStartBeforeQuit = async (mainWindow: BrowserWindow, st
         validateIpcMessage({ ipcEvent });
         deferredResponse.resolve(response);
     });
-    mainWindow.webContents.send('app/auto-start/popup-request');
+
+    mainWindow.once('closed', () => {
+        deferredResponse.resolve('quit-now');
+    });
+
+    try {
+        mainWindow.webContents.send('app/auto-start/popup-request');
+    } catch {
+        deferredResponse.resolve('quit-now');
+    }
 
     // Fallback if modal not shown at the moment
     // This can happen on some screens like onboarding, where normal modal might not be shown


### PR DESCRIPTION
## Description

Defensive programming hoping to solve https://github.com/trezor/trezor-suite/issues/26370, but I could not reproduce that.

## Notes for QA

- On Linux, run AppImage built from testing branch with version set to 26.3.0, [deployed here](https://github.com/trezor/trezor-suite/actions/runs/25922558768)
- Update
- Should correctly relaunch as the new version
- Check autoupdate on all platforms (win/lin/mac)

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26370

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect the desktop Electron app entry point (app.ts) and the auto-start module. The app.ts change is high risk as it orchestrates the entire desktop app lifecycle including bridge spawning, window management, and module loading. The auto-start module change is lower risk but could affect startup behavior. Testing should focus on desktop-specific bridge/app lifecycle tests, with secondary coverage on initial run behavior. Most web-only tests (analytics, trading, wallet operations) are unaffected since they don't depend on the Electron main process code.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite-desktop-core/src/app.ts`
- `packages/suite-desktop-core/src/modules/auto-start.ts`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `../../suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — This test directly exercises the Electron app lifecycle including bridge spawning, window management, and app initialization — all of which are orchestrated by app.ts. Changes to the app entry point could affect how the bridge process is spawned, how the app initializes, and how it behaves on close.
- `../../suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — This test validates daemon mode bridge spawning and app lifecycle (launching in bridgeDaemon mode, closing the UI vs daemon). Changes to app.ts could directly impact how daemon mode is handled and how bridge processes are managed across app instances.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `../../suite/e2e/tests/suite/initial-run.test.ts` — The initial-run test validates the app's first launch behavior including onboarding persistence across reloads. Changes to app.ts could affect how the app initializes on first run, how state is persisted, and how modules like auto-start are loaded during startup.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `../../suite/e2e/tests/settings/general.test.ts` — The auto-start module likely relates to application startup settings. The general settings test covers various application settings and could indirectly be affected if auto-start introduces or modifies a setting visible in the general settings page.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite-desktop-core/src/modules/auto-start.ts`

_Updated: 2026-05-15T14:16:18.924Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/desktop-update-autorestart-linux&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/desktop-update-autorestart-linux&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect webextension -> Suite Web > call cancelled from calling application | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-15T14:21:38.884Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-15T14:19:34.586Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/desktop-update-autorestart-linux/web/](https://dev.suite.sldev.cz/suite-web/fix/desktop-update-autorestart-linux/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->