### PR TITLE
perf(wallet-core): refetch only descriptor-matched account on tx notification

### DIFF
--- a/packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts
@@ -575,7 +575,7 @@ export const onNotification = [
         getAccountInfo: 0,
     },
     {
-        description: 'pending btc tx, multiple accounts update',
+        description: 'pending btc tx, only matched account refetched',
         initialState: {
             accounts: [
                 DEFAULT_ACCOUNT,
@@ -590,10 +590,10 @@ export const onNotification = [
         actions: [
             { type: notificationsActions.addEvent.type, payload: { formattedAmount: '0.001 BTC' } },
         ],
-        getAccountInfo: 3,
+        getAccountInfo: 1,
     },
     {
-        description: 'pending token tx, one account update',
+        description: 'pending token tx, only matched account refetched',
         initialState: {
             accounts: [
                 { ...DEFAULT_ACCOUNT, symbol: 'eth', networkType: 'ethereum' },
@@ -613,10 +613,10 @@ export const onNotification = [
                 payload: { formattedAmount: '0.001 erc20' },
             },
         ],
-        getAccountInfo: 2,
+        getAccountInfo: 1,
     },
     {
-        description: 'sent btc, multiple accounts update',
+        description: 'sent btc, only matched account refetched',
         initialState: {
             accounts: [
                 DEFAULT_ACCOUNT,
@@ -629,10 +629,10 @@ export const onNotification = [
             coin: { shortcut: 'btc' },
         },
         actions: [],
-        getAccountInfo: 3,
+        getAccountInfo: 1,
     },
     {
-        description: 'sent eth, one account update',
+        description: 'sent eth, only matched account refetched',
         initialState: {
             accounts: [
                 { ...DEFAULT_ACCOUNT, symbol: 'eth', networkType: 'ethereum' },
@@ -644,7 +644,7 @@ export const onNotification = [
             coin: { shortcut: 'eth' },
         },
         actions: [],
-        getAccountInfo: 2,
+        getAccountInfo: 1,
     },
     {
         description: 'sent ripple, no account update',

--- a/packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts
@@ -552,7 +552,7 @@ export const onNotification = [
         getAccountInfo: 0,
     },
     {
-        description: 'pending btc tx, multiple accounts update',
+        description: 'pending btc tx, only matched account refetched',
         initialState: {
             accounts: [
                 DEFAULT_ACCOUNT,
@@ -567,10 +567,10 @@ export const onNotification = [
         actions: [
             { type: notificationsActions.addEvent.type, payload: { formattedAmount: '0.001 BTC' } },
         ],
-        getAccountInfo: 3,
+        getAccountInfo: 1,
     },
     {
-        description: 'pending token tx, one account update',
+        description: 'pending token tx, only matched account refetched',
         initialState: {
             accounts: [
                 { ...DEFAULT_ACCOUNT, symbol: 'eth', networkType: 'ethereum' },
@@ -590,10 +590,10 @@ export const onNotification = [
                 payload: { formattedAmount: '0.001 erc20' },
             },
         ],
-        getAccountInfo: 2,
+        getAccountInfo: 1,
     },
     {
-        description: 'sent btc, multiple accounts update',
+        description: 'sent btc, only matched account refetched',
         initialState: {
             accounts: [
                 DEFAULT_ACCOUNT,
@@ -606,10 +606,10 @@ export const onNotification = [
             coin: { shortcut: 'btc' },
         },
         actions: [],
-        getAccountInfo: 3,
+        getAccountInfo: 1,
     },
     {
-        description: 'sent eth, one account update',
+        description: 'sent eth, only matched account refetched',
         initialState: {
             accounts: [
                 { ...DEFAULT_ACCOUNT, symbol: 'eth', networkType: 'ethereum' },
@@ -621,7 +621,7 @@ export const onNotification = [
             coin: { shortcut: 'eth' },
         },
         actions: [],
-        getAccountInfo: 2,
+        getAccountInfo: 1,
     },
     {
         description: 'sent ripple, no account update',

--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
@@ -311,7 +311,7 @@ export const onBlockMinedThunk = createThunk(
 
 export const onBlockchainNotificationThunk = createThunk(
     `${BLOCKCHAIN_MODULE_PREFIX}/onNotificationThunk`,
-    (payload: BlockchainNotification, { dispatch, getState }) => {
+    (payload: BlockchainNotification, { dispatch, getState, extra }) => {
         const { descriptor, tx } = payload.notification;
         const symbol = payload.coin.shortcut.toLowerCase();
         if (!isNetworkSymbol(symbol)) {
@@ -359,9 +359,19 @@ export const onBlockchainNotificationThunk = createThunk(
         // it's pointless to fetch ripple accounts
         // TODO: investigate more how to keep ripple pending tx until they are confirmed/rejected
         // xrpl.js doesn't send "pending" txs in history
-        if (account.networkType !== 'ripple') {
-            dispatch(syncAccountsWithBlockchainThunk(symbol));
-        }
+        if (account.networkType === 'ripple') return;
+
+        // Refetch only descriptor-matched accounts instead of every account on this symbol.
+        // The previous symbol-wide sync caused N getAccountInfo calls per notification for users
+        // with N accounts on the same network, hammering blockbook at ~10k connections.
+        // Periodic background sync still runs on its own timer chain (seeded by
+        // onBlockchainConnectThunk), so unrelated accounts stay up to date.
+        const { selectIsWindowVisible } = extra.selectors;
+        if (!selectIsWindowVisible(getState())) return;
+
+        accounts.forEach(matchedAccount =>
+            dispatch(fetchAndUpdateAccountThunk({ accountKey: matchedAccount.key })),
+        );
     },
 );
 

--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
@@ -306,7 +306,7 @@ export const onBlockMinedThunk = createThunk(
 
 export const onBlockchainNotificationThunk = createThunk(
     `${BLOCKCHAIN_MODULE_PREFIX}/onNotificationThunk`,
-    (payload: BlockchainNotification, { dispatch, getState }) => {
+    (payload: BlockchainNotification, { dispatch, getState, extra }) => {
         const { descriptor, tx } = payload.notification;
         const symbol = payload.coin.shortcut.toLowerCase();
         if (!isNetworkSymbol(symbol)) {
@@ -353,9 +353,19 @@ export const onBlockchainNotificationThunk = createThunk(
         // it's pointless to fetch ripple accounts
         // TODO: investigate more how to keep ripple pending tx until they are confirmed/rejected
         // xrpl.js doesn't send "pending" txs in history
-        if (account.networkType !== 'ripple') {
-            dispatch(syncAccountsWithBlockchainThunk(symbol));
-        }
+        if (account.networkType === 'ripple') return;
+
+        // Refetch only descriptor-matched accounts instead of every account on this symbol.
+        // The previous symbol-wide sync caused N getAccountInfo calls per notification for users
+        // with N accounts on the same network, hammering blockbook at ~10k connections.
+        // Periodic background sync still runs on its own timer chain (seeded by
+        // onBlockchainConnectThunk), so unrelated accounts stay up to date.
+        const { selectIsWindowVisible } = extra.selectors;
+        if (!selectIsWindowVisible(getState())) return;
+
+        accounts.forEach(matchedAccount =>
+            dispatch(fetchAndUpdateAccountThunk({ accountKey: matchedAccount.key })),
+        );
     },
 );
 


### PR DESCRIPTION
## Description

Cut redundant `getAccountInfo` calls back to blockbook in the WebSocket-notification hot path. Currently every notification triggers a refetch of **every** account on the affected network; this PR narrows it to the descriptor-matched account(s) only.

## Problem

`onBlockchainNotificationThunk` in `suite-common/wallet-core/src/blockchain/blockchainThunks.ts` runs each time blockbook pushes a tx that touches a subscribed descriptor. Before this PR, it dispatched `syncAccountsWithBlockchainThunk(symbol)`, which iterates over **all** accounts on that network and calls `fetchAndUpdateAccountThunk` for each. That thunk always issues at least one `getAccountInfo({ details: 'basic' })` call to blockbook even when its internal staleness check (`isAccountOutdated`) ends up returning `false`.

Concretely, a user with N accounts on the same chain pays N `getAccountInfo` calls for every incoming tx notification, even though only one of those accounts is actually affected. The other (N - 1) calls just confirm "no change" and are wasted round-trips.

The existing test fixtures encoded the bug: `pending btc tx, multiple accounts update` set up 3 BTC accounts (only one matching the notification descriptor) and asserted `getAccountInfo` was called 3 times.

## Fix

`onBlockchainNotificationThunk` now dispatches `fetchAndUpdateAccountThunk` only for accounts returned by `findAccountsByDescriptor(descriptor, …)` — i.e. the account(s) actually pointed at by the incoming notification.

Behaviour preserved:

- **Window-visibility gate.** Same `selectIsWindowVisible` check that `syncAccountsWithBlockchainThunk` applied — if the window is hidden, no refetch fires.
- **Ripple early-exit.** Same condition as before; ripple still skips refetch entirely (xrpl.js doesn't send pending txs, see existing TODO).
- **Periodic background sync.** Unaffected. The 60s recursive timer chain is seeded by `onBlockchainConnectThunk` and re-arms itself in `syncAccountsWithBlockchainThunk`; we just don't reset that timer on every notification anymore.
- **Multi-device same-descriptor case.** `findAccountsByDescriptor` returns *all* matched accounts (e.g. same xpub on multiple devices) — the loop still refetches each of them.
- **`details: 'txs'` short-circuit.** `fetchAndUpdateAccountThunk` already short-circuits before the expensive `details: 'txs'` call when `!isAccountOutdated(...) && !pendingTxs.length` — that staleness check is untouched.

## Expected load reduction on blockbook

In the notification-handler hot path, this PR cuts the `getAccountInfo` calls fanned out per arriving tx notification from **N → 1**, where N is the number of accounts the receiving client has on the affected chain (typically 1–5 for retail desktop/web users, larger for EVM-heavy wallets).

| | Before | After |
|---|---|---|
| `getAccountInfo` calls per notification | N | 1 |

The **aggregate** blockbook savings scale with the notification arrival rate (txs landing on subscribed descriptors), not with the size of the active connection pool — most concurrent WS connections aren't receiving a notification at any given moment. So the absolute reduction depends on operational tx activity, which is server-side data and not something this PR can quantify from the client.

What this PR does guarantee: the per-notification ratio above, no behavioural regression, and no path where the new handler issues *more* blockbook calls than the old one.

## What this PR is *not*

- Not a protocol change — no blockbook deploy required.
- Not a change to the `onBlockMinedThunk` path (EVM new-block handler still calls the symbol-wide sync; a separate optimisation, out of scope here).
- Not a change to `fetchAndUpdateAccountThunk`'s internal logic — its `isAccountOutdated` short-circuit was already correct.

## Multi-account transactions (what if the tx touches more than one account?)

Still correct — and still strictly better than before. Blockbook fires **one notification per subscribed descriptor** the tx touched (see `publishNewBlockTxsByAddr` → `sendOnNewTxAddr` in `server/websocket.go`): it iterates the matched descriptors and emits a separate notification for each, each carrying the same tx but addressed to a different `descriptor`.

So for a tx touching two of the user's accounts A and B on the same chain:

| | Before this PR | After this PR |
|---|---|---|
| Notification 1 (descriptor A) | refetch all N accounts on chain | refetch A only |
| Notification 2 (descriptor B) | refetch all N accounts on chain | refetch B only |
| **Total `getAccountInfo` calls** | **2 × N** | **2** |

Each affected account is refetched exactly once — its notification arrives, `findAccountsByDescriptor(descriptor, …)` returns the matched account, the `forEach` refetches it. Unrelated accounts that the tx didn't touch correctly stay quiet.

**Sub-cases verified:**

- **Self-transfer A → B (same chain):** blockbook fires 2 notifications; we refetch A and B once each. ✓
- **One tx touching multiple addresses inside the same xpub** (e.g. xpub-derived addr 0 → xpub-derived addr 1): blockbook fires *one* notification per *descriptor* — the xpub itself, not per derived address — so one refetch for that xpub account. ✓
- **Same descriptor across multiple devices** (rare; same xpub imported twice): `findAccountsByDescriptor` returns both, the `forEach` refetches both — same as previous behaviour. ✓
- **Tx received between two Trezor users:** each side gets its own notification on its own WS connection; independent.

**Not addressed by this PR:** if the same descriptor receives multiple notifications in rapid succession (e.g. mempool → confirmation, or RBF), each still triggers a refetch. `suite-native` already debounces via a 10 s per-account throttle (`shouldRefetchAccount` in `suite-native/blockchain/src/blockchainThunks.ts:23-34`); porting that to desktop/web is a candidate follow-up if blockbook metrics show these patterns are hot.

## Tests

- All 6 `onNotification` fixtures in `packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts` updated: the four multi-account fixtures previously asserted `getAccountInfo: 2` or `3`; they now correctly assert `getAccountInfo: 1`, encoding the matched-only behaviour. Descriptions clarified (`'multiple accounts update'` → `'only matched account refetched'`).
- `yarn workspace @trezor/suite test:unit blockchainActions` — 44/44 pass.
- `yarn workspace @suite-common/wallet-core test:unit blockchain` — 5/5 pass.
- No type-check regressions in `blockchainThunks.ts` or related fixtures (only pre-existing `TS6305` artifact-build noise unrelated to this change).

## suite-native is already fine

`suite-native/blockchain/src/blockchainThunks.ts`'s `onBlockchainNotificationThunk` already fetches only the descriptor-matched account (with extra per-account throttling). The bug only affected the desktop/web path through `suite-common`.

## Test plan

- [ ] CI: type-check, lint, unit tests
- [ ] Smoke: verify on desktop that a received tx still appears in the account list and the receive-toast still fires
- [ ] Optional: verify with multiple accounts on the same network (e.g. two BTC accounts or two ETH accounts) that an incoming tx for one no longer triggers blockbook calls for the other(s) — observable in DevTools network panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect blockchainThunks.ts, a core module managing blockchain connections, subscriptions, and discovery orchestration, plus its unit test fixtures. Since blockchainThunks maps to 121 E2E tests (virtually all of them), only tests that directly exercise blockchain connection, discovery, balance fetching, custom backend configuration, and transaction lifecycle are recommended. The fixture file has no E2E coverage but serves unit tests. The highest-risk areas are discovery completion, custom backend connectivity, and transaction state management.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts`
- `suite-common/wallet-core/src/blockchain/blockchainThunks.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `../../suite/e2e/tests/wallet/discovery.test.ts` — blockchainThunks.ts is core infrastructure for blockchain interactions including discovery. This test directly exercises multi-coin discovery (BTC, ETH, LTC, ETC, BCH, DOGE, XRP, ZEC), checks Redux wallet.discovery state transitions, and validates that discovery completes after page reload — all of which depend on blockchain thunk behavior.
- `../../suite/e2e/tests/wallet/coin-balance.test.ts` — This test verifies account balance display after receiving BTC on regtest, which directly exercises blockchain subscription and balance update flows managed by blockchainThunks. Changes to blockchain thunks could break balance fetching or update propagation.
- `../../suite/e2e/tests/wallet/pending-transactions.test.ts` — This test sends BTC transactions, verifies pending/confirmed status transitions, and checks that mining blocks updates transaction state. blockchainThunks handles blockchain event subscriptions and transaction notifications that drive these state changes.
- `../../suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test configures custom blockbook backends for BTC/ETH and verifies discovery succeeds or fails based on backend connectivity. blockchainThunks manages backend connection logic, making this a direct test of the changed code's connection and discovery paths.
- `../../suite/e2e/tests/settings/electrum.test.ts` — Configures an Electrum backend for RegTest and verifies discovery completes with balance display. blockchainThunks handles backend type switching and connection logic, making this test directly relevant to changes in blockchain connection infrastructure.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `../../suite/e2e/tests/general/wallet-discovery.test.ts` — Tests wallet discovery after ejecting and re-adding a standard wallet, verifying BTC balance visibility. This exercises the discovery flow which is orchestrated through blockchainThunks.
- `../../suite/e2e/tests/settings/coins.test.ts` — Tests enabling/disabling networks, custom backends, and the dashboard empty state when no coins are enabled. Network activation triggers blockchain subscription logic in blockchainThunks.
- `../../suite/e2e/tests/wallet/send-form-regtest.test.ts` — Tests sending transactions on regtest with multiple outputs, locktime, and OP_RETURN — all requiring active blockchain connections managed by blockchainThunks for fee estimation, broadcasting, and pending tx tracking.
- `../../suite/e2e/tests/wallet/send-form-ltc.test.ts` — Tests LTC send with a mocked blockbook backend. The custom backend connection and discovery flow depend on blockchainThunks for establishing and managing the blockchain connection.
- `../../suite/e2e/tests/suite/multiple-sessions.test.ts` — Tests Bridge session management including session stealing and recovery. blockchainThunks may be involved in reconnection logic when sessions are reclaimed, as device reconnection triggers blockchain re-subscription.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts`

_Updated: 2026-05-20T18:02:34.496Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=perf/narrow-notification-refetch&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=perf/narrow-notification-refetch&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=perf/narrow-notification-refetch&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "sol staking,unstake and claim on SOL account" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-26T12:21:29.920Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |

</details>

_Updated: 2026-06-26T12:20:19.544Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/perf/narrow-notification-refetch/web/](https://dev.suite.sldev.cz/suite-web/perf/narrow-notification-refetch/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes touch blockchainThunks.ts, which is core infrastructure for blockchain connections, subscriptions, and wallet discovery. While it maps to 121 tests (indicating it's a broadly shared module), the highest risk is in tests that directly exercise discovery, backend connections, balance updates, and transaction status changes. The fixture file change (blockchainActions.ts) is a unit test fixture with no E2E coverage. The recommended strategy focuses on discovery and blockchain connectivity tests that would directly surface regressions in the thunk logic.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts`
- `suite-common/wallet-core/src/blockchain/blockchainThunks.ts`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/wallet/discovery.test.ts` — blockchainThunks.ts is core infrastructure for wallet discovery. This test explicitly verifies discovery status transitions (starting → complete) and checks that all activated coins have visible balances, directly exercising the blockchain subscription and discovery logic in blockchainThunks.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test configures custom blockbook backends and verifies discovery completes successfully with the dashboard graph visible. blockchainThunks handles blockchain backend connections and subscriptions, making this a direct functional test of the changed code.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — This test verifies account balance updates after receiving BTC on regtest, which requires blockchain subscription and balance refresh logic handled by blockchainThunks. It directly tests real-time balance updating which is a core responsibility of the changed module.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — Tests wallet discovery flow including ejecting and re-adding a standard wallet with balance verification. blockchainThunks manages the blockchain connection lifecycle that discovery depends on.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — Tests custom backend configuration for BTC/ETH including successful connection vs error states. blockchainThunks likely handles backend connection/reconnection logic, so changes could affect how custom backends are connected and errors are surfaced.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — Tests pending transaction display and confirmation status transitions on regtest. blockchainThunks handles blockchain notifications including new transaction and block events that drive pending→confirmed transitions.
- `suite/e2e/tests/settings/electrum.test.ts` — Tests Electrum backend configuration and successful discovery completion. blockchainThunks manages backend type connections, and Electrum is an alternative backend type that exercises different connection paths.
- `suite/e2e/tests/settings/coins.test.ts` — Tests enabling/disabling coin networks and custom backend configuration. blockchainThunks handles subscribing/unsubscribing to blockchain backends when networks are toggled, directly relevant to this test's assertions about discovery and backend indicators.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts`

_Updated: 2026-06-26T12:16:55.987Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->