### PR TITLE
Yield speed up transaction support

### DIFF
--- a/packages/suite/src/actions/wallet/stablecoin-yield/claimMerkleRewardsThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/claimMerkleRewardsThunk.ts
@@ -1,4 +1,4 @@
-import { fromWei, hexToNumberString } from 'web3-utils';
+import { fromWei, hexToNumberString, numberToHex } from 'web3-utils';
 
 import { closeModal, openDeferredModal, preserveModal } from '@suite/modal';
 import { Calldata, asEvmAddress } from '@suite-common/calldata';
@@ -298,7 +298,7 @@ export const claimMerkleRewardsThunk = createThunk(
                         to: unsignedClaimTx.to,
                         chainId: unsignedClaimTx.chainId,
                         value: '0x0',
-                        nonce: unsignedClaimTx.nonce,
+                        nonce: numberToHex(unsignedClaimTx.nonce),
                         data: sanitizeHex(unsignedClaimTx.data),
                         gasLimit: parsedSelectedFee.gasLimit,
                         ...(parsedSelectedFee.type === 'eip1559'

--- a/packages/suite/src/actions/wallet/stablecoin-yield/claimMerkleRewardsThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/claimMerkleRewardsThunk.ts
@@ -209,7 +209,7 @@ export const claimMerkleRewardsThunk = createThunk(
 
         try {
             const sender = asEvmAddress(account.descriptor);
-            const claimResult = Calldata.evm.distributor.claim(
+            const claimResult = Calldata.evm.distributor.claim.encode(
                 {
                     users: rewards.map(() => sender),
                     tokens: rewards.map(reward => asEvmAddress(reward.token.address)),

--- a/packages/suite/src/actions/wallet/stablecoin-yield/composeYieldWithdrawTransaction.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/composeYieldWithdrawTransaction.ts
@@ -69,7 +69,7 @@ export const composeYieldWithdrawTransaction = async ({
     });
 
     const builderResult = isSharesInput
-        ? Calldata.evm.erc4626.redeem(
+        ? Calldata.evm.erc4626.redeem.encode(
               {
                   shares: amountSubunits,
                   receiver: account.descriptor,
@@ -77,7 +77,7 @@ export const composeYieldWithdrawTransaction = async ({
               },
               { sender: ownerAddress },
           )
-        : Calldata.evm.erc4626.withdraw(
+        : Calldata.evm.erc4626.withdraw.encode(
               {
                   assets: amountSubunits,
                   receiver: account.descriptor,

--- a/packages/suite/src/components/earn/yield/common/YieldApproveModal.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldApproveModal.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef } from 'react';
 
 import { events } from '@suite/analytics';
-import { toTokenCryptoId } from '@suite-common/trading';
+import { KNOWN_VAULTS } from '@suite-common/suite-constants';
+import { parseCryptoId, toTokenCryptoId } from '@suite-common/trading';
 import { type Account } from '@suite-common/wallet-types';
 import { getAssetLogoUrl } from '@trezor/asset-utils';
 import { exhaustive } from '@trezor/type-utils';
@@ -10,8 +11,6 @@ import { ApproveModal } from 'src/components/suite/modals/ReduxModal/UserContext
 import { RevokeModal } from 'src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/RevokeModal';
 import { useAllowanceContext } from 'src/hooks/wallet/allowance';
 import { useAnalytics } from 'src/support/useAnalytics';
-
-import { EARN_PROVIDER_METADATA } from '../../providers/providerMetadata';
 
 export type YieldApproveModalProps = {
     amount: string;
@@ -42,11 +41,17 @@ export const YieldApproveModal = ({
     } = useAllowanceContext();
     const handledTxidRef = useRef<string | null>(null);
     const cryptoId = toTokenCryptoId(account.symbol, contractAddress);
+    const { networkId, contractAddress: parsedContract } = parseCryptoId(cryptoId);
+    const vaultName = KNOWN_VAULTS[spender.toLowerCase()];
 
     const provider = {
-        name: EARN_PROVIDER_METADATA.morpho.name,
-        companyName: EARN_PROVIDER_METADATA.morpho.companyName,
-        logo: getAssetLogoUrl({ ...EARN_PROVIDER_METADATA.morpho.tokenLogo, size: 80 }),
+        name: vaultName,
+        companyName: vaultName,
+        logo: getAssetLogoUrl({
+            coingeckoId: networkId,
+            contractAddress: parsedContract,
+            size: 80,
+        }),
         isActive: true,
     };
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/BumpFeeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/BumpFeeModal.tsx
@@ -1,8 +1,8 @@
 import { Translation } from '@suite/intl';
 import { selectTransactionConfirmations } from '@suite-common/wallet-core';
 import {
+    type Account,
     type ChainedTransactions,
-    type SelectedAccountLoaded,
     type WalletAccountTransactionWithRequiredRbfParams,
 } from '@suite-common/wallet-types';
 import { Modal } from '@trezor/components';
@@ -21,7 +21,7 @@ type BumpFeeModalProps = {
     onBackClick: () => void;
     onShowChained: () => void;
     chainedTxs?: ChainedTransactions;
-    selectedAccount: SelectedAccountLoaded;
+    account: Account;
 };
 
 export const BumpFeeModal = ({
@@ -30,10 +30,9 @@ export const BumpFeeModal = ({
     onBackClick,
     onShowChained,
     chainedTxs,
-    selectedAccount,
+    account,
 }: BumpFeeModalProps) => {
-    const { account } = selectedAccount;
-    const contextValues = useRbf({ rbfParams: tx.rbfParams, chainedTxs, selectedAccount });
+    const contextValues = useRbf({ rbfParams: tx.rbfParams, chainedTxs, account });
 
     const confirmations = useSelector(state =>
         selectTransactionConfirmations(state, tx.txid, account.key),
@@ -64,7 +63,7 @@ export const BumpFeeModal = ({
                         networkType={account.networkType}
                     />
                 ) : (
-                    <ChangeFee tx={tx} chainedTxs={chainedTxs} showChained={onShowChained} />
+                    <ChangeFee tx={tx} showChained={onShowChained} />
                 )}
             </TxDetailModalBase>
         </RbfContext.Provider>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ChangeFee.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ChangeFee.tsx
@@ -11,15 +11,14 @@ import { spacings } from '@trezor/theme';
 
 import { BaseCurrencyValue } from 'src/components/suite/BaseCurrencyValue';
 import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
-import { useSelector } from 'src/hooks/suite';
-import { type UseRbfProps, useRbfContext } from 'src/hooks/wallet/useRbfForm';
+import { useRbfContext } from 'src/hooks/wallet/useRbfForm';
 
 import { RbfFees } from './RbfFees';
 import { AffectedTransactions } from '../AffectedTransactions/AffectedTransactions';
 import { DecreasedOutputs } from '../AffectedTransactions/DecreasedOutputs';
 
 /* children are only for test purposes, this prop is not available in regular build */
-interface ChangeFeeProps extends UseRbfProps {
+interface ChangeFeeProps {
     tx: WalletAccountTransaction;
     children?: ReactNode;
     showChained: () => void;
@@ -113,17 +112,10 @@ const ChangeFeeLoaded = (props: ChangeFeeProps) => {
     );
 };
 
-export const ChangeFee = (props: Omit<ChangeFeeProps, 'selectedAccount' | 'rbfParams'>) => {
-    const selectedAccount = useSelector(state => state.wallet.selectedAccount);
-    if (selectedAccount.status !== 'loaded' || !props.tx.rbfParams) {
+export const ChangeFee = (props: ChangeFeeProps) => {
+    if (!props.tx.rbfParams) {
         return null;
     }
 
-    return (
-        <ChangeFeeLoaded
-            selectedAccount={selectedAccount}
-            rbfParams={props.tx.rbfParams}
-            {...props}
-        />
-    );
+    return <ChangeFeeLoaded {...props} />;
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModal.tsx
@@ -76,9 +76,7 @@ export const TxDetailModal = ({
         };
     }, [originalTx, filteredInternalTransfers]);
 
-    const account = useSelector(state => selectAccountByKey(state, accountKey)) as Account;
-    const network = getNetwork(account.symbol);
-    const networkFeatures = network.accountTypes[account.accountType]?.features ?? network.features;
+    const account = useSelector(state => selectAccountByKey(state, accountKey));
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
 
     const transactions = useSelector(selectAllPendingTransactions);
@@ -112,7 +110,7 @@ export const TxDetailModal = ({
         setTab(undefined);
     };
 
-    if (tx === null) {
+    if (tx === null || !account) {
         return (
             <Modal onCancel={onCancel} heading={<Translation id="TR_TRANSACTION_DETAILS" />}>
                 <Translation id="TR_TRANSACTION_NOT_FOUND" />
@@ -120,12 +118,11 @@ export const TxDetailModal = ({
         );
     }
 
+    const network = getNetwork(account.symbol);
+    const networkFeatures = network.accountTypes[account.accountType]?.features ?? network.features;
+
     const canReplaceTransaction =
-        hasRbfParams(tx) &&
-        networkFeatures?.includes('rbf') &&
-        !tx.deadline &&
-        tx.type !== 'joint' &&
-        selectedAccount.status === 'loaded';
+        hasRbfParams(tx) && networkFeatures?.includes('rbf') && !tx.deadline && tx.type !== 'joint';
 
     const canCancelTransaction = network.networkType === 'bitcoin' && tx.type !== 'joint';
 
@@ -137,12 +134,16 @@ export const TxDetailModal = ({
                 onBackClick={onBackClick}
                 onShowChained={onShowChained}
                 chainedTxs={chainedTxs}
-                selectedAccount={selectedAccount}
+                account={account}
             />
         );
     }
 
-    if (section === 'cancel-transaction' && canReplaceTransaction) {
+    if (
+        section === 'cancel-transaction' &&
+        canReplaceTransaction &&
+        selectedAccount.status === 'loaded'
+    ) {
         return (
             <CancelTransactionModal
                 tx={tx}

--- a/packages/suite/src/hooks/wallet/__tests__/useRbfForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/__tests__/useRbfForm.test.tsx
@@ -171,15 +171,16 @@ describe('useRbfForm hook', () => {
             const callback: TestCallback = {};
 
             const TestComponent = () => {
+                const selectedAccount = f.store.selectedAccount as SelectedAccountLoaded;
                 const contextValues = useRbf({
                     rbfParams: f.tx.rbfParams,
                     chainedTxs: f.chainedTxs,
-                    selectedAccount: f.store.selectedAccount as SelectedAccountLoaded,
+                    account: selectedAccount.account,
                 });
 
                 return (
                     <RbfContext.Provider value={contextValues}>
-                        <ChangeFee tx={f.tx} chainedTxs={f.chainedTxs} showChained={() => {}}>
+                        <ChangeFee tx={f.tx} showChained={() => {}}>
                             <Component callback={callback} />
                             <ReplaceTxButton />
                         </ChangeFee>

--- a/packages/suite/src/hooks/wallet/form/useCompose.ts
+++ b/packages/suite/src/hooks/wallet/form/useCompose.ts
@@ -19,8 +19,7 @@ import { type FeeLevel } from '@trezor/connect';
 import { useDebounce } from '@trezor/react-utils';
 
 import { signAndPushSendFormTransactionThunk } from 'src/actions/wallet/send/sendFormThunks';
-import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
+import { useDispatch } from 'src/hooks/suite';
 import { type SendContextValues } from 'src/types/wallet/sendForm';
 
 const DEFAULT_FIELD = 'outputs.0.amount';
@@ -48,7 +47,6 @@ export const useCompose = <TFieldValues extends FormState>({
         useState<SendContextValues['composedLevels']>(undefined);
     const [composeField, setComposeField] = useState<string | undefined>(undefined);
     const { translationString } = useTranslation();
-    const selectedAccount = useSelector(selectSelectedAccount);
 
     const dispatch = useDispatch();
 
@@ -267,7 +265,7 @@ export const useCompose = <TFieldValues extends FormState>({
                 signAndPushSendFormTransactionThunk({
                     formState,
                     precomposedTransaction,
-                    selectedAccount,
+                    selectedAccount: state.account,
                 }),
             ).unwrap();
 

--- a/packages/suite/src/hooks/wallet/useRbfForm.ts
+++ b/packages/suite/src/hooks/wallet/useRbfForm.ts
@@ -1,6 +1,7 @@
 import { createContext, useContext, useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 
+import { getNetwork } from '@suite-common/wallet-config';
 import {
     DEFAULT_OPRETURN,
     DEFAULT_PAYMENT,
@@ -9,6 +10,7 @@ import {
 } from '@suite-common/wallet-constants';
 import { DEFAULT_FEE_INFO, selectRawNetworkFeeInfo } from '@suite-common/wallet-core';
 import {
+    type Account,
     type ChainedTransactions,
     type FeeInfo,
     type FormOptions,
@@ -16,7 +18,6 @@ import {
     type RbfTransactionParams,
     type RbfTransactionParamsBitcoin,
     type RbfTransactionParamsEthereum,
-    type SelectedAccountLoaded,
 } from '@suite-common/wallet-types';
 import {
     calculateChainedTransactionsFeeForRbf,
@@ -36,7 +37,7 @@ import { useBitcoinAmountUnit } from './useBitcoinAmountUnit';
 const MIN_FEE_RATE_PER_VB = 1; // minimum fee rate in sat/vB, introduced because nodes lowered min relay tx fee, but not incremental fee
 
 export type UseRbfProps = {
-    selectedAccount: SelectedAccountLoaded;
+    account: Account;
     rbfParams: RbfTransactionParams;
     chainedTxs?: ChainedTransactions;
 };
@@ -125,14 +126,13 @@ const getRbfFeeInfo = (info: FeeInfo, rbfParams: RbfTransactionParams) => {
     return info;
 };
 
-const useRbfState = ({ selectedAccount, rbfParams, chainedTxs }: UseRbfProps) => {
-    const { account, network } = selectedAccount;
-
+const useRbfState = ({ account, rbfParams, chainedTxs }: UseRbfProps) => {
     const networkFees = useSelector(state => selectRawNetworkFeeInfo(state, account.symbol));
     const targetAnonymity = useSelector(selectCurrentTargetAnonymity);
     const coinjoinRegisteredUtxos = useCoinjoinRegisteredUtxos({ account });
 
     const { shouldSendInSats } = useBitcoinAmountUnit(account.symbol);
+    const network = getNetwork(account.symbol);
 
     return useMemo(() => {
         const rbfFeeInfo = networkFees ? getRbfFeeInfo(networkFees, rbfParams) : DEFAULT_FEE_INFO;

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingApproveModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingApproveModal.tsx
@@ -3,7 +3,7 @@ import { useCallback, useMemo } from 'react';
 import { type CryptoId, type DexApprovalType } from 'invity-api';
 
 import { events } from '@suite/analytics';
-import { getEvmApprovalTxData } from '@suite-common/wallet-utils';
+import { Calldata } from '@suite-common/calldata';
 import { useCurrentRef } from '@trezor/react-utils';
 
 import { ApproveModal } from 'src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModal';
@@ -91,7 +91,7 @@ export const TradingApproveModal = ({ amount, cryptoId }: TradingApproveModalPro
         const exchange = selectedQuote?.exchange;
         const provider = exchange ? providersInfo?.[exchange] : null;
 
-        const approvalData = getEvmApprovalTxData(selectedQuote?.dexTx?.data);
+        const approvalData = Calldata.evm.erc20.approve.decode(selectedQuote?.dexTx?.data);
         const spender = approvalData?.spender ?? null;
 
         return provider && spender ? { provider, spender } : null;

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingRevokeModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingRevokeModal.tsx
@@ -3,7 +3,7 @@ import { useCallback, useMemo } from 'react';
 import { type CryptoId } from 'invity-api';
 
 import { events } from '@suite/analytics';
-import { getEvmApprovalTxData } from '@suite-common/wallet-utils';
+import { Calldata } from '@suite-common/calldata';
 
 import { RevokeModal } from 'src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/RevokeModal';
 import { useAllowanceContext } from 'src/hooks/wallet/allowance';
@@ -67,7 +67,7 @@ export const TradingRevokeModal = ({ cryptoId }: TradingRevokeModalProps) => {
         const provider = exchange ? providersInfo?.[exchange] : null;
 
         const dexTxData = context.selectedQuote?.dexTx?.data;
-        const approvalData = getEvmApprovalTxData(dexTxData);
+        const approvalData = Calldata.evm.erc20.approve.decode(dexTxData);
         const spender = approvalData?.spender ?? null;
 
         const preapprovedAmount = context.selectedQuote?.preapprovedStringAmount;

--- a/scripts/list-outdated-dependencies/wallet-dependencies.txt
+++ b/scripts/list-outdated-dependencies/wallet-dependencies.txt
@@ -59,7 +59,6 @@ reselect
 toml
 varuint-bitcoin
 wif
-web3-eth-abi
 web3-utils
 worker-loader
 xrpl

--- a/suite-common/calldata/README.md
+++ b/suite-common/calldata/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Type-safe calldata builder and verifier for blockchain transactions. The builder validates inputs, normalizes values, and encodes transaction data. The verifier decodes externally-provided calldata and checks it against expected params. Built with a chain-agnostic core — currently implements EVM using viem.
+Type-safe calldata for blockchain transactions: encoding, decoding, and verification. Chain-agnostic core — currently implements EVM using viem.
 
 ---
 
@@ -14,7 +14,7 @@ Type-safe calldata builder and verifier for blockchain transactions. The builder
 import { Calldata } from '@suite-common/calldata';
 import { BigNumber } from '@trezor/utils';
 
-const result = Calldata.evm.erc20.approve(
+const result = Calldata.evm.erc20.approve.encode(
     {
         spender: '0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE',
         amount: new BigNumber('1000000'),
@@ -177,6 +177,40 @@ export const Calldata = {
     evm: {
         myContract: {
             myMethod: buildMyMethod,
+        },
+    },
+};
+```
+
+---
+
+## Decoder
+
+Decodes calldata to a typed Record of named parameters. Returns `null` for unrecognized selectors or malformed data.
+
+### Usage
+
+```typescript
+import { Calldata } from '@suite-common/calldata';
+
+const decoded = Calldata.evm.erc20.approve.decode(calldata);
+// decoded: { spender: `0x${string}`, amount: bigint } | null
+```
+
+### Adding New Decoders
+
+Add `decode` next to `encode` in the `Calldata` object:
+
+```typescript
+import { createEvmDecoder } from './decoder/evm';
+
+export const Calldata = {
+    evm: {
+        erc20: {
+            approve: {
+                encode: buildApprove,
+                decode: createEvmDecoder(EVM_ABI.erc20.approve),
+            },
         },
     },
 };

--- a/suite-common/calldata/src/calldata.ts
+++ b/suite-common/calldata/src/calldata.ts
@@ -9,31 +9,48 @@ import { buildRedeem } from './builder/evm/redeem';
 import { buildTransfer } from './builder/evm/transfer';
 import { buildWithdraw } from './builder/evm/withdraw';
 import { buildTrc20Transfer } from './builder/tron/trc20/transfer';
+import { EVM_ABI } from './constants/evm';
+import { createEvmDecoder } from './decoder/evm';
 
 export const Calldata = {
     evm: {
         erc20: {
-            allowance: buildAllowance,
-            approve: buildApprove,
-            transfer: buildTransfer,
+            allowance: { encode: buildAllowance },
+            approve: {
+                encode: buildApprove,
+                decode: createEvmDecoder(EVM_ABI.erc20.approve),
+            },
+            transfer: {
+                encode: buildTransfer,
+                decode: createEvmDecoder(EVM_ABI.erc20.transfer),
+            },
         },
         erc4626: {
-            deposit: buildDeposit,
-            withdraw: buildWithdraw,
-            redeem: buildRedeem,
+            deposit: {
+                encode: buildDeposit,
+                decode: createEvmDecoder(EVM_ABI.erc4626.deposit),
+            },
+            withdraw: {
+                encode: buildWithdraw,
+                decode: createEvmDecoder(EVM_ABI.erc4626.withdraw),
+            },
+            redeem: {
+                encode: buildRedeem,
+                decode: createEvmDecoder(EVM_ABI.erc4626.redeem),
+            },
         },
         distributor: {
-            claim: buildClaim,
+            claim: { encode: buildClaim },
         },
         everstake: {
-            stake: buildStake,
-            unstake: buildUnstake,
-            claimWithdrawRequest: buildClaimWithdrawRequest,
+            stake: { encode: buildStake },
+            unstake: { encode: buildUnstake },
+            claimWithdrawRequest: { encode: buildClaimWithdrawRequest },
         },
     },
     tron: {
         trc20: {
-            transfer: buildTrc20Transfer,
+            transfer: { encode: buildTrc20Transfer },
         },
     },
 } as const;

--- a/suite-common/calldata/src/decoder/evm.ts
+++ b/suite-common/calldata/src/decoder/evm.ts
@@ -1,0 +1,51 @@
+import { type Abi, type AbiFunction, decodeFunctionData } from 'viem';
+
+import { type DecodedAbiInputs, type Decoder } from '../types/decoder';
+
+const normalizers: Record<string, (value: unknown) => unknown> = {
+    address: value => (typeof value === 'string' ? value.toLowerCase() : value),
+};
+
+const normalize = (value: unknown, type: string): unknown => {
+    const arrayMatch = type.match(/^(.+?)\[/);
+    if (arrayMatch && Array.isArray(value)) {
+        return value.map(item => normalize(item, arrayMatch[1]));
+    }
+
+    return normalizers[type]?.(value) ?? value;
+};
+
+export const createEvmDecoder = <const T extends Abi>(abi: T): Decoder<T> => {
+    const functions = abi.filter((item): item is AbiFunction => item.type === 'function');
+    if (functions.length === 0) throw new Error('No function in ABI');
+    if (functions.length > 1) throw new Error('ABI must contain exactly one function');
+
+    const fn = functions[0];
+
+    const paramNames = fn.inputs.map(input => {
+        if (!input.name) {
+            throw new Error(`ABI function '${fn.name}' has unnamed parameters`);
+        }
+
+        return input.name;
+    });
+
+    return (data?: string) => {
+        if (!data) return null;
+        const normalized = (
+            data.toLowerCase().startsWith('0x') ? data.toLowerCase() : `0x${data.toLowerCase()}`
+        ) as `0x${string}`;
+        try {
+            const { args } = decodeFunctionData({ abi, data: normalized });
+            const values = (args as readonly unknown[]).map((v, i) =>
+                normalize(v, fn.inputs[i].type),
+            );
+
+            return Object.fromEntries(
+                paramNames.map((name, i) => [name, values[i]]),
+            ) as DecodedAbiInputs<T>;
+        } catch {
+            return null;
+        }
+    };
+};

--- a/suite-common/calldata/src/tests/decoder/evm.test.ts
+++ b/suite-common/calldata/src/tests/decoder/evm.test.ts
@@ -1,0 +1,76 @@
+import { BigNumber } from '@trezor/utils';
+
+import { buildClaim } from '../../builder/evm/claim';
+import { buildTransfer } from '../../builder/evm/transfer';
+import { EVM_ABI } from '../../constants/evm';
+import { createEvmDecoder } from '../../decoder/evm';
+import { asEvmAddress } from '../../types/evm';
+
+const SENDER = asEvmAddress('0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3');
+const RECIPIENT = asEvmAddress('0xB836472D21991eB9842e15BEaE1AF6c8B63D6a96');
+const TOKEN = asEvmAddress('0x58D97B57BB95320F9a05dC918Aef65434969c2B2');
+
+describe('createEvmDecoder', () => {
+    const decode = createEvmDecoder(EVM_ABI.erc20.transfer);
+
+    const VALID_CALLDATA = buildTransfer(
+        { to: RECIPIENT, amount: new BigNumber(1000) },
+        { sender: SENDER },
+    ).data!;
+
+    it('decodes calldata to named params', () => {
+        expect(decode(VALID_CALLDATA)).toEqual({
+            to: RECIPIENT.toLowerCase(),
+            amount: 1000n,
+        });
+    });
+
+    it('returns null when data is undefined', () => {
+        expect(decode(undefined)).toBeNull();
+    });
+
+    it('returns null when data is empty', () => {
+        expect(decode('')).toBeNull();
+    });
+
+    it('returns null when selector does not match', () => {
+        const wrongSelector = '0xdeadbeef' + VALID_CALLDATA.slice(10);
+        expect(decode(wrongSelector)).toBeNull();
+    });
+
+    it('returns null for garbage payload after selector', () => {
+        expect(decode(VALID_CALLDATA.slice(0, 10) + 'ff'.repeat(31))).toBeNull();
+    });
+
+    it('tolerates missing 0x prefix', () => {
+        expect(decode(VALID_CALLDATA.slice(2))).toEqual({
+            to: RECIPIENT.toLowerCase(),
+            amount: 1000n,
+        });
+    });
+
+    it('tolerates uppercase hex', () => {
+        expect(decode(VALID_CALLDATA.toUpperCase())).toEqual({
+            to: RECIPIENT.toLowerCase(),
+            amount: 1000n,
+        });
+    });
+
+    it('lowercases addresses inside address[] params', () => {
+        const arrayDecode = createEvmDecoder(EVM_ABI.distributor.claim);
+        const calldata = buildClaim(
+            {
+                users: [SENDER],
+                tokens: [TOKEN],
+                amounts: [new BigNumber(1)],
+                proofs: [[]],
+            },
+            { sender: SENDER },
+        ).data!;
+
+        expect(arrayDecode(calldata)).toMatchObject({
+            users: [SENDER.toLowerCase()],
+            tokens: [TOKEN.toLowerCase()],
+        });
+    });
+});

--- a/suite-common/calldata/src/types/decoder.ts
+++ b/suite-common/calldata/src/types/decoder.ts
@@ -1,0 +1,15 @@
+import { type Abi, type AbiParameterToPrimitiveType } from 'viem';
+
+import { type ExtractAbiFunction, type NamedAbiParameter } from './abi';
+
+export type DecodedAbiInputs<T extends Abi> =
+    ExtractAbiFunction<T>['inputs'][number] extends infer P
+        ? {
+              [Param in Extract<
+                  P,
+                  NamedAbiParameter
+              > as Param['name']]: AbiParameterToPrimitiveType<Param>;
+          }
+        : never;
+
+export type Decoder<T extends Abi> = (data?: string) => DecodedAbiInputs<T> | null;

--- a/suite-common/staking/src/utils/ethereumStaking.ts
+++ b/suite-common/staking/src/utils/ethereumStaking.ts
@@ -68,7 +68,10 @@ const verifyCalldata = (label: string, result: { isValid: boolean; issues: Verif
 };
 
 export const buildStakeData = () => {
-    const data = encodeCalldata('stake', Calldata.evm.everstake.stake({ source: STAKE_SOURCE }));
+    const data = encodeCalldata(
+        'stake',
+        Calldata.evm.everstake.stake.encode({ source: STAKE_SOURCE }),
+    );
     verifyCalldata('stake', Verifier.evm.everstake.stake(data, { source: STAKE_SOURCE_BIGINT }));
 
     return data;
@@ -77,7 +80,7 @@ export const buildStakeData = () => {
 export const buildUnstakeData = (amountWei: string, interchanges: number) => {
     const data = encodeCalldata(
         'unstake',
-        Calldata.evm.everstake.unstake({
+        Calldata.evm.everstake.unstake.encode({
             value: new BigNumber(amountWei),
             allowedInterchangeNum: new BigNumber(interchanges),
             source: STAKE_SOURCE,
@@ -98,7 +101,7 @@ export const buildUnstakeData = (amountWei: string, interchanges: number) => {
 export const buildClaimWithdrawRequestData = () => {
     const data = encodeCalldata(
         'claimWithdrawRequest',
-        Calldata.evm.everstake.claimWithdrawRequest({}),
+        Calldata.evm.everstake.claimWithdrawRequest.encode({}),
     );
     verifyCalldata('claimWithdrawRequest', Verifier.evm.everstake.claimWithdrawRequest(data, {}));
 

--- a/suite-common/wallet-core/src/accounts/accountsThunks.ts
+++ b/suite-common/wallet-core/src/accounts/accountsThunks.ts
@@ -159,9 +159,24 @@ export const fetchAndUpdateAccountThunk = createThunk(
                 dispatch(transactionsActions.removeTransaction({ account, txs: analyze.remove }));
             }
             if (analyze.add.length > 0) {
+                // Blockbook returns empty tokens for pending contract calls. Copy them
+                // from our fake tx (identified by `deadline`) so RBF on this pending tx still
+                // has token + amount.
+                const enrichedAdd = analyze.add.map(freshTx => {
+                    if ((freshTx.tokens?.length ?? 0) > 0) return freshTx;
+                    const fakeMatch = accountTxs.find(
+                        t =>
+                            t.txid === freshTx.txid &&
+                            'deadline' in t &&
+                            (t.tokens?.length ?? 0) > 0,
+                    );
+
+                    return fakeMatch ? { ...freshTx, tokens: fakeMatch.tokens } : freshTx;
+                });
+
                 dispatch(
                     transactionsActions.addTransaction({
-                        transactions: analyze.add.reverse(),
+                        transactions: enrichedAdd.reverse(),
                         account,
                     }),
                 );

--- a/suite-common/wallet-core/src/allowance/fetchAllowance.ts
+++ b/suite-common/wallet-core/src/allowance/fetchAllowance.ts
@@ -17,7 +17,7 @@ export const fetchAllowance = async ({
     tokenContractAddress,
     coin,
 }: FetchAllowanceParams) => {
-    const allowanceCalldata = Calldata.evm.erc20.allowance({ owner, spender });
+    const allowanceCalldata = Calldata.evm.erc20.allowance.encode({ owner, spender });
 
     if (!allowanceCalldata.data) {
         throw new Error('Allowance calldata could not be built.');

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -25,11 +25,13 @@ import {
     formatNetworkAmount,
     getAccountDecimals,
     getAreSatoshisUsed,
+    getEvmTransactionTextSignature,
     getMevProtectedTxData,
     getPendingAccount,
     hasNetworkFeatures,
     isCardanoTx,
-    isEvmApprovalTx,
+    isEvmApprovalTxByTextSignature,
+    isEvmYieldTxByTextSignature,
     isExchangeTradingForm,
     isMaxAllowance,
     subunitsToUnits,
@@ -697,10 +699,12 @@ export const enhancePrecomposedTransactionThunk = createThunk<
         // Contract calldata (e.g. DEX swap) must not carry `token` on the precomposed object:
         // signing uses prepareEthereumTransaction, which would replace calldata with an ERC-20
         // transfer if `token` is set.
+        const sig = getEvmTransactionTextSignature(formValues.transactionData);
         if (
             selectedAccount.networkType === 'ethereum' &&
             formValues.transactionData &&
-            !isEvmApprovalTx(formValues.transactionData)
+            !isEvmApprovalTxByTextSignature(sig) &&
+            !isEvmYieldTxByTextSignature(sig)
         ) {
             enhancedPrecomposedTransaction = cloneObject(enhancedPrecomposedTransaction);
             delete (enhancedPrecomposedTransaction as { token?: unknown }).token;

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -1,6 +1,7 @@
 import { G } from '@mobily/ts-belt';
 import { isRejected } from '@reduxjs/toolkit';
 
+import { Calldata } from '@suite-common/calldata';
 import { selectSelectedDevice } from '@suite-common/device';
 import { type ActionsFromAsyncThunk, createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
@@ -24,7 +25,6 @@ import {
     formatNetworkAmount,
     getAccountDecimals,
     getAreSatoshisUsed,
-    getEvmApprovalTxData,
     getMevProtectedTxData,
     getPendingAccount,
     hasNetworkFeatures,
@@ -357,21 +357,22 @@ export const pushSendFormTransactionThunk = createThunk<
             : '0';
 
         const areSatoshisUsed = getAreSatoshisUsed(bitcoinAmountUnit, selectedAccount);
-        const evmApprovalData = getEvmApprovalTxData(precomposedForm?.transactionData);
+        const evmApprovalData = Calldata.evm.erc20.approve.decode(precomposedForm?.transactionData);
 
         if (pushTxResponse.success) {
             const { txid } = pushTxResponse.payload;
 
             if (evmApprovalData && token) {
-                const isInfiniteApproval = isMaxAllowance(evmApprovalData.amount);
+                const amountString = evmApprovalData.amount.toString();
+                const isInfiniteApproval = isMaxAllowance(amountString);
                 const amount = subunitsToUnits({
-                    value: asAmountSubunit(new BigNumber(evmApprovalData.amount)),
+                    value: asAmountSubunit(new BigNumber(amountString)),
                     decimals: token.decimals,
                 }).toString();
 
                 dispatch(
                     notificationsActions.addToast({
-                        type: evmApprovalData.type === 'approve' ? 'tx-approved' : 'tx-revoked',
+                        type: evmApprovalData.amount === 0n ? 'tx-revoked' : 'tx-approved',
                         isInfiniteApproval,
                         formattedAmount: amount,
                         token,

--- a/suite-common/wallet-core/src/send/sendFormTronThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormTronThunks.ts
@@ -43,7 +43,7 @@ export const getTronEstimateFeeParams = (
     token?: TokenInfo,
 ) => {
     if (token) {
-        const result = Calldata.tron.trc20.transfer({
+        const result = Calldata.tron.trc20.transfer.encode({
             to,
             amount: new BigNumber(amountInSubunits),
         });
@@ -405,7 +405,7 @@ export const signTronSendFormTransactionThunk = createThunk<
 
         let tokenData: string | undefined;
         if (token) {
-            const calldataResult = Calldata.tron.trc20.transfer({
+            const calldataResult = Calldata.tron.trc20.transfer.encode({
                 to: output.address,
                 amount: new BigNumber(amountInSubunits),
             });

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
@@ -15,6 +15,7 @@ import type {
     YieldFlowType,
     YieldPendingTransactionState,
 } from './stablecoinYieldTypes';
+import { transactionsActions } from '../transactions/transactionsActions';
 
 type StablecoinYieldTranslationKey = string;
 
@@ -439,6 +440,19 @@ export const stablecoinYieldSlice = createSlice({
             state.txReview.serializedTx = undefined;
             state.txReview.accountKey = undefined;
         },
+    },
+    extraReducers: builder => {
+        builder.addCase(transactionsActions.replaceTransaction, (state, { payload }) => {
+            const { txid: prevTxid, tx } = payload;
+            (['deposit', 'withdraw', 'claim'] as const).forEach(flowType => {
+                const bucket = state[flowType];
+                Object.values(bucket).forEach(session => {
+                    if (session.action.pendingTransaction?.txid === prevTxid) {
+                        session.action.pendingTransaction.txid = tx.txid;
+                    }
+                });
+            });
+        });
     },
 });
 

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
@@ -1,3 +1,4 @@
+import { Calldata } from '@suite-common/calldata';
 import {
     type TransactionDto,
     TransactionDtoStatus,
@@ -7,10 +8,7 @@ import {
 } from '@suite-common/earn-stablecoin-api';
 import type { NetworkSymbol } from '@suite-common/wallet-config';
 import { type AccountKey } from '@suite-common/wallet-types';
-import {
-    getContractAddressForNetworkSymbol,
-    getEvmApprovalTxData,
-} from '@suite-common/wallet-utils';
+import { getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
 
 import type {
@@ -201,9 +199,10 @@ const isTransactionReadyForSigning = (transaction: TransactionDto) =>
 
 const getApprovalTxDataType = (transaction: TransactionDto) => {
     const parsed = parseUnsignedEvmTransaction(transaction.unsignedTransaction);
-    const approvalData = getEvmApprovalTxData(parsed?.data);
+    const approvalData = Calldata.evm.erc20.approve.decode(parsed?.data);
+    if (!approvalData) return null;
 
-    return approvalData?.type ?? null;
+    return approvalData.amount === 0n ? 'revoke' : 'approve';
 };
 
 export const getYieldRevokeTransaction = (transactions: TransactionDto[]) =>
@@ -245,7 +244,7 @@ export const getYieldWithdrawTransaction = (transactions: TransactionDto[]) =>
 
 export const getYieldApprovalSpender = (transaction?: TransactionDto | null): string | null => {
     const parsedTransaction = parseUnsignedEvmTransaction(transaction?.unsignedTransaction);
-    const approvalData = getEvmApprovalTxData(parsedTransaction?.data);
+    const approvalData = Calldata.evm.erc20.approve.decode(parsedTransaction?.data);
 
     return approvalData?.spender ?? null;
 };

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -17,9 +17,11 @@ import {
     ensureHexPrefix,
     findAccountsByAddress,
     findTransactions,
+    getEvmTransactionTextSignature,
     getPendingAccount,
     getRbfParams,
     isEip1559,
+    isEvmYieldTxByTextSignature,
     isRbfBumpFeeTransaction,
     isTrezorConnectBackendType,
     replaceEthereumSpecific,
@@ -286,6 +288,8 @@ const buildFakePendingEvmTx = ({
             multiTokenValues: token.multiTokenValues,
         };
 
+        const voutAddress = precomposedForm?.transactionData ? toAddress : token.contract;
+
         return {
             ...common,
             amount: '0',
@@ -297,7 +301,7 @@ const buildFakePendingEvmTx = ({
                     {
                         value: '0',
                         n: 0,
-                        addresses: [token.contract],
+                        addresses: [voutAddress],
                         isAddress: true,
                     },
                 ],
@@ -365,13 +369,16 @@ export const addFakePendingEvmTxThunk = createThunk(
         const FAKE_TX_TTL_SECONDS = 15 * 60; // keep fake tx for 15 minutes
         const deadline = FAKE_TX_TTL_SECONDS / rawFeeInfo!.blockTime;
 
+        const sig = getEvmTransactionTextSignature(precomposedForm.transactionData);
+        const transfersToken =
+            !precomposedForm.transactionData ||
+            sig === 'transfer' ||
+            isEvmYieldTxByTextSignature(sig);
+
         const fakeTx = buildFakePendingEvmTx({
             precomposedTransaction,
             precomposedForm,
-            token:
-                precomposedTransaction.token && !precomposedForm.transactionData
-                    ? precomposedTransaction.token
-                    : undefined,
+            token: transfersToken ? precomposedTransaction.token : undefined,
             txid,
             account,
             nonce,

--- a/suite-common/wallet-utils/package.json
+++ b/suite-common/wallet-utils/package.json
@@ -14,6 +14,7 @@
     },
     "dependencies": {
         "@scure/base": "^2.0.0",
+        "@suite-common/calldata": "workspace:*",
         "@suite-common/earn-staking-api": "workspace:*",
         "@suite-common/fiat-services": "workspace:*",
         "@suite-common/suite-constants": "workspace:*",
@@ -35,7 +36,6 @@
         "date-fns": "^4.1.0",
         "react": "19.2.4",
         "react-hook-form": "^7.71.2",
-        "web3-eth-abi": "^4.4.1",
         "web3-utils": "^4.3.3"
     }
 }

--- a/suite-common/wallet-utils/src/__fixtures__/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/__fixtures__/sendFormUtils.ts
@@ -37,7 +37,6 @@ export const prepareEthereumTransaction = [
             nonce: '11',
             gasLimit: '200000',
             gasPrice: '5',
-            data: 'deadbeef-not-used',
         },
         result: {
             to: '0xa74476443119A942dE498590Fe1f2454d7D4aC0d',
@@ -90,7 +89,6 @@ export const prepareEthereumTransaction = [
             nonce: '11',
             gasLimit: '200000',
             gasPrice: '5',
-            data: 'deadbeef-not-used',
             maxFeePerGas: '1',
             maxPriorityFeePerGas: '0.5',
         },
@@ -122,7 +120,6 @@ export const prepareEthereumTransaction = [
             nonce: '11',
             gasLimit: '200000',
             gasPrice: '5',
-            data: 'deadbeef-not-used',
             maxFeePerGas: '1',
             maxPriorityFeePerGas: '0.5',
         },

--- a/suite-common/wallet-utils/src/__tests__/ethUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/ethUtils.test.ts
@@ -1,11 +1,10 @@
+import { Calldata } from '@suite-common/calldata';
 import { UINT256_MAX } from '@suite-common/suite-constants';
 import { BigNumber } from '@trezor/utils';
 
 import {
     buildApprovalTransactionData,
-    getEvmApprovalTxData,
     getEvmTransactionTextSignature,
-    getEvmTransferTxData,
     padLeftEven,
     sanitizeHex,
     strip,
@@ -30,101 +29,6 @@ describe('eth utils', () => {
         expect(strip('0x')).toBe('');
         expect(strip('0x2540be3ff')).toBe('02540be3ff');
         expect(strip('2540be3ff')).toBe('02540be3ff');
-    });
-
-    describe('getEvmApprovalTxData', () => {
-        it('returns null if data is underfined or empty', () => {
-            expect(getEvmApprovalTxData(undefined)).toBeNull();
-            expect(getEvmApprovalTxData('')).toBeNull();
-        });
-
-        it('returns "approval" for approve transactions', () => {
-            const approveData =
-                '0x095ea7b3' +
-                '000000000000000000000000742d35cc6634c0532925a3b8d40e592e43a73654' + // spender
-                '0000000000000000000000000000000000000000000000000de0b6b3a7640000'; // amount (32 bytes) - 1 ETH in wei
-
-            const result = getEvmApprovalTxData(approveData);
-
-            expect(result).toEqual({
-                type: 'approve',
-                spender: '0x742d35cc6634c0532925a3b8d40e592e43a73654',
-                amount: '1000000000000000000',
-            });
-        });
-
-        it('returns "revoke" for approve transactions with zero amount', () => {
-            const revokeData =
-                '0x095ea7b3' +
-                '000000000000000000000000742d35cc6634c0532925a3b8d40e592e43a73654' + // spender
-                '0000000000000000000000000000000000000000000000000000000000000000'; // amount (32 bytes) - 0
-            const result = getEvmApprovalTxData(revokeData);
-
-            expect(result).toEqual({
-                type: 'revoke',
-                spender: '0x742d35cc6634c0532925a3b8d40e592e43a73654',
-                amount: '0',
-            });
-        });
-
-        it('returns "approval" for maximum uint256 approval', () => {
-            const maxApprovalData =
-                '0x095ea7b3' +
-                '000000000000000000000000742d35cc6634c0532925a3b8d40e592e43a73654' + // spender
-                'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'; // max uint256
-
-            const result = getEvmApprovalTxData(maxApprovalData);
-            expect(result?.type).toBe('approve');
-        });
-
-        it('should handle data without 0x prefix', () => {
-            const dataWithoutPrefix =
-                '095ea7b3' +
-                '000000000000000000000000742d35cc6634c0532925a3b8d40e592e43a73654' +
-                '0000000000000000000000000000000000000000000000000de0b6b3a7640000';
-
-            const result = getEvmApprovalTxData(dataWithoutPrefix);
-
-            expect(result?.type).toEqual('approve');
-        });
-
-        it('should handle uppercase hex data', () => {
-            const uppercaseData =
-                '0X095EA7B3' +
-                '000000000000000000000000742D35CC6634C0532925A3B8D40E592E43A73654' +
-                '0000000000000000000000000000000000000000000000000000000000000000';
-
-            expect(getEvmApprovalTxData(uppercaseData)?.type).toBe('revoke');
-        });
-
-        it('returns null for invalid hex input', () => {
-            expect(getEvmApprovalTxData('0xZZZ')).toBeNull();
-            expect(getEvmApprovalTxData('ZZZ')).toBeNull();
-        });
-
-        it('returns null for data shorter than selector', () => {
-            expect(getEvmApprovalTxData('0x09')).toBeNull();
-            expect(getEvmApprovalTxData('09')).toBeNull();
-        });
-
-        it('returns null for selector present but parameters too short', () => {
-            const tooShort = '0x095ea7b3' + '00'.repeat(10); // way less than 2 * 32 bytes
-            expect(getEvmApprovalTxData(tooShort)).toBeNull();
-        });
-
-        it('returns null when decoded parameter types are invalid (garbage after selector)', () => {
-            // not enough bytes to form valid address+uint256
-            const invalidParams = '0x095ea7b3' + 'ff'.repeat(31);
-            expect(getEvmApprovalTxData(invalidParams)).toBeNull();
-        });
-
-        it('handles uppercase without 0x prefix', () => {
-            const data =
-                '095EA7B3' +
-                '000000000000000000000000742D35CC6634C0532925A3B8D40E592E43A73654' +
-                '0000000000000000000000000000000000000000000000000DE0B6B3A7640000';
-            expect(getEvmApprovalTxData(data)?.type).toBe('approve');
-        });
     });
 
     describe('getEvmTransactionTextSignature', () => {
@@ -283,9 +187,7 @@ describe('eth utils', () => {
             ['non-hex characters', '0xZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ'],
             ['empty string', ''],
         ])('throws for invalid spender address (%s)', (_, spender) => {
-            expect(() => buildApprovalTransactionData({ amount: '1000', spender })).toThrow(
-                'Invalid spender address',
-            );
+            expect(() => buildApprovalTransactionData({ amount: '1000', spender })).toThrow();
         });
 
         it.each([
@@ -294,83 +196,23 @@ describe('eth utils', () => {
             ['decimal', '1.5'],
             ['exceeds uint256 max', new BigNumber(UINT256_MAX).plus(1).toString(10)],
         ])('throws for invalid amount (%s)', (_, amount) => {
-            expect(() => buildApprovalTransactionData({ amount, spender: VALID_SPENDER })).toThrow(
-                'Invalid amount',
-            );
+            expect(() =>
+                buildApprovalTransactionData({ amount, spender: VALID_SPENDER }),
+            ).toThrow();
         });
 
-        it('produces calldata that getEvmApprovalTxData can decode', () => {
+        it('produces calldata that the calldata decoder can decode', () => {
             const amount = '1000000000000000000';
             const calldata = buildApprovalTransactionData({
                 amount,
                 spender: VALID_SPENDER,
             });
 
-            const decoded = getEvmApprovalTxData(calldata);
+            const decoded = Calldata.evm.erc20.approve.decode(calldata);
 
             expect(decoded).not.toBeNull();
             expect(decoded?.spender).toBe(VALID_SPENDER.toLowerCase());
-            expect(decoded?.amount).toBe(amount);
-            expect(decoded?.type).toBe('approve');
-        });
-    });
-
-    describe('getEvmTransferTxData', () => {
-        it('returns transfer for valid ERC-20 transfer', () => {
-            const data =
-                '0xa9059cbb' +
-                '000000000000000000000000742d35cc6634c0532925a3b8d40e592e43a73654' + // to
-                '00000000000000000000000000000000000000000000000000000000000003e8'; // 1000
-            const res = getEvmTransferTxData(data);
-            expect(res).toEqual({
-                type: 'transfer',
-                recipient: '0x742d35cc6634c0532925a3b8d40e592e43a73654',
-                amount: '1000',
-            });
-        });
-
-        it('handles zero-amount transfer', () => {
-            const data =
-                '0xa9059cbb' +
-                '000000000000000000000000742d35cc6634c0532925a3b8d40e592e43a73654' +
-                '0000000000000000000000000000000000000000000000000000000000000000';
-            const res = getEvmTransferTxData(data);
-            expect(res).toEqual({
-                type: 'transfer',
-                recipient: '0x742d35cc6634c0532925a3b8d40e592e43a73654',
-                amount: '0',
-            });
-        });
-
-        it('returns null for data without 0x prefix (still valid)', () => {
-            const noPrefix =
-                'a9059cbb' +
-                '000000000000000000000000742d35cc6634c0532925a3b8d40e592e43a73654' +
-                '00000000000000000000000000000000000000000000000000000000000003e8';
-            const res = getEvmTransferTxData(noPrefix);
-            expect(res?.type).toBe('transfer');
-        });
-
-        it('handles uppercase hex (with 0X prefix)', () => {
-            const upper =
-                '0XA9059CBB' +
-                '000000000000000000000000742D35CC6634C0532925A3B8D40E592E43A73654' +
-                '00000000000000000000000000000000000000000000000000000000000003E8';
-            expect(getEvmTransferTxData(upper)?.type).toBe('transfer');
-        });
-
-        it('returns null for selector only (too short)', () => {
-            expect(getEvmTransferTxData('0xa9059cbb')).toBeNull();
-        });
-
-        it('returns null for invalid hex payload', () => {
-            expect(
-                getEvmTransferTxData(
-                    '0xa9059cbb' +
-                        '000000000000000000000000742d35cc6634c0532925a3b8d40e592e43a73654' +
-                        'GGGG000000000000000000000000000000000000000000000000000000000000',
-                ),
-            ).toBeNull();
+            expect(decoded?.amount.toString()).toBe(amount);
         });
     });
 });

--- a/suite-common/wallet-utils/src/ethUtils.ts
+++ b/suite-common/wallet-utils/src/ethUtils.ts
@@ -41,6 +41,10 @@ export const getEvmTransactionTextSignature = (data?: string): EvmTransactionPur
     const approve = Calldata.evm.erc20.approve.decode(data);
     if (approve) return approve.amount === 0n ? 'revoke' : 'approve';
 
+    if (Calldata.evm.erc4626.deposit.decode(data)) return 'deposit';
+    if (Calldata.evm.erc4626.withdraw.decode(data)) return 'withdraw';
+    if (Calldata.evm.erc4626.redeem.decode(data)) return 'redeem';
+
     return 'unknown';
 };
 
@@ -52,6 +56,9 @@ export type EvmApprovalPurpose = Extract<EvmTransactionPurpose, 'approve' | 'rev
 export const isEvmApprovalTxByTextSignature = (
     textSignature?: EvmTransactionPurpose,
 ): textSignature is EvmApprovalPurpose => textSignature === 'approve' || textSignature === 'revoke';
+
+export const isEvmYieldTxByTextSignature = (textSignature?: EvmTransactionPurpose) =>
+    textSignature === 'deposit' || textSignature === 'withdraw' || textSignature === 'redeem';
 
 export const ensureHexPrefix = (hex?: string): string => {
     if (!hex) return '';

--- a/suite-common/wallet-utils/src/ethUtils.ts
+++ b/suite-common/wallet-utils/src/ethUtils.ts
@@ -1,6 +1,4 @@
-import { decodeParameters } from 'web3-eth-abi';
-import { sha3 } from 'web3-utils';
-
+import { Calldata } from '@suite-common/calldata';
 import { UINT256_MAX } from '@suite-common/suite-constants';
 import { type EvmTransactionPurpose } from '@suite-common/wallet-types';
 import { type TokenInfo } from '@trezor/blockchain-link-types';
@@ -9,7 +7,6 @@ import { BigNumber } from '@trezor/utils';
 
 import { asAmountSubunit, asAmountUnit } from './AmountTypes';
 import { unitsToSubunits } from './amountUtils';
-import { isAddressValid } from './validationUtils';
 
 export const isEip1559 = (
     tx: Record<string, any> | null | undefined,
@@ -36,95 +33,19 @@ export const strip = (str: string): string => {
     return padLeftEven(str);
 };
 
-interface EvmTxData {
-    type: EvmTransactionPurpose;
-    amount: string;
-}
-
-interface EvmTxApprovalData extends EvmTxData {
-    spender: string;
-}
-
-interface EvmTxTransferData extends EvmTxData {
-    recipient: string;
-}
-
-const normalizeHex = (data: string) =>
-    data.toLowerCase().startsWith('0x') ? data.toLowerCase() : `0x${data.toLowerCase()}`;
-
-const ERC20_APPROVE_SELECTOR = sha3('approve(address,uint256)')!.slice(0, 10);
-const ERC20_TRANSFER_SELECTOR = sha3('transfer(address,uint256)')!.slice(0, 10);
-
-export const getEvmApprovalTxData = (data?: string): EvmTxApprovalData | null => {
-    if (!data) return null;
-
-    const dataWithPrefix = normalizeHex(data);
-    const dataLowercase = dataWithPrefix.toLowerCase();
-    try {
-        const hasApprovalPrefix = dataLowercase.startsWith(ERC20_APPROVE_SELECTOR);
-
-        if (!hasApprovalPrefix) return null;
-
-        const decodedData = decodeParameters(['address', 'uint256'], dataLowercase.slice(10)); // [spender, approval_amount]
-
-        if (typeof decodedData[0] !== 'string' || typeof decodedData[1] !== 'bigint') return null;
-
-        return {
-            type: decodedData[1] === 0n ? 'revoke' : 'approve',
-            spender: decodedData[0].toLowerCase(),
-            amount: decodedData[1].toString(),
-        };
-    } catch {
-        return null;
-    }
-};
-
-export const getEvmTransferTxData = (data?: string): EvmTxTransferData | null => {
-    if (!data) return null;
-
-    const d = normalizeHex(data);
-
-    try {
-        if (!d.startsWith(ERC20_TRANSFER_SELECTOR)) return null;
-
-        const decoded = decodeParameters(['address', 'uint256'], d.slice(10)); // [to, amount]
-
-        if (typeof decoded[0] !== 'string' || typeof decoded[1] !== 'bigint') return null;
-
-        return {
-            type: 'transfer',
-            recipient: decoded[0].toLowerCase(),
-            amount: decoded[1].toString(),
-        };
-    } catch {
-        return null;
-    }
-};
-
 export const getEvmTransactionTextSignature = (data?: string): EvmTransactionPurpose => {
-    // no data -> no method > no text signature
-    if (!data) {
-        return '';
-    }
+    if (!data) return '';
 
-    const tokenTransferTxData = getEvmTransferTxData(data);
-    if (tokenTransferTxData?.type) {
-        return tokenTransferTxData.type;
-    }
+    if (Calldata.evm.erc20.transfer.decode(data)) return 'transfer';
 
-    const approvalTxData = getEvmApprovalTxData(data);
-    if (approvalTxData?.type) {
-        return approvalTxData.type;
-    }
+    const approve = Calldata.evm.erc20.approve.decode(data);
+    if (approve) return approve.amount === 0n ? 'revoke' : 'approve';
 
     return 'unknown';
 };
 
-export const isEvmApprovalTx = (data?: string): boolean => {
-    const result = getEvmApprovalTxData(data);
-
-    return result !== null;
-};
+export const isEvmApprovalTx = (data?: string): boolean =>
+    Calldata.evm.erc20.approve.decode(data) !== null;
 
 export type EvmApprovalPurpose = Extract<EvmTransactionPurpose, 'approve' | 'revoke'>;
 
@@ -143,24 +64,21 @@ interface BuildTransactionDataParams {
     spender: string;
 }
 
+// TODO: drop this wrapper and migrate callers to `Calldata.evm.erc20.approve.encode` directly.
 export const buildApprovalTransactionData = ({
     amount: rawAmount,
     spender: rawSpender,
 }: BuildTransactionDataParams): string => {
-    if (!isAddressValid(rawSpender, 'base')) {
-        throw new Error('Invalid spender address');
+    const result = Calldata.evm.erc20.approve.encode({
+        spender: rawSpender,
+        amount: new BigNumber(rawAmount),
+    });
+
+    if (!result.isValid || !result.data) {
+        throw new Error(result.errors[0]?.code ?? 'INVALID_APPROVAL_PARAMS');
     }
 
-    const amount = new BigNumber(rawAmount);
-    const spender = rawSpender.toLowerCase().replace(/^0x/, '').padStart(64, '0');
-
-    if (amount.isNaN() || !amount.isInteger() || amount.isNegative() || amount.gt(UINT256_MAX)) {
-        throw new Error('Invalid amount');
-    }
-
-    const amountHex = amount.toString(16).padStart(64, '0');
-
-    return `${ERC20_APPROVE_SELECTOR}${spender}${amountHex}`;
+    return result.data;
 };
 
 interface GetAllowanceAmountParams {

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.ts
@@ -20,7 +20,11 @@ import { versionUtils } from '@trezor/utils';
 import { datetimeToLocktime } from './bitcoinUtils';
 import { getShortFingerprint, isCardanoTx } from './cardanoUtils';
 import { isApprovalFlowSupported as isApprovalSupported } from './deviceUtils';
-import { isEvmApprovalTx } from './ethUtils';
+import {
+    getEvmTransactionTextSignature,
+    isEvmApprovalTx,
+    isEvmYieldTxByTextSignature,
+} from './ethUtils';
 import { getStakeType } from './ethereumStakingUtils';
 import { isExchangeTradingForm } from './sendFormUtils';
 import { isRbfBumpFeeTransaction } from './transactionUtils';
@@ -295,11 +299,20 @@ const constructNewFlow = ({
     const hasDestinationTag = 'destinationTag' in precomposedForm;
     const trading = precomposedForm?.trading;
 
-    if (precomposedForm.yieldMetadata && isUpdatedEthereumSendFlow) {
-        outputs.push(
-            { type: 'data', value: '' },
-            { type: 'address', value: precomposedForm.yieldMetadata.vaultName },
-        );
+    const evmTxType = getEvmTransactionTextSignature(precomposedForm.transactionData);
+    const isYieldOp = !!precomposedForm.yieldMetadata || isEvmYieldTxByTextSignature(evmTxType);
+
+    if (isYieldOp && isUpdatedEthereumSendFlow) {
+        const fallbackAddress = precomposedTx.outputs.find(
+            o => 'address' in o && typeof o.address === 'string',
+        )?.address;
+        const vaultName =
+            precomposedForm.yieldMetadata?.vaultName ??
+            (typeof fallbackAddress === 'string'
+                ? (KNOWN_VAULTS[fallbackAddress.toLowerCase()] ?? fallbackAddress)
+                : '');
+
+        outputs.push({ type: 'data', value: '' }, { type: 'address', value: vaultName });
 
         precomposedTx.outputs.forEach(o => {
             if ('address' in o && typeof o.address === 'string') {

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.ts
@@ -1,5 +1,6 @@
 import { fromWei, toWei } from 'web3-utils';
 
+import { Calldata } from '@suite-common/calldata';
 import { EVM_SPENDER_LABELS, KNOWN_VAULTS } from '@suite-common/suite-constants';
 import { type TrezorDevice } from '@suite-common/suite-types';
 import { networks } from '@suite-common/wallet-config';
@@ -19,7 +20,7 @@ import { versionUtils } from '@trezor/utils';
 import { datetimeToLocktime } from './bitcoinUtils';
 import { getShortFingerprint, isCardanoTx } from './cardanoUtils';
 import { isApprovalFlowSupported as isApprovalSupported } from './deviceUtils';
-import { getEvmApprovalTxData, isEvmApprovalTx } from './ethUtils';
+import { isEvmApprovalTx } from './ethUtils';
 import { getStakeType } from './ethereumStakingUtils';
 import { isExchangeTradingForm } from './sendFormUtils';
 import { isRbfBumpFeeTransaction } from './transactionUtils';
@@ -285,7 +286,7 @@ const constructNewFlow = ({
     const isSolana = account.networkType === 'solana';
     const isStellar = account.networkType === 'stellar';
     const isTron = account.networkType === 'tron';
-    const evmApprovalTxData = getEvmApprovalTxData(precomposedForm.transactionData);
+    const evmApprovalTxData = Calldata.evm.erc20.approve.decode(precomposedForm.transactionData);
     const isEvmApproval = isEvmApprovalTx(precomposedForm.transactionData);
     const stakeType = getStakeType(precomposedForm, outputs);
 
@@ -467,18 +468,16 @@ const constructNewFlow = ({
     }
 
     if (evmApprovalTxData && networkType === 'ethereum' && isApprovalFlowSupported) {
+        const { spender } = evmApprovalTxData;
         outputs.push({
             type: 'contract',
-            value:
-                KNOWN_VAULTS[evmApprovalTxData.spender] ??
-                EVM_SPENDER_LABELS[evmApprovalTxData.spender] ??
-                evmApprovalTxData.spender,
+            value: KNOWN_VAULTS[spender] ?? EVM_SPENDER_LABELS[spender] ?? spender,
         });
 
         if (precomposedTx.token) {
             outputs.push({
                 type: 'approve_data',
-                value: evmApprovalTxData.amount,
+                value: evmApprovalTxData.amount.toString(),
                 value2: networks[symbol].name,
                 token: precomposedTx.token,
             });

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -58,12 +58,7 @@ import {
     networkAmountToSmallestUnit,
 } from './amountUtils';
 import { isBaseCurrencyWithSats } from './baseCurrency';
-import {
-    getEvmTransactionTextSignature,
-    isEip1559,
-    isEvmApprovalTxByTextSignature,
-    sanitizeHex,
-} from './ethUtils';
+import { isEip1559, isEvmApprovalTx, sanitizeHex } from './ethUtils';
 
 export const calculateTotal = (amount: string, fee: string): string => {
     try {
@@ -212,18 +207,17 @@ export const prepareEthereumTransaction = (
         result.data = sanitizeHex(txInfo.data);
     }
 
-    // Build erc20 'transfer' method or use provided data in case of approve/revoke transaction
     if (txInfo.token) {
-        // join data
-        const evmTxTextSignature = getEvmTransactionTextSignature(txInfo.data);
+        const isApprovalTx = isEvmApprovalTx(txInfo.data);
 
-        result.data = isEvmApprovalTxByTextSignature(evmTxTextSignature)
-            ? txInfo.data
-            : getSerializedErc20Transfer(txInfo.token, txInfo.to, txInfo.amount);
-
-        // replace tx recipient to smart contract address
-        result.to = txInfo.token.contract;
-        // replace tx value
+        if (txInfo.data && txInfo.data !== '0x' && !isApprovalTx) {
+            result.data = sanitizeHex(txInfo.data);
+        } else {
+            result.data = isApprovalTx
+                ? txInfo.data
+                : getSerializedErc20Transfer(txInfo.token, txInfo.to, txInfo.amount);
+            result.to = txInfo.token.contract;
+        }
         result.value = '0x00';
     }
 

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -1,6 +1,7 @@
 import { addDays, startOfMonth } from 'date-fns';
 import { fromWei, toWei } from 'web3-utils';
 
+import { Calldata } from '@suite-common/calldata';
 import { type SignOperator } from '@suite-common/suite-types';
 import { type NetworkType, getNetworkType } from '@suite-common/wallet-config';
 import {
@@ -32,7 +33,7 @@ import { BigNumber, arrayPartition, typedObjectKeys } from '@trezor/utils';
 
 import { convertAmountSubunitsToUnits, formatNetworkAmount } from './amountUtils';
 import { isCardanoStakingTx } from './cardanoStakingUtils';
-import { getEvmApprovalTxData, getEvmTransactionTextSignature } from './ethUtils';
+import { getEvmTransactionTextSignature } from './ethUtils';
 import { isStakeTypeTx } from './ethereumStakingUtils';
 import { toFiatCurrency } from './fiatConverterUtils';
 import { getFiatRateKey, roundTimestampToNearestPastHour } from './fiatRatesUtils';
@@ -726,18 +727,16 @@ const getEthereumRbfParams = (
         }
         case 'approve':
         case 'revoke': {
-            const approvalData = getEvmApprovalTxData(data);
+            const approvalData = Calldata.evm.erc20.approve.decode(data);
+            const amount = approvalData?.amount.toString() ?? '0';
 
             const token = account.tokens?.find(t => t.contract === toAddress);
 
             output = {
                 address: toAddress,
                 token: toAddress, // approval is send to token address
-                amount: approvalData?.amount || '0',
-                formattedAmount: convertAmountSubunitsToUnits(
-                    approvalData?.amount || '0',
-                    token?.decimals || 0,
-                ),
+                amount,
+                formattedAmount: convertAmountSubunitsToUnits(amount, token?.decimals || 0),
             };
             break;
         }

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -740,12 +740,27 @@ const getEthereumRbfParams = (
             };
             break;
         }
-        default:
-            output = {
-                address: toAddress,
-                amount: vout[0].value!,
-                formattedAmount: formatNetworkAmount(vout[0].value!, account.symbol),
-            };
+        default: {
+            // Token-moving contract calls report value=0 in vout; pull the amount from tokens[0].
+            const tokenTransfer = tx.tokens?.[0];
+            if (tokenTransfer) {
+                output = {
+                    address: toAddress,
+                    token: tokenTransfer.contract,
+                    amount: tokenTransfer.amount,
+                    formattedAmount: convertAmountSubunitsToUnits(
+                        tokenTransfer.amount,
+                        tokenTransfer.decimals,
+                    ),
+                };
+            } else {
+                output = {
+                    address: toAddress,
+                    amount: vout[0].value!,
+                    formattedAmount: formatNetworkAmount(vout[0].value!, account.symbol),
+                };
+            }
+        }
     }
 
     return {

--- a/suite-common/wallet-utils/tsconfig.json
+++ b/suite-common/wallet-utils/tsconfig.json
@@ -3,6 +3,7 @@
     "compilerOptions": { "outDir": "libDev" },
     "include": [".", "**/*.json"],
     "references": [
+        { "path": "../calldata" },
         { "path": "../earn-staking-api" },
         { "path": "../fiat-services" },
         { "path": "../suite-constants" },

--- a/suite-native/module-trading/package.json
+++ b/suite-native/module-trading/package.json
@@ -21,6 +21,7 @@
         "@react-navigation/native-stack": "7.12.0",
         "@reduxjs/toolkit": "2.11.2",
         "@shopify/flash-list": "2.3.0",
+        "@suite-common/calldata": "workspace:*",
         "@suite-common/device": "workspace:*",
         "@suite-common/flags": "workspace:*",
         "@suite-common/formatters": "workspace:*",

--- a/suite-native/module-trading/src/thunks.ts
+++ b/suite-native/module-trading/src/thunks.ts
@@ -1,6 +1,7 @@
 import { isFulfilled, isRejected } from '@reduxjs/toolkit';
 import { type DexApprovalType, type ExchangeTrade } from 'invity-api';
 
+import { Calldata } from '@suite-common/calldata';
 import { selectIsMevProtectionFeatureEnabled } from '@suite-common/mev';
 import { createThunk } from '@suite-common/redux-utils';
 import {
@@ -41,7 +42,6 @@ import {
 import {
     buildApprovalTransactionData,
     getAllowanceAmount,
-    getEvmApprovalTxData,
     tryGetAccountIdentity,
 } from '@suite-common/wallet-utils';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
@@ -288,8 +288,9 @@ export const composeEvmApprovalFeeLevelsThunk = createThunk(
                 return rejectWithValue('DEX quote with dexTx data is required');
             }
 
-            const approvalData = getEvmApprovalTxData(dexTx.data);
-            if (!approvalData?.spender) {
+            const approvalData = Calldata.evm.erc20.approve.decode(dexTx.data);
+            const spender = approvalData?.spender;
+            if (!spender) {
                 return rejectWithValue('Could not extract spender from dexTx data');
             }
 
@@ -322,7 +323,7 @@ export const composeEvmApprovalFeeLevelsThunk = createThunk(
 
             const data = buildApprovalTransactionData({
                 amount: allowanceAmount,
-                spender: approvalData.spender,
+                spender,
             });
 
             const response = await dispatch(

--- a/suite-native/module-trading/tsconfig.json
+++ b/suite-native/module-trading/tsconfig.json
@@ -2,6 +2,7 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
     "references": [
+        { "path": "../../suite-common/calldata" },
         { "path": "../../suite-common/device" },
         { "path": "../../suite-common/flags" },
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11205,6 +11205,7 @@ __metadata:
   resolution: "@suite-common/wallet-utils@workspace:suite-common/wallet-utils"
   dependencies:
     "@scure/base": "npm:^2.0.0"
+    "@suite-common/calldata": "workspace:*"
     "@suite-common/earn-staking-api": "workspace:*"
     "@suite-common/fiat-services": "workspace:*"
     "@suite-common/suite-constants": "workspace:*"
@@ -11226,7 +11227,6 @@ __metadata:
     date-fns: "npm:^4.1.0"
     react: "npm:19.2.4"
     react-hook-form: "npm:^7.71.2"
-    web3-eth-abi: "npm:^4.4.1"
     web3-utils: "npm:^4.3.3"
   languageName: unknown
   linkType: soft
@@ -13183,6 +13183,7 @@ __metadata:
     "@react-navigation/native-stack": "npm:7.12.0"
     "@reduxjs/toolkit": "npm:2.11.2"
     "@shopify/flash-list": "npm:2.3.0"
+    "@suite-common/calldata": "workspace:*"
     "@suite-common/device": "workspace:*"
     "@suite-common/flags": "workspace:*"
     "@suite-common/formatters": "workspace:*"
@@ -18914,19 +18915,6 @@ __metadata:
   version: 4.0.0
   resolution: "abbrev@npm:4.0.0"
   checksum: 10/e2f0c6a6708ad738b3e8f50233f4800de31ad41a6cdc50e0cbe51b76fed69fd0213516d92c15ce1a9985fca71a14606a9be22bf00f8475a58987b9bfb671c582
-  languageName: node
-  linkType: hard
-
-"abitype@npm:0.7.1":
-  version: 0.7.1
-  resolution: "abitype@npm:0.7.1"
-  peerDependencies:
-    typescript: ">=4.9.4"
-    zod: ^3 >=3.19.1
-  peerDependenciesMeta:
-    zod:
-      optional: true
-  checksum: 10/deee4a18c9c7218ab2e5e57e07e4cb3e2f3e785657be364d098ab0587cd552c4fbb41e1bdddbc6fa52387f51ebd181461fe70a13127cc77091655775fdfb18fe
   languageName: node
   linkType: hard
 
@@ -46244,19 +46232,6 @@ __metadata:
   dependencies:
     web3-types: "npm:^1.10.0"
   checksum: 10/0d1cb0e02701a4bd619f856b0a6702fdd4cdc0a434029c3c3dcde3f3cc4acaca418117ad10238002aa697745840e7fd312bd43ad5341482b3ff8f9e6eb438a31
-  languageName: node
-  linkType: hard
-
-"web3-eth-abi@npm:^4.4.1":
-  version: 4.4.1
-  resolution: "web3-eth-abi@npm:4.4.1"
-  dependencies:
-    abitype: "npm:0.7.1"
-    web3-errors: "npm:^1.3.1"
-    web3-types: "npm:^1.10.0"
-    web3-utils: "npm:^4.3.3"
-    web3-validator: "npm:^2.0.6"
-  checksum: 10/0c7f4f9f05f04e0ac98f6029edfb3bf7e514efc325f6be83e999203f49c7a0cdc9759f4b1011ce12d80c2044c74a867f7fc0ee83538408c2ebb4c9f407027b7f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

## Description

### Speed up TX
- **Speed Up** button is now visible in the tx detail modal for all yield flows
- The 'replace transaction' tx review modal renders the correct token + amount + vault name
- Yield session's tracked `pendingTransaction.txid` is updated after a successful replace transaction

### Claim nonce
- Aligned claim's nonce format with the convention used by other thunks - convert to hex
- Before the change it was causing issue with speeding up txs

### Calldata package 🤏 refactor
- Introduced a typed EVM decoder API (`Calldata.evm.*.*.decode`) built on viem
- Restructured `Calldata.evm.*.*` from a callable encoder to { `encode`, `decode` } per method
- Replaced the `getEvmApprovalTxData` / `getEvmTransferTxData` and selector matching in `getEvmTransactionTextSignature` with the new typed decoders.

### Yield Approve Modal
- Replaced hardcoded `EARN_PROVIDER_METADATA.morpho` with a generic `KNOWN_VAULTS[spender]` lookup

## Notes for QA

- Approve modal should now show vault name instead of hardcoded "Morpho"
- Every yield tx (claim, withdraw, redeem, deposit) should be replaceable with higher fee

## Related Issue

Resolve #27813
Resolve #27815

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/rbf-yield&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/rbf-yield&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/rbf-yield&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-20T19:46:47.343Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-20T20:28:27.656Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/rbf-yield/web/](https://dev.suite.sldev.cz/suite-web/fix/rbf-yield/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->