### PR TITLE
refactor(connect-web): convert (x && x.y) checks to optional chaining

### DIFF
--- a/packages/connect-web/src/bootstrap/bootstrap.ts
+++ b/packages/connect-web/src/bootstrap/bootstrap.ts
@@ -195,7 +195,7 @@ const startForwarding = (broadcast: BroadcastChannel, owner: Window, ownerOrigin
 
     const onBroadcastMessage = (event: MessageEvent): void => {
         const channel = event.data?.channel;
-        if (!channel || channel.here !== PEERS.POPUP || channel.peer !== PEERS.WEB) {
+        if (channel?.here !== PEERS.POPUP || channel.peer !== PEERS.WEB) {
             return;
         }
 
@@ -210,7 +210,7 @@ const startForwarding = (broadcast: BroadcastChannel, owner: Window, ownerOrigin
         }
 
         const channel = event.data?.channel;
-        if (!channel || channel.here !== PEERS.WEB || channel.peer !== PEERS.POPUP) {
+        if (channel?.here !== PEERS.WEB || channel.peer !== PEERS.POPUP) {
             return;
         }
 

--- a/packages/connect-web/src/impl/core-in-suite-web.ts
+++ b/packages/connect-web/src/impl/core-in-suite-web.ts
@@ -124,7 +124,7 @@ export class CoreInSuiteWeb implements ConnectImpl {
             if (!response?.payload) {
                 throw ERRORS.TypedError('Method_NoResponse');
             }
-            if (response.payload.error && response.payload.error.code) {
+            if (response.payload.error?.code) {
                 throw response.payload.error;
             }
 


### PR DESCRIPTION
## Summary

Part of a series splitting parent PR #27834 (`mroz22/prefer-optional-chain`) into per-package PRs so each is reviewable on its own. See the parent PR for the full rationale, scope, and behavioural notes. This PR contains only the `packages/connect-web` portion.

Converts redundant `x && x.y` guards to optional chaining (`x?.y`). No semantic changes outside the well-known difference: optional chaining returns `undefined` for the missing case, where `&&` returns the falsy operand itself. All edits inspected; none rely on the falsy-but-defined value.

The original combined branch also enables `@typescript-eslint/prefer-optional-chain` in the eslint config and includes the resulting autofixes. Those will land in a final PR after all per-package PRs are merged.

## Sibling PRs in this series
- #27892 — `packages/address-validator`
- #27893 — `packages/blockchain-link`
- #27894 — `packages/connect-web`
- #27895 — `packages/utxo-lib`
- #27896 — `packages/connect-explorer`
- _more to follow for the remaining packages_

## Test plan
- [ ] CI green