### PR TITLE
Fixes/yield

### DIFF
--- a/packages/suite/src/actions/wallet/stablecoin-yield/claimMerkleRewardsThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/claimMerkleRewardsThunk.ts
@@ -328,6 +328,8 @@ export const claimMerkleRewardsThunk = createThunk(
                     chunkify: addressDisplayType === AddressDisplayOptions.CHUNKED,
                 });
 
+                userAcceptedTxSimulation?.resolve();
+
                 if (!signingResponse.success) {
                     dispatch(closeModal());
                     throw new Error(signingResponse.error.message);

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts
@@ -140,6 +140,8 @@ export const submitYieldDepositThunk = createThunk(
                 selectedFee,
             });
 
+            userAcceptedTxSimulation?.resolve();
+
             if (!result) {
                 asTypedDesktopAnalytics(extra.services.analytics).report({
                     type: events.yieldDepositEvent.name,

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts
@@ -90,6 +90,8 @@ export const submitYieldWithdrawThunk = createThunk(
                 selectedFee,
             });
 
+            userAcceptedTxSimulation?.resolve();
+
             if (!result) {
                 asTypedDesktopAnalytics(extra.services.analytics).report({
                     type: events.yieldWithdrawEvent.name,

--- a/packages/suite/src/components/tx-simulation/earn-stablecoin/EarnYieldTxSimulationModalInner.tsx
+++ b/packages/suite/src/components/tx-simulation/earn-stablecoin/EarnYieldTxSimulationModalInner.tsx
@@ -58,6 +58,8 @@ export function EarnYieldTxSimulationModalInner({
         accountBalance: account.availableBalance,
     });
 
+    const [confirming, setConfirming] = useState<boolean>(false);
+
     const simulation = useTxSimulation(action, {
         onSuccess(result) {
             if (isTxSimulationResultWithMethods(TX_METHODS_WITH_FEES, result)) {
@@ -87,13 +89,22 @@ export function EarnYieldTxSimulationModalInner({
     }
 
     function confirm() {
+        setConfirming(true);
+
         const selectedFee = areTxSimulationMethods(TX_METHODS_WITH_FEES, action)
             ? getSelectedFee()
             : null;
 
-        decision.resolve({
-            value: true,
-            selectedFee,
+        const confirmingPromise = new Promise<void>(resolve => {
+            decision.resolve({
+                value: true,
+                selectedFee,
+                resolve,
+            });
+        });
+
+        confirmingPromise.finally(() => {
+            setConfirming(false);
         });
     }
 
@@ -114,6 +125,7 @@ export function EarnYieldTxSimulationModalInner({
                         onConfirm={confirm}
                         onCancel={cancel}
                         isConfirmDisabled={isConfirmDisabled}
+                        isConfirmLoading={confirming}
                     />
                 }
                 // Disable shadow bottom to make `Fees` component fully visible

--- a/suite-common/earn-stablecoin-api/src/hooks/useGetMerkleRewards.ts
+++ b/suite-common/earn-stablecoin-api/src/hooks/useGetMerkleRewards.ts
@@ -40,7 +40,8 @@ export function useGetMerkleRewards<Address extends string>(
                     params: {
                         chainId: entry.chainId,
                         claimableOnly: true,
-                        reloadChainId: meta?.bypassCache ? entry.chainId : entry.reloadChainId,
+                        // Force fresh data by default. This will be improved later, but for now it seems that Merkle sends obsolete data (reloadChainId).
+                        reloadChainId: meta?.bypassCache === false ? undefined : entry.chainId,
                     },
                     signal,
                 }),

--- a/suite-common/suite-types/src/modal.ts
+++ b/suite-common/suite-types/src/modal.ts
@@ -225,6 +225,11 @@ export type UserContextPayload =
               | {
                     value: true;
                     selectedFee: EvmSelectedFee | null;
+                    /**
+                     * Send a signal from the thunk to the modal that the related business logic has finished.
+                     * Used for tracking the loading state of the confirm button in the modal.
+                     */
+                    resolve: () => void;
                 }
               | {
                     value: false;

--- a/suite/tx-simulation/src/common/components/TxSimulationFooter.tsx
+++ b/suite/tx-simulation/src/common/components/TxSimulationFooter.tsx
@@ -5,12 +5,14 @@ interface TxSimulationFooterProps {
     onConfirm: () => void;
     onCancel: () => void;
     isConfirmDisabled: boolean;
+    isConfirmLoading?: boolean;
 }
 
 export function TxSimulationFooter({
     onConfirm,
     onCancel,
     isConfirmDisabled,
+    isConfirmLoading,
 }: TxSimulationFooterProps) {
     return (
         <>
@@ -18,6 +20,7 @@ export function TxSimulationFooter({
                 onClick={onConfirm}
                 data-testid="@tx-simulation-modal/confirm-button"
                 isDisabled={isConfirmDisabled}
+                isLoading={isConfirmLoading}
             >
                 <Translation id="TR_CONFIRM" />
             </Modal.Button>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Fix: handle confirm button loading state in tx simulation modal
- ~~Fix: add tooltip for claimable amount in debug mode and always fetch fresh rewards~~ Moved to another [PR](https://github.com/trezor/trezor-suite/pull/27974) (it's turned to be complex problem)


## Notes for QA

- Add loading state to confirm button in TX simulation modal.

## Related Issue

Resolve #27317

## Screenshots:


**Confirming button in TX simulation**
https://github.com/user-attachments/assets/6fcc5265-d086-4063-8b15-a040db786d6d


https://github.com/user-attachments/assets/c0a63b88-a579-498d-bb13-2eeef909c468


https://github.com/user-attachments/assets/dbd789b3-bab7-45d9-ae1c-4e70511e2f4f




<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fixes/yield&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fixes/yield&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fixes/yield&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 16 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox - watches files over time | 🤖 auto |
| Dropbox API errors > Incomplete data returned from provider | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Metadata - switching between cloud providers > Start with one and switch to another | 🤖 auto |
| Metadata - address labeling > google provider | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Remembered device > google provider | 🤖 auto |
| Dropbox API errors > Malformed token | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Account metadata > google - watches files over time | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-22T15:49:18.622Z • 16 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-21T12:06:09.446Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fixes/yield/web/](https://dev.suite.sldev.cz/suite-web/fixes/yield/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->