### PR TITLE
chore(redux-utils): remove unused notImplementedOriginalReduxThunk factory

### DIFF
--- a/suite-common/redux-utils/src/notImplemented.ts
+++ b/suite-common/redux-utils/src/notImplemented.ts
@@ -29,12 +29,6 @@ export const notImplementedThunk = (type: string) =>
         return thunkPayload;
     });
 
-export const notImplementedOriginalReduxThunk = (type: string) => () => (thunkPayload: any) => {
-    mockedConsoleLog(`Calling not implemented thunk: ${type} and payload: `);
-
-    return thunkPayload;
-};
-
 export const notImplementedSelector =
     <TReturn>(name: string, mockedReturnValue: TReturn, selectorArgs: any = {}) =>
     () => {


### PR DESCRIPTION
## Summary

Removes the unused `notImplementedOriginalReduxThunk` factory from `@suite-common/redux-utils`. Confirmed no callers across the monorepo.

Split out from the staging dead-code PR #27551 (suite-common/* batch).

## Related PRs

Sibling PRs in this batch (each removes one piece of dead code from `suite-common/*`):

- #27836 — chore(wallet-utils): remove unused readUtxoOutpoint function
- #27837 — chore(suite-utils): remove unused PollingController.isScheduled method
- #27838 — chore(connect-popup): remove unused selectWalletConnectAppPermissions selector
- #27839 — chore(suite-types): remove unused GitHub API response types
- #27840 — chore(analytics): drop unnecessary export from ANALYTICS_EVENT_NAME_KEBAB_SEGMENT
- #27841 — chore(wallet-config): remove unused hasNetworkSettlementLayer and isProdStakingNetworkSymbol

Parent staging PR: #27551

## Test plan

- [ ] CI typecheck and tests pass

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file `suite-common/redux-utils/src/notImplemented.ts` is a low-level utility in the redux-utils package that likely provides a helper for marking unimplemented functionality (e.g., throwing errors for abstract methods). No tests statically map to this file, and none of the LLM-analyzed E2E tests reference `notImplemented` or `redux-utils` in their source hints. This is a foundational utility whose changes would most likely manifest as build-time or unit-test failures rather than E2E behavioral regressions. No E2E tests are recommended; unit tests and type checks should provide sufficient coverage.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/redux-utils/src/notImplemented.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `suite-common/redux-utils/src/notImplemented.ts`

_Updated: 2026-05-17T06:43:25.218Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-redux-utils&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-redux-utils&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-redux-utils&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-17T06:48:19.950Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-17T06:47:22.461Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-redux-utils/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-redux-utils/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->