### PR TITLE
test(blockchain-link): paginate Horizon to reduce Stellar pushTransaction flake

### DIFF
--- a/packages/blockchain-link/tests/integration/stellar.test.ts
+++ b/packages/blockchain-link/tests/integration/stellar.test.ts
@@ -44,13 +44,24 @@ describe('Stellar', () => {
     });
 
     it('pushTransaction', async () => {
-        const latestTx = (
-            await horizonServer.transactions().order('desc').limit(200).includeFailed(false).call()
-        ).records.find(tx => !tx.fee_bump_transaction);
+        // Stellar mainnet traffic is sometimes dominated by fee-bump transactions; paginate
+        // until a non-fee-bump tx is found so the test doesn't flake when the first page is
+        // all fee-bumps.
+        const maxPages = 5;
+        let page = await horizonServer
+            .transactions()
+            .order('desc')
+            .limit(200)
+            .includeFailed(false)
+            .call();
+        let latestTx = page.records.find(tx => !tx.fee_bump_transaction);
+        for (let i = 1; !latestTx && i < maxPages; i++) {
+            page = await page.next();
+            if (!page.records.length) break;
+            latestTx = page.records.find(tx => !tx.fee_bump_transaction);
+        }
         if (!latestTx) {
-            // This error may be thrown with a small probability and can be resolved by retrying.
-            // For simplicity, no extensive design is implemented here.
-            throw new Error('No transactions found');
+            throw new Error(`No non-fee-bump transactions found in the last ${maxPages} pages`);
         }
         const xdr = Buffer.from(latestTx.envelope_xdr, 'base64').toString('hex');
         const result = await blockchain.pushTransaction({ hex: xdr });


### PR DESCRIPTION
## Summary

Band-aid for a recurring flake in the `[Test] blockchain-link e2e` workflow: `Stellar › pushTransaction` periodically fails with `No transactions found` (e.g. https://github.com/trezor/trezor-suite/actions/runs/25992231472/job/76402525986, and at least 3 of the last 4 workflow failures show the same signature).

### Why it flakes

`tests/integration/stellar.test.ts` fetches the 200 newest Stellar mainnet transactions from `https://horizon.stellar.org` and picks the first non-fee-bump one to re-submit:

```ts
const latestTx = (
    await horizonServer.transactions().order('desc').limit(200).includeFailed(false).call()
).records.find(tx => !tx.fee_bump_transaction);
```

When that 200-record window contains only fee-bump transactions (which Stellar mainnet does produce in bursts), `find()` returns `undefined` and the test throws. The pre-existing comment in the test acknowledged this: _"This error may be thrown with a small probability and can be resolved by retrying."_ In practice the probability is not that small.

### What this PR changes

Paginate through up to 5 Horizon pages (1000 transactions) until a non-fee-bump transaction is found. The `maxPages` cap guards against infinite iteration if Horizon ever returns only fee-bumps.

### Why band-aid, not fix

The test still depends on live Stellar mainnet — Horizon outages, rate limits, or some other transient mainnet condition can still fail it. A proper fix would move this test to **Stellar testnet** and build a deterministic fixture (Friendbot-funded account + self-signed transaction). That is a larger piece of work; this PR just stops the most common failure mode.

## Test plan

- [x] CI: `[Test] blockchain-link e2e` workflow passes — first green run on this branch: https://github.com/trezor/trezor-suite/actions/runs/26020840670 (`PASS tests/integration/stellar.test.ts`, 37 passed / 4 skipped)
- [ ] Spot-check: re-run the workflow a few times to confirm the flake rate drops

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is an integration test file itself (packages/blockchain-link/tests/integration/stellar.test.ts), not application source code. This is a test-only change within the blockchain-link package's own integration test suite, which is not an E2E test and does not map to any Suite E2E tests. None of the Suite E2E tests exercise or depend on the Stellar blockchain-link integration test file. There is no risk of regression in the Suite application from this change, so no E2E tests need to be run.

<details><summary><b>Changed files (1)</b></summary>

- `packages/blockchain-link/tests/integration/stellar.test.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/blockchain-link/tests/integration/stellar.test.ts`

_Updated: 2026-05-18T07:58:29.336Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/flaky-blockchain-link-test&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/flaky-blockchain-link-test&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-18T08:03:38.620Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-18T08:01:50.842Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/flaky-blockchain-link-test/web/](https://dev.suite.sldev.cz/suite-web/mroz22/flaky-blockchain-link-test/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->
