### PR TITLE
refactor(utxo-lib): convert (x && x.y) checks to optional chaining

### DIFF
--- a/packages/utxo-lib/src/coinselect/coinselectUtils.ts
+++ b/packages/utxo-lib/src/coinselect/coinselectUtils.ts
@@ -202,7 +202,7 @@ function getDogeFee(
 
     // find all outputs below dust limit
     const limit = new BN(dustThreshold);
-    const dustOutputsCount = outputs.filter(({ value }) => value && value.lt(limit)).length;
+    const dustOutputsCount = outputs.filter(({ value }) => value?.lt(limit)).length;
 
     // increase for every output below dustThreshold
     return fee + dustOutputsCount * dustThreshold;

--- a/packages/utxo-lib/src/payments/p2sh.ts
+++ b/packages/utxo-lib/src/payments/p2sh.ts
@@ -62,7 +62,7 @@ export function p2sh(a: Payment, opts?: PaymentOpts): Payment {
 
     let { network } = a;
     if (!network) {
-        network = (a.redeem && a.redeem.network) || BITCOIN_NETWORK;
+        network = a.redeem?.network || BITCOIN_NETWORK;
     }
 
     const o: Payment = { name: 'p2sh', network };
@@ -92,7 +92,7 @@ export function p2sh(a: Payment, opts?: PaymentOpts): Payment {
         // in order of least effort
         if (a.output) return a.output.subarray(2, 22);
         if (a.address) return _address().hash;
-        if (o.redeem && o.redeem.output) return bcrypto.hash160(o.redeem.output);
+        if (o.redeem?.output) return bcrypto.hash160(o.redeem.output);
     });
     lazy.prop(o, 'output', () => {
         if (!o.hash) return;
@@ -107,19 +107,19 @@ export function p2sh(a: Payment, opts?: PaymentOpts): Payment {
         return _redeem();
     });
     lazy.prop(o, 'input', () => {
-        if (!a.redeem || !a.redeem.input || !a.redeem.output) return;
+        if (!a.redeem?.input || !a.redeem.output) return;
 
         return bscript.compile(
             ([] as Stack).concat(bscript.decompile(a.redeem.input) as Stack, a.redeem.output),
         );
     });
     lazy.prop(o, 'witness', () => {
-        if (o.redeem && o.redeem.witness) return o.redeem.witness;
+        if (o.redeem?.witness) return o.redeem.witness;
         if (o.input) return [];
     });
     lazy.prop(o, 'name', () => {
         const nameParts = ['p2sh'];
-        if (o.redeem !== undefined && o.redeem.name !== undefined) nameParts.push(o.redeem.name!);
+        if (o.redeem?.name !== undefined) nameParts.push(o.redeem.name!);
 
         return nameParts.join('-');
     });
@@ -203,7 +203,7 @@ export function p2sh(a: Payment, opts?: PaymentOpts): Payment {
         }
 
         if (a.witness) {
-            if (a.redeem && a.redeem.witness && !stacksEqual(a.redeem.witness, a.witness))
+            if (a.redeem?.witness && !stacksEqual(a.redeem.witness, a.witness))
                 throw new TypeError('Witness and redeem.witness mismatch');
         }
     }

--- a/packages/utxo-lib/src/payments/p2wsh.ts
+++ b/packages/utxo-lib/src/payments/p2wsh.ts
@@ -79,7 +79,7 @@ export function p2wsh(a: Payment, opts?: PaymentOpts): Payment {
 
     let { network } = a;
     if (!network) {
-        network = (a.redeem && a.redeem.network) || BITCOIN_NETWORK;
+        network = a.redeem?.network || BITCOIN_NETWORK;
     }
 
     const o: Payment = { name: 'p2wsh', network };
@@ -94,7 +94,7 @@ export function p2wsh(a: Payment, opts?: PaymentOpts): Payment {
     lazy.prop(o, 'hash', () => {
         if (a.output) return a.output.subarray(2);
         if (a.address) return _address().data;
-        if (o.redeem && o.redeem.output) return bcrypto.sha256(o.redeem.output);
+        if (o.redeem?.output) return bcrypto.sha256(o.redeem.output);
     });
     lazy.prop(o, 'output', () => {
         if (!o.hash) return;
@@ -118,8 +118,7 @@ export function p2wsh(a: Payment, opts?: PaymentOpts): Payment {
     lazy.prop(o, 'witness', () => {
         // transform redeem input to witness stack?
         if (
-            a.redeem &&
-            a.redeem.input &&
+            a.redeem?.input &&
             a.redeem.input.length > 0 &&
             a.redeem.output &&
             a.redeem.output.length > 0
@@ -141,7 +140,7 @@ export function p2wsh(a: Payment, opts?: PaymentOpts): Payment {
     });
     lazy.prop(o, 'name', () => {
         const nameParts = ['p2wsh'];
-        if (o.redeem !== undefined && o.redeem.name !== undefined) nameParts.push(o.redeem.name!);
+        if (o.redeem?.name !== undefined) nameParts.push(o.redeem.name!);
 
         return nameParts.join('-');
     });
@@ -210,7 +209,7 @@ export function p2wsh(a: Payment, opts?: PaymentOpts): Payment {
 
         if (a.witness && a.witness.length > 0) {
             const wScript = a.witness[a.witness.length - 1];
-            if (a.redeem && a.redeem.output && !a.redeem.output.equals(wScript))
+            if (a.redeem?.output && !a.redeem.output.equals(wScript))
                 throw new TypeError('Witness and redeem.output mismatch');
             if (
                 a.witness.some(chunkHasUncompressedPubkey) ||


### PR DESCRIPTION
## Summary

Part of a series splitting parent PR #27834 (`mroz22/prefer-optional-chain`) into per-package PRs so each is reviewable on its own. See the parent PR for the full rationale, scope, and behavioural notes. This PR contains only the `packages/utxo-lib` portion.

Converts redundant `x && x.y` guards to optional chaining (`x?.y`). No semantic changes outside the well-known difference: optional chaining returns `undefined` for the missing case, where `&&` returns the falsy operand itself. All edits inspected; none rely on the falsy-but-defined value.

The original combined branch also enables `@typescript-eslint/prefer-optional-chain` in the eslint config and includes the resulting autofixes. Those will land in a final PR after all per-package PRs are merged.

## Sibling PRs in this series
- #27892 — `packages/address-validator`
- #27893 — `packages/blockchain-link`
- #27894 — `packages/connect-web`
- #27895 — `packages/utxo-lib`
- #27896 — `packages/connect-explorer`
- _more to follow for the remaining packages_

## Test plan
- [ ] CI green