### PR TITLE
Show errors in CI logs

### DIFF
--- a/packages/connect/e2e/tests/device/methods.test.ts
+++ b/packages/connect/e2e/tests/device/methods.test.ts
@@ -125,7 +125,7 @@ describe(`TrezorConnect methods`, () => {
                         // @ts-expect-error, string + params union
                         const result = await TrezorConnect[testCase.method](t.params);
                         let expected = t.result
-                            ? { success: true, payload: t.result }
+                            ? { success: true, payload: t.result, error: undefined }
                             : { success: false };
 
                         // find legacy result
@@ -134,13 +134,13 @@ describe(`TrezorConnect methods`, () => {
                             legacyResults.forEach(r => {
                                 if (skipTest(r.rules)) {
                                     expected = r.payload
-                                        ? { success: true, payload: r.payload }
+                                        ? { success: true, payload: r.payload, error: undefined }
                                         : { success: false };
                                 }
                             });
                         }
 
-                        expect(result).toMatchObject(expected);
+                        expect({ error: undefined, ...result }).toMatchObject(expected);
 
                         const { deviceScreen } = t;
                         // Skip the screen assertion when the matrix expects failure


### PR DESCRIPTION
## Description

Adding `error: undefined` to and expecting it in successful method results allows us to see the error message in CI logs when the tests fail, which saves some time.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/connect-e2e-errors/web/](https://dev.suite.sldev.cz/suite-web/test/connect-e2e-errors/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/connect-e2e-errors&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/connect-e2e-errors&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-21T08:43:20.081Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->