### PR TITLE
refactor(types): replace typeof undefined with never in discriminated unions

### DIFF
--- a/packages/blockchain-link-types/src/messages.ts
+++ b/packages/blockchain-link-types/src/messages.ts
@@ -151,7 +151,7 @@ export interface GetContractInfo {
 }
 
 export type Message =
-    | ChannelMessage<{ type: typeof MESSAGES.TERMINATE; payload?: typeof undefined }>
+    | ChannelMessage<{ type: typeof MESSAGES.TERMINATE; payload?: never }>
     | ChannelMessage<{ type: typeof MESSAGES.HANDSHAKE; settings: BlockchainSettings }>
     | ChannelMessage<Connect>
     | ChannelMessage<Disconnect>

--- a/packages/blockchain-link-types/src/responses.ts
+++ b/packages/blockchain-link-types/src/responses.ts
@@ -175,7 +175,7 @@ export interface GetContractInfo {
 interface WithoutPayload {
     id: number;
     type: typeof HANDSHAKE | typeof RESPONSES.CONNECTED;
-    payload?: typeof undefined;
+    payload?: never;
 }
 
 // extended

--- a/packages/connect-common/src/events/popup.ts
+++ b/packages/connect-common/src/events/popup.ts
@@ -51,7 +51,7 @@ export interface PopupCloseWindow {
 export type PopupEvent =
     | {
           type: typeof POPUP.CORE_LOADED;
-          payload?: typeof undefined;
+          payload?: never;
       }
     | PopupInit
     | PopupHandshake

--- a/packages/connect-common/src/events/ui-request.ts
+++ b/packages/connect-common/src/events/ui-request.ts
@@ -59,15 +59,15 @@ export const UI_REQUEST = {
 export type UiRequestWithoutPayload =
     | {
           type: typeof UI_REQUEST.TRANSPORT;
-          payload?: typeof undefined;
+          payload?: never;
       }
     | {
           type: typeof UI_REQUEST.INSUFFICIENT_FUNDS;
-          payload?: typeof undefined;
+          payload?: never;
       }
     | {
           type: typeof UI_REQUEST.CLOSE_UI_WINDOW;
-          payload?: typeof undefined;
+          payload?: never;
       };
 
 export type UiRequestDeviceAction =
@@ -89,28 +89,28 @@ export type UiRequestDeviceAction =
           type: typeof UI_REQUEST.INVALID_PIN;
           payload: {
               device: Device;
-              type?: typeof undefined;
+              type?: never;
           };
       }
     | {
           type: typeof UI_REQUEST.INVALID_PIN_ATTEMPTS_DEPLETED;
           payload: {
               device: Device;
-              type?: typeof undefined;
+              type?: never;
           };
       }
     | {
           type: typeof UI_REQUEST.REQUEST_PASSPHRASE_ON_DEVICE;
           payload: {
               device: Device;
-              type?: typeof undefined;
+              type?: never;
           };
       }
     | {
           type: typeof UI_REQUEST.REQUEST_PASSPHRASE;
           payload: {
               device: Device;
-              type?: typeof undefined;
+              type?: never;
           };
       };
 

--- a/packages/connect-common/src/types/api/bitcoin/index.ts
+++ b/packages/connect-common/src/types/api/bitcoin/index.ts
@@ -28,7 +28,7 @@ export type RefTransaction =
           version: number;
           inputs: PROTO.PrevInput[];
           bin_outputs: PROTO.TxOutputBinType[];
-          outputs?: typeof undefined;
+          outputs?: never;
           lock_time: number;
           extra_data?: string;
           expiry?: number;
@@ -41,7 +41,7 @@ export type RefTransaction =
           hash: string;
           version: number;
           inputs: PROTO.TxInput[];
-          bin_outputs?: typeof undefined;
+          bin_outputs?: never;
           outputs: PROTO.TxOutputType[];
           lock_time: number;
           extra_data?: string;

--- a/packages/connect-common/src/types/device.ts
+++ b/packages/connect-common/src/types/device.ts
@@ -149,7 +149,7 @@ export type KnownDevice = BaseDevice & {
 
     /** @deprecated, use features.label instead */
     label: string;
-    error?: typeof undefined;
+    error?: never;
     firmware: DeviceFirmwareStatus;
     firmwareReleaseConfigInfo?: FirmwareReleaseConfigInfo | null;
     firmwareType?: FirmwareType;
@@ -176,19 +176,19 @@ export type UnknownDevice = BaseDevice & {
     type: 'unacquired';
     /** @deprecated, use features.label instead */
     label: 'Unacquired device';
-    id?: typeof undefined;
-    error?: typeof undefined;
-    features?: typeof undefined;
+    id?: never;
+    error?: never;
+    features?: never;
     thp?: DeviceThpState;
-    firmware?: typeof undefined;
-    firmwareReleaseConfigInfo?: typeof undefined;
-    firmwareType?: typeof undefined;
-    color?: typeof undefined;
+    firmware?: never;
+    firmwareReleaseConfigInfo?: never;
+    firmwareType?: never;
+    color?: never;
     status?: DeviceStatus;
-    mode?: typeof undefined;
-    state?: typeof undefined;
-    unavailableCapabilities?: typeof undefined;
-    availableTranslations?: typeof undefined;
+    mode?: never;
+    state?: never;
+    unavailableCapabilities?: never;
+    availableTranslations?: never;
     transportSessionOwner?: string;
     hid?: undefined;
 };
@@ -198,18 +198,18 @@ export type UnreadableDevice = BaseDevice & {
     /** @deprecated, use features.label instead */
     label: 'Unreadable device';
     error: string;
-    id?: typeof undefined;
-    features?: typeof undefined;
-    thp?: typeof undefined;
-    firmware?: typeof undefined;
-    firmwareReleaseConfigInfo?: typeof undefined;
-    firmwareType?: typeof undefined;
-    color?: typeof undefined;
-    status?: typeof undefined;
-    mode?: typeof undefined;
-    state?: typeof undefined;
-    unavailableCapabilities?: typeof undefined;
-    availableTranslations?: typeof undefined;
+    id?: never;
+    features?: never;
+    thp?: never;
+    firmware?: never;
+    firmwareReleaseConfigInfo?: never;
+    firmwareType?: never;
+    color?: never;
+    status?: never;
+    mode?: never;
+    state?: never;
+    unavailableCapabilities?: never;
+    availableTranslations?: never;
     transportSessionOwner?: undefined;
     hid: boolean;
 };

--- a/packages/device-authenticity/src/types.ts
+++ b/packages/device-authenticity/src/types.ts
@@ -29,7 +29,7 @@ export type VerifyAuthenticityProofResult =
           valid: true;
           caPubKey?: string;
           rootPubKey: string;
-          error?: typeof undefined;
+          error?: never;
           serialNumber?: string;
       }
     | {

--- a/packages/protobuf/scripts/protobuf-patches/TxInputType.ts
+++ b/packages/protobuf/scripts/protobuf-patches/TxInputType.ts
@@ -30,7 +30,7 @@ export type TxInputType =
           script_type?: InternalInputScriptType;
       })
     | (CommonTxInputType & {
-          address_n?: typeof undefined;
+          address_n?: never;
           script_type: 'EXTERNAL';
           script_pubkey: string;
       });

--- a/packages/protobuf/scripts/protobuf-patches/TxOutputType.ts
+++ b/packages/protobuf/scripts/protobuf-patches/TxOutputType.ts
@@ -9,7 +9,7 @@ export type ChangeOutputScriptType = Exclude<OutputScriptType, 'PAYTOOPRETURN'>;
 export type TxOutputType =
     | {
           address: string;
-          address_n?: typeof undefined;
+          address_n?: never;
           script_type?: 'PAYTOADDRESS';
           amount: UintType;
           multisig?: MultisigRedeemScriptType;
@@ -18,7 +18,7 @@ export type TxOutputType =
           payment_req_index?: number;
       }
     | {
-          address?: typeof undefined;
+          address?: never;
           address_n: number[];
           script_type?: ChangeOutputScriptType;
           amount: UintType;
@@ -28,8 +28,8 @@ export type TxOutputType =
           payment_req_index?: number;
       }
     | {
-          address?: typeof undefined;
-          address_n?: typeof undefined;
+          address?: never;
+          address_n?: never;
           amount: '0' | 0;
           op_return_data: string;
           script_type: 'PAYTOOPRETURN';

--- a/packages/utxo-lib/src/types/coinselect.ts
+++ b/packages/utxo-lib/src/types/coinselect.ts
@@ -74,8 +74,8 @@ export interface CoinSelectSuccess {
 
 export interface CoinSelectFailure {
     fee: number;
-    inputs?: typeof undefined;
-    outputs?: typeof undefined;
+    inputs?: never;
+    outputs?: never;
 }
 
 export type CoinSelectResult = CoinSelectSuccess | CoinSelectFailure;

--- a/packages/utxo-lib/src/types/compose.ts
+++ b/packages/utxo-lib/src/types/compose.ts
@@ -37,14 +37,14 @@ export interface ComposeOutputSendMax {
 
 export interface ComposeOutputSendMaxNoAddress {
     type: 'send-max-noaddress';
-    amount?: typeof undefined;
+    amount?: never;
 }
 
 export interface ComposeOutputOpreturn {
     type: 'opreturn'; // it doesn't need to have address
     dataHex: string;
-    amount?: typeof undefined;
-    address?: typeof undefined;
+    amount?: never;
+    address?: never;
 }
 
 // NOTE: this interface **is not** accepted by ComposeRequest['utxos']


### PR DESCRIPTION
This work was originally motivated by findings during migration to tsdown (https://github.com/trezor/trezor-suite/pull/27239) — tsdown does not correctly emit types for typeof undefined, which surfaced these occurrences as a real problem rather than just a style issue.

## Summary

In discriminated union members, `?: never` correctly expresses "this variant cannot have this field". Using `?: typeof undefined` (equivalent to `?: undefined`) still permits explicit `undefined` assignments and does not aid exhaustive narrowing.

- 47 occurrences replaced with `?: never` across 11 files
- 5 remaining `typeof undefined` uses left intentionally (plain optionals: function parameters, variable annotations, and one `payload: typeof undefined` without `?` in `PopupCloseWindow`)
- No callsite fixups were required — no code assigned `undefined` to any of the now-`never` fields
- Zero new type errors introduced (verified with `tsc --noEmit` on all affected packages)

## Files changed

| File | Types updated |
|------|--------------|
| `packages/connect-common/src/types/device.ts` | `KnownDevice.error`, `UnknownDevice` (11 fields), `UnreadableDevice` (12 fields) |
| `packages/connect-common/src/events/popup.ts` | `PopupEvent` CORE_LOADED variant |
| `packages/connect-common/src/events/ui-request.ts` | `UiRequestWithoutPayload` (3 variants), `UiRequestDeviceAction` (4 variants) |
| `packages/connect-common/src/types/api/bitcoin/index.ts` | `RefTransaction` (both variants) |
| `packages/device-authenticity/src/types.ts` | `VerifyAuthenticityProofResult` valid=true variant |
| `packages/utxo-lib/src/types/compose.ts` | `ComposeOutputSendMaxNoAddress`, `ComposeOutputOpreturn` |
| `packages/utxo-lib/src/types/coinselect.ts` | `CoinSelectFailure` |
| `packages/protobuf/scripts/protobuf-patches/TxInputType.ts` | `TxInputType` external variant |
| `packages/protobuf/scripts/protobuf-patches/TxOutputType.ts` | `TxOutputType` (all 3 variants) |
| `packages/blockchain-link-types/src/responses.ts` | `WithoutPayload` |
| `packages/blockchain-link-types/src/messages.ts` | `Message` TERMINATE variant |

## Out of scope (intentionally left)

- `packages/schema-utils/src/codegen.ts` — string replacement (`/typeof undefined/g`)
- `suite-common/wallet-core/src/discovery/selectDeviceThunk.ts` — plain variable type
- `suite-common/wallet-utils/src/accountUtils.ts` — function parameter
- `packages/suite/src/utils/wallet/accountUtils.ts` — function parameter
- `packages/connect/src/core/index.ts` — plain variable type
- `packages/connect-common/src/events/popup.ts:48` — `payload: typeof undefined` without `?` in `PopupCloseWindow`

## Test plan

- [ ] `yarn nx run-many --target=type-check`
- [ ] `yarn nx run-many --target=test:unit`
- [ ] `yarn nx run-many --target=build:lib`
- [ ] `yarn nx run-many --target=lint:js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/never-discriminated-unions/web/](https://dev.suite.sldev.cz/suite-web/mroz22/never-discriminated-unions/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/never-discriminated-unions&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/never-discriminated-unions&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-20T14:23:03.292Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-20T14:21:44.952Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->