### PR TITLE
chore(analytics): drop unnecessary export from ANALYTICS_EVENT_NAME_KEBAB_SEGMENT

### DIFF
--- a/suite-common/analytics/src/eventNameValidation.ts
+++ b/suite-common/analytics/src/eventNameValidation.ts
@@ -26,7 +26,7 @@ export const ANALYTICS_ALLOWED_DOMAINS = [
 
 export type AnalyticsDomain = (typeof ANALYTICS_ALLOWED_DOMAINS)[number];
 
-export const ANALYTICS_EVENT_NAME_KEBAB_SEGMENT = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+const ANALYTICS_EVENT_NAME_KEBAB_SEGMENT = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 
 const ALLOWED_DOMAINS_SET = new Set<string>(ANALYTICS_ALLOWED_DOMAINS);
 

--- a/suite-common/analytics/src/index.ts
+++ b/suite-common/analytics/src/index.ts
@@ -2,7 +2,6 @@ export { type AnalyticsSharedEvents } from './analyticsEvents';
 export type { AttributeDef, EventDef, EventInstance, AppVersion } from './eventDefinition';
 export {
     ANALYTICS_ALLOWED_DOMAINS,
-    ANALYTICS_EVENT_NAME_KEBAB_SEGMENT,
     isValidEventPart,
     validateAnalyticsEventName,
 } from './eventNameValidation';


### PR DESCRIPTION
## Summary

Drops the unnecessary public export of `ANALYTICS_EVENT_NAME_KEBAB_SEGMENT` from `@suite-common/analytics`. The constant is used internally only.

Split out from the staging dead-code PR #27551 (suite-common/* batch).

## Related PRs

Sibling PRs in this batch (each removes one piece of dead code from `suite-common/*`):

- #27835 — chore(redux-utils): remove unused notImplementedOriginalReduxThunk factory
- #27836 — chore(wallet-utils): remove unused readUtxoOutpoint function
- #27837 — chore(suite-utils): remove unused PollingController.isScheduled method
- #27838 — chore(connect-popup): remove unused selectWalletConnectAppPermissions selector
- #27839 — chore(suite-types): remove unused GitHub API response types
- #27841 — chore(wallet-config): remove unused hasNetworkSettlementLayer and isProdStakingNetworkSymbol

Parent staging PR: #27551

## Test plan

- [ ] CI typecheck and tests pass

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are in `suite-common/analytics/src/eventNameValidation.ts` and its barrel `index.ts`. These files govern analytics event name validation logic used across the Suite application. The risk is moderate — if event name validation rules change, any test that asserts on specific analytics event types or payloads could break. The recommended strategy focuses on the dedicated analytics E2E tests which directly exercise event type matching and payload validation, plus the settings/general test which also validates multiple analytics events.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/analytics/src/eventNameValidation.ts`
- `suite-common/analytics/src/index.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `../../suite/e2e/tests/analytics/events.test.ts` — This test directly exercises analytics event types and event validation. The changed file `eventNameValidation.ts` likely validates analytics event names, and the `index.ts` re-exports this module. This test fires and validates multiple analytics events (SuiteReady, DeviceConnect, TransportType, DeviceDisconnect, settingsAnalytics) and checks their payloads, making it the most direct consumer of analytics event name infrastructure.
- `../../suite/e2e/tests/analytics/toggle.test.ts` — This test validates analytics enable/disable lifecycle, event firing (settingsAnalyticsEvent, settingsGeneralChangeFiatEvent, suiteReadyEvent, routerLocationChangeEvent), and metadata fields (c_type, c_session_id, c_instance_id). Changes to event name validation could break event type matching or event identification in these assertions.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `../../suite/e2e/tests/analytics/promo-banner-events.test.ts` — This test asserts that analytics payloads contain correct c_type matching EventType.PromoDashboardBanner. If eventNameValidation changes how event names are validated or formatted, this test's event type assertions could fail.
- `../../suite/e2e/tests/analytics/staking-events.test.ts` — This test validates StakingNavigate analytics events with specific c_type and networkSymbol payloads. Changes to event name validation could affect how these event types are validated or dispatched.
- `../../suite/e2e/tests/analytics/wallet-connect-events.test.ts` — This test checks WalletConnect analytics events (WalletConnectInit, WalletConnectPaired, WalletConnectProposal, etc.) by c_type. The source_hints explicitly reference '@suite-common/analytics (EventType constants)' which is the changed package. Event name validation changes could affect these event type checks.
- `../../suite/e2e/tests/settings/general.test.ts` — This test validates analytics events for fiat change, theme change, language change, and analytics toggle (settingsGeneralChangeFiatEvent, settingsGeneralChangeThemeEvent, settingsGeneralChangeLanguageEvent, settingsAnalyticsEvent). These events flow through the analytics module where event name validation applies.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/analytics/src/eventNameValidation.ts`

_Updated: 2026-05-17T06:44:03.837Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-analytics&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-analytics&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-analytics&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-17T06:49:02.270Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-17T06:47:25.468Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-analytics/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-analytics/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->