### PR TITLE
feat(trading): add fiat flags to desktop currency picker

### DIFF
--- a/packages/components/src/components/CardList/CardListItem.tsx
+++ b/packages/components/src/components/CardList/CardListItem.tsx
@@ -2,11 +2,12 @@ import type { Padding } from '../../utils/frameProps';
 import { Row } from '../Flex/Flex';
 import { GhostContainer, type GhostContainerProps } from '../GhostContainer/GhostContainer';
 
-export const cardListItemPaddingTypes = ['normal', 'small'] as const;
+export const cardListItemPaddingTypes = ['normal', 'medium', 'small'] as const;
 export type CardListItemPaddingType = (typeof cardListItemPaddingTypes)[number];
 
 const paddingMap: Record<CardListItemPaddingType, Padding> = {
     normal: { vertical: 16, horizontal: 20 },
+    medium: { vertical: 12, horizontal: 20 },
     small: { vertical: 8, horizontal: 12 },
 };
 

--- a/suite/trading/src/ui/currency-picker/CurrencyPickerModal.tsx
+++ b/suite/trading/src/ui/currency-picker/CurrencyPickerModal.tsx
@@ -1,7 +1,9 @@
 import { Translation, useTranslation } from '@suite/intl';
+import { getFiatCurrencyFlag } from '@suite-common/flags';
 import {
     CardList,
     Column,
+    Flag,
     IconCircle,
     Input,
     Modal,
@@ -18,6 +20,8 @@ type CurrencyPickerModalProps = ModalProps & {
     onCurrencySelect: (currency: CurrencyPickerOption) => void;
     options: CurrencyPickerOption[];
 };
+
+type FiatCurrencyFlagInput = Parameters<typeof getFiatCurrencyFlag>[0];
 
 export const CurrencyPickerModal = ({
     onCurrencySelect,
@@ -44,25 +48,41 @@ export const CurrencyPickerModal = ({
 
                 {filteredData.length > 0 && (
                     <CardList>
-                        {filteredData.map(option => (
-                            <CardList.Item
-                                key={option.value}
-                                onClick={() => handleCurrencySelect(option)}
-                                data-testid={`@trading/form/currency-picker/option/${option.value}`}
-                            >
-                                <Row gap={16}>
-                                    <Column>
-                                        <IconCircle name="coin" size={32} intent="neutral" />
-                                    </Column>
-                                    <Column>
-                                        <Text typographyStyle="body-md">{option.label}</Text>
-                                        <Text typographyStyle="body-sm" color="contentSecondary">
-                                            {option.shortLabel}
-                                        </Text>
-                                    </Column>
-                                </Row>
-                            </CardList.Item>
-                        ))}
+                        {filteredData.map(option => {
+                            const flag = getFiatCurrencyFlag(option.value as FiatCurrencyFlagInput);
+
+                            return (
+                                <CardList.Item
+                                    key={option.value}
+                                    paddingType="medium"
+                                    onClick={() => handleCurrencySelect(option)}
+                                    data-testid={`@trading/form/currency-picker/option/${option.value}`}
+                                >
+                                    <Row gap={16}>
+                                        <Column>
+                                            {flag ? (
+                                                <Flag country={flag} size={32} />
+                                            ) : (
+                                                <IconCircle
+                                                    name="coin"
+                                                    size={32}
+                                                    intent="neutral"
+                                                />
+                                            )}
+                                        </Column>
+                                        <Column>
+                                            <Text typographyStyle="body-md">{option.label}</Text>
+                                            <Text
+                                                typographyStyle="body-sm"
+                                                color="contentSecondary"
+                                            >
+                                                {option.shortLabel}
+                                            </Text>
+                                        </Column>
+                                    </Row>
+                                </CardList.Item>
+                            );
+                        })}
                     </CardList>
                 )}
                 {!filteredData.length && (


### PR DESCRIPTION
## Description

- Show fiat flags in the desktop trading currency picker when a mapped flag is available.
- Keep the existing coin icon as the fallback for fiat currencies without a flag mapping.
- Reduce currency picker row padding by adding a medium CardList item spacing variant used by this modal.

## Notes for QA

- Open the desktop trading currency picker and verify currencies with flag mappings render a flag icon next to the label.
- Verify a currency without a flag mapping still renders the neutral coin icon instead of a broken or empty state.
- Check that the currency picker rows are visually more compact than before and the selection behavior is unchanged.

## Related Issue

Resolve #24195

## Screenshots:

N/A

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies two files: a generic UI component (CardListItem) used across 121+ tests, and a trading-specific CurrencyPickerModal with no static test coverage. The primary risk is in the CurrencyPickerModal, which is likely exercised by trading/buy and trading/sell tests that involve currency and asset selection. CardListItem is a broadly shared component, so only tests with specific card-rendering behaviors warrant inclusion. The recommended strategy focuses on trading buy/sell flows that directly exercise currency picking, with lower priority for shared component rendering tests.

<details><summary><b>Changed files (2)</b></summary>

- `packages/components/src/components/CardList/CardListItem.tsx`
- `suite/trading/src/ui/currency-picker/CurrencyPickerModal.tsx`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `../../suite/e2e/tests/trading/buy-bitcoin.test.ts` — CurrencyPickerModal.tsx is part of the trading currency picker UI. The buy-bitcoin test exercises the full buy flow including fiat currency selection and asset picking, which directly uses the currency picker modal. This test is the most likely to catch regressions in the currency picker.
- `../../suite/e2e/tests/trading/buy-negative.test.ts` — This test validates buy form input validation and fiat currency selection (selectFiatCurrency), which directly exercises the CurrencyPickerModal. Changes to the modal could affect currency selection behavior and error states.
- `../../suite/e2e/tests/trading/buy-ethereum.test.ts` — The buy-ethereum test uses the trading page's asset picker and buy form flow, which involves currency/asset selection modals. CurrencyPickerModal changes could directly affect the asset selection experience in buy flows.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `../../suite/e2e/tests/trading/buy-solana-token.test.ts` — This test selects a specific token asset via the asset picker with network and search filters, and switches between fiat/crypto input modes. The CurrencyPickerModal changes could affect the asset/currency selection UI used here.
- `../../suite/e2e/tests/trading/sell-inputs.test.ts` — This test explicitly switches fiat currency (to EUR) on the sell form for both BTC and SOL, exercising currency picker functionality. CurrencyPickerModal changes could affect fiat currency selection in sell flows.
- `../../suite/e2e/tests/trading/navigation.test.ts` — This test navigates to Buy/Sell/Swap forms from multiple entry points and verifies correct cryptocurrency names are displayed. The CurrencyPickerModal is part of the trading UI that determines which asset/currency is shown in these forms.
- `../../suite/e2e/tests/trading/sell-bitcoin.test.ts` — The sell-bitcoin flow involves the trading page where currency/asset selection occurs. Changes to CurrencyPickerModal could impact the sell form's asset picker or currency display.
- `../../suite/e2e/tests/staking/staking-form.test.ts` — The staking form test exercises crypto/fiat switching and percentage buttons, which may use currency picker components. The switchInputs behavior between crypto (ETH) and fiat (USD) modes could be affected by CurrencyPickerModal changes.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `../../suite/e2e/tests/dashboard/assets.test.ts` — CardListItem.tsx is used broadly, but the assets test specifically exercises asset card views (grid and table) and the 'Enable more coins' modal which could render CardListItem components for displaying asset information.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/trading/src/ui/currency-picker/CurrencyPickerModal.tsx`

_Updated: 2026-05-21T06:54:37.591Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/trading-currency-picker-flags-desktop&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/trading-currency-picker-flags-desktop&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-21T07:47:49.112Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-21T07:46:29.407Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/trading-currency-picker-flags-desktop/web/](https://dev.suite.sldev.cz/suite-web/feat/trading-currency-picker-flags-desktop/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->