### PR TITLE
chore(connect-popup): remove unused selectWalletConnectAppPermissions selector

### DIFF
--- a/suite-common/connect-popup/src/connectPopupReducer.ts
+++ b/suite-common/connect-popup/src/connectPopupReducer.ts
@@ -205,6 +205,3 @@ export const selectIsConnectAppSilentModeByOrigin = (
 ) =>
     !!origin &&
     state.connectPopup.permissions.some(p => p.origin === origin && p.silentMode === true);
-
-export const selectWalletConnectAppPermissions = (state: ConnectPopupStateRootState) =>
-    state.connectPopup.permissions.filter(p => p.type === CALL_SOURCE_WALLETCONNECT);


### PR DESCRIPTION
## Summary

Removes the unused `selectWalletConnectAppPermissions` selector from `@suite-common/connect-popup`. Confirmed no callers across the monorepo.

Split out from the staging dead-code PR #27551 (suite-common/* batch).

## Related PRs

Sibling PRs in this batch (each removes one piece of dead code from `suite-common/*`):

- #27835 — chore(redux-utils): remove unused notImplementedOriginalReduxThunk factory
- #27836 — chore(wallet-utils): remove unused readUtxoOutpoint function
- #27837 — chore(suite-utils): remove unused PollingController.isScheduled method
- #27839 — chore(suite-types): remove unused GitHub API response types
- #27840 — chore(analytics): drop unnecessary export from ANALYTICS_EVENT_NAME_KEBAB_SEGMENT
- #27841 — chore(wallet-config): remove unused hasNetworkSettlementLayer and isProdStakingNetworkSymbol

Parent staging PR: #27551

## Test plan

- [ ] CI typecheck and tests pass

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to connectPopupReducer.ts, which manages TrezorConnect popup state (permissions, silent mode, popup lifecycle). This file maps to 121 tests via transitive imports, but the vast majority are unrelated to connect popup functionality — they simply import it as part of the broader Redux store. The highest risk is in TrezorConnect popup/permissions tests that directly exercise popup state transitions. The recommended strategy focuses on the 4 high-priority tests that directly validate popup permissions, lifecycle, and silent mode, plus 6 medium-priority tests covering other TrezorConnect API flows that go through the permissions modal.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/connect-popup/src/connectPopupReducer.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — The connectPopupReducer is the core state management for the TrezorConnect popup flow. This test directly exercises the popup lifecycle (open, close, permissions, cancellation) which is the primary functionality managed by connectPopupReducer.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — This test exercises the same TrezorConnect popup permission and lifecycle flows as the web variant but through a webextension context. Changes to connectPopupReducer directly affect popup state transitions tested here (permissions modal, cancellation, recovery after force-close).
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — This test directly validates granting, remembering, and forgetting TrezorConnect app permissions — state that is explicitly managed by connectPopupReducer (connectPopup.permissions). Changes to the reducer could break permission persistence and revocation flows.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — This test explicitly asserts on Redux state at connectPopup.permissions[0].silentMode, directly validating state managed by connectPopupReducer. It also tests the permissions modal remember/silent-mode checkbox interactions that the reducer handles.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — This test exercises the connect permissions modal and address confirmation flow that goes through the connect popup state. The loading header text and permission granting are managed by popup state from connectPopupReducer.
- `suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — This test exercises the connect permissions modal (confirmButton text, permission granting) which relies on state managed by connectPopupReducer. A regression in popup state could break the account selection flow.
- `suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts` — This test uses connectPermissionsModal to confirm permissions before signing, which depends on connect popup state management. Changes to the reducer could affect the permission confirmation flow.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — This test confirms connect permissions via the modal and then proceeds through device confirmation steps. The permissions modal state is driven by connectPopupReducer.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — This test confirms connect permissions and proceeds through device confirmation prompts. The permission confirmation flow depends on connectPopupReducer state management.
- `suite/e2e/tests/trezor-connect/error.test.ts` — This test validates error display in the connect popup (@connect-popup-error/message) when an invalid path is provided. The error state rendering may depend on connectPopupReducer state.

</details>

_Updated: 2026-05-17T06:44:07.561Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-connect-popup&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-connect-popup&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-connect-popup&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-17T06:48:36.788Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-17T06:47:30.011Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-connect-popup/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-connect-popup/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->