### PR TITLE
chore(eslint): enable prefer-optional-chain (POC, split from #27472)

### DIFF
--- a/coins/coins-solana/src/runtime/stakingUtils.ts
+++ b/coins/coins-solana/src/runtime/stakingUtils.ts
@@ -344,7 +344,7 @@ export function isCompilableTransactionMessage(
 }
 
 export const getStakingParams = (estimatedFee?: Fee) =>
-    !estimatedFee || !estimatedFee.feePerUnit || !estimatedFee.feeLimit
+    !estimatedFee?.feePerUnit || !estimatedFee.feeLimit
         ? {
               computeUnitPrice: BigInt(SOL_COMPUTE_UNIT_PRICE),
               computeUnitLimit: SOL_COMPUTE_UNIT_LIMIT,

--- a/packages/address-validator/src/bitcoin_validator.ts
+++ b/packages/address-validator/src/bitcoin_validator.ts
@@ -110,7 +110,7 @@ function isValidPayToWitnessScriptHashAddress(
         const hrp = currency.segwitHrp[networkType];
         const decoded = bech32.decode(hrp, address);
 
-        return !!(decoded && decoded.version === 0 && decoded.program.length === 32);
+        return !!(decoded?.version === 0 && decoded.program.length === 32);
     } catch {
         return false;
     }
@@ -125,7 +125,7 @@ function isValidPayToWitnessPublicKeyHashAddress(
         const hrp = currency.segwitHrp[networkType];
         const decoded = bech32.decode(hrp, address);
 
-        return !!(decoded && decoded.version === 0 && decoded.program.length === 20);
+        return !!(decoded?.version === 0 && decoded.program.length === 20);
     } catch {
         return false;
     }
@@ -136,7 +136,7 @@ function isValidPayToTaprootAddress(address: string, currency: any, networkType:
         const hrp = currency.segwitHrp[networkType];
         const decoded = bech32.decode(hrp, address, true);
 
-        return !!(decoded && decoded.version === 1 && decoded.program.length === 32);
+        return !!(decoded?.version === 1 && decoded.program.length === 32);
     } catch {
         return false;
     }

--- a/packages/address-validator/src/crypto/bech32.ts
+++ b/packages/address-validator/src/crypto/bech32.ts
@@ -49,7 +49,7 @@ export function decode(hrp: string, addr: string, m = false): Bech32Decoded | nu
     } catch {
         return null;
     }
-    if (dec === null || dec.prefix !== hrp || dec.words.length < 1 || dec.words[0] > 16) {
+    if (dec?.prefix !== hrp || dec.words.length < 1 || dec.words[0] > 16) {
         return null;
     }
     const res = convertbits(dec.words.slice(1), 5, 8, false);

--- a/packages/address-validator/src/index.ts
+++ b/packages/address-validator/src/index.ts
@@ -13,7 +13,7 @@ export function validate(
 ): boolean {
     const currency = currencies.getByNameOrSymbol(currencyNameOrSymbol || DEFAULT_CURRENCY_NAME);
 
-    if (currency && currency.validator) {
+    if (currency?.validator) {
         return currency.validator.isValidAddress(address, currency, networkType);
     }
 
@@ -26,7 +26,7 @@ export function getAddressType(
     networkType?: string,
 ): AddressType | undefined {
     const currency = currencies.getByNameOrSymbol(currencyNameOrSymbol || DEFAULT_CURRENCY_NAME);
-    if (!currency || !currency.validator) {
+    if (!currency?.validator) {
         throw new Error('getAddressType: No validator for currency: ' + currencyNameOrSymbol);
     }
     if (currency.validator.getAddressType) {

--- a/packages/analytics-docs/src/utils/extractAttributeTypes.ts
+++ b/packages/analytics-docs/src/utils/extractAttributeTypes.ts
@@ -195,7 +195,7 @@ const getEventDefTypeArgs = (
     }
     const t = varDecl.getType();
     const alias = t.getAliasSymbol();
-    if (!alias || alias.getName() !== 'EventDef') return undefined;
+    if (alias?.getName() !== 'EventDef') return undefined;
     const args = t.getAliasTypeArguments();
     if (args.length < 1) return undefined;
 

--- a/packages/coinjoin/src/client/round/connectionConfirmation.ts
+++ b/packages/coinjoin/src/client/round/connectionConfirmation.ts
@@ -70,11 +70,7 @@ const confirmInput = async (
     );
 
     // stop here if it's confirmationInterval at phase 0
-    if (
-        !confirmationData ||
-        !confirmationData.RealAmountCredentials ||
-        !confirmationData.RealVsizeCredentials
-    ) {
+    if (!confirmationData?.RealAmountCredentials || !confirmationData.RealVsizeCredentials) {
         logger.info(`Confirmed in phase ${round.phase} ~~${input.outpoint}~~ in ~~${round.id}~~`);
 
         return input;

--- a/packages/components/src/components/Menu/Menu.tsx
+++ b/packages/components/src/components/Menu/Menu.tsx
@@ -111,7 +111,7 @@ export const Menu = forwardRef<HTMLUListElement, MenuProps>(
         // handle selecting an item
         useEffect(() => {
             const handleKeyDown = (e: KeyboardEvent) => {
-                if (!visibleItems || !visibleItems.length || focusedItemIndex === null) {
+                if (!visibleItems?.length || focusedItemIndex === null) {
                     return;
                 }
 

--- a/packages/connect/src/api/bitcoin/TransactionComposer.ts
+++ b/packages/connect/src/api/bitcoin/TransactionComposer.ts
@@ -135,7 +135,7 @@ export class TransactionComposer {
         const { levels } = this.feeLevels;
         levels.forEach(level => {
             const tx = this.composed[level.label];
-            if (tx && tx.type === 'final') {
+            if (tx?.type === 'final') {
                 list.push({
                     name: level.label,
                     fee: tx.fee,

--- a/packages/connect/src/api/bitcoin/enhanceSignTx.ts
+++ b/packages/connect/src/api/bitcoin/enhanceSignTx.ts
@@ -24,7 +24,7 @@ export const enhanceSignTx = (
         // use branch_id from backend or fallback to default
         if (typeof options.branch_id !== 'number') {
             const backend = findBackend(coinInfo.shortcut);
-            if (backend && backend.serverInfo?.consensusBranchId) {
+            if (backend?.serverInfo?.consensusBranchId) {
                 options.branch_id = backend.serverInfo.consensusBranchId;
             } else {
                 options.branch_id = 0xc2d6d0b4;

--- a/packages/connect/src/api/bitcoin/inputs.ts
+++ b/packages/connect/src/api/bitcoin/inputs.ts
@@ -68,7 +68,7 @@ export const enhanceTrezorInputs = (
         if (!input.amount) {
             console.warn('TrezorConnect.signTransaction deprecation: missing input amount.');
             const refTx = rawTxs.find(t => t.getId() === input.prev_hash);
-            if (refTx && refTx.outs[input.prev_index]) {
+            if (refTx?.outs[input.prev_index]) {
                 input.amount = refTx.outs[input.prev_index].value;
             }
         }

--- a/packages/connect/src/api/cardano/api/cardanoSignTransaction.ts
+++ b/packages/connect/src/api/cardano/api/cardanoSignTransaction.ts
@@ -93,7 +93,7 @@ export default class CardanoSignTransaction extends AbstractMethod<
         }
 
         // @ts-expect-error payload.auxiliaryData.blob is a legacy param
-        if (payload.auxiliaryData && payload.auxiliaryData.blob) {
+        if (payload.auxiliaryData?.blob) {
             throw ERRORS.TypedError(
                 'Method_InvalidParameter',
                 'Auxiliary data can now only be sent as a hash.',
@@ -104,7 +104,7 @@ export default class CardanoSignTransaction extends AbstractMethod<
         // payload.auxiliaryData.governanceRegistrationParameters
         // are legacy params kept for backward compatibility (for now)
         // @ts-expect-error
-        if (payload.auxiliaryData && payload.auxiliaryData.catalystRegistrationParameters) {
+        if (payload.auxiliaryData?.catalystRegistrationParameters) {
             console.warn(
                 'Please use cVoteRegistrationParameters instead of catalystRegistrationParameters.',
             );
@@ -113,7 +113,7 @@ export default class CardanoSignTransaction extends AbstractMethod<
                 payload.auxiliaryData.catalystRegistrationParameters;
         }
         // @ts-expect-error
-        if (payload.auxiliaryData && payload.auxiliaryData.governanceRegistrationParameters) {
+        if (payload.auxiliaryData?.governanceRegistrationParameters) {
             console.warn(
                 'Please use cVoteRegistrationParameters instead of governanceRegistrationParameters.',
             );

--- a/packages/connect/src/api/composeTransaction.ts
+++ b/packages/connect/src/api/composeTransaction.ts
@@ -284,7 +284,7 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
         const { coinInfo } = this.params;
         const dfd = context.createUiPromise(UI_RESPONSE.RECEIVE_ACCOUNT, this.getDevice());
 
-        if (this.discovery && this.discovery.completed) {
+        if (this.discovery?.completed) {
             const { discovery } = this;
             context.sendCoreMessage(
                 createUiMessage(

--- a/packages/connect/src/api/signTransaction.ts
+++ b/packages/connect/src/api/signTransaction.ts
@@ -254,7 +254,7 @@ export default class SignTransaction extends AbstractMethod<'signTransaction', P
 
         // TODO: validate inputs address_n's === same account
         const accountPath = inputs.find(i => i.address_n);
-        if (!accountPath || !accountPath.address_n) {
+        if (!accountPath?.address_n) {
             throw ERRORS.TypedError('Runtime', 'Account not found');
         }
         const address_n = accountPath.address_n.slice(0, 3);

--- a/packages/connect/src/api/solana/api/solanaComposeTransaction.ts
+++ b/packages/connect/src/api/solana/api/solanaComposeTransaction.ts
@@ -94,24 +94,23 @@ export default class SolanaComposeTransaction extends AbstractMethod<
               )
             : [undefined, undefined];
 
-        const tokenTransferTxAndDestinationAddress =
-            this.params.token && this.params.token.accounts
-                ? await buildTokenTransferTransaction(
-                      this.params.fromAddress,
-                      this.params.toAddress,
-                      recipientAccountOwner || SYSTEM_PROGRAM_PUBLIC_KEY, // toAddressOwner
-                      this.params.token.mint,
-                      this.params.amount || '0',
-                      this.params.token.decimals,
-                      this.params.token.accounts,
-                      recipientTokenAccounts,
-                      this.params.blockHash,
-                      this.params.lastValidBlockHeight,
-                      this.params.priorityFees,
-                      this.params.token.program,
-                      this.params.memo,
-                  )
-                : undefined;
+        const tokenTransferTxAndDestinationAddress = this.params.token?.accounts
+            ? await buildTokenTransferTransaction(
+                  this.params.fromAddress,
+                  this.params.toAddress,
+                  recipientAccountOwner || SYSTEM_PROGRAM_PUBLIC_KEY, // toAddressOwner
+                  this.params.token.mint,
+                  this.params.amount || '0',
+                  this.params.token.decimals,
+                  this.params.token.accounts,
+                  recipientTokenAccounts,
+                  this.params.blockHash,
+                  this.params.lastValidBlockHeight,
+                  this.params.priorityFees,
+                  this.params.token.program,
+                  this.params.memo,
+              )
+            : undefined;
 
         if (this.params.token && !tokenTransferTxAndDestinationAddress)
             throw ERRORS.TypedError('Method_InvalidParameter', 'Token accounts not found');

--- a/packages/connect/src/api/stellar/api/stellarSignTransaction.ts
+++ b/packages/connect/src/api/stellar/api/stellarSignTransaction.ts
@@ -80,17 +80,11 @@ export default class StellarSignTransaction extends AbstractMethod<
 
     _ensureFirmwareSupportsParams() {
         const { params } = this;
-        if (
-            params.transaction.operations &&
-            params.transaction.operations.find(o => o.type === 'manageBuyOffer')
-        ) {
+        if (params.transaction.operations?.find(o => o.type === 'manageBuyOffer')) {
             this._ensureFeatureIsSupported('manageBuyOffer');
         }
 
-        if (
-            params.transaction.operations &&
-            params.transaction.operations.find(o => o.type === 'pathPaymentStrictSend')
-        ) {
+        if (params.transaction.operations?.find(o => o.type === 'pathPaymentStrictSend')) {
             this._ensureFeatureIsSupported('pathPaymentStrictSend');
         }
     }

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -765,9 +765,7 @@ export class Core extends EventEmitter {
 
     private sendCoreMessage(message: CoreEventMessage) {
         if (message.event === RESPONSE_EVENT) {
-            const index = this.callMethods.findIndex(
-                call => call && call.responseID === message.id,
-            );
+            const index = this.callMethods.findIndex(call => call?.responseID === message.id);
             if (index >= 0) {
                 this.callMethods.splice(index, 1);
                 if (this.callMethods.length === 0) {

--- a/packages/connect/src/data/defaultFeeLevels.ts
+++ b/packages/connect/src/data/defaultFeeLevels.ts
@@ -18,7 +18,7 @@ const BLOCKS_FOR_FEE_LEVEL: Record<string, Record<string, number>> = {
 const DEFAULT_BLOCK_FOR_FEE_LEVEL = 1;
 
 const getDefaultBlocksForFeeLevel = (shortcut: string, label: string) =>
-    BLOCKS_FOR_FEE_LEVEL[shortcut] && BLOCKS_FOR_FEE_LEVEL[shortcut][label]
+    BLOCKS_FOR_FEE_LEVEL[shortcut]?.[label]
         ? BLOCKS_FOR_FEE_LEVEL[shortcut][label]
         : DEFAULT_BLOCK_FOR_FEE_LEVEL;
 

--- a/packages/connect/src/data/firmwareInfo.ts
+++ b/packages/connect/src/data/firmwareInfo.ts
@@ -423,7 +423,7 @@ const getChangelog = (releases: FirmwareRelease[], features: StrictFeatures) => 
 };
 
 const isRequired = (changelog: ReturnType<typeof getChangelog>) => {
-    if (!changelog || !changelog.length) return null;
+    if (!changelog?.length) return null;
 
     return changelog.some(item => item.required);
 };

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -697,7 +697,7 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
             return; // This happens when device has no features (not yet connected)
         }
 
-        if (this.features && this.features.bootloader_mode === true) {
+        if (this.features?.bootloader_mode === true) {
             return;
         }
 
@@ -746,7 +746,7 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
         const capabilities = parseCapabilities(feat);
         feat.capabilities = capabilities;
         // GetFeatures doesn't return 'session_id'
-        if (this.features && this.features.session_id && !feat.session_id) {
+        if (this.features?.session_id && !feat.session_id) {
             feat.session_id = this.features.session_id;
         }
         feat.unlocked = feat.unlocked ?? true;

--- a/packages/connect/src/device/DeviceCommands.ts
+++ b/packages/connect/src/device/DeviceCommands.ts
@@ -138,7 +138,7 @@ export const DeviceCommands = (deviceTypedCall: TypedCallProvider) => {
                 script_type = 'SPENDADDRESS';
             }
         }
-        if (multisig && multisig.pubkeys) {
+        if (multisig?.pubkeys) {
             // convert xpub strings to HDNodeTypes
             multisig.pubkeys.forEach(pk => {
                 if (typeof pk.node === 'string') {

--- a/packages/connect/src/device/thp/handshake.ts
+++ b/packages/connect/src/device/thp/handshake.ts
@@ -16,9 +16,9 @@ const getPairingMethods = (
 ) =>
     deviceMethods?.flatMap(dm => {
         const value = protocolThp.getThpPairingMethod(dm);
-        const isRequested =
-            settingsMethods &&
-            settingsMethods.find(sm => value === protocolThp.getThpPairingMethod(sm));
+        const isRequested = settingsMethods?.find(
+            sm => value === protocolThp.getThpPairingMethod(sm),
+        );
 
         return isRequested ? value : [];
     });

--- a/packages/connect/src/utils/deviceFeaturesUtils.ts
+++ b/packages/connect/src/utils/deviceFeaturesUtils.ts
@@ -32,7 +32,7 @@ const DEFAULT_CAPABILITIES_TT: PROTO.Capability[] = [
 export const parseCapabilities = (features?: Features): PROTO.Capability[] => {
     if (!features || features.firmware_present === false) return []; // no features or no firmware - no capabilities
     // fallback for older firmware that does not report capabilities
-    if (!features.capabilities || !features.capabilities.length) {
+    if (!features.capabilities?.length) {
         return features.major_version === 1 ? DEFAULT_CAPABILITIES_T1 : DEFAULT_CAPABILITIES_TT;
     }
 

--- a/packages/connect/src/utils/firmwareReleaseConfigUtils.ts
+++ b/packages/connect/src/utils/firmwareReleaseConfigUtils.ts
@@ -129,7 +129,7 @@ const fetchRemoteJws = async (firmwareChannel?: FirmwareChannel): Promise<JwsInf
 const verifyAndDecodeJws = (jws: string, publicKey: string): FirmwareReleaseConfig => {
     const decoded = decode(jws);
 
-    if (!decoded || !decoded.payload || !decoded.header) {
+    if (!decoded?.payload || !decoded.header) {
         throw new Error('Invalid JWS structure.');
     }
 

--- a/packages/device-authenticity/src/findSubjectContentByOid.ts
+++ b/packages/device-authenticity/src/findSubjectContentByOid.ts
@@ -6,7 +6,7 @@ export const findSubjectContentByOid = (
 ): Uint8Array<ArrayBufferLike> | null => {
     const subjectItems = deviceCert.tbsCertificate.subject;
     const matchedItem = subjectItems.find(({ algorithmOid }) => algorithmOid === oid);
-    if (!matchedItem || !matchedItem.parameters) return null;
+    if (!matchedItem?.parameters) return null;
 
     return matchedItem.parameters.asn1.contents;
 };

--- a/packages/e2e-utils/src/mocks/backendServer.ts
+++ b/packages/e2e-utils/src/mocks/backendServer.ts
@@ -139,7 +139,7 @@ export class BackendWebsocketServerMock extends WebSocketServer {
 
         if (Array.isArray(fixtures)) {
             // find nearest fixture with requested method
-            const fixtureIndex = fixtures.findIndex(f => f && f.method === method);
+            const fixtureIndex = fixtures.findIndex(f => f?.method === method);
             if (fixtureIndex >= 0) {
                 const fixture = fixtures[fixtureIndex];
                 if (typeof fixture.response === 'function') {

--- a/packages/eslint/src/typescriptConfig.mjs
+++ b/packages/eslint/src/typescriptConfig.mjs
@@ -142,6 +142,7 @@ export const typescriptConfig = [
                     fixMixedExportsWithInlineTypeSpecifier: true,
                 },
             ],
+            '@typescript-eslint/prefer-optional-chain': ['error'],
         },
     },
 ];

--- a/packages/protocol/src/protocol-v2/encode.ts
+++ b/packages/protocol/src/protocol-v2/encode.ts
@@ -22,7 +22,7 @@ export const getHeaders: TransportProtocol['getHeaders'] = data => {
 
 // encode `protocol-thp` message
 export const encode: TransportProtocol['encode'] = (data, options) => {
-    if (!options.header || options.header.byteLength !== HEADER_SIZE) {
+    if (options.header?.byteLength !== HEADER_SIZE) {
         throw new Error(ERRORS.PROTOCOL_MALFORMED);
     }
 

--- a/packages/requirements/src/requirements/package-json/requirePublishConfig.ts
+++ b/packages/requirements/src/requirements/package-json/requirePublishConfig.ts
@@ -156,7 +156,7 @@ const validateExports = (
 
         // ESM-only packages do not ship lib/, so any ./lib/... export key would
         // resolve to a non-existent file once published.
-        if (isEsmOnly && match && match[1] === 'lib') {
+        if (isEsmOnly && match?.[1] === 'lib') {
             errors.push(
                 `Disallowed CJS export key ${JSON.stringify(exportKey)} in ESM-only package`,
             );

--- a/packages/suite-desktop-core/src/libs/http-receiver.ts
+++ b/packages/suite-desktop-core/src/libs/http-receiver.ts
@@ -97,7 +97,7 @@ export const createHttpReceiver = (options?: { port?: number }) => {
         allowReferers(['', 'localhost:3000', '*.invity.io', 'invity.io']),
         (request, response) => {
             const { query } = parseRequestUrl(request.url);
-            if (query && query.p) {
+            if (query?.p) {
                 httpReceiver.emit('buy/redirect', query.p.toString());
             }
 
@@ -149,7 +149,7 @@ export const createHttpReceiver = (options?: { port?: number }) => {
         allowReferers(['']), // No referer
         (request, response) => {
             const { query } = parseRequestUrl(request.url);
-            if (query && query.p) {
+            if (query?.p) {
                 httpReceiver.emit('sell/redirect', query.p.toString());
             }
 
@@ -163,7 +163,7 @@ export const createHttpReceiver = (options?: { port?: number }) => {
         allowReferers(['']), // No referer
         (request, response) => {
             const { query } = parseRequestUrl(request.url);
-            if (query && query.p) {
+            if (query?.p) {
                 httpReceiver.emit('exchange/redirect', query.p.toString());
             }
 

--- a/packages/suite-desktop-core/src/modules/trezor-connect.ts
+++ b/packages/suite-desktop-core/src/modules/trezor-connect.ts
@@ -30,7 +30,7 @@ const emitOnSetCustomBackendToMainThreadToAllowDomains = ({
 }: EmitOnSetCustomBackendToMainThreadToAllowDomainsParams) => {
     const param = params[0];
 
-    if (param !== undefined && param.blockchainLink !== undefined) {
+    if (param?.blockchainLink !== undefined) {
         const domains = (param.blockchainLink.url ?? []).map(url => {
             const electrumUrlResult = parseElectrumUrl(url);
             if (electrumUrlResult !== undefined) {

--- a/packages/suite-storage/src/index.ts
+++ b/packages/suite-storage/src/index.ts
@@ -243,7 +243,7 @@ class CommonDB<TDBStructure> {
         const tx = db.transaction(store);
         if (indexName) {
             const index = tx.store.index(indexName);
-            if (filters && filters.key !== undefined) {
+            if (filters?.key !== undefined) {
                 if (filters.offset !== undefined || filters.count !== undefined) {
                     // cursor with keyrange for given accountId (covers all timestamps)
                     let cursor = await index.openCursor(

--- a/packages/suite-storage/src/index.ts
+++ b/packages/suite-storage/src/index.ts
@@ -273,7 +273,7 @@ class CommonDB<TDBStructure> {
                 return index.getAll(keyRange);
             }
 
-            if (filters && filters.reverse) {
+            if (filters?.reverse) {
                 // get items in reverse order
                 let cursor = await index.openCursor(undefined, 'prev');
                 const items = [];

--- a/packages/suite/src/actions/settings/deviceSettingsActions.ts
+++ b/packages/suite/src/actions/settings/deviceSettingsActions.ts
@@ -130,7 +130,7 @@ export const resetDevice =
             }
         }
 
-        if (!device || !device.features) return;
+        if (!device?.features) return;
 
         if (device.mode !== 'initialize') {
             dispatch(

--- a/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
@@ -135,35 +135,35 @@ const getInitialState = (prevState?: Partial<PartialState>, action?: any) => ({
     ),
     wallet: {
         accounts: accountsReducer(
-            prevState && prevState.wallet ? prevState.wallet.accounts : undefined,
+            prevState?.wallet ? prevState.wallet.accounts : undefined,
             action || ({ type: 'foo' } as any),
         ),
         coinjoin: coinjoinReducer(
-            prevState && prevState.wallet ? prevState.wallet.coinjoin : undefined,
+            prevState?.wallet ? prevState.wallet.coinjoin : undefined,
             action || ({ type: 'foo' } as any),
         ),
         settings: walletSettingsReducer(
-            prevState && prevState.wallet ? prevState.wallet.settings : undefined,
+            prevState?.wallet ? prevState.wallet.settings : undefined,
             action || ({ type: 'foo' } as any),
         ),
         discovery: discoveryReducer(
-            prevState && prevState.wallet ? prevState.wallet.discovery : undefined,
+            prevState?.wallet ? prevState.wallet.discovery : undefined,
             action || ({ type: 'foo' } as any),
         ),
         send: sendFormReducer(
-            prevState && prevState.wallet ? prevState.wallet.send : undefined,
+            prevState?.wallet ? prevState.wallet.send : undefined,
             action || ({ type: 'foo' } as any),
         ),
         transactions: transactionsReducer(
-            prevState && prevState.wallet ? prevState.wallet.transactions : undefined,
+            prevState?.wallet ? prevState.wallet.transactions : undefined,
             action || ({ type: 'foo' } as any),
         ),
         fiat: fiatRatesReducer(
-            prevState && prevState.wallet ? prevState.wallet.fiat : undefined,
+            prevState?.wallet ? prevState.wallet.fiat : undefined,
             action || ({ type: 'foo' } as any),
         ),
         graph: graphReducer(
-            prevState && prevState.wallet ? prevState.wallet.graph : undefined,
+            prevState?.wallet ? prevState.wallet.graph : undefined,
             action || ({ type: 'foo' } as any),
         ),
         formDrafts: {},

--- a/packages/suite/src/actions/wallet/__tests__/publicKeyActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/publicKeyActions.test.ts
@@ -14,7 +14,7 @@ const setTrezorConnectFixtures = (fixture: any) => {
     let buttonRequest: ((e?: any) => any) | undefined;
 
     const getPublicKey = (_params: any) => {
-        if (fixture && fixture.getPublicKey) {
+        if (fixture?.getPublicKey) {
             if (fixture.getPublicKey.success && buttonRequest) {
                 buttonRequest({ code: 'ButtonRequest_PublicKey' });
             }
@@ -107,7 +107,7 @@ describe('PublicKeyActions', () => {
             await store.dispatch(connectInitThunk());
             await store.dispatch(f.action() as any);
 
-            if (f.result && f.result.actions) {
+            if (f.result?.actions) {
                 expect(store.getActions()).toMatchObject(f.result.actions);
             }
         });

--- a/packages/suite/src/actions/wallet/__tests__/receiveActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/receiveActions.test.ts
@@ -24,7 +24,7 @@ const setTrezorConnectFixtures = (fixture?: any) => {
     let buttonRequest: ((e?: any) => any) | undefined;
 
     const getAddress = (_params: any) => {
-        if (fixture && fixture.getAddress) {
+        if (fixture?.getAddress) {
             if (fixture.getAddress.success && buttonRequest) {
                 buttonRequest({ code: 'ButtonRequest_Address' });
             }
@@ -149,7 +149,7 @@ describe('ReceiveActions', () => {
             await store.dispatch(connectInitThunk());
             await store.dispatch(f.action());
 
-            if (f.result && f.result.actions) {
+            if (f.result?.actions) {
                 expect(store.getActions()).toMatchObject(f.result.actions);
             }
         });

--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -796,7 +796,7 @@ export const restoreCoinjoinSession =
         }
         // get fresh data from reducer
         const coinjoinAccount = selectCoinjoinAccountByKey(getState(), account.key);
-        if (!coinjoinAccount || !coinjoinAccount.session) {
+        if (!coinjoinAccount?.session) {
             return errorToast('Coinjoin account session is missing');
         }
 

--- a/packages/suite/src/actions/wallet/exportTransactionsActions.ts
+++ b/packages/suite/src/actions/wallet/exportTransactionsActions.ts
@@ -50,7 +50,7 @@ export const exportTransactionsThunk = createThunk(
         );
         const metadataKeys = account?.metadata[1];
         let labels = {};
-        if (!metadataKeys || !metadataKeys?.fileName || !provider?.data[metadataKeys.fileName]) {
+        if (!metadataKeys?.fileName || !provider?.data[metadataKeys.fileName]) {
             labels = { outputLabels: {} };
         } else {
             labels = provider.data[metadataKeys.fileName];

--- a/packages/suite/src/actions/wallet/selectedAccountActions.ts
+++ b/packages/suite/src/actions/wallet/selectedAccountActions.ts
@@ -98,7 +98,7 @@ export const getAccountState = (state: AppState): SelectedAccountStatus => {
     // get selected account
     const account = getSelectedAccount(device.state.staticSessionId, state.wallet.accounts, params);
     // account does exist
-    if (account && account.visible) {
+    if (account?.visible) {
         if (account.backendType === 'coinjoin') {
             if (account.status === 'initial' || (account.status === 'error' && account.syncing)) {
                 return {

--- a/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
@@ -94,7 +94,7 @@ export const prepareTxPlan = async (
     cardanoPools: AdaPools['pools'],
     votingDelegation?: VotingDelegationOption,
 ) => {
-    if (!account || account.networkType !== 'cardano') return;
+    if (account?.networkType !== 'cardano') return;
 
     const changeAddress = getUnusedChangeAddress(account);
     const stakingPath = getStakingPath(account);
@@ -307,12 +307,7 @@ export const signTransaction =
         if (!selectedAccount?.account) return;
 
         const device = selectSelectedDevice(getState());
-        if (
-            selectedAccount.status !== 'loaded' ||
-            !device ||
-            !transactionInfo ||
-            transactionInfo.type !== 'final'
-        ) {
+        if (selectedAccount.status !== 'loaded' || !device || transactionInfo?.type !== 'final') {
             return;
         }
 

--- a/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
@@ -304,7 +304,7 @@ export const signTransaction =
     async (dispatch: Dispatch, getState: GetState, extra: ExtraDependencies) => {
         const { selectedAccount, stake } = getState().wallet;
         const cardanoPools = selectCardanoPoolsInfo(getState());
-        if (!selectedAccount || !selectedAccount.account) return;
+        if (!selectedAccount?.account) return;
 
         const device = selectSelectedDevice(getState());
         if (

--- a/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
@@ -115,12 +115,7 @@ export const signTransaction =
     async (dispatch: Dispatch, getState: GetState, extra: ExtraDependencies) => {
         const { selectedAccount } = getState().wallet;
         const device = selectSelectedDevice(getState());
-        if (
-            selectedAccount.status !== 'loaded' ||
-            !device ||
-            !transactionInfo ||
-            transactionInfo.type !== 'final'
-        )
+        if (selectedAccount.status !== 'loaded' || !device || transactionInfo?.type !== 'final')
             return;
 
         const { account, network } = selectedAccount;

--- a/packages/suite/src/actions/wallet/stake/stakeFormSolanaActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormSolanaActions.ts
@@ -256,12 +256,7 @@ export const signTransaction =
         const { selectedAccount, blockchain } = getState().wallet;
 
         const device = selectSelectedDevice(getState());
-        if (
-            selectedAccount.status !== 'loaded' ||
-            !device ||
-            !transactionInfo ||
-            transactionInfo.type !== 'final'
-        ) {
+        if (selectedAccount.status !== 'loaded' || !device || transactionInfo?.type !== 'final') {
             return;
         }
 

--- a/packages/suite/src/components/connection/BluetoothConnectionModal.tsx
+++ b/packages/suite/src/components/connection/BluetoothConnectionModal.tsx
@@ -36,9 +36,7 @@ export const BluetoothConnectionModal = ({ onClose }: BluetoothConnectionModalPr
     };
 
     if (
-        selectedDevice !== undefined &&
-        selectedDevice !== null &&
-        selectedDevice.connectionStatus.type === 'pairing' &&
+        selectedDevice?.connectionStatus.type === 'pairing' &&
         (selectedDevice.connectionStatus?.pin?.length ?? 0) > 0
     ) {
         return (

--- a/packages/suite/src/components/earn/dashboard/common/EarnInactiveNetworkOpportunity.tsx
+++ b/packages/suite/src/components/earn/dashboard/common/EarnInactiveNetworkOpportunity.tsx
@@ -35,7 +35,7 @@ export const EarnInactiveNetworkOpportunity = ({
     const isDiscoveringThisNetwork = isDiscoveryRunning && isNetworkEnabled;
     const { name } = getNetwork(symbol);
 
-    const isDeviceDisconnected = !device || !device.connected;
+    const isDeviceDisconnected = !device?.connected;
     const isButtonDisabled = isDeviceDisconnected || isDiscoveryRunning;
     const tooltipMessage = isDeviceDisconnected ? (
         <Translation id="TR_TO_ADD_NEW_ACCOUNT_PLEASE_CONNECT" />

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldInactiveVaultOpportunity.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldInactiveVaultOpportunity.tsx
@@ -30,7 +30,7 @@ export const EarnYieldInactiveVaultOpportunity = ({
     const isDiscoveringThisNetwork = isDiscoveryRunning && isNetworkEnabled;
     const { name } = getNetwork(opportunity.networkSymbol);
 
-    const isDeviceDisconnected = !device || !device.connected;
+    const isDeviceDisconnected = !device?.connected;
     const isButtonDisabled = isDeviceDisconnected || isDiscoveryRunning;
     const tooltipMessage = isDeviceDisconnected ? (
         <Translation id="TR_TO_ADD_NEW_ACCOUNT_PLEASE_CONNECT" />

--- a/packages/suite/src/components/guide/GuideCategories.tsx
+++ b/packages/suite/src/components/guide/GuideCategories.tsx
@@ -29,7 +29,7 @@ type GuideCategoriesProps = {
 };
 
 export const GuideCategories = ({ node, label }: GuideCategoriesProps) => {
-    if (!node || node.type !== 'category') {
+    if (node?.type !== 'category') {
         return null;
     }
 

--- a/packages/suite/src/components/suite/TorLoader/TorLoader.tsx
+++ b/packages/suite/src/components/suite/TorLoader/TorLoader.tsx
@@ -46,7 +46,7 @@ export const TorLoader = ({ callback }: TorLoadingScreenProps) => {
         if (progress === 100) {
             setProgress(0);
         }
-        if (torBootstrap && torBootstrap.current) {
+        if (torBootstrap?.current) {
             setProgress(torBootstrap.current);
             if (torBootstrap.current === torBootstrap.total) {
                 dispatch(updateTorStatus(TorStatus.Enabled));

--- a/packages/suite/src/components/suite/banners/SuiteBanners/OutOfQuotaBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/OutOfQuotaBanner.tsx
@@ -20,7 +20,7 @@ export const OutOfQuotaBanner = () => {
     if (shouldDisplay === false) return null;
 
     const handleDismiss = () => {
-        if (!device || !device.id) return false;
+        if (!device?.id) return false;
 
         dispatch(noQuotaLeftWarningDismissed({ deviceId: device.id }));
     };

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/AppShortcuts.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/AppShortcuts.tsx
@@ -13,8 +13,7 @@ export const AppShortcuts = () => {
     const dispatch = useDispatch();
 
     const discoveryStatus = useSelector(selectDiscoveryOverallStatus);
-    const discoveryInProgress =
-        discoveryStatus !== undefined && discoveryStatus.status === 'loading';
+    const discoveryInProgress = discoveryStatus?.status === 'loading';
 
     useEvent('keydown', e => {
         const { altKey, metaKey } = e;

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceSelector.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceSelector.tsx
@@ -110,7 +110,7 @@ export const DeviceSelector = () => {
                     </Box>
 
                     <ExpandedSidebarOnly>
-                        {selectedDevice && selectedDevice.state && (
+                        {selectedDevice?.state && (
                             <CaretContainer>
                                 <Icon size={20} name="caretCircleDown" />
                             </CaretContainer>

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal/GlobalReceiveModal.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal/GlobalReceiveModal.tsx
@@ -28,7 +28,7 @@ export const GlobalReceiveModal = ({ onCancel, onSubmit }: GlobalReceiveModalPro
     const analytics = useAnalytics();
     const { device } = useDevice();
     const { isDiscoveryRunning } = useDiscovery();
-    const isAddAccountDisabled = isDiscoveryRunning || !device || !device.connected;
+    const isAddAccountDisabled = isDiscoveryRunning || !device?.connected;
     const accountModal = useModal(false);
     const dispatch = useDispatch();
 

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Sidebar.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Sidebar.tsx
@@ -133,10 +133,7 @@ export const Sidebar = ({ showAccounts = true }: SidebarProps) => {
     }, [setAutoCollapseSuppressed]);
 
     const showAccountsAndIsDeviceReady =
-        !shouldDisplayDeviceCompromised &&
-        selectedDevice !== undefined &&
-        selectedDevice.mode === 'normal' &&
-        showAccounts;
+        !shouldDisplayDeviceCompromised && selectedDevice?.mode === 'normal' && showAccounts;
 
     useEffect(() => {
         if (contentWidth == null) return;

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseModal.tsx
@@ -80,7 +80,7 @@ export const PassphraseModal = ({ device }: { device: TrezorDevice }) => {
 
     const offerPassphraseOnDevice = useSelector(selectHasDevicePassphraseEntryCapability);
 
-    if (!device || !discovery || !discovery.isAddingHiddenWallet) return null;
+    if (!device || !discovery?.isAddingHiddenWallet) return null;
 
     switch (discovery.status) {
         case 'progress':

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApproveModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApproveModal.tsx
@@ -210,9 +210,7 @@ export const ApproveModal = ({
 
     const providers = getProvidersInfoProps(context);
     const provider =
-        selectedQuote && selectedQuote.exchange && providers
-            ? providers[selectedQuote.exchange]
-            : undefined;
+        selectedQuote?.exchange && providers ? providers[selectedQuote.exchange] : undefined;
 
     return (
         <Modal

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConfirmUnverifiedModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConfirmUnverifiedModal.tsx
@@ -56,7 +56,7 @@ export const ConfirmUnverifiedModal = ({
     const enablePassphraseAndContinue = async () => {
         if (!device?.available) {
             const result = await dispatch(applySettings({ use_passphrase: true }));
-            if (!result || !result.success) return;
+            if (!result?.success) return;
         }
     };
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/RevokeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/RevokeModal.tsx
@@ -139,9 +139,7 @@ export const RevokeModal = ({ setIsWaitingForDevice, onCancel }: RevokeModalProp
 
     const providers = getProvidersInfoProps(context);
     const provider =
-        selectedQuote && selectedQuote.exchange && providers
-            ? providers[selectedQuote.exchange]
-            : undefined;
+        selectedQuote?.exchange && providers ? providers[selectedQuote.exchange] : undefined;
 
     return (
         <Modal

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ReplaceTxButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ReplaceTxButton.tsx
@@ -13,8 +13,7 @@ export const ReplaceTxButton = () => {
 
     const values = getValues();
     const composedTx = composedLevels ? composedLevels[values.selectedFee || 'normal'] : undefined;
-    const isDisabled =
-        !composedTx || composedTx.type !== 'final' || isLocked() || (device && !device.available);
+    const isDisabled = composedTx?.type !== 'final' || isLocked() || (device && !device.available);
 
     const areFeesLoading = useSelector(state => selectAreFeesLoading(state, account.symbol));
 

--- a/packages/suite/src/components/wallet/WalletLayout/AccountException/DiscoveryFailed.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountException/DiscoveryFailed.tsx
@@ -11,8 +11,7 @@ import { useDiscovery, useDispatch } from 'src/hooks/suite';
 export const DiscoveryFailed = () => {
     const dispatch = useDispatch();
     const { discovery } = useDiscovery();
-    const description =
-        discovery !== undefined && discovery.status === 'failed' ? discovery.error : undefined;
+    const description = discovery?.status === 'failed' ? discovery.error : undefined;
 
     const handleClick = () => dispatch(startOrRestartDiscoveryThunk());
 

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
@@ -55,8 +55,7 @@ const Accounts = ({
         <>
             {accounts.map(account => {
                 const isSelected = (account: Account) =>
-                    params &&
-                    account.symbol === params.symbol &&
+                    account.symbol === params?.symbol &&
                     account.accountType === params.accountType &&
                     account.index === params.accountIndex;
 
@@ -102,7 +101,7 @@ export const AccountsList = ({
     const { isSidebarCollapsed } = useResponsiveContext();
     const { coinFilter, searchString } = useAccountSearch();
     const discoveryStatus = useSelector(selectDiscoveryOverallStatus);
-    const discoveryInProgress = discoveryStatus && discoveryStatus.status === 'loading';
+    const discoveryInProgress = discoveryStatus?.status === 'loading';
 
     if (!device) {
         return null;

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AddAccountButton.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AddAccountButton.tsx
@@ -23,7 +23,7 @@ export const AddAccountButton = ({ device, isIconOnly }: AddAccountButtonProps) 
     const dispatch = useDispatch();
 
     // TODO: add more cases when adding account is not possible
-    const addAccountDisabled = isDiscoveryRunning || !device || !device.connected;
+    const addAccountDisabled = isDiscoveryRunning || !device?.connected;
     const tooltipMessage = getExplanationMessage(device, isDiscoveryRunning);
     const dataTestId = '@account-menu/add-account';
 

--- a/packages/suite/src/hooks/earn/useCardanoStaking.ts
+++ b/packages/suite/src/hooks/earn/useCardanoStaking.ts
@@ -157,7 +157,7 @@ export const useCardanoStaking = (): CardanoStaking => {
     );
 
     // TODO: improve this hook for non-cardano accounts
-    if (!account || account.networkType !== 'cardano') {
+    if (account?.networkType !== 'cardano') {
         return {
             isStakingDisabled: true,
             deposit: undefined,

--- a/packages/suite/src/hooks/earn/useClaimForm.ts
+++ b/packages/suite/src/hooks/earn/useClaimForm.ts
@@ -123,7 +123,7 @@ export const useClaimForm = ({ account }: UseClaimFormsProps): ClaimContextValue
     const signTx = useCallback(async () => {
         const values = getValues();
         const composedTx = composedLevels ? composedLevels[selectedFee] : undefined;
-        if (composedTx && composedTx.type === 'final') {
+        if (composedTx?.type === 'final') {
             const result = await dispatch(
                 signTransaction(values, composedTx as PrecomposedTransactionFinal),
             );

--- a/packages/suite/src/hooks/earn/useSupplyForm.ts
+++ b/packages/suite/src/hooks/earn/useSupplyForm.ts
@@ -355,7 +355,7 @@ export const useSupplyForm = ({ account }: UseSupplyFormProps): SupplyContextVal
     const signTx = useCallback(async () => {
         const values = getValues();
         const composedTx = composedLevels ? composedLevels[selectedFee] : undefined;
-        if (composedTx && composedTx.type === 'final') {
+        if (composedTx?.type === 'final') {
             setIsLoading(true);
             const result = await dispatch(
                 signTransaction(values, composedTx as PrecomposedTransactionFinal),

--- a/packages/suite/src/hooks/earn/useWithdrawalForm.ts
+++ b/packages/suite/src/hooks/earn/useWithdrawalForm.ts
@@ -272,7 +272,7 @@ export const useWithdrawalForm = ({ account }: UseWithdrawalFormProps): Withdraw
     const signTx = useCallback(async () => {
         const values = getValues();
         const composedTx = composedLevels ? composedLevels[selectedFee] : undefined;
-        if (composedTx && composedTx.type === 'final') {
+        if (composedTx?.type === 'final') {
             const result = await dispatch(
                 signTransaction(values, composedTx as PrecomposedTransactionFinal),
             );

--- a/packages/suite/src/hooks/suite/useDiscovery.ts
+++ b/packages/suite/src/hooks/suite/useDiscovery.ts
@@ -10,11 +10,11 @@ export const useDiscovery = () => {
     const discovery = useSelector(state => selectDiscoveryByDevicePath(state, device?.path));
 
     const calculateProgress = useCallback(() => {
-        if (discovery && discovery.status === 'starting') {
+        if (discovery?.status === 'starting') {
             return 1;
         }
 
-        if (discovery && discovery.status === 'progress') {
+        if (discovery?.status === 'progress') {
             return discovery.progress;
         }
 

--- a/packages/suite/src/hooks/wallet/form/useCompose.ts
+++ b/packages/suite/src/hooks/wallet/form/useCompose.ts
@@ -258,7 +258,7 @@ export const useCompose = <TFieldValues extends FormState>({
         const precomposedTransaction = composedLevels
             ? composedLevels[formState.selectedFee || 'normal']
             : undefined;
-        if (precomposedTransaction && precomposedTransaction.type === 'final') {
+        if (precomposedTransaction?.type === 'final') {
             // sign workflow in Actions:
             // signSendFormTransactionThunk > sign[COIN]TransactionThunk > sendFormActions.storeSignedTransaction (modal with promise decision)
             const result = await dispatch(

--- a/packages/suite/src/hooks/wallet/form/useFees.ts
+++ b/packages/suite/src/hooks/wallet/form/useFees.ts
@@ -140,7 +140,7 @@ export const useFees = <TFieldValues extends FeesFormValues>({
             )!;
             // set custom values from a previously selected composed transaction
             // or from previously selected FeeLevel
-            const transactionInfo = composedLevels && composedLevels[currentLevel.label];
+            const transactionInfo = composedLevels?.[currentLevel.label];
 
             const hasNoError = !baseFee && transactionInfo && transactionInfo.type !== 'error';
 

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
@@ -182,8 +182,7 @@ export const useTradingFormActions = <T extends TradingSellExchangeFormProps>({
     const onCryptoCurrencyChange = async (selected: TradingAssetSellOption) => {
         const cryptoSelectedCurrent = getValues(TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT);
         const isSameCryptoSelected =
-            cryptoSelectedCurrent &&
-            cryptoSelectedCurrent.accountKey === selected.accountKey &&
+            cryptoSelectedCurrent?.accountKey === selected.accountKey &&
             cryptoSelectedCurrent.id === selected.id;
         const account = accounts.find(item => item.key === selected.accountKey);
 

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -608,7 +608,7 @@ export const useTradingExchangeForm = ({
 
         const quote = requiresApproval ? selectedQuote : dexQuotes[0];
 
-        if (!quote || !quote.dexTx) {
+        if (!quote?.dexTx) {
             setValue('transactionData', '');
             setValue(TRADING_FORM_OUTPUT_ADDRESS, '');
 

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeWatchApproval.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeWatchApproval.ts
@@ -22,7 +22,7 @@ export const useTradingExchangeWatchApproval = ({
     const [refreshCount, setRefreshCount] = useState(1);
 
     useEffect(() => {
-        if (selectedQuote && selectedQuote.status === 'APPROVAL_PENDING' && !isScheduled) {
+        if (selectedQuote?.status === 'APPROVAL_PENDING' && !isScheduled) {
             const poll = async () => {
                 await watchApproval({ refreshCount });
                 setRefreshCount(prev => prev + 1);

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingReceiveAddress.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingReceiveAddress.ts
@@ -250,9 +250,7 @@ export const useTradingReceiveAddress = ({
                 : undefined;
 
         const matchingAccount = suiteReceiveAccounts?.find(account =>
-            sendAccount && sendAccount.symbol === account.symbol
-                ? account.key === sendAccount.key
-                : true,
+            sendAccount?.symbol === account.symbol ? account.key === sendAccount.key : true,
         );
 
         if (matchingAccount) {

--- a/packages/suite/src/hooks/wallet/trading/useTradingWatchTrade.ts
+++ b/packages/suite/src/hooks/wallet/trading/useTradingWatchTrade.ts
@@ -25,7 +25,7 @@ export const tradeFinalStatuses: Record<TradingType, TradingTradeStatusType[]> =
 };
 
 const shouldRefreshTrade = (trade: TradingTransaction | undefined) =>
-    trade && trade.data.status && !tradeFinalStatuses[trade.tradeType].includes(trade.data.status);
+    trade?.data.status && !tradeFinalStatuses[trade.tradeType].includes(trade.data.status);
 
 export const useTradingWatchTrade = <T extends TradingType>({
     account,

--- a/packages/suite/src/hooks/wallet/useChangeDelegateForm.ts
+++ b/packages/suite/src/hooks/wallet/useChangeDelegateForm.ts
@@ -110,7 +110,7 @@ export const useChangeDelegateForm = ({
     const signTx = useCallback(async () => {
         const values = getValues();
         const composedTx = composedLevels ? composedLevels[selectedFee] : undefined;
-        if (composedTx && composedTx.type === 'final') {
+        if (composedTx?.type === 'final') {
             const result = await dispatch(
                 signTransaction(values, composedTx as PrecomposedTransactionFinal),
             );

--- a/packages/suite/src/middlewares/suite/redirectMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/redirectMiddleware.ts
@@ -14,7 +14,7 @@ import { type Action, type AppState, type Dispatch, type TrezorDevice } from 'sr
 
 const handleDeviceRedirect = (dispatch: Dispatch, state: AppState, device?: TrezorDevice) => {
     // no device, no redirect
-    if (!device || !device.features) {
+    if (!device?.features) {
         return;
     }
 

--- a/packages/suite/src/middlewares/suite/redirectMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/redirectMiddleware.ts
@@ -31,11 +31,7 @@ const handleDeviceRedirect = (dispatch: Dispatch, state: AppState, device?: Trez
         dispatch(goto({ routeName: 'suite-start' }));
     }
     // firmware none (T2T1) or unknown (T1B1) indicates freshly unpacked device
-    if (
-        device.mode === 'bootloader' &&
-        device.features &&
-        device.features.firmware_present === false
-    ) {
+    if (device.mode === 'bootloader' && device.features?.firmware_present === false) {
         dispatch(goto({ routeName: 'suite-start' }));
     }
     // device firmware update required, redirect to "firmware update"

--- a/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
@@ -38,13 +38,8 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
         let becomesConnected = false;
         if (deviceActions.updateSelectedDevice.match(action)) {
             const prevDevice = prevState.device.selectedDevice;
-            becomesAcquired = !!(prevDevice && !prevDevice.features && device && device.features);
-            becomesConnected = !!(
-                prevDevice &&
-                !prevDevice.connected &&
-                device &&
-                device.connected
-            );
+            becomesAcquired = !!(prevDevice && !prevDevice.features && device?.features);
+            becomesConnected = !!(prevDevice && !prevDevice.connected && device?.connected);
         }
 
         // device becomesAcquired (device-change event) and is locked at the same time.

--- a/packages/suite/src/middlewares/wallet/replaceByFeeErrorMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/replaceByFeeErrorMiddleware.ts
@@ -30,7 +30,7 @@ export const replaceByFeeErrorMiddleware =
 
         const addedTransaction = transactions.find(tx => tx.txid === precomposedTx.prevTxid);
 
-        if (addedTransaction !== undefined && addedTransaction.blockHeight !== undefined) {
+        if (addedTransaction?.blockHeight !== undefined) {
             api.dispatch(replaceByFeeErrorThunk());
         }
 

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -196,7 +196,7 @@ const updateSession = (
     }: ExtractActionPayload<typeof COINJOIN.SESSION_ROUND_CHANGED>,
 ) => {
     const account = getAccount(draft, accountKey);
-    if (!account || !account.session) return;
+    if (!account?.session) return;
 
     const { roundPhase } = account.session;
     const { phase, phaseDeadline } = round;
@@ -222,7 +222,7 @@ const sessionTxSigned = (
     payload: ExtractActionPayload<typeof COINJOIN.SESSION_TX_SIGNED>,
 ) => {
     const account = getAccount(draft, payload.accountKey);
-    if (!account || !account.session) return;
+    if (!account?.session) return;
     account.rawLiquidityClue = payload.rawLiquidityClue;
     account.session = {
         ...account.session,
@@ -250,7 +250,7 @@ const removeTxCandidate = (
 ) => {
     payload.accountKeys.forEach(key => {
         const account = getAccount(draft, key);
-        if (account && account.transactionCandidates) {
+        if (account?.transactionCandidates) {
             account.transactionCandidates = account.transactionCandidates.filter(
                 tx => tx.roundId !== payload.round.id,
             );
@@ -266,7 +266,7 @@ const updateSessionStarting = (
     payload: ExtractActionPayload<typeof COINJOIN.SESSION_STARTING>,
 ) => {
     const account = getAccount(draft, payload.accountKey);
-    if (!account || !account.session) return;
+    if (!account?.session) return;
     if (payload.isStarting) {
         account.session = {
             ...account.session,
@@ -302,7 +302,7 @@ const pauseSession = (
     payload: ExtractActionPayload<typeof COINJOIN.SESSION_PAUSE>,
 ) => {
     const account = getAccount(draft, payload.accountKey);
-    if (!account || !account.session) return;
+    if (!account?.session) return;
 
     delete account.session.roundPhase;
     delete account.session.sessionDeadline;
@@ -316,7 +316,7 @@ const restoreSession = (
     payload: ExtractActionPayload<typeof COINJOIN.SESSION_RESTORE>,
 ) => {
     const account = getAccount(draft, payload.accountKey);
-    if (!account || !account.session) return;
+    if (!account?.session) return;
 
     delete account.session.paused;
     delete account.session.isAutoStopEnabled;
@@ -402,7 +402,7 @@ const updateSessionPhase = (
         accountKey => getAccount(draft, accountKey) || [],
     );
 
-    if (!accounts || !accounts.length) {
+    if (!accounts?.length) {
         return;
     }
 

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -986,8 +986,7 @@ export const selectCurrentCoinjoinWheelStates = (state: CoinjoinRootState & Devi
         coinjoinClient?.version?.legalDocumentsVersion ?? ZKSNACKS_LEGAL_DOCUMENTS_VERSION;
 
     const isLegalDocumentConfirmed =
-        agreedToLegalDocumentVersions &&
-        agreedToLegalDocumentVersions.zkSNACKs === latestZkSNACKsLegalDocumentVersion &&
+        agreedToLegalDocumentVersions?.zkSNACKs === latestZkSNACKsLegalDocumentVersion &&
         agreedToLegalDocumentVersions.trezor === latestTezorLegalDocumentVersion;
 
     // error state

--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -462,9 +462,7 @@ export const runLegacyMigrations: OnUpgradeFunc<SuiteDBSchema> = async (
             const { features } = device;
 
             device.firmwareType =
-                features &&
-                features.capabilities &&
-                !features.capabilities.includes('Capability_Bitcoin_like')
+                features?.capabilities && !features.capabilities.includes('Capability_Bitcoin_like')
                     ? FirmwareType.BitcoinOnly
                     : FirmwareType.Universal;
 

--- a/packages/suite/src/storage/migrations/versions/25.8.0.ts
+++ b/packages/suite/src/storage/migrations/versions/25.8.0.ts
@@ -11,7 +11,7 @@ export default createMigration<SuiteDBSchema>('25.8.0', async (db, tx) => {
         const store = tx.objectStore('suiteSettings');
         const suiteSettings = await store.get('suite');
 
-        if (suiteSettings && suiteSettings.settings) {
+        if (suiteSettings?.settings) {
             if (
                 typeof suiteSettings.settings.language === 'string' &&
                 suiteSettings.settings.language.length === 2

--- a/packages/suite/src/utils/suite/env.ts
+++ b/packages/suite/src/utils/suite/env.ts
@@ -49,7 +49,7 @@ export const submitRequestForm = async (
 const getDarkThemeQuery = (): MediaQueryList | undefined => {
     const matchMedia = window?.matchMedia;
 
-    return matchMedia && matchMedia('(prefers-color-scheme: dark)');
+    return matchMedia?.('(prefers-color-scheme: dark)');
 };
 
 export const getOsTheme = () => (getDarkThemeQuery()?.matches ? 'dark' : 'light');

--- a/packages/suite/src/utils/wallet/coinjoinUtils.ts
+++ b/packages/suite/src/utils/wallet/coinjoinUtils.ts
@@ -85,7 +85,7 @@ export const calculateAnonymityProgress = ({
     anonymitySet: AnonymitySet | undefined;
     utxos: Account['utxo'];
 }): number => {
-    if (!anonymitySet || targetAnonymity === undefined || !utxos || !utxos.length) {
+    if (!anonymitySet || targetAnonymity === undefined || !utxos?.length) {
         return 0;
     }
 

--- a/packages/suite/src/utils/wallet/exportTransactionsUtils.ts
+++ b/packages/suite/src/utils/wallet/exportTransactionsUtils.ts
@@ -263,7 +263,7 @@ const prepareContent = (
                 });
             }
 
-            if (t.cardanoSpecific && t.cardanoSpecific.subtype) {
+            if (t.cardanoSpecific?.subtype) {
                 const { subtype, withdrawal = '0', deposit = '0' } = t.cardanoSpecific;
 
                 const amount = (() => {

--- a/packages/suite/src/utils/wallet/graph/utils.ts
+++ b/packages/suite/src/utils/wallet/graph/utils.ts
@@ -197,7 +197,7 @@ export const calcYDomain = (
 
     // no txs, but there could be non zero balance we still need to show
     const lastBalanceBn = lastBalance ? new BigNumber(lastBalance) : null;
-    if (lastBalanceBn && lastBalanceBn.gt(0)) {
+    if (lastBalanceBn?.gt(0)) {
         return [minValue, lastBalanceBn.toNumber() * 1.2];
     }
 

--- a/packages/suite/src/utils/wallet/trading/tradingUtils.ts
+++ b/packages/suite/src/utils/wallet/trading/tradingUtils.ts
@@ -224,7 +224,7 @@ interface GetTradeProviderProps {
 }
 
 export const getTradeProvider = ({ trade, providerInfo }: GetTradeProviderProps) => {
-    if (!trade || !trade.exchange) return undefined;
+    if (!trade?.exchange) return undefined;
 
     return providerInfo?.[trade.exchange];
 };

--- a/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
@@ -170,9 +170,8 @@ export const AssetsView = () => {
         currentFiatRates,
     );
 
-    const discoveryInProgress = discoveryStatus && discoveryStatus.status === 'loading';
-    const isError =
-        discoveryStatus && discoveryStatus.status === 'exception' && !assetSymbols.length;
+    const discoveryInProgress = discoveryStatus?.status === 'loading';
+    const isError = discoveryStatus?.status === 'exception' && !assetSymbols.length;
 
     const openActivateAssetsModal = () => {
         analytics.report({
@@ -183,7 +182,7 @@ export const AssetsView = () => {
     };
     const setTable = () => dispatch(setFlag({ key: 'dashboardAssetsGridMode', value: false }));
     const setGrid = () => dispatch(setFlag({ key: 'dashboardAssetsGridMode', value: true }));
-    const isDiscoveryEmpty = discoveryStatus && discoveryStatus.type === 'discovery-empty';
+    const isDiscoveryEmpty = discoveryStatus?.type === 'discovery-empty';
     const showCards = isBelowTablet || dashboardAssetsGridMode;
 
     if (isDiscoveryEmpty) {

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
@@ -70,7 +70,7 @@ export const PortfolioCard = memo(() => {
     // 3. Discovery stops (no accounts added), Loading unmounted, new instance of DashboardGraph gets mounted
 
     let body = null;
-    if (discoveryStatus && discoveryStatus.status === 'exception') {
+    if (discoveryStatus?.status === 'exception') {
         body = (
             <PortfolioCardException
                 exception={discoveryStatus}
@@ -89,7 +89,7 @@ export const PortfolioCard = memo(() => {
                 failed={failedAccounts}
             />
         );
-    } else if (discoveryStatus && discoveryStatus.status === 'loading') {
+    } else if (discoveryStatus?.status === 'loading') {
         if (isDeviceEmpty) {
             body = <EmptyWalletSkeleton />;
         } else if (hasLoadedNonEmptyAccount && hasNetworkWithEnabledGraph) {

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardException.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardException.tsx
@@ -103,7 +103,7 @@ const discoveryFailedMessage = (
     discovery: DiscoveryStatus | undefined,
     failed: FailedAccount[],
 ) => {
-    if (!discovery || discovery.status !== 'failed') return '';
+    if (discovery?.status !== 'failed') return '';
     if (discovery.error) return <div>{discovery.error}</div>;
 
     // Group all failed networks into array of errors.

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardException.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardException.tsx
@@ -195,7 +195,7 @@ export const PortfolioCardException = ({
                         action: async () => {
                             // enable passphrase
                             const result = await dispatch(applySettings({ use_passphrase: true }));
-                            if (!result || !result.success) return;
+                            if (!result?.success) return;
                             // restart discovery
                             dispatch(startOrRestartDiscoveryThunk());
                         },

--- a/packages/suite/src/views/onboarding/steps/BackupTypeStep.tsx
+++ b/packages/suite/src/views/onboarding/steps/BackupTypeStep.tsx
@@ -59,7 +59,7 @@ export const BackupTypeStep = () => {
         }
     }, [deviceModel, handleSubmit, unitPackaging, deviceDefaultBackupType]);
 
-    if (!device || !device.features) {
+    if (!device?.features) {
         return null;
     }
 

--- a/packages/suite/src/views/onboarding/steps/PinStep.tsx
+++ b/packages/suite/src/views/onboarding/steps/PinStep.tsx
@@ -62,14 +62,14 @@ export const PinStep = () => {
                 }
             }
 
-            if (device && device.features.pin_protection) {
+            if (device?.features.pin_protection) {
                 setStatus('success');
                 goToNextStep();
             }
         }
     }, [device, goToNextStep]);
 
-    if (!device || !device.features) {
+    if (!device?.features) {
         return null;
     }
 

--- a/packages/suite/src/views/onboarding/steps/RecoveryStep/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/RecoveryStep/index.tsx
@@ -30,7 +30,7 @@ export const RecoveryStep = () => {
     const recoveryWordRequestInputType = useSelector(selectRecoveryWordRequestInputType);
     const dispatch = useDispatch();
 
-    if (!device || !device.features) {
+    if (!device?.features) {
         return null;
     }
 

--- a/packages/suite/src/views/onboarding/steps/RecoveryStep/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/RecoveryStep/index.tsx
@@ -212,7 +212,7 @@ export const RecoveryStep = () => {
         );
     }
 
-    if (device && device.mode === 'normal') {
+    if (device?.mode === 'normal') {
         // Ready to continue to the next step
         const handleClick = () => dispatch(goToNextStep('set-pin'));
 

--- a/packages/suite/src/views/settings/SettingsDebug/CoinjoinApi.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/CoinjoinApi.tsx
@@ -124,10 +124,7 @@ export const CoinjoinApi = () => {
                         symbol={symbol}
                         version={clients[symbol]?.version}
                         environments={environments}
-                        value={
-                            debug?.coinjoinServerEnvironment &&
-                            debug?.coinjoinServerEnvironment[symbol]
-                        }
+                        value={debug?.coinjoinServerEnvironment?.[symbol]}
                         onChange={handleServerChange}
                     />
                 );

--- a/packages/suite/src/views/settings/SettingsDevice/Homescreen.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/Homescreen.tsx
@@ -61,7 +61,7 @@ export const Homescreen = ({ isDeviceLocked }: HomescreenProps) => {
     };
 
     const onUploadHomescreen = async (files: FileList | null) => {
-        if (!files || !files.length) return;
+        if (!files?.length) return;
         let file = files[0];
 
         let validationResult = await validateImage({ file, deviceModelInternal });

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
@@ -114,8 +114,8 @@ const TokenRowBasicActions = ({
                 getContractAddressForNetworkSymbol(account.symbol, token.contract),
     );
 
-    const isSupplyButtonDisabled = !availableVault || !availableVault.status.enter;
-    const isWithdrawButtonDisabled = !availableVault || !availableVault.status.exit;
+    const isSupplyButtonDisabled = !availableVault?.status.enter;
+    const isWithdrawButtonDisabled = !availableVault?.status.exit;
 
     if (!unusedAddress || !device) return null;
 

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailBuy/TradingDetailBuy.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailBuy/TradingDetailBuy.tsx
@@ -59,8 +59,7 @@ export const TradingDetailBuy = () => {
     const composedTransaction = useSelector(selectTradingComposedTransactionInfo);
 
     const exchange = trade?.data?.exchange;
-    const provider =
-        info && info.providerInfos && exchange ? info.providerInfos[exchange] : undefined;
+    const provider = info?.providerInfos && exchange ? info.providerInfos[exchange] : undefined;
 
     const country = trade?.data?.country;
 

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchange.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchange.tsx
@@ -67,8 +67,7 @@ export const TradingDetailExchange = () => {
     const composedTransaction = useSelector(selectTradingComposedTransactionInfo);
 
     const exchange = trade?.data?.exchange;
-    const provider =
-        info && info.providerInfos && exchange ? info.providerInfos[exchange] : undefined;
+    const provider = info?.providerInfos && exchange ? info.providerInfos[exchange] : undefined;
 
     const quoteAmounts: TradingGetCryptoQuoteAmountProps = {
         sendAmount: trade?.data?.sendStringAmount ?? '',

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSell/TradingDetailSell.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSell/TradingDetailSell.tsx
@@ -52,8 +52,7 @@ export const TradingDetailSell = () => {
     const composedTransaction = useSelector(selectTradingComposedTransactionInfo);
 
     const exchange = trade?.data?.exchange;
-    const provider =
-        info && info.providerInfos && exchange ? info.providerInfos[exchange] : undefined;
+    const provider = info?.providerInfos && exchange ? info.providerInfos[exchange] : undefined;
 
     const country = trade?.data?.country;
 

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx
@@ -99,7 +99,7 @@ export const TradingFormApproval = () => {
     };
 
     const onRevokeClick = async () => {
-        if (!selectedQuote || !selectedQuote.receiveAddress) {
+        if (!selectedQuote?.receiveAddress) {
             return;
         }
 
@@ -121,7 +121,7 @@ export const TradingFormApproval = () => {
     };
 
     const onProceedToSwapClick = async () => {
-        if (!selectedQuote || !selectedQuote.receiveAddress) {
+        if (!selectedQuote?.receiveAddress) {
             return;
         }
 

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputFiat.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputFiat.tsx
@@ -205,8 +205,9 @@ export const TradingFormInputFiat = ({
                                   selectedCurrencyCode || 'usd',
                                   tokenAddress,
                               );
-                              const rate =
-                                  rates && rates[fiatRateKey] ? rates[fiatRateKey].rate : undefined;
+                              const rate = rates?.[fiatRateKey]
+                                  ? rates[fiatRateKey].rate
+                                  : undefined;
                               const minFiat = toFiatCurrency({
                                   amount: context.amountLimits.minCrypto,
                                   rate,

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer/components/TradingFormOfferOTC.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer/components/TradingFormOfferOTC.tsx
@@ -71,7 +71,7 @@ export const TradingFormOfferOTC = () => {
 
     const fiatAmount = amountInCrypto ? fiatAmountConverted : fiatInput;
 
-    if (!otcData || !otcData.minFiatLimits || !otcData.links || !fiatAmount) {
+    if (!otcData?.minFiatLimits || !otcData.links || !fiatAmount) {
         return null;
     }
 
@@ -86,7 +86,7 @@ export const TradingFormOfferOTC = () => {
         return null;
     }
 
-    if (otcProviders && otcProviders.length === 0) {
+    if (otcProviders?.length === 0) {
         return null;
     }
 

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeSlippageModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeSlippageModal.tsx
@@ -73,7 +73,6 @@ export const TradingOfferExchangeSlippageModal = ({
             if (slippage !== CUSTOM_SLIPPAGE) return;
 
             if (
-                selectedQuote &&
                 selectedQuote?.dexTx &&
                 selectedQuote.receiveAddress &&
                 !customSlippageError &&

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferSell/TradingOfferSellBankAccount.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferSell/TradingOfferSellBankAccount.tsx
@@ -128,7 +128,7 @@ export const TradingOfferSellBankAccount = () => {
         selectedQuote?.bankAccounts ? selectedQuote?.bankAccounts[0] : undefined,
     );
 
-    if (!selectedQuote || !selectedQuote.bankAccounts) return null;
+    if (!selectedQuote?.bankAccounts) return null;
 
     const { bankAccounts } = selectedQuote;
 

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferSell/TradingOfferSellTransaction.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferSell/TradingOfferSellTransaction.tsx
@@ -67,7 +67,7 @@ export const TradingSelectedOfferSellTransaction = () => {
     });
     const sellTrade = trade?.data || selectedQuote;
 
-    if (!sellTrade || !sellTrade.exchange) return null;
+    if (!sellTrade?.exchange) return null;
 
     const {
         exchange,

--- a/packages/transport-common/src/sessions/background.ts
+++ b/packages/transport-common/src/sessions/background.ts
@@ -113,7 +113,7 @@ export class SessionsBackground
                 id: message.type,
             } as HandleMessageResponse<M>;
         } finally {
-            if (result && result.success && result.payload) {
+            if (result?.success && result.payload) {
                 if ('descriptors' in result.payload) {
                     const { descriptors } = result.payload;
                     this.emit('descriptors', descriptors);

--- a/suite-common/calldata/src/validation/evm/address.ts
+++ b/suite-common/calldata/src/validation/evm/address.ts
@@ -15,7 +15,7 @@ export const findZeroAddressIssue: InspectFn<EvmAddress> = value =>
 type SenderContext = ContextWith<{ sender?: EvmAddress }>;
 
 export const findSelfAddressIssue: InspectFn<EvmAddress, SenderContext> = (value, context) =>
-    context?.sender && value.toLowerCase() === context.sender.toLowerCase() ? 'SELF_ADDRESS' : null;
+    value.toLowerCase() === context?.sender?.toLowerCase() ? 'SELF_ADDRESS' : null;
 
 export const findSenderMismatchIssue: InspectFn<EvmAddress, SenderContext> = (value, context) =>
     context?.sender && value.toLowerCase() !== context.sender.toLowerCase()

--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -105,7 +105,7 @@ export const connectPopupCallThunkInner = createThunk<
             // todo: be smarter about the timeout based on actual connection events
             const maxAttempts = source.type === CALL_SOURCE_DEEPLINK ? 10 : 5;
             // retry loop to wait for device to reconnect
-            while (!device || !device.connected) {
+            while (!device?.connected) {
                 await resolveAfter(1000);
                 device = selectSelectedDevice(getState());
                 attempt++;
@@ -247,7 +247,7 @@ export const connectPopupDeeplinkThunk = createThunk<void, { url: string }>(
         const queryParams = Object.fromEntries(parsedUrl.searchParams.entries());
 
         // Validate params
-        const version = path && path.split('/').slice(-2, -1)[0];
+        const version = path?.split('/').slice(-2, -1)[0];
         if (
             !queryParams?.method ||
             !queryParams?.params ||
@@ -319,7 +319,7 @@ export const connectPopupVerifyAddressThunk = createThunk<void, { index: number 
 
         const device = selectSelectedDevice(getState());
         const call = selectConnectPopupCall(getState());
-        if (!device || !call || call.state !== 'address-confirmation') return;
+        if (!device || call?.state !== 'address-confirmation') return;
 
         // Update loading state of addresses
         dispatch(

--- a/suite-common/connect-popup/src/methodHooks/bitcoinSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/bitcoinSignTransaction.ts
@@ -30,7 +30,7 @@ const preCallHook = async <M extends CallMethodKeys>({
                 throw new Error(`Network not supported`);
             }
             const accountPath = txSigningPrecomposed.inputs.find(i => i.address_n);
-            if (!accountPath || !accountPath.address_n) {
+            if (!accountPath?.address_n) {
                 throw new Error('Account not found in inputs');
             }
             const path = getSerializedPath(accountPath.address_n.slice(0, 3)) as Bip43Path;

--- a/suite-common/device/src/deviceReducer.ts
+++ b/suite-common/device/src/deviceReducer.ts
@@ -395,7 +395,7 @@ const disconnectDevice = (draft: DeviceReducerState, device: TrezorDevice) => {
  */
 const updateTimestamp = (draft: DeviceReducerState, device?: TrezorDevice) => {
     // only acquired devices
-    if (!device || !device.features) return;
+    if (!device?.features) return;
     const index = deviceUtils.findInstanceIndex(draft.devices, device);
     if (!draft.devices[index]) return;
     // update timestamp
@@ -414,7 +414,7 @@ const updateTimestamp = (draft: DeviceReducerState, device?: TrezorDevice) => {
 // TODO: this now can only be used for imported device!
 const createInstance = (draft: DeviceReducerState, device: TrezorDevice) => {
     // only acquired devices
-    if (!device || !device.features) return;
+    if (!device?.features) return;
 
     const isPortfolioTrackerDevice = device.id === PORTFOLIO_TRACKER_DEVICE_ID;
 
@@ -444,7 +444,7 @@ const createInstance = (draft: DeviceReducerState, device: TrezorDevice) => {
  */
 const remember = (draft: DeviceReducerState, device: TrezorDevice, shouldRemember: boolean) => {
     // only acquired devices
-    if (!device || !device.features) return;
+    if (!device?.features) return;
     draft.devices.forEach(d => {
         if (deviceUtils.isSelectedInstance(device, d)) {
             d.remember = shouldRemember;
@@ -463,7 +463,7 @@ const setTemporaryRememberedDevice = (
     device: TrezorDevice,
     temporaryRemember: boolean,
 ) => {
-    if (!device || !device.features) return;
+    if (!device?.features) return;
     const index = deviceUtils.findInstanceIndex(draft.devices, device);
     const selectedInstance = draft.devices[index];
     if (!selectedInstance) return;
@@ -486,7 +486,7 @@ const setTemporaryRememberedDevice = (
  */
 const forget = (draft: DeviceReducerState, device: TrezorDevice) => {
     // only acquired devices
-    if (!device || !device.features) return;
+    if (!device?.features) return;
     const index = deviceUtils.findInstanceIndex(draft.devices, device);
     if (!draft.devices[index]) return;
     const others = deviceUtils.getDeviceInstances(device, draft.devices, true);
@@ -513,7 +513,7 @@ const addButtonRequest = (
     buttonRequest: ButtonRequest,
 ) => {
     // only acquired devices
-    if (!device || !device.features) return;
+    if (!device?.features) return;
     const index = deviceUtils.findInstanceIndex(draft.devices, device);
     if (!draft.devices[index]) return;
     // update state
@@ -527,7 +527,7 @@ const removeButtonRequests = (
     buttonRequestCode?: ButtonRequest['code'],
 ) => {
     // only acquired devices
-    if (!device || !device.features) return;
+    if (!device?.features) return;
     const index = deviceUtils.findInstanceIndex(draft.devices, device);
     if (!draft.devices[index]) return;
     // update state

--- a/suite-common/device/src/deviceUtils.ts
+++ b/suite-common/device/src/deviceUtils.ts
@@ -50,8 +50,4 @@ export const isStablecoinYieldSupported = (device: TrezorDevice | undefined) => 
 export const isTrezorDeviceWithState = (
     device: TrezorDevice | undefined,
 ): device is TrezorDeviceWithState =>
-    device !== undefined &&
-    device.id !== null &&
-    device.state !== undefined &&
-    device.state !== null &&
-    device.state.staticSessionId !== undefined;
+    device !== undefined && device.id !== null && device.state?.staticSessionId !== undefined;

--- a/suite-common/firmware-authenticity/src/useReportDeviceCompromised.ts
+++ b/suite-common/firmware-authenticity/src/useReportDeviceCompromised.ts
@@ -107,7 +107,7 @@ const useReportHashCheck = ({ device, selectAllowPrerelease }: CommonProps) => {
     }, [dispatch, commonData, errorType, errorPayload, attemptCount, shouldReport]);
 
     // success bears warning if it needed retries, so we report the previous error payload, see Device.ts in connect
-    const isHashCheckSuccess = hashCheck && hashCheck.success;
+    const isHashCheckSuccess = hashCheck?.success;
     const warningPayload = isHashCheckSuccess ? hashCheck.warningPayload : null;
     useEffect(() => {
         if (warningPayload) {

--- a/suite-common/firmware/src/hooks/useFirmwareInstallation.ts
+++ b/suite-common/firmware/src/hooks/useFirmwareInstallation.ts
@@ -204,7 +204,7 @@ export const useFirmwareInstallation = () => {
             return {
                 operation: 'restarting',
                 // NOTE: when restarting to bootloader, set the progress to 0 (can't be finished yet)
-                progress: reconnectEvent && reconnectEvent.target === 'bootloader' ? 0 : 100,
+                progress: reconnectEvent?.target === 'bootloader' ? 0 : 100,
             };
         }
 

--- a/suite-common/graph/src/graphDataFetching.ts
+++ b/suite-common/graph/src/graphDataFetching.ts
@@ -110,7 +110,7 @@ const getBalanceFromAccountInfo = ({
     const findTokenBalance = () => {
         const token = accountInfo.tokens?.find(t => t.contract === contractId);
 
-        if (token && token.balance) {
+        if (token?.balance) {
             // this is raw value from getAccountInfo, we need to divide it by 10^decimals (in redux it's already formatted)
             return new BigNumber(token.balance).div(10 ** token.decimals).toFixed();
         }

--- a/suite-common/message-system/src/featureFlagUtils.ts
+++ b/suite-common/message-system/src/featureFlagUtils.ts
@@ -6,7 +6,7 @@ import { Feature as FeatureDefinitions } from './messageSystemTypes';
 export const parseTimeoutThresholdsPerModel = (
     feature: Feature | undefined,
 ): Partial<FirmwareHashCheckTimeouts> => {
-    if (feature === undefined || feature.domain !== FeatureDefinitions.firmwareHashCheckTimeout) {
+    if (feature?.domain !== FeatureDefinitions.firmwareHashCheckTimeout) {
         return {};
     }
 

--- a/suite-common/message-system/src/messageSystemUtils.ts
+++ b/suite-common/message-system/src/messageSystemUtils.ts
@@ -202,7 +202,7 @@ export const isDeviceCompatible = (deviceConditions: Device[], device?: TrezorDe
     if (!deviceConditions.length) {
         return !device;
     }
-    if (!device || !device.features) {
+    if (!device?.features) {
         return false;
     }
 

--- a/suite-common/staking/src/utils/ethereumStaking.ts
+++ b/suite-common/staking/src/utils/ethereumStaking.ts
@@ -628,7 +628,6 @@ export const getDaysToAddToPool = (
     validatorsQueue?: EthValidatorsQueue | null,
 ) => {
     if (
-        !validatorsQueue ||
         validatorsQueue?.addingDelay === undefined ||
         validatorsQueue?.activationTime === undefined
     ) {
@@ -670,7 +669,6 @@ export const getDaysToUnstake = (
 
 export const getDaysToAddToPoolInitial = (validatorsQueue?: EthValidatorsQueue | null) => {
     if (
-        !validatorsQueue ||
         validatorsQueue?.addingDelay === undefined ||
         validatorsQueue?.activationTime === undefined
     ) {

--- a/suite-common/test-utils/__mocks__/@trezor/connect.ts
+++ b/suite-common/test-utils/__mocks__/@trezor/connect.ts
@@ -21,7 +21,7 @@ const getNextFixture = (_methodName: string) => {
 
 const result = (methodName: string, defaults: any) =>
     jest.fn(params => {
-        if (params && params.__info) {
+        if (params?.__info) {
             realMethods['init']({
                 manifest: {
                     email: '',

--- a/suite-common/trading/src/__tests__/utils.test.ts
+++ b/suite-common/trading/src/__tests__/utils.test.ts
@@ -77,7 +77,7 @@ describe('filterQuotesAccordingTags', () => {
 
         expect(filterQuotesAccordingTags([])).toStrictEqual([]);
         expect(filterQuotesAccordingTags(quotes).length).toStrictEqual(
-            quotes.filter(q => !q.tags || !q.tags.includes('alternativeCurrency')).length,
+            quotes.filter(q => !q.tags?.includes('alternativeCurrency')).length,
         );
     });
 });

--- a/suite-common/trading/src/thunks/buy/confirmBuyTradeThunk.ts
+++ b/suite-common/trading/src/thunks/buy/confirmBuyTradeThunk.ts
@@ -59,7 +59,7 @@ export const confirmBuyTradeThunk = createThunk(
             returnUrl,
         });
 
-        if (!response || !response.trade || !response.trade.paymentId) {
+        if (!response?.trade?.paymentId) {
             dispatch(
                 logErrorThunk({
                     errorMessage: 'No response from the server',

--- a/suite-common/trading/src/thunks/buy/loadBuyInfoThunk.ts
+++ b/suite-common/trading/src/thunks/buy/loadBuyInfoThunk.ts
@@ -13,7 +13,7 @@ export const loadBuyInfoThunk = createThunk<BuyInfo>(
     async (_, { fulfillWithValue }) => {
         const buyInfo = await invityAPI.getBuyList();
 
-        if (!buyInfo || !buyInfo.providers) {
+        if (!buyInfo?.providers) {
             return fulfillWithValue({
                 buyInfo: {
                     country: regional.UNKNOWN_COUNTRY,

--- a/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
+++ b/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
@@ -160,12 +160,7 @@ export const recomposeAndSignTxThunk = createThunk<
                 }),
             ).unwrap();
 
-            if (
-                !normalLevels ||
-                !normalLevels.normal ||
-                normalLevels.normal.type !== 'final' ||
-                !normalLevels.normal.feeLimit
-            ) {
+            if (normalLevels?.normal?.type !== 'final' || !normalLevels.normal.feeLimit) {
                 const error: TradingSendRejectedProps['error'] =
                     normalLevels?.normal?.type === 'error' && normalLevels?.normal?.errorMessage
                         ? {
@@ -204,7 +199,7 @@ export const recomposeAndSignTxThunk = createThunk<
 
         const precomposedToSign = composedLevels.payload[selectedFee];
 
-        if (!precomposedToSign || precomposedToSign.type !== 'final') {
+        if (precomposedToSign?.type !== 'final') {
             const error: TradingSendRejectedProps['error'] =
                 precomposedToSign?.type === 'error' && precomposedToSign.errorMessage
                     ? {

--- a/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts
@@ -58,8 +58,7 @@ export const sendDexTransactionThunk = createThunk<
         const providers = selectTradingExchangeProviders(getState());
 
         if (
-            !selectedQuote ||
-            !selectedQuote.dexTx ||
+            !selectedQuote?.dexTx ||
             !selectedQuote.receiveAddress ||
             (selectedQuote.status !== 'APPROVAL_REQ' && selectedQuote.status !== 'CONFIRM')
         ) {

--- a/suite-common/trading/src/thunks/exchange/sendTransactionThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/sendTransactionThunk.ts
@@ -83,12 +83,7 @@ export const sendTransactionThunk = createThunk<
             }
         }
 
-        if (
-            !selectedTrade ||
-            !selectedTrade.orderId ||
-            !selectedTrade.sendStringAmount ||
-            !sendAddress
-        ) {
+        if (!selectedTrade?.orderId || !selectedTrade.sendStringAmount || !sendAddress) {
             return rejectWithValue({
                 type: 'error',
                 error: { id: 'TR_TRADING_CANNOT_SEND_TRANSACTION' },

--- a/suite-common/trading/src/thunks/sell/sendSellTransactionThunk.ts
+++ b/suite-common/trading/src/thunks/sell/sendSellTransactionThunk.ts
@@ -57,12 +57,7 @@ export const sendSellTransactionThunk = createThunk(
 
         dispatch(tradingActions.setModalAccountKey(account.key));
 
-        if (
-            !selectedTrade ||
-            !selectedTrade.orderId ||
-            !destinationAddress ||
-            !selectedTrade.cryptoStringAmount
-        ) {
+        if (!selectedTrade?.orderId || !destinationAddress || !selectedTrade.cryptoStringAmount) {
             return rejectWithValue({
                 type: 'error',
                 error: { id: 'TR_TRADING_CANNOT_SEND_TRANSACTION' },

--- a/suite-common/trading/src/utils.ts
+++ b/suite-common/trading/src/utils.ts
@@ -239,7 +239,7 @@ export const getDefaultCountrySubdivision = (
 
 export const filterQuotesAccordingTags = <T extends TradingTradeBuySellType>(
     quotes: TradingTradeBuySellMapProps[T][],
-) => quotes.filter(q => !q.tags || !q.tags.includes('alternativeCurrency'));
+) => quotes.filter(q => !q.tags?.includes('alternativeCurrency'));
 
 // fill orderId for all, paymentId for sell and buy, quoteId for exchange
 export const addIdsToQuotes = <T extends TradingType>(

--- a/suite-common/trading/src/utils.ts
+++ b/suite-common/trading/src/utils.ts
@@ -340,7 +340,7 @@ export const getTradingFormState = ({
 
             const networkData = cryptoIdToNetworkAndContractAddress(trade.cryptoCurrency);
 
-            if (!networkData || !networkData.network) {
+            if (!networkData?.network) {
                 return defaultState;
             }
 

--- a/suite-common/trading/src/utils/sell/sellUtils.ts
+++ b/suite-common/trading/src/utils/sell/sellUtils.ts
@@ -93,8 +93,9 @@ const needToRegisterOrVerifyBankAccount = ({
 
     // for BANK_ACCOUNT flow a message is shown if bank account is not verified
     if (provider?.flow === 'BANK_ACCOUNT') {
-        const isSomeBankAccountVerified =
-            quote.bankAccounts && quote.bankAccounts.some(bankAccount => bankAccount.verified);
+        const isSomeBankAccountVerified = quote.bankAccounts?.some(
+            bankAccount => bankAccount.verified,
+        );
 
         return !!quote.quoteId && !isSomeBankAccountVerified;
     }

--- a/suite-common/trading/src/utils/signature/__tests__/signatureUtils.test.ts
+++ b/suite-common/trading/src/utils/signature/__tests__/signatureUtils.test.ts
@@ -188,7 +188,7 @@ describe('signatureUtils', () => {
             const result = tradingExchangeCreatePaymentRequest(propsWithTestnet);
 
             expect(result).toBeDefined();
-            if (result && result.memos && result.memos[0]) {
+            if (result?.memos?.[0]) {
                 expect(result.memos[0].coin_purchase_memo?.coin_type).toBe(1); // ALL_TESTNETS - HARDENED_OFFSET
             }
         });
@@ -208,7 +208,7 @@ describe('signatureUtils', () => {
             const result = tradingExchangeCreatePaymentRequest(propsWithBch);
 
             expect(result).toBeDefined();
-            if (result && result.memos && result.memos[0]) {
+            if (result?.memos?.[0]) {
                 expect(result.memos[0].coin_purchase_memo?.coin_type).toBe(145); // BCH coin type
             }
         });
@@ -228,7 +228,7 @@ describe('signatureUtils', () => {
             const result = tradingExchangeCreatePaymentRequest(propsWithLtc);
 
             expect(result).toBeDefined();
-            if (result && result.memos && result.memos[0]) {
+            if (result?.memos?.[0]) {
                 expect(result.memos[0].coin_purchase_memo?.coin_type).toBe(2); // LTC coin type
             }
         });
@@ -375,7 +375,7 @@ describe('signatureUtils', () => {
             const result = tradingSellCreatePaymentRequest(propsWithEmptyMemo);
 
             expect(result).toBeDefined();
-            if (result && result.memos && result.memos[0]) {
+            if (result?.memos?.[0]) {
                 expect(result.memos[0].text_memo?.text).toBe('');
             }
         });
@@ -389,7 +389,7 @@ describe('signatureUtils', () => {
             const result = tradingSellCreatePaymentRequest(propsWithSpecialMemo);
 
             expect(result).toBeDefined();
-            if (result && result.memos && result.memos[0]) {
+            if (result?.memos?.[0]) {
                 expect(result.memos[0].text_memo?.text).toBe('Special chars: àáâãäåæçèéêë');
             }
         });
@@ -438,7 +438,7 @@ describe('signatureUtils', () => {
             });
 
             expect(result).toBeDefined();
-            if (result && result.memos && result.memos[0]) {
+            if (result?.memos?.[0]) {
                 expect(result.amount).toBe('99999999999999'); // subunits (satoshis)
                 expect(result.memos[0].coin_purchase_memo?.amount).toBe('1000000.12345678 ETH');
             }
@@ -486,7 +486,7 @@ describe('signatureUtils', () => {
             });
 
             expect(result).toBeDefined();
-            if (result && result.memos && result.memos[0]) {
+            if (result?.memos?.[0]) {
                 expect(result.amount).toBe('1'); // subunits (satoshis)
                 expect(result.memos[0].coin_purchase_memo?.amount).toBe('0.00000001 ETH');
             }

--- a/suite-common/transaction-search/src/getExcludedUtxos.ts
+++ b/suite-common/transaction-search/src/getExcludedUtxos.ts
@@ -23,7 +23,7 @@ export const getExcludedUtxos = ({
     const excludedUtxos: ExcludedUtxos = {};
     utxos?.forEach(utxo => {
         const outpoint = getUtxoOutpoint(utxo);
-        const anonymity = (anonymitySet && anonymitySet[utxo.address]) || 1;
+        const anonymity = anonymitySet?.[utxo.address] || 1;
         if (new BigNumber(utxo.amount).lt(Number(dustLimit))) {
             // is lower than dust limit
             excludedUtxos[outpoint] = 'dust';

--- a/suite-common/wallet-core/src/accounts/accountsThunks.ts
+++ b/suite-common/wallet-core/src/accounts/accountsThunks.ts
@@ -185,7 +185,7 @@ export const fetchAndUpdateAccountThunk = createThunk(
             const devices = selectDevices(getState());
             const accountDevice = findAccountDevice(account, devices);
             analyze.newTransactions.forEach(tx => {
-                const token = tx.tokens && tx.tokens.length ? tx.tokens[0] : undefined;
+                const token = tx.tokens?.length ? tx.tokens[0] : undefined;
 
                 const bitcoinAmountUnit = selectBitcoinAmountUnit(getState());
                 const areSatoshisUsed = getAreSatoshisUsed(bitcoinAmountUnit, account);

--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
@@ -326,7 +326,7 @@ export const onBlockchainNotificationThunk = createThunk(
         if (tx.type === 'recv' && !tx.blockHeight) {
             const accountDevice = findAccountDevice(account, selectDevices(getState()));
 
-            const token = tx.tokens && tx.tokens.length ? tx.tokens[0] : undefined;
+            const token = tx.tokens?.length ? tx.tokens[0] : undefined;
             const areSatoshisUsed = getAreSatoshisUsed(
                 selectBitcoinAmountUnit(getState()),
                 account,

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -72,7 +72,7 @@ function assertDeviceIsAuthorized(device?: TrezorDevice): asserts device is Auth
 }
 
 function assertDeviceIsAcquired(device?: TrezorDevice): asserts device is AcquiredDevice {
-    if (!device || !device.features) {
+    if (!device?.features) {
         throw new Error('assertion error: device is not acquired');
     }
 }

--- a/suite-common/wallet-core/src/selectors.ts
+++ b/suite-common/wallet-core/src/selectors.ts
@@ -224,7 +224,7 @@ export const selectIsTxOutputInternal = createMemoizedSelector(
         }),
     ],
     (accounts, { symbol, output }) => {
-        if (!symbol || !output || output.type !== 'address') return false;
+        if (!symbol || output?.type !== 'address') return false;
         const matchingAccounts = findAccountsByAddress(symbol, output.value, accounts);
 
         return matchingAccounts.length > 0;

--- a/suite-common/wallet-core/src/send/composeCancelTransaction/resolveCancelAddress.ts
+++ b/suite-common/wallet-core/src/send/composeCancelTransaction/resolveCancelAddress.ts
@@ -10,11 +10,7 @@ type ResolveCancelAddress = {
 export const resolveCancelAddress = ({ account, tx }: ResolveCancelAddress): string => {
     const firstChangeAddress = tx.details.vout.find(vout => vout.isAccountOwned);
 
-    if (
-        firstChangeAddress !== undefined &&
-        firstChangeAddress.addresses !== undefined &&
-        firstChangeAddress.addresses.length > 0
-    ) {
+    if (firstChangeAddress?.addresses !== undefined && firstChangeAddress.addresses.length > 0) {
         return firstChangeAddress.addresses[0];
     }
 

--- a/suite-common/wallet-core/src/send/sendFormRippleStellarThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormRippleStellarThunks.ts
@@ -74,7 +74,7 @@ const calculate = (
         } as const;
     }
 
-    if (requiredAmount && requiredAmount.gt(amount)) {
+    if (requiredAmount?.gt(amount)) {
         return {
             type: 'error',
             error: 'AMOUNT_IS_LESS_THAN_RESERVE',

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -541,7 +541,7 @@ export const signTransactionThunk = createThunk<
     ) => {
         const device = selectSelectedDevice(getState());
 
-        if (!device || !precomposedTransaction || precomposedTransaction.type !== 'final')
+        if (!device || precomposedTransaction?.type !== 'final')
             return rejectWithValue({
                 error: 'sign-transaction-failed',
                 message: 'Invalid input data.',

--- a/suite-common/wallet-core/src/settings/walletSettingsReducer.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsReducer.ts
@@ -157,7 +157,7 @@ export const selectIsAmountInSats = (
     }
 
     const network = getNetwork(symbol);
-    const isAmountUnitSupported = network && network.features.includes('amount-unit');
+    const isAmountUnitSupported = network?.features.includes('amount-unit');
 
     return isAmountUnitSupported && selectAreSatsAmountUnit(state);
 };

--- a/suite-common/wallet-core/src/transactions/transactionsReducer.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsReducer.ts
@@ -39,7 +39,7 @@ export const prepareTransactionsReducer = createReducerWithExtraDeps(
             .addCase(transactionsActions.replaceTransaction, (state, { payload }) => {
                 const { key, txid, tx } = payload;
                 const accountTxs = initializeAccount(state, key);
-                const index = accountTxs.findIndex(t => t && t.txid === txid);
+                const index = accountTxs.findIndex(t => t?.txid === txid);
                 if (accountTxs[index]) accountTxs[index] = tx;
             })
             .addCase(transactionsActions.removeTransaction, (state, { payload }) => {
@@ -82,7 +82,7 @@ export const prepareTransactionsReducer = createReducerWithExtraDeps(
                     } else {
                         // update the transaction if conditions are met
                         const existingTxIndex = accountTxs.findIndex(
-                            t => t && t.txid === existingTx.txid,
+                            t => t?.txid === existingTx.txid,
                         );
                         const existingBlockHeight = existingTx.blockHeight ?? 0;
                         const incomingBlockHeight = transaction.blockHeight ?? 0;

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -498,7 +498,7 @@ export const fetchTransactionsPageThunk = createThunk(
             throw new Error(`Account not found: ${accountKey}`);
         }
 
-        if (result && result.success) {
+        if (result?.success) {
             const updateAction = accountsActions.updateAccount(currentAccount, result.payload);
             const updatedAccount = updateAction.payload;
             const updatedTransactions = result.payload.history.transactions || [];

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -117,7 +117,7 @@ export const sortByBIP44AddressIndex = <T extends { path: string }>(
 export const parseBIP44Path = (path: string) => {
     const regEx = /m\/(\d+'?)\/(\d+'?)\/(\d+'?)\/([0,1])\/(\d+)/;
     const tokens = path.match(regEx);
-    if (!tokens || tokens.length !== 6) {
+    if (tokens?.length !== 6) {
         return null;
     }
 
@@ -720,8 +720,8 @@ export const getAccountSpecific = (accountInfo: Partial<AccountInfo>, networkTyp
         return {
             networkType,
             misc: {
-                sequence: misc && misc.sequence ? misc.sequence : 0,
-                reserve: misc && misc.reserve ? misc.reserve : '0',
+                sequence: misc?.sequence ? misc.sequence : 0,
+                reserve: misc?.reserve ? misc.reserve : '0',
             },
             marker: accountInfo.marker,
             stellarCursor: undefined,
@@ -734,7 +734,7 @@ export const getAccountSpecific = (accountInfo: Partial<AccountInfo>, networkTyp
             networkType,
             misc: {
                 ...misc,
-                nonce: misc && misc.nonce ? misc.nonce : '0',
+                nonce: misc?.nonce ? misc.nonce : '0',
             },
             marker: undefined,
             stellarCursor: undefined,
@@ -747,11 +747,11 @@ export const getAccountSpecific = (accountInfo: Partial<AccountInfo>, networkTyp
             networkType,
             misc: {
                 staking: {
-                    rewards: misc && misc.staking ? misc.staking.rewards : '0',
-                    isActive: misc && misc.staking ? misc.staking.isActive : false,
-                    address: misc && misc.staking ? misc.staking.address : '',
-                    poolId: misc && misc.staking ? misc.staking.poolId : null,
-                    drep: misc && misc.staking ? misc.staking.drep : null,
+                    rewards: misc?.staking ? misc.staking.rewards : '0',
+                    isActive: misc?.staking ? misc.staking.isActive : false,
+                    address: misc?.staking ? misc.staking.address : '',
+                    poolId: misc?.staking ? misc.staking.poolId : null,
+                    drep: misc?.staking ? misc.staking.drep : null,
                 },
             },
             marker: undefined,

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -395,7 +395,7 @@ export const getBitcoinComposeOutputs = (
     // one Output is valid and "final" but other has only address
     // to prevent composing "final" transaction switch it to not-final (noaddress)
     const hasIncompleteOutput = values.outputs.find(
-        (o, i) => setMaxOutputId !== i && o && o.address && !o.amount,
+        (o, i) => setMaxOutputId !== i && o?.address && !o.amount,
     );
     if (hasIncompleteOutput) {
         const finalOutput = result.find(o => o.type === 'send-max' || o.type === 'payment');

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -337,7 +337,7 @@ export const sumTransactionsFiat = (
 };
 
 export const findTransaction = (txid: string, transactions: WalletAccountTransaction[]) =>
-    transactions.find(t => t && t.txid === txid);
+    transactions.find(t => t?.txid === txid);
 
 export const findTransactions = (
     txid: string,

--- a/suite-common/walletconnect/src/walletConnectThunks.ts
+++ b/suite-common/walletconnect/src/walletConnectThunks.ts
@@ -269,11 +269,7 @@ export const sessionProposalApproveThunk = createThunk<
     async ({ eventId, selectedDefaultAccount }, { dispatch, getState, extra }) => {
         try {
             const pendingProposal = selectPendingProposal(getState());
-            if (
-                !pendingProposal ||
-                pendingProposal.eventId !== eventId ||
-                pendingProposal.expired
-            ) {
+            if (pendingProposal?.eventId !== eventId || pendingProposal.expired) {
                 throw new Error('Proposal not found');
             }
 

--- a/suite-native/device/src/deviceThunks.ts
+++ b/suite-native/device/src/deviceThunks.ts
@@ -54,7 +54,7 @@ export const createAndBackupWalletThunk = createThunk<
         // Used only in tests! See deviceReducer for the property definition.
         const simulatedFailResult = selectSimulatedEntropyCheckFail(getState());
 
-        if (!device || !device.features || !devicePath) {
+        if (!device?.features || !devicePath) {
             return rejectWithValue('Device not found');
         }
 

--- a/suite-native/module-accounts-management/src/components/StellarTokenActions.tsx
+++ b/suite-native/module-accounts-management/src/components/StellarTokenActions.tsx
@@ -41,7 +41,7 @@ export const StellarTokenActions = ({ accountKey, tokenContract }: StellarTokenA
         selectAccountTokenBalance(state, accountKey, tokenContract),
     );
 
-    if (!account || account.networkType !== 'stellar' || !tokenContract) {
+    if (account?.networkType !== 'stellar' || !tokenContract) {
         return null;
     }
 

--- a/suite-native/module-accounts-management/src/components/TronResources/TronResources.tsx
+++ b/suite-native/module-accounts-management/src/components/TronResources/TronResources.tsx
@@ -26,7 +26,7 @@ export const TronResources = ({ accountKey }: TronResourcesProps) => {
         selectAccountByKey(state, accountKey),
     );
 
-    if (!account || account.networkType !== 'tron') return null;
+    if (account?.networkType !== 'tron') return null;
 
     const { tronResources } = account.misc;
 

--- a/suite-native/module-send/src/components/TronAccountActivationInfo.tsx
+++ b/suite-native/module-send/src/components/TronAccountActivationInfo.tsx
@@ -30,7 +30,7 @@ export const TronAccountActivationInfo = ({ accountKey }: TronAccountActivationI
     );
     const feeLevels = useSelector((state: NativeSendRootState) => selectFeeLevels(state));
 
-    if (!account || account.networkType !== 'tron') return null;
+    if (account?.networkType !== 'tron') return null;
 
     const normalLevel = feeLevels.normal;
 

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeFiatDeviationWarning.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeFiatDeviationWarning.tsx
@@ -32,7 +32,7 @@ export const ExchangeFiatDeviationWarning = ({ quote }: ExchangeFiatDeviationWar
         [locale],
     );
 
-    if (!quote || !exchangeDeviation || !exchangeDeviation.exceedsThreshold) {
+    if (!quote || !exchangeDeviation?.exceedsThreshold) {
         return null;
     }
 

--- a/suite-native/module-trading/src/components/general/Footer.tsx
+++ b/suite-native/module-trading/src/components/general/Footer.tsx
@@ -20,7 +20,7 @@ interface FooterProviderContentProps {
 }
 
 const FooterProviderContent = ({ provider }: FooterProviderContentProps) => {
-    if (!provider || !provider.termsUrl) {
+    if (!provider?.termsUrl) {
         return (
             <Text variant="body-sm" color="contentSecondary" textAlign="center">
                 <Translation id="moduleTrading.tradingScreen.footer.termsAndConditionsGeneric" />

--- a/suite-native/module-trading/src/components/sell/SellPreview/SellToFiatTradePreviewCard.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/SellToFiatTradePreviewCard.tsx
@@ -13,7 +13,7 @@ export type SellToFiatTradePreviewCardProps = {
 export const SellToFiatTradePreviewCard = ({ quote }: SellToFiatTradePreviewCardProps) => {
     const { toStringValue } = useChangeStringsExtractor(quote);
 
-    if (!quote || !quote.paymentMethod || !quote.fiatCurrency || !toStringValue) {
+    if (!quote?.paymentMethod || !quote.fiatCurrency || !toStringValue) {
         return null;
     }
 

--- a/suite-native/module-trading/src/hooks/general/useWatchTrade.ts
+++ b/suite-native/module-trading/src/hooks/general/useWatchTrade.ts
@@ -34,7 +34,7 @@ const REFRESH_SECONDS_BASE = 30;
 const REFRESH_SECONDS_IN_PROGRESS = 10;
 
 export const shouldRefreshTrade = (trade: TradingTransaction | undefined) =>
-    trade && trade.data.status && !tradeFinalStatuses[trade.tradeType].includes(trade.data.status);
+    trade?.data.status && !tradeFinalStatuses[trade.tradeType].includes(trade.data.status);
 
 export const useWatchTrade = ({ accountKey, orderId, isInProgress }: TradingUseWatchTradeProps) => {
     const dispatch = useDispatch();

--- a/suite-native/navigation/src/routeUtils.ts
+++ b/suite-native/navigation/src/routeUtils.ts
@@ -15,7 +15,7 @@ export type AppNavigationState = NavigationState<AppTabsParamList>;
  * Recursively get the most specific active route name from the hierarchy of navigation states.
  */
 export const getActiveRouteName = (state: AppNavigationState): string | undefined => {
-    if (!state || !state.routes || state.index == null) return undefined;
+    if (!state?.routes || state.index == null) return undefined;
 
     const route = state.routes[state.index];
 

--- a/suite-native/passphrase/src/passphraseSelectors.ts
+++ b/suite-native/passphrase/src/passphraseSelectors.ts
@@ -44,7 +44,7 @@ export { selectIsCreatingNewPassphraseWallet };
 export const selectPassphraseDeviceNotEmpty = (state: DiscoveryRootState & DeviceRootState) => {
     const discovery = selectDiscoveryByDevicePath(state, state.device.selectedDevice?.path);
 
-    if (!discovery || !discovery.isAddingHiddenWallet) {
+    if (!discovery?.isAddingHiddenWallet) {
         return null;
     }
 
@@ -61,7 +61,7 @@ export const selectPassphraseDeviceNotEmpty = (state: DiscoveryRootState & Devic
 export const selectPassphraseDiscoveryCompleted = (state: DiscoveryRootState & DeviceRootState) => {
     const discovery = selectDiscoveryByDevicePath(state, state.device.selectedDevice?.path);
 
-    if (!discovery || !discovery.isAddingHiddenWallet) {
+    if (!discovery?.isAddingHiddenWallet) {
         return null;
     }
 

--- a/suite-native/staking/src/cardanoStakingSelectors.ts
+++ b/suite-native/staking/src/cardanoStakingSelectors.ts
@@ -34,7 +34,7 @@ export const selectCardanoStakedBalanceByAccountKey = (
     accountKey: AccountKey,
 ) => {
     const account = selectAccountByKey(state, accountKey);
-    if (!account || account.networkType !== 'cardano') return null;
+    if (account?.networkType !== 'cardano') return null;
 
     const stakingData = getStakingDataForNetwork(account);
 
@@ -46,7 +46,7 @@ export const selectCardanoRewardsBalanceByAccountKey = (
     accountKey: AccountKey,
 ) => {
     const account = selectAccountByKey(state, accountKey);
-    if (!account || account.networkType !== 'cardano') return null;
+    if (account?.networkType !== 'cardano') return null;
 
     const stakingData = getStakingDataForNetwork(account);
 
@@ -58,7 +58,7 @@ export const selectCardanoTotalStakePendingByAccountKey = (
     accountKey: AccountKey,
 ) => {
     const account = selectAccountByKey(state, accountKey);
-    if (!account || account.networkType !== 'cardano') return null;
+    if (account?.networkType !== 'cardano') return null;
 
     const stakingData = getStakingDataForNetwork(account);
 
@@ -70,7 +70,7 @@ export const selectIsCardanoStakedWithFiveBinaries = (
     accountKey: AccountKey,
 ) => {
     const account = selectAccountByKey(state, accountKey);
-    if (!account || account.networkType !== 'cardano') return false;
+    if (account?.networkType !== 'cardano') return false;
 
     return isCardanoStakedWithFiveBinaries(account);
 };
@@ -80,7 +80,7 @@ export const selectIsCardanoStakedOutsideEverstake = (
     accountKey: AccountKey,
 ) => {
     const account = selectAccountByKey(state, accountKey);
-    if (!account || account.networkType !== 'cardano') return false;
+    if (account?.networkType !== 'cardano') return false;
 
     const cardanoStakingPool = selectCardanoPoolsInfo(state);
 

--- a/suite-native/staking/src/stakeFormEthereumNativeThunks.ts
+++ b/suite-native/staking/src/stakeFormEthereumNativeThunks.ts
@@ -101,7 +101,7 @@ const prepareEthereumStakingContext = (
     const { accountKey, stakeType, precomposedTransaction } = args;
 
     const account = selectAccountByKey(state, accountKey);
-    if (!account || account.networkType !== 'ethereum') {
+    if (account?.networkType !== 'ethereum') {
         return failed(
             'Ethereum account not found.',
             `Ethereum account not found for key ${accountKey}`,

--- a/suite-native/storage/src/migrations/account/v2.ts
+++ b/suite-native/storage/src/migrations/account/v2.ts
@@ -15,7 +15,7 @@ type MigratedAccount = {
 
 export const migrateAccountLabel = (oldAccounts: OldAccount[]): MigratedAccount[] =>
     oldAccounts.map(oldAccount => {
-        if (!oldAccount.metadata || !oldAccount.metadata.accountLabel) {
+        if (!oldAccount.metadata?.accountLabel) {
             return oldAccount;
         }
 

--- a/suite-native/storage/src/transforms/utils.ts
+++ b/suite-native/storage/src/transforms/utils.ts
@@ -8,7 +8,7 @@ import type { DeviceRootState } from '@suite-common/device';
  */
 export const selectDeviceStatesNotRemembered = (state: DeviceRootState) =>
     A.filterMap(state.device.devices, device =>
-        device.remember || !device.state || !device.state.staticSessionId
+        device.remember || !device.state?.staticSessionId
             ? O.None
             : O.Some(
                   typeof device.state === 'string'

--- a/suite-native/tokens/src/tokensSelectors.ts
+++ b/suite-native/tokens/src/tokensSelectors.ts
@@ -44,7 +44,7 @@ export const selectAccountTokenInfo = createMemoizedSelector(
         (_state, _accountKey?: AccountKey, tokenAddress?: TokenAddress) => tokenAddress,
     ],
     (account, tokenAddress?: TokenAddress): TokenInfoBranded | null => {
-        if (!account || !account.tokens) {
+        if (!account?.tokens) {
             return null;
         }
 

--- a/suite-native/transaction-management/src/components/fees/TronFeeSummaryCard/TronFeeSummaryCard.tsx
+++ b/suite-native/transaction-management/src/components/fees/TronFeeSummaryCard/TronFeeSummaryCard.tsx
@@ -40,7 +40,7 @@ export const TronFeeSummaryCard = ({
     );
     const { translate } = useTranslate();
 
-    if (!account || account.networkType !== 'tron') return null;
+    if (account?.networkType !== 'tron') return null;
 
     const breakdown = calculateTronFeeBreakdown(
         feeLevels.normal,

--- a/suite-native/transaction-management/src/hooks/useSubscribeForSolanaBlockUpdates.ts
+++ b/suite-native/transaction-management/src/hooks/useSubscribeForSolanaBlockUpdates.ts
@@ -7,7 +7,7 @@ export const useSubscribeForSolanaBlockUpdates = (account: Account | null) => {
     useEffect(() => {
         // Subscribe to blocks for Solana, since they are not fetched globally
         // this is needed for correct Solana fee estimation
-        if (account && account.networkType === 'solana') {
+        if (account?.networkType === 'solana') {
             TrezorConnect.blockchainSubscribe({
                 coin: account.symbol,
                 blocks: true,

--- a/suite/firmware-upgrade/src/useFirmwareDesktopUpdate.ts
+++ b/suite/firmware-upgrade/src/useFirmwareDesktopUpdate.ts
@@ -71,8 +71,7 @@ export const useFirmwareDesktopUpdate = () => {
     // NOTE: Asume that when the device is restarting back to normal mode and is PIN protected, the PIN will be requested and hence display "device modal"
     const restartingToNormalWithPinProtection =
         rest.operation === 'restarting' &&
-        reconnectEvent &&
-        reconnectEvent.target === 'normal' &&
+        reconnectEvent?.target === 'normal' &&
         originalDevice?.features?.pin_protection &&
         // NOTE: when the device is wiped, the PIN is also wiped
         !rest.deviceWillBeWiped;

--- a/suite/metadata/src/metadataReducer.ts
+++ b/suite/metadata/src/metadataReducer.ts
@@ -171,7 +171,7 @@ export const selectLabelingDataForSelectedAccount = (state: {
     const { selectedAccount } = state.wallet;
 
     const metadataKeys = selectedAccount?.account?.metadata[METADATA_LABELING.ENCRYPTION_VERSION];
-    if (!metadataKeys || !metadataKeys.fileName || !provider?.data[metadataKeys.fileName]) {
+    if (!metadataKeys?.fileName || !provider?.data[metadataKeys.fileName]) {
         return DEFAULT_ACCOUNT_METADATA;
     }
 
@@ -190,7 +190,7 @@ export const selectLabelingDataForAccount = (
     const account = selectAccountByKey(state, accountKey);
     const metadataKeys = account?.metadata?.[METADATA_LABELING.ENCRYPTION_VERSION];
 
-    if (!metadataKeys || !metadataKeys?.fileName || !provider?.data[metadataKeys.fileName]) {
+    if (!metadataKeys?.fileName || !provider?.data[metadataKeys.fileName]) {
         return DEFAULT_ACCOUNT_METADATA;
     }
 
@@ -210,11 +210,7 @@ export const selectAccountLabelsLegacy = (state: {
     return state.wallet.accounts.reduce(
         (dict, account) => {
             const metadataKeys = account?.metadata?.[METADATA_LABELING.ENCRYPTION_VERSION];
-            if (
-                !metadataKeys ||
-                !metadataKeys?.fileName ||
-                !provider?.data[metadataKeys.fileName]
-            ) {
+            if (!metadataKeys?.fileName || !provider?.data[metadataKeys.fileName]) {
                 return dict;
             }
             const data = provider.data[metadataKeys.fileName];
@@ -249,7 +245,7 @@ export const selectLabelingDataForWallet = (
     }
     const metadataKeys = device?.metadata[METADATA_LABELING.ENCRYPTION_VERSION];
 
-    if (metadataKeys && metadataKeys.fileName && provider?.data[metadataKeys.fileName]) {
+    if (metadataKeys?.fileName && provider?.data[metadataKeys.fileName]) {
         return provider.data[metadataKeys.fileName] as WalletLabels;
     }
 
@@ -352,7 +348,6 @@ export const selectIsLabelingAvailableForEntity = (
 
     return Boolean(
         selectIsLabelingAvailable(state) &&
-        entity &&
         entity?.[METADATA_LABELING.ENCRYPTION_VERSION]?.fileName,
     );
 };
@@ -368,7 +363,7 @@ export const selectPasswordManagerState = (
 ) => {
     const provider = selectSelectedProviderForPasswords(state);
 
-    if (!fileName || !provider || !provider?.data?.[fileName]) {
+    if (!fileName || !provider?.data?.[fileName]) {
         return METADATA_PASSWORDS.DEFAULT_PASSWORD_MANAGER_STATE;
     }
 

--- a/suite/router/src/routerThunks.ts
+++ b/suite/router/src/routerThunks.ts
@@ -131,7 +131,7 @@ export const closeModalApp = createThunk<void, boolean | undefined>(
         ).suiteRouterHistory.getLocation();
         const route = findRoute(location.pathname);
 
-        if (route && route.isForegroundApp) {
+        if (route?.isForegroundApp) {
             dispatch(goto({ routeName: 'suite-index' }));
 
             return;


### PR DESCRIPTION
## Summary

Split-out from #27472. Enforces `@typescript-eslint/prefer-optional-chain` as an error across the monorepo and applies the autofix.

Three commits:

1. **`refactor: convert (x && x.y) checks to optional chaining`** — 34-file manual refactor cherry-picked from #27472.
2. **`chore(eslint): enable @typescript-eslint/prefer-optional-chain`** — turns the rule on in `packages/eslint/src/typescriptConfig.mjs`, scoped to `**/src/**/*.{ts,tsx}` where type-aware linting is already set up.
3. **`refactor: apply prefer-optional-chain across monorepo`** — `eslint --fix` run on the whole repo, plus ~15 manual rewrites for cases where the autofixer was conservative (chain inside ternary condition, mixed `&& !x.y` continuations, optional function-call guard, bracket access). **145 files, +212 / −245**.

## Why enable this rule

The rule catches a specific class of latent bugs and noisy patterns that are easy to miss in review:

1. **Repeated property access drifts out of sync.** In `obj.a && obj.a.b && obj.a.b.c`, every chain has to be edited in lock-step when the shape of `obj.a` changes. `obj.a?.b?.c` keeps the access expressed once. Refactors that rename `a` won't accidentally leave a stale guard.
2. **`&&` short-circuits on every falsy value, not just `null`/`undefined`.** `balance && balance.amount` returns `0n` (or `""`, `0`, `false`) when `balance` is falsy-but-defined — silently bleeding the wrong type into downstream code. `balance?.amount` always returns `undefined` for the missing case, which is what the surrounding code almost always assumes. This matters concretely in wallet code that handles bigint amounts and numeric balances.
3. **Method-call guards are subtly wrong.** `obj.fn && obj.fn()` reads the property twice — if `obj.fn` is a getter with side-effects, or if the value changes between accesses (proxies, mocks), behavior diverges. `obj.fn?.()` evaluates `obj.fn` exactly once. (One real instance fixed here: `packages/suite/src/utils/suite/env.ts:52` — `matchMedia && matchMedia('…')` → `matchMedia?.('…')`.)
4. **The rule is type-aware**, so it doesn't fire on plain truthiness checks where `&&` is intentional (`isReady && doThing()`). It only flags chains where the left operand is the prefix of the right.
5. **Autofixable.** Most violations are mechanical and `eslint --fix` handles them without manual intervention. The non-mechanical cases (semantic differences around falsy-but-defined operands) are exactly the cases worth surfacing for human review.
6. **Consistency.** The codebase already mixes `&&`-chains and `?.` in similar contexts. Enforcing one form removes a recurring review nit and makes diffs easier to scan.

## Pre-fix violation count (for context)

CI lint with the rule enabled but before the autofix reported **218 errors across 39 packages**. Top offenders:

| Package | Violations |
|---|---:|
| `@trezor/suite` | 76 |
| `@trezor/connect` | 17 |
| `@suite-common/trading` | 16 |
| `@trezor/utxo-lib` | 12 |
| `@suite-common/wallet-utils` | 11 |
| `@suite-common/wallet-core` | 9 |
| `@suite-common/device` | 8 |
| 32 other packages | ≤6 each |

After autofix + manual rewrites the count is **0**.

## Manual rewrites (autofix was conservative here)

These 15 sites needed a manual touch — typically because the chain sat inside a ternary condition or because a follow-on operand reused the chained variable:

- `packages/connect/src/data/defaultFeeLevels.ts:21` (bracket access)
- `packages/connect/src/device/Device.ts:744`
- `packages/suite/src/actions/wallet/__tests__/publicKeyActions.test.ts:110`
- `packages/suite/src/actions/wallet/__tests__/receiveActions.test.ts:152`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/RevokeModal.tsx:142`
- `packages/suite/src/storage/migrations/index.ts:465`
- `packages/suite/src/utils/suite/env.ts:52` (function-call guard)
- `packages/suite/src/utils/wallet/graph/utils.ts:200`
- `suite-common/connect-popup/src/connectPopupThunks.ts:250`
- `suite-common/firmware-authenticity/src/useReportDeviceCompromised.ts:110`
- `suite-common/wallet-core/src/accounts/accountsThunks.ts:173`
- `suite-common/wallet-core/src/blockchain/blockchainThunks.ts:329`
- `suite-common/wallet-core/src/settings/walletSettingsReducer.ts:160`
- `suite-common/wallet-utils/src/sendFormUtils.ts:404`
- `suite/metadata/src/metadataReducer.ts:251`

All inspected for the `&&`-vs-`?.` semantic difference; none rely on the falsy-but-defined value of the guard.

## Test plan

- [ ] CI: `Linting and formatting` job passes (rule is on, autofix applied)
- [ ] CI: type-check / unit tests pass
- [ ] Spot-check manual rewrites above

## Related

- Umbrella PR: #27472

<!-- PREVIEW-LINKS:SECTION:START -->
<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/prefer-optional-chain/web/](https://dev.suite.sldev.cz/suite-web/mroz22/prefer-optional-chain/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/prefer-optional-chain&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/prefer-optional-chain&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-17T12:29:34.467Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->