### PR TITLE
fix(suite-native): sync behavior with iOS and detect gesture only on indicator

### DIFF
--- a/suite-native/confirm-on-trezor/src/components/ConfirmOnTrezorContent.tsx
+++ b/suite-native/confirm-on-trezor/src/components/ConfirmOnTrezorContent.tsx
@@ -147,15 +147,12 @@ export const ConfirmOnTrezorContent = ({
                     locations={[0, 1]}
                 />
             </AnimatedBox>
-            <GestureDetector gesture={panGesture}>
-                <AnimatedBox
-                    flex={1}
-                    style={[
-                        applyStyle(contentContainerStyle, { colorVariant }),
-                        animatedSheetStyle,
-                    ]}
-                    layout={LinearTransition}
-                >
+            <AnimatedBox
+                flex={1}
+                style={[applyStyle(contentContainerStyle, { colorVariant }), animatedSheetStyle]}
+                layout={LinearTransition}
+            >
+                <GestureDetector gesture={panGesture}>
                     <AnimatedBox style={animatedHandleStyle}>
                         <AnimatedBox
                             style={[
@@ -164,19 +161,19 @@ export const ConfirmOnTrezorContent = ({
                             ]}
                         />
                     </AnimatedBox>
-                    {isFullscreen && (
-                        <AnimatedBox exiting={FadeOut} entering={FadeIn}>
-                            {defaultHeader}
-                        </AnimatedBox>
-                    )}
-                    <Screen
-                        systemThemeStyle={!isFullscreen ? 'light' : undefined}
-                        containerStyle={applyStyle(innerContainerStyle)}
-                    >
-                        {children}
-                    </Screen>
-                </AnimatedBox>
-            </GestureDetector>
+                </GestureDetector>
+                {isFullscreen && (
+                    <AnimatedBox exiting={FadeOut} entering={FadeIn}>
+                        {defaultHeader}
+                    </AnimatedBox>
+                )}
+                <Screen
+                    systemThemeStyle={!isFullscreen ? 'light' : undefined}
+                    containerStyle={applyStyle(innerContainerStyle)}
+                >
+                    {children}
+                </Screen>
+            </AnimatedBox>
         </>
     );
 };


### PR DESCRIPTION
## Description

* wrap `<GestureDetector/>` only around indicator to mimic iOS on android and enable scroll on android 


## Notes for QA

## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/27734

## Screenshots:


https://github.com/user-attachments/assets/527a8987-c4b1-4209-b1b4-f63718b73e82




<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/27734-calldata-in-dex-flow-on-mobile-is-not-scrollable&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->