### PR TITLE
chore(suite-desktop): capture http-receiver start failures in Sentry 

### DIFF
--- a/packages/suite-desktop-core/src/modules/http-receiver.ts
+++ b/packages/suite-desktop-core/src/modules/http-receiver.ts
@@ -1,6 +1,8 @@
 /**
  * Local web server for handling requests to app
  */
+import { captureMessage } from '@sentry/electron/main';
+
 import { isMacOs, isWindows } from '@trezor/env-utils';
 import { validateIpcMessage } from '@trezor/ipc-proxy';
 import { isArrayMember } from '@trezor/utils';
@@ -117,6 +119,10 @@ export const initBackground: ModuleInitBackground = ({
             logger.error(
                 SERVICE_NAME,
                 `Failed to start server:  ${startResult.error}, error details: ${startResult.message}`,
+            );
+            captureMessage(
+                `http-receiver failed to start: ${startResult.error} (${startResult.message})`,
+                'warning',
             );
 
             return { url: null };


### PR DESCRIPTION
## Summary

The http-receiver module currently swallows start failures: when the server can't bind to its port, we `logger.error` and continue (the comment literally reads `Don't fail hard if the server can't start`). The `logger.error` call routes through `console.log`, not `console.error`, so the Sentry `captureConsoleIntegration` (configured for the `error` level only) does **not** pick it up. Net effect: zero telemetry on how often this happens in the wild.

This adds an explicit `captureMessage` on the start-failure branch (warning level, since the app continues to function — only labeling/Invity/connect-popup features degrade). The message includes `startResult.error` (`port already in use` vs `other error`) and `startResult.message`, which for `EADDRINUSE` already contains the name + PID of the process holding the port (see `findProcessFromIncomingPort` in `HttpServer.start`).

## Why this matters — connect-popup impact

This is more than a labeling/Invity edge case. `libs/connect-ws.ts:280` attaches the connect-popup WebSocket server directly to `httpReceiver.server` via an `upgrade` event handler. If the http-receiver fails to start, the underlying `http.Server` never enters the listening state, so no `upgrade` event ever fires and **the `/connect-ws` endpoint is silently unavailable** — meaning connect-popup integration (third-party dapps talking to Suite Desktop via localhost WebSocket) is fully broken for that user, with no surfaced error.

Without Sentry coverage on this branch, we have no idea how many users this is currently affecting. That alone justifies the investigation.

## Why now

Related to #20244, which proposes a fallback ports list for the http-receiver to recover from port collisions. That PR is motivated by "already rare cases" (author's words) but has no measurement to back it up, and its open TODOs around OAuth whitelisting in Dropbox/Google admin and Invity compatibility suggest non-trivial follow-up work. Before investing in the fallback, it would help to have a Sentry baseline so we can:

- confirm the problem is real and worth fixing (especially given the connect-popup blast radius above),
- size the fallback ports list based on actual collision frequency,
- understand what typically blocks the port (zombie Suite process? other app? AV?).

This PR is intentionally minimal observability instrumentation; it does not change runtime behavior.

## Test plan

- [ ] CI green
- [ ] Manually verify the Sentry event fires when the port is occupied (e.g. start a dummy server on 21335, launch Suite, confirm the event in the Sentry project)

Related: #20244

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mvarmuza/sentry-http-receiver-failure/web/](https://dev.suite.sldev.cz/suite-web/mvarmuza/sentry-http-receiver-failure/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-19T15:08:52.970Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-19T15:07:19.319Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mvarmuza/sentry-http-receiver-failure&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->