### PR TITLE
Coin packages improvements

### DIFF
--- a/coins/README.md
+++ b/coins/README.md
@@ -4,8 +4,9 @@ Coin-specific packages providing types, constants, and runtime utilities for ind
 
 Ideally, all 3rd party dependencies related to this coin should be in this package, and either reexported or used inside exported functions.
 Moreover, types, runtime constants (independent on dependencies) and runtime functions should be separated so it's clear on importer's side
-what overhead is expected. Utilities using 3rd party code in runtime should always be dynamically reexported in `runtime/index.ts` so this
-code is loaded on-demand, for security and performance reasons.
+what overhead is expected. Utilities using 3rd party code in runtime should always be exported in `runtime/exports.ts` and dynamically
+reexported in `runtime/index.ts` so this code is loaded on-demand, for security and performance reasons. From top-level index file,
+`runtime/exports.ts` is directly exported instead, but importing from package root is restricted by eslint rule in this monorepo.
 
 ## Package structure
 
@@ -16,7 +17,7 @@ coins/coins-<coin-name>/src/
   constants/   – Static values, constants, custom enums etc…
   types/       – TypeScript type definitions (incl. reexported by using `export type`)
   runtime/     – Dynamically exported utilities, helpers, reexported functions…
-  index.ts     – Empty - root import not supported
+  index.ts     – Reexport from constants/index.ts, types/index.ts and runtime/exports.ts
 ```
 
 Exports field in `package.json` should restrict access to package internals:
@@ -35,6 +36,12 @@ Import from a specific entrypoint rather than the package root:
 ```ts
 import { TOKEN_PROGRAM_PUBLIC_KEY } from '@trezor/coins-solana/constants';
 import type { SolanaTransaction } from '@trezor/coins-solana/types';
+
+// Possible, but restricted. Mostly for tests, scripts and 3rd parties where we don't care about proper bundling
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+import { util } from '@trezor/coins-solana';
+
+// Correct way
 import loadSolanaUtils from '@trezor/coins-solana/runtime';
 
 const { util } = await loadSolanaUtils();

--- a/coins/coins-solana/src/index.ts
+++ b/coins/coins-solana/src/index.ts
@@ -1,2 +1,3 @@
-/** Import from root not supported. Import from /constants, /runtime or /types instead. */
-export {};
+export * from './constants';
+export * from './runtime/exports';
+export type * from './types';

--- a/packages/eslint/src/typescriptConfig.mjs
+++ b/packages/eslint/src/typescriptConfig.mjs
@@ -15,6 +15,11 @@ const buildArtifactPatterns = {
         'Import from the package root instead. Deep paths into "lib/", "libDev/" or "libESM/" target build artifacts that may not exist or may diverge from the workspace source.',
 };
 
+const coinsPackagePatterns = {
+    regex: '^@trezor/coins-[a-z]+$',
+    message: 'Import from /constants, /runtime or /types subpath.',
+};
+
 // Deep-path imports that bypass the public barrels of the connect-tier packages.
 // Tracked in https://github.com/trezor/trezor-suite/issues/27376.
 // External consumers must import from the package root (e.g. `@trezor/connect`).
@@ -65,7 +70,11 @@ export const typescriptConfig = [
                 'error',
                 {
                     paths: [{ name: '.' }, { name: '..' }, { name: '../..' }],
-                    patterns: [buildArtifactPatterns, ...connectDeepImportPatterns],
+                    patterns: [
+                        buildArtifactPatterns,
+                        coinsPackagePatterns,
+                        ...connectDeepImportPatterns,
+                    ],
                 },
             ],
 
@@ -104,6 +113,7 @@ export const typescriptConfig = [
                     patterns: [
                         buildArtifactPatterns,
                         suiteInternalPatterns,
+                        coinsPackagePatterns,
                         ...connectDeepImportPatterns,
                     ],
                 },

--- a/suite-native/app/metro.config.js
+++ b/suite-native/app/metro.config.js
@@ -72,9 +72,6 @@ const config = {
                 '@evolu/common/local-first': `${rootNodeModulesPath}/@evolu/common/dist/src/local-first/index.js`,
                 '@evolu/common/polyfills': `${rootNodeModulesPath}/@evolu/common/dist/src/Polyfills.js`,
                 '@evolu/react-native/polyfills': `${rootNodeModulesPath}/@evolu/react-native/dist/src/Polyfills.js`,
-                '@trezor/coins-solana/constants': `${rootNodeModulesPath}/@trezor/coins-solana/src/constants/index.ts`,
-                '@trezor/coins-solana/runtime': `${rootNodeModulesPath}/@trezor/coins-solana/src/runtime/index.ts`,
-                '@trezor/coins-solana/types': `${rootNodeModulesPath}/@trezor/coins-solana/src/types/index.ts`,
                 uuid: `${rootNodeModulesPath}/uuid/dist/index.js`,
 
                 // tiny-secp256k1 used by @trezor/utxo-lib is terribly slow because WASM is not supported.
@@ -88,6 +85,14 @@ const config = {
 
             if (overrides[moduleName]) {
                 return getSourceFile(overrides[moduleName]);
+            }
+
+            // @trezor/coins-* packages have exports paths defined in package.json
+            const coinsModuleMatch = moduleName.match(/^@trezor\/coins-([^/]+)\/([^/]+)$/);
+            if (coinsModuleMatch) {
+                const source = `${rootNodeModulesPath}/@trezor/coins-${coinsModuleMatch[1]}/src/${coinsModuleMatch[2]}/index.ts`;
+
+                return getSourceFile(source);
             }
 
             if (moduleName.startsWith('@emurgo/cardano')) {

--- a/suite/e2e/scripts/decode-sol-staking-account.ts
+++ b/suite/e2e/scripts/decode-sol-staking-account.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs';
 
-import solana from '@trezor/coins-solana/runtime';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+import { decodeStakeResponses } from '@trezor/coins-solana';
 
 const bigintReplacer = (_: string, value: unknown) =>
     typeof value === 'bigint' ? value.toString() : value;
@@ -17,7 +18,6 @@ if (!fs.existsSync(inputFile)) {
 const raw = fs.readFileSync(inputFile, 'utf8');
 const input = JSON.parse(raw);
 
-const { decodeStakeResponses } = await solana();
 const decoded = decodeStakeResponses(input);
 const pretty = JSON.stringify(decoded, bigintReplacer, 2);
 console.log(pretty);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the structure and import conventions for the `@trezor/coins-*` packages, especially `@trezor/coins-solana` _(which is currently the only one existing, thank you very much, clanker)_, to improve modularity, enforce stricter import rules, and streamline package exports. It also updates ESLint rules and Metro bundler configuration to align with these changes.

**Package structure and exports:**

* Root barrel file now actually exports everything from `/constants`, `/types` and `/runtime`.
* For `/runtime`, it however reexports `/runtime/exports.ts` so dynamic importing is not required e.g. for tests or 3rd parties

**Linting and import enforcement:**

* Added new ESLint pattern (`coinsPackagePatterns`) to enforce imports from `/constants`, `/runtime`, or `/types` subpaths for `@trezor/coins-*` packages in this monorepo, and integrated it into the TypeScript ESLint config.

**Metro bundler configuration:**

* Updated Metro config to remove hardcoded `@trezor/coins-solana` path aliases and add logic to resolve subpath imports for all `@trezor/coins-*` packages automatically.

**README.md update:**

* Updated documentation in `coins/README.md` to clarify the new export structure, recommend importing from specific subpaths, and explain ESLint restrictions on root imports.

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes involve two files: the core Solana coins module (coins/coins-solana/src/index.ts) and an E2E script for decoding Solana staking accounts. The Solana module change poses moderate risk as it could affect any Solana-related functionality including sending, receiving, staking, and trading. The decode script is a support utility with no direct test coverage. Testing should focus on Solana transaction flows (send, stake, swap, sell) that directly exercise the coins-solana module, with no static test mappings available so all recommendations are inferred from behavioral analysis.

<details><summary><b>Changed files (2)</b></summary>

- `coins/coins-solana/src/index.ts`
- `suite/e2e/scripts/decode-sol-staking-account.ts`

</details>

**Recommended tests (14)**

<details><summary>🟡 <b>Medium priority (11)</b></summary>

- `../../suite/e2e/tests/staking/sol/initial-stake.test.ts` — This test exercises Solana staking functionality. Changes to coins/coins-solana/src/index.ts could affect Solana transaction construction, signing, or account handling used during the initial stake flow.
- `../../suite/e2e/tests/staking/sol/rewards.test.ts` — This test verifies Solana staking rewards display and account balances. Changes to the Solana coins module could affect how staking account data is parsed or presented.
- `../../suite/e2e/tests/staking/sol/stake-more.test.ts` — This test covers the stake-more flow for Solana, which involves Solana transaction construction and signing. Changes to coins-solana could break this transaction flow.
- `../../suite/e2e/tests/staking/sol/unstake.test.ts` — This test covers Solana unstaking and claiming, which involves Solana-specific transaction types. Changes to the Solana coins module could affect unstake/claim transaction construction.
- `../../suite/e2e/tests/wallet/send-sol.test.ts` — This test verifies sending SOL including address formatting, fee calculation, and device confirmation. Changes to coins/coins-solana/src/index.ts could directly affect Solana send transaction construction and fee handling.
- `../../suite/e2e/tests/wallet/receive.test.ts` — This test verifies receiving addresses for multiple coins including SOL. Changes to the Solana coins module could affect Solana address derivation or formatting used in the receive flow.
- `../../suite/e2e/tests/trading/swap-coins.test.ts` — This test swaps SOL to BTC, involving Solana transaction construction and sending. Changes to coins-solana could break the Solana send portion of the swap flow.
- `../../suite/e2e/tests/trading/swap-coin-to-token.test.ts` — This test swaps SOL to USDC, requiring Solana transaction handling. The coins-solana module change could affect the Solana send/signing portion of this cross-chain swap.
- `../../suite/e2e/tests/trading/swap-token-to-coin.test.ts` — This test swaps a Solana-based USDT token to BTC, involving Solana SPL token transaction handling that could be affected by coins-solana changes.
- `../../suite/e2e/tests/trading/swap-tokens.test.ts` — This test swaps Solana SPL tokens (USDT to USDC), directly exercising Solana token transaction construction that could be impacted by coins-solana changes.
- `../../suite/e2e/tests/trading/sell-solana.test.ts` — This test sells SOL through the trading flow, which involves constructing and sending a Solana transaction. Changes to coins-solana could affect the transaction construction or signing.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `../../suite/e2e/tests/trading/sell-inputs.test.ts` — This test validates sell form inputs for SOL including balance calculations and fee retrieval. Changes to coins-solana could affect how SOL balance or fee data is provided to the form.
- `../../suite/e2e/tests/trading/buy-solana-token.test.ts` — This test buys a Solana SPL token (JUP). While mostly about the buy/trading UI, the Solana account and receive address handling could be affected by coins-solana changes.
- `../../suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — This test involves a Solana-based USDT token swap to a disabled network. The Solana token handling portion could be affected by coins-solana changes.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/e2e/scripts/decode-sol-staking-account.ts`

_Updated: 2026-05-19T08:53:03.683Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/coins-improvement/web/](https://dev.suite.sldev.cz/suite-web/chore/coins-improvement/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/coins-improvement&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/coins-improvement&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/coins-improvement&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-19T10:09:16.572Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-19T10:07:31.455Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->