### PR TITLE
fix(suite): respect MEV protection setting in yield

### DIFF
--- a/packages/suite/src/actions/wallet/stablecoin-yield/claimMerkleRewardsThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/claimMerkleRewardsThunk.ts
@@ -16,6 +16,7 @@ import { ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT } from '@suite-common/wallet-constan
 import {
     STABLECOIN_YIELD_PREFIX,
     selectAddressDisplayType,
+    selectIsMevProtectionEnabled,
     stablecoinYieldActions,
     synchronizeSentTransactionThunk,
 } from '@suite-common/wallet-core';
@@ -27,7 +28,7 @@ import {
     type FormState,
     type PrecomposedTransactionFinal,
 } from '@suite-common/wallet-types';
-import { getAccountIdentity, sanitizeHex } from '@suite-common/wallet-utils';
+import { getAccountIdentity, getMevProtectedTxData, sanitizeHex } from '@suite-common/wallet-utils';
 import TrezorConnect, { type StaticSessionId } from '@trezor/connect';
 import { BigNumber } from '@trezor/utils';
 
@@ -335,8 +336,13 @@ export const claimMerkleRewardsThunk = createThunk(
                     return null;
                 }
 
+                const isMevProtectionEnabled = selectIsMevProtectionEnabled(getState());
                 const pushResponse = await TrezorConnect.pushTransaction({
-                    tx: signingResponse.payload.serializedTx,
+                    tx: getMevProtectedTxData(
+                        account.symbol,
+                        signingResponse.payload.serializedTx,
+                        isMevProtectionEnabled,
+                    ),
                     coin: account.symbol,
                     identity: getAccountIdentity(account),
                 });

--- a/packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts
@@ -8,6 +8,7 @@ import { type NetworkSymbol } from '@suite-common/wallet-config';
 import {
     type YieldFlowDisplayToken,
     selectAddressDisplayType,
+    selectIsMevProtectionEnabled,
     stablecoinYieldActions,
     synchronizeSentTransactionThunk,
 } from '@suite-common/wallet-core';
@@ -23,6 +24,7 @@ import {
     asAmountUnit,
     getAccountIdentity,
     getContractAddressForNetworkSymbol,
+    getMevProtectedTxData,
     unitsToSubunits,
 } from '@suite-common/wallet-utils';
 import TrezorConnect, { type EthereumSignTransaction, type TokenInfo } from '@trezor/connect';
@@ -284,8 +286,13 @@ export const sendYieldTransaction = async ({
             return;
         }
 
+        const isMevProtectionEnabled = selectIsMevProtectionEnabled(getState());
         const pushResponse = await TrezorConnect.pushTransaction({
-            tx: signingResponse.payload.serializedTx,
+            tx: getMevProtectedTxData(
+                account.symbol,
+                signingResponse.payload.serializedTx,
+                isMevProtectionEnabled,
+            ),
             coin: account.symbol,
             identity: getAccountIdentity(account),
         });


### PR DESCRIPTION
## Description

Yield push paths ignored the MEV protection setting. Wrap serialized tx with `getMevProtectedTxData(...)` before push in claim and deposit/withdraw/redeem, same as the send-form path.

## Notes for QA

Toggle the MEV protection in setting and observe is yield transaction respect it.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27916

## Screenshots:

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect stablecoin yield claim logic (claimMerkleRewardsThunk) and associated signing helpers, which are a specialized feature with no direct E2E test coverage. No static test mappings exist for these files, and no E2E test in the suite explicitly tests stablecoin yield or Merkle reward claiming. The closest related tests are the ETH staking tests, which exercise similar Ethereum transaction signing and device confirmation flows. The risk is moderate — changes to signing helpers could theoretically affect shared transaction composition patterns, but the stablecoin yield feature appears to be untested at the E2E level.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/actions/wallet/stablecoin-yield/claimMerkleRewardsThunk.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts`

</details>

**Recommended tests (3)**

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `../../suite/e2e/tests/staking/eth/unstake.test.ts` — The changed files relate to stablecoin yield claiming/signing logic. The ETH unstake test exercises the full claim flow (unstaking → cooldown → claim transaction → device confirmation → balance update), which is the closest E2E flow to a Merkle rewards claim. The signingHelpers likely share infrastructure with ETH staking transaction signing.
- `../../suite/e2e/tests/staking/eth/initial-stake.test.ts` — ETH initial staking exercises the Ethereum transaction signing and confirmation flow, which likely shares signing helper infrastructure (e.g., EIP-712 or contract interaction patterns) with the stablecoin yield signing helpers being modified.
- `../../suite/e2e/tests/staking/eth/stake-more.test.ts` — The stake-more test covers additional ETH staking transactions including device confirmation and signing flows. Changes to signingHelpers could affect shared Ethereum transaction composition or signing patterns used across staking and yield features.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/actions/wallet/stablecoin-yield/claimMerkleRewardsThunk.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts`

_Updated: 2026-05-21T08:48:28.156Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/yield-mev-protection&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/yield-mev-protection&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-21T08:53:41.818Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-21T08:51:42.522Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/yield-mev-protection/web/](https://dev.suite.sldev.cz/suite-web/fix/yield-mev-protection/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->