### PR TITLE
test(e2e): nightly fix — After basic T1B1 onboarding with no networks added, the dashboard renders @exception/discovery-empty, not @dashboard/wallet-ready (EmptyWallet), because enabledNetworks.length === 0 triggers the discovery-empty exception path immediately.

### DIFF
--- a/suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts
+++ b/suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts
@@ -75,7 +75,7 @@ test.describe('Onboarding - create wallet', { tag: ['@firmware-ready', '@T1B1'] 
             await test.step('Finish wallet creation', async () => {
                 await onboardingPage.finalButton.click();
                 await expect(onboardingPage.suiteLoadedIndicator).toBeVisible();
-                await expect(dashboardPage.walletReady).toBeVisible();
+                await dashboardPage.verifyDiscoveryEmpty();
             });
         },
     );


### PR DESCRIPTION
## Nightly fix — 2026-05-19

**Task:** fix-002
**Scope:** TEST_CODE
**Result:** ✅ pass

### Root cause

After basic T1B1 onboarding with no networks added, the dashboard renders `@exception/discovery-empty`, not `@dashboard/wallet-ready` (EmptyWallet), because `enabledNetworks.length === 0` triggers the `discovery-empty` exception path immediately.

### Fix

In `suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts` line 78, replaced:
```ts
await expect(dashboardPage.walletReady).toBeVisible();
```
with:
```ts
await dashboardPage.verifyDiscoveryEmpty();
```

The `verifyDiscoveryEmpty()` helper (`dashboardPage.ts:232–240`) asserts `TR_YOUR_WALLET_IS_READY_WHAT` on `@exception/discovery-empty/header`, `TR_DASHBOARD_ACTIVATE_ASSETS_DESC` on description, and `TR_DASHBOARD_GET_STARTED` on the primary button — all rendered by `PortfolioCardException` when `enabledNetworks` is empty.

### Validations

| Status | Platform | Group | Spec |
|--------|----------|-------|------|
| ✅ | web | T1B1 | suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts |

### Commits

```
aa3f0d22f9 test(e2e): fix T1B1 create wallet assertion for discovery-empty state
```

### Prompt gaps

- The pre-flight check required a `git submodule update --init` step to populate `submodules/trezor-common/releases.json` in the worktree before tests could run — this is not mentioned in the agent instructions.
- The T1B1 emulator exhibited intermittent `Failure_UnexpectedMessage` errors during PIN setup (unrelated to the target bug), causing ~50% of runs to fail at line 67 before reaching line 78. A manual `docker restart trezor-user-env.unix` resolved the flakiness. The instructions don't mention this recovery step.

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is the T1B1 create wallet E2E test itself. The risk is confined to the T1B1 onboarding flow. The changed test must be run directly (high priority), and the other T1B1 onboarding tests should be run as well (medium priority) since they share the same device model, page objects, and onboarding flow components — any refactoring in the create-wallet test likely reflects patterns or page object changes that could impact sibling T1B1 tests.

<details><summary><b>Changed files (1)</b></summary>

- `suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts` — This is the exact file that was changed. It tests wallet creation on the T1B1 device during onboarding, including analytics consent, firmware setup, seed backup, PIN setup, and dashboard landing. Any modifications to this test file must be validated by running it directly.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-success.test.ts` — This test covers the T1B1 onboarding recovery flow which shares the same device model, onboarding page objects, analytics consent, firmware steps, and PIN setup components as the changed t1b1-create-wallet test. Changes to onboarding patterns for T1B1 could affect recovery flows.
- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-advanced.test.ts` — This test exercises the T1B1 advanced recovery onboarding flow, sharing the same device model setup, analytics consent, and firmware continuation steps as the changed create-wallet test. If shared T1B1 onboarding page object methods were modified, this would be affected.
- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-fail.test.ts` — Another T1B1 onboarding test covering recovery failure and retry scenarios. It shares the same device model, analyticsSection, firmware bypass, and devicePrompt interactions as the changed test file.

</details>

_Updated: 2026-05-19T11:40:52.850Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/nightly-2026-05-19-t1b1-wallet-ready-locator/web/](https://dev.suite.sldev.cz/suite-web/fix/nightly-2026-05-19-t1b1-wallet-ready-locator/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/nightly-2026-05-19-t1b1-wallet-ready-locator&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/nightly-2026-05-19-t1b1-wallet-ready-locator&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-19T11:45:41.863Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-19T11:44:21.815Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->