### PR TITLE
chore(wallet-config): remove unused hasNetworkSettlementLayer and isProdStakingNetworkSymbol

### DIFF
--- a/suite-common/wallet-config/src/utils.ts
+++ b/suite-common/wallet-config/src/utils.ts
@@ -1,8 +1,7 @@
 import { type NetworkDtoId } from '@suite-common/earn-stablecoin-api';
 import { exhaustive } from '@trezor/type-utils';
-import { isArrayMember } from '@trezor/utils';
 
-import { PROD_STAKING_SYMBOLS, type ProdStakingNetworkSymbol, networks } from './networksConfig';
+import { networks } from './networksConfig';
 import {
     type AccountType,
     type Network,
@@ -126,14 +125,6 @@ export const isNetworkSymbol = (symbol: NetworkSymbolExtended): symbol is Networ
 export const getNetwork = (symbol: NetworkSymbol): Network => networks[symbol];
 
 /**
- * Check wether the network has a settlement layer. Used to check Ethereum L2s.
- * @param symbol
- * @returns boolean
- */
-export const hasNetworkSettlementLayer = (symbol: NetworkSymbol) =>
-    !!getNetwork(symbol).settlementLayer;
-
-/**
  * Use instead of getNetwork, if there is not a guarantee that the symbol is a valid network symbol.
  * @param symbol
  */
@@ -189,7 +180,3 @@ export const getNetworkDecimals = (symbol: NetworkSymbolExtended) => {
 
 export const getNetworkByYieldXyzId = (yieldXyzId: NetworkDtoId) =>
     networksCollection.find(n => n.yieldXyzId === yieldXyzId) ?? null;
-
-export const isProdStakingNetworkSymbol = (
-    symbol: NetworkSymbol,
-): symbol is ProdStakingNetworkSymbol => isArrayMember(symbol, PROD_STAKING_SYMBOLS);


### PR DESCRIPTION
## Summary

Removes the unused exports `hasNetworkSettlementLayer` and `isProdStakingNetworkSymbol` from `@suite-common/wallet-config`. Confirmed no callers across the monorepo.

Split out from the staging dead-code PR #27551 (suite-common/* batch).

## Related PRs

Sibling PRs in this batch (each removes one piece of dead code from `suite-common/*`):

- #27835 — chore(redux-utils): remove unused notImplementedOriginalReduxThunk factory
- #27836 — chore(wallet-utils): remove unused readUtxoOutpoint function
- #27837 — chore(suite-utils): remove unused PollingController.isScheduled method
- #27838 — chore(connect-popup): remove unused selectWalletConnectAppPermissions selector
- #27839 — chore(suite-types): remove unused GitHub API response types
- #27840 — chore(analytics): drop unnecessary export from ANALYTICS_EVENT_NAME_KEBAB_SEGMENT

Parent staging PR: #27551

## Test plan

- [ ] CI typecheck and tests pass

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file `suite-common/wallet-config/src/utils.ts` is a broad shared utility that maps to 121 tests, indicating it is a foundational/global dependency. Without seeing the specific diff, we cannot determine which particular network configurations, backend utilities, or wallet config behaviors were altered. None of the 121 tests in the LLM analysis show direct, specific reliance on particular logic within `wallet-config/src/utils.ts` that would make them clearly more affected than others — they all transitively import it through network configuration, coin settings, or discovery flows. Given the extremely broad mapping and lack of specific evidence that any single test's code path is more directly affected, the recommended strategy is to rely on unit tests for this utility file rather than running a large set of E2E tests. If the change is known to affect specific network resolution, coin enablement, or backend selection logic, targeted tests like `coins.test.ts`, `coins-custom-backend.test.ts`, or `discovery.test.ts` would be the most relevant candidates, but without that specificity, no E2E tests can be confidently prioritized above others.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/wallet-config/src/utils.ts`

</details>

_No test recommendations found._

_Updated: 2026-05-17T06:44:31.926Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-wallet-config&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-wallet-config&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-wallet-config&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-17T06:48:36.759Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-17T06:47:42.804Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-wallet-config/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-wallet-config/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->