### PR TITLE
fix(suite): handle fully deposited yield vaults

### DIFF
--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx
@@ -47,7 +47,7 @@ export const EarnYieldAccountOpportunity = ({ opportunity }: EarnYieldAccountOpp
 
     const hasSuppliedBalance = opportunity.hasVaultPosition;
     const hasDisplayableSuppliedAmount = new BigNumber(opportunity.suppliedAmount).gt(0);
-    const hasMatchedTokenWithBalance = new BigNumber(opportunity.additionalSupplyAmount).gt(0);
+    const hasAdditionalDepositAmount = new BigNumber(opportunity.additionalSupplyAmount).gt(0);
     const { hasRewardsData } = opportunity;
     const hasApy = opportunity.apyPercentage !== null && opportunity.apyPercentage > 0;
     const yearlyRewards = hasDisplayableSuppliedAmount
@@ -62,7 +62,8 @@ export const EarnYieldAccountOpportunity = ({ opportunity }: EarnYieldAccountOpp
               .toString()
         : '0';
     const hasPotentialRewards = new BigNumber(potentialRewards).gt(0);
-    const shouldSpanRewardsCells = !hasApy && !hasPotentialRewards;
+    const hasMaximumDeposited = hasSuppliedBalance && !hasAdditionalDepositAmount;
+    const shouldSpanRewardsCells = !hasApy && !hasPotentialRewards && !hasMaximumDeposited;
     const formattedSuppliedAmount = CryptoAmountFormatter.format(opportunity.suppliedAmount, {
         symbol: opportunity.suppliedSymbol,
         withSymbol: false,
@@ -218,6 +219,8 @@ export const EarnYieldAccountOpportunity = ({ opportunity }: EarnYieldAccountOpp
     const isDepositDisabled = depositMessageSystem.isDisabled;
     const isWithdrawDisabled = withdrawMessageSystem.isDisabled;
     const isSupplyNowDisabled = !opportunity.vault.status.enter || isDepositDisabled;
+    const isDepositMoreDisabled =
+        !opportunity.vault.status.enter || !hasAdditionalDepositAmount || isDepositDisabled;
 
     return (
         <>
@@ -294,31 +297,42 @@ export const EarnYieldAccountOpportunity = ({ opportunity }: EarnYieldAccountOpp
 
                         {!shouldSpanRewardsCells && (
                             <Table.Cell>
-                                {hasPotentialRewards && (
-                                    <Column>
-                                        <EarnRewardsAmount
-                                            symbol={opportunity.suppliedSymbol}
-                                            rewards={potentialRewards}
-                                            apy={opportunity.apyPercentage}
-                                            intent="brand"
-                                        />
+                                {hasMaximumDeposited ? (
+                                    <Paragraph
+                                        typographyStyle="body-md"
+                                        intent="neutral"
+                                        priority="secondary"
+                                    >
+                                        <Translation id="TR_EARN_YIELD_MAXIMUM_DEPOSITED" />
+                                    </Paragraph>
+                                ) : (
+                                    hasPotentialRewards && (
+                                        <Column>
+                                            <EarnRewardsAmount
+                                                symbol={opportunity.suppliedSymbol}
+                                                rewards={potentialRewards}
+                                                apy={opportunity.apyPercentage}
+                                                intent="brand"
+                                            />
 
-                                        <Paragraph
-                                            typographyStyle="body-sm"
-                                            intent="neutral"
-                                            priority="secondary"
-                                        >
-                                            <HiddenPlaceholder>
-                                                <Translation
-                                                    id="TR_EARN_STAKING_DASHBOARD_IF_YOU_ADD"
-                                                    values={{
-                                                        amount: formattedAdditionalSupplyAmount,
-                                                        displaySymbol: opportunity.suppliedSymbol,
-                                                    }}
-                                                />
-                                            </HiddenPlaceholder>
-                                        </Paragraph>
-                                    </Column>
+                                            <Paragraph
+                                                typographyStyle="body-sm"
+                                                intent="neutral"
+                                                priority="secondary"
+                                            >
+                                                <HiddenPlaceholder>
+                                                    <Translation
+                                                        id="TR_EARN_STAKING_DASHBOARD_IF_YOU_ADD"
+                                                        values={{
+                                                            amount: formattedAdditionalSupplyAmount,
+                                                            displaySymbol:
+                                                                opportunity.suppliedSymbol,
+                                                        }}
+                                                    />
+                                                </HiddenPlaceholder>
+                                            </Paragraph>
+                                        </Column>
+                                    )
                                 )}
                             </Table.Cell>
                         )}
@@ -334,7 +348,7 @@ export const EarnYieldAccountOpportunity = ({ opportunity }: EarnYieldAccountOpp
                                 <Tooltip content={depositMessageSystem.content}>
                                     <Button
                                         size="small"
-                                        isDisabled={isDepositDisabled}
+                                        isDisabled={isDepositMoreDisabled}
                                         iconLeft={isDepositDisabled ? 'info' : undefined}
                                         onClick={navigateToYieldSupply}
                                     >
@@ -356,7 +370,7 @@ export const EarnYieldAccountOpportunity = ({ opportunity }: EarnYieldAccountOpp
                             </>
                         )}
 
-                        {!hasSuppliedBalance && hasMatchedTokenWithBalance && (
+                        {!hasSuppliedBalance && hasAdditionalDepositAmount && (
                             <Tooltip content={depositMessageSystem.content}>
                                 <Button
                                     size="small"
@@ -369,7 +383,7 @@ export const EarnYieldAccountOpportunity = ({ opportunity }: EarnYieldAccountOpp
                             </Tooltip>
                         )}
 
-                        {!hasSuppliedBalance && !hasMatchedTokenWithBalance && (
+                        {!hasSuppliedBalance && !hasAdditionalDepositAmount && (
                             <Button
                                 size="small"
                                 intent="neutral"

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -9516,6 +9516,10 @@ export const messages = defineMessages({
         id: 'TR_EARN_YIELD_DASHBOARD_SUPPLY_MORE',
         defaultMessage: 'Deposit more',
     },
+    TR_EARN_YIELD_MAXIMUM_DEPOSITED: {
+        id: 'TR_EARN_YIELD_MAXIMUM_DEPOSITED',
+        defaultMessage: 'Maximum deposited',
+    },
     TR_EARN_YIELD_DASHBOARD_WITHDRAW: {
         id: 'TR_EARN_YIELD_DASHBOARD_WITHDRAW',
         defaultMessage: 'Withdraw',


### PR DESCRIPTION
## Description

When the full token balance is already deposited, the dashboard now:
- shows “Maximum deposited” in the Potential rewards column
- disables the “Deposit more” CTA to avoid opening a zero-amount deposit flow

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27804

## Screenshots:

<img width="1207" height="486" alt="image" src="https://github.com/user-attachments/assets/066132eb-1e76-4427-8595-34fa0bbfc348" />

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes involve an earn/staking yield opportunity component (EarnYieldAccountOpportunity.tsx) and the global internationalization messages file (messages.ts). The yield component change is focused on the earn/staking dashboard area, making staking-related E2E tests the highest priority. The messages.ts file is a very broad dependency (maps to 0 tests statically but is used across the entire app), so only tests with concrete translation assertions related to staking/earn UI are recommended. The risk is moderate — the component change could affect staking opportunity display, while messages.ts changes could affect any translated string but are most likely related to the earn/yield feature given the co-change.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/analytics/staking-events.test.ts` — This test directly exercises staking navigation from the dashboard assets section, which is the exact area where EarnYieldAccountOpportunity is rendered. Changes to the earn/yield component could affect how staking navigation buttons appear and fire analytics events on the dashboard.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — EarnYieldAccountOpportunity is an earn/staking dashboard component that likely renders staking opportunities for ETH. This test covers the full ETH staking flow including the staking dashboard card and empty card states, which the changed component may influence.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — This test verifies the staking dashboard with existing staked amounts and the 'Stake More' flow for ETH. The EarnYieldAccountOpportunity component likely renders yield/opportunity information on the staking dashboard that this test validates.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — This test covers the ETH unstaking and claiming flow, including staking dashboard amounts display. The EarnYieldAccountOpportunity component renders yield information on the staking dashboard that could affect the unstake flow's UI.
- `suite/e2e/tests/staking/staking-form.test.ts` — This test validates the ETH staking form including navigation from the staking tab and the 'Stake More' button. The EarnYieldAccountOpportunity component is part of the earn dashboard and may affect how staking opportunities and entry points are presented.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — This test covers the Solana initial staking flow with staking dashboard empty/filled states. The EarnYieldAccountOpportunity component may render yield opportunities for SOL on the staking dashboard.
- `suite/e2e/tests/staking/ada/stake.test.ts` — This test covers the Cardano staking flow including staking dashboard state. The EarnYieldAccountOpportunity component may render yield account opportunities for ADA, and messages.ts changes could affect displayed translations in this flow.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/settings/autodetect.test.ts` — This test validates translation rendering based on locale autodetection, referencing @suite/intl messages directly. Changes to messages.ts could affect the translation keys used in the analytics/onboarding heading text assertions.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/intl/src/messages.ts`

_Updated: 2026-05-15T15:38:34.531Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/yield-max-deposited-state/web/](https://dev.suite.sldev.cz/suite-web/fix/yield-max-deposited-state/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/yield-max-deposited-state&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/yield-max-deposited-state&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect webextension -> Suite Web > call cancelled from calling application | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-15T15:47:19.152Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-15T15:45:40.130Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->