### PR TITLE
fix(suite): handle unavailable yield apy

### DIFF
--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx
@@ -49,7 +49,7 @@ export const EarnYieldAccountOpportunity = ({ opportunity }: EarnYieldAccountOpp
     const hasDisplayableSuppliedAmount = new BigNumber(opportunity.suppliedAmount).gt(0);
     const hasMatchedTokenWithBalance = new BigNumber(opportunity.additionalSupplyAmount).gt(0);
     const { hasRewardsData } = opportunity;
-    const hasApy = opportunity.apyPercentage !== null;
+    const hasApy = opportunity.apyPercentage !== null && opportunity.apyPercentage > 0;
     const yearlyRewards = hasDisplayableSuppliedAmount
         ? new BigNumber(opportunity.suppliedAmount)
               .times(opportunity.vault.rewardRate.total)
@@ -62,6 +62,7 @@ export const EarnYieldAccountOpportunity = ({ opportunity }: EarnYieldAccountOpp
               .toString()
         : '0';
     const hasPotentialRewards = new BigNumber(potentialRewards).gt(0);
+    const shouldSpanRewardsCells = !hasApy && !hasPotentialRewards;
     const formattedSuppliedAmount = CryptoAmountFormatter.format(opportunity.suppliedAmount, {
         symbol: opportunity.suppliedSymbol,
         withSymbol: false,
@@ -252,7 +253,7 @@ export const EarnYieldAccountOpportunity = ({ opportunity }: EarnYieldAccountOpp
 
                 {hasRewardsData ? (
                     <>
-                        <Table.Cell>
+                        <Table.Cell colSpan={shouldSpanRewardsCells ? 2 : undefined}>
                             <Row width="100%" alignItems="center" justifyContent="space-between">
                                 <Column>
                                     <EarnRewardsAmount
@@ -291,34 +292,36 @@ export const EarnYieldAccountOpportunity = ({ opportunity }: EarnYieldAccountOpp
                             </Row>
                         </Table.Cell>
 
-                        <Table.Cell>
-                            {hasPotentialRewards && (
-                                <Column>
-                                    <EarnRewardsAmount
-                                        symbol={opportunity.suppliedSymbol}
-                                        rewards={potentialRewards}
-                                        apy={opportunity.apyPercentage}
-                                        intent="brand"
-                                    />
+                        {!shouldSpanRewardsCells && (
+                            <Table.Cell>
+                                {hasPotentialRewards && (
+                                    <Column>
+                                        <EarnRewardsAmount
+                                            symbol={opportunity.suppliedSymbol}
+                                            rewards={potentialRewards}
+                                            apy={opportunity.apyPercentage}
+                                            intent="brand"
+                                        />
 
-                                    <Paragraph
-                                        typographyStyle="body-sm"
-                                        intent="neutral"
-                                        priority="secondary"
-                                    >
-                                        <HiddenPlaceholder>
-                                            <Translation
-                                                id="TR_EARN_STAKING_DASHBOARD_IF_YOU_ADD"
-                                                values={{
-                                                    amount: formattedAdditionalSupplyAmount,
-                                                    displaySymbol: opportunity.suppliedSymbol,
-                                                }}
-                                            />
-                                        </HiddenPlaceholder>
-                                    </Paragraph>
-                                </Column>
-                            )}
-                        </Table.Cell>
+                                        <Paragraph
+                                            typographyStyle="body-sm"
+                                            intent="neutral"
+                                            priority="secondary"
+                                        >
+                                            <HiddenPlaceholder>
+                                                <Translation
+                                                    id="TR_EARN_STAKING_DASHBOARD_IF_YOU_ADD"
+                                                    values={{
+                                                        amount: formattedAdditionalSupplyAmount,
+                                                        displaySymbol: opportunity.suppliedSymbol,
+                                                    }}
+                                                />
+                                            </HiddenPlaceholder>
+                                        </Paragraph>
+                                    </Column>
+                                )}
+                            </Table.Cell>
+                        )}
                     </>
                 ) : (
                     <Table.Cell colSpan={2} />

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyBreakdown.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyBreakdown.tsx
@@ -35,6 +35,7 @@ export const EarnYieldApyBreakdown = ({
     <Column gap={16} padding={{ vertical: 10, horizontal: 8 }}>
         {sortRewardsByUnderlyingToken(rewards, underlyingToken).map((reward, index) => {
             const ratePercent = getApyPercent(reward.rate);
+            const hasRatePercent = ratePercent !== null && ratePercent > 0;
             const translationId = getYieldSourceTranslationId(reward.yieldSource);
             const description = translationId ? (
                 <Translation id={translationId} />
@@ -60,11 +61,20 @@ export const EarnYieldApyBreakdown = ({
                             </Text>
                         )}
                     </Column>
-                    {ratePercent !== null && ratePercent > 0 && (
-                        <Text typographyStyle="body-sm" intent="brand">
-                            +{ratePercent}%
-                        </Text>
-                    )}
+                    <Text
+                        typographyStyle="body-sm"
+                        intent={hasRatePercent ? 'brand' : 'neutral'}
+                        priority={hasRatePercent ? 'primary' : 'secondary'}
+                    >
+                        {hasRatePercent ? (
+                            <>+{ratePercent}%</>
+                        ) : (
+                            <>
+                                <Translation id="TR_EARN_APY_N_A" />{' '}
+                                <Translation id="TR_STAKE_APY_ABBR" />
+                            </>
+                        )}
+                    </Text>
                 </Row>
             );
         })}

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyTooltip.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyTooltip.tsx
@@ -11,9 +11,10 @@ import { ApyValue } from 'src/views/wallet/staking/components/ApyValue';
 import { EarnYieldApyBreakdown } from './EarnYieldApyBreakdown';
 
 const Abbr = styled.abbr`
-    border-bottom: 1px dotted ${({ theme }) => theme.contentSecondary};
     cursor: help;
-    text-decoration: none;
+    text-decoration: underline dotted ${({ theme }) => theme.contentSecondary};
+    text-decoration-thickness: 1px;
+    text-underline-offset: 3px;
 `;
 
 type EarnYieldApyTooltipProps = {
@@ -28,18 +29,24 @@ export const EarnYieldApyTooltip = ({
     apyPercentage,
     networkSymbol,
     children,
-}: EarnYieldApyTooltipProps) => (
-    <Tooltip
-        content={
-            <EarnYieldApyBreakdown
-                rewards={vault.rewardRate.components}
-                networkSymbol={networkSymbol}
-                underlyingToken={vault.token}
-            />
-        }
-        maxWidth={600}
-        placement="top"
-    >
-        <Abbr>{children ?? <ApyValue apy={apyPercentage} />}</Abbr>
-    </Tooltip>
-);
+}: EarnYieldApyTooltipProps) => {
+    if (!children && !apyPercentage) {
+        return <ApyValue apy={apyPercentage} />;
+    }
+
+    return (
+        <Tooltip
+            content={
+                <EarnYieldApyBreakdown
+                    rewards={vault.rewardRate.components}
+                    networkSymbol={networkSymbol}
+                    underlyingToken={vault.token}
+                />
+            }
+            maxWidth={600}
+            placement="top"
+        >
+            <Abbr>{children ?? <ApyValue apy={apyPercentage} />}</Abbr>
+        </Tooltip>
+    );
+};

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/components/YieldSupplyingInfo.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/components/YieldSupplyingInfo.tsx
@@ -8,11 +8,11 @@ import { formatApyValue } from 'src/components/earn/utils/earnApyUtils';
 
 import { EarnInfoRow } from './EarnInfoRow';
 
-interface YieldSupplyingInfoProps {
+type YieldSupplyingInfoProps = {
     apy: number | null;
     vault: YieldDto | undefined;
     networkSymbol: NetworkSymbol;
-}
+};
 
 export const YieldSupplyingInfo = ({ apy, vault, networkSymbol }: YieldSupplyingInfoProps) => (
     <BulletList bulletGap={12} gap={16} bulletSize="small" titleGap={2}>
@@ -24,21 +24,30 @@ export const YieldSupplyingInfo = ({ apy, vault, networkSymbol }: YieldSupplying
             heading={<Translation id="TR_EARN_SIGN_SUPPLYING_TRANSACTION" />}
             content={{ text: <Translation id="TR_TRADING_NETWORK_FEE" />, isBadge: true }}
         />
-        {apy !== null && vault && (
+        {vault && (
             <EarnInfoRow
                 heading={<Translation id="TR_EARN_YIELD_EARN_REWARDS_EACH_BLOCK" />}
                 content={{
                     text: (
-                        <EarnYieldApyTooltip
-                            vault={vault}
-                            apyPercentage={apy}
-                            networkSymbol={networkSymbol}
-                        >
-                            <Translation
-                                id="TR_EARN_APY_APPROX"
-                                values={{ apyPercent: formatApyValue(apy) }}
-                            />
-                        </EarnYieldApyTooltip>
+                        <>
+                            {apy !== null && apy > 0 ? (
+                                <EarnYieldApyTooltip
+                                    vault={vault}
+                                    apyPercentage={apy}
+                                    networkSymbol={networkSymbol}
+                                >
+                                    <Translation
+                                        id="TR_EARN_APY_APPROX"
+                                        values={{ apyPercent: formatApyValue(apy) }}
+                                    />
+                                </EarnYieldApyTooltip>
+                            ) : (
+                                <>
+                                    <Translation id="TR_EARN_APY_N_A" />{' '}
+                                    <Translation id="TR_STAKE_APY_ABBR" />
+                                </>
+                            )}
+                        </>
                     ),
                 }}
             />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes unavailable APY rendering in stablecoin yield UI. After discussion, we decided not to show the tooltip at all when APY is unavailable. 

- Shows `N/A APY` for unavailable APY in the APY breakdown tooltip.
- Shows `N/A APY` instead of `~0% APY` in the stablecoin yield nutshell modal.
- Hides the rewards arrow when APY is unavailable.
- Keeps unavailable APY in the table as plain `Not available` without tooltip styling. 

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27747

## Screenshots:

<img width="1211" height="847" alt="image" src="https://github.com/user-attachments/assets/62ab27ef-4ffe-4b53-90a4-56844bd1f9ca" />

<img width="509" height="722" alt="image" src="https://github.com/user-attachments/assets/51ad3a05-063b-4206-9eab-3436cd1cb2b0" />

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are scoped to four earn/staking UI components: three yield dashboard components (EarnYieldAccountOpportunity, EarnYieldApyBreakdown, EarnYieldApyTooltip) and one modal component (YieldSupplyingInfo in EarnInANutshell). These are presentation-layer changes in the earn/staking feature area. The primary risk is visual regressions or broken rendering on staking dashboards and staking info modals. Despite EarnYieldAccountOpportunity mapping to 121 tests statically, the vast majority are unrelated (backup, browser, metadata, etc.) and should be skipped. The recommended strategy focuses on staking E2E tests for ETH, SOL, and ADA that exercise the staking dashboard and staking initiation flows where these components are rendered.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx`
- `packages/suite/src/components/earn/dashboard/yield/EarnYieldApyBreakdown.tsx`
- `packages/suite/src/components/earn/dashboard/yield/EarnYieldApyTooltip.tsx`
- `packages/suite/src/components/earn/modals/EarnInANutshell/components/YieldSupplyingInfo.tsx`

</details>

**Recommended tests (12)**

<details><summary>🟡 <b>Medium priority (10)</b></summary>

- `suite/e2e/tests/analytics/staking-events.test.ts` — This test exercises staking navigation from the dashboard and account menu for ETH and ADA. The changed EarnYieldAccountOpportunity component is part of the earn/staking dashboard UI that users interact with when navigating to staking, making it plausibly affected by changes to yield opportunity display components.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test covers the full ETH staking flow including the staking dashboard display with empty states, staking info modal ('Staking in a Nutshell'), and staking amounts. The changed EarnYieldApyBreakdown, EarnYieldApyTooltip, and EarnYieldAccountOpportunity components are part of the earn/staking dashboard UI, and the YieldSupplyingInfo component is used in the 'EarnInANutshell' modal that appears during the staking flow.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — This test verifies the ETH staking dashboard with staked amounts, rewards, and the stake-more flow. The changed yield dashboard components (EarnYieldAccountOpportunity, EarnYieldApyBreakdown, EarnYieldApyTooltip) directly affect how staking yield information is displayed on the staking dashboard.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — This test exercises the ETH staking dashboard showing pending, staked, rewards, and unstaking amounts. The changed yield dashboard components are part of this staking dashboard UI and could affect how yield/APY information is rendered alongside staking amounts.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — This test covers the SOL initial staking flow including the 'Staking in a Nutshell' modal. The changed YieldSupplyingInfo component is part of that modal, and the yield dashboard components affect the staking dashboard display.
- `suite/e2e/tests/staking/sol/rewards.test.ts` — This test displays the Solana staking dashboard with staked, unstaking, and rewards amounts. The changed yield dashboard components (EarnYieldAccountOpportunity, APY breakdown/tooltip) are part of the staking dashboard UI that renders alongside these amounts.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — This test verifies the SOL staking dashboard and stake-more flow. The changed yield dashboard components affect how yield/APY information is rendered on the staking dashboard for Solana.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — This test exercises the SOL staking dashboard and full unstake/claim flow. The changed yield dashboard components are part of the staking dashboard UI rendered during this flow.
- `suite/e2e/tests/staking/staking-form.test.ts` — This test navigates to the ETH staking form via the staking tab and interacts with the staking dashboard (Stake More button). The yield dashboard components are rendered on the staking tab page that this test navigates through.
- `suite/e2e/tests/staking/ada/stake.test.ts` — This test covers the ADA staking flow including the 'Staking in a Nutshell' informational modal. The changed YieldSupplyingInfo component is part of that modal, and the staking dashboard yield components affect how the ADA staking UI is rendered.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — This test views a staked Cardano account's staking dashboard. While the yield dashboard components may appear on this page, the test primarily focuses on claiming rewards rather than yield/APY display.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — This test exercises the ADA unstaking flow and views the staking dashboard. The yield dashboard components may be rendered on the staking tab, though the test focuses on unstaking mechanics.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/suite/src/components/earn/dashboard/yield/EarnYieldApyBreakdown.tsx`
- `packages/suite/src/components/earn/dashboard/yield/EarnYieldApyTooltip.tsx`
- `packages/suite/src/components/earn/modals/EarnInANutshell/components/YieldSupplyingInfo.tsx`

_Updated: 2026-05-15T14:45:18.076Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/unavailable-yield-apy&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/unavailable-yield-apy&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect webextension -> Suite Web > call cancelled from calling application | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-15T14:49:38.508Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-15T14:48:25.689Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/unavailable-yield-apy/web/](https://dev.suite.sldev.cz/suite-web/fix/unavailable-yield-apy/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->