### PR TITLE
refactor(connect-explorer): convert (x && x.y) checks to optional chaining

### DIFF
--- a/packages/connect-explorer/src/reducers/methodCommon.ts
+++ b/packages/connect-explorer/src/reducers/methodCommon.ts
@@ -166,7 +166,7 @@ export const setAffectedValues = (state: MethodState, field: Field<unknown>) => 
     if (!field.affect) return field;
 
     const data = field.data?.find(d => d.value === field.value);
-    if (data && data.affectedValue) {
+    if (data?.affectedValue) {
         const affectedFieldNames = !Array.isArray(field.affect) ? [field.affect] : field.affect;
         const values = !Array.isArray(data.affectedValue)
             ? [data.affectedValue]

--- a/packages/connect-explorer/src/reducers/methodReducer.ts
+++ b/packages/connect-explorer/src/reducers/methodReducer.ts
@@ -64,7 +64,7 @@ const onFieldChange = (state: MethodState, _field: Field<any>, value: any) => {
 const onAddBatch = (state: MethodState, _field: Field<any>, item: any) => {
     const newState = JSON.parse(JSON.stringify(state));
     const field = findField(newState, _field);
-    if (!field || field.type !== 'array') return state;
+    if (field?.type !== 'array') return state;
     field.items = [...field.items, item];
     prepareBundle(field);
 
@@ -74,12 +74,12 @@ const onAddBatch = (state: MethodState, _field: Field<any>, item: any) => {
 // Remove batch
 const onRemoveBatch = (state: MethodState, _field: Field<any>, _batch: any) => {
     const field = findField(state, _field);
-    if (!field || field.type !== 'array') return state;
+    if (field?.type !== 'array') return state;
     const items = field?.items?.filter(batch => batch !== _batch);
 
     const newState = JSON.parse(JSON.stringify(state));
     const newField = findField(newState, field);
-    if (!newField || newField.type !== 'array') return state;
+    if (newField?.type !== 'array') return state;
 
     newField.items = items;
     prepareBundle(newField);
@@ -91,7 +91,7 @@ const onRemoveBatch = (state: MethodState, _field: Field<any>, _batch: any) => {
 const onSetUnion = (state: MethodState, _field: Field<any>, current: any) => {
     const newState = JSON.parse(JSON.stringify(state));
     const field = findField(newState, _field);
-    if (!field || field.type !== 'union') return state;
+    if (field?.type !== 'union') return state;
     field.current = current;
     prepareBundle(field);
 


### PR DESCRIPTION
## Summary

Part of a series splitting parent PR #27834 (`mroz22/prefer-optional-chain`) into per-package PRs so each is reviewable on its own. See the parent PR for the full rationale, scope, and behavioural notes. This PR contains only the `packages/connect-explorer` portion.

Converts redundant `x && x.y` guards to optional chaining (`x?.y`). No semantic changes outside the well-known difference: optional chaining returns `undefined` for the missing case, where `&&` returns the falsy operand itself. All edits inspected; none rely on the falsy-but-defined value.

The original combined branch also enables `@typescript-eslint/prefer-optional-chain` in the eslint config and includes the resulting autofixes. Those will land in a final PR after all per-package PRs are merged.

## Sibling PRs in this series
- #27892 — `packages/address-validator`
- #27893 — `packages/blockchain-link`
- #27894 — `packages/connect-web`
- #27895 — `packages/utxo-lib`
- #27896 — `packages/connect-explorer`
- _more to follow for the remaining packages_

## Test plan
- [ ] CI green