### PR TITLE
feat(suite): show Claim button in Earn Staking table when claim is available

### DIFF
--- a/packages/suite/src/components/earn/dashboard/staking/EarnStakingAccountRow.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/EarnStakingAccountRow.tsx
@@ -1,16 +1,24 @@
 import { events } from '@suite/analytics';
 import { Translation } from '@suite/intl';
+import { openModal } from '@suite/modal';
 import { goto } from '@suite/router';
 import { useFormatters } from '@suite-common/formatters';
 import { getNetworkAdjustedStakingBalance } from '@suite-common/staking';
+import { EarnFlow } from '@suite-common/suite-types/src/staking';
 import { getTradingPrefilledFromAccountData, tradingActions } from '@suite-common/trading';
 import { getDisplaySymbol } from '@suite-common/wallet-config';
-import { selectAccountIsStakingActive, selectPoolStatsApy } from '@suite-common/wallet-core';
+import {
+    selectAccountClaimTransactions,
+    selectAccountIsStakingActive,
+    selectPoolStatsApy,
+} from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import {
     calculateRewards,
     getAccountTotalStakingBalance,
+    getStakingDataForNetwork,
     getStakingLimitsByNetworkSymbol,
+    isPending,
 } from '@suite-common/wallet-utils';
 import { Card, Column, Icon, Paragraph, Row, Table } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
@@ -43,7 +51,14 @@ export const EarnStakingAccountRow = ({
     const displaySymbol = getDisplaySymbol(account.symbol);
     const isCardanoNetworkType = account.networkType === 'cardano';
     const isStakingActive = useSelector(state => selectAccountIsStakingActive(state, account.key));
-    const { isStakingDisabled, stakingMessageContent } = useMessageSystemStaking(account.symbol);
+    const isClaimPending = useSelector(state =>
+        selectAccountClaimTransactions(state, account.key).some(tx => isPending(tx)),
+    );
+    const { isStakingDisabled, stakingMessageContent, isClaimingDisabled, claimingMessageContent } =
+        useMessageSystemStaking(account.symbol);
+
+    const { canClaim = false } = getStakingDataForNetwork(account) ?? {};
+    const isClaimButtonDisabled = isClaimingDisabled || isClaimPending;
 
     const minStakingAmount = getStakingLimitsByNetworkSymbol(
         account.symbol,
@@ -94,6 +109,64 @@ export const EarnStakingAccountRow = ({
             payload: {
                 action: 'navigate',
                 from: `dashboard/staking-dashboard/${stakingStatus}`,
+                networkSymbol: account.symbol,
+            },
+        });
+    };
+
+    const openStakeModal = (event: React.MouseEvent<HTMLButtonElement>) => {
+        event.stopPropagation();
+
+        if (isStakingDisabled) {
+            return;
+        }
+
+        dispatch(
+            goto({
+                routeName: 'wallet-staking',
+                params: {
+                    symbol: account.symbol,
+                    accountIndex: account.index,
+                    accountType: account.accountType,
+                },
+            }),
+        );
+        dispatch(openModal({ type: 'stake', flow: EarnFlow.Stake, account }));
+
+        analytics.report({
+            type: events.stakingStakeEvent.name,
+            payload: {
+                action: 'continue',
+                step: 'staking-dashboard',
+                networkSymbol: account.symbol,
+            },
+        });
+    };
+
+    const openClaimModal = (event: React.MouseEvent<HTMLButtonElement>) => {
+        event.stopPropagation();
+
+        if (isClaimButtonDisabled) {
+            return;
+        }
+
+        dispatch(
+            goto({
+                routeName: 'wallet-staking',
+                params: {
+                    symbol: account.symbol,
+                    accountIndex: account.index,
+                    accountType: account.accountType,
+                },
+            }),
+        );
+        dispatch(openModal({ type: 'claim', account }));
+
+        analytics.report({
+            type: events.stakingClaimEvent.name,
+            payload: {
+                action: 'continue',
+                step: 'staking-dashboard',
                 networkSymbol: account.symbol,
             },
         });
@@ -154,8 +227,14 @@ export const EarnStakingAccountRow = ({
         stakingStatus,
         isStakingDisabled,
         stakingMessageContent,
+        canClaim,
+        isClaimButtonDisabled,
+        claimingMessageContent,
         onBuy: navigateToTradingBuy,
-        onStake: navigateToStaking,
+        onStake: openStakeModal,
+        onStakeNow: navigateToStaking,
+        onUpdateProvider: navigateToStaking,
+        onClaim: openClaimModal,
     } as const;
 
     if (isCardLayout) {

--- a/packages/suite/src/components/earn/dashboard/staking/EarnStakingActionButtons.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/EarnStakingActionButtons.tsx
@@ -9,27 +9,53 @@ type EarnStakingActionButtonsProps = {
     stakingStatus: StakingAccountStatus;
     isStakingDisabled: boolean | undefined;
     stakingMessageContent: ReactNode;
+    canClaim: boolean;
+    isClaimButtonDisabled: boolean | undefined;
+    claimingMessageContent: ReactNode;
     onBuy: (event: MouseEvent<HTMLButtonElement>) => void;
     onStake: (event: MouseEvent<HTMLButtonElement>) => void;
+    onStakeNow: (event: MouseEvent<HTMLButtonElement>) => void;
+    onUpdateProvider: (event: MouseEvent<HTMLButtonElement>) => void;
+    onClaim: (event: MouseEvent<HTMLButtonElement>) => void;
 };
 
 export const EarnStakingActionButtons = ({
     stakingStatus,
     isStakingDisabled,
     stakingMessageContent,
+    canClaim,
+    isClaimButtonDisabled,
+    claimingMessageContent,
     onBuy,
     onStake,
+    onStakeNow,
+    onUpdateProvider,
+    onClaim,
 }: EarnStakingActionButtonsProps) => (
     <>
         {(stakingStatus === 'insufficient-funds' ||
             stakingStatus === 'staking-max' ||
-            stakingStatus === 'staked-but-insufficient-funds') && (
-            <Button intent="neutral" priority="secondary" size="small" onClick={onBuy}>
-                <Translation id="TR_BUY" />
-            </Button>
-        )}
+            stakingStatus === 'staked-but-insufficient-funds') &&
+            (canClaim ? (
+                <Tooltip content={claimingMessageContent}>
+                    <Button
+                        intent="brand"
+                        size="small"
+                        isDisabled={isClaimButtonDisabled}
+                        iconLeft={isClaimButtonDisabled ? 'info' : undefined}
+                        onClick={onClaim}
+                        data-testid="@account/staking/claim-button"
+                    >
+                        <Translation id="TR_STAKE_CLAIM" />
+                    </Button>
+                </Tooltip>
+            ) : (
+                <Button intent="neutral" priority="secondary" size="small" onClick={onBuy}>
+                    <Translation id="TR_BUY" />
+                </Button>
+            ))}
 
-        {(stakingStatus === 'staking-active' || stakingStatus === 'staking-inactive') && (
+        {stakingStatus === 'staking-active' && (
             <Tooltip content={stakingMessageContent}>
                 <Button
                     intent="brand"
@@ -38,13 +64,21 @@ export const EarnStakingActionButtons = ({
                     iconLeft={isStakingDisabled ? 'info' : undefined}
                     onClick={onStake}
                 >
-                    <Translation
-                        id={
-                            stakingStatus === 'staking-active'
-                                ? 'TR_EARN_STAKING_DASHBOARD_STAKE_MORE'
-                                : 'TR_EARN_STAKING_DASHBOARD_STAKE_NOW'
-                        }
-                    />
+                    <Translation id="TR_EARN_STAKING_DASHBOARD_STAKE_MORE" />
+                </Button>
+            </Tooltip>
+        )}
+
+        {stakingStatus === 'staking-inactive' && (
+            <Tooltip content={stakingMessageContent}>
+                <Button
+                    intent="brand"
+                    size="small"
+                    isDisabled={isStakingDisabled}
+                    iconLeft={isStakingDisabled ? 'info' : undefined}
+                    onClick={onStakeNow}
+                >
+                    <Translation id="TR_EARN_STAKING_DASHBOARD_STAKE_NOW" />
                 </Button>
             </Tooltip>
         )}
@@ -56,7 +90,7 @@ export const EarnStakingActionButtons = ({
                     size="small"
                     isDisabled={isStakingDisabled}
                     iconLeft={isStakingDisabled ? 'info' : undefined}
-                    onClick={onStake}
+                    onClick={onUpdateProvider}
                 >
                     <Translation id="TR_EARN_UPDATE_PROVIDER" />
                 </Button>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In the Earn Staking table, rows now show a **Claim** button instead of **Buy** when a claim is available for the account. Clicking it navigates to the staking detail and opens the claim modal directly.

**Stake More / Stake Now** now also navigates and opens the stake modal in one click (instead of just navigating).

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27583

## Screenshots:

<img width="1215" height="569" alt="image" src="https://github.com/user-attachments/assets/83a4d373-b687-4709-ac3a-56e439dd5be0" />


<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to a single staking UI component (EarnStakingAccountRow.tsx) used in the earn/staking dashboard. Despite mapping to 121 tests via transitive imports, the actual risk is concentrated in staking-related tests. The ETH staking tests should be run at high priority since they most directly exercise the staking dashboard row rendering (amounts, buttons, progress indicators). ADA and SOL staking tests plus the staking form test provide additional coverage at medium priority. All other 100+ mapped tests are unrelated to staking functionality and can be safely skipped.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/earn/dashboard/staking/EarnStakingAccountRow.tsx`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/analytics/staking-events.test.ts` — This test directly exercises staking navigation from both the dashboard and account menu for ETH and ADA. The EarnStakingAccountRow component is part of the staking dashboard UI that users interact with to navigate to staking, making this test directly relevant to the changed component.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test covers the ETH staking dashboard which displays staking account rows, progress indicators, and staking amounts — all of which EarnStakingAccountRow is responsible for rendering. Changes to this component could directly affect the staking dashboard card visibility, amounts display, and button states tested here.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — This test verifies the staking dashboard displays correct staked amounts, rewards, pending/unstaking sections, and action buttons (Stake More, Unstake to Claim) — UI elements likely rendered by EarnStakingAccountRow. It also tests instant staking banner display and progress indicators.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — This test checks staking dashboard amounts (pending, staked, rewards, unstaking), button states (unstake enabled/disabled), and claim card visibility — all of which are part of the staking account row UI that EarnStakingAccountRow renders.

</details>

<details><summary>🟡 <b>Medium priority (8)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — This test verifies Cardano staking account display including reward amounts, claim button states, unstake button states, and full balance staking text — UI elements that EarnStakingAccountRow likely renders for ADA staking accounts.
- `suite/e2e/tests/staking/ada/stake.test.ts` — This test covers the ADA staking tab including visibility of staking account items, claim/unstake button states, and staking balance display — UI that the EarnStakingAccountRow component is responsible for rendering in the Cardano staking context.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — This test verifies ADA staking dashboard showing staked balance, reward amounts, claim/unstake button states, and post-unstake UI changes — all rendered through the staking account row component.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — This test checks SOL staking dashboard empty state, staking amounts display, button visibility (Stake More, Unstake/Claim), and progress indicators — UI elements rendered by EarnStakingAccountRow for Solana staking accounts.
- `suite/e2e/tests/staking/sol/rewards.test.ts` — This test verifies Solana staking dashboard amounts (staked, rewards, unstaking), staking account balance display, and button states — directly related to the EarnStakingAccountRow component's rendering logic.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — This test checks the SOL staking dashboard showing staked amounts, action buttons, and progress indicators after staking more — UI directly rendered by EarnStakingAccountRow.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — This test verifies SOL staking dashboard states through unstake and claim flows including button states, amount displays, and claim card visibility — all rendered by the staking account row component.
- `suite/e2e/tests/staking/staking-form.test.ts` — This test navigates to the staking form via the Stake More button on the staking dashboard, which is rendered by EarnStakingAccountRow. Changes to the component could affect the button's visibility or behavior.

</details>

_Updated: 2026-05-18T11:59:24.703Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/earn-staking-claim-button-in-row/web/](https://dev.suite.sldev.cz/suite-web/feat/earn-staking-claim-button-in-row/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-18T12:03:52.693Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-18T14:20:16.592Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/earn-staking-claim-button-in-row&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/earn-staking-claim-button-in-row&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->