### PR TITLE
chore(wallet-utils): remove unused readUtxoOutpoint function

### DIFF
--- a/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
@@ -17,7 +17,6 @@ import {
     hasNetworkFeatures,
     isTestnet,
     parseBIP44Path,
-    readUtxoOutpoint,
     sortByBIP44AddressIndex,
     sortByCoin,
     substituteBip43Path,
@@ -263,21 +262,13 @@ describe('account utils', () => {
         expect(hasNetworkFeatures(ethAcc, ['tokens', 'rbf'])).toEqual(true);
     });
 
-    it('getUtxoOutpoint/readUtxoOutpoint', () => {
+    it('getUtxoOutpoint', () => {
         expect(
             getUtxoOutpoint({
                 txid: '0dac366fd8a67b2a89fbb0d31086e7acded7a5bbf9ef9daa935bc873229ef5b5',
                 vout: 1,
             }),
         ).toEqual('b5f59e2273c85b93aa9deff9bba5d7deace78610d3b0fb892a7ba6d86f36ac0d01000000');
-        expect(
-            readUtxoOutpoint(
-                'b5f59e2273c85b93aa9deff9bba5d7deace78610d3b0fb892a7ba6d86f36ac0d01000000',
-            ),
-        ).toEqual({
-            txid: '0dac366fd8a67b2a89fbb0d31086e7acded7a5bbf9ef9daa935bc873229ef5b5',
-            vout: 1,
-        });
     });
 
     it('sortByBIP44AddressIndex', () => {

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -1071,15 +1071,6 @@ export const getUtxoOutpoint = (utxo: { txid: string; vout: number }) => {
     return buffer.toString('hex');
 };
 
-// https://developer.bitcoin.org/reference/transactions.html#outpoint-the-specific-part-of-a-specific-output
-export const readUtxoOutpoint = (outpoint: string) => {
-    const buffer = Buffer.from(outpoint, 'hex');
-    const txid = bufferUtils.reverseBuffer(buffer.subarray(0, 32));
-    const vout = buffer.readUInt32LE(txid.length);
-
-    return { txid: txid.toString('hex'), vout };
-};
-
 export const isSameUtxo = (a: AccountUtxo, b: AccountUtxo) =>
     a.txid === b.txid && a.vout === b.vout;
 


### PR DESCRIPTION
## Summary

Removes the unused `readUtxoOutpoint` helper from `@suite-common/wallet-utils` along with its test. Confirmed no callers across the monorepo.

Split out from the staging dead-code PR #27551 (suite-common/* batch).

## Related PRs

Sibling PRs in this batch (each removes one piece of dead code from `suite-common/*`):

- #27835 — chore(redux-utils): remove unused notImplementedOriginalReduxThunk factory
- #27837 — chore(suite-utils): remove unused PollingController.isScheduled method
- #27838 — chore(connect-popup): remove unused selectWalletConnectAppPermissions selector
- #27839 — chore(suite-types): remove unused GitHub API response types
- #27840 — chore(analytics): drop unnecessary export from ANALYTICS_EVENT_NAME_KEBAB_SEGMENT
- #27841 — chore(wallet-config): remove unused hasNetworkSettlementLayer and isProdStakingNetworkSymbol

Parent staging PR: #27551

## Test plan

- [ ] CI typecheck and tests pass

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are limited to `suite-common/wallet-utils/src/accountUtils.ts` and its corresponding unit test file. While `accountUtils.ts` is a widely-imported utility (mapping to 121 E2E tests), none of the LLM-analyzed E2E tests directly exercise account utility logic in a way that would be affected by typical changes to this file. The unit test file (`accountUtils.test.ts`) has no static E2E coverage mapping, which is expected since it is itself a unit test. The safest strategy is to rely on the unit tests for `accountUtils` and skip E2E tests, as no E2E test has specific evidence of being affected by changes in account utility functions like account formatting, sorting, or derivation helpers. If the change modifies account discovery, account labeling/naming, or account filtering behavior specifically, then tests like `wallet/account-search`, `wallet/add-account-types`, or `wallet/discovery` could be relevant, but without knowing the exact nature of the change within accountUtils.ts, there is insufficient evidence to recommend any E2E test at high or medium priority.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/wallet-utils/src/__tests__/accountUtils.test.ts`
- `suite-common/wallet-utils/src/accountUtils.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `suite-common/wallet-utils/src/__tests__/accountUtils.test.ts`

_Updated: 2026-05-17T06:43:50.848Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-wallet-utils&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-wallet-utils&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-wallet-utils&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-17T06:48:49.348Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-17T06:47:25.078Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-wallet-utils/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-wallet-utils/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->