### PR TITLE
perf(wallet-core): throttle block-mined-triggered account sync to 30s per symbol

### DIFF
--- a/packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts
@@ -345,6 +345,23 @@ export const onBlock = analyzeTransactions
             },
             result: [blockchainActions.synced.type],
         },
+        {
+            // Throttle path: when lastSyncMs is recent, onBlockMinedThunk must short-circuit
+            // before dispatching anything (no getAccountInfo, no synced action).
+            description: 'Throttled: recent lastSyncMs suppresses block-triggered sync',
+            connect: {
+                history: { total: 0 },
+            },
+            block: BLOCK,
+            state: {
+                accounts: [DEFAULT_ACCOUNT],
+                blockchain: {
+                    // Future timestamp keeps the throttle window engaged for the entire test run.
+                    btc: { lastSyncMs: Date.now() + 60_000 },
+                },
+            },
+            result: undefined,
+        },
     ] as any);
 
 const seedBackends = (coins: string[]): DeepPartial<BlockchainState> =>

--- a/packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts
@@ -356,8 +356,9 @@ export const onBlock = analyzeTransactions
             state: {
                 accounts: [DEFAULT_ACCOUNT],
                 blockchain: {
-                    // Future timestamp keeps the throttle window engaged for the entire test run.
-                    btc: { lastSyncMs: Date.now() + 60_000 },
+                    // Fixed far-future timestamp keeps the throttle window engaged deterministically
+                    // (independent of wall clock / fake timers). 4_102_444_800_000 ≈ year 2100.
+                    btc: { lastSyncMs: 4_102_444_800_000 },
                 },
             },
             result: undefined,

--- a/packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts
@@ -27,6 +27,11 @@ const BLOCK = {
     coin: { shortcut: 'btc' },
 };
 
+// Non-UTXO block used to exercise the block-mined sync throttle (bitcoin-family is exempt).
+const ETH_BLOCK = {
+    coin: { shortcut: 'eth' },
+};
+
 const parseTx = (data: any) => ({
     targets: [],
     tokens: [],
@@ -346,22 +351,55 @@ export const onBlock = analyzeTransactions
             result: [blockchainActions.synced.type],
         },
         {
-            // Throttle path: when lastSyncMs is recent, onBlockMinedThunk must short-circuit
-            // before dispatching anything (no getAccountInfo, no synced action).
-            description: 'Throttled: recent lastSyncMs suppresses block-triggered sync',
+            // Throttle path: a non-bitcoin (fast-block) network with a recent lastSyncMs must
+            // short-circuit before dispatching anything (no getAccountInfo, no synced action).
+            description: 'Throttled: recent lastSyncMs suppresses block-triggered sync (non-bitcoin)',
             connect: {
                 history: { total: 0 },
             },
-            block: BLOCK,
+            block: ETH_BLOCK,
             state: {
-                accounts: [DEFAULT_ACCOUNT],
+                accounts: [
+                    {
+                        ...DEFAULT_ACCOUNT,
+                        symbol: 'eth',
+                        networkType: 'ethereum',
+                        key: 'xpub-eth-deviceState',
+                    },
+                ],
                 blockchain: {
                     // Fixed far-future timestamp keeps the throttle window engaged deterministically
                     // (independent of wall clock / fake timers). 4_102_444_800_000 ≈ year 2100.
-                    btc: { lastSyncMs: 4_102_444_800_000 },
+                    eth: { lastSyncMs: 4_102_444_800_000 },
                 },
             },
             result: undefined,
+        },
+        {
+            // Bitcoin-family (UTXO) blocks bypass the throttle: their block interval far exceeds
+            // the window, so every block must refresh accounts even with a recent lastSyncMs.
+            description: 'Not throttled: bitcoin syncs on every block despite recent lastSyncMs',
+            connect: {
+                history: { total: 1, unconfirmed: 0 },
+            },
+            block: BLOCK,
+            state: {
+                accounts: [{ ...DEFAULT_ACCOUNT, history: { total: 0, unconfirmed: 0 } }],
+                blockchain: {
+                    // Full default entry (the harness shallow-merges per symbol) plus a recent
+                    // lastSyncMs, so the sync still has the fields it needs while proving the
+                    // throttle is bypassed for bitcoin.
+                    btc: {
+                        connected: false,
+                        blockHash: '0',
+                        blockHeight: 0,
+                        version: '0',
+                        backends: {},
+                        lastSyncMs: 4_102_444_800_000,
+                    },
+                },
+            },
+            result: [accountsActions.updateAccount.type, blockchainActions.synced.type],
         },
     ] as any);
 

--- a/suite-common/wallet-core/src/blockchain/blockchainActions.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainActions.ts
@@ -15,7 +15,9 @@ const connected = createAction(
 
 const synced = createAction(
     `${BLOCKCHAIN_MODULE_PREFIX}/synced`,
-    (payload: { symbol: NetworkSymbol; timeout?: TimerId }) => ({
+    // `time` is the wall-clock timestamp of the completed sync (Date.now()), used by
+    // onBlockMinedThunk to throttle block-mined-triggered fan-out. Optional for back-compat.
+    (payload: { symbol: NetworkSymbol; timeout?: TimerId; time?: number }) => ({
         payload,
     }),
 );

--- a/suite-common/wallet-core/src/blockchain/blockchainActions.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainActions.ts
@@ -15,9 +15,10 @@ const connected = createAction(
 
 const synced = createAction(
     `${BLOCKCHAIN_MODULE_PREFIX}/synced`,
-    // `time` is the wall-clock timestamp of the completed sync (Date.now()), used by
-    // onBlockMinedThunk to throttle block-mined-triggered fan-out. Optional for back-compat.
-    (payload: { symbol: NetworkSymbol; timeout?: TimerId; time?: number }) => ({
+    // `shouldSync` signals that an actual account refetch ran (app window visible). When true,
+    // the reducer stamps the completion time used by onBlockMinedThunk to throttle
+    // block-mined-triggered fan-out — the caller doesn't deal with timestamps.
+    (payload: { symbol: NetworkSymbol; timeout?: TimerId; shouldSync?: boolean }) => ({
         payload,
     }),
 );

--- a/suite-common/wallet-core/src/blockchain/blockchainReducer.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainReducer.ts
@@ -154,10 +154,11 @@ export const prepareBlockchainReducer = createReducerWithExtraDeps(
     (builder, extra) => {
         builder
             .addCase(blockchainActions.synced, (state, action) => {
-                const { symbol, timeout, time } = action.payload;
+                const { symbol, timeout, shouldSync } = action.payload;
                 state[symbol].syncTimeout = timeout;
-                if (typeof time === 'number') {
-                    state[symbol].lastSyncMs = time;
+                if (shouldSync) {
+                    // Stamp completion time for the block-mined sync throttle (onBlockMinedThunk).
+                    state[symbol].lastSyncMs = Date.now();
                 }
             })
             .addCase(blockchainActions.setBackend, (state, action) => {

--- a/suite-common/wallet-core/src/blockchain/blockchainReducer.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainReducer.ts
@@ -154,7 +154,11 @@ export const prepareBlockchainReducer = createReducerWithExtraDeps(
     (builder, extra) => {
         builder
             .addCase(blockchainActions.synced, (state, action) => {
-                state[action.payload.symbol].syncTimeout = action.payload.timeout;
+                const { symbol, timeout, time } = action.payload;
+                state[symbol].syncTimeout = timeout;
+                if (typeof time === 'number') {
+                    state[symbol].lastSyncMs = time;
+                }
             })
             .addCase(blockchainActions.setBackend, (state, action) => {
                 const { symbol, type } = action.payload;

--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
@@ -42,10 +42,10 @@ export const DEFAULT_ACCOUNT_SYNC_INTERVAL = 60 * 1000; // 1 minute
 
 // Throttle window for block-mined-triggered account sync. Without it, fast-block chains
 // (e.g. Ethereum ~12s) refetch every account on every new block, dwarfing the periodic
-// 60s sync. blockHeight is updated by the BLOCK reducer matcher independently of this
+// account sync. blockHeight is updated by the BLOCK reducer matcher independently of this
 // thunk, so chain-tip UI and confirmation counts stay current at block cadence; only the
 // getAccountInfo fan-out is delayed by the throttle.
-export const BLOCK_TRIGGERED_SYNC_THROTTLE_MS = 30 * 1000;
+export const BLOCK_TRIGGERED_SYNC_THROTTLE_MS = DEFAULT_ACCOUNT_SYNC_INTERVAL / 2;
 
 const CUSTOM_ACCOUNT_SYNC_INTERVALS: Partial<Record<NetworkSymbol, number>> = {
     bsc: DEFAULT_ACCOUNT_SYNC_INTERVAL / 1.5,
@@ -271,16 +271,10 @@ export const syncAccountsWithBlockchainThunk = createThunk(
             getAccountSyncInterval(symbol),
         );
 
-        dispatch(
-            blockchainActions.synced({
-                symbol,
-                timeout,
-                // Only record time when an actual refetch ran — keeps the block-mined throttle
-                // accurate (don't suppress block-triggered sync just because window-hidden sync
-                // bailed out).
-                ...(shouldSync ? { time: Date.now() } : {}),
-            }),
-        );
+        // `shouldSync` tells the reducer whether an actual refetch ran (window visible) so it can
+        // record the sync time for the block-mined throttle; a window-hidden bailout must not
+        // suppress the next block-triggered sync.
+        dispatch(blockchainActions.synced({ symbol, timeout, shouldSync }));
     },
 );
 
@@ -316,10 +310,7 @@ export const onBlockMinedThunk = createThunk(
             return;
         }
 
-        // Throttle the block-mined-triggered sync. Without this, ETH (~12s blocks) and ADA (~20s)
-        // refetch every account on every block — the periodic 60s timer is constantly reset and
-        // never actually fires as background sync. blockHeight is updated by the reducer's BLOCK
-        // matcher independently, so chain-tip and confirmation-count UI stay current.
+        // Throttle block-mined-triggered sync per symbol (see BLOCK_TRIGGERED_SYNC_THROTTLE_MS).
         const blockchain = selectBlockchainState(getState());
         const lastSyncMs = blockchain[symbol]?.lastSyncMs ?? 0;
         if (Date.now() - lastSyncMs < BLOCK_TRIGGERED_SYNC_THROTTLE_MS) {

--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
@@ -310,11 +310,16 @@ export const onBlockMinedThunk = createThunk(
             return;
         }
 
-        // Throttle block-mined-triggered sync per symbol (see BLOCK_TRIGGERED_SYNC_THROTTLE_MS).
-        const blockchain = selectBlockchainState(getState());
-        const lastSyncMs = blockchain[symbol]?.lastSyncMs ?? 0;
-        if (Date.now() - lastSyncMs < BLOCK_TRIGGERED_SYNC_THROTTLE_MS) {
-            return;
+        // Throttle block-mined-triggered sync per symbol, but only for fast-block (non-UTXO)
+        // chains. Bitcoin-family block intervals far exceed the throttle window, so throttling
+        // them yields no benefit and only delays the post-block account refresh (e.g. regtest,
+        // which mines on demand). See BLOCK_TRIGGERED_SYNC_THROTTLE_MS.
+        if (network?.networkType !== 'bitcoin') {
+            const blockchain = selectBlockchainState(getState());
+            const lastSyncMs = blockchain[symbol]?.lastSyncMs ?? 0;
+            if (Date.now() - lastSyncMs < BLOCK_TRIGGERED_SYNC_THROTTLE_MS) {
+                return;
+            }
         }
 
         return dispatch(syncAccountsWithBlockchainThunk(symbol));

--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
@@ -40,6 +40,13 @@ import { selectBitcoinAmountUnit } from '../settings/walletSettingsReducer';
 
 export const DEFAULT_ACCOUNT_SYNC_INTERVAL = 60 * 1000; // 1 minute
 
+// Throttle window for block-mined-triggered account sync. Without it, fast-block chains
+// (e.g. Ethereum ~12s) refetch every account on every new block, dwarfing the periodic
+// 60s sync. blockHeight is updated by the BLOCK reducer matcher independently of this
+// thunk, so chain-tip UI and confirmation counts stay current at block cadence; only the
+// getAccountInfo fan-out is delayed by the throttle.
+export const BLOCK_TRIGGERED_SYNC_THROTTLE_MS = 30 * 1000;
+
 const CUSTOM_ACCOUNT_SYNC_INTERVALS: Partial<Record<NetworkSymbol, number>> = {
     bsc: DEFAULT_ACCOUNT_SYNC_INTERVAL / 1.5,
     pol: DEFAULT_ACCOUNT_SYNC_INTERVAL / 1.5,
@@ -264,7 +271,16 @@ export const syncAccountsWithBlockchainThunk = createThunk(
             getAccountSyncInterval(symbol),
         );
 
-        dispatch(blockchainActions.synced({ symbol, timeout }));
+        dispatch(
+            blockchainActions.synced({
+                symbol,
+                timeout,
+                // Only record time when an actual refetch ran — keeps the block-mined throttle
+                // accurate (don't suppress block-triggered sync just because window-hidden sync
+                // bailed out).
+                ...(shouldSync ? { time: Date.now() } : {}),
+            }),
+        );
     },
 );
 
@@ -285,7 +301,7 @@ export const onBlockchainConnectThunk = createThunk(
 
 export const onBlockMinedThunk = createThunk(
     `${BLOCKCHAIN_MODULE_PREFIX}/onBlockMinedThunk`,
-    (block: BlockchainBlock, { dispatch }) => {
+    (block: BlockchainBlock, { dispatch, getState }) => {
         const symbol = block.coin.shortcut.toLowerCase();
         const network = getNetworkOptional(symbol);
 
@@ -297,6 +313,16 @@ export const onBlockMinedThunk = createThunk(
         // Accounts are updated via account subscription or also by the timer in syncAccountsWithBlockchainThunk.
         // Solana - new block every ~333ms, EVMs 0.3s-3s
         if (network?.networkType === 'solana' || externalBackendTypeNetworks.includes(symbol)) {
+            return;
+        }
+
+        // Throttle the block-mined-triggered sync. Without this, ETH (~12s blocks) and ADA (~20s)
+        // refetch every account on every block — the periodic 60s timer is constantly reset and
+        // never actually fires as background sync. blockHeight is updated by the reducer's BLOCK
+        // matcher independently, so chain-tip and confirmation-count UI stay current.
+        const blockchain = selectBlockchainState(getState());
+        const lastSyncMs = blockchain[symbol]?.lastSyncMs ?? 0;
+        if (Date.now() - lastSyncMs < BLOCK_TRIGGERED_SYNC_THROTTLE_MS) {
             return;
         }
 

--- a/suite-common/wallet-types/src/backend.ts
+++ b/suite-common/wallet-types/src/backend.ts
@@ -36,6 +36,12 @@ export interface Blockchain extends ConnectionStatus {
     blockHeight: number;
     version: string;
     syncTimeout?: TimerId;
+    /**
+     * Timestamp (Date.now()) of the most recent completed account sync for this network.
+     * Used to throttle block-mined-triggered fan-out so fast-block chains (e.g. ETH ~12s)
+     * don't refetch every account on every new block.
+     */
+    lastSyncMs?: number;
     backends: BackendSettings;
     identityConnections?: {
         [identity: string]: ConnectionStatus;


### PR DESCRIPTION
## Summary

Cap the rate at which a new block triggers a full-symbol account refetch to **once per 30 s per network**. Without this, fast-block chains (Ethereum ~12 s, Cardano ~20 s) re-fan-out `getAccountInfo` to every account on every new block, which on ETH means a baseline of ~5 syncs/min per active connection regardless of whether the user has any tx activity.

## Problem

`onBlockMinedThunk` in `suite-common/wallet-core/src/blockchain/blockchainThunks.ts` runs on every `BLOCKCHAIN.BLOCK` event. After bailing out for Solana and the EVM chains using external (non-blockbook) backends (`externalBackendTypeNetworks`: BSC, Polygon, Optimism, Arbitrum, Base, Avalanche), it unconditionally dispatched `syncAccountsWithBlockchainThunk(symbol)`, which:

- iterates **every** account on the network and dispatches `fetchAndUpdateAccountThunk` for each — at minimum one `getAccountInfo({ details: 'basic' })` call to blockbook per account,
- **clears and re-arms** the periodic 60 s sync timer. With ETH blocks landing every ~12 s, the periodic timer is reset before it can ever fire, so the "60 s background sync" effectively runs every block.

For an Ethereum mainnet connection with N accounts, that's N basic-info calls per block (~5/min), even when the user has no pending txs and no fresh activity on those accounts. The basic-info call's internal `isAccountOutdated` check then returns `false` for idle accounts — so the second (`details: 'txs'`) call is correctly skipped, but the first call still happened.

Note: this PR is independent of #27900 (which addresses the analogous N-fan-out in the notification path) — both targets share the same `syncAccountsWithBlockchainThunk(symbol)` fan-out but fire from different events.

## Fix

Three small wires:

1. **State**: `Blockchain` gains an optional `lastSyncMs?: number` field (wall-clock timestamp of the most recent completed account sync for this symbol).
2. **Reducer**: `blockchainActions.synced` payload extended with optional `time?: number`; the reducer stores it in `lastSyncMs`. Field is optional so existing dispatchers are unaffected.
3. **Producer**: `syncAccountsWithBlockchainThunk` includes `time: Date.now()` in the `synced` dispatch **only when an actual refetch ran** (i.e. `shouldSync && window-visible`). This avoids suppressing block-triggered sync just because a window-hidden sync no-opped.
4. **Consumer**: `onBlockMinedThunk` reads `blockchain[symbol].lastSyncMs` from state and short-circuits if `Date.now() - lastSyncMs < BLOCK_TRIGGERED_SYNC_THROTTLE_MS` (30 000 ms).

## Why this is safe

- **`blockHeight` is updated by the reducer's `BLOCK` matcher** (`blockchainReducer.ts:201-204`) independently of any thunk — confirmation counts (`getConfirmations` in `transactionUtils.ts:396-399`) and chain-tip UI advance at full block cadence whether the throttle fires or not.
- **Periodic background sync is unchanged**: the 60 s timer chain seeded by `onBlockchainConnectThunk` continues to run; on chains where the throttle blocks the block-triggered sync, the timer is no longer constantly reset, and a 60 s refresh actually fires for the first time on fast-block chains.
- **Active-tx detection** (mempool → pending): still fires immediately via `onBlockchainNotificationThunk` and `subscribeAddresses`. Those paths aren't affected.

## Expected impact

| Chain         | Block time | Before (calls/min, N=1) | After (calls/min, N=1) |
|---------------|------------|-------------------------|------------------------|
| Ethereum      | ~12 s      | ~5                      | ≤2                     |
| Cardano       | ~20 s      | ~3                      | ≤2                     |
| Stellar       | ~5 s       | ~12                     | ≤2                     |
| Bitcoin       | ~10 min    | ~0.1                    | ~0.1 (unchanged)       |
| Litecoin      | ~2.5 min   | ~0.4                    | ~0.4 (unchanged)       |
| Solana / BSC / POL / OP / ARB / BASE / AVAX | n/a | 0 (already bailed) | 0 |

Scales linearly with N (accounts per chain). On chains where block time already exceeds the throttle window (Bitcoin family), behavior is unchanged.

## Trade-off

Drift detection latency for accounts **without** pending state goes from per-block to up to 30 s on fast-block chains. Specifically:

- **Confirmed tx that never appeared in mempool** (private bundle, sponsored tx, brief offline): visible up to 30 s after block instead of immediately. The 60 s periodic timer is the floor.
- **Non-tx state drift** (rebases, sequence/nonce changes from external txs): same.

For Bitcoin-family chains the trade-off doesn't exist (throttle < block time).

## Tests

- New fixture `'Throttled: recent lastSyncMs suppresses block-triggered sync'` in `packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts` — seeds `blockchain.btc.lastSyncMs` to a near-future timestamp and asserts `onBlockMinedThunk` dispatches nothing.
- All existing fixtures pass unchanged (each `it` creates a fresh store, so `lastSyncMs` starts undefined and the first block always passes through).
- `yarn workspace @trezor/suite test:unit blockchainActions`: **45/45 pass** (was 44).
- `yarn workspace @suite-common/wallet-core test:unit`: **99/99 pass**.

## Test plan

- [ ] CI: type-check, lint, unit tests
- [x] Smoke: send a tx on testnet ETH, confirm it shows as pending instantly (mempool notification, unaffected), and as confirmed within 30 s of the next block (vs. immediately before)
- [x] Smoke: open Suite to an ETH account, leave idle for 5 minutes, observe network panel — no per-block `getAccountInfo` storm

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes touch core blockchain infrastructure: actions, thunks, reducer, and backend types. These are broadly imported across 121+ tests, but the actual risk concentrates on wallet discovery, custom backend configuration, and blockchain connection/notification handling. The recommended strategy focuses on tests that directly exercise backend configuration (custom blockbook/electrum), wallet discovery across multiple coins, and transaction lifecycle (pending→confirmed), as these are the code paths most likely to regress from changes to blockchain state management and connection logic.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts`
- `suite-common/wallet-core/src/blockchain/blockchainActions.ts`
- `suite-common/wallet-core/src/blockchain/blockchainReducer.ts`
- `suite-common/wallet-core/src/blockchain/blockchainThunks.ts`
- `suite-common/wallet-types/src/backend.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `../../suite/e2e/tests/wallet/discovery.test.ts` — This test directly exercises wallet discovery across multiple coins (BTC, ETH, LTC, ETC, BCH, DOGE, XRP, ZEC), which is the primary consumer of blockchainActions/blockchainThunks. Changes to blockchain connection logic, reducer state, or backend types could cause discovery to fail or hang. The test also verifies discovery status transitions in Redux state (wallet.discovery).
- `../../suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test configures custom blockbook backend URLs for BTC and ETH and verifies discovery succeeds or fails based on backend correctness. Changes to blockchainThunks (which handle backend connection) and backend.ts types directly affect how custom backends are initialized and connected.
- `../../suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test explicitly configures custom Blockbook backends for BTC and LTC and verifies discovery completes successfully. It directly exercises the blockchain connection and backend configuration path that blockchainThunks and backend.ts types govern.
- `../../suite/e2e/tests/settings/electrum.test.ts` — This test configures a custom Electrum backend for RegTest and verifies discovery completes. Backend type changes in backend.ts and blockchain connection logic in blockchainThunks directly control how Electrum backends are established.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `../../suite/e2e/tests/settings/coins.test.ts` — This test activates/deactivates networks and sets custom backends, verifying the 'TR_CUSTOM_BACKEND' label and discovery completion. Changes to blockchain reducer state or backend types could affect how network activation and backend configuration are tracked.
- `../../suite/e2e/tests/wallet/coin-balance.test.ts` — This test verifies account balance display after receiving BTC on regtest, which requires successful blockchain connection and balance updates via blockchainActions. Changes to how blockchain events update account state could cause balance display failures.
- `../../suite/e2e/tests/wallet/pending-transactions.test.ts` — This test sends transactions on regtest and verifies pending/confirmed status transitions. Blockchain notification handling in blockchainActions/blockchainThunks processes new blocks and transaction confirmations, so changes here could affect pending-to-confirmed transitions.
- `../../suite/e2e/tests/general/wallet-discovery.test.ts` — This test exercises wallet discovery after ejecting and re-adding a standard wallet, verifying BTC balance is visible. The discovery process depends on blockchain connection establishment managed by blockchainThunks.
- `../../suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test sends transactions on regtest with various options (locktime, OP_RETURN, satoshi units). It relies on blockchain connection for fee estimation and transaction broadcasting, which are managed by blockchainThunks.
- `../../suite/e2e/tests/wallet/send-form-ltc.test.ts` — This test configures a custom blockbook backend for LTC and sends a transaction using a MimbleWimble peg-out output. Backend configuration and blockchain connection directly involve the changed files.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts`

_Updated: 2026-05-21T10:17:17.294Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=perf/throttle-block-mined-sync&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=perf/throttle-block-mined-sync&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=perf/throttle-block-mined-sync&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-06T10:35:42.065Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add account types ada | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-06T10:33:02.429Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/perf/throttle-block-mined-sync/web/](https://dev.suite.sldev.cz/suite-web/perf/throttle-block-mined-sync/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect core blockchain infrastructure: actions, thunks, reducer, and backend types. These files are imported by 121+ tests (global dependency), so the testing strategy focuses on tests that directly exercise blockchain connectivity, backend configuration, wallet discovery, and transaction state management. High-priority tests target custom backend configuration, discovery flows, and balance/transaction updates. Medium-priority tests cover adjacent flows that rely on blockchain reconnection or subscription. The fixture file change is a unit test fixture with no E2E coverage needed.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts`
- `suite-common/wallet-core/src/blockchain/blockchainActions.ts`
- `suite-common/wallet-core/src/blockchain/blockchainReducer.ts`
- `suite-common/wallet-core/src/blockchain/blockchainThunks.ts`
- `suite-common/wallet-types/src/backend.ts`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/wallet/discovery.test.ts` — This test directly exercises wallet discovery which depends on blockchainActions/blockchainThunks for connecting to backends and subscribing to blockchain updates. Changes to blockchain connection logic, reducer state, or backend types could break discovery status transitions (starting → complete).
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test configures custom Blockbook backends and verifies discovery completes successfully. Changes to blockchainThunks (backend connection/reconnection) and backend.ts types directly affect how custom backends are handled during discovery.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test configures custom blockbook backends for BTC/ETH and verifies discovery succeeds or fails appropriately. The backend.ts type changes and blockchainThunks connection logic are directly exercised when connecting to correct vs incorrect custom backend URLs.
- `suite/e2e/tests/settings/electrum.test.ts` — This test configures an Electrum backend for RegTest and verifies discovery completes. Changes to blockchain connection logic in blockchainThunks and backend type definitions directly impact Electrum backend connectivity.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — This test verifies account balance updates after receiving BTC on regtest, which requires blockchain subscription and event handling managed by blockchainActions/blockchainThunks. Balance change detection relies on the blockchain notification/subscription system.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — This test sends transactions and verifies pending→confirmed status transitions on regtest, which relies on blockchain notification subscriptions and transaction update events handled by blockchainThunks and blockchainActions.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/general/wallet-discovery.test.ts` — Tests wallet discovery via device switcher (eject and re-add standard wallet), exercising blockchain reconnection logic in blockchainThunks when a new wallet is discovered.
- `suite/e2e/tests/settings/coins.test.ts` — Tests activating/deactivating coin networks and configuring custom backends. Network activation triggers blockchain connection through blockchainThunks, and backend configuration touches the backend type definitions.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — Tests bridge session stealing and recovery which involves device reconnection. The blockchain reconnection/resubscription logic in blockchainThunks is exercised when the session is reclaimed and the device reconnects.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — Tests sending transactions on regtest network, which requires blockchain backend connectivity managed by blockchainThunks and proper state in blockchainReducer for the regtest network.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — ETH staking with a mocked blockbook backend exercises blockchain connection setup through blockchainThunks, and transaction status updates rely on blockchain subscription events.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts`

_Updated: 2026-06-06T10:30:18.036Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->