### PR TITLE
Mobile Swap - remove preselectedQuote and use selectedQuote

### DIFF
--- a/suite-common/trading/src/reducers/__fixtures__/exchangeTradingReducer.ts
+++ b/suite-common/trading/src/reducers/__fixtures__/exchangeTradingReducer.ts
@@ -188,20 +188,6 @@ export const exchangeTradingFixtures = [
         },
     },
     {
-        description: 'should save preselected quote',
-        initialState: exchangeInitialState,
-        actions: [
-            {
-                type: tradingExchangeActions.savePreselectedQuote.type,
-                payload: changellyExchangeQuote,
-            },
-        ],
-        result: {
-            ...exchangeInitialState,
-            preselectedQuote: changellyExchangeQuote,
-        },
-    },
-    {
         description: 'should set status whether is from redirect',
         initialState: exchangeInitialState,
         actions: [

--- a/suite-common/trading/src/reducers/exchangeReducer.ts
+++ b/suite-common/trading/src/reducers/exchangeReducer.ts
@@ -27,7 +27,6 @@ export interface TradingExchangeState {
     receiveAddress?: string;
     extraField?: string;
     selectedQuote: ExchangeTrade | undefined;
-    preselectedQuote: ExchangeTrade | undefined;
     isFromRedirect: boolean;
     isLoading: boolean;
     dexQuoteApprovalPrefetchLoadingQuoteId: string | undefined;
@@ -47,7 +46,6 @@ export const exchangeInitialState: TradingExchangeState = {
     receiveAddress: undefined,
     extraField: undefined,
     selectedQuote: undefined,
-    preselectedQuote: undefined,
     isFromRedirect: false,
     isLoading: false,
     dexQuoteApprovalPrefetchLoadingQuoteId: undefined,
@@ -88,9 +86,6 @@ const tradingExchangeSlice = createSlice({
         },
         saveSelectedQuote(state, action: PayloadAction<ExchangeTrade | undefined>) {
             state.selectedQuote = action.payload;
-        },
-        savePreselectedQuote(state, action: PayloadAction<ExchangeTrade | undefined>) {
-            state.preselectedQuote = action.payload;
         },
         setIsFromRedirect(state, action: PayloadAction<boolean>) {
             state.isFromRedirect = action.payload;

--- a/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
+++ b/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
@@ -50,7 +50,6 @@ import {
     selectTradingCoinSymbolByCryptoId,
     selectTradingComposedTransactionInfo,
     selectTradingExchange,
-    selectTradingExchangeActiveQuote,
     selectTradingExchangeAmountLimits,
     selectTradingExchangeBuyCryptoIds,
     selectTradingExchangeCexQuotes,
@@ -656,33 +655,6 @@ describe('tradingSelectors', () => {
         expect(selectTradingExchangeSelectedQuote(state)).toBe(
             state.wallet.trading.exchange.selectedQuote,
         );
-    });
-
-    describe('selectTradingExchangeActiveQuote', () => {
-        it('should return selectedQuote when it is defined', () => {
-            state.wallet.trading.exchange.selectedQuote = invityAPIFixtures.exchangeTrade;
-            state.wallet.trading.exchange.preselectedQuote = {
-                ...invityAPIFixtures.exchangeTrade,
-                exchange: 'preselected-exchange',
-            };
-
-            expect(selectTradingExchangeActiveQuote(state)).toBe(
-                state.wallet.trading.exchange.selectedQuote,
-            );
-        });
-
-        it('should fall back to preselectedQuote when selectedQuote is undefined', () => {
-            state.wallet.trading.exchange.selectedQuote = undefined;
-            state.wallet.trading.exchange.preselectedQuote = invityAPIFixtures.exchangeTrade;
-
-            expect(selectTradingExchangeActiveQuote(state)).toBe(
-                state.wallet.trading.exchange.preselectedQuote,
-            );
-        });
-
-        it('should return undefined when both quotes are undefined', () => {
-            expect(selectTradingExchangeActiveQuote(state)).toBeUndefined();
-        });
     });
 
     it('selectTradingSellSelectedQuote should return correct data', () => {

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -343,12 +343,6 @@ export const selectTradingBuySelectedQuote = (state: TradingRootState) =>
 export const selectTradingExchangeSelectedQuote = (state: TradingRootState) =>
     state.wallet.trading.exchange.selectedQuote;
 
-export const selectTradingExchangePreselectedQuote = (state: TradingRootState) =>
-    state.wallet.trading.exchange.preselectedQuote;
-
-export const selectTradingExchangeActiveQuote = (state: TradingRootState) =>
-    selectTradingExchangeSelectedQuote(state) ?? selectTradingExchangePreselectedQuote(state);
-
 export const selectTradingSellSelectedQuote = (state: TradingRootState) =>
     state.wallet.trading.sell.selectedQuote;
 

--- a/suite-native/module-trading/src/components/exchange/Approval/LimitInfoRow.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/LimitInfoRow.tsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 
 import {
     cryptoIdToNetworkAndContractAddress,
-    selectTradingExchangeActiveQuote,
+    selectTradingExchangeSelectedQuote,
 } from '@suite-common/trading';
 import { HStack, Text, VStack } from '@suite-native/atoms';
 import { CryptoIcon, Icon } from '@suite-native/icons';
@@ -21,7 +21,7 @@ type LimitInfoRowProps = PropsWithChildren<{
 }>;
 
 export const LimitInfoRow = ({ onPress, testID, withCaret, children }: LimitInfoRowProps) => {
-    const quote = useSelector(selectTradingExchangeActiveQuote);
+    const quote = useSelector(selectTradingExchangeSelectedQuote);
 
     if (!quote?.send) {
         return null;

--- a/suite-native/module-trading/src/components/exchange/Approval/LimitPicker.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/LimitPicker.tsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 
 import type { DexApprovalType } from 'invity-api';
 
-import { selectTradingExchangeActiveQuote } from '@suite-common/trading';
+import { selectTradingExchangeSelectedQuote } from '@suite-common/trading';
 import { Text } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { useBottomSheetControls } from '@suite-native/trading-atoms';
@@ -17,7 +17,7 @@ type LimitPickerProps = {
 };
 
 export const LimitPicker = ({ onApprovalTypeChange }: LimitPickerProps) => {
-    const quote = useSelector(selectTradingExchangeActiveQuote);
+    const quote = useSelector(selectTradingExchangeSelectedQuote);
     const { isSheetVisible, showSheet, hideSheet } = useBottomSheetControls();
 
     const handleApprovalTypeChange = useCallback(

--- a/suite-native/module-trading/src/components/exchange/Approval/OriginalLimit.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/OriginalLimit.tsx
@@ -2,7 +2,7 @@ import { useSelector } from 'react-redux';
 
 import {
     cryptoIdToNetworkAndContractAddress,
-    selectTradingExchangeActiveQuote,
+    selectTradingExchangeSelectedQuote,
 } from '@suite-common/trading';
 import { HStack, Text } from '@suite-native/atoms';
 import { CryptoIcon } from '@suite-native/icons';
@@ -13,7 +13,7 @@ import { hasPreapprovedLimit } from '../../../utils/exchange/quotesUtils';
 import { TradingCoinAmountFormatter } from '../../general/TradingCoinAmountFormatter';
 
 export const OriginalLimit = () => {
-    const quote = useSelector(selectTradingExchangeActiveQuote);
+    const quote = useSelector(selectTradingExchangeSelectedQuote);
 
     if (!quote?.send || !hasPreapprovedLimit(quote)) {
         return null;

--- a/suite-native/module-trading/src/components/exchange/Approval/RevokeLimitInfoRow.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/RevokeLimitInfoRow.tsx
@@ -2,7 +2,7 @@ import { useSelector } from 'react-redux';
 
 import {
     cryptoIdToNetworkAndContractAddress,
-    selectTradingExchangeActiveQuote,
+    selectTradingExchangeSelectedQuote,
 } from '@suite-common/trading';
 import { isMaxAllowance } from '@suite-common/wallet-utils';
 import { HStack, Text } from '@suite-native/atoms';
@@ -14,7 +14,7 @@ import { UnlimitedAllowanceLabel } from './UnlimitedAllowanceLabel';
 import { TradingCoinAmountFormatter } from '../../general/TradingCoinAmountFormatter';
 
 export const RevokeLimitInfoRow = () => {
-    const quote = useSelector(selectTradingExchangeActiveQuote);
+    const quote = useSelector(selectTradingExchangeSelectedQuote);
 
     if (!quote?.send) {
         return null;

--- a/suite-native/module-trading/src/components/exchange/Approval/__tests__/ExchangeApprovalDetails.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/__tests__/ExchangeApprovalDetails.test.tsx
@@ -24,7 +24,7 @@ describe('ExchangeApprovalDetails', () => {
             trading: {
                 exchange: {
                     tradingAccountKey: eth1NormalAccount.key,
-                    preselectedQuote: mercuryoFixedWorstQuote,
+                    selectedQuote: mercuryoFixedWorstQuote,
                 },
             },
         },
@@ -67,7 +67,7 @@ describe('ExchangeApprovalDetails', () => {
                 trading: {
                     exchange: {
                         tradingAccountKey: 'unknown-account-key' as AccountKey,
-                        preselectedQuote: mercuryoFixedWorstQuote,
+                        selectedQuote: mercuryoFixedWorstQuote,
                     },
                 },
             },

--- a/suite-native/module-trading/src/components/exchange/Approval/__tests__/ExchangeRevokeDetails.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/__tests__/ExchangeRevokeDetails.test.tsx
@@ -17,7 +17,7 @@ describe('ExchangeRevokeDetails', () => {
             trading: {
                 exchange: {
                     tradingAccountKey: eth1NormalAccount.key,
-                    preselectedQuote: mercuryoFixedWorstQuote,
+                    selectedQuote: mercuryoFixedWorstQuote,
                 },
             },
         },
@@ -57,7 +57,7 @@ describe('ExchangeRevokeDetails', () => {
                 trading: {
                     exchange: {
                         tradingAccountKey: 'unknown-account-key' as AccountKey,
-                        preselectedQuote: mercuryoFixedWorstQuote,
+                        selectedQuote: mercuryoFixedWorstQuote,
                     },
                 },
             },

--- a/suite-native/module-trading/src/components/exchange/Approval/__tests__/LimitPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/__tests__/LimitPicker.test.tsx
@@ -1,4 +1,4 @@
-import { selectTradingExchangeActiveQuote, tradingExchangeActions } from '@suite-common/trading';
+import { selectTradingExchangeSelectedQuote, tradingExchangeActions } from '@suite-common/trading';
 import { getTranslation } from '@suite-native/intl';
 import {
     type TestStore,
@@ -20,7 +20,7 @@ describe('LimitPicker', () => {
             <LimitPicker
                 onApprovalTypeChange={approvalType => {
                     mockOnApprovalTypeChange(approvalType);
-                    const quote = selectTradingExchangeActiveQuote(store.getState());
+                    const quote = selectTradingExchangeSelectedQuote(store.getState());
                     if (!quote) {
                         return;
                     }
@@ -43,7 +43,7 @@ describe('LimitPicker', () => {
                 wallet: {
                     trading: {
                         exchange: {
-                            preselectedQuote: quote,
+                            selectedQuote: quote,
                         },
                     },
                 },
@@ -94,7 +94,7 @@ describe('LimitPicker', () => {
                 }),
             ),
         ).toBeOnTheScreen();
-        expect(selectTradingExchangeActiveQuote(store.getState())).toEqual(
+        expect(selectTradingExchangeSelectedQuote(store.getState())).toEqual(
             expect.objectContaining({ approvalType: 'INFINITE' }),
         );
     });
@@ -115,13 +115,12 @@ describe('LimitPicker', () => {
                 getTranslation('moduleTrading.exchangeApprovalLimitSheet.limitedCard.info'),
             ),
         ).toBeOnTheScreen();
-        expect(selectTradingExchangeActiveQuote(store.getState())).toEqual(
+        expect(selectTradingExchangeSelectedQuote(store.getState())).toEqual(
             expect.objectContaining({ approvalType: 'MINIMAL' }),
         );
     });
 
     it('should render nothing without quote', () => {
-        store.dispatch(tradingExchangeActions.savePreselectedQuote(undefined));
         store.dispatch(tradingExchangeActions.saveSelectedQuote(undefined));
 
         const { toJSON } = renderLimitPicker();

--- a/suite-native/module-trading/src/components/exchange/Approval/__tests__/OriginalLimit.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/__tests__/OriginalLimit.test.tsx
@@ -6,12 +6,12 @@ import { getWalletState } from '@suite-native/trading-fixtures';
 
 import { OriginalLimit } from '../OriginalLimit';
 
-const mockSelectTradingExchangeActiveQuote = jest.fn();
+const mockSelectTradingExchangeSelectedQuote = jest.fn();
 
 jest.mock('@suite-common/trading', () => ({
     ...jest.requireActual('@suite-common/trading'),
-    selectTradingExchangeActiveQuote: (...args: unknown[]) =>
-        mockSelectTradingExchangeActiveQuote(...args),
+    selectTradingExchangeSelectedQuote: (...args: unknown[]) =>
+        mockSelectTradingExchangeSelectedQuote(...args),
 }));
 
 describe('OriginalLimit', () => {
@@ -38,7 +38,7 @@ describe('OriginalLimit', () => {
         ],
         ['quote.preapprovedStringAmount is "0"', { send: 'bitcoin', preapprovedStringAmount: '0' }],
     ] as const)('should render nothing when %s', (_description, quote) => {
-        mockSelectTradingExchangeActiveQuote.mockReturnValue(quote);
+        mockSelectTradingExchangeSelectedQuote.mockReturnValue(quote);
 
         const { toJSON } = renderOriginalLimit();
 
@@ -46,7 +46,7 @@ describe('OriginalLimit', () => {
     });
 
     it('should render limit label and amount when quote has valid data', () => {
-        mockSelectTradingExchangeActiveQuote.mockReturnValue({
+        mockSelectTradingExchangeSelectedQuote.mockReturnValue({
             send: 'bitcoin',
             preapprovedStringAmount: '100',
         } as Partial<ExchangeTrade>);

--- a/suite-native/module-trading/src/components/exchange/Approval/__tests__/RevokeLimitInfoRow.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/__tests__/RevokeLimitInfoRow.test.tsx
@@ -20,7 +20,7 @@ describe('RevokeLimitInfoRow', () => {
         wallet: {
             trading: {
                 exchange: {
-                    preselectedQuote: {
+                    selectedQuote: {
                         ...mercuryoFixedWorstQuote,
                         preapprovedStringAmount: '100',
                     },

--- a/suite-native/module-trading/src/components/exchange/Confirmation/ConfirmationQuoteDebugView.tsx
+++ b/suite-native/module-trading/src/components/exchange/Confirmation/ConfirmationQuoteDebugView.tsx
@@ -1,6 +1,6 @@
 import { useSelector } from 'react-redux';
 
-import { type TransactionStatus, selectTradingExchangeActiveQuote } from '@suite-common/trading';
+import { type TransactionStatus, selectTradingExchangeSelectedQuote } from '@suite-common/trading';
 import { Button, HStack, Text } from '@suite-native/atoms';
 import { DebugModeView, type TransactionStatusWithOverride } from '@suite-native/trading-debug';
 
@@ -15,7 +15,7 @@ export const ConfirmationQuoteDebugView = ({
     forceStatus,
     transactionStatus,
 }: ConfirmationQuoteDebugViewProps) => {
-    const quote = useSelector(selectTradingExchangeActiveQuote);
+    const quote = useSelector(selectTradingExchangeSelectedQuote);
 
     return (
         <DebugModeView>

--- a/suite-native/module-trading/src/components/exchange/Confirmation/ExchangeConfirmationHeader.tsx
+++ b/suite-native/module-trading/src/components/exchange/Confirmation/ExchangeConfirmationHeader.tsx
@@ -6,7 +6,7 @@ import { useNavigation } from '@react-navigation/native';
 import {
     type TradingRootState,
     selectTradingCoinSymbolByCryptoId,
-    selectTradingExchangeActiveQuote,
+    selectTradingExchangeSelectedQuote,
 } from '@suite-common/trading';
 import { Translation } from '@suite-native/intl';
 import {
@@ -26,7 +26,7 @@ type NavigationProp = StackNavigationProps<RootStackParamList, RootStackRoutes.T
 export const ExchangeConfirmationHeader = ({ flowType }: ExchangeConfirmationHeaderProps) => {
     const navigation = useNavigation<NavigationProp>();
 
-    const quote = useSelector(selectTradingExchangeActiveQuote);
+    const quote = useSelector(selectTradingExchangeSelectedQuote);
 
     const symbol = useSelector((state: TradingRootState) =>
         selectTradingCoinSymbolByCryptoId(state, quote?.send),

--- a/suite-native/module-trading/src/components/exchange/Confirmation/ExchangeConfirmationInfo.tsx
+++ b/suite-native/module-trading/src/components/exchange/Confirmation/ExchangeConfirmationInfo.tsx
@@ -6,7 +6,7 @@ import type { ExchangeFee } from 'invity-api';
 import { useFormatters } from '@suite-common/formatters';
 import {
     cryptoIdToNetworkAndContractAddress,
-    selectTradingExchangeActiveQuote,
+    selectTradingExchangeSelectedQuote,
 } from '@suite-common/trading';
 import { AnimatedVStack, Card, Text, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
@@ -42,7 +42,7 @@ export const ExchangeConfirmationInfo = ({
     const { DateFormatter, TimeFormatter } = useFormatters();
 
     const date = transaction?.blockTime ? new Date(transaction.blockTime * 1000) : null;
-    const quote = useSelector(selectTradingExchangeActiveQuote);
+    const quote = useSelector(selectTradingExchangeSelectedQuote);
 
     if (!quote?.send) {
         return null;

--- a/suite-native/module-trading/src/hooks/exchange/Approval/__tests__/useApprovalFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/Approval/__tests__/useApprovalFlow.test.ts
@@ -1,0 +1,58 @@
+import { exchangeThunks, selectTradingExchangeSelectedQuote } from '@suite-common/trading';
+import { act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
+import { invityDexQuote } from '@suite-native/trading-fixtures';
+
+import { createTradingLightStore } from '../../../../__tests__/tradingTestUtils';
+import { useApprovalFlow } from '../useApprovalFlow';
+
+const mockConfirmApprovalThunk: any = () => () => ({
+    unwrap: () => Promise.resolve({}),
+});
+jest.spyOn(exchangeThunks, 'confirmApprovalThunk').mockImplementation(mockConfirmApprovalThunk);
+
+describe('useApprovalFlow', () => {
+    it('should return selected quote from exchange state', () => {
+        const store = createTradingLightStore({
+            tradeType: 'exchange',
+            overrides: {
+                wallet: {
+                    trading: {
+                        exchange: {
+                            selectedQuote: invityDexQuote,
+                        },
+                    },
+                },
+            },
+        });
+
+        const { result } = renderHookWithStoreProvider(() => useApprovalFlow(), { store });
+
+        expect(result.current.quote).toEqual(invityDexQuote);
+    });
+
+    it('should update selected quote approval type', async () => {
+        const quote = { ...invityDexQuote, approvalType: 'MINIMAL' as const };
+        const store = createTradingLightStore({
+            tradeType: 'exchange',
+            overrides: {
+                wallet: {
+                    trading: {
+                        exchange: {
+                            selectedQuote: quote,
+                        },
+                    },
+                },
+            },
+        });
+        const { result } = renderHookWithStoreProvider(() => useApprovalFlow(), { store });
+
+        await act(async () => {
+            await result.current.onApprovalTypeChange('INFINITE');
+        });
+
+        expect(selectTradingExchangeSelectedQuote(store.getState())).toEqual({
+            ...quote,
+            approvalType: 'INFINITE',
+        });
+    });
+});

--- a/suite-native/module-trading/src/hooks/exchange/Approval/useApprovalFlow.ts
+++ b/suite-native/module-trading/src/hooks/exchange/Approval/useApprovalFlow.ts
@@ -5,7 +5,7 @@ import type { DexApprovalType, ExchangeTrade } from 'invity-api';
 
 import {
     exchangeThunks,
-    selectTradingExchangeActiveQuote,
+    selectTradingExchangeSelectedQuote,
     tradingExchangeActions,
 } from '@suite-common/trading';
 import { useTranslate } from '@suite-native/intl';
@@ -20,7 +20,7 @@ export const useApprovalFlow = () => {
     const dispatch = useDispatch();
     const { translate } = useTranslate();
 
-    const quote = useSelector(selectTradingExchangeActiveQuote);
+    const quote = useSelector(selectTradingExchangeSelectedQuote);
     const sendAccount = useSelector(selectExchangeSelectedSendAccount);
     const toAccount = useSelector(selectExchangeSelectedReceiveAccount);
     const receiveAddress = getReceiveAccountAddressText(toAccount);

--- a/suite-native/module-trading/src/hooks/exchange/Approval/useEvmApprovalFees.ts
+++ b/suite-native/module-trading/src/hooks/exchange/Approval/useEvmApprovalFees.ts
@@ -5,7 +5,7 @@ import { type DexApprovalType } from 'invity-api';
 
 import {
     selectTradingComposedTransactionInfo,
-    selectTradingExchangeActiveQuote,
+    selectTradingExchangeSelectedQuote,
 } from '@suite-common/trading';
 import {
     type AccountsRootState,
@@ -30,7 +30,7 @@ export const useEvmApprovalFees = ({ approvalTypeOverride }: UseEvmApprovalFeesP
     const [isComposing, setIsComposing] = useState(false);
     const [error, setError] = useState<string | null>(null);
 
-    const quote = useSelector(selectTradingExchangeActiveQuote);
+    const quote = useSelector(selectTradingExchangeSelectedQuote);
     const sendAccount = useSelector(selectExchangeSelectedSendAccount);
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, sendAccount?.key),

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeSelectQuote.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeSelectQuote.test.ts
@@ -446,10 +446,12 @@ describe('useExchangeSelectQuote', () => {
             });
 
             expect(mockNavigation.navigate).toHaveBeenCalledWith('TradingExchangePreview', {});
-            expect(dispatchSpy).not.toHaveBeenCalledWith({
-                type: '@trading-exchange/savePreselectedQuote',
-                payload: expect.anything(),
+            expect(dispatchSpy).toHaveBeenCalledWith({
+                type: '@trading-exchange/saveSelectedQuote',
+                payload: mercuryoFixedBestQuote,
             });
+            const dispatchedTypes = dispatchSpy.mock.calls.map(([action]) => (action as any)?.type);
+            expect(dispatchedTypes).not.toContain('@trading-exchange/savePreselectedQuote');
         });
 
         it('should navigate to TradingExchangePreview when approval status is "not_needed"', () => {
@@ -475,6 +477,10 @@ describe('useExchangeSelectQuote', () => {
             });
 
             expect(mockNavigation.navigate).toHaveBeenCalledWith('TradingExchangePreview', {});
+            expect(dispatchSpy).toHaveBeenCalledWith({
+                type: '@trading-exchange/saveSelectedQuote',
+                payload: mercuryoFixedBestQuote,
+            });
         });
 
         it('should navigate to TradingExchangeApproval when approval status is "needs_approval"', () => {
@@ -500,11 +506,13 @@ describe('useExchangeSelectQuote', () => {
             });
 
             expect(mockNavigation.navigate).toHaveBeenCalledWith('TradingExchangeApproval', {});
-
+            // The hook persists candidateQuote to selectedQuote before navigating to the approval screen.
             expect(dispatchSpy).toHaveBeenCalledWith({
-                type: '@trading-exchange/savePreselectedQuote',
+                type: '@trading-exchange/saveSelectedQuote',
                 payload: mercuryoFixedBestQuote,
             });
+            const dispatchedTypes = dispatchSpy.mock.calls.map(([action]) => (action as any)?.type);
+            expect(dispatchedTypes).not.toContain('@trading-exchange/savePreselectedQuote');
         });
 
         it('should navigate to TradingExchangeApproval with shouldIncreaseLimit when approval status is "needs_increase" and token supports increasing allowance', () => {
@@ -533,9 +541,11 @@ describe('useExchangeSelectQuote', () => {
                 shouldIncreaseLimit: true,
             });
             expect(dispatchSpy).toHaveBeenCalledWith({
-                type: '@trading-exchange/savePreselectedQuote',
+                type: '@trading-exchange/saveSelectedQuote',
                 payload: mercuryoFixedBestQuote,
             });
+            const dispatchedTypes = dispatchSpy.mock.calls.map(([action]) => (action as any)?.type);
+            expect(dispatchedTypes).not.toContain('@trading-exchange/savePreselectedQuote');
         });
 
         it('should navigate to TradingExchangeRevoke when approval status is "needs_increase" and token does not support increasing allowance', () => {
@@ -562,6 +572,10 @@ describe('useExchangeSelectQuote', () => {
 
             expect(mockNavigation.navigate).toHaveBeenCalledWith('TradingExchangeRevoke', {
                 shouldIncreaseLimit: true,
+            });
+            expect(dispatchSpy).toHaveBeenCalledWith({
+                type: '@trading-exchange/saveSelectedQuote',
+                payload: mercuryoFixedBestQuote,
             });
         });
 
@@ -593,9 +607,13 @@ describe('useExchangeSelectQuote', () => {
                     shouldIncreaseLimit: false,
                 });
                 expect(dispatchSpy).toHaveBeenCalledWith({
-                    type: '@trading-exchange/savePreselectedQuote',
+                    type: '@trading-exchange/saveSelectedQuote',
                     payload: mercuryoFixedBestQuote,
                 });
+                const dispatchedTypes = dispatchSpy.mock.calls.map(
+                    ([action]) => (action as any)?.type,
+                );
+                expect(dispatchedTypes).not.toContain('@trading-exchange/savePreselectedQuote');
             },
         );
 

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeFlow.tsx
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeFlow.tsx
@@ -8,7 +8,7 @@ import { useServices } from '@suite-common/dependency-injection';
 import {
     type TradingSendRejectedProps,
     exchangeThunks,
-    selectTradingExchangeActiveQuote,
+    selectTradingExchangeSelectedQuote,
 } from '@suite-common/trading';
 import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
 import {
@@ -50,7 +50,7 @@ export const useExchangeFlow = ({ flowType }: UseExchangeFlowProps = {}) => {
         >();
     const dispatch = useDispatch();
     const { analytics } = useServices<NativeAnalyticsDep>();
-    const quote = useSelector(selectTradingExchangeActiveQuote);
+    const quote = useSelector(selectTradingExchangeSelectedQuote);
 
     const sendAccount = useSelector(selectExchangeSelectedSendAccount);
 

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeSelectQuote.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeSelectQuote.ts
@@ -103,13 +103,16 @@ export const useExchangeSelectQuote = (form: ExchangeFormType) => {
 
     const selectQuote = () =>
         dispatchSelectQuote('continue', approvalStatus => {
-            if (approvalStatus === 'approved' || approvalStatus === 'not_needed') {
-                return navigation.navigate(RootStackRoutes.TradingExchangePreview, {});
-            }
-
-            dispatch(tradingExchangeActions.savePreselectedQuote(candidateQuote));
+            // selectExchangeQuoteThunk skips saveSelectedQuote for DEX ERC-20 quotes in pre-CONFIRM
+            // status to preserve desktop behavior. The approval/revoke screens read selectedQuote,
+            // so persist it explicitly here.
+            dispatch(tradingExchangeActions.saveSelectedQuote(candidateQuote));
 
             switch (approvalStatus) {
+                case 'approved':
+                case 'not_needed':
+                    return navigation.navigate(RootStackRoutes.TradingExchangePreview, {});
+
                 case 'needs_increase':
                     return navigation.navigate(RootStackRoutes.TradingExchangeApproval, {
                         shouldIncreaseLimit: true,
@@ -143,7 +146,7 @@ export const useExchangeSelectQuote = (form: ExchangeFormType) => {
                 case 'needs_increase':
                 case 'needs_revoke':
                 case 'approved':
-                    dispatch(tradingExchangeActions.savePreselectedQuote(candidateQuote));
+                    dispatch(tradingExchangeActions.saveSelectedQuote(candidateQuote));
 
                     return navigation.navigate(RootStackRoutes.TradingExchangeRevoke, {
                         shouldIncreaseLimit: false,

--- a/suite-native/module-trading/src/screens/TradingConfirmingScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingConfirmingScreen.tsx
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useFocusEffect } from '@react-navigation/native';
 
 import {
-    selectTradingExchangeActiveQuote,
+    selectTradingExchangeSelectedQuote,
     tradingExchangeActions,
     useAllowanceTxTracking,
 } from '@suite-common/trading';
@@ -41,7 +41,7 @@ export const TradingConfirmingScreen = ({
 
     const dispatch = useDispatch();
     const sendAccount = useSelector(selectExchangeSelectedSendAccount);
-    const activeQuote = useSelector(selectTradingExchangeActiveQuote);
+    const activeQuote = useSelector(selectTradingExchangeSelectedQuote);
     const accountKey = sendAccount?.key ?? null;
     const approvalSendTxHash = activeQuote?.approvalSendTxHash;
 
@@ -96,14 +96,18 @@ export const TradingConfirmingScreen = ({
             const handleConfirmed = async () => {
                 switch (flowType) {
                     case 'approve': {
-                        let response = await confirmApproval(activeQuote);
+                        const response = await confirmApproval(activeQuote);
 
                         if (response?.status === 'APPROVAL_PENDING') {
                             // we know it was confirmed, so we can set the status to CONFIRM even if it came as APPROVAL_PENDING
                             // that is basically what api does (but it takes time)
                             // so we need to do it here to avoid the approval screen transition through useExchangeFlow
-                            response = { ...response, status: 'CONFIRM' };
-                            dispatch(tradingExchangeActions.saveSelectedQuote(response));
+                            dispatch(
+                                tradingExchangeActions.saveSelectedQuote({
+                                    ...response,
+                                    status: 'CONFIRM',
+                                }),
+                            );
                         }
 
                         if (!response) {
@@ -123,8 +127,20 @@ export const TradingConfirmingScreen = ({
 
                     case 'revoke-and-approve':
                         dispatch(sendFormActions.dispose());
-                        dispatch(tradingExchangeActions.saveSelectedQuote(undefined));
-                        // preselectedQuote is preserved in the store, so we can navigate to the approval screen with it
+                        // The post-revoke quote carries the revoke transaction's
+                        // approvalSendTxHash and approvalType: 'ZERO'. Strip them so the
+                        // next confirmApproval call requests a fresh approval rather than
+                        // re-using the revoke txid as the approval txid.
+                        if (activeQuote) {
+                            dispatch(
+                                tradingExchangeActions.saveSelectedQuote({
+                                    ...activeQuote,
+                                    approvalSendTxHash: undefined,
+                                    approvalType: undefined,
+                                    status: 'APPROVAL_REQ',
+                                }),
+                            );
+                        }
                         navigation.popToTop();
                         navigation.push(RootStackRoutes.TradingExchangeApproval, {
                             isRevoked: true,
@@ -134,7 +150,6 @@ export const TradingConfirmingScreen = ({
                     case 'revoke':
                         dispatch(sendFormActions.dispose());
                         dispatch(tradingExchangeActions.saveSelectedQuote(undefined));
-                        dispatch(tradingExchangeActions.savePreselectedQuote(undefined));
                         navigation.popToTop();
                         break;
 

--- a/suite-native/module-trading/src/screens/TradingExchangeApprovalScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingExchangeApprovalScreen.tsx
@@ -6,7 +6,7 @@ import type { ExchangeTrade } from 'invity-api';
 import {
     type TradingRootState,
     selectTradingCoinSymbolByCryptoId,
-    selectTradingExchangeActiveQuote,
+    selectTradingExchangeSelectedQuote,
     tradingExchangeActions,
 } from '@suite-common/trading';
 import { InlineAlertBox, VStack } from '@suite-native/atoms';
@@ -38,7 +38,7 @@ export const TradingExchangeApprovalScreen = ({
     const { shouldIncreaseLimit, isRevoked } = params;
     const dispatch = useDispatch();
 
-    const quote = useSelector(selectTradingExchangeActiveQuote);
+    const quote = useSelector(selectTradingExchangeSelectedQuote);
 
     const {
         isReady,

--- a/suite-native/module-trading/src/screens/TradingExchangePreviewScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingExchangePreviewScreen.tsx
@@ -9,7 +9,7 @@ import { useAlert } from '@suite-native/alerts';
 import { Translation } from '@suite-native/intl';
 import {
     type RootStackParamList,
-    type RootStackRoutes,
+    RootStackRoutes,
     Screen,
     type StackProps,
 } from '@suite-native/navigation';
@@ -108,6 +108,12 @@ const TradingExchangePreviewScreenContent = ({
             }
         }, [handleConfirmTrade, isFinalized]),
     );
+
+    useEffect(() => {
+        if (quote?.status === 'APPROVAL_REQ') {
+            navigation.navigate(RootStackRoutes.TradingExchangeApproval, {});
+        }
+    }, [navigation, quote?.status]);
 
     // clear trading state on unmount
     useEffect(

--- a/suite-native/module-trading/src/screens/TradingExchangeRevokeScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingExchangeRevokeScreen.tsx
@@ -6,7 +6,7 @@ import type { ExchangeTrade } from 'invity-api';
 import {
     type TradingRootState,
     selectTradingCoinSymbolByCryptoId,
-    selectTradingExchangeActiveQuote,
+    selectTradingExchangeSelectedQuote,
     tradingExchangeActions,
 } from '@suite-common/trading';
 import { InlineAlertBox, VStack } from '@suite-native/atoms';
@@ -38,7 +38,7 @@ export const TradingExchangeRevokeScreen = ({
     const { shouldIncreaseLimit } = params;
     const dispatch = useDispatch();
 
-    const quote = useSelector(selectTradingExchangeActiveQuote);
+    const quote = useSelector(selectTradingExchangeSelectedQuote);
 
     const { isReady, isConfirming, error: confirmError, confirmApproval } = useApprovalFlow();
 

--- a/suite-native/module-trading/src/screens/__tests__/TradingConfirmingScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingConfirmingScreen.test.tsx
@@ -1,6 +1,5 @@
 import type { TransactionStatus } from '@suite-common/trading';
 import {
-    selectTradingExchangePreselectedQuote,
     selectTradingExchangeSelectedQuote,
     tradingExchangeActions,
     useAllowanceTxTracking,
@@ -204,8 +203,19 @@ describe('TradingConfirmingScreen', () => {
         expect(mockNavigation.push).not.toHaveBeenCalled();
     });
 
-    it('revoke-and-approve: navigates to TradingExchangeApproval and clears selectedQuote', () => {
+    it('revoke-and-approve: navigates to TradingExchangeApproval and strips revoke-tx artifacts from selectedQuote', () => {
+        // Seed selectedQuote with revoke artifacts that the post-revoke confirmExchangeTradeThunk would have written.
+        store.dispatch(
+            tradingExchangeActions.saveSelectedQuote({
+                ...testQuote,
+                approvalType: 'ZERO',
+                approvalSendTxHash: 'revoke-txid',
+                status: 'APPROVAL_PENDING',
+            }),
+        );
         mockUseAllowanceTxTracking.mockReturnValue(confirmedStatus);
+
+        const dispatchSpy = jest.spyOn(store, 'dispatch');
 
         renderScreen({ flowType: 'revoke-and-approve' });
 
@@ -213,11 +223,23 @@ describe('TradingConfirmingScreen', () => {
         expect(mockNavigation.push).toHaveBeenCalledWith(RootStackRoutes.TradingExchangeApproval, {
             isRevoked: true,
         });
-        expect(selectTradingExchangeSelectedQuote(store.getState())).toBeUndefined();
+        const dispatchedActions = dispatchSpy.mock.calls.map(([action]) => action);
+        // savePreselectedQuote action no longer exists; assert against the action-type string.
+        expect(
+            dispatchedActions.find(
+                (action: any) => action?.type === '@trading-exchange/savePreselectedQuote',
+            ),
+        ).toBeUndefined();
+        const persisted = selectTradingExchangeSelectedQuote(store.getState());
+        expect(persisted).toBeDefined();
+        expect(persisted?.approvalSendTxHash).toBeUndefined();
+        expect(persisted?.approvalType).toBeUndefined();
+        expect(persisted?.status).toBe('APPROVAL_REQ');
+
+        dispatchSpy.mockRestore();
     });
 
-    it('revoke: pops to top and clears selectedQuote and preselectedQuote', () => {
-        store.dispatch(tradingExchangeActions.savePreselectedQuote(testQuote));
+    it('revoke: pops to top and clears selectedQuote', () => {
         mockUseAllowanceTxTracking.mockReturnValue(confirmedStatus);
 
         renderScreen({ flowType: 'revoke' });
@@ -225,7 +247,6 @@ describe('TradingConfirmingScreen', () => {
         expect(mockNavigation.popToTop).toHaveBeenCalled();
         expect(mockNavigation.push).not.toHaveBeenCalled();
         expect(selectTradingExchangeSelectedQuote(store.getState())).toBeUndefined();
-        expect(selectTradingExchangePreselectedQuote(store.getState())).toBeUndefined();
     });
 
     it('should render the explore in blockchain button', () => {

--- a/suite-native/module-trading/src/screens/__tests__/TradingExchangeApprovalScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingExchangeApprovalScreen.test.tsx
@@ -102,7 +102,7 @@ describe('TradingExchangeApprovalScreen', () => {
         mockIsDeviceConnected = true;
 
         store = createTradingLightStore({ tradeType: 'exchange' });
-        store.dispatch(tradingExchangeActions.savePreselectedQuote(testQuote));
+        store.dispatch(tradingExchangeActions.saveSelectedQuote(testQuote));
         store.dispatch(tradingExchangeActions.setTradingAccountKey(eth1NormalAccount.key));
     });
 
@@ -152,7 +152,6 @@ describe('TradingExchangeApprovalScreen', () => {
     });
 
     it('should render alert when no quote is provided', () => {
-        store.dispatch(tradingExchangeActions.savePreselectedQuote(undefined));
         store.dispatch(tradingExchangeActions.saveSelectedQuote(undefined));
 
         const { getByText, queryByText } = renderScreen();

--- a/suite-native/module-trading/src/screens/__tests__/TradingExchangePreviewScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingExchangePreviewScreen.test.tsx
@@ -4,7 +4,7 @@ import type { ExchangeTrade } from 'invity-api';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { events } from '@suite-native/analytics';
 import { getTranslation } from '@suite-native/intl';
-import { type RootStackParamList, type RootStackRoutes } from '@suite-native/navigation';
+import { type RootStackParamList, RootStackRoutes } from '@suite-native/navigation';
 import {
     type TestStore,
     renderWithStoreProvider,
@@ -338,6 +338,23 @@ describe('TradingExchangePreviewScreen', () => {
                 step: 'transaction-preview',
                 action: 'continue',
             }),
+        });
+    });
+
+    describe('Approval Required Redirect', () => {
+        it('redirects to TradingExchangeApproval when selectedQuote.status is APPROVAL_REQ', async () => {
+            const approvalReqQuote: ExchangeTrade = {
+                ...mercuryoFixedWorstQuote,
+                status: 'APPROVAL_REQ',
+            };
+            const testStore = createStore(approvalReqQuote);
+
+            renderTradingExchangePreviewScreen(false, testStore);
+
+            await waitFor(() => {
+                expect(mockNavigate).toHaveBeenCalledTimes(1);
+            });
+            expect(mockNavigate).toHaveBeenCalledWith(RootStackRoutes.TradingExchangeApproval, {});
         });
     });
 

--- a/suite-native/module-trading/src/screens/__tests__/TradingExchangeRevokeScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingExchangeRevokeScreen.test.tsx
@@ -100,7 +100,7 @@ describe('TradingExchangeRevokeScreen', () => {
         mockIsDeviceConnected = true;
 
         store = createTradingLightStore({ tradeType: 'exchange' });
-        store.dispatch(tradingExchangeActions.savePreselectedQuote(testQuote));
+        store.dispatch(tradingExchangeActions.saveSelectedQuote(testQuote));
         store.dispatch(tradingExchangeActions.setTradingAccountKey(eth1NormalAccount.key));
     });
 
@@ -141,7 +141,6 @@ describe('TradingExchangeRevokeScreen', () => {
     });
 
     it('should render alert when no quote is provided', () => {
-        store.dispatch(tradingExchangeActions.savePreselectedQuote(undefined));
         store.dispatch(tradingExchangeActions.saveSelectedQuote(undefined));
 
         const { getByText, queryByText } = renderScreen();


### PR DESCRIPTION
## Description

Persist exchange approval flow state through `selectedQuote` and remove the obsolete `preselectedQuote` fallback.

This updates exchange approval, revoke, confirmation, and preview flows to read from `selectedQuote`, saves DEX approval candidates before navigation, and fixes revoke-and-approve by stripping revoke transaction artifacts before returning to approval.

## Notes for QA

Focus on native exchange DEX approval flows:

- Selecting a quote that needs approval opens the approval screen.
- Quotes that need revoke or increase preserve the selected quote correctly.
- Revoke-and-approve returns to approval with a clean approval quote.
- Preview redirects to approval when the selected quote is still in `APPROVAL_REQ`.
- Revoke-only flow clears the selected quote.



<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native-trade-remove-swap-preselected-quote&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native-trade-remove-swap-preselected-quote&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native-trade-remove-swap-preselected-quote&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-18T22:10:38.680Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-18T22:08:51.262Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/native-trade-remove-swap-preselected-quote/web/](https://dev.suite.sldev.cz/suite-web/feat/native-trade-remove-swap-preselected-quote/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->