### PR TITLE
[nitpick cleanup]: chore(types): use PropertyKey instead of keyof any

### DIFF
--- a/packages/type-utils/src/utils.ts
+++ b/packages/type-utils/src/utils.ts
@@ -120,7 +120,7 @@ export type PrimitiveType = string | number | boolean | Date | null | undefined;
  *  const p: PartialRecord<'a' | 'b' | 'c', string>; = { b: 'value' };
  *  ```
  */
-export type PartialRecord<K extends keyof any, T> = { [P in K]?: T };
+export type PartialRecord<K extends PropertyKey, T> = { [P in K]?: T };
 
 /**
  * This infers the union literal type from ReturnType but exclude undefined

--- a/packages/utils/src/getMutex.ts
+++ b/packages/utils/src/getMutex.ts
@@ -21,9 +21,9 @@
  */
 export const getMutex = () => {
     const DEFAULT_ID = Symbol();
-    const locks: Record<keyof any, Promise<void>> = {};
+    const locks: Record<PropertyKey, Promise<void>> = {};
 
-    return async (lockId: keyof any = DEFAULT_ID) => {
+    return async (lockId: PropertyKey = DEFAULT_ID) => {
         while (locks[lockId]) {
             await locks[lockId];
         }

--- a/packages/utils/src/getSynchronize.ts
+++ b/packages/utils/src/getSynchronize.ts
@@ -18,7 +18,10 @@ import { getMutex } from './getMutex';
 export const getSynchronize = (mutex?: ReturnType<typeof getMutex>) => {
     const lock = mutex ?? getMutex();
 
-    return <T>(action: () => T, lockId?: keyof any): T extends Promise<unknown> ? T : Promise<T> =>
+    return <T>(
+        action: () => T,
+        lockId?: PropertyKey,
+    ): T extends Promise<unknown> ? T : Promise<T> =>
         lock(lockId).then(unlock => Promise.resolve().then(action).finally(unlock)) as any;
 };
 


### PR DESCRIPTION
## Summary

**Pure syntax modernization — no TypeScript behavior change whatsoever.**

`keyof any` and `PropertyKey` are exact aliases in TypeScript's standard library. From `lib.es5.d.ts`:

```ts
type PropertyKey = string | number | symbol;
```

…which is precisely what `keyof any` resolves to. The TS compiler treats the two as fully interchangeable in every position (type parameters, constraints, indexed access, etc.). This PR replaces the 4 remaining occurrences of the old `keyof any` spelling with the modern `PropertyKey` spelling. The emitted JavaScript is byte-identical and no type-check behavior changes anywhere — including in downstream consumers of these public types.

### Completes the migration

After this PR merges, **the repository contains zero `keyof any` occurrences** (`rg 'keyof any' '**/*.{ts,tsx}'` returns nothing). These four sites are the last of the idiom in the codebase.

### Why bother, then?

`PropertyKey` is the idiomatic spelling in modern TypeScript (the `keyof any` form is a TS 2.x idiom kept around for historical reasons). It reads more clearly at call sites and removes 4 `any` occurrences from public type surface, which is convenient if/when the repo wants to enforce `@typescript-eslint/no-explicit-any` more strictly.

That's the entire value proposition — this is housekeeping, not a typesafety improvement.

### Diff

7 added / 4 removed across 3 files (the 3 extra added lines are prettier reflow of an existing line after the change):

- **`@trezor/utils`** (`getMutex.ts`, `getSynchronize.ts`): 3 sites — `locks: Record<keyof any, _>`, the `lockId` parameter in `getMutex`, and the `lockId` parameter in `getSynchronize`.
- **`@trezor/type-utils`** (`utils.ts`): 1 site — `PartialRecord<K extends keyof any, T>` → `K extends PropertyKey`.

## Related PRs

Cherry-picked from the types-hardening staging branch in #27649. Sibling PR:

- #27852 — public-API `any` tightenings (transport Logger, blockchain-link-types blockfrost, components Menu/Link, metadata-types setFileContent)

## Test plan

- [ ] CI typecheck passes (expected: identical to base — no semantic change)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/quito-any-quick-wins&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->