### PR TITLE
feat(suite): responsive card layout for earn dashboard

### DIFF
--- a/packages/components/src/components/IconCircle/types.ts
+++ b/packages/components/src/components/IconCircle/types.ts
@@ -10,5 +10,5 @@ export const iconCircleIntents = [
 ] as const satisfies UIIntent[];
 export type IconCircleIntent = Extract<UIIntent, (typeof iconCircleIntents)[number]>;
 
-export const iconCircleSizes = [16, 24, 32, 40, 96, 112] as const;
+export const iconCircleSizes = [16, 24, 32, 40, 64, 96, 112] as const;
 export type IconCircleSize = (typeof iconCircleSizes)[number];

--- a/packages/components/src/components/IconCircle/utils.ts
+++ b/packages/components/src/components/IconCircle/utils.ts
@@ -22,6 +22,7 @@ export const mapSizeToBorderWidth = (size: IconCircleSize): BorderWidths => {
         24: 0,
         32: 0,
         40: 0,
+        64: 6,
         96: 10,
         112: 12,
     };
@@ -57,6 +58,7 @@ export const mapSizeToIconSize = (size: IconCircleSize): IconSize => {
         24: 12,
         32: 16,
         40: 20,
+        64: 32,
         96: 40,
         112: 48,
     };

--- a/packages/components/src/components/buttons/IconButton/IconButton.tsx
+++ b/packages/components/src/components/buttons/IconButton/IconButton.tsx
@@ -57,10 +57,12 @@ export type IconButtonProps = CommonButtonProps &
         size?: ButtonSize;
         icon: IconName;
         'data-testid'?: string;
+        'aria-label'?: string;
     };
 
 export const IconButton = ({
     'data-testid': dataTestId,
+    'aria-label': ariaLabel,
     icon,
     size = 'medium',
     isFloating = false,
@@ -78,6 +80,7 @@ export const IconButton = ({
     return (
         <Container
             data-testid={dataTestId}
+            aria-label={ariaLabel}
             $size={size}
             $priority={priority}
             $intent={intent}

--- a/packages/suite/src/components/dashboard/DashboardSection.tsx
+++ b/packages/suite/src/components/dashboard/DashboardSection.tsx
@@ -50,7 +50,12 @@ export const DashboardSection = forwardRef(
                     <Column data-testid={dataTestId} gap={16}>
                         {renderHeader && (
                             <Column width="100%" gap={2}>
-                                <Row as="header" justifyContent="space-between">
+                                <Row
+                                    as="header"
+                                    justifyContent="space-between"
+                                    flexWrap="wrap"
+                                    gap={8}
+                                >
                                     {heading && (
                                         <H3>
                                             <Row as="span">{heading}</Row>

--- a/packages/suite/src/components/earn/dashboard/common/EarnActivateButton.tsx
+++ b/packages/suite/src/components/earn/dashboard/common/EarnActivateButton.tsx
@@ -1,0 +1,78 @@
+import { useDevice } from '@suite/device';
+import { Translation } from '@suite/intl';
+import { openModal } from '@suite/modal';
+import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import {
+    selectEnabledNetworks,
+    selectHasRunningDiscovery,
+    startOrRestartDiscoveryThunk,
+} from '@suite-common/wallet-core';
+import { Button, TOOLTIP_DELAY_NORMAL, Tooltip } from '@trezor/components';
+
+import { useDispatch, useSelector } from 'src/hooks/suite';
+
+type EarnActivateButtonProps = {
+    symbol: NetworkSymbol;
+};
+
+export const EarnActivateButton = ({ symbol }: EarnActivateButtonProps) => {
+    const dispatch = useDispatch();
+    const { device } = useDevice();
+    const enabledNetworks = useSelector(selectEnabledNetworks);
+    const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
+    const isNetworkEnabled = enabledNetworks.includes(symbol);
+    const isDiscoveringThisNetwork = isDiscoveryRunning && isNetworkEnabled;
+    const { name } = getNetwork(symbol);
+
+    const isDeviceDisconnected = !device?.connected;
+    const isButtonDisabled = isDeviceDisconnected || isDiscoveryRunning;
+    const tooltipMessage = isDeviceDisconnected ? (
+        <Translation id="TR_TO_ADD_NEW_ACCOUNT_PLEASE_CONNECT" />
+    ) : undefined;
+
+    const handleActivate = () => {
+        if (!device) {
+            return;
+        }
+
+        if (isNetworkEnabled) {
+            dispatch(startOrRestartDiscoveryThunk());
+
+            return;
+        }
+
+        dispatch(
+            openModal({
+                type: 'add-account',
+                device,
+                symbol,
+                noRedirect: true,
+                isCoinjoinDisabled: true,
+                isBackClickDisabled: true,
+            }),
+        );
+    };
+
+    return (
+        <Tooltip
+            isActive={!!tooltipMessage}
+            tooltipMaxWidth={200}
+            content={tooltipMessage}
+            placement="top"
+            cursor="not-allowed"
+            delayShow={TOOLTIP_DELAY_NORMAL}
+        >
+            <Button
+                size="small"
+                onClick={handleActivate}
+                isDisabled={isButtonDisabled}
+                isLoading={isDiscoveringThisNetwork}
+            >
+                <Translation
+                    id="TR_EARN_STAKING_DASHBOARD_ACTIVATE"
+                    values={{ networkName: name }}
+                />
+            </Button>
+        </Tooltip>
+    );
+};

--- a/packages/suite/src/components/earn/dashboard/common/EarnDashboardTableHeader.tsx
+++ b/packages/suite/src/components/earn/dashboard/common/EarnDashboardTableHeader.tsx
@@ -4,30 +4,38 @@ import { Table } from '@trezor/components';
 type EarnDashboardTableHeaderProps = {
     accountColumnTranslationId: TranslationKey;
     showRewardsColumns?: boolean;
+    hidden?: boolean;
 };
 
 export const EarnDashboardTableHeader = ({
     accountColumnTranslationId,
     showRewardsColumns = true,
-}: EarnDashboardTableHeaderProps) => (
-    <Table.Header>
-        <Table.Row>
-            <Table.Cell>
-                <Translation id={accountColumnTranslationId} />
-            </Table.Cell>
-            <Table.Cell>
-                <Translation id="TR_EARN_DASHBOARD_TABLE_APY" />
-            </Table.Cell>
-            <Table.Cell>
-                {showRewardsColumns && <Translation id="TR_EARN_DASHBOARD_TABLE_YEARLY_REWARDS" />}
-            </Table.Cell>
-            <Table.Cell>
-                {showRewardsColumns && (
-                    <Translation id="TR_EARN_DASHBOARD_TABLE_POTENTIAL_REWARDS" />
-                )}
-            </Table.Cell>
-            {/* Actions column */}
-            <Table.Cell />
-        </Table.Row>
-    </Table.Header>
-);
+    hidden = false,
+}: EarnDashboardTableHeaderProps) => {
+    if (hidden) return null;
+
+    return (
+        <Table.Header>
+            <Table.Row>
+                <Table.Cell>
+                    <Translation id={accountColumnTranslationId} />
+                </Table.Cell>
+                <Table.Cell>
+                    <Translation id="TR_EARN_DASHBOARD_TABLE_APY" />
+                </Table.Cell>
+                <Table.Cell>
+                    {showRewardsColumns && (
+                        <Translation id="TR_EARN_DASHBOARD_TABLE_YEARLY_REWARDS" />
+                    )}
+                </Table.Cell>
+                <Table.Cell>
+                    {showRewardsColumns && (
+                        <Translation id="TR_EARN_DASHBOARD_TABLE_POTENTIAL_REWARDS" />
+                    )}
+                </Table.Cell>
+                {/* Actions column */}
+                <Table.Cell />
+            </Table.Row>
+        </Table.Header>
+    );
+};

--- a/packages/suite/src/components/earn/dashboard/common/EarnInactiveNetworkOpportunity.tsx
+++ b/packages/suite/src/components/earn/dashboard/common/EarnInactiveNetworkOpportunity.tsx
@@ -1,68 +1,50 @@
 import { type ReactNode } from 'react';
 
-import { useDevice } from '@suite/device';
-import { Translation } from '@suite/intl';
-import { openModal } from '@suite/modal';
-import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
-import {
-    selectEnabledNetworks,
-    selectHasRunningDiscovery,
-    startOrRestartDiscoveryThunk,
-} from '@suite-common/wallet-core';
-import { Button, Paragraph, TOOLTIP_DELAY_NORMAL, Table, Tooltip } from '@trezor/components';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { Card, Column, Paragraph, Row, Table } from '@trezor/components';
 
-import { useDispatch, useSelector } from 'src/hooks/suite';
 import { ApyValue } from 'src/views/wallet/staking/components/ApyValue';
 
 import { EarnAccountCell } from './EarnAccountCell';
+import { EarnActivateButton } from './EarnActivateButton';
 
 type EarnInactiveNetworkOpportunityProps = {
     symbol: NetworkSymbol;
     apy: number | null;
     note?: ReactNode;
+    isCardLayout: boolean;
 };
 
 export const EarnInactiveNetworkOpportunity = ({
     symbol,
     apy,
     note,
+    isCardLayout,
 }: EarnInactiveNetworkOpportunityProps) => {
-    const dispatch = useDispatch();
-    const { device } = useDevice();
-    const enabledNetworks = useSelector(selectEnabledNetworks);
-    const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
-    const isNetworkEnabled = enabledNetworks.includes(symbol);
-    const isDiscoveringThisNetwork = isDiscoveryRunning && isNetworkEnabled;
-    const { name } = getNetwork(symbol);
+    const noteParagraph = note && (
+        <Paragraph typographyStyle="body-md" intent="neutral">
+            {note}
+        </Paragraph>
+    );
 
-    const isDeviceDisconnected = !device?.connected;
-    const isButtonDisabled = isDeviceDisconnected || isDiscoveryRunning;
-    const tooltipMessage = isDeviceDisconnected ? (
-        <Translation id="TR_TO_ADD_NEW_ACCOUNT_PLEASE_CONNECT" />
-    ) : undefined;
+    if (isCardLayout) {
+        return (
+            <Card paddingType="small">
+                <Column gap={12} width="100%">
+                    <Row justifyContent="space-between" alignItems="flex-start">
+                        <EarnAccountCell symbol={symbol} />
+                        <ApyValue apy={apy} />
+                    </Row>
 
-    const handleActivate = () => {
-        if (!device) {
-            return;
-        }
+                    {noteParagraph}
 
-        if (isNetworkEnabled) {
-            dispatch(startOrRestartDiscoveryThunk());
-
-            return;
-        }
-
-        dispatch(
-            openModal({
-                type: 'add-account',
-                device,
-                symbol,
-                noRedirect: true,
-                isCoinjoinDisabled: true,
-                isBackClickDisabled: true,
-            }),
+                    <Row>
+                        <EarnActivateButton symbol={symbol} />
+                    </Row>
+                </Column>
+            </Card>
         );
-    };
+    }
 
     return (
         <Table.Row>
@@ -74,35 +56,10 @@ export const EarnInactiveNetworkOpportunity = ({
                 <ApyValue apy={apy} />
             </Table.Cell>
 
-            <Table.Cell colSpan={2}>
-                {note && (
-                    <Paragraph typographyStyle="body-md" intent="neutral">
-                        {note}
-                    </Paragraph>
-                )}
-            </Table.Cell>
+            <Table.Cell colSpan={2}>{noteParagraph}</Table.Cell>
 
             <Table.Cell align="end">
-                <Tooltip
-                    isActive={!!tooltipMessage}
-                    tooltipMaxWidth={200}
-                    content={tooltipMessage}
-                    placement="top"
-                    cursor="not-allowed"
-                    delayShow={TOOLTIP_DELAY_NORMAL}
-                >
-                    <Button
-                        size="small"
-                        onClick={handleActivate}
-                        isDisabled={isButtonDisabled}
-                        isLoading={isDiscoveringThisNetwork}
-                    >
-                        <Translation
-                            id="TR_EARN_STAKING_DASHBOARD_ACTIVATE"
-                            values={{ networkName: name }}
-                        />
-                    </Button>
-                </Tooltip>
+                <EarnActivateButton symbol={symbol} />
             </Table.Cell>
         </Table.Row>
     );

--- a/packages/suite/src/components/earn/dashboard/staking/EarnStakingAccountRow.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/EarnStakingAccountRow.tsx
@@ -1,47 +1,48 @@
-import { useMemo } from 'react';
-
 import { events } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { goto } from '@suite/router';
 import { useFormatters } from '@suite-common/formatters';
-import { Feature, selectIsFeatureEnabled } from '@suite-common/message-system';
 import { getNetworkAdjustedStakingBalance } from '@suite-common/staking';
 import { getTradingPrefilledFromAccountData, tradingActions } from '@suite-common/trading';
 import { getDisplaySymbol } from '@suite-common/wallet-config';
-import {
-    selectAccountIsStakingActive,
-    selectCardanoPoolsInfo,
-    selectPoolStatsApy,
-} from '@suite-common/wallet-core';
+import { selectAccountIsStakingActive, selectPoolStatsApy } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import {
     calculateRewards,
     getAccountTotalStakingBalance,
     getStakingLimitsByNetworkSymbol,
-    isCardanoStakedOutsideEverstake,
 } from '@suite-common/wallet-utils';
-import { Button, Column, Icon, Paragraph, Row, Table, Tooltip } from '@trezor/components';
+import { Card, Column, Icon, Paragraph, Row, Table } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
 
-import { formatApyValue } from 'src/components/earn/utils/earnApyUtils';
-import { HiddenPlaceholder } from 'src/components/suite/HiddenPlaceholder';
 import { useDispatch, useSelector } from 'src/hooks/suite';
+import { useLayoutSize } from 'src/hooks/suite/useLayoutSize';
 import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
 import { useAnalytics } from 'src/support/useAnalytics';
 import { ApyValue } from 'src/views/wallet/staking/components/ApyValue';
 
+import { EarnStakingActionButtons } from './EarnStakingActionButtons';
+import { EarnStakingCurrentRewards } from './EarnStakingCurrentRewards';
+import { EarnStakingOutdatedProvider } from './EarnStakingOutdatedProvider';
+import { EarnStakingPotentialRewards } from './EarnStakingPotentialRewards';
+import { useStakingAccountStatus } from './hooks/useStakingAccountStatus';
 import { EarnAccountCell } from '../common/EarnAccountCell';
-import { EarnRewardsAmount } from '../common/EarnRewardsAmount';
 
-export const EarnStakingAccountRow = ({ account }: { account: Account }) => {
+export const EarnStakingAccountRow = ({
+    account,
+    isCardLayout,
+}: {
+    account: Account;
+    isCardLayout: boolean;
+}) => {
     const dispatch = useDispatch();
     const { CryptoAmountFormatter } = useFormatters();
     const analytics = useAnalytics();
+    const { isBelowMobile } = useLayoutSize();
     const apy = useSelector(state => selectPoolStatsApy(state, { account }));
     const displaySymbol = getDisplaySymbol(account.symbol);
     const isCardanoNetworkType = account.networkType === 'cardano';
     const isStakingActive = useSelector(state => selectAccountIsStakingActive(state, account.key));
-    const cardanoStakingPools = useSelector(selectCardanoPoolsInfo);
     const { isStakingDisabled, stakingMessageContent } = useMessageSystemStaking(account.symbol);
 
     const minStakingAmount = getStakingLimitsByNetworkSymbol(
@@ -51,53 +52,9 @@ export const EarnStakingAccountRow = ({ account }: { account: Account }) => {
     const accountBalance = account.formattedBalance;
     const stakingBalance = getAccountTotalStakingBalance(account) ?? '0';
 
-    const isNewProviderBannerEnabled = useSelector(state =>
-        selectIsFeatureEnabled(state, Feature.banners.staking.ada.newProvider, true),
-    );
+    const stakingStatus = useStakingAccountStatus(account);
 
-    const state = useMemo(() => {
-        if (
-            isCardanoStakedOutsideEverstake(account, cardanoStakingPools) &&
-            isNewProviderBannerEnabled
-        ) {
-            return 'staking-outdated-provider';
-        }
-
-        if (
-            (accountBalance === '0' && stakingBalance !== '0') ||
-            (isCardanoNetworkType && isStakingActive)
-        ) {
-            return 'staking-max';
-        }
-
-        const hasEnoughBalanceForStaking =
-            minStakingAmount && new BigNumber(accountBalance).gte(minStakingAmount);
-
-        if (stakingBalance !== '0') {
-            if (!hasEnoughBalanceForStaking) {
-                return 'staked-but-insufficient-funds';
-            }
-
-            return 'staking-active';
-        }
-
-        if (!hasEnoughBalanceForStaking) {
-            return 'insufficient-funds';
-        }
-
-        return 'staking-inactive';
-    }, [
-        account,
-        accountBalance,
-        stakingBalance,
-        minStakingAmount,
-        isCardanoNetworkType,
-        isStakingActive,
-        cardanoStakingPools,
-        isNewProviderBannerEnabled,
-    ]);
-
-    const navigateToTradingBuy = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    const navigateToTradingBuy = (event: React.MouseEvent<HTMLButtonElement>) => {
         event.stopPropagation();
 
         dispatch(
@@ -134,7 +91,7 @@ export const EarnStakingAccountRow = ({ account }: { account: Account }) => {
             type: events.stakingNavigateEvent.name,
             payload: {
                 action: 'navigate',
-                from: `dashboard/staking-dashboard/${state}`,
+                from: `dashboard/staking-dashboard/${stakingStatus}`,
                 networkSymbol: account.symbol,
             },
         });
@@ -149,82 +106,145 @@ export const EarnStakingAccountRow = ({ account }: { account: Account }) => {
             maxDisplayedDecimals: 8,
         });
 
-    const CurrentRewardsCell = () => {
-        const currentRewards = calculateRewards(stakingBalance, apy);
+    const currentRewards = calculateRewards(stakingBalance, apy);
+    const totalBalance = new BigNumber(stakingBalance).plus(accountBalance).toString();
+    const potentialRewards = calculateRewards(
+        getNetworkAdjustedStakingBalance(totalBalance, account),
+        apy,
+    );
+    const formattedStakingBalance = formatCryptoAmount(stakingBalance);
+    const formattedAccountBalance = formatCryptoAmount(accountBalance);
 
+    const currentRewardsProps = {
+        symbol: account.symbol,
+        rewards: currentRewards,
+        apy,
+        isStakingActive,
+        formattedStakingBalance,
+        displaySymbol,
+    } as const;
+
+    const potentialRewardsProps = {
+        symbol: account.symbol,
+        rewards: potentialRewards,
+        apy,
+        isCardanoNetworkType,
+        formattedAccountBalance,
+        displaySymbol,
+    } as const;
+
+    const minStakeParagraph = (
+        <Paragraph typographyStyle="body-md" intent="neutral" priority="secondary">
+            <Translation
+                id="TR_EARN_STAKING_DASHBOARD_MINIMUM_STAKE"
+                values={{ amount: minStakingAmount?.toString(), displaySymbol }}
+            />
+        </Paragraph>
+    );
+
+    const maxStakeParagraph = (
+        <Paragraph typographyStyle="body-md" intent="neutral" priority="secondary">
+            <Translation id="TR_EARN_STAKING_DASHBOARD_MAXIMUM_STAKE" />
+        </Paragraph>
+    );
+
+    const actionButtonsProps = {
+        stakingStatus,
+        isStakingDisabled,
+        stakingMessageContent,
+        onBuy: navigateToTradingBuy,
+        onStake: navigateToStaking,
+    } as const;
+
+    if (isCardLayout) {
         return (
-            <Table.Cell>
-                <Row width="100%" alignItems="center" justifyContent="space-between">
-                    <Column alignItems="flex-start">
-                        <EarnRewardsAmount
-                            symbol={account.symbol}
-                            rewards={isStakingActive ? currentRewards : '0'}
-                            apy={apy}
+            <Card paddingType="small" onClick={navigateToStaking}>
+                <Column gap={12} width="100%">
+                    <Row justifyContent="space-between" alignItems="flex-start">
+                        <EarnAccountCell account={account} />
+                        <ApyValue
+                            apy={stakingStatus === 'staking-outdated-provider' ? null : apy}
                         />
+                    </Row>
 
-                        {isStakingActive && (
-                            <Paragraph
-                                typographyStyle="body-sm"
-                                intent="neutral"
-                                priority="secondary"
-                            >
-                                <HiddenPlaceholder>
-                                    <Translation
-                                        id="TR_EARN_STAKING_DASHBOARD_STAKED"
-                                        values={{
-                                            amount: formatCryptoAmount(stakingBalance),
-                                            displaySymbol,
-                                        }}
+                    {stakingStatus === 'insufficient-funds' && minStakeParagraph}
+
+                    {stakingStatus === 'staking-outdated-provider' && (
+                        <EarnStakingOutdatedProvider apy={apy} />
+                    )}
+
+                    {(stakingStatus === 'staking-active' || stakingStatus === 'staking-inactive') &&
+                        (isBelowMobile ? (
+                            <Column gap={4}>
+                                <EarnStakingCurrentRewards {...currentRewardsProps} />
+                                {apy && (
+                                    <Icon
+                                        name="arrowDown"
+                                        intent="neutral"
+                                        priority="secondary"
+                                        size={20}
                                     />
-                                </HiddenPlaceholder>
-                            </Paragraph>
-                        )}
-                    </Column>
+                                )}
+                                <EarnStakingPotentialRewards {...potentialRewardsProps} />
+                            </Column>
+                        ) : (
+                            <Row alignItems="center">
+                                <Column flex="2">
+                                    <EarnStakingCurrentRewards {...currentRewardsProps} />
+                                </Column>
+                                {apy && (
+                                    <Column flex="1" alignItems="center">
+                                        <Icon
+                                            name="arrowRight"
+                                            intent="neutral"
+                                            priority="secondary"
+                                            size={20}
+                                        />
+                                    </Column>
+                                )}
+                                <Column flex="2">
+                                    <EarnStakingPotentialRewards {...potentialRewardsProps} />
+                                </Column>
+                            </Row>
+                        ))}
 
-                    {apy && (
-                        <Icon name="arrowRight" intent="neutral" priority="secondary" size={20} />
-                    )}
-                </Row>
-            </Table.Cell>
-        );
-    };
+                    {stakingStatus === 'staking-max' &&
+                        (isBelowMobile ? (
+                            <Column gap={4}>
+                                <EarnStakingCurrentRewards {...currentRewardsProps} />
+                                {maxStakeParagraph}
+                            </Column>
+                        ) : (
+                            <Row gap={16} alignItems="center">
+                                <Column flex="1">
+                                    <EarnStakingCurrentRewards {...currentRewardsProps} />
+                                </Column>
+                                <Column flex="1">{maxStakeParagraph}</Column>
+                            </Row>
+                        ))}
 
-    const PotentialRewardsCell = () => {
-        const totalBalance = new BigNumber(stakingBalance).plus(accountBalance).toString();
-        const potentialRewards = calculateRewards(
-            getNetworkAdjustedStakingBalance(totalBalance, account),
-            apy,
-        );
+                    {stakingStatus === 'staked-but-insufficient-funds' &&
+                        (isBelowMobile ? (
+                            <Column gap={4}>
+                                <EarnStakingCurrentRewards {...currentRewardsProps} />
+                                {minStakeParagraph}
+                            </Column>
+                        ) : (
+                            <Row gap={16} alignItems="center">
+                                <Column flex="1">
+                                    <EarnStakingCurrentRewards {...currentRewardsProps} />
+                                </Column>
+                                <Column flex="1">{minStakeParagraph}</Column>
+                            </Row>
+                        ))}
 
-        return (
-            <Table.Cell>
-                <Column>
-                    {apy && (
-                        <EarnRewardsAmount
-                            symbol={account.symbol}
-                            rewards={potentialRewards}
-                            apy={apy}
-                            intent="brand"
-                        />
-                    )}
-
-                    {!isCardanoNetworkType && apy && (
-                        <Paragraph typographyStyle="body-sm" intent="neutral" priority="secondary">
-                            <HiddenPlaceholder>
-                                <Translation
-                                    id="TR_EARN_STAKING_DASHBOARD_IF_YOU_ADD"
-                                    values={{
-                                        amount: formatCryptoAmount(accountBalance),
-                                        displaySymbol,
-                                    }}
-                                />
-                            </HiddenPlaceholder>
-                        </Paragraph>
-                    )}
+                    <Row gap={8}>
+                        <EarnStakingActionButtons {...actionButtonsProps} />
+                    </Row>
                 </Column>
-            </Table.Cell>
+            </Card>
         );
-    };
+    }
 
     return (
         <Table.Row onClick={navigateToStaking}>
@@ -233,145 +253,81 @@ export const EarnStakingAccountRow = ({ account }: { account: Account }) => {
             </Table.Cell>
 
             <Table.Cell>
-                {state === 'staking-outdated-provider' ? (
+                {stakingStatus === 'staking-outdated-provider' ? (
                     <Translation id="TR_EARN_NOT_AVAILABLE" />
                 ) : (
                     <ApyValue apy={apy} />
                 )}
             </Table.Cell>
 
-            {state === 'insufficient-funds' && (
+            {stakingStatus === 'insufficient-funds' && (
                 <>
-                    <Table.Cell colSpan={2}>
-                        <Paragraph typographyStyle="body-md" intent="neutral" priority="secondary">
-                            <Translation
-                                id="TR_EARN_STAKING_DASHBOARD_MINIMUM_STAKE"
-                                values={{
-                                    amount: minStakingAmount?.toString(),
-                                    displaySymbol,
-                                }}
-                            />
-                        </Paragraph>
-                    </Table.Cell>
-
+                    <Table.Cell colSpan={2}>{minStakeParagraph}</Table.Cell>
                     <Table.Cell align="end">
-                        <Button
-                            intent="neutral"
-                            priority="secondary"
-                            size="small"
-                            onClick={navigateToTradingBuy}
-                        >
-                            <Translation id="TR_BUY" />
-                        </Button>
+                        <EarnStakingActionButtons {...actionButtonsProps} />
                     </Table.Cell>
                 </>
             )}
 
-            {(state === 'staking-active' || state === 'staking-inactive') && (
+            {(stakingStatus === 'staking-active' || stakingStatus === 'staking-inactive') && (
                 <>
-                    <CurrentRewardsCell />
-                    <PotentialRewardsCell />
-
-                    <Table.Cell align="end">
-                        <Tooltip content={stakingMessageContent}>
-                            <Button
-                                intent="brand"
-                                size="small"
-                                isDisabled={isStakingDisabled}
-                                iconLeft={isStakingDisabled ? 'info' : undefined}
-                                onClick={navigateToStaking}
-                            >
-                                <Translation
-                                    id={
-                                        state === 'staking-active'
-                                            ? 'TR_EARN_STAKING_DASHBOARD_STAKE_MORE'
-                                            : 'TR_EARN_STAKING_DASHBOARD_STAKE_NOW'
-                                    }
-                                />
-                            </Button>
-                        </Tooltip>
-                    </Table.Cell>
-                </>
-            )}
-
-            {state === 'staking-max' && (
-                <>
-                    <CurrentRewardsCell />
-
                     <Table.Cell>
-                        <Paragraph typographyStyle="body-md" intent="neutral" priority="secondary">
-                            <Translation id="TR_EARN_STAKING_DASHBOARD_MAXIMUM_STAKE" />
-                        </Paragraph>
-                    </Table.Cell>
-
-                    <Table.Cell align="end">
-                        <Button
-                            intent="neutral"
-                            priority="secondary"
-                            size="small"
-                            onClick={navigateToTradingBuy}
-                        >
-                            <Translation id="TR_BUY" />
-                        </Button>
-                    </Table.Cell>
-                </>
-            )}
-
-            {state === 'staked-but-insufficient-funds' && (
-                <>
-                    <CurrentRewardsCell />
-
-                    <Table.Cell>
-                        <Paragraph typographyStyle="body-md" intent="neutral" priority="secondary">
-                            <Translation
-                                id="TR_EARN_STAKING_DASHBOARD_MINIMUM_STAKE"
-                                values={{
-                                    amount: minStakingAmount?.toString(),
-                                    displaySymbol,
-                                }}
-                            />
-                        </Paragraph>
-                    </Table.Cell>
-
-                    <Table.Cell align="end">
-                        <Button
-                            intent="neutral"
-                            priority="secondary"
-                            size="small"
-                            onClick={navigateToTradingBuy}
-                        >
-                            <Translation id="TR_BUY" />
-                        </Button>
-                    </Table.Cell>
-                </>
-            )}
-
-            {state === 'staking-outdated-provider' && (
-                <>
-                    <Table.Cell colSpan={2}>
-                        <Row gap={4}>
-                            <Icon name="warning" size={24} intent="warning" />
-                            <Paragraph typographyStyle="body-md" intent="warning">
-                                <Translation
-                                    id="TR_EARN_STAKING_DASHBOARD_OUTDATED_PROVIDER"
-                                    values={{ apy: formatApyValue(apy) }}
+                        <Row width="100%" alignItems="center" justifyContent="space-between">
+                            <EarnStakingCurrentRewards {...currentRewardsProps} />
+                            {apy && (
+                                <Icon
+                                    name="arrowRight"
+                                    intent="neutral"
+                                    priority="secondary"
+                                    size={20}
                                 />
-                            </Paragraph>
+                            )}
                         </Row>
                     </Table.Cell>
-
+                    <Table.Cell>
+                        <EarnStakingPotentialRewards {...potentialRewardsProps} />
+                    </Table.Cell>
                     <Table.Cell align="end">
-                        <Tooltip content={stakingMessageContent}>
-                            <Button
-                                intent="brand"
-                                size="small"
-                                isDisabled={isStakingDisabled}
-                                iconLeft={isStakingDisabled ? 'info' : undefined}
-                                onClick={navigateToStaking}
-                            >
-                                <Translation id="TR_EARN_UPDATE_PROVIDER" />
-                            </Button>
-                        </Tooltip>
+                        <EarnStakingActionButtons {...actionButtonsProps} />
+                    </Table.Cell>
+                </>
+            )}
+
+            {stakingStatus === 'staking-max' && (
+                <>
+                    <Table.Cell>
+                        <Row width="100%" alignItems="center" justifyContent="space-between">
+                            <EarnStakingCurrentRewards {...currentRewardsProps} />
+                        </Row>
+                    </Table.Cell>
+                    <Table.Cell>{maxStakeParagraph}</Table.Cell>
+                    <Table.Cell align="end">
+                        <EarnStakingActionButtons {...actionButtonsProps} />
+                    </Table.Cell>
+                </>
+            )}
+
+            {stakingStatus === 'staked-but-insufficient-funds' && (
+                <>
+                    <Table.Cell>
+                        <Row width="100%" alignItems="center" justifyContent="space-between">
+                            <EarnStakingCurrentRewards {...currentRewardsProps} />
+                        </Row>
+                    </Table.Cell>
+                    <Table.Cell>{minStakeParagraph}</Table.Cell>
+                    <Table.Cell align="end">
+                        <EarnStakingActionButtons {...actionButtonsProps} />
+                    </Table.Cell>
+                </>
+            )}
+
+            {stakingStatus === 'staking-outdated-provider' && (
+                <>
+                    <Table.Cell colSpan={2}>
+                        <EarnStakingOutdatedProvider apy={apy} />
+                    </Table.Cell>
+                    <Table.Cell align="end">
+                        <EarnStakingActionButtons {...actionButtonsProps} />
                     </Table.Cell>
                 </>
             )}

--- a/packages/suite/src/components/earn/dashboard/staking/EarnStakingAccountRow.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/EarnStakingAccountRow.tsx
@@ -75,7 +75,9 @@ export const EarnStakingAccountRow = ({
         });
     };
 
-    const navigateToStaking = () => {
+    const navigateToStaking = (event?: React.MouseEvent) => {
+        event?.stopPropagation();
+
         dispatch(
             goto({
                 routeName: 'wallet-staking',

--- a/packages/suite/src/components/earn/dashboard/staking/EarnStakingActionButtons.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/EarnStakingActionButtons.tsx
@@ -1,0 +1,66 @@
+import { type MouseEvent, type ReactNode } from 'react';
+
+import { Translation } from '@suite/intl';
+import { Button, Tooltip } from '@trezor/components';
+
+import { type StakingAccountStatus } from './hooks/useStakingAccountStatus';
+
+type EarnStakingActionButtonsProps = {
+    stakingStatus: StakingAccountStatus;
+    isStakingDisabled: boolean | undefined;
+    stakingMessageContent: ReactNode;
+    onBuy: (event: MouseEvent<HTMLButtonElement>) => void;
+    onStake: () => void;
+};
+
+export const EarnStakingActionButtons = ({
+    stakingStatus,
+    isStakingDisabled,
+    stakingMessageContent,
+    onBuy,
+    onStake,
+}: EarnStakingActionButtonsProps) => (
+    <>
+        {(stakingStatus === 'insufficient-funds' ||
+            stakingStatus === 'staking-max' ||
+            stakingStatus === 'staked-but-insufficient-funds') && (
+            <Button intent="neutral" priority="secondary" size="small" onClick={onBuy}>
+                <Translation id="TR_BUY" />
+            </Button>
+        )}
+
+        {(stakingStatus === 'staking-active' || stakingStatus === 'staking-inactive') && (
+            <Tooltip content={stakingMessageContent}>
+                <Button
+                    intent="brand"
+                    size="small"
+                    isDisabled={isStakingDisabled}
+                    iconLeft={isStakingDisabled ? 'info' : undefined}
+                    onClick={onStake}
+                >
+                    <Translation
+                        id={
+                            stakingStatus === 'staking-active'
+                                ? 'TR_EARN_STAKING_DASHBOARD_STAKE_MORE'
+                                : 'TR_EARN_STAKING_DASHBOARD_STAKE_NOW'
+                        }
+                    />
+                </Button>
+            </Tooltip>
+        )}
+
+        {stakingStatus === 'staking-outdated-provider' && (
+            <Tooltip content={stakingMessageContent}>
+                <Button
+                    intent="brand"
+                    size="small"
+                    isDisabled={isStakingDisabled}
+                    iconLeft={isStakingDisabled ? 'info' : undefined}
+                    onClick={onStake}
+                >
+                    <Translation id="TR_EARN_UPDATE_PROVIDER" />
+                </Button>
+            </Tooltip>
+        )}
+    </>
+);

--- a/packages/suite/src/components/earn/dashboard/staking/EarnStakingActionButtons.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/EarnStakingActionButtons.tsx
@@ -10,7 +10,7 @@ type EarnStakingActionButtonsProps = {
     isStakingDisabled: boolean | undefined;
     stakingMessageContent: ReactNode;
     onBuy: (event: MouseEvent<HTMLButtonElement>) => void;
-    onStake: () => void;
+    onStake: (event: MouseEvent<HTMLButtonElement>) => void;
 };
 
 export const EarnStakingActionButtons = ({

--- a/packages/suite/src/components/earn/dashboard/staking/EarnStakingActivateRow.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/EarnStakingActivateRow.tsx
@@ -8,7 +8,13 @@ import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking
 
 import { EarnInactiveNetworkOpportunity } from '../common/EarnInactiveNetworkOpportunity';
 
-export const EarnStakingActivateRow = ({ symbol }: { symbol: NetworkSymbol }) => {
+export const EarnStakingActivateRow = ({
+    symbol,
+    isCardLayout,
+}: {
+    symbol: NetworkSymbol;
+    isCardLayout: boolean;
+}) => {
     const apy = useSelector(state => selectPoolStatsApy(state, { networkSymbol: symbol }));
     const { isStakingDisabled } = useMessageSystemStaking(symbol);
 
@@ -22,6 +28,7 @@ export const EarnStakingActivateRow = ({ symbol }: { symbol: NetworkSymbol }) =>
         <EarnInactiveNetworkOpportunity
             symbol={symbol}
             apy={apy}
+            isCardLayout={isCardLayout}
             note={
                 <Translation
                     id="TR_EARN_STAKING_DASHBOARD_MINIMUM_STAKE"

--- a/packages/suite/src/components/earn/dashboard/staking/EarnStakingCurrentRewards.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/EarnStakingCurrentRewards.tsx
@@ -1,0 +1,40 @@
+import { Translation } from '@suite/intl';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { Column, Paragraph } from '@trezor/components';
+
+import { HiddenPlaceholder } from 'src/components/suite/HiddenPlaceholder';
+
+import { EarnRewardsAmount } from '../common/EarnRewardsAmount';
+
+type EarnStakingCurrentRewardsProps = {
+    symbol: NetworkSymbol;
+    rewards: string;
+    apy: number | null;
+    isStakingActive: boolean;
+    formattedStakingBalance: string;
+    displaySymbol: string;
+};
+
+export const EarnStakingCurrentRewards = ({
+    symbol,
+    rewards,
+    apy,
+    isStakingActive,
+    formattedStakingBalance,
+    displaySymbol,
+}: EarnStakingCurrentRewardsProps) => (
+    <Column alignItems="flex-start">
+        <EarnRewardsAmount symbol={symbol} rewards={isStakingActive ? rewards : '0'} apy={apy} />
+
+        {isStakingActive && (
+            <Paragraph typographyStyle="body-sm" intent="neutral" priority="secondary">
+                <HiddenPlaceholder>
+                    <Translation
+                        id="TR_EARN_STAKING_DASHBOARD_STAKED"
+                        values={{ amount: formattedStakingBalance, displaySymbol }}
+                    />
+                </HiddenPlaceholder>
+            </Paragraph>
+        )}
+    </Column>
+);

--- a/packages/suite/src/components/earn/dashboard/staking/EarnStakingOutdatedProvider.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/EarnStakingOutdatedProvider.tsx
@@ -1,0 +1,20 @@
+import { Translation } from '@suite/intl';
+import { Icon, Paragraph, Row } from '@trezor/components';
+
+import { formatApyValue } from 'src/components/earn/utils/earnApyUtils';
+
+type EarnStakingOutdatedProviderProps = {
+    apy: number | null;
+};
+
+export const EarnStakingOutdatedProvider = ({ apy }: EarnStakingOutdatedProviderProps) => (
+    <Row gap={4}>
+        <Icon name="warning" size={24} intent="warning" />
+        <Paragraph typographyStyle="body-md" intent="warning">
+            <Translation
+                id="TR_EARN_STAKING_DASHBOARD_OUTDATED_PROVIDER"
+                values={{ apy: formatApyValue(apy) }}
+            />
+        </Paragraph>
+    </Row>
+);

--- a/packages/suite/src/components/earn/dashboard/staking/EarnStakingPotentialRewards.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/EarnStakingPotentialRewards.tsx
@@ -1,0 +1,40 @@
+import { Translation } from '@suite/intl';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { Column, Paragraph } from '@trezor/components';
+
+import { HiddenPlaceholder } from 'src/components/suite/HiddenPlaceholder';
+
+import { EarnRewardsAmount } from '../common/EarnRewardsAmount';
+
+type EarnStakingPotentialRewardsProps = {
+    symbol: NetworkSymbol;
+    rewards: string;
+    apy: number | null;
+    isCardanoNetworkType: boolean;
+    formattedAccountBalance: string;
+    displaySymbol: string;
+};
+
+export const EarnStakingPotentialRewards = ({
+    symbol,
+    rewards,
+    apy,
+    isCardanoNetworkType,
+    formattedAccountBalance,
+    displaySymbol,
+}: EarnStakingPotentialRewardsProps) => (
+    <Column>
+        {apy && <EarnRewardsAmount symbol={symbol} rewards={rewards} apy={apy} intent="brand" />}
+
+        {!isCardanoNetworkType && apy && (
+            <Paragraph typographyStyle="body-sm" intent="neutral" priority="secondary">
+                <HiddenPlaceholder>
+                    <Translation
+                        id="TR_EARN_STAKING_DASHBOARD_IF_YOU_ADD"
+                        values={{ amount: formattedAccountBalance, displaySymbol }}
+                    />
+                </HiddenPlaceholder>
+            </Paragraph>
+        )}
+    </Column>
+);

--- a/packages/suite/src/components/earn/dashboard/staking/EarnStakingTable.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/EarnStakingTable.tsx
@@ -1,83 +1,40 @@
-import { useMemo } from 'react';
-
 import { Translation } from '@suite/intl';
 import { EarnAnchor, useAnchor } from '@suite/router';
 import { Context } from '@suite-common/message-system';
-import { type StakingNetworkSymbol } from '@suite-common/wallet-config';
-import {
-    selectAccountIsStakingActive,
-    selectDeviceSupportedNetworks,
-    selectVisibleDeviceAccounts,
-} from '@suite-common/wallet-core';
-import { isCardanoStakedWithFiveBinaries } from '@suite-common/wallet-utils';
 import { Button, Card, Column, Table } from '@trezor/components';
 import { OutlineHighlight } from '@trezor/product-components';
 
 import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
-import { useSelector } from 'src/hooks/suite';
+import { useLayoutSize } from 'src/hooks/suite/useLayoutSize';
 
 import { EarnStakingAccountRow } from './EarnStakingAccountRow';
 import { EarnStakingActivateRow } from './EarnStakingActivateRow';
 import { EarnDashboardSection } from '../common/EarnDashboardSection';
 import { EarnDashboardTableHeader } from '../common/EarnDashboardTableHeader';
 import { getEarnDashboardBadgeState } from '../utils/earnDashboardBadgeUtils';
-import { useCryptoCurrentRate } from './hooks/useCryptoCurrencyRate';
-import { useStakingAccountsVisibility } from './hooks/useStakingAccountsVisibility';
+import { useStakingTableData } from './hooks/useStakingTableData';
 
 export const EarnStakingTable = () => {
     const { anchorRef, shouldHighlight } = useAnchor(EarnAnchor.Staking);
-    const ethCurrentRate = useCryptoCurrentRate('eth');
-    const solCurrentRate = useCryptoCurrentRate('sol');
-    const adaCurrentRate = useCryptoCurrentRate('ada');
+    const { isBelowLaptop } = useLayoutSize();
+    const isCardLayout = isBelowLaptop;
 
-    const currentRates: Record<StakingNetworkSymbol, number | undefined> = useMemo(
-        () => ({
-            eth: ethCurrentRate,
-            sol: solCurrentRate,
-            ada: adaCurrentRate,
-            thod: ethCurrentRate,
-            dsol: solCurrentRate,
-        }),
-        [ethCurrentRate, solCurrentRate, adaCurrentRate],
-    );
-
-    const accounts = useSelector(selectVisibleDeviceAccounts);
-
-    const stakingAccounts = accounts.filter(
-        account => account.symbol === 'eth' || account.symbol === 'sol' || account.symbol === 'ada',
-    );
-
-    const isStakingActive = useSelector(state =>
-        stakingAccounts.some(account => selectAccountIsStakingActive(state, account.key)),
-    );
-    const deviceSupportedNetworkSymbols = useSelector(selectDeviceSupportedNetworks);
-
-    const ethNotActivated =
-        deviceSupportedNetworkSymbols.includes('eth') &&
-        !stakingAccounts.some(account => account.symbol === 'eth');
-
-    const solNotActivated =
-        deviceSupportedNetworkSymbols.includes('sol') &&
-        !stakingAccounts.some(account => account.symbol === 'sol');
-
-    const adaNotActivated =
-        deviceSupportedNetworkSymbols.includes('ada') &&
-        !stakingAccounts.some(account => account.symbol === 'ada');
-
-    const { displayedAccounts, isExpandable, isExpanded, toggleExpanded, hasAnyRewardsData } =
-        useStakingAccountsVisibility({
-            stakingAccounts,
-            currentRates,
-            ethNotActivated,
-            solNotActivated,
-            adaNotActivated,
-        });
+    const {
+        displayedAccounts,
+        ethNotActivated,
+        adaNotActivated,
+        solNotActivated,
+        isExpandable,
+        isExpanded,
+        toggleExpanded,
+        hasAnyRewardsData,
+        isStakingActive,
+        isSectionOutdated,
+    } = useStakingTableData();
 
     const badge = getEarnDashboardBadgeState({
         isSectionActive: isStakingActive,
-        isSectionOutdated: stakingAccounts.some(account =>
-            isCardanoStakedWithFiveBinaries(account),
-        ),
+        isSectionOutdated,
         activeLabelId: 'TR_EARN_DASHBOARD_ACTIVE',
         notActiveLabelId: 'TR_EARN_DASHBOARD_NOT_ACTIVE',
         outdatedLabelId: 'TR_EARN_STAKING_DASHBOARD_OUTDATED',
@@ -96,27 +53,64 @@ export const EarnStakingTable = () => {
                     sectionRef={anchorRef}
                 >
                     <Column gap={16} alignItems="center">
-                        <Card paddingType="none">
-                            <Table isRowHighlightedOnHover margin={{ top: 8 }}>
-                                <EarnDashboardTableHeader
-                                    accountColumnTranslationId="TR_EARN_DASHBOARD_TABLE_ACCOUNT_BALANCE"
-                                    showRewardsColumns={hasAnyRewardsData}
-                                />
+                        {isCardLayout ? (
+                            <Column gap={8} width="100%">
+                                {displayedAccounts.map(account => (
+                                    <EarnStakingAccountRow
+                                        account={account}
+                                        key={account.key}
+                                        isCardLayout
+                                    />
+                                ))}
 
-                                <Table.Body>
-                                    {displayedAccounts.map(account => (
-                                        <EarnStakingAccountRow
-                                            account={account}
-                                            key={account.key}
-                                        />
-                                    ))}
+                                {ethNotActivated && (
+                                    <EarnStakingActivateRow symbol="eth" isCardLayout />
+                                )}
+                                {adaNotActivated && (
+                                    <EarnStakingActivateRow symbol="ada" isCardLayout />
+                                )}
+                                {solNotActivated && (
+                                    <EarnStakingActivateRow symbol="sol" isCardLayout />
+                                )}
+                            </Column>
+                        ) : (
+                            <Card paddingType="none">
+                                <Table isRowHighlightedOnHover margin={{ top: 8 }}>
+                                    <EarnDashboardTableHeader
+                                        accountColumnTranslationId="TR_EARN_DASHBOARD_TABLE_ACCOUNT_BALANCE"
+                                        showRewardsColumns={hasAnyRewardsData}
+                                    />
+                                    <Table.Body>
+                                        {displayedAccounts.map(account => (
+                                            <EarnStakingAccountRow
+                                                account={account}
+                                                key={account.key}
+                                                isCardLayout={false}
+                                            />
+                                        ))}
 
-                                    {ethNotActivated && <EarnStakingActivateRow symbol="eth" />}
-                                    {adaNotActivated && <EarnStakingActivateRow symbol="ada" />}
-                                    {solNotActivated && <EarnStakingActivateRow symbol="sol" />}
-                                </Table.Body>
-                            </Table>
-                        </Card>
+                                        {ethNotActivated && (
+                                            <EarnStakingActivateRow
+                                                symbol="eth"
+                                                isCardLayout={false}
+                                            />
+                                        )}
+                                        {adaNotActivated && (
+                                            <EarnStakingActivateRow
+                                                symbol="ada"
+                                                isCardLayout={false}
+                                            />
+                                        )}
+                                        {solNotActivated && (
+                                            <EarnStakingActivateRow
+                                                symbol="sol"
+                                                isCardLayout={false}
+                                            />
+                                        )}
+                                    </Table.Body>
+                                </Table>
+                            </Card>
+                        )}
 
                         {isExpandable && (
                             <Button intent="neutral" priority="secondary" onClick={toggleExpanded}>

--- a/packages/suite/src/components/earn/dashboard/staking/hooks/useStakingAccountStatus.ts
+++ b/packages/suite/src/components/earn/dashboard/staking/hooks/useStakingAccountStatus.ts
@@ -1,0 +1,78 @@
+import { useMemo } from 'react';
+
+import { Feature, selectIsFeatureEnabled } from '@suite-common/message-system';
+import { selectAccountIsStakingActive, selectCardanoPoolsInfo } from '@suite-common/wallet-core';
+import { type Account } from '@suite-common/wallet-types';
+import {
+    getAccountTotalStakingBalance,
+    getStakingLimitsByNetworkSymbol,
+    isCardanoStakedOutsideEverstake,
+} from '@suite-common/wallet-utils';
+import { BigNumber } from '@trezor/utils';
+
+import { useSelector } from 'src/hooks/suite';
+
+export type StakingAccountStatus =
+    | 'insufficient-funds'
+    | 'staking-active'
+    | 'staking-inactive'
+    | 'staking-max'
+    | 'staked-but-insufficient-funds'
+    | 'staking-outdated-provider';
+
+export const useStakingAccountStatus = (account: Account): StakingAccountStatus => {
+    const isStakingActive = useSelector(state => selectAccountIsStakingActive(state, account.key));
+    const cardanoStakingPools = useSelector(selectCardanoPoolsInfo);
+    const isNewProviderBannerEnabled = useSelector(state =>
+        selectIsFeatureEnabled(state, Feature.banners.staking.ada.newProvider, true),
+    );
+
+    const accountBalance = account.formattedBalance;
+    const stakingBalance = getAccountTotalStakingBalance(account) ?? '0';
+    const isCardanoNetworkType = account.networkType === 'cardano';
+    const minStakingAmount = getStakingLimitsByNetworkSymbol(
+        account.symbol,
+    )?.MIN_AMOUNT_FOR_STAKING_DASHBOARD;
+
+    return useMemo(() => {
+        if (
+            isCardanoStakedOutsideEverstake(account, cardanoStakingPools) &&
+            isNewProviderBannerEnabled
+        ) {
+            return 'staking-outdated-provider';
+        }
+
+        if (
+            (accountBalance === '0' && stakingBalance !== '0') ||
+            (isCardanoNetworkType && isStakingActive)
+        ) {
+            return 'staking-max';
+        }
+
+        const hasEnoughBalanceForStaking =
+            minStakingAmount && new BigNumber(accountBalance).gte(minStakingAmount);
+
+        if (stakingBalance !== '0') {
+            if (!hasEnoughBalanceForStaking) {
+                return 'staked-but-insufficient-funds';
+            }
+
+            return 'staking-active';
+        }
+
+        if (!hasEnoughBalanceForStaking) {
+            return 'insufficient-funds';
+        }
+
+        return 'staking-inactive';
+    }, [
+        account,
+        accountBalance,
+        stakingBalance,
+        minStakingAmount,
+        isCardanoNetworkType,
+        isStakingActive,
+        cardanoStakingPools,
+        isNewProviderBannerEnabled,
+    ]);
+};

--- a/packages/suite/src/components/earn/dashboard/staking/hooks/useStakingTableData.ts
+++ b/packages/suite/src/components/earn/dashboard/staking/hooks/useStakingTableData.ts
@@ -1,0 +1,94 @@
+import { useMemo } from 'react';
+
+import { type StakingNetworkSymbol } from '@suite-common/wallet-config';
+import {
+    selectAccountIsStakingActive,
+    selectDeviceSupportedNetworks,
+    selectVisibleDeviceAccounts,
+} from '@suite-common/wallet-core';
+import { type Account } from '@suite-common/wallet-types';
+import { isCardanoStakedWithFiveBinaries } from '@suite-common/wallet-utils';
+
+import { useSelector } from 'src/hooks/suite';
+
+import { useCryptoCurrentRate } from './useCryptoCurrencyRate';
+import { useStakingAccountsVisibility } from './useStakingAccountsVisibility';
+
+type UseStakingTableDataResult = {
+    displayedAccounts: Account[];
+    ethNotActivated: boolean;
+    adaNotActivated: boolean;
+    solNotActivated: boolean;
+    isExpandable: boolean;
+    isExpanded: boolean;
+    toggleExpanded: () => void;
+    hasAnyRewardsData: boolean;
+    isStakingActive: boolean;
+    isSectionOutdated: boolean;
+};
+
+export const useStakingTableData = (): UseStakingTableDataResult => {
+    const ethCurrentRate = useCryptoCurrentRate('eth');
+    const solCurrentRate = useCryptoCurrentRate('sol');
+    const adaCurrentRate = useCryptoCurrentRate('ada');
+
+    const currentRates: Record<StakingNetworkSymbol, number | undefined> = useMemo(
+        () => ({
+            eth: ethCurrentRate,
+            sol: solCurrentRate,
+            ada: adaCurrentRate,
+            thod: ethCurrentRate,
+            dsol: solCurrentRate,
+        }),
+        [ethCurrentRate, solCurrentRate, adaCurrentRate],
+    );
+
+    const accounts = useSelector(selectVisibleDeviceAccounts);
+
+    const stakingAccounts = accounts.filter(
+        account => account.symbol === 'eth' || account.symbol === 'sol' || account.symbol === 'ada',
+    );
+
+    const isStakingActive = useSelector(state =>
+        stakingAccounts.some(account => selectAccountIsStakingActive(state, account.key)),
+    );
+    const deviceSupportedNetworkSymbols = useSelector(selectDeviceSupportedNetworks);
+
+    const ethNotActivated =
+        deviceSupportedNetworkSymbols.includes('eth') &&
+        !stakingAccounts.some(account => account.symbol === 'eth');
+
+    const solNotActivated =
+        deviceSupportedNetworkSymbols.includes('sol') &&
+        !stakingAccounts.some(account => account.symbol === 'sol');
+
+    const adaNotActivated =
+        deviceSupportedNetworkSymbols.includes('ada') &&
+        !stakingAccounts.some(account => account.symbol === 'ada');
+
+    const { displayedAccounts, isExpandable, isExpanded, toggleExpanded, hasAnyRewardsData } =
+        useStakingAccountsVisibility({
+            stakingAccounts,
+            currentRates,
+            ethNotActivated,
+            solNotActivated,
+            adaNotActivated,
+        });
+
+    const isSectionOutdated = stakingAccounts.some(account =>
+        isCardanoStakedWithFiveBinaries(account),
+    );
+
+    return {
+        displayedAccounts,
+        ethNotActivated,
+        adaNotActivated,
+        solNotActivated,
+        isExpandable,
+        isExpanded,
+        toggleExpanded,
+        hasAnyRewardsData,
+        isStakingActive,
+        isSectionOutdated,
+    };
+};

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import { events } from '@suite/analytics';
 import { FirmwareUpgradeNeededModal } from '@suite/firmware-upgrade';
-import { Translation, useTranslation } from '@suite/intl';
+import { useTranslation } from '@suite/intl';
 import { openModal } from '@suite/modal';
 import { goto } from '@suite/router';
 import { isStablecoinYieldSupported, selectSelectedDevice } from '@suite-common/device';
@@ -15,29 +15,36 @@ import {
 } from '@suite-common/trading';
 import { getYieldVaultContractAddress } from '@suite-common/wallet-core';
 import { getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils';
-import { Button, Column, Icon, Paragraph, Row, Table, Tooltip } from '@trezor/components';
+import { Card, Column, Icon, Row, Table } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
 
-import { HiddenPlaceholder } from 'src/components/suite/HiddenPlaceholder';
 import { useDispatch, useSelector } from 'src/hooks/suite';
+import { useLayoutSize } from 'src/hooks/suite/useLayoutSize';
 import { useMessageSystemYield } from 'src/hooks/suite/useMessageSystemYield';
 import { useAnalytics } from 'src/support/useAnalytics';
 
+import { EarnYieldActionButtons } from './EarnYieldActionButtons';
 import { EarnYieldApyTooltip } from './EarnYieldApyTooltip';
+import { EarnYieldPotentialRewards } from './EarnYieldPotentialRewards';
+import { EarnYieldYearlyRewards } from './EarnYieldYearlyRewards';
 import { type YieldAccountOpportunity } from './types';
 import { getEarnRouteParams } from '../../utils/getEarnRouteParams';
 import { EarnAccountCell } from '../common/EarnAccountCell';
-import { EarnRewardsAmount } from '../common/EarnRewardsAmount';
 
 type EarnYieldAccountOpportunityProps = {
     opportunity: YieldAccountOpportunity;
+    isCardLayout: boolean;
 };
 
-export const EarnYieldAccountOpportunity = ({ opportunity }: EarnYieldAccountOpportunityProps) => {
+export const EarnYieldAccountOpportunity = ({
+    opportunity,
+    isCardLayout,
+}: EarnYieldAccountOpportunityProps) => {
     const dispatch = useDispatch();
     const analytics = useAnalytics();
     const { CryptoAmountFormatter } = useFormatters();
     const { translationString } = useTranslation();
+    const { isBelowMobile } = useLayoutSize();
     const [isFirmwareModalOpen, setIsFirmwareModalOpen] = useState(false);
     const selectedDevice = useSelector(selectSelectedDevice);
     const isFirmwareOutdated = !isStablecoinYieldSupported(selectedDevice);
@@ -222,67 +229,150 @@ export const EarnYieldAccountOpportunity = ({ opportunity }: EarnYieldAccountOpp
     const isDepositMoreDisabled =
         !opportunity.vault.status.enter || !hasAdditionalDepositAmount || isDepositDisabled;
 
+    const firmwareModal = isFirmwareModalOpen && (
+        <FirmwareUpgradeNeededModal
+            onClose={() => setIsFirmwareModalOpen(false)}
+            featureName={translationString('TR_EARN_STABLECOIN_YIELD_TITLE')}
+        />
+    );
+
+    const yearlyRewardsProps = {
+        symbol: opportunity.suppliedSymbol,
+        rewards: yearlyRewards,
+        apy: opportunity.apyPercentage,
+        hasDisplayableSuppliedAmount,
+        formattedSuppliedAmount,
+        displaySymbol: opportunity.suppliedSymbol,
+    } as const;
+
+    const potentialRewardsProps = {
+        hasMaximumDeposited,
+        hasPotentialRewards,
+        symbol: opportunity.suppliedSymbol,
+        rewards: potentialRewards,
+        apy: opportunity.apyPercentage,
+        formattedAdditionalSupplyAmount,
+        displaySymbol: opportunity.suppliedSymbol,
+    } as const;
+
+    const actionButtonsProps = {
+        hasSuppliedBalance,
+        hasAdditionalDepositAmount,
+        isDepositMoreDisabled,
+        isDepositDisabled,
+        isSupplyNowDisabled,
+        isWithdrawDisabled,
+        depositMessageContent: depositMessageSystem.content,
+        withdrawMessageContent: withdrawMessageSystem.content,
+        onSupplyMore: navigateToYieldSupply,
+        onWithdraw: navigateToYieldWithdraw,
+        onSupplyNow: openYieldSupplyFlow,
+        onBuy: navigateToTradingBuy,
+    } as const;
+
+    const accountCell = (
+        <EarnAccountCell
+            account={opportunity.account}
+            symbol={opportunity.networkSymbol}
+            iconToken={opportunity.vault.token}
+            showAssetNetworkIcon
+            subtitle={opportunity.vault.outputToken?.name ?? ''}
+            tokenBalance={{
+                value: opportunity.additionalSupplyAmount,
+                symbol: opportunity.suppliedSymbol,
+                contractAddress: opportunity.suppliedContractAddress,
+            }}
+        />
+    );
+
+    const apyCell = (
+        <EarnYieldApyTooltip
+            vault={opportunity.vault}
+            apyPercentage={opportunity.apyPercentage}
+            networkSymbol={opportunity.networkSymbol}
+        />
+    );
+
+    if (isCardLayout) {
+        return (
+            <>
+                {firmwareModal}
+                <Card paddingType="small">
+                    <Column gap={12} width="100%">
+                        <Row justifyContent="space-between" alignItems="flex-start">
+                            {accountCell}
+                            {apyCell}
+                        </Row>
+
+                        {hasRewardsData &&
+                            (isBelowMobile ? (
+                                <Column gap={4}>
+                                    <EarnYieldYearlyRewards {...yearlyRewardsProps} />
+
+                                    {!shouldSpanRewardsCells && (
+                                        <>
+                                            {hasApy && (
+                                                <Icon
+                                                    name="arrowDown"
+                                                    intent="neutral"
+                                                    priority="secondary"
+                                                    size={20}
+                                                />
+                                            )}
+                                            <EarnYieldPotentialRewards {...potentialRewardsProps} />
+                                        </>
+                                    )}
+                                </Column>
+                            ) : (
+                                <Row alignItems="center">
+                                    <Column flex="2">
+                                        <EarnYieldYearlyRewards {...yearlyRewardsProps} />
+                                    </Column>
+
+                                    {!shouldSpanRewardsCells && (
+                                        <>
+                                            {hasApy && (
+                                                <Column flex="1" alignItems="center">
+                                                    <Icon
+                                                        name="arrowRight"
+                                                        intent="neutral"
+                                                        priority="secondary"
+                                                        size={20}
+                                                    />
+                                                </Column>
+                                            )}
+                                            <Column flex="2">
+                                                <EarnYieldPotentialRewards
+                                                    {...potentialRewardsProps}
+                                                />
+                                            </Column>
+                                        </>
+                                    )}
+                                </Row>
+                            ))}
+
+                        <Row gap={8}>
+                            <EarnYieldActionButtons {...actionButtonsProps} />
+                        </Row>
+                    </Column>
+                </Card>
+            </>
+        );
+    }
+
     return (
         <>
-            {isFirmwareModalOpen && (
-                <FirmwareUpgradeNeededModal
-                    onClose={() => setIsFirmwareModalOpen(false)}
-                    featureName={translationString('TR_EARN_STABLECOIN_YIELD_TITLE')}
-                />
-            )}
+            {firmwareModal}
             <Table.Row>
-                <Table.Cell>
-                    <EarnAccountCell
-                        account={opportunity.account}
-                        symbol={opportunity.networkSymbol}
-                        iconToken={opportunity.vault.token}
-                        showAssetNetworkIcon
-                        subtitle={opportunity.vault.outputToken?.name ?? ''}
-                        tokenBalance={{
-                            value: opportunity.additionalSupplyAmount,
-                            symbol: opportunity.suppliedSymbol,
-                            contractAddress: opportunity.suppliedContractAddress,
-                        }}
-                    />
-                </Table.Cell>
+                <Table.Cell>{accountCell}</Table.Cell>
 
-                <Table.Cell>
-                    <EarnYieldApyTooltip
-                        vault={opportunity.vault}
-                        apyPercentage={opportunity.apyPercentage}
-                        networkSymbol={opportunity.networkSymbol}
-                    />
-                </Table.Cell>
+                <Table.Cell>{apyCell}</Table.Cell>
 
                 {hasRewardsData ? (
                     <>
                         <Table.Cell colSpan={shouldSpanRewardsCells ? 2 : undefined}>
                             <Row width="100%" alignItems="center" justifyContent="space-between">
-                                <Column>
-                                    <EarnRewardsAmount
-                                        symbol={opportunity.suppliedSymbol}
-                                        rewards={yearlyRewards}
-                                        apy={opportunity.apyPercentage}
-                                    />
-
-                                    {hasDisplayableSuppliedAmount && (
-                                        <Paragraph
-                                            typographyStyle="body-sm"
-                                            intent="neutral"
-                                            priority="secondary"
-                                        >
-                                            <HiddenPlaceholder>
-                                                <Translation
-                                                    id="TR_EARN_YIELD_DASHBOARD_SUPPLIED"
-                                                    values={{
-                                                        amount: formattedSuppliedAmount,
-                                                        displaySymbol: opportunity.suppliedSymbol,
-                                                    }}
-                                                />
-                                            </HiddenPlaceholder>
-                                        </Paragraph>
-                                    )}
-                                </Column>
+                                <EarnYieldYearlyRewards {...yearlyRewardsProps} />
 
                                 {hasApy && (
                                     <Icon
@@ -297,43 +387,7 @@ export const EarnYieldAccountOpportunity = ({ opportunity }: EarnYieldAccountOpp
 
                         {!shouldSpanRewardsCells && (
                             <Table.Cell>
-                                {hasMaximumDeposited ? (
-                                    <Paragraph
-                                        typographyStyle="body-md"
-                                        intent="neutral"
-                                        priority="secondary"
-                                    >
-                                        <Translation id="TR_EARN_YIELD_MAXIMUM_DEPOSITED" />
-                                    </Paragraph>
-                                ) : (
-                                    hasPotentialRewards && (
-                                        <Column>
-                                            <EarnRewardsAmount
-                                                symbol={opportunity.suppliedSymbol}
-                                                rewards={potentialRewards}
-                                                apy={opportunity.apyPercentage}
-                                                intent="brand"
-                                            />
-
-                                            <Paragraph
-                                                typographyStyle="body-sm"
-                                                intent="neutral"
-                                                priority="secondary"
-                                            >
-                                                <HiddenPlaceholder>
-                                                    <Translation
-                                                        id="TR_EARN_STAKING_DASHBOARD_IF_YOU_ADD"
-                                                        values={{
-                                                            amount: formattedAdditionalSupplyAmount,
-                                                            displaySymbol:
-                                                                opportunity.suppliedSymbol,
-                                                        }}
-                                                    />
-                                                </HiddenPlaceholder>
-                                            </Paragraph>
-                                        </Column>
-                                    )
-                                )}
+                                <EarnYieldPotentialRewards {...potentialRewardsProps} />
                             </Table.Cell>
                         )}
                     </>
@@ -343,56 +397,7 @@ export const EarnYieldAccountOpportunity = ({ opportunity }: EarnYieldAccountOpp
 
                 <Table.Cell align="end">
                     <Row justifyContent="flex-end" gap={8}>
-                        {hasSuppliedBalance && (
-                            <>
-                                <Tooltip content={depositMessageSystem.content}>
-                                    <Button
-                                        size="small"
-                                        isDisabled={isDepositMoreDisabled}
-                                        iconLeft={isDepositDisabled ? 'info' : undefined}
-                                        onClick={navigateToYieldSupply}
-                                    >
-                                        <Translation id="TR_EARN_YIELD_DASHBOARD_SUPPLY_MORE" />
-                                    </Button>
-                                </Tooltip>
-                                <Tooltip content={withdrawMessageSystem.content}>
-                                    <Button
-                                        size="small"
-                                        intent="brand"
-                                        priority="secondary"
-                                        isDisabled={isWithdrawDisabled}
-                                        iconLeft={isWithdrawDisabled ? 'info' : undefined}
-                                        onClick={navigateToYieldWithdraw}
-                                    >
-                                        <Translation id="TR_EARN_YIELD_DASHBOARD_WITHDRAW" />
-                                    </Button>
-                                </Tooltip>
-                            </>
-                        )}
-
-                        {!hasSuppliedBalance && hasAdditionalDepositAmount && (
-                            <Tooltip content={depositMessageSystem.content}>
-                                <Button
-                                    size="small"
-                                    isDisabled={isSupplyNowDisabled}
-                                    iconLeft={isDepositDisabled ? 'info' : undefined}
-                                    onClick={openYieldSupplyFlow}
-                                >
-                                    <Translation id="TR_EARN_YIELD_DASHBOARD_SUPPLY_NOW" />
-                                </Button>
-                            </Tooltip>
-                        )}
-
-                        {!hasSuppliedBalance && !hasAdditionalDepositAmount && (
-                            <Button
-                                size="small"
-                                intent="neutral"
-                                priority="secondary"
-                                onClick={navigateToTradingBuy}
-                            >
-                                <Translation id="TR_BUY" />
-                            </Button>
-                        )}
+                        <EarnYieldActionButtons {...actionButtonsProps} />
                     </Row>
                 </Table.Cell>
             </Table.Row>

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldActionButtons.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldActionButtons.tsx
@@ -1,0 +1,82 @@
+import { type ReactNode } from 'react';
+
+import { Translation } from '@suite/intl';
+import { Button, Tooltip } from '@trezor/components';
+
+type EarnYieldActionButtonsProps = {
+    hasSuppliedBalance: boolean;
+    hasAdditionalDepositAmount: boolean;
+    isDepositMoreDisabled: boolean;
+    isDepositDisabled: boolean;
+    isSupplyNowDisabled: boolean;
+    isWithdrawDisabled: boolean;
+    depositMessageContent: ReactNode;
+    withdrawMessageContent: ReactNode;
+    onSupplyMore: () => void;
+    onWithdraw: () => void;
+    onSupplyNow: () => void;
+    onBuy: () => void;
+};
+
+export const EarnYieldActionButtons = ({
+    hasSuppliedBalance,
+    hasAdditionalDepositAmount,
+    isDepositMoreDisabled,
+    isDepositDisabled,
+    isSupplyNowDisabled,
+    isWithdrawDisabled,
+    depositMessageContent,
+    withdrawMessageContent,
+    onSupplyMore,
+    onWithdraw,
+    onSupplyNow,
+    onBuy,
+}: EarnYieldActionButtonsProps) => (
+    <>
+        {hasSuppliedBalance && (
+            <>
+                <Tooltip content={depositMessageContent}>
+                    <Button
+                        size="small"
+                        isDisabled={isDepositMoreDisabled}
+                        iconLeft={isDepositDisabled ? 'info' : undefined}
+                        onClick={onSupplyMore}
+                    >
+                        <Translation id="TR_EARN_YIELD_DASHBOARD_SUPPLY_MORE" />
+                    </Button>
+                </Tooltip>
+                <Tooltip content={withdrawMessageContent}>
+                    <Button
+                        size="small"
+                        intent="brand"
+                        priority="secondary"
+                        isDisabled={isWithdrawDisabled}
+                        iconLeft={isWithdrawDisabled ? 'info' : undefined}
+                        onClick={onWithdraw}
+                    >
+                        <Translation id="TR_EARN_YIELD_DASHBOARD_WITHDRAW" />
+                    </Button>
+                </Tooltip>
+            </>
+        )}
+
+        {!hasSuppliedBalance && hasAdditionalDepositAmount && (
+            <Tooltip content={depositMessageContent}>
+                <Button
+                    size="small"
+                    isDisabled={isSupplyNowDisabled}
+                    iconLeft={isDepositDisabled ? 'info' : undefined}
+                    onClick={onSupplyNow}
+                >
+                    <Translation id="TR_EARN_YIELD_DASHBOARD_SUPPLY_NOW" />
+                </Button>
+            </Tooltip>
+        )}
+
+        {!hasSuppliedBalance && !hasAdditionalDepositAmount && (
+            <Button size="small" intent="neutral" priority="secondary" onClick={onBuy}>
+                <Translation id="TR_BUY" />
+            </Button>
+        )}
+    </>
+);

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldEmptyState.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldEmptyState.tsx
@@ -1,0 +1,24 @@
+import { Translation } from '@suite/intl';
+import { Paragraph, Table } from '@trezor/components';
+
+type EarnYieldEmptyStateProps = {
+    isCardLayout: boolean;
+};
+
+export const EarnYieldEmptyState = ({ isCardLayout }: EarnYieldEmptyStateProps) => {
+    const message = (
+        <Paragraph typographyStyle="body-md" intent="neutral" priority="secondary">
+            <Translation id="TR_ACCOUNT_NO_ACCOUNTS" />
+        </Paragraph>
+    );
+
+    if (isCardLayout) return message;
+
+    return (
+        <Table.Body>
+            <Table.Row>
+                <Table.Cell colSpan={5}>{message}</Table.Cell>
+            </Table.Row>
+        </Table.Body>
+    );
+};

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldErrorState.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldErrorState.tsx
@@ -1,0 +1,33 @@
+import { Translation } from '@suite/intl';
+import { Banner, Table } from '@trezor/components';
+
+type EarnYieldErrorStateProps = {
+    isCardLayout: boolean;
+    onRetry: () => void;
+};
+
+export const EarnYieldErrorState = ({ isCardLayout, onRetry }: EarnYieldErrorStateProps) => {
+    const banner = (
+        <Banner
+            icon
+            intent="warning"
+            title={<Translation id="TR_EARN_YIELD_LOAD_ERROR_TITLE" />}
+            description={<Translation id="TR_EARN_YIELD_LOAD_ERROR_DESCRIPTION" />}
+            rightContent={
+                <Banner.Button onClick={onRetry}>
+                    <Translation id="TR_TRY_AGAIN" />
+                </Banner.Button>
+            }
+        />
+    );
+
+    if (isCardLayout) return banner;
+
+    return (
+        <Table.Body>
+            <Table.Row>
+                <Table.Cell colSpan={5}>{banner}</Table.Cell>
+            </Table.Row>
+        </Table.Body>
+    );
+};

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldInactiveVaultOpportunity.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldInactiveVaultOpportunity.tsx
@@ -1,106 +1,62 @@
-import { useDevice } from '@suite/device';
-import { Translation } from '@suite/intl';
-import { openModal } from '@suite/modal';
-import { getNetwork } from '@suite-common/wallet-config';
-import {
-    selectEnabledNetworks,
-    selectHasRunningDiscovery,
-    startOrRestartDiscoveryThunk,
-} from '@suite-common/wallet-core';
-import { Button, TOOLTIP_DELAY_NORMAL, Table, Tooltip } from '@trezor/components';
-
-import { useDispatch, useSelector } from 'src/hooks/suite';
+import { Card, Column, Row, Table } from '@trezor/components';
 
 import { EarnYieldApyTooltip } from './EarnYieldApyTooltip';
 import { type YieldInactiveVaultOpportunity } from './types';
 import { EarnAccountCell } from '../common/EarnAccountCell';
+import { EarnActivateButton } from '../common/EarnActivateButton';
 
 type EarnYieldInactiveVaultOpportunityProps = {
     opportunity: YieldInactiveVaultOpportunity;
+    isCardLayout: boolean;
 };
 
 export const EarnYieldInactiveVaultOpportunity = ({
     opportunity,
+    isCardLayout,
 }: EarnYieldInactiveVaultOpportunityProps) => {
-    const dispatch = useDispatch();
-    const { device } = useDevice();
-    const enabledNetworks = useSelector(selectEnabledNetworks);
-    const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
-    const isNetworkEnabled = enabledNetworks.includes(opportunity.networkSymbol);
-    const isDiscoveringThisNetwork = isDiscoveryRunning && isNetworkEnabled;
-    const { name } = getNetwork(opportunity.networkSymbol);
+    const accountCell = (
+        <EarnAccountCell
+            symbol={opportunity.networkSymbol}
+            iconToken={opportunity.vault.token}
+            showAssetNetworkIcon
+            subtitle={opportunity.vault.outputToken?.name ?? ''}
+        />
+    );
 
-    const isDeviceDisconnected = !device?.connected;
-    const isButtonDisabled = isDeviceDisconnected || isDiscoveryRunning;
-    const tooltipMessage = isDeviceDisconnected ? (
-        <Translation id="TR_TO_ADD_NEW_ACCOUNT_PLEASE_CONNECT" />
-    ) : undefined;
+    const apyCell = (
+        <EarnYieldApyTooltip
+            vault={opportunity.vault}
+            apyPercentage={opportunity.apyPercentage}
+            networkSymbol={opportunity.networkSymbol}
+        />
+    );
 
-    const handleActivate = () => {
-        if (!device) {
-            return;
-        }
-
-        if (isNetworkEnabled) {
-            dispatch(startOrRestartDiscoveryThunk());
-
-            return;
-        }
-
-        dispatch(
-            openModal({
-                type: 'add-account',
-                device,
-                symbol: opportunity.networkSymbol,
-                noRedirect: true,
-                isCoinjoinDisabled: true,
-                isBackClickDisabled: true,
-            }),
+    if (isCardLayout) {
+        return (
+            <Card paddingType="small">
+                <Column gap={12} width="100%">
+                    <Row justifyContent="space-between" alignItems="flex-start">
+                        {accountCell}
+                        {apyCell}
+                    </Row>
+                    <Row>
+                        <EarnActivateButton symbol={opportunity.networkSymbol} />
+                    </Row>
+                </Column>
+            </Card>
         );
-    };
+    }
 
     return (
         <Table.Row>
-            <Table.Cell>
-                <EarnAccountCell
-                    symbol={opportunity.networkSymbol}
-                    iconToken={opportunity.vault.token}
-                    showAssetNetworkIcon
-                    subtitle={opportunity.vault.outputToken?.name ?? ''}
-                />
-            </Table.Cell>
+            <Table.Cell>{accountCell}</Table.Cell>
 
-            <Table.Cell>
-                <EarnYieldApyTooltip
-                    vault={opportunity.vault}
-                    apyPercentage={opportunity.apyPercentage}
-                    networkSymbol={opportunity.networkSymbol}
-                />
-            </Table.Cell>
+            <Table.Cell>{apyCell}</Table.Cell>
 
             <Table.Cell colSpan={2} />
 
             <Table.Cell align="end">
-                <Tooltip
-                    isActive={!!tooltipMessage}
-                    tooltipMaxWidth={200}
-                    content={tooltipMessage}
-                    placement="top"
-                    cursor="not-allowed"
-                    delayShow={TOOLTIP_DELAY_NORMAL}
-                >
-                    <Button
-                        size="small"
-                        onClick={handleActivate}
-                        isDisabled={isButtonDisabled}
-                        isLoading={isDiscoveringThisNetwork}
-                    >
-                        <Translation
-                            id="TR_EARN_STAKING_DASHBOARD_ACTIVATE"
-                            values={{ networkName: name }}
-                        />
-                    </Button>
-                </Tooltip>
+                <EarnActivateButton symbol={opportunity.networkSymbol} />
             </Table.Cell>
         </Table.Row>
     );

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldLoadingState.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldLoadingState.tsx
@@ -1,0 +1,23 @@
+import { Row, Spinner, Table } from '@trezor/components';
+
+type EarnYieldLoadingStateProps = {
+    isCardLayout: boolean;
+};
+
+export const EarnYieldLoadingState = ({ isCardLayout }: EarnYieldLoadingStateProps) => {
+    const spinner = (
+        <Row width="100%" justifyContent="center" padding={{ vertical: 16 }}>
+            <Spinner size={24} />
+        </Row>
+    );
+
+    if (isCardLayout) return spinner;
+
+    return (
+        <Table.Body>
+            <Table.Row>
+                <Table.Cell colSpan={5}>{spinner}</Table.Cell>
+            </Table.Row>
+        </Table.Body>
+    );
+};

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldPotentialRewards.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldPotentialRewards.tsx
@@ -1,0 +1,54 @@
+import { Translation } from '@suite/intl';
+import { type TokenSymbol } from '@suite-common/wallet-types';
+import { Column, Paragraph } from '@trezor/components';
+
+import { HiddenPlaceholder } from 'src/components/suite/HiddenPlaceholder';
+
+import { EarnRewardsAmount } from '../common/EarnRewardsAmount';
+
+type EarnYieldPotentialRewardsProps = {
+    hasMaximumDeposited: boolean;
+    hasPotentialRewards: boolean;
+    symbol: TokenSymbol;
+    rewards: string;
+    apy: number | null;
+    formattedAdditionalSupplyAmount: string;
+    displaySymbol: string;
+};
+
+export const EarnYieldPotentialRewards = ({
+    hasMaximumDeposited,
+    hasPotentialRewards,
+    symbol,
+    rewards,
+    apy,
+    formattedAdditionalSupplyAmount,
+    displaySymbol,
+}: EarnYieldPotentialRewardsProps) => {
+    if (hasMaximumDeposited) {
+        return (
+            <Paragraph typographyStyle="body-md" intent="neutral" priority="secondary">
+                <Translation id="TR_EARN_YIELD_MAXIMUM_DEPOSITED" />
+            </Paragraph>
+        );
+    }
+
+    if (!hasPotentialRewards) {
+        return null;
+    }
+
+    return (
+        <Column>
+            <EarnRewardsAmount symbol={symbol} rewards={rewards} apy={apy} intent="brand" />
+
+            <Paragraph typographyStyle="body-sm" intent="neutral" priority="secondary">
+                <HiddenPlaceholder>
+                    <Translation
+                        id="TR_EARN_STAKING_DASHBOARD_IF_YOU_ADD"
+                        values={{ amount: formattedAdditionalSupplyAmount, displaySymbol }}
+                    />
+                </HiddenPlaceholder>
+            </Paragraph>
+        </Column>
+    );
+};

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldRows.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldRows.tsx
@@ -1,0 +1,41 @@
+import { Table } from '@trezor/components';
+
+import { EarnYieldAccountOpportunity } from './EarnYieldAccountOpportunity';
+import { EarnYieldInactiveVaultOpportunity } from './EarnYieldInactiveVaultOpportunity';
+import { type YieldAccountOpportunity, type YieldInactiveVaultOpportunity } from './types';
+
+type EarnYieldRowsProps = {
+    accountOpportunities: YieldAccountOpportunity[];
+    inactiveVaultOpportunities: YieldInactiveVaultOpportunity[];
+    isCardLayout: boolean;
+};
+
+export const EarnYieldRows = ({
+    accountOpportunities,
+    inactiveVaultOpportunities,
+    isCardLayout,
+}: EarnYieldRowsProps) => {
+    const rows = (
+        <>
+            {accountOpportunities.map(opportunity => (
+                <EarnYieldAccountOpportunity
+                    key={opportunity.key}
+                    opportunity={opportunity}
+                    isCardLayout={isCardLayout}
+                />
+            ))}
+
+            {inactiveVaultOpportunities.map(opportunity => (
+                <EarnYieldInactiveVaultOpportunity
+                    key={opportunity.key}
+                    opportunity={opportunity}
+                    isCardLayout={isCardLayout}
+                />
+            ))}
+        </>
+    );
+
+    if (isCardLayout) return rows;
+
+    return <Table.Body>{rows}</Table.Body>;
+};

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx
@@ -11,6 +11,7 @@ import { OutlineHighlight } from '@trezor/product-components';
 
 import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
 import { useDispatch, useSelector } from 'src/hooks/suite';
+import { useLayoutSize } from 'src/hooks/suite/useLayoutSize';
 import { useMessageSystemYield } from 'src/hooks/suite/useMessageSystemYield';
 
 import { EarnYieldClaimRewardsBanner } from './EarnYieldClaimRewardsBanner';
@@ -25,6 +26,8 @@ import { getEarnDashboardBadgeState } from '../utils/earnDashboardBadgeUtils';
 
 export const EarnYieldTable = () => {
     const { anchorRef, shouldHighlight } = useAnchor(EarnAnchor.Yield);
+    const { isBelowLaptop } = useLayoutSize();
+    const isCardLayout = isBelowLaptop;
     const dispatch = useDispatch();
     const [isClaimModalOpen, setIsClaimModalOpen] = useState(false);
     const claimMessageSystem = useMessageSystemYield('claim');
@@ -127,12 +130,9 @@ export const EarnYieldTable = () => {
                                 )}
                             </>
                         )}
-                        <Card paddingType="none">
-                            <Table isRowHighlightedOnHover margin={{ top: 8 }}>
-                                <EarnDashboardTableHeader
-                                    accountColumnTranslationId="TR_EARN_DASHBOARD_TABLE_ACCOUNT_VAULT"
-                                    showRewardsColumns={hasAnyRewardsData}
-                                />
+
+                        {isCardLayout ? (
+                            <Column gap={8} width="100%">
                                 <EarnYieldTableBody
                                     isYieldOpportunitiesLoading={isYieldOpportunitiesLoading}
                                     isYieldOpportunitiesError={isYieldOpportunitiesError}
@@ -141,9 +141,31 @@ export const EarnYieldTable = () => {
                                     yieldInactiveVaultOpportunities={
                                         yieldInactiveVaultOpportunities
                                     }
+                                    isCardLayout={isCardLayout}
                                 />
-                            </Table>
-                        </Card>
+                            </Column>
+                        ) : (
+                            <Card paddingType="none">
+                                <Table isRowHighlightedOnHover margin={{ top: 8 }}>
+                                    <EarnDashboardTableHeader
+                                        accountColumnTranslationId="TR_EARN_DASHBOARD_TABLE_ACCOUNT_VAULT"
+                                        showRewardsColumns={hasAnyRewardsData}
+                                    />
+                                    <EarnYieldTableBody
+                                        isYieldOpportunitiesLoading={isYieldOpportunitiesLoading}
+                                        isYieldOpportunitiesError={isYieldOpportunitiesError}
+                                        onRetry={refetchYieldOpportunities}
+                                        yieldAccountOpportunities={
+                                            displayedYieldAccountOpportunities
+                                        }
+                                        yieldInactiveVaultOpportunities={
+                                            yieldInactiveVaultOpportunities
+                                        }
+                                        isCardLayout={isCardLayout}
+                                    />
+                                </Table>
+                            </Card>
+                        )}
 
                         {hasHiddenYieldAccountOpportunities && (
                             <Button

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldTableBody.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldTableBody.tsx
@@ -1,8 +1,7 @@
-import { Translation } from '@suite/intl';
-import { Banner, Paragraph, Row, Spinner, Table } from '@trezor/components';
-
-import { EarnYieldAccountOpportunity } from './EarnYieldAccountOpportunity';
-import { EarnYieldInactiveVaultOpportunity } from './EarnYieldInactiveVaultOpportunity';
+import { EarnYieldEmptyState } from './EarnYieldEmptyState';
+import { EarnYieldErrorState } from './EarnYieldErrorState';
+import { EarnYieldLoadingState } from './EarnYieldLoadingState';
+import { EarnYieldRows } from './EarnYieldRows';
 import { type YieldAccountOpportunity, type YieldInactiveVaultOpportunity } from './types';
 
 type EarnYieldTableBodyProps = {
@@ -11,6 +10,7 @@ type EarnYieldTableBodyProps = {
     onRetry: () => void;
     yieldAccountOpportunities: YieldAccountOpportunity[];
     yieldInactiveVaultOpportunities: YieldInactiveVaultOpportunity[];
+    isCardLayout: boolean;
 };
 
 export const EarnYieldTableBody = ({
@@ -19,69 +19,25 @@ export const EarnYieldTableBody = ({
     onRetry,
     yieldAccountOpportunities,
     yieldInactiveVaultOpportunities,
+    isCardLayout,
 }: EarnYieldTableBodyProps) => {
     if (isYieldOpportunitiesLoading) {
-        return (
-            <Table.Body>
-                <Table.Row>
-                    <Table.Cell colSpan={5}>
-                        <Row width="100%" justifyContent="center" padding={{ vertical: 16 }}>
-                            <Spinner size={24} />
-                        </Row>
-                    </Table.Cell>
-                </Table.Row>
-            </Table.Body>
-        );
+        return <EarnYieldLoadingState isCardLayout={isCardLayout} />;
     }
 
     if (isYieldOpportunitiesError) {
-        return (
-            <Table.Body>
-                <Table.Row>
-                    <Table.Cell colSpan={5}>
-                        <Banner
-                            icon
-                            intent="warning"
-                            title={<Translation id="TR_EARN_YIELD_LOAD_ERROR_TITLE" />}
-                            description={<Translation id="TR_EARN_YIELD_LOAD_ERROR_DESCRIPTION" />}
-                            rightContent={
-                                <Banner.Button onClick={onRetry}>
-                                    <Translation id="TR_TRY_AGAIN" />
-                                </Banner.Button>
-                            }
-                        />
-                    </Table.Cell>
-                </Table.Row>
-            </Table.Body>
-        );
+        return <EarnYieldErrorState isCardLayout={isCardLayout} onRetry={onRetry} />;
     }
 
     if (yieldAccountOpportunities.length === 0 && yieldInactiveVaultOpportunities.length === 0) {
-        return (
-            <Table.Body>
-                <Table.Row>
-                    <Table.Cell colSpan={5}>
-                        <Paragraph typographyStyle="body-md" intent="neutral" priority="secondary">
-                            <Translation id="TR_ACCOUNT_NO_ACCOUNTS" />
-                        </Paragraph>
-                    </Table.Cell>
-                </Table.Row>
-            </Table.Body>
-        );
+        return <EarnYieldEmptyState isCardLayout={isCardLayout} />;
     }
 
     return (
-        <Table.Body>
-            {yieldAccountOpportunities.map(opportunity => (
-                <EarnYieldAccountOpportunity key={opportunity.key} opportunity={opportunity} />
-            ))}
-
-            {yieldInactiveVaultOpportunities.map(opportunity => (
-                <EarnYieldInactiveVaultOpportunity
-                    key={opportunity.key}
-                    opportunity={opportunity}
-                />
-            ))}
-        </Table.Body>
+        <EarnYieldRows
+            accountOpportunities={yieldAccountOpportunities}
+            inactiveVaultOpportunities={yieldInactiveVaultOpportunities}
+            isCardLayout={isCardLayout}
+        />
     );
 };

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldYearlyRewards.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldYearlyRewards.tsx
@@ -1,0 +1,40 @@
+import { Translation } from '@suite/intl';
+import { type TokenSymbol } from '@suite-common/wallet-types';
+import { Column, Paragraph } from '@trezor/components';
+
+import { HiddenPlaceholder } from 'src/components/suite/HiddenPlaceholder';
+
+import { EarnRewardsAmount } from '../common/EarnRewardsAmount';
+
+type EarnYieldYearlyRewardsProps = {
+    symbol: TokenSymbol;
+    rewards: string;
+    apy: number | null;
+    hasDisplayableSuppliedAmount: boolean;
+    formattedSuppliedAmount: string;
+    displaySymbol: string;
+};
+
+export const EarnYieldYearlyRewards = ({
+    symbol,
+    rewards,
+    apy,
+    hasDisplayableSuppliedAmount,
+    formattedSuppliedAmount,
+    displaySymbol,
+}: EarnYieldYearlyRewardsProps) => (
+    <Column>
+        <EarnRewardsAmount symbol={symbol} rewards={rewards} apy={apy} />
+
+        {hasDisplayableSuppliedAmount && (
+            <Paragraph typographyStyle="body-sm" intent="neutral" priority="secondary">
+                <HiddenPlaceholder>
+                    <Translation
+                        id="TR_EARN_YIELD_DASHBOARD_SUPPLIED"
+                        values={{ amount: formattedSuppliedAmount, displaySymbol }}
+                    />
+                </HiddenPlaceholder>
+            </Paragraph>
+        )}
+    </Column>
+);

--- a/packages/suite/src/components/earn/yield/common/YieldFlowComplete.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldFlowComplete.tsx
@@ -8,6 +8,7 @@ import { Button, Card, Column, Divider, Icon, IconCircle, Row, Text } from '@tre
 import { FeedbackCard } from '@trezor/product-components';
 
 import { useDispatch } from 'src/hooks/suite';
+import { useLayoutSize } from 'src/hooks/suite/useLayoutSize';
 import { useAnalytics } from 'src/support/useAnalytics';
 
 type YieldFlowCompleteProps = {
@@ -28,6 +29,7 @@ export const YieldFlowComplete = ({
     const dispatch = useDispatch();
     const analytics = useAnalytics();
     const { translationString } = useTranslation();
+    const { isBelowMobile } = useLayoutSize();
 
     const handleBackToOverview = () => {
         analytics.report({
@@ -59,7 +61,7 @@ export const YieldFlowComplete = ({
 
     return (
         <Column gap={16}>
-            <IconCircle name="check" intent="brand" size={96} />
+            <IconCircle name="check" intent="brand" size={isBelowMobile ? 64 : 96} />
 
             <Column gap={4}>
                 <Text typographyStyle="headline-md">{heading}</Text>

--- a/packages/suite/src/components/earn/yield/common/YieldFlowTransferRow.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldFlowTransferRow.tsx
@@ -2,6 +2,8 @@ import { Translation, type TranslationId } from '@suite/intl';
 import { type YieldFlowCompleteValue } from '@suite-common/wallet-core';
 import { Column, Icon, Row, Text } from '@trezor/components';
 
+import { useLayoutSize } from 'src/hooks/suite/useLayoutSize';
+
 import { YieldTokenValue } from './YieldTokenValue';
 
 type YieldFlowTransferRowProps = {
@@ -16,12 +18,10 @@ export const YieldFlowTransferRow = ({
     outputLabelId,
     input,
     output,
-}: YieldFlowTransferRowProps) => (
-    <Row
-        justifyContent="space-between"
-        alignItems="center"
-        padding={{ vertical: 16, horizontal: 20 }}
-    >
+}: YieldFlowTransferRowProps) => {
+    const { isBelowTablet } = useLayoutSize();
+
+    const inputColumn = (
         <Column gap={8}>
             <Text typographyStyle="body-md">
                 <Translation id={inputLabelId} />
@@ -34,8 +34,10 @@ export const YieldFlowTransferRow = ({
                 amount={input.amount}
             />
         </Column>
-        <Icon name="arrowRight" size={20} intent="neutral" priority="secondary" />
-        <Column gap={8} alignItems="flex-end">
+    );
+
+    const outputColumn = (
+        <Column gap={8} alignItems={isBelowTablet ? 'flex-start' : 'flex-end'}>
             <Text typographyStyle="body-md">
                 <Translation id={outputLabelId} />
             </Text>
@@ -47,5 +49,27 @@ export const YieldFlowTransferRow = ({
                 amount={output.amount}
             />
         </Column>
-    </Row>
-);
+    );
+
+    if (isBelowTablet) {
+        return (
+            <Column gap={12} padding={{ vertical: 16, horizontal: 20 }}>
+                {inputColumn}
+                <Icon name="arrowDown" size={20} intent="neutral" priority="secondary" />
+                {outputColumn}
+            </Column>
+        );
+    }
+
+    return (
+        <Row
+            justifyContent="space-between"
+            alignItems="center"
+            padding={{ vertical: 16, horizontal: 20 }}
+        >
+            {inputColumn}
+            <Icon name="arrowRight" size={20} intent="neutral" priority="secondary" />
+            {outputColumn}
+        </Row>
+    );
+};

--- a/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 
 import { events } from '@suite/analytics';
-import { Translation, type TranslationKey } from '@suite/intl';
+import { Translation, type TranslationKey, useTranslation } from '@suite/intl';
 import { openModal } from '@suite/modal';
 import { type EarnParams, goto } from '@suite/router';
 import { useAllYieldOpportunities } from '@suite-common/earn-stablecoin-api';
@@ -17,6 +17,7 @@ import { AssetLogo } from '@trezor/product-components';
 import { AccountLabel } from 'src/components/suite';
 import { PageHeader } from 'src/components/suite/layouts/SuiteLayout';
 import { useDispatch } from 'src/hooks/suite';
+import { useLayoutSize } from 'src/hooks/suite/useLayoutSize';
 import { useAnalytics } from 'src/support/useAnalytics';
 
 interface YieldPageHeaderProps {
@@ -34,6 +35,8 @@ export const YieldPageHeader = ({
 }: YieldPageHeaderProps) => {
     const dispatch = useDispatch();
     const analytics = useAnalytics();
+    const { translationString } = useTranslation();
+    const { isBelowMobile } = useLayoutSize();
     const { data: yieldOpportunities, isSuccess } = useAllYieldOpportunities();
     const vault = useMemo(
         () =>
@@ -88,7 +91,7 @@ export const YieldPageHeader = ({
     };
 
     return (
-        <PageHeader>
+        <PageHeader expandable>
             <Row width="100%" gap={16} alignItems="center">
                 <IconButton
                     icon="caretLeft"
@@ -132,14 +135,26 @@ export const YieldPageHeader = ({
                 )}
 
                 <Box margin={{ left: 'auto' }}>
-                    <Button
-                        intent="neutral"
-                        priority="secondary"
-                        onClick={onHowItWorksClick}
-                        isDisabled={!account || !routeParams}
-                    >
-                        <Translation id="TR_EARN_HOW_IT_WORKS" />
-                    </Button>
+                    {isBelowMobile ? (
+                        <IconButton
+                            icon="info"
+                            intent="neutral"
+                            priority="secondary"
+                            size="large"
+                            aria-label={translationString('TR_EARN_HOW_IT_WORKS')}
+                            onClick={onHowItWorksClick}
+                            isDisabled={!account || !routeParams}
+                        />
+                    ) : (
+                        <Button
+                            intent="neutral"
+                            priority="secondary"
+                            onClick={onHowItWorksClick}
+                            isDisabled={!account || !routeParams}
+                        >
+                            <Translation id="TR_EARN_HOW_IT_WORKS" />
+                        </Button>
+                    )}
                 </Box>
             </Row>
         </PageHeader>

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageHeader.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageHeader.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode } from 'react';
 
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { isAccountTabRoute, resolveEffectiveBackgroundRouteName, selectRoute } from '@suite/router';
 import { selectAccounts } from '@suite-common/wallet-core';
@@ -18,7 +18,7 @@ import { HeaderDropdown } from './HeaderDropdown';
 import { PageName } from './PageNames/PageName';
 import { TradeActions } from './TradeActions';
 
-const Container = styled.div`
+const Container = styled.div<{ $expandable?: boolean }>`
     position: sticky;
     top: 0;
     display: flex;
@@ -26,13 +26,18 @@ const Container = styled.div`
     justify-content: space-between;
     width: 100%;
     gap: ${spacingsPx.xs};
-    height: ${HEADER_HEIGHT};
     min-height: ${HEADER_HEIGHT};
     padding: ${spacingsPx.xs} ${spacingsPx.md};
     background: ${({ theme }) => theme.surfaceFillPage};
     border-bottom: 1px solid ${({ theme }) => theme.borderNeutral};
-    overflow: hidden;
     z-index: ${zIndices.pageHeader};
+
+    ${({ $expandable }) =>
+        !$expandable &&
+        css`
+            height: ${HEADER_HEIGHT};
+            overflow: hidden;
+        `}
 `;
 
 const PageHeaderIndex = () => {
@@ -51,9 +56,10 @@ const PageHeaderIndex = () => {
 
 interface PageHeaderProps {
     children?: ReactNode;
+    expandable?: boolean;
 }
 
-export const PageHeader = ({ children }: PageHeaderProps) => {
+export const PageHeader = ({ children, expandable }: PageHeaderProps) => {
     const selectedAccountKey = useSelector(selectSelectedAccountKey);
     const route = useSelector(selectRoute);
     const { suiteRouterHistory } = useSuiteServices();
@@ -67,7 +73,7 @@ export const PageHeader = ({ children }: PageHeaderProps) => {
     const isTradeSection = !!effectiveRouteName?.includes('wallet-trading');
 
     if (isTradeSection || children != null) {
-        return <Container>{children}</Container>;
+        return <Container $expandable={expandable}>{children}</Container>;
     }
 
     return (

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/AllowanceModalProviderInfo.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/AllowanceModalProviderInfo.tsx
@@ -57,7 +57,12 @@ export const AllowanceModalProviderInfo = ({
                     {providerLogoSource && <ProviderLogo src={providerLogoSource} alt="" />}
                     <Column>
                         {providerName && <Text>{providerName}</Text>}
-                        <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
+                        <Text
+                            typographyStyle="body-sm"
+                            intent="neutral"
+                            priority="secondary"
+                            wordBreak="break-all"
+                        >
                             {spender}
                         </Text>
                     </Column>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
@@ -25,6 +25,7 @@ import { BigNumber } from '@trezor/utils';
 import { FormattedDateWithBullet } from 'src/components/suite/FormattedDateWithBullet';
 import { TransactionHeader } from 'src/components/wallet/TransactionItem/TransactionHeader';
 import { useExternalLink } from 'src/hooks/suite';
+import { useLayoutSize } from 'src/hooks/suite/useLayoutSize';
 import { type WalletAccountTransaction } from 'src/types/wallet';
 import { BlurUrls } from 'src/views/wallet/tokens/common/BlurUrls';
 
@@ -76,6 +77,7 @@ export const BasicTxDetails = ({
     explorerUrlQueryString,
 }: BasicTxDetailsProps) => {
     const { elevation } = useElevation();
+    const { isBelowTablet } = useLayoutSize();
     const explorerLink = useExternalLink(`${explorerUrl}${tx.txid}${explorerUrlQueryString ?? ''}`);
     // all solana txs which are fetched are already confirmed
     const isConfirmed = confirmations > 0 || tx.solanaSpecific?.status === 'confirmed';
@@ -133,7 +135,7 @@ export const BasicTxDetails = ({
 
             <Divider />
 
-            <Grid columns={2} columnGap={32} rowGap={12} forceEqualColumns>
+            <Grid columns={isBelowTablet ? 1 : 2} columnGap={32} rowGap={12} forceEqualColumns>
                 {/* MINED TIME */}
                 <Item
                     label={


### PR DESCRIPTION
## Description

Staking & Yield tables collapse into stacked cards below the laptop breakpoint (992px) where the 5-column table no longer fits
Row internals (rewards, action buttons, activate button, state messages) extracted into shared components used by both table and card branches

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27814

## Screenshots:

<img width="893" height="707" alt="image" src="https://github.com/user-attachments/assets/dd327bab-f061-4809-a370-1be0c11b61c5" />

<img width="487" height="885" alt="image" src="https://github.com/user-attachments/assets/d2486716-23e9-4ccb-8338-8ee410590041" />

<img width="360" height="804" alt="image" src="https://github.com/user-attachments/assets/91d9e9b9-fa8b-4b77-9e5e-1316880792ac" />

<img width="546" height="671" alt="image" src="https://github.com/user-attachments/assets/5232967b-2593-49fe-8114-044639f142f8" />

<img width="379" height="717" alt="image" src="https://github.com/user-attachments/assets/c942458f-973e-4dec-83a5-b590a644e19f" />

<img width="485" height="610" alt="image" src="https://github.com/user-attachments/assets/0b35fef9-49af-427a-bace-67a974bb651a" />

<img width="378" height="334" alt="image" src="https://github.com/user-attachments/assets/3250eb70-7cb3-4c78-bd93-d8b1ed58bedb" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/earn-dashboard-responsive&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/earn-dashboard-responsive&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-19T23:18:10.918Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-19T23:16:42.282Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/earn-dashboard-responsive/web/](https://dev.suite.sldev.cz/suite-web/feat/earn-dashboard-responsive/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->