### PR TITLE
chore(intl): remove unused translation strings

### DIFF
--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10696,14 +10696,6 @@ export const messages = defineMessages({
         id: 'TR_URL_IN_TOKEN',
         defaultMessage: "Never visit URLs in token names or symbols; they're usually scams.",
     },
-    TR_PASSPHRASE_WALLET_CONFIRMATION_STEP1_HINT: {
-        id: 'TR_PASSPHRASE_WALLET_CONFIRMATION_STEP1_HINT',
-        defaultMessage: 'Learn how a passphrase works',
-    },
-    TR_PASSPHRASE_WALLET_CONFIRMATION_STEP1_HINT_LINK: {
-        id: 'TR_PASSPHRASE_WALLET_CONFIRMATION_STEP1_HINT_LINK',
-        defaultMessage: 'Go',
-    },
     TR_PASSPHRASE_WALLET_CONFIRMATION_STEP1_TITLE: {
         id: 'TR_PASSPHRASE_WALLET_CONFIRMATION_STEP1_TITLE',
         defaultMessage: 'This Passphrase wallet is empty',


### PR DESCRIPTION
## Summary
Removes unused translation strings from `messages.ts` that are no longer referenced in the codebase.

**Keys removed (2):**
- `TR_PASSPHRASE_WALLET_CONFIRMATION_STEP1_HINT`
- `TR_PASSPHRASE_WALLET_CONFIRMATION_STEP1_HINT_LINK`

Identified by the `translations:list-unused` CI check.

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change to suite/intl/src/messages.ts affects the central internationalization message definitions used across the entire Trezor Suite application. Since this is a broad shared dependency, the risk depends on the nature of the change (adding new keys, modifying existing keys, restructuring). Tests that directly assert on translation keys or translated text content are most at risk. The recommended strategy prioritizes tests that explicitly check translated strings or language-related behavior (autodetect, general settings, coin settings), with medium priority for tests that assert specific translation keys in modals and UI elements. Tests were inferred from LLM analysis since no static mapping was available.

<details><summary><b>Changed files (1)</b></summary>

- `suite/intl/src/messages.ts`

</details>

**Recommended tests (17)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `../../suite/e2e/tests/settings/autodetect.test.ts` — This test directly validates internationalized heading text from @suite/intl messages (TR_ONBOARDING_DATA_COLLECTION_HEADING) in multiple locales (English and Spanish), and asserts that the correct translated string is rendered. Changes to messages.ts could alter these translation keys or default values, causing direct test failures.
- `../../suite/e2e/tests/settings/general.test.ts` — This test changes the application language from English to Spanish and verifies analytics events that include language identifiers. It relies on @suite/intl messages for settings UI labels and fiat currency display. A change to messages.ts could break language-related assertions or settings page translations.

</details>

<details><summary>🟡 <b>Medium priority (12)</b></summary>

- `../../suite/e2e/tests/settings/coins.test.ts` — This test asserts multiple translation keys (TR_YOUR_WALLET_IS_READY_WHAT, TR_DASHBOARD_ACTIVATE_ASSETS_DESC, TR_DASHBOARD_GET_STARTED, TR_CUSTOM_BACKEND) from @suite/intl messages for the dashboard empty state and coin settings. Changes to these message definitions would directly break these assertions.
- `../../suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test asserts translation keys TR_CUSTOM_BACKEND, TR_ACCOUNT_IS_EMPTY_TITLE, and TR_ACCOUNT_EXCEPTION_DISCOVERY_ERROR from @suite/intl messages. Changes to these message definitions or their structure could cause assertion failures.
- `../../suite/e2e/tests/settings/forget-device.test.ts` — This test verifies multiple forget-device modal translation keys (TR_FORGET_DEVICE_MODAL_HEADING, TR_FORGET_DEVICE_MODAL_BULLET_FORGET, TR_FORGET_DEVICE_MODAL_BULLET_NOT_WIPE, TR_FORGET_DEVICE_MODAL_BLUETOOTH_REMOVED, TR_FORGET_DEVICE_MODAL_FINISH_HEADING). Changes to these message definitions would break modal content assertions.
- `../../suite/e2e/tests/suite/db-locale-migration.test.ts` — This test validates that the Spanish language label is preserved across a database migration by checking the language select input. It directly relies on @suite/intl language definitions and the settingsPage language map, which references intl message keys.
- `../../suite/e2e/tests/passphrase/passphrase.test.ts` — This test asserts translation keys TR_PASSPHRASE_MISMATCH, TR_PASSPHRASE_MISMATCH_DESCRIPTION, and TR_PASSPHRASE_WALLET from @suite/intl messages. Changes to these keys would break the passphrase mismatch error and wallet label assertions.
- `../../suite/e2e/tests/passphrase/passphrase-duplicate.test.ts` — This test asserts TR_WALLET_DUPLICATE_TITLE and TR_WALLET_DUPLICATE_DESC translation keys from @suite/intl. Changes to these message definitions would directly break the duplicate passphrase warning assertions.
- `../../suite/e2e/tests/staking/staking-form.test.ts` — This test asserts multiple translation keys (TR_BUY_VALIDATION_ERROR_MINIMUM_CRYPTO, AMOUNT_IS_NOT_IN_RANGE_DECIMALS, AMOUNT_IS_NOT_ENOUGH, AMOUNT_IS_NOT_SET, TR_STAKE_LEFT_AMOUNT_FOR_WITHDRAWAL) from @suite/intl messages for staking form validation errors. Changes could break validation message assertions.
- `../../suite/e2e/tests/staking/ada/stake.test.ts` — This test asserts translation keys TR_EARN_STAKING_IN_A_NUTSHELL, TR_EARN_YOUR_FUNDS_STAY_ACCESSIBLE, TR_EARN_STAKE_TOKEN, and TR_STAKE_FULL_BALANCE from @suite/intl messages in the staking info modal and post-staking UI. Changes could cause assertion failures.
- `../../suite/e2e/tests/staking/ada/unstake.test.ts` — This test asserts translation keys TR_STAKE_UNSTAKE_TOKEN and TR_STAKE_FULL_BALANCE from @suite/intl messages. Changes to these message definitions would break unstaking modal and status assertions.
- `../../suite/e2e/tests/wallet/transactions.test.ts` — This test asserts @suite/intl translation keys for graph time range labels (TR_DATE_DAY_LONG, TR_DATE_WEEK_LONG, TR_DATE_MONTH_LONG, TR_DATE_YEAR_LONG, TR_ALL). Changes to these message definitions would directly break the time range filter assertions.
- `../../suite/e2e/tests/suite/multiple-sessions.test.ts` — This test asserts translation keys TR_USE_HERE and TR_CONNECTED for device session status labels. Changes to these messages in @suite/intl would break session management UI assertions.
- `../../suite/e2e/tests/trading/swap-history.test.ts` — This test explicitly references @suite/intl messages for trade status translations (TR_EXCHANGE_STATUS_*, TR_TRADING_LAST_TRANSACTIONS, TR_TRADING_SWAP_COUNTER, TR_TRADING_TRANS_ID) and uses intl formatting. Changes to these message definitions would break multiple assertions.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `../../suite/e2e/tests/wallet/send-eth.test.ts` — This test references @suite/intl messages (TR_GAS_LIMIT) for Ethereum fee label assertions. A change to this specific message key would break the gas limit label assertion on the send form.
- `../../suite/e2e/tests/wallet/send-base.test.ts` — This test references @suite/intl messages (TR_GAS_LIMIT) for fee label assertions on the Base network send form. A change to this specific message key would break the assertion.
- `../../suite/e2e/tests/trading/sell-inputs.test.ts` — This test asserts @suite/intl messages for sell form validation errors (AMOUNT_IS_NOT_IN_RANGE_DECIMALS, AMOUNT_IS_NOT_ENOUGH, TR_TRADING_COUNTRY_WORLD). Changes to these specific messages could affect validation display assertions.

</details>

_Updated: 2026-05-20T10:00:34.032Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/remove-unused-strings-20260520&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/remove-unused-strings-20260520&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-20T10:04:55.528Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-20T10:03:22.294Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/remove-unused-strings-20260520/web/](https://dev.suite.sldev.cz/suite-web/chore/remove-unused-strings-20260520/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->