### PR TITLE
refactor(address-validator): strongly type networkType arg

### DIFF
--- a/packages/address-validator/src/ada_validator.ts
+++ b/packages/address-validator/src/ada_validator.ts
@@ -4,9 +4,9 @@ import CRC from 'crc';
 
 import * as base58 from './crypto/base58';
 import { addressType } from './crypto/utils';
-import type { Currency } from './currency-types';
+import type { Currency, NetworkEnvironment } from './currency-types';
 
-const DEFAULT_NETWORK_TYPE = 'prod';
+const DEFAULT_NETWORK: NetworkEnvironment = 'prod';
 
 function getDecoded(address: string): any {
     try {
@@ -34,18 +34,22 @@ function isValidLegacyAddress(address: string): boolean {
     return crc === validCrc;
 }
 
-function isValidBech32Address(address: string, currency: any, networkType: string): boolean {
+function isValidBech32Address(
+    address: string,
+    currency: any,
+    network: NetworkEnvironment,
+): boolean {
     if (!currency.segwitHrp) {
         return false;
     }
-    const hrp = currency.segwitHrp[networkType];
+    const hrp = currency.segwitHrp[network];
     if (!hrp) {
         return false;
     }
 
     let dec;
     try {
-        dec = bech32.decode(address as `${string}1${string}`, networkType === 'prod' ? 103 : 108);
+        dec = bech32.decode(address as `${string}1${string}`, network === 'prod' ? 103 : 108);
     } catch {
         return false;
     }
@@ -54,7 +58,7 @@ function isValidBech32Address(address: string, currency: any, networkType: strin
         dec === null ||
         dec.prefix !== hrp ||
         dec.words.length < 1 ||
-        (dec.words[0] > 16 && networkType !== 'stake')
+        (dec.words[0] > 16 && network !== 'stake')
     ) {
         return false;
     }
@@ -65,15 +69,21 @@ function isValidBech32Address(address: string, currency: any, networkType: strin
 export const isValidAddress = (
     address: string,
     currency?: Currency,
-    networkType?: string,
+    network?: NetworkEnvironment,
 ): boolean => {
-    const network = networkType || DEFAULT_NETWORK_TYPE;
+    const resolvedNetwork = network || DEFAULT_NETWORK;
 
-    return isValidLegacyAddress(address) || isValidBech32Address(address, currency, network);
+    return (
+        isValidLegacyAddress(address) || isValidBech32Address(address, currency, resolvedNetwork)
+    );
 };
 
-export const getAddressType = (address: string, currency?: Currency, networkType?: string) => {
-    if (isValidAddress(address, currency, networkType)) {
+export const getAddressType = (
+    address: string,
+    currency?: Currency,
+    network?: NetworkEnvironment,
+) => {
+    if (isValidAddress(address, currency, network)) {
         return addressType.ADDRESS;
     }
 

--- a/packages/address-validator/src/bch_validator.ts
+++ b/packages/address-validator/src/bch_validator.ts
@@ -2,9 +2,9 @@
 // https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/cashaddr.md
 import * as BTCValidator from './bitcoin_validator';
 import { addressType } from './crypto/utils';
-import type { Currency } from './currency-types';
+import type { Currency, NetworkEnvironment } from './currency-types';
 
-const DEFAULT_NETWORK_TYPE = 'prod';
+const DEFAULT_NETWORK: NetworkEnvironment = 'prod';
 
 // Base32 charset used for the cashaddr payload (see "Base32" in the spec).
 const CASHADDR_CHARSET = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';
@@ -94,14 +94,18 @@ function validateAddress(address: string, currency: any): boolean {
 export const isValidAddress = (
     address: string,
     currency?: Currency,
-    networkType?: string,
+    network?: NetworkEnvironment,
 ): boolean =>
     validateAddress(address, currency) ||
-    (currency?.symbol !== 'bch' && BTCValidator.isValidAddress(address, currency, networkType));
+    (currency?.symbol !== 'bch' && BTCValidator.isValidAddress(address, currency, network));
 
-export const getAddressType = (address: string, currency?: Currency, networkType?: string) => {
-    const network = networkType || DEFAULT_NETWORK_TYPE;
-    if (isValidAddress(address, currency, network)) {
+export const getAddressType = (
+    address: string,
+    currency?: Currency,
+    network?: NetworkEnvironment,
+) => {
+    const resolvedNetwork = network || DEFAULT_NETWORK;
+    if (isValidAddress(address, currency, resolvedNetwork)) {
         return addressType.ADDRESS;
     }
 

--- a/packages/address-validator/src/bitcoin_validator.ts
+++ b/packages/address-validator/src/bitcoin_validator.ts
@@ -2,9 +2,9 @@ import * as base58 from './crypto/base58';
 import * as bech32 from './crypto/bech32';
 import * as cryptoUtils from './crypto/utils';
 import { addressType } from './crypto/utils';
-import type { Currency } from './currency-types';
+import type { Currency, NetworkEnvironment } from './currency-types';
 
-const DEFAULT_NETWORK_TYPE = 'prod';
+const DEFAULT_NETWORK: NetworkEnvironment = 'prod';
 
 function getDecoded(address: string): number[] | null {
     try {
@@ -67,11 +67,15 @@ function getAddressTypeHex(address: string, currency: any): string | null {
     return null;
 }
 
-function getOutputIndex(address: string, currency: any, networkType: string): number | null {
+function getOutputIndex(
+    address: string,
+    currency: any,
+    network: NetworkEnvironment,
+): number | null {
     const hex = getAddressTypeHex(address, currency);
     if (hex) {
         const correctAddressTypes =
-            currency.addressTypes[networkType] ||
+            currency.addressTypes[network] ||
             Object.keys(currency.addressTypes).reduce(
                 (all: string[], key: string) => all.concat(currency.addressTypes[key]),
                 [],
@@ -86,17 +90,17 @@ function getOutputIndex(address: string, currency: any, networkType: string): nu
 function isValidPayToPublicKeyHashAddress(
     address: string,
     currency: any,
-    networkType: string,
+    network: NetworkEnvironment,
 ): boolean {
-    return getOutputIndex(address, currency, networkType) === 0;
+    return getOutputIndex(address, currency, network) === 0;
 }
 
 function isValidPayToScriptHashAddress(
     address: string,
     currency: any,
-    networkType: string,
+    network: NetworkEnvironment,
 ): boolean {
-    const idx = getOutputIndex(address, currency, networkType);
+    const idx = getOutputIndex(address, currency, network);
 
     return idx !== null && idx > 0;
 }
@@ -104,10 +108,10 @@ function isValidPayToScriptHashAddress(
 function isValidPayToWitnessScriptHashAddress(
     address: string,
     currency: any,
-    networkType: string,
+    network: NetworkEnvironment,
 ): boolean {
     try {
-        const hrp = currency.segwitHrp[networkType];
+        const hrp = currency.segwitHrp[network];
         const decoded = bech32.decode(hrp, address);
 
         return !!(decoded?.version === 0 && decoded.program.length === 32);
@@ -119,10 +123,10 @@ function isValidPayToWitnessScriptHashAddress(
 function isValidPayToWitnessPublicKeyHashAddress(
     address: string,
     currency: any,
-    networkType: string,
+    network: NetworkEnvironment,
 ): boolean {
     try {
-        const hrp = currency.segwitHrp[networkType];
+        const hrp = currency.segwitHrp[network];
         const decoded = bech32.decode(hrp, address);
 
         return !!(decoded?.version === 0 && decoded.program.length === 20);
@@ -131,9 +135,13 @@ function isValidPayToWitnessPublicKeyHashAddress(
     }
 }
 
-function isValidPayToTaprootAddress(address: string, currency: any, networkType: string): boolean {
+function isValidPayToTaprootAddress(
+    address: string,
+    currency: any,
+    network: NetworkEnvironment,
+): boolean {
     try {
-        const hrp = currency.segwitHrp[networkType];
+        const hrp = currency.segwitHrp[network];
         const decoded = bech32.decode(hrp, address, true);
 
         return !!(decoded?.version === 1 && decoded.program.length === 32);
@@ -142,11 +150,15 @@ function isValidPayToTaprootAddress(address: string, currency: any, networkType:
     }
 }
 
-function isValidSegwitAddress(address: string, currency: any, networkType: string): boolean {
+function isValidSegwitAddress(
+    address: string,
+    currency: any,
+    network: NetworkEnvironment,
+): boolean {
     if (!currency.segwitHrp) {
         return false;
     }
-    const hrp = currency.segwitHrp[networkType];
+    const hrp = currency.segwitHrp[network];
     if (!hrp) {
         return false;
     }
@@ -168,24 +180,28 @@ function isValidSegwitAddress(address: string, currency: any, networkType: strin
     return false;
 }
 
-export const getAddressType = (address: string, currency?: Currency, networkType?: string) => {
-    const network = networkType || DEFAULT_NETWORK_TYPE;
-    if (isValidPayToPublicKeyHashAddress(address, currency, network)) {
+export const getAddressType = (
+    address: string,
+    currency?: Currency,
+    network?: NetworkEnvironment,
+) => {
+    const resolvedNetwork = network || DEFAULT_NETWORK;
+    if (isValidPayToPublicKeyHashAddress(address, currency, resolvedNetwork)) {
         return addressType.P2PKH;
     }
-    if (isValidPayToScriptHashAddress(address, currency, network)) {
+    if (isValidPayToScriptHashAddress(address, currency, resolvedNetwork)) {
         return addressType.P2SH;
     }
-    if (isValidPayToWitnessScriptHashAddress(address, currency, network)) {
+    if (isValidPayToWitnessScriptHashAddress(address, currency, resolvedNetwork)) {
         return addressType.P2WSH;
     }
-    if (isValidPayToWitnessPublicKeyHashAddress(address, currency, network)) {
+    if (isValidPayToWitnessPublicKeyHashAddress(address, currency, resolvedNetwork)) {
         return addressType.P2WPKH;
     }
-    if (isValidPayToTaprootAddress(address, currency, network)) {
+    if (isValidPayToTaprootAddress(address, currency, resolvedNetwork)) {
         return addressType.P2TR;
     }
-    if (isValidSegwitAddress(address, currency, network)) {
+    if (isValidSegwitAddress(address, currency, resolvedNetwork)) {
         return addressType.WITNESS_UNKNOWN;
     }
 
@@ -195,10 +211,10 @@ export const getAddressType = (address: string, currency?: Currency, networkType
 export const isValidAddress = (
     address: string,
     currency?: Currency,
-    networkType?: string,
+    network?: NetworkEnvironment,
 ): boolean => {
-    const network = networkType || DEFAULT_NETWORK_TYPE;
-    const addrType = getAddressType(address, currency, network);
+    const resolvedNetwork = network || DEFAULT_NETWORK;
+    const addrType = getAddressType(address, currency, resolvedNetwork);
 
     return addrType !== undefined && addrType !== addressType.WITNESS_UNKNOWN;
 };

--- a/packages/address-validator/src/currency-types.ts
+++ b/packages/address-validator/src/currency-types.ts
@@ -2,12 +2,24 @@ import type { addressType } from './crypto/utils';
 
 type AddressType = (typeof addressType)[keyof typeof addressType];
 
+export type NetworkEnvironment =
+    | 'prod'
+    | 'testnet'
+    | 'regtest'
+    // TODO: 'stake' is a Cardano address kind (stake vs payment), not a network
+    // environment, and is orthogonal to mainnet/testnet. It is wedged in here
+    // because the validator currently dispatches HRP/length rules through this
+    // single parameter. Refactor: detect stake addresses inside ada_validator
+    // and drop this member.
+    | 'stake'
+    | 'both';
+
 export interface Validator {
-    isValidAddress: (address: string, currency?: Currency, networkType?: string) => boolean;
+    isValidAddress: (address: string, currency?: Currency, network?: NetworkEnvironment) => boolean;
     getAddressType?: (
         address: string,
         currency?: Currency,
-        networkType?: string,
+        network?: NetworkEnvironment,
     ) => AddressType | undefined;
 }
 

--- a/packages/address-validator/src/ethereum_validator.ts
+++ b/packages/address-validator/src/ethereum_validator.ts
@@ -1,6 +1,6 @@
 import * as cryptoUtils from './crypto/utils';
 import { addressType } from './crypto/utils';
-import type { Currency } from './currency-types';
+import type { Currency, NetworkEnvironment } from './currency-types';
 
 function verifyChecksum(address: string): boolean {
     const stripped = address.replace('0x', '');
@@ -32,7 +32,11 @@ export const isValidAddress = (address: string): boolean => {
     return verifyChecksum(address);
 };
 
-export const getAddressType = (address: string, _currency?: Currency, _networkType?: string) => {
+export const getAddressType = (
+    address: string,
+    _currency?: Currency,
+    _network?: NetworkEnvironment,
+) => {
     if (isValidAddress(address)) {
         return addressType.ADDRESS;
     }

--- a/packages/address-validator/src/index.ts
+++ b/packages/address-validator/src/index.ts
@@ -1,6 +1,6 @@
 import { addressType } from './crypto/utils';
 import * as currencies from './currencies';
-import type { Currency } from './currency-types';
+import type { Currency, NetworkEnvironment } from './currency-types';
 
 type AddressType = (typeof addressType)[keyof typeof addressType];
 
@@ -9,12 +9,12 @@ const DEFAULT_CURRENCY_NAME = 'bitcoin';
 export function validate(
     address: string,
     currencyNameOrSymbol?: string,
-    networkType?: string,
+    network?: NetworkEnvironment,
 ): boolean {
     const currency = currencies.getByNameOrSymbol(currencyNameOrSymbol || DEFAULT_CURRENCY_NAME);
 
     if (currency?.validator) {
-        return currency.validator.isValidAddress(address, currency, networkType);
+        return currency.validator.isValidAddress(address, currency, network);
     }
 
     throw new Error('Missing validator for currency: ' + currencyNameOrSymbol);
@@ -23,14 +23,14 @@ export function validate(
 export function getAddressType(
     address: string,
     currencyNameOrSymbol?: string,
-    networkType?: string,
+    network?: NetworkEnvironment,
 ): AddressType | undefined {
     const currency = currencies.getByNameOrSymbol(currencyNameOrSymbol || DEFAULT_CURRENCY_NAME);
     if (!currency?.validator) {
         throw new Error('getAddressType: No validator for currency: ' + currencyNameOrSymbol);
     }
     if (currency.validator.getAddressType) {
-        return currency.validator.getAddressType(address, currency, networkType);
+        return currency.validator.getAddressType(address, currency, network);
     }
     throw new Error('getAddressType not defined for currency: ' + currencyNameOrSymbol);
 }
@@ -44,4 +44,4 @@ export function findCurrency(symbol: string): Currency | null {
 }
 
 export { addressType };
-export type { Currency, AddressType };
+export type { Currency, AddressType, NetworkEnvironment };

--- a/packages/address-validator/src/ripple_validator.ts
+++ b/packages/address-validator/src/ripple_validator.ts
@@ -2,7 +2,7 @@ import { base58xrp } from '@scure/base';
 
 import * as cryptoUtils from './crypto/utils';
 import { addressType } from './crypto/utils';
-import type { Currency } from './currency-types';
+import type { Currency, NetworkEnvironment } from './currency-types';
 
 const ALLOWED_CHARS = 'rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz';
 
@@ -24,7 +24,11 @@ export const isValidAddress = (address: string): boolean => {
     return false;
 };
 
-export const getAddressType = (address: string, _currency?: Currency, _networkType?: string) => {
+export const getAddressType = (
+    address: string,
+    _currency?: Currency,
+    _network?: NetworkEnvironment,
+) => {
     if (isValidAddress(address)) {
         return addressType.ADDRESS;
     }

--- a/packages/address-validator/src/solana_validator.ts
+++ b/packages/address-validator/src/solana_validator.ts
@@ -1,6 +1,6 @@
 import * as base58 from './crypto/base58';
 import { addressType } from './crypto/utils';
-import type { Currency } from './currency-types';
+import type { Currency, NetworkEnvironment } from './currency-types';
 
 export const isValidAddress = (address: string): boolean => {
     try {
@@ -12,7 +12,11 @@ export const isValidAddress = (address: string): boolean => {
     }
 };
 
-export const getAddressType = (address: string, _currency?: Currency, _networkType?: string) => {
+export const getAddressType = (
+    address: string,
+    _currency?: Currency,
+    _network?: NetworkEnvironment,
+) => {
     if (isValidAddress(address)) {
         return addressType.ADDRESS;
     }

--- a/packages/address-validator/src/stellar_validator.ts
+++ b/packages/address-validator/src/stellar_validator.ts
@@ -3,7 +3,7 @@ import crc from 'crc';
 
 import * as cryptoUtils from './crypto/utils';
 import { addressType } from './crypto/utils';
-import type { Currency } from './currency-types';
+import type { Currency, NetworkEnvironment } from './currency-types';
 
 const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
 
@@ -39,7 +39,11 @@ export const isValidAddress = (address: string): boolean => {
     return false;
 };
 
-export const getAddressType = (address: string, _currency?: Currency, _networkType?: string) => {
+export const getAddressType = (
+    address: string,
+    _currency?: Currency,
+    _network?: NetworkEnvironment,
+) => {
     if (isValidAddress(address)) {
         return addressType.ADDRESS;
     }

--- a/packages/address-validator/src/tron_validator.ts
+++ b/packages/address-validator/src/tron_validator.ts
@@ -1,6 +1,6 @@
 import * as cryptoUtils from './crypto/utils';
 import { addressType } from './crypto/utils';
-import type { Currency } from './currency-types';
+import type { Currency, NetworkEnvironment } from './currency-types';
 
 function decodeBase58Address(base58Sting: unknown): number[] | false {
     if (typeof base58Sting !== 'string') {
@@ -36,8 +36,8 @@ function decodeBase58Address(base58Sting: unknown): number[] | false {
     return false;
 }
 
-function getEnv(currency: any, networkType?: string): number {
-    let evn = networkType || 'prod';
+function getEnv(currency: any, network?: NetworkEnvironment): number {
+    let evn: NetworkEnvironment = network || 'prod';
 
     if (evn !== 'prod' && evn !== 'testnet') evn = 'prod';
 
@@ -47,7 +47,7 @@ function getEnv(currency: any, networkType?: string): number {
 export const isValidAddress = (
     mainAddress: string,
     currency?: Currency,
-    networkType?: string,
+    network?: NetworkEnvironment,
 ): boolean => {
     const address = decodeBase58Address(mainAddress);
 
@@ -59,11 +59,15 @@ export const isValidAddress = (
         return false;
     }
 
-    return getEnv(currency, networkType) === address[0];
+    return getEnv(currency, network) === address[0];
 };
 
-export const getAddressType = (address: string, currency?: Currency, networkType?: string) => {
-    if (isValidAddress(address, currency, networkType)) {
+export const getAddressType = (
+    address: string,
+    currency?: Currency,
+    network?: NetworkEnvironment,
+) => {
+    if (isValidAddress(address, currency, network)) {
         return addressType.ADDRESS;
     }
 

--- a/packages/address-validator/tests/wallet_address_validator.test.ts
+++ b/packages/address-validator/tests/wallet_address_validator.test.ts
@@ -1,24 +1,25 @@
 import * as WAValidator from '../src';
+import type { NetworkEnvironment } from '../src';
 
 const { addressType } = WAValidator;
 
 function isValidAddressType(
     address: string,
     currency: string,
-    networkType: string | undefined,
+    network: NetworkEnvironment | undefined,
     expectedType: string | undefined,
 ) {
-    const type = WAValidator.getAddressType(address, currency, networkType);
+    const type = WAValidator.getAddressType(address, currency, network);
     expect({ address, addressType: type }).toEqual({ address, addressType: expectedType });
 }
 
-function valid(address: string, currency?: string, networkType?: string) {
-    const isValid = WAValidator.validate(address, currency, networkType);
+function valid(address: string, currency?: string, network?: NetworkEnvironment) {
+    const isValid = WAValidator.validate(address, currency, network);
     expect({ address, currency, valid: isValid }).toEqual({ address, currency, valid: true });
 }
 
-function invalid(address: string, currency?: string, networkType?: string) {
-    const isValid = WAValidator.validate(address, currency, networkType);
+function invalid(address: string, currency?: string, network?: NetworkEnvironment) {
+    const isValid = WAValidator.validate(address, currency, network);
     expect({ address, currency, valid: isValid }).toEqual({ address, currency, valid: false });
 }
 

--- a/suite-common/wallet-utils/src/validationUtils.ts
+++ b/suite-common/wallet-utils/src/validationUtils.ts
@@ -4,10 +4,10 @@ import { toChecksumAddress } from 'web3-utils';
 
 import { getTestnetSymbols } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
-import { getAddressType, validate } from '@trezor/address-validator';
+import { type NetworkEnvironment, getAddressType, validate } from '@trezor/address-validator';
 import { type AccountInfo } from '@trezor/blockchain-link-types';
 
-const getNetworkType = (symbol: Account['symbol'], address: string) => {
+const getNetworkEnvironment = (symbol: Account['symbol'], address: string): NetworkEnvironment => {
     if (symbol === 'regtest') return symbol;
     const testnets = getTestnetSymbols();
 
@@ -36,10 +36,10 @@ const getCoinFromTestnet = (symbol: Account['symbol']) => {
 };
 
 export const isAddressValid = (address: string, symbol: Account['symbol']) => {
-    const networkType = getNetworkType(symbol, address);
+    const network = getNetworkEnvironment(symbol, address);
     const updatedSymbol = getCoinFromTestnet(symbol);
 
-    return validate(address, updatedSymbol.toUpperCase(), networkType);
+    return validate(address, updatedSymbol.toUpperCase(), network);
 };
 
 export const isAddressDeprecated = (address: string, symbol: Account['symbol']) => {
@@ -55,10 +55,10 @@ export const isAddressDeprecated = (address: string, symbol: Account['symbol']) 
 };
 
 export const isTaprootAddress = (address: string, symbol: Account['symbol']) => {
-    const networkType = getNetworkType(symbol, address);
+    const network = getNetworkEnvironment(symbol, address);
     const updatedSymbol = getCoinFromTestnet(symbol);
 
-    return getAddressType(address, updatedSymbol.toUpperCase(), networkType) === 'p2tr';
+    return getAddressType(address, updatedSymbol.toUpperCase(), network) === 'p2tr';
 };
 
 export const hasBitcoinCashAddressPrefix = (address: string) =>


### PR DESCRIPTION
## Summary

- Replace `networkType: string` in `@trezor/address-validator` with a `NetworkType` string-literal union: `'prod' | 'testnet' | 'regtest' | 'stake' | 'both'`.
- Propagate the new type through the public API (`validate`, `getAddressType`, `Validator` interface) and every per-coin validator (BTC/BCH/ADA/TRX/ETH/XRP/SOL/XLM).
- Annotate `getNetworkType` return type in `suite-common/wallet-utils/src/validationUtils.ts` so internal callers stay typed end-to-end.
- Export `NetworkType` from the package entrypoint.

Union members were derived from actual usage in the repo:
- `'prod'` / `'testnet'` — segwitHrp / addressTypes map keys for all coins
- `'regtest'` — BTC-only (`segwitHrp.regtest = 'bcrt'`)
- `'stake'` — ADA-only (stake addresses, used in `validationUtils.getNetworkType`)
- `'both'` — sentinel used in tests; falls through validators to "check all networkTypes"

Runtime is unchanged.

## Breaking change

External consumers calling `validate(address, symbol, networkType)` or `getAddressType(...)` with a `networkType` typed as a broader `string` will need to narrow to `NetworkType`. All in-repo callers (`suite-common/wallet-utils`, `packages/suite`) already pass concrete literals from this union, so internal usage is unaffected.

## Test plan

- [ ] `yarn workspace @trezor/address-validator type-check`
- [ ] `yarn workspace @trezor/address-validator test:unit`
- [ ] `yarn workspace @suite-common/wallet-utils type-check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/address-validator-network-type-literals&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/address-validator-network-type-literals&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/address-validator-network-type-literals&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-26T16:14:36.453Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-18T18:00:47.616Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/address-validator-network-type-literals/web/](https://dev.suite.sldev.cz/suite-web/mroz22/address-validator-network-type-literals/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->