### PR TITLE
refactor(blockchain-link): convert (x && x.y) checks to optional chaining

### DIFF
--- a/packages/blockchain-link/src/workers/ripple/index.ts
+++ b/packages/blockchain-link/src/workers/ripple/index.ts
@@ -546,7 +546,7 @@ class RippleWorker extends BaseWorker<Client> {
     }
 
     async onPing() {
-        if (!this.api || !this.api.isConnected()) return;
+        if (!this.api?.isConnected()) return;
 
         if (this.state.hasSubscriptions() || this.settings.keepAlive) {
             try {

--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -93,7 +93,7 @@ const fetchTransactionPage = async (
     ).filter(nonNullable);
 
 const isValidTransaction = (tx: ParsedTransactionWithMeta): tx is SolanaValidParsedTxWithMeta =>
-    !!(tx && tx.meta && tx.transaction && tx.blockTime);
+    !!(tx?.meta && tx.transaction && tx.blockTime);
 
 const pushTransaction = async (request: Request<MessageTypes.PushTransaction>) => {
     const rawTx = request.payload.hex.startsWith('0x')


### PR DESCRIPTION
## Summary

Part of a series splitting parent PR #27834 (`mroz22/prefer-optional-chain`) into per-package PRs so each is reviewable on its own. See the parent PR for the full rationale, scope, and behavioural notes. This PR contains only the `packages/blockchain-link` portion.

Converts redundant `x && x.y` guards to optional chaining (`x?.y`). No semantic changes outside the well-known difference: optional chaining returns `undefined` for the missing case, where `&&` returns the falsy operand itself. All edits inspected; none rely on the falsy-but-defined value.

The original combined branch also enables `@typescript-eslint/prefer-optional-chain` in the eslint config and includes the resulting autofixes. Those will land in a final PR after all per-package PRs are merged.

## Sibling PRs in this series
- #27892 — `packages/address-validator`
- #27893 — `packages/blockchain-link`
- #27894 — `packages/connect-web`
- #27895 — `packages/utxo-lib`
- #27896 — `packages/connect-explorer`
- _more to follow for the remaining packages_

## Test plan
- [ ] CI green