### PR TITLE
refactor: simplify ternaries to optional chaining and nullish coalescing (follow-up to #27834)

### DIFF
--- a/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
@@ -134,38 +134,23 @@ const getInitialState = (prevState?: Partial<PartialState>, action?: any) => ({
         action || ({ type: 'foo' } as any),
     ),
     wallet: {
-        accounts: accountsReducer(
-            prevState?.wallet ? prevState.wallet.accounts : undefined,
-            action || ({ type: 'foo' } as any),
-        ),
-        coinjoin: coinjoinReducer(
-            prevState?.wallet ? prevState.wallet.coinjoin : undefined,
-            action || ({ type: 'foo' } as any),
-        ),
+        accounts: accountsReducer(prevState?.wallet?.accounts, action || ({ type: 'foo' } as any)),
+        coinjoin: coinjoinReducer(prevState?.wallet?.coinjoin, action || ({ type: 'foo' } as any)),
         settings: walletSettingsReducer(
-            prevState?.wallet ? prevState.wallet.settings : undefined,
+            prevState?.wallet?.settings,
             action || ({ type: 'foo' } as any),
         ),
         discovery: discoveryReducer(
-            prevState?.wallet ? prevState.wallet.discovery : undefined,
+            prevState?.wallet?.discovery,
             action || ({ type: 'foo' } as any),
         ),
-        send: sendFormReducer(
-            prevState?.wallet ? prevState.wallet.send : undefined,
-            action || ({ type: 'foo' } as any),
-        ),
+        send: sendFormReducer(prevState?.wallet?.send, action || ({ type: 'foo' } as any)),
         transactions: transactionsReducer(
-            prevState?.wallet ? prevState.wallet.transactions : undefined,
+            prevState?.wallet?.transactions,
             action || ({ type: 'foo' } as any),
         ),
-        fiat: fiatRatesReducer(
-            prevState?.wallet ? prevState.wallet.fiat : undefined,
-            action || ({ type: 'foo' } as any),
-        ),
-        graph: graphReducer(
-            prevState?.wallet ? prevState.wallet.graph : undefined,
-            action || ({ type: 'foo' } as any),
-        ),
+        fiat: fiatRatesReducer(prevState?.wallet?.fiat, action || ({ type: 'foo' } as any)),
+        graph: graphReducer(prevState?.wallet?.graph, action || ({ type: 'foo' } as any)),
         formDrafts: {},
     },
 });

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApproveModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApproveModal.tsx
@@ -209,8 +209,7 @@ export const ApproveModal = ({
     };
 
     const providers = getProvidersInfoProps(context);
-    const provider =
-        selectedQuote?.exchange && providers ? providers[selectedQuote.exchange] : undefined;
+    const provider = selectedQuote?.exchange ? providers?.[selectedQuote.exchange] : undefined;
 
     return (
         <Modal

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConfirmUnverifiedModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConfirmUnverifiedModal.tsx
@@ -55,8 +55,7 @@ export const ConfirmUnverifiedModal = ({
 
     const enablePassphraseAndContinue = async () => {
         if (!device?.available) {
-            const result = await dispatch(applySettings({ use_passphrase: true }));
-            if (!result?.success) return;
+            await dispatch(applySettings({ use_passphrase: true }));
         }
     };
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/RevokeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/RevokeModal.tsx
@@ -138,8 +138,7 @@ export const RevokeModal = ({ setIsWaitingForDevice, onCancel }: RevokeModalProp
     const isIncreasingAllowanceSupported = tokenSupportsIncreasingAllowance(contractAddress);
 
     const providers = getProvidersInfoProps(context);
-    const provider =
-        selectedQuote?.exchange && providers ? providers[selectedQuote.exchange] : undefined;
+    const provider = selectedQuote?.exchange ? providers?.[selectedQuote.exchange] : undefined;
 
     return (
         <Modal

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingReceiveAddress.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingReceiveAddress.ts
@@ -249,8 +249,8 @@ export const useTradingReceiveAddress = ({
                 ? accounts.find(account => account.key === sendAccountKey)
                 : undefined;
 
-        const matchingAccount = suiteReceiveAccounts?.find(account =>
-            sendAccount?.symbol === account.symbol ? account.key === sendAccount.key : true,
+        const matchingAccount = suiteReceiveAccounts?.find(
+            account => sendAccount?.symbol !== account.symbol || account.key === sendAccount.key,
         );
 
         if (matchingAccount) {

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailBuy/TradingDetailBuy.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailBuy/TradingDetailBuy.tsx
@@ -59,7 +59,7 @@ export const TradingDetailBuy = () => {
     const composedTransaction = useSelector(selectTradingComposedTransactionInfo);
 
     const exchange = trade?.data?.exchange;
-    const provider = info?.providerInfos && exchange ? info.providerInfos[exchange] : undefined;
+    const provider = exchange ? info?.providerInfos?.[exchange] : undefined;
 
     const country = trade?.data?.country;
 

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchange.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchange.tsx
@@ -67,7 +67,7 @@ export const TradingDetailExchange = () => {
     const composedTransaction = useSelector(selectTradingComposedTransactionInfo);
 
     const exchange = trade?.data?.exchange;
-    const provider = info?.providerInfos && exchange ? info.providerInfos[exchange] : undefined;
+    const provider = exchange ? info?.providerInfos?.[exchange] : undefined;
 
     const quoteAmounts: TradingGetCryptoQuoteAmountProps = {
         sendAmount: trade?.data?.sendStringAmount ?? '',

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSell/TradingDetailSell.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSell/TradingDetailSell.tsx
@@ -52,7 +52,7 @@ export const TradingDetailSell = () => {
     const composedTransaction = useSelector(selectTradingComposedTransactionInfo);
 
     const exchange = trade?.data?.exchange;
-    const provider = info?.providerInfos && exchange ? info.providerInfos[exchange] : undefined;
+    const provider = exchange ? info?.providerInfos?.[exchange] : undefined;
 
     const country = trade?.data?.country;
 

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputFiat.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputFiat.tsx
@@ -205,9 +205,7 @@ export const TradingFormInputFiat = ({
                                   selectedCurrencyCode || 'usd',
                                   tokenAddress,
                               );
-                              const rate = rates?.[fiatRateKey]
-                                  ? rates[fiatRateKey].rate
-                                  : undefined;
+                              const rate = rates?.[fiatRateKey]?.rate;
                               const minFiat = toFiatCurrency({
                                   amount: context.amountLimits.minCrypto,
                                   rate,

--- a/suite-common/wallet-core/src/accounts/accountsThunks.ts
+++ b/suite-common/wallet-core/src/accounts/accountsThunks.ts
@@ -185,7 +185,7 @@ export const fetchAndUpdateAccountThunk = createThunk(
             const devices = selectDevices(getState());
             const accountDevice = findAccountDevice(account, devices);
             analyze.newTransactions.forEach(tx => {
-                const token = tx.tokens?.length ? tx.tokens[0] : undefined;
+                const token = tx.tokens?.[0];
 
                 const bitcoinAmountUnit = selectBitcoinAmountUnit(getState());
                 const areSatoshisUsed = getAreSatoshisUsed(bitcoinAmountUnit, account);

--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
@@ -326,7 +326,7 @@ export const onBlockchainNotificationThunk = createThunk(
         if (tx.type === 'recv' && !tx.blockHeight) {
             const accountDevice = findAccountDevice(account, selectDevices(getState()));
 
-            const token = tx.tokens?.length ? tx.tokens[0] : undefined;
+            const token = tx.tokens?.[0];
             const areSatoshisUsed = getAreSatoshisUsed(
                 selectBitcoinAmountUnit(getState()),
                 account,

--- a/suite-common/wallet-core/src/send/composeCancelTransaction/resolveCancelAddress.ts
+++ b/suite-common/wallet-core/src/send/composeCancelTransaction/resolveCancelAddress.ts
@@ -10,7 +10,7 @@ type ResolveCancelAddress = {
 export const resolveCancelAddress = ({ account, tx }: ResolveCancelAddress): string => {
     const firstChangeAddress = tx.details.vout.find(vout => vout.isAccountOwned);
 
-    if (firstChangeAddress?.addresses !== undefined && firstChangeAddress.addresses.length > 0) {
+    if (firstChangeAddress?.addresses?.length) {
         return firstChangeAddress.addresses[0];
     }
 

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -720,8 +720,8 @@ export const getAccountSpecific = (accountInfo: Partial<AccountInfo>, networkTyp
         return {
             networkType,
             misc: {
-                sequence: misc?.sequence ? misc.sequence : 0,
-                reserve: misc?.reserve ? misc.reserve : '0',
+                sequence: misc?.sequence ?? 0,
+                reserve: misc?.reserve ?? '0',
             },
             marker: accountInfo.marker,
             stellarCursor: undefined,
@@ -734,7 +734,7 @@ export const getAccountSpecific = (accountInfo: Partial<AccountInfo>, networkTyp
             networkType,
             misc: {
                 ...misc,
-                nonce: misc?.nonce ? misc.nonce : '0',
+                nonce: misc?.nonce ?? '0',
             },
             marker: undefined,
             stellarCursor: undefined,
@@ -747,11 +747,11 @@ export const getAccountSpecific = (accountInfo: Partial<AccountInfo>, networkTyp
             networkType,
             misc: {
                 staking: {
-                    rewards: misc?.staking ? misc.staking.rewards : '0',
-                    isActive: misc?.staking ? misc.staking.isActive : false,
-                    address: misc?.staking ? misc.staking.address : '',
-                    poolId: misc?.staking ? misc.staking.poolId : null,
-                    drep: misc?.staking ? misc.staking.drep : null,
+                    rewards: misc?.staking?.rewards ?? '0',
+                    isActive: misc?.staking?.isActive ?? false,
+                    address: misc?.staking?.address ?? '',
+                    poolId: misc?.staking?.poolId ?? null,
+                    drep: misc?.staking?.drep ?? null,
                 },
             },
             marker: undefined,


### PR DESCRIPTION
## Summary

Follow-up to #27834 (parent PR — merged). Addresses review suggestions from @marekrjpolak that the `@typescript-eslint/prefer-optional-chain` autofixer is too conservative to handle on its own: ternary-to-chain simplifications, optional indexed access (`?.[…]`), and `?? default` in place of the truthy `x ? x : default` pattern.

## Changes by file (each line links the original review comment)

- `packages/suite/src/actions/suite/__tests__/storageActions.test.ts` — collapse `prevState?.wallet ? prevState.wallet.X : undefined` → `prevState?.wallet?.X` across all wallet sub-reducers. [comment](https://github.com/trezor/trezor-suite/pull/27834/changes#r3274348671)
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApproveModal.tsx` — `selectedQuote?.exchange ? providers?.[selectedQuote.exchange] : undefined`. [comment](https://github.com/trezor/trezor-suite/pull/27834/changes#r3274832371)
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConfirmUnverifiedModal.tsx` — drop the dead `if (!result?.success) return;` trailing statement (last line of the function, so the early return is a no-op). [comment](https://github.com/trezor/trezor-suite/pull/27834/changes#r3274853926)
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/RevokeModal.tsx` — same shape as `ApproveModal`. [comment](https://github.com/trezor/trezor-suite/pull/27834/changes#r3274858334)
- `packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailBuy/TradingDetailBuy.tsx` — `exchange ? info?.providerInfos?.[exchange] : undefined`. [comment](https://github.com/trezor/trezor-suite/pull/27834/changes#r3274926369)
- `packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchange.tsx` — same. [comment](https://github.com/trezor/trezor-suite/pull/27834/changes#r3274930051)
- `packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSell/TradingDetailSell.tsx` — same. [comment](https://github.com/trezor/trezor-suite/pull/27834/changes#r3274936060)
- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputFiat.tsx` — `rates?.[fiatRateKey]?.rate`. [comment](https://github.com/trezor/trezor-suite/pull/27834/changes#r3274947193)
- `packages/suite/src/hooks/wallet/trading/form/useTradingReceiveAddress.ts` — ternary rewritten as `sendAccount?.symbol !== account.symbol || account.key === sendAccount.key`. [comment](https://github.com/trezor/trezor-suite/pull/27834/changes#r3274893655)
- `suite-common/wallet-core/src/accounts/accountsThunks.ts` — `tx.tokens?.[0]`. [comment](https://github.com/trezor/trezor-suite/pull/27834/changes#r3274996022)
- `suite-common/wallet-core/src/blockchain/blockchainThunks.ts` — same. [comment](https://github.com/trezor/trezor-suite/pull/27834/changes#r3275000076)
- `suite-common/wallet-core/src/send/composeCancelTransaction/resolveCancelAddress.ts` — `if (firstChangeAddress?.addresses?.length)`. [comment](https://github.com/trezor/trezor-suite/pull/27834/changes#r3275006754)
- `suite-common/wallet-utils/src/accountUtils.ts` — `?? default` instead of `x ? x : default` across `getAccountSpecific` (ripple / ethereum / cardano misc), matching the stellar branch which already used `??`. [comment](https://github.com/trezor/trezor-suite/pull/27834/changes#r3275021015)

## Deliberately excluded review comments

- `suite-common/device/src/deviceUtils.ts` — the suggested `device?.id !== null && device.state?.staticSessionId !== undefined` is unsafe: if `device` is `undefined`, `device?.id` is `undefined` and `undefined !== null` evaluates to `true`, so the guard would let `device.state` through and crash at runtime. The current explicit `device !== undefined && device.id !== null && …` form is intentional for the type predicate. Not applied. [comment](https://github.com/trezor/trezor-suite/pull/27834/changes#r3274971364)

## Test plan
- [ ] CI green
- [ ] Manual sanity check on trading approve / revoke flows

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/prefer-optional-chain-followup/web/](https://dev.suite.sldev.cz/suite-web/mroz22/prefer-optional-chain-followup/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->