### PR TITLE
`throwError` improvement

### DIFF
--- a/coins/coins-solana/src/runtime/fees.ts
+++ b/coins/coins-solana/src/runtime/fees.ts
@@ -17,7 +17,7 @@ import {
 import { getTokenSize as _getTokenSize } from '@solana-program/token';
 import { getTokenSize as _getToken2022Size } from '@solana-program/token-2022';
 
-import { BigNumber, safeBigIntStringify } from '@trezor/utils';
+import { BigNumber, safeBigIntStringify, throwError } from '@trezor/utils';
 
 import { COMPUTE_BUDGET_PROGRAM_ID, STAKE_ACCOUNT_V2_SIZE } from '../constants';
 import type {
@@ -78,13 +78,10 @@ const getBaseFee = async (api: Rpc<GetFeeForMessageApi>, message: CompiledTransa
         getBase64Decoder().decode,
     ) as TransactionMessageBytesBase64;
     const result = await api.getFeeForMessage(messageWithoutComputeBudget).send();
+
     // The result can be null, for example if the transaction blockhash is invalid.
     // In this case, we should fall back to the default fee.
-    if (result.value == null) {
-        throw new Error('Could not estimate fee for transaction.');
-    }
-
-    return result.value;
+    return result.value ?? throwError('Could not estimate fee for transaction.');
 };
 
 // More about Solana priority fees here:

--- a/packages/analytics-docs/src/contexts/ThemeContext.tsx
+++ b/packages/analytics-docs/src/contexts/ThemeContext.tsx
@@ -8,6 +8,8 @@ import {
     useState,
 } from 'react';
 
+import { throwError } from '@trezor/utils';
+
 const STORAGE_KEY = 'analytics-docs-theme';
 
 export type ThemePreference = 'system' | 'light' | 'dark';
@@ -34,12 +36,8 @@ type ThemeContextValue = {
 
 const ThemeContext = createContext<ThemeContextValue | null>(null);
 
-export const useTheme = () => {
-    const ctx = useContext(ThemeContext);
-    if (!ctx) throw new Error('useTheme must be used within ThemeProvider');
-
-    return ctx;
-};
+export const useTheme = () =>
+    useContext(ThemeContext) ?? throwError('useTheme must be used within ThemeProvider');
 
 export const ThemeContextProvider = ({ children }: { children: ReactNode }) => {
     const [preference, setPreferenceState] = useState<ThemePreference>(getStoredPreference);

--- a/packages/blockchain-link/src/workers/electrum/sockets/index.ts
+++ b/packages/blockchain-link/src/workers/electrum/sockets/index.ts
@@ -1,5 +1,5 @@
 import { CustomError } from '@trezor/blockchain-link-types';
-import { parseElectrumUrl } from '@trezor/utils';
+import { parseElectrumUrl, throwError } from '@trezor/utils';
 
 import type { SocketBase, SocketOptions } from './base';
 import { TcpSocket } from './tcp';
@@ -7,9 +7,8 @@ import { TlsSocket } from './tls';
 import { TorSocket } from './tor';
 
 export const createSocket = (url: string, options?: SocketOptions): SocketBase => {
-    const parsed = parseElectrumUrl(url);
-    if (!parsed) throw new CustomError('Invalid electrum url');
-    const { host, port, protocol } = parsed;
+    const { host, port, protocol } =
+        parseElectrumUrl(url) ?? throwError(new CustomError('Invalid electrum url'));
     const { timeout, keepAlive, proxyAgent } = options || {};
     // Onion address is TCP over Tor
     if (proxyAgent /* host.endsWith('.onion') */) {

--- a/packages/coinjoin/src/client/round/outputDecomposition.ts
+++ b/packages/coinjoin/src/client/round/outputDecomposition.ts
@@ -1,4 +1,4 @@
-import { arrayToDictionary, getWeakRandomId } from '@trezor/utils';
+import { arrayToDictionary, getWeakRandomId, throwError } from '@trezor/utils';
 
 import type { CoinjoinRoundOptions, CoinjoinRoundShape } from '../../types/round';
 import { getExternalOutputSize } from '../../utils/coordinatorUtils';
@@ -470,13 +470,9 @@ export const outputDecomposition = async (
     );
 
     // combine everything into DecomposedOutputs objects and return the result to outputRegistration
-    return Object.keys(groupInputsByAccount).map((accountKey, index) => {
-        if (!joinedCredentials[index])
-            throw new Error(`Missing joined credentials at index ${index}`);
-
-        return {
-            accountKey,
-            outputs: joinedCredentials[index],
-        };
-    });
+    return Object.keys(groupInputsByAccount).map((accountKey, index) => ({
+        accountKey,
+        outputs:
+            joinedCredentials[index] || throwError(`Missing joined credentials at index ${index}`),
+    }));
 };

--- a/packages/components/src/components/Banner/BannerContext.ts
+++ b/packages/components/src/components/Banner/BannerContext.ts
@@ -1,5 +1,7 @@
 import { createContext, useContext } from 'react';
 
+import { throwError } from '@trezor/utils';
+
 import { DEFAULT_INTENT } from './consts';
 import { type BannerIntent } from './types';
 
@@ -7,11 +9,6 @@ export const BannerContext = createContext<{
     intent?: BannerIntent;
 }>({ intent: DEFAULT_INTENT });
 
-export const useBannerContext = () => {
-    const context = useContext(BannerContext);
-    if (!context) {
-        throw new Error('useBannerContextContext must be used within a BannerContext');
-    }
-
-    return context;
-};
+export const useBannerContext = () =>
+    useContext(BannerContext) ??
+    throwError('useBannerContextContext must be used within a BannerContext');

--- a/packages/components/src/components/Modal/ModalContext.tsx
+++ b/packages/components/src/components/Modal/ModalContext.tsx
@@ -1,17 +1,12 @@
 import { createContext, useContext } from 'react';
 
+import { throwError } from '@trezor/utils';
+
 import { type ModalIntent } from './types';
 
 export const ModalContext = createContext<{
     intent?: ModalIntent;
 }>({ intent: undefined });
 
-export const useModalContext = () => {
-    const context = useContext(ModalContext);
-
-    if (!context) {
-        throw new Error('useModalContext must be used within a ModalContext');
-    }
-
-    return context;
-};
+export const useModalContext = () =>
+    useContext(ModalContext) ?? throwError('useModalContext must be used within a ModalContext');

--- a/packages/components/src/components/Popover/Popover.tsx
+++ b/packages/components/src/components/Popover/Popover.tsx
@@ -18,6 +18,7 @@ import {
 import { useTheme } from 'styled-components';
 
 import { zIndices } from '@trezor/theme';
+import { throwError } from '@trezor/utils';
 
 import { type PopoverPlacement, convertPopoverPlacement } from './utils';
 import { intermediaryTheme } from '../../config/colors';
@@ -108,15 +109,9 @@ type ContextType =
 
 const PopoverContext = React.createContext<ContextType>(null);
 
-export const usePopoverContext = () => {
-    const context = React.useContext(PopoverContext);
-
-    if (context == null) {
-        throw new Error('Popover components must be wrapped in <Popover />');
-    }
-
-    return context;
-};
+export const usePopoverContext = () =>
+    React.useContext(PopoverContext) ??
+    throwError('Popover components must be wrapped in <Popover />');
 
 type PopoverTriggerProps = {
     children: React.ReactNode;

--- a/packages/components/src/components/SubTabs/SubTabsContext.tsx
+++ b/packages/components/src/components/SubTabs/SubTabsContext.tsx
@@ -1,5 +1,7 @@
 import { createContext, useContext } from 'react';
 
+import { throwError } from '@trezor/utils';
+
 import { type SubTabsSize } from './types';
 
 export const SubTabsContext = createContext<{
@@ -7,12 +9,6 @@ export const SubTabsContext = createContext<{
     size: SubTabsSize;
 }>({ size: 'medium' });
 
-export const useSubTabsContext = () => {
-    const context = useContext(SubTabsContext);
-
-    if (!context) {
-        throw new Error('useSubTabsContext must be used within a SubTabsContext');
-    }
-
-    return context;
-};
+export const useSubTabsContext = () =>
+    useContext(SubTabsContext) ??
+    throwError('useSubTabsContext must be used within a SubTabsContext');

--- a/packages/components/src/components/Tabs/TabsContext.tsx
+++ b/packages/components/src/components/Tabs/TabsContext.tsx
@@ -1,5 +1,7 @@
 import { createContext, useContext } from 'react';
 
+import { throwError } from '@trezor/utils';
+
 import { type TabsSize } from './types';
 
 export const TabsContext = createContext<{
@@ -9,12 +11,5 @@ export const TabsContext = createContext<{
     activeItemId?: string;
 }>({ size: 'medium', isDisabled: false });
 
-export const useTabsContext = () => {
-    const context = useContext(TabsContext);
-
-    if (!context) {
-        throw new Error('useTabsContext must be used within a TabsContext');
-    }
-
-    return context;
-};
+export const useTabsContext = () =>
+    useContext(TabsContext) ?? throwError('useTabsContext must be used within a TabsContext');

--- a/packages/components/src/components/Tooltip/TooltipFloatingUi.tsx
+++ b/packages/components/src/components/Tooltip/TooltipFloatingUi.tsx
@@ -33,6 +33,7 @@ import {
 import type { Placement, ShiftOptions, UseFloatingReturn } from '@floating-ui/react';
 
 import { spacings } from '@trezor/theme';
+import { throwError } from '@trezor/utils';
 
 /**
  * Based on https://floating-ui.com/docs/tooltip but heavily modified
@@ -133,15 +134,8 @@ type ContextType = ReturnType<typeof useTooltip>;
 
 export const TooltipContext = createContext<ContextType | null>(null);
 
-export const useTooltipState = (): ContextType => {
-    const context = useContext(TooltipContext);
-
-    if (context == null) {
-        throw new Error('Tooltip components must be wrapped in <Tooltip />');
-    }
-
-    return context;
-};
+export const useTooltipState = (): ContextType =>
+    useContext(TooltipContext) ?? throwError('Tooltip components must be wrapped in <Tooltip />');
 
 type TooltipFloatingUiProps = { children: ReactNode } & TooltipOptions;
 

--- a/packages/components/src/components/colors.stories.tsx
+++ b/packages/components/src/components/colors.stories.tsx
@@ -4,7 +4,7 @@ import { type Meta } from '@storybook/react';
 import styled, { useTheme } from 'styled-components';
 
 import { type CSSColor, colorVariants, colorsV2, typography } from '@trezor/theme';
-import { hexToRgba } from '@trezor/utils';
+import { hexToRgba, throwError } from '@trezor/utils';
 
 import { Badge } from './Badge/Badge';
 import { Box } from './Box/Box';
@@ -107,14 +107,9 @@ type ColorFiltersContextValue = {
 
 const ColorFiltersContext = React.createContext<ColorFiltersContextValue | undefined>(undefined);
 
-const useColorFilters = () => {
-    const ctx = React.useContext(ColorFiltersContext);
-    if (!ctx) {
-        throw new Error('useColorFilters must be used within ColorFiltersContext');
-    }
-
-    return ctx;
-};
+const useColorFilters = () =>
+    React.useContext(ColorFiltersContext) ??
+    throwError('useColorFilters must be used within ColorFiltersContext');
 
 const Header = () => {
     const {

--- a/packages/suite/src/components/earn/yield/supply/useYieldSupplyContext.ts
+++ b/packages/suite/src/components/earn/yield/supply/useYieldSupplyContext.ts
@@ -1,16 +1,11 @@
 import { createContext, useContext } from 'react';
 
+import { throwError } from '@trezor/utils';
+
 import { type YieldFlowContextValues } from '../hooks/useYieldFlow';
 
 export const YieldSupplyContext = createContext<YieldFlowContextValues | null>(null);
 YieldSupplyContext.displayName = 'YieldSupplyContext';
 
-export const useYieldSupplyContext = () => {
-    const context = useContext(YieldSupplyContext);
-
-    if (context === null) {
-        throw Error('YieldSupplyContext used without Context');
-    }
-
-    return context;
-};
+export const useYieldSupplyContext = () =>
+    useContext(YieldSupplyContext) ?? throwError('YieldSupplyContext used without Context');

--- a/packages/suite/src/components/earn/yield/withdraw/useYieldWithdrawContext.ts
+++ b/packages/suite/src/components/earn/yield/withdraw/useYieldWithdrawContext.ts
@@ -1,16 +1,11 @@
 import { createContext, useContext } from 'react';
 
+import { throwError } from '@trezor/utils';
+
 import { type YieldFlowContextValues } from '../hooks/useYieldFlow';
 
 export const YieldWithdrawContext = createContext<YieldFlowContextValues | null>(null);
 YieldWithdrawContext.displayName = 'YieldWithdrawContext';
 
-export const useYieldWithdrawContext = () => {
-    const context = useContext(YieldWithdrawContext);
-
-    if (context === null) {
-        throw Error('YieldWithdrawContext used without Context');
-    }
-
-    return context;
-};
+export const useYieldWithdrawContext = () =>
+    useContext(YieldWithdrawContext) ?? throwError('YieldWithdrawContext used without Context');

--- a/packages/suite/src/components/wallet/Fees/context/FeesContext.ts
+++ b/packages/suite/src/components/wallet/Fees/context/FeesContext.ts
@@ -7,6 +7,7 @@ import {
     type PrecomposedLevelsCardano,
 } from '@suite-common/wallet-types';
 import { type FeeLevel } from '@trezor/connect';
+import { throwError } from '@trezor/utils';
 
 export type TronResources = {
     availableFreeBandwidth: number;
@@ -29,12 +30,5 @@ export type FeesContextType = {
 
 export const FeesContext = createContext<FeesContextType | null>(null);
 
-export const useFeesContext = () => {
-    const context = useContext(FeesContext);
-
-    if (!context) {
-        throw new Error('useFeesContext must be used within a FeesContext');
-    }
-
-    return context;
-};
+export const useFeesContext = () =>
+    useContext(FeesContext) ?? throwError('useFeesContext must be used within a FeesContext');

--- a/packages/suite/src/hooks/earn/useClaimForm.ts
+++ b/packages/suite/src/hooks/earn/useClaimForm.ts
@@ -6,6 +6,7 @@ import { getNetwork } from '@suite-common/wallet-config';
 import { selectBaseCurrency, selectRawNetworkFeeInfo } from '@suite-common/wallet-core';
 import { type Account, type PrecomposedTransactionFinal } from '@suite-common/wallet-types';
 import { getConvertedOrDefaultFeeInfo } from '@suite-common/wallet-utils';
+import { throwError } from '@trezor/utils';
 
 import { signTransaction } from 'src/actions/wallet/stakeActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -161,9 +162,5 @@ export const useClaimForm = ({ account }: UseClaimFormsProps): ClaimContextValue
     };
 };
 
-export const useClaimFormContext = () => {
-    const ctx = useContext(ClaimFormContext);
-    if (ctx === null) throw Error('useClaimFormContext used without Context');
-
-    return ctx;
-};
+export const useClaimFormContext = () =>
+    useContext(ClaimFormContext) ?? throwError('useClaimFormContext used without Context');

--- a/packages/suite/src/hooks/earn/useSupplyForm.ts
+++ b/packages/suite/src/hooks/earn/useSupplyForm.ts
@@ -24,7 +24,7 @@ import {
     getStakingLimitsByNetworkSymbol,
     toFiatCurrency,
 } from '@suite-common/wallet-utils';
-import { isChanged } from '@trezor/utils';
+import { isChanged, throwError } from '@trezor/utils';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import { signTransaction } from 'src/actions/wallet/stakeActions';
@@ -424,9 +424,5 @@ export const useSupplyForm = ({ account }: UseSupplyFormProps): SupplyContextVal
     };
 };
 
-export const useSupplyFormContext = () => {
-    const ctx = useContext(SupplyFormContext);
-    if (ctx === null) throw Error('useSupplyFormContext used without Context');
-
-    return ctx;
-};
+export const useSupplyFormContext = () =>
+    useContext(SupplyFormContext) ?? throwError('useSupplyFormContext used without Context');

--- a/packages/suite/src/hooks/earn/useWithdrawalForm.ts
+++ b/packages/suite/src/hooks/earn/useWithdrawalForm.ts
@@ -23,7 +23,7 @@ import {
     getStakingDataForNetwork,
     toFiatCurrency,
 } from '@suite-common/wallet-utils';
-import { BigNumber, isChanged } from '@trezor/utils';
+import { BigNumber, isChanged, throwError } from '@trezor/utils';
 
 import { signTransaction } from 'src/actions/wallet/stakeActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -310,9 +310,6 @@ export const useWithdrawalForm = ({ account }: UseWithdrawalFormProps): Withdraw
     };
 };
 
-export const useWithdrawalFormContext = () => {
-    const ctx = useContext(WithdrawalFormContext);
-    if (ctx === null) throw Error('useWithdrawalFormContext used without Context');
-
-    return ctx;
-};
+export const useWithdrawalFormContext = () =>
+    useContext(WithdrawalFormContext) ??
+    throwError('useWithdrawalFormContext used without Context');

--- a/packages/suite/src/hooks/wallet/allowance/useAllowanceContext.ts
+++ b/packages/suite/src/hooks/wallet/allowance/useAllowanceContext.ts
@@ -1,6 +1,7 @@
 import { createContext, useContext } from 'react';
 
 import { type useAllowanceTxTracking } from '@suite-common/trading';
+import { throwError } from '@trezor/utils';
 
 import { type useAllowanceState } from './useAllowanceState';
 
@@ -12,11 +13,6 @@ export interface AllowanceContextValue {
 export const AllowanceContext = createContext<AllowanceContextValue | null>(null);
 AllowanceContext.displayName = 'AllowanceContext';
 
-export const useAllowanceContext = () => {
-    const context = useContext(AllowanceContext);
-    if (context === null) {
-        throw new Error('useAllowanceContext must be used within AllowanceContext.Provider');
-    }
-
-    return context;
-};
+export const useAllowanceContext = () =>
+    useContext(AllowanceContext) ??
+    throwError('useAllowanceContext must be used within AllowanceContext.Provider');

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingCommonForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingCommonForm.ts
@@ -1,15 +1,13 @@
 import { createContext, useContext } from 'react';
 
 import type { TradingType } from '@suite-common/trading';
+import { throwError } from '@trezor/utils';
 
 import { type TradingFormContextValues } from 'src/types/trading/tradingForm';
 
 export const TradingFormContext = createContext<TradingFormContextValues<TradingType> | null>(null);
 TradingFormContext.displayName = 'TradingFormContext';
 
-export const useTradingFormContext = <T extends TradingType>() => {
-    const context = useContext(TradingFormContext);
-    if (context === null) throw Error('TradingFormContext used without Context');
-
-    return context as TradingFormContextValues<T>;
-};
+export const useTradingFormContext = <T extends TradingType>() =>
+    (useContext(TradingFormContext) as TradingFormContextValues<T>) ??
+    throwError('TradingFormContext used without Context');

--- a/packages/suite/src/hooks/wallet/trading/useTradingDetail.ts
+++ b/packages/suite/src/hooks/wallet/trading/useTradingDetail.ts
@@ -6,6 +6,7 @@ import {
     type TradingUseDetailPropsWithoutAccount,
     useTradingDetail as useTradingDetailCommon,
 } from '@suite-common/trading';
+import { throwError } from '@trezor/utils';
 
 import { useServerEnvironment } from 'src/hooks/wallet/trading/useServerEnviroment';
 import { useTradingWatchTrade } from 'src/hooks/wallet/trading/useTradingWatchTrade';
@@ -37,9 +38,6 @@ export const useTradingDetail = <T extends TradingType>(
 export const TradingDetailContext = createContext<TradingDetailContextValues<any> | null>(null);
 TradingDetailContext.displayName = 'TradingDetailContext';
 
-export const useTradingDetailContext = <T extends TradingType>() => {
-    const context = useContext<TradingDetailContextValues<T> | null>(TradingDetailContext);
-    if (context === null) throw Error('TradingDetailContext used without Context');
-
-    return context;
-};
+export const useTradingDetailContext = <T extends TradingType>() =>
+    useContext<TradingDetailContextValues<T> | null>(TradingDetailContext) ??
+    throwError('TradingDetailContext used without Context');

--- a/packages/suite/src/hooks/wallet/useCancelTxContext.ts
+++ b/packages/suite/src/hooks/wallet/useCancelTxContext.ts
@@ -1,6 +1,7 @@
 import { createContext, useContext } from 'react';
 
 import { type PrecomposeResultFinal } from '@trezor/connect';
+import { throwError } from '@trezor/utils';
 
 type CancelTxContextValues = {
     composedCancelTx: PrecomposeResultFinal | null;
@@ -11,9 +12,5 @@ CancelTxContext.displayName = 'CancelTxContext';
 
 // Used across rbf form components
 // Provide combined context of `react-hook-form` with custom values as RbfContextValues
-export const useCancelTxContext = () => {
-    const ctx = useContext(CancelTxContext);
-    if (ctx === null) throw Error('useCancelTxContext used without Context');
-
-    return ctx;
-};
+export const useCancelTxContext = () =>
+    useContext(CancelTxContext) ?? throwError('useCancelTxContext used without Context');

--- a/packages/suite/src/hooks/wallet/useChangeDelegateForm.ts
+++ b/packages/suite/src/hooks/wallet/useChangeDelegateForm.ts
@@ -13,6 +13,7 @@ import {
     type SelectedAccountLoaded,
 } from '@suite-common/wallet-types';
 import { getConvertedOrDefaultFeeInfo } from '@suite-common/wallet-utils';
+import { throwError } from '@trezor/utils';
 
 import { signTransaction } from 'src/actions/wallet/stakeActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -139,9 +140,6 @@ export const useChangeDelegateForm = ({
     };
 };
 
-export const useChangeDelegateFormContext = () => {
-    const ctx = useContext(ChangeDelegateFormContext);
-    if (ctx === null) throw Error('useChangeDelegateFormContext used without Context');
-
-    return ctx;
-};
+export const useChangeDelegateFormContext = () =>
+    useContext(ChangeDelegateFormContext) ??
+    throwError('useChangeDelegateFormContext used without Context');

--- a/packages/suite/src/hooks/wallet/useRbfForm.ts
+++ b/packages/suite/src/hooks/wallet/useRbfForm.ts
@@ -23,7 +23,7 @@ import {
     getConvertedOrDefaultFeeInfo,
     isEip1559,
 } from '@suite-common/wallet-utils';
-import { BigNumber } from '@trezor/utils';
+import { BigNumber, throwError } from '@trezor/utils';
 
 import { useSelector } from 'src/hooks/suite';
 import { useCoinjoinRegisteredUtxos } from 'src/hooks/wallet/form/useCoinjoinRegisteredUtxos';
@@ -334,9 +334,5 @@ RbfContext.displayName = 'RbfContext';
 
 // Used across rbf form components
 // Provide combined context of `react-hook-form` with custom values as RbfContextValues
-export const useRbfContext = () => {
-    const ctx = useContext(RbfContext);
-    if (ctx === null) throw Error('useRbfContext used without Context');
-
-    return ctx;
-};
+export const useRbfContext = () =>
+    useContext(RbfContext) ?? throwError('useRbfContext used without Context');

--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -22,6 +22,7 @@ import {
 } from '@suite-common/wallet-utils';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 import { useDidUpdate } from '@trezor/react-utils';
+import { throwError } from '@trezor/utils';
 
 import { fillSendForm, resetProtocol } from 'src/actions/suite/protocolActions';
 import {
@@ -465,9 +466,5 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
 
 // Used across send form components
 // Provide combined context of `react-hook-form` with custom values as SendContextValues
-export const useSendFormContext = () => {
-    const ctx = useContext(SendContext);
-    if (ctx === null) throw Error('useSendFormContext used without Context');
-
-    return ctx;
-};
+export const useSendFormContext = () =>
+    useContext(SendContext) ?? throwError('useSendFormContext used without Context');

--- a/packages/suite/src/support/suite/ResponsiveContext.tsx
+++ b/packages/suite/src/support/suite/ResponsiveContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useMemo, useState } from 'react';
 
 import { selectSidebarWidth } from '@suite/settings';
+import { throwError } from '@trezor/utils';
 
 import {
     SIDEBAR_COLLAPSED_WIDTH,
@@ -75,10 +76,6 @@ export const ResponsiveContextProvider = ({ children }: { children: React.ReactN
     return <ResponsiveContext.Provider value={value}>{children}</ResponsiveContext.Provider>;
 };
 
-export const useResponsiveContext = () => {
-    const ctx = useContext(ResponsiveContext);
-    if (!ctx)
-        throw new Error('useResponsiveContext must be used within a ResponsiveContextProvider');
-
-    return ctx;
-};
+export const useResponsiveContext = () =>
+    useContext(ResponsiveContext) ??
+    throwError('useResponsiveContext must be used within a ResponsiveContextProvider');

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/AssetOptionsContext.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/AssetOptionsContext.tsx
@@ -3,6 +3,7 @@ import { type ReactNode, createContext, useContext, useMemo } from 'react';
 import { type CryptoId } from 'invity-api';
 
 import { type TradingAssetOption, useTradingAssets } from '@suite-common/trading';
+import { throwError } from '@trezor/utils';
 
 const AssetOptionsContext = createContext<{
     assets: TradingAssetOption[];
@@ -37,12 +38,6 @@ export function AssetOptionsProvider({
     );
 }
 
-export function useAssetsContext() {
-    const context = useContext(AssetOptionsContext);
-
-    if (context === null) {
-        throw Error(`Can't use useAssetsContext outside of AssetOptionsProvider`);
-    }
-
-    return context;
-}
+export const useAssetsContext = () =>
+    useContext(AssetOptionsContext) ??
+    throwError(`Can't use useAssetsContext outside of AssetOptionsProvider`);

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetOptionsContext.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetOptionsContext.tsx
@@ -2,6 +2,8 @@ import { type ReactNode, createContext, useContext, useMemo } from 'react';
 
 import { type CryptoId } from 'invity-api';
 
+import { throwError } from '@trezor/utils';
+
 const AssetOptionsContext = createContext<{
     includedCryptoIds: Set<CryptoId>;
     excludedCryptoIds: Set<CryptoId>;
@@ -31,12 +33,6 @@ export function AssetOptionsProvider({
     );
 }
 
-export function useAssetsContext() {
-    const context = useContext(AssetOptionsContext);
-
-    if (context === null) {
-        throw Error(`Can't use useAssetsContext outside of AssetOptionsProvider`);
-    }
-
-    return context;
-}
+export const useAssetsContext = () =>
+    useContext(AssetOptionsContext) ??
+    throwError(`Can't use useAssetsContext outside of AssetOptionsProvider`);

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/useReceiveAddressModalControls.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/useReceiveAddressModalControls.tsx
@@ -1,5 +1,7 @@
 import { type ReactNode, createContext, useContext, useState } from 'react';
 
+import { throwError } from '@trezor/utils';
+
 import { TradingExtraFieldModal } from './TradingExtraFieldModal';
 import { TradingReceiveAccountModal } from './TradingReceiveAccountModal/TradingReceiveAccountModal';
 import { TradingReceiveAddressModal } from './TradingReceiveAddressModal';
@@ -49,14 +51,8 @@ export const ReceiveAddressModalControlsProvider = ({ children }: { children: Re
     );
 };
 
-export const useReceiveAddressModalControls = () => {
-    const context = useContext(ReceiveAddressModalControlsContext);
-
-    if (!context) {
-        throw new Error(
-            'useReceiveAddressModalControls must be used within a ReceiveAddressModalControlsProvider',
-        );
-    }
-
-    return context;
-};
+export const useReceiveAddressModalControls = () =>
+    useContext(ReceiveAddressModalControlsContext) ??
+    throwError(
+        'useReceiveAddressModalControls must be used within a ReceiveAddressModalControlsProvider',
+    );

--- a/packages/utils/src/throwError.ts
+++ b/packages/utils/src/throwError.ts
@@ -1,4 +1,4 @@
 // Tiny helper for throwing errors from expressions
-export const throwError = (reason: string) => {
-    throw new Error(reason);
+export const throwError = (reason: string | Error) => {
+    throw reason instanceof Error ? reason : new Error(reason);
 };

--- a/packages/utxo-lib/src/compose/request.ts
+++ b/packages/utxo-lib/src/compose/request.ts
@@ -1,3 +1,5 @@
+import { throwError } from '@trezor/utils';
+
 import { toOutputScript } from '../address';
 import {
     INPUT_SCRIPT_LENGTH,
@@ -103,20 +105,14 @@ function transformOutput(
 ): CoinSelectOutput {
     const script = { length: OUTPUT_SCRIPT_LENGTH[txType] };
     if (output.type === 'payment') {
-        const value = bignumberOrNaN(output.amount);
-        if (!value) throw new Error('Invalid amount');
-
         return {
-            value,
+            value: bignumberOrNaN(output.amount) || throwError('Invalid amount'),
             script: toOutputScript(output.address, network),
         };
     }
     if (output.type === 'payment-noaddress') {
-        const value = bignumberOrNaN(output.amount);
-        if (!value) throw new Error('Invalid amount');
-
         return {
-            value,
+            value: bignumberOrNaN(output.amount) || throwError('Invalid amount'),
             script,
         };
     }

--- a/suite-common/staking/src/utils/ethereumStaking.ts
+++ b/suite-common/staking/src/utils/ethereumStaking.ts
@@ -31,7 +31,7 @@ import TrezorConnect, {
 } from '@trezor/connect';
 import { type BlockchainEstimatedFee } from '@trezor/connect-common/src/types/api/blockchainEstimateFee';
 import { type Ok, type PartialRecord } from '@trezor/type-utils';
-import { BigNumber } from '@trezor/utils';
+import { BigNumber, throwError } from '@trezor/utils';
 
 import {
     ETH_NETWORK_ADDRESSES,
@@ -173,11 +173,9 @@ export const stake = async ({
     }
 
     try {
-        const ethAddresses = getEthNetworkAddresses(symbol);
-        if (!ethAddresses) {
-            throw new Error(`Unsupported staking network symbol: ${symbol}`);
-        }
-        const { addressContractPool } = ethAddresses;
+        const { addressContractPool } =
+            getEthNetworkAddresses(symbol) ??
+            throwError(`Unsupported staking network symbol: ${symbol}`);
         const data = buildStakeData();
 
         // gasLimit calculation based on address, amount and data size
@@ -249,11 +247,9 @@ export const unstake = async ({
         }
 
         const amountWei = toWei(amount, 'ether');
-        const ethAddresses = getEthNetworkAddresses(symbol);
-        if (!ethAddresses) {
-            throw new Error(`Unsupported staking network symbol: ${symbol}`);
-        }
-        const { addressContractPool } = ethAddresses;
+        const { addressContractPool } =
+            getEthNetworkAddresses(symbol) ??
+            throwError(`Unsupported staking network symbol: ${symbol}`);
         const data = buildUnstakeData(amountWei, interchanges);
 
         // gasLimit calculation based on address, amount and data size
@@ -316,11 +312,9 @@ export const claimWithdrawRequest = async ({
         }
         if (!readyForClaim.eq(requested)) throw new Error('Unstake request not filled yet');
 
-        const ethAddresses = getEthNetworkAddresses(symbol);
-        if (!ethAddresses) {
-            throw new Error(`Unsupported staking network symbol: ${symbol}`);
-        }
-        const { addressContractAccounting } = ethAddresses;
+        const { addressContractAccounting } =
+            getEthNetworkAddresses(symbol) ??
+            throwError(`Unsupported staking network symbol: ${symbol}`);
         const data = buildClaimWithdrawRequestData();
 
         // gasLimit calculation based on address, amount and data size

--- a/suite-common/walletconnect/src/adapters/ethereum.ts
+++ b/suite-common/walletconnect/src/adapters/ethereum.ts
@@ -18,7 +18,7 @@ import TrezorConnect, {
     type CallMethodResponse,
     type EthereumSignTypedData,
 } from '@trezor/connect';
-import { isAscii, isHex } from '@trezor/utils';
+import { isAscii, isHex, throwError } from '@trezor/utils';
 
 import { WALLETCONNECT_MODULE } from '../walletConnectConstants';
 import { selectSessionByTopic } from '../walletConnectReducer';
@@ -45,19 +45,14 @@ const ethereumRequestThunk = createThunk<
     const isMevProtectionEnabled = selectIsMevProtectionEnabled(getState());
     const isMevProtectionFeatureEnabled = selectIsMevProtectionFeatureEnabled(getState());
 
-    const getAccount = (address: string, chainId?: number) => {
-        const account = selectAccounts(getState()).find(
+    const getAccount = (address: string, chainId?: number) =>
+        selectAccounts(getState()).find(
             a =>
                 a.descriptor.toLowerCase() === address.toLowerCase() &&
                 a.networkType === 'ethereum' &&
                 (!chainId || getNetwork(a.symbol).chainId === chainId),
-        );
-        if (!account) {
-            throw new Error('Account not found');
-        }
+        ) || throwError('Account not found');
 
-        return account;
-    };
     const session = selectSessionByTopic(getState(), event.topic);
     if (!session) {
         throw new Error('WalletConnect Session not found');

--- a/suite-native/module-earn/src/components/EarnPortfolioTrackerGuard.tsx
+++ b/suite-native/module-earn/src/components/EarnPortfolioTrackerGuard.tsx
@@ -5,6 +5,7 @@ import { useBottomSheetModal as useBottomSheetModalContext } from '@gorhom/botto
 
 import { selectIsPortfolioTrackerDevice } from '@suite-common/device';
 import { useBottomSheetModal } from '@suite-native/atoms';
+import { throwError } from '@trezor/utils';
 
 import { PortfolioTrackerEarnBottomSheet } from './PortfolioTrackerEarnBottomSheet';
 
@@ -55,14 +56,6 @@ export const EarnPortfolioTrackerGuard = ({ children }: EarnPortfolioTrackerGuar
     );
 };
 
-export const useEarnPortfolioTrackerGuard = (): EarnPortfolioTrackerGuardContextValue => {
-    const context = useContext(EarnPortfolioTrackerGuardContext);
-
-    if (context === null) {
-        throw new Error(
-            'useEarnPortfolioTrackerGuard must be used within EarnPortfolioTrackerGuard',
-        );
-    }
-
-    return context;
-};
+export const useEarnPortfolioTrackerGuard = (): EarnPortfolioTrackerGuardContextValue =>
+    useContext(EarnPortfolioTrackerGuardContext) ??
+    throwError('useEarnPortfolioTrackerGuard must be used within EarnPortfolioTrackerGuard');

--- a/suite-native/navigation/src/components/DynamicHeader/DynamicScreenHeaderContext.tsx
+++ b/suite-native/navigation/src/components/DynamicHeader/DynamicScreenHeaderContext.tsx
@@ -3,6 +3,8 @@ import { type ReactNode, createContext, useCallback, useContext, useState } from
 import { type NativeScrollEvent } from 'react-native/Libraries/Components/ScrollView/ScrollView';
 import { type NativeSyntheticEvent } from 'react-native/Libraries/Types/CoreEventTypes';
 
+import { throwError } from '@trezor/utils';
+
 type HeaderContextType = {
     setScrollableHeaderHeight: (height: number) => void;
     isScrollableHeaderScrolled: boolean;
@@ -40,12 +42,6 @@ export const DynamicHeaderProvider = ({ children }: HeaderProviderProps) => {
     );
 };
 
-export const useDynamicHeader = () => {
-    const context = useContext(HeaderContext);
-
-    if (!context) {
-        throw new Error('useHeader must be used within a HeaderProvider');
-    }
-
-    return context;
-};
+export const useDynamicHeader = () =>
+    useContext(HeaderContext) ??
+    throwError('useDynamicHeader must be used within a HeaderProvider');

--- a/suite/metadata/src/metadataLabelingActions.ts
+++ b/suite/metadata/src/metadataLabelingActions.ts
@@ -19,7 +19,7 @@ import { type ExtraDependencies } from '@suite-common/redux-utils';
 import { type TrezorDevice } from '@suite-common/suite-types';
 import { type Account } from '@suite-common/wallet-types';
 import TrezorConnect, { type StaticSessionId } from '@trezor/connect';
-import { cloneObject } from '@trezor/utils';
+import { cloneObject, throwError } from '@trezor/utils';
 
 import type { MetadataAction } from './metadataActions';
 import * as metadataActions from './metadataActions';
@@ -65,12 +65,8 @@ const fetchMetadata =
             throw new Error('no provider instance');
         }
 
-        const entityMetadata = entity[encryptionVersion];
-        if (!entityMetadata) {
-            throw new Error('trying to fetch entity without metadata');
-        }
-
-        const { fileName, aesKey } = entityMetadata;
+        const { fileName, aesKey } =
+            entity[encryptionVersion] ?? throwError('trying to fetch entity without metadata');
 
         const response = await providerInstance.getFileContent(fileName);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request standardizes and simplifies error handling across the codebase by replacing direct `throw new Error(...)` statements with utility function `throwError` from `@trezor/utils`. This approach is applied to many React context hooks and other utility functions, making the code more concise and consistent.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/functional-throw&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/functional-throw&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/functional-throw&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/functional-throw/web/](https://dev.suite.sldev.cz/suite-web/chore/functional-throw/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-19T10:56:57.256Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-19T10:54:28.643Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->