### PR TITLE
refactor(address-validator): convert (x && x.y) checks to optional chaining

### DIFF
--- a/packages/address-validator/src/bitcoin_validator.ts
+++ b/packages/address-validator/src/bitcoin_validator.ts
@@ -110,7 +110,7 @@ function isValidPayToWitnessScriptHashAddress(
         const hrp = currency.segwitHrp[networkType];
         const decoded = bech32.decode(hrp, address);
 
-        return !!(decoded && decoded.version === 0 && decoded.program.length === 32);
+        return !!(decoded?.version === 0 && decoded.program.length === 32);
     } catch {
         return false;
     }
@@ -125,7 +125,7 @@ function isValidPayToWitnessPublicKeyHashAddress(
         const hrp = currency.segwitHrp[networkType];
         const decoded = bech32.decode(hrp, address);
 
-        return !!(decoded && decoded.version === 0 && decoded.program.length === 20);
+        return !!(decoded?.version === 0 && decoded.program.length === 20);
     } catch {
         return false;
     }
@@ -136,7 +136,7 @@ function isValidPayToTaprootAddress(address: string, currency: any, networkType:
         const hrp = currency.segwitHrp[networkType];
         const decoded = bech32.decode(hrp, address, true);
 
-        return !!(decoded && decoded.version === 1 && decoded.program.length === 32);
+        return !!(decoded?.version === 1 && decoded.program.length === 32);
     } catch {
         return false;
     }

--- a/packages/address-validator/src/crypto/bech32.ts
+++ b/packages/address-validator/src/crypto/bech32.ts
@@ -49,7 +49,7 @@ export function decode(hrp: string, addr: string, m = false): Bech32Decoded | nu
     } catch {
         return null;
     }
-    if (dec === null || dec.prefix !== hrp || dec.words.length < 1 || dec.words[0] > 16) {
+    if (dec?.prefix !== hrp || dec.words.length < 1 || dec.words[0] > 16) {
         return null;
     }
     const res = convertbits(dec.words.slice(1), 5, 8, false);

--- a/packages/address-validator/src/index.ts
+++ b/packages/address-validator/src/index.ts
@@ -13,7 +13,7 @@ export function validate(
 ): boolean {
     const currency = currencies.getByNameOrSymbol(currencyNameOrSymbol || DEFAULT_CURRENCY_NAME);
 
-    if (currency && currency.validator) {
+    if (currency?.validator) {
         return currency.validator.isValidAddress(address, currency, networkType);
     }
 
@@ -26,7 +26,7 @@ export function getAddressType(
     networkType?: string,
 ): AddressType | undefined {
     const currency = currencies.getByNameOrSymbol(currencyNameOrSymbol || DEFAULT_CURRENCY_NAME);
-    if (!currency || !currency.validator) {
+    if (!currency?.validator) {
         throw new Error('getAddressType: No validator for currency: ' + currencyNameOrSymbol);
     }
     if (currency.validator.getAddressType) {


### PR DESCRIPTION
## Summary

Part of a series splitting parent PR #27834 (`mroz22/prefer-optional-chain`) into per-package PRs so each is reviewable on its own. See the parent PR for the full rationale, scope, and behavioural notes. This PR contains only the `packages/address-validator` portion.

Converts redundant `x && x.y` guards to optional chaining (`x?.y`). No semantic changes outside the well-known difference: optional chaining returns `undefined` for the missing case, where `&&` returns the falsy operand itself. All edits inspected; none rely on the falsy-but-defined value.

The original combined branch also enables `@typescript-eslint/prefer-optional-chain` in the eslint config and includes the resulting autofixes. Those will land in a final PR after all per-package PRs are merged.

## Sibling PRs in this series
- #27892 — `packages/address-validator`
- #27893 — `packages/blockchain-link`
- #27894 — `packages/connect-web`
- #27895 — `packages/utxo-lib`
- #27896 — `packages/connect-explorer`
- _more to follow for the remaining packages_

## Test plan
- [ ] CI green