### PR TITLE
fix(suite): show error banner when yield vaults fetch fails

### DIFF
--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx
@@ -38,8 +38,12 @@ export const EarnYieldTable = () => {
         return new Set(normalAccounts.map(account => account.symbol));
     }, [visibleAccounts]);
 
-    const { data: availableVaults, isLoading: isYieldOpportunitiesLoading } =
-        useAllYieldOpportunities();
+    const {
+        data: availableVaults,
+        isLoading: isYieldOpportunitiesLoading,
+        isError: isYieldOpportunitiesError,
+        refetch: refetchYieldOpportunities,
+    } = useAllYieldOpportunities();
 
     const {
         yieldAccountOpportunities,
@@ -131,6 +135,8 @@ export const EarnYieldTable = () => {
                                 />
                                 <EarnYieldTableBody
                                     isYieldOpportunitiesLoading={isYieldOpportunitiesLoading}
+                                    isYieldOpportunitiesError={isYieldOpportunitiesError}
+                                    onRetry={refetchYieldOpportunities}
                                     yieldAccountOpportunities={displayedYieldAccountOpportunities}
                                     yieldInactiveVaultOpportunities={
                                         yieldInactiveVaultOpportunities

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldTableBody.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldTableBody.tsx
@@ -1,5 +1,5 @@
 import { Translation } from '@suite/intl';
-import { Paragraph, Row, Spinner, Table } from '@trezor/components';
+import { Banner, Paragraph, Row, Spinner, Table } from '@trezor/components';
 
 import { EarnYieldAccountOpportunity } from './EarnYieldAccountOpportunity';
 import { EarnYieldInactiveVaultOpportunity } from './EarnYieldInactiveVaultOpportunity';
@@ -7,12 +7,16 @@ import { type YieldAccountOpportunity, type YieldInactiveVaultOpportunity } from
 
 type EarnYieldTableBodyProps = {
     isYieldOpportunitiesLoading: boolean;
+    isYieldOpportunitiesError: boolean;
+    onRetry: () => void;
     yieldAccountOpportunities: YieldAccountOpportunity[];
     yieldInactiveVaultOpportunities: YieldInactiveVaultOpportunity[];
 };
 
 export const EarnYieldTableBody = ({
     isYieldOpportunitiesLoading,
+    isYieldOpportunitiesError,
+    onRetry,
     yieldAccountOpportunities,
     yieldInactiveVaultOpportunities,
 }: EarnYieldTableBodyProps) => {
@@ -24,6 +28,28 @@ export const EarnYieldTableBody = ({
                         <Row width="100%" justifyContent="center" padding={{ vertical: 16 }}>
                             <Spinner size={24} />
                         </Row>
+                    </Table.Cell>
+                </Table.Row>
+            </Table.Body>
+        );
+    }
+
+    if (isYieldOpportunitiesError) {
+        return (
+            <Table.Body>
+                <Table.Row>
+                    <Table.Cell colSpan={5}>
+                        <Banner
+                            icon
+                            intent="warning"
+                            title={<Translation id="TR_EARN_YIELD_LOAD_ERROR_TITLE" />}
+                            description={<Translation id="TR_EARN_YIELD_LOAD_ERROR_DESCRIPTION" />}
+                            rightContent={
+                                <Banner.Button onClick={onRetry}>
+                                    <Translation id="TR_TRY_AGAIN" />
+                                </Banner.Button>
+                            }
+                        />
                     </Table.Cell>
                 </Table.Row>
             </Table.Body>

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -9669,6 +9669,15 @@ export const messages = defineMessages({
         id: 'TR_EARN_YIELD_ERROR_GENERIC',
         defaultMessage: 'Something went wrong. Try again.',
     },
+    TR_EARN_YIELD_LOAD_ERROR_TITLE: {
+        id: 'TR_EARN_YIELD_LOAD_ERROR_TITLE',
+        defaultMessage: 'Unable to load yield opportunities',
+    },
+    TR_EARN_YIELD_LOAD_ERROR_DESCRIPTION: {
+        id: 'TR_EARN_YIELD_LOAD_ERROR_DESCRIPTION',
+        defaultMessage:
+            'This may be due to a network or connectivity issue. Check your connection or try again later.',
+    },
     TR_EARN_YIELD_ERROR_TRANSACTION_FAILED: {
         id: 'TR_EARN_YIELD_ERROR_TRANSACTION_FAILED',
         defaultMessage: 'Transaction failed',


### PR DESCRIPTION
## Description

When fetching yield opportunities failed, the earn dashboard showed "No accounts" - a misleading state that gave no indication of what went wrong.

This replaces that fallback with a warning Banner containing the message **"Unable to load yield opportunities"** and a **"Try again"** button that triggers a refetch.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27795

## Screenshots:

https://github.com/user-attachments/assets/ab01251a-3ccd-454e-a776-a4f77deecbea


<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes target the EarnYieldTable and EarnYieldTableBody components (earn/staking dashboard yield display) and the global messages.ts translation file. The yield table components are earn-specific UI, so the highest-risk tests are those that directly exercise staking/earn dashboard views and navigation. The messages.ts file is a global dependency (no static test mapping), but since it's changed alongside earn components, the risk is concentrated in staking/earn flows. The 121 tests statically mapped to these components are due to broad transitive imports, so only staking-related tests that plausibly render earn dashboard content are recommended.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx`
- `packages/suite/src/components/earn/dashboard/yield/EarnYieldTableBody.tsx`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/analytics/staking-events.test.ts` — This test navigates to staking from the dashboard assets section and account menu. The changed EarnYieldTable/EarnYieldTableBody components are part of the earn/staking dashboard UI, and this test exercises staking navigation flows that would surface rendering issues in yield table components. The messages.ts change could affect translation keys used in staking UI.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test exercises the ETH staking dashboard view including staking amounts, empty states, and staking form flows. The EarnYieldTable components render yield/staking data on the earn dashboard, and changes here could affect how staking information is displayed. Translation changes in messages.ts could affect staking-related labels.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — This test views the staking dashboard with staked amounts and interacts with staking forms. The EarnYieldTable components display yield information that may be visible on staking dashboard views, and messages.ts changes could affect staking-related translations like TR_EARN_AMOUNT_STAKED_INSTANTLY.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — This test exercises the ETH staking dashboard view with staked amounts, unstaking flows, and claiming. Changes to the yield table components and messages could affect how staking dashboard data is rendered and labeled.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — This test covers Solana staking dashboard including empty states and staking flows. The EarnYieldTable components are part of the earn dashboard that shows yield data across networks, potentially including SOL staking views.
- `suite/e2e/tests/staking/staking-form.test.ts` — This test navigates to staking from the dashboard and exercises the staking form. The earn yield table components are part of the earn/staking dashboard UI surface, and messages.ts changes could affect validation or label translations used in the staking form.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/intl/src/messages.ts`

_Updated: 2026-05-15T17:04:06.714Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/earn-yield-vaults-fetch-error-state/web/](https://dev.suite.sldev.cz/suite-web/fix/earn-yield-vaults-fetch-error-state/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect webextension -> Suite Web > call cancelled from calling application | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-15T17:09:29.141Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-15T17:07:44.247Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/earn-yield-vaults-fetch-error-state&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->