### PR TITLE
chore(eslint): forbid `typeof undefined` in type positions

### DIFF
--- a/packages/blockchain-link-types/src/messages.ts
+++ b/packages/blockchain-link-types/src/messages.ts
@@ -151,7 +151,7 @@ export interface GetContractInfo {
 }
 
 export type Message =
-    | ChannelMessage<{ type: typeof MESSAGES.TERMINATE; payload?: typeof undefined }>
+    | ChannelMessage<{ type: typeof MESSAGES.TERMINATE; payload?: never }>
     | ChannelMessage<{ type: typeof MESSAGES.HANDSHAKE; settings: BlockchainSettings }>
     | ChannelMessage<Connect>
     | ChannelMessage<Disconnect>

--- a/packages/blockchain-link-types/src/responses.ts
+++ b/packages/blockchain-link-types/src/responses.ts
@@ -175,7 +175,7 @@ export interface GetContractInfo {
 interface WithoutPayload {
     id: number;
     type: typeof HANDSHAKE | typeof RESPONSES.CONNECTED;
-    payload?: typeof undefined;
+    payload?: never;
 }
 
 // extended

--- a/packages/connect-common/src/events/popup.ts
+++ b/packages/connect-common/src/events/popup.ts
@@ -51,7 +51,7 @@ export interface PopupCloseWindow {
 export type PopupEvent =
     | {
           type: typeof POPUP.CORE_LOADED;
-          payload?: typeof undefined;
+          payload?: never;
       }
     | PopupInit
     | PopupHandshake

--- a/packages/connect-common/src/events/popup.ts
+++ b/packages/connect-common/src/events/popup.ts
@@ -45,7 +45,7 @@ export interface PopupClosedMessage {
 
 export interface PopupCloseWindow {
     type: typeof POPUP.CLOSE_WINDOW;
-    payload: typeof undefined;
+    payload?: never;
 }
 
 export type PopupEvent =

--- a/packages/connect-common/src/events/ui-request.ts
+++ b/packages/connect-common/src/events/ui-request.ts
@@ -59,15 +59,15 @@ export const UI_REQUEST = {
 export type UiRequestWithoutPayload =
     | {
           type: typeof UI_REQUEST.TRANSPORT;
-          payload?: typeof undefined;
+          payload?: never;
       }
     | {
           type: typeof UI_REQUEST.INSUFFICIENT_FUNDS;
-          payload?: typeof undefined;
+          payload?: never;
       }
     | {
           type: typeof UI_REQUEST.CLOSE_UI_WINDOW;
-          payload?: typeof undefined;
+          payload?: never;
       };
 
 export type UiRequestDeviceAction =
@@ -89,28 +89,28 @@ export type UiRequestDeviceAction =
           type: typeof UI_REQUEST.INVALID_PIN;
           payload: {
               device: Device;
-              type?: typeof undefined;
+              type?: never;
           };
       }
     | {
           type: typeof UI_REQUEST.INVALID_PIN_ATTEMPTS_DEPLETED;
           payload: {
               device: Device;
-              type?: typeof undefined;
+              type?: never;
           };
       }
     | {
           type: typeof UI_REQUEST.REQUEST_PASSPHRASE_ON_DEVICE;
           payload: {
               device: Device;
-              type?: typeof undefined;
+              type?: never;
           };
       }
     | {
           type: typeof UI_REQUEST.REQUEST_PASSPHRASE;
           payload: {
               device: Device;
-              type?: typeof undefined;
+              type?: never;
           };
       };
 

--- a/packages/connect-common/src/types/api/bitcoin/index.ts
+++ b/packages/connect-common/src/types/api/bitcoin/index.ts
@@ -28,7 +28,7 @@ export type RefTransaction =
           version: number;
           inputs: PROTO.PrevInput[];
           bin_outputs: PROTO.TxOutputBinType[];
-          outputs?: typeof undefined;
+          outputs?: never;
           lock_time: number;
           extra_data?: string;
           expiry?: number;
@@ -41,7 +41,7 @@ export type RefTransaction =
           hash: string;
           version: number;
           inputs: PROTO.TxInput[];
-          bin_outputs?: typeof undefined;
+          bin_outputs?: never;
           outputs: PROTO.TxOutputType[];
           lock_time: number;
           extra_data?: string;

--- a/packages/connect-common/src/types/device.ts
+++ b/packages/connect-common/src/types/device.ts
@@ -149,7 +149,7 @@ export type KnownDevice = BaseDevice & {
 
     /** @deprecated, use features.label instead */
     label: string;
-    error?: typeof undefined;
+    error?: never;
     firmware: DeviceFirmwareStatus;
     firmwareReleaseConfigInfo?: FirmwareReleaseConfigInfo | null;
     firmwareType?: FirmwareType;
@@ -176,19 +176,19 @@ export type UnknownDevice = BaseDevice & {
     type: 'unacquired';
     /** @deprecated, use features.label instead */
     label: 'Unacquired device';
-    id?: typeof undefined;
-    error?: typeof undefined;
-    features?: typeof undefined;
+    id?: never;
+    error?: never;
+    features?: never;
     thp?: DeviceThpState;
-    firmware?: typeof undefined;
-    firmwareReleaseConfigInfo?: typeof undefined;
-    firmwareType?: typeof undefined;
-    color?: typeof undefined;
+    firmware?: never;
+    firmwareReleaseConfigInfo?: never;
+    firmwareType?: never;
+    color?: never;
     status?: DeviceStatus;
-    mode?: typeof undefined;
-    state?: typeof undefined;
-    unavailableCapabilities?: typeof undefined;
-    availableTranslations?: typeof undefined;
+    mode?: never;
+    state?: never;
+    unavailableCapabilities?: never;
+    availableTranslations?: never;
     transportSessionOwner?: string;
     hid?: undefined;
 };
@@ -198,18 +198,18 @@ export type UnreadableDevice = BaseDevice & {
     /** @deprecated, use features.label instead */
     label: 'Unreadable device';
     error: string;
-    id?: typeof undefined;
-    features?: typeof undefined;
-    thp?: typeof undefined;
-    firmware?: typeof undefined;
-    firmwareReleaseConfigInfo?: typeof undefined;
-    firmwareType?: typeof undefined;
-    color?: typeof undefined;
-    status?: typeof undefined;
-    mode?: typeof undefined;
-    state?: typeof undefined;
-    unavailableCapabilities?: typeof undefined;
-    availableTranslations?: typeof undefined;
+    id?: never;
+    features?: never;
+    thp?: never;
+    firmware?: never;
+    firmwareReleaseConfigInfo?: never;
+    firmwareType?: never;
+    color?: never;
+    status?: never;
+    mode?: never;
+    state?: never;
+    unavailableCapabilities?: never;
+    availableTranslations?: never;
     transportSessionOwner?: undefined;
     hid: boolean;
 };

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -80,7 +80,7 @@ const createSendCoreMessageWithCallId =
 const selectDevice = ({ deviceList }: CoreContext, methodCallDevice?: DeviceIdentity) => {
     assertDeviceListConnected(deviceList);
 
-    let device: Device | typeof undefined;
+    let device: Device | undefined;
 
     if (methodCallDevice?.state?.staticSessionId) {
         device = deviceList.getDeviceByStaticState(methodCallDevice.state.staticSessionId);

--- a/packages/device-authenticity/src/types.ts
+++ b/packages/device-authenticity/src/types.ts
@@ -29,7 +29,7 @@ export type VerifyAuthenticityProofResult =
           valid: true;
           caPubKey?: string;
           rootPubKey: string;
-          error?: typeof undefined;
+          error?: never;
           serialNumber?: string;
       }
     | {

--- a/packages/eslint/src/javascriptConfig.mjs
+++ b/packages/eslint/src/javascriptConfig.mjs
@@ -62,6 +62,11 @@ export const javascriptConfig = [
                     selector:
                         "BinaryExpression[left.type='CallExpression'][left.callee.type='MemberExpression'][left.callee.property.name='indexOf']:matches([operator='>='][right.value=0], [operator='<'][right.value=0], [operator='>'][right.type='UnaryExpression'][right.operator='-'][right.argument.value=1], [operator='==='][right.type='UnaryExpression'][right.operator='-'][right.argument.value=1], [operator='!=='][right.type='UnaryExpression'][right.operator='-'][right.argument.value=1], [operator='=='][right.type='UnaryExpression'][right.operator='-'][right.argument.value=1], [operator='!='][right.type='UnaryExpression'][right.operator='-'][right.argument.value=1])",
                 },
+                {
+                    selector: "TSTypeQuery > Identifier[name='undefined']",
+                    message:
+                        'Use `undefined` (or `never` in discriminated unions) instead of `typeof undefined` in type position.',
+                },
             ],
             'object-shorthand': [
                 'error',

--- a/packages/protobuf/scripts/protobuf-patches/TxInputType.ts
+++ b/packages/protobuf/scripts/protobuf-patches/TxInputType.ts
@@ -30,7 +30,7 @@ export type TxInputType =
           script_type?: InternalInputScriptType;
       })
     | (CommonTxInputType & {
-          address_n?: typeof undefined;
+          address_n?: never;
           script_type: 'EXTERNAL';
           script_pubkey: string;
       });

--- a/packages/protobuf/scripts/protobuf-patches/TxOutputType.ts
+++ b/packages/protobuf/scripts/protobuf-patches/TxOutputType.ts
@@ -9,7 +9,7 @@ export type ChangeOutputScriptType = Exclude<OutputScriptType, 'PAYTOOPRETURN'>;
 export type TxOutputType =
     | {
           address: string;
-          address_n?: typeof undefined;
+          address_n?: never;
           script_type?: 'PAYTOADDRESS';
           amount: UintType;
           multisig?: MultisigRedeemScriptType;
@@ -18,7 +18,7 @@ export type TxOutputType =
           payment_req_index?: number;
       }
     | {
-          address?: typeof undefined;
+          address?: never;
           address_n: number[];
           script_type?: ChangeOutputScriptType;
           amount: UintType;
@@ -28,8 +28,8 @@ export type TxOutputType =
           payment_req_index?: number;
       }
     | {
-          address?: typeof undefined;
-          address_n?: typeof undefined;
+          address?: never;
+          address_n?: never;
           amount: '0' | 0;
           op_return_data: string;
           script_type: 'PAYTOOPRETURN';

--- a/packages/suite/src/utils/wallet/accountUtils.ts
+++ b/packages/suite/src/utils/wallet/accountUtils.ts
@@ -4,7 +4,7 @@ import { type StaticSessionId } from '@trezor/connect';
 import { type WalletParams } from 'src/types/wallet';
 
 export const getSelectedAccount = (
-    deviceState: StaticSessionId | typeof undefined,
+    deviceState: StaticSessionId | undefined,
     accounts: Account[],
     routerParams: WalletParams | undefined,
 ) => {

--- a/packages/utxo-lib/src/types/coinselect.ts
+++ b/packages/utxo-lib/src/types/coinselect.ts
@@ -74,8 +74,8 @@ export interface CoinSelectSuccess {
 
 export interface CoinSelectFailure {
     fee: number;
-    inputs?: typeof undefined;
-    outputs?: typeof undefined;
+    inputs?: never;
+    outputs?: never;
 }
 
 export type CoinSelectResult = CoinSelectSuccess | CoinSelectFailure;

--- a/packages/utxo-lib/src/types/compose.ts
+++ b/packages/utxo-lib/src/types/compose.ts
@@ -37,14 +37,14 @@ export interface ComposeOutputSendMax {
 
 export interface ComposeOutputSendMaxNoAddress {
     type: 'send-max-noaddress';
-    amount?: typeof undefined;
+    amount?: never;
 }
 
 export interface ComposeOutputOpreturn {
     type: 'opreturn'; // it doesn't need to have address
     dataHex: string;
-    amount?: typeof undefined;
-    address?: typeof undefined;
+    amount?: never;
+    address?: never;
 }
 
 // NOTE: this interface **is not** accepted by ComposeRequest['utxos']

--- a/suite-common/wallet-core/src/discovery/selectDeviceThunk.ts
+++ b/suite-common/wallet-core/src/discovery/selectDeviceThunk.ts
@@ -26,7 +26,7 @@ export const selectDeviceThunk = createThunk<
 >(
     `${DEVICE_MODULE_PREFIX}/selectDevice`,
     ({ device }, { dispatch, getState, fulfillWithValue }) => {
-        let trezorDevice: TrezorDevice | typeof undefined;
+        let trezorDevice: TrezorDevice | undefined;
         const devices = selectDevices(getState());
         if (device) {
             // "ts" is one of the field which distinguish Device from TrezorDevice

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -353,7 +353,7 @@ export const findAccountDevice = (account: Account, devices: TrezorDevice[]) =>
     devices.find(d => d.state?.staticSessionId === account.deviceState);
 
 export const getAllAccounts = (
-    deviceState: DeviceState | StaticSessionId | typeof undefined,
+    deviceState: DeviceState | StaticSessionId | undefined,
     accounts: Account[],
 ) => {
     if (!deviceState) return [];


### PR DESCRIPTION
## Summary

Stacked on top of #27876 (replace `typeof undefined` with `never` in discriminated unions).

- Adds a `no-restricted-syntax` selector that bans `typeof undefined` in TypeScript type positions — merged into the existing selector array in `packages/eslint/src/javascriptConfig.mjs`, not duplicated
- Uses `TSTypeQuery > Identifier[name='undefined']` which is a TypeScript-only AST node, so it naturally scopes to `.ts`/`.tsx` files with no extra `files:` filter needed
- Cleans up the 5 remaining plain-optional `typeof undefined` occurrences left by the previous PR (function params + variable annotations)

The only surviving `typeof undefined` in the codebase after this PR is a string-replacement regex in `packages/schema-utils/src/codegen.ts`, which is not a type annotation and is unaffected by `TSTypeQuery`.

## Files changed

| File | Change |
|------|--------|
| `packages/eslint/src/javascriptConfig.mjs` | New selector merged into existing `no-restricted-syntax` array |
| `packages/connect-common/src/events/popup.ts` | `PopupCloseWindow.payload: typeof undefined` → `payload?: never` |
| `packages/connect/src/core/index.ts` | variable annotation `typeof undefined` → `undefined` |
| `suite-common/wallet-core/src/discovery/selectDeviceThunk.ts` | variable annotation `typeof undefined` → `undefined` |
| `suite-common/wallet-utils/src/accountUtils.ts` | function param `typeof undefined` → `undefined` |
| `packages/suite/src/utils/wallet/accountUtils.ts` | function param `typeof undefined` → `undefined` |

## Verification

- Rule fires on `type X = { x?: typeof undefined }` with message "Use `undefined` (or `never` in discriminated unions) instead of `typeof undefined` in type position." ✓
- Rule does NOT fire on `if (typeof x === 'undefined')` (runtime `UnaryExpression`, not `TSTypeQuery`) ✓
- No files in the repo contain `typeof undefined` in a TypeScript type position after this PR ✓

## Test plan

- [ ] `yarn nx run-many --target=lint:js`
- [ ] `yarn nx run-many --target=type-check`
- [ ] `yarn nx run-many --target=test:unit`
- [ ] `yarn nx run-many --target=build:lib`

🤖 Generated with [Claude Code](https://claude.com/claude-code)