### PR TITLE
chore(eslint): forbid `typeof undefined` in type positions

### DIFF
--- a/packages/connect-common/src/events/popup.ts
+++ b/packages/connect-common/src/events/popup.ts
@@ -45,7 +45,10 @@ export interface PopupClosedMessage {
 
 export interface PopupCloseWindow {
     type: typeof POPUP.CLOSE_WINDOW;
-    payload: typeof undefined;
+    // TODO: This field could be dropped entirely (no construction sites read it),
+    // but the same applies to other payload-less events in this file, so it's
+    // out of scope for this PR.
+    payload?: never;
 }
 
 export type PopupEvent =

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -80,7 +80,7 @@ const createSendCoreMessageWithCallId =
 const selectDevice = ({ deviceList }: CoreContext, methodCallDevice?: DeviceIdentity) => {
     assertDeviceListConnected(deviceList);
 
-    let device: Device | typeof undefined;
+    let device: Device | undefined;
 
     if (methodCallDevice?.state?.staticSessionId) {
         device = deviceList.getDeviceByStaticState(methodCallDevice.state.staticSessionId);

--- a/packages/eslint/src/javascriptConfig.mjs
+++ b/packages/eslint/src/javascriptConfig.mjs
@@ -62,6 +62,11 @@ export const javascriptConfig = [
                     selector:
                         "BinaryExpression[left.type='CallExpression'][left.callee.type='MemberExpression'][left.callee.property.name='indexOf']:matches([operator='>='][right.value=0], [operator='<'][right.value=0], [operator='>'][right.type='UnaryExpression'][right.operator='-'][right.argument.value=1], [operator='==='][right.type='UnaryExpression'][right.operator='-'][right.argument.value=1], [operator='!=='][right.type='UnaryExpression'][right.operator='-'][right.argument.value=1], [operator='=='][right.type='UnaryExpression'][right.operator='-'][right.argument.value=1], [operator='!='][right.type='UnaryExpression'][right.operator='-'][right.argument.value=1])",
                 },
+                {
+                    selector: "TSTypeQuery > Identifier[name='undefined']",
+                    message:
+                        'Use `undefined` (or `never` in discriminated unions) instead of `typeof undefined` in type position.',
+                },
             ],
             'object-shorthand': [
                 'error',

--- a/packages/suite/src/utils/wallet/accountUtils.ts
+++ b/packages/suite/src/utils/wallet/accountUtils.ts
@@ -4,7 +4,7 @@ import { type StaticSessionId } from '@trezor/connect';
 import { type WalletParams } from 'src/types/wallet';
 
 export const getSelectedAccount = (
-    deviceState: StaticSessionId | typeof undefined,
+    deviceState: StaticSessionId | undefined,
     accounts: Account[],
     routerParams: WalletParams | undefined,
 ) => {

--- a/suite-common/wallet-core/src/discovery/selectDeviceThunk.ts
+++ b/suite-common/wallet-core/src/discovery/selectDeviceThunk.ts
@@ -26,7 +26,7 @@ export const selectDeviceThunk = createThunk<
 >(
     `${DEVICE_MODULE_PREFIX}/selectDevice`,
     ({ device }, { dispatch, getState, fulfillWithValue }) => {
-        let trezorDevice: TrezorDevice | typeof undefined;
+        let trezorDevice: TrezorDevice | undefined;
         const devices = selectDevices(getState());
         if (device) {
             // "ts" is one of the field which distinguish Device from TrezorDevice

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -353,7 +353,7 @@ export const findAccountDevice = (account: Account, devices: TrezorDevice[]) =>
     devices.find(d => d.state?.staticSessionId === account.deviceState);
 
 export const getAllAccounts = (
-    deviceState: DeviceState | StaticSessionId | typeof undefined,
+    deviceState: DeviceState | StaticSessionId | undefined,
     accounts: Account[],
 ) => {
     if (!deviceState) return [];


### PR DESCRIPTION
## Summary

Stacked on top of #27890 (replace `typeof undefined` with `never` in discriminated unions).

- Adds a `no-restricted-syntax` selector that bans `typeof undefined` in TypeScript type positions — merged into the existing selector array in `packages/eslint/src/javascriptConfig.mjs`, not duplicated
- Uses `TSTypeQuery > Identifier[name='undefined']` which is a TypeScript-only AST node, so it naturally scopes to `.ts`/`.tsx` files with no extra `files:` filter needed
- Cleans up the 5 remaining plain-optional `typeof undefined` occurrences left by the previous PR (function params + variable annotations)

The only surviving `typeof undefined` in the codebase after this PR is a string-replacement regex in `packages/schema-utils/src/codegen.ts`, which is not a type annotation and is unaffected by `TSTypeQuery`.

## Files changed

| File | Change |
|------|--------|
| `packages/eslint/src/javascriptConfig.mjs` | New selector merged into existing `no-restricted-syntax` array |
| `packages/connect-common/src/events/popup.ts` | `PopupCloseWindow.payload: typeof undefined` → `payload?: never` |
| `packages/connect/src/core/index.ts` | variable annotation `typeof undefined` → `undefined` |
| `suite-common/wallet-core/src/discovery/selectDeviceThunk.ts` | variable annotation `typeof undefined` → `undefined` |
| `suite-common/wallet-utils/src/accountUtils.ts` | function param `typeof undefined` → `undefined` |
| `packages/suite/src/utils/wallet/accountUtils.ts` | function param `typeof undefined` → `undefined` |

## Verification

- Rule fires on `type X = { x?: typeof undefined }` with message "Use `undefined` (or `never` in discriminated unions) instead of `typeof undefined` in type position." ✓
- Rule does NOT fire on `if (typeof x === 'undefined')` (runtime `UnaryExpression`, not `TSTypeQuery`) ✓
- No files in the repo contain `typeof undefined` in a TypeScript type position after this PR ✓

## Test plan

- [ ] `yarn nx run-many --target=lint:js`
- [ ] `yarn nx run-many --target=type-check`
- [ ] `yarn nx run-many --target=test:unit`
- [ ] `yarn nx run-many --target=build:lib`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/eslint-forbid-typeof-undefined&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/eslint-forbid-typeof-undefined&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/eslint-forbid-typeof-undefined&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-20T14:23:23.621Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-20T14:21:59.901Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/eslint-forbid-typeof-undefined/web/](https://dev.suite.sldev.cz/suite-web/mroz22/eslint-forbid-typeof-undefined/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->