### PR TITLE
fix(suite): handle disconnected device in yield firmware update prompt

### DIFF
--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { events } from '@suite/analytics';
 import { FirmwareUpgradeNeededModal } from '@suite/firmware-upgrade';
@@ -18,6 +18,8 @@ import { getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils';
 import { Card, Column, Icon, Row, Table } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
 
+import { selectIsConnectionModalOpen } from 'src/actions/device/deviceSelectors';
+import { setConnectionModal, setConnectionMode } from 'src/actions/device/deviceSlice';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useLayoutSize } from 'src/hooks/suite/useLayoutSize';
 import { useMessageSystemYield } from 'src/hooks/suite/useMessageSystemYield';
@@ -46,8 +48,46 @@ export const EarnYieldAccountOpportunity = ({
     const { translationString } = useTranslation();
     const { isBelowMobile } = useLayoutSize();
     const [isFirmwareModalOpen, setIsFirmwareModalOpen] = useState(false);
+    const [isAwaitingConnectionForFwUpdate, setIsAwaitingConnectionForFwUpdate] = useState(false);
     const selectedDevice = useSelector(selectSelectedDevice);
+    const isConnectionModalOpen = useSelector(selectIsConnectionModalOpen);
     const isFirmwareOutdated = !isStablecoinYieldSupported(selectedDevice);
+
+    useEffect(() => {
+        if (isAwaitingConnectionForFwUpdate && !isConnectionModalOpen) {
+            setIsAwaitingConnectionForFwUpdate(false);
+            if (selectedDevice?.connected) {
+                setIsFirmwareModalOpen(false);
+                dispatch(goto({ routeName: 'firmware-index', params: { cancelable: true } }));
+            }
+        }
+    }, [
+        isAwaitingConnectionForFwUpdate,
+        isConnectionModalOpen,
+        selectedDevice?.connected,
+        dispatch,
+    ]);
+
+    const handleFirmwareModalClose = () => {
+        setIsFirmwareModalOpen(false);
+        setIsAwaitingConnectionForFwUpdate(false);
+    };
+
+    const handleFirmwareUpdate = () => {
+        if (!selectedDevice?.connected) {
+            if (selectedDevice?.descriptor?.apiType === 'bluetooth') {
+                dispatch(setConnectionMode('bluetooth'));
+            }
+            setIsAwaitingConnectionForFwUpdate(true);
+            dispatch(setConnectionModal(true));
+
+            return;
+        }
+
+        setIsFirmwareModalOpen(false);
+        dispatch(goto({ routeName: 'firmware-index', params: { cancelable: true } }));
+    };
+
     const vaultContractAddress = getYieldVaultContractAddress(opportunity.vault);
     const depositMessageSystem = useMessageSystemYield('deposit', { vaultContractAddress });
     const withdrawMessageSystem = useMessageSystemYield('withdraw', { vaultContractAddress });
@@ -269,7 +309,8 @@ export const EarnYieldAccountOpportunity = ({
 
     const firmwareModal = isFirmwareModalOpen && (
         <FirmwareUpgradeNeededModal
-            onClose={() => setIsFirmwareModalOpen(false)}
+            onClose={handleFirmwareModalClose}
+            onUpdate={handleFirmwareUpdate}
             featureName={translationString('TR_EARN_STABLECOIN_YIELD_TITLE')}
         />
     );

--- a/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
@@ -126,7 +126,10 @@ export const YieldPageHeader = ({
                             />
                         )}
                         <Column gap={2} overflow="hidden">
-                            <Text typographyStyle="body-md-strong" ellipsisLineCount={1}>
+                            <Text
+                                typographyStyle="body-md-strong"
+                                ellipsisLineCount={isBelowMobile ? 0 : 1}
+                            >
                                 {vaultName}
                             </Text>
                             <AccountLabel

--- a/suite/firmware-upgrade/src/FirmwareUpgradeNeededModal.tsx
+++ b/suite/firmware-upgrade/src/FirmwareUpgradeNeededModal.tsx
@@ -8,16 +8,23 @@ import { Card, Modal, Paragraph } from '@trezor/components';
 type FirmwareUpgradeNeededModalProps = {
     onClose: () => void;
     featureName: string;
+    onUpdate?: () => void;
 };
 
 export const FirmwareUpgradeNeededModal = ({
     onClose,
     featureName,
+    onUpdate,
 }: FirmwareUpgradeNeededModalProps) => {
     const dispatch = useDispatch();
     const deviceLabel = useSelector(selectSelectedDeviceLabelOrName);
 
     const onClick = () => {
+        if (onUpdate) {
+            onUpdate();
+
+            return;
+        }
         // Update will disconnect device in the process and our Firmware Update
         // flow won't allow us to navigate back. So we just redirect the user
         // and close the modal.


### PR DESCRIPTION
## Description

In the yield deposit/withdraw flow, clicking **Update** in the firmware-required modal with a disconnected (remembered) device now opens `ConnectDeviceGlobalModal` on top. After the device connects, the user is auto-navigated to the firmware update screen instead of getting stuck on a misleading "Device connected" state.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27921

## Screenshots:


https://github.com/user-attachments/assets/2bb368e7-be92-4003-915b-66902af08a92


<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies two components: EarnYieldAccountOpportunity (a staking/yield dashboard component) and FirmwareUpgradeNeededModal (a firmware upgrade prompt modal). The staking component change has the highest risk and is best covered by ETH and ADA staking E2E tests that directly exercise the staking dashboard. The EarnYieldAccountOpportunity file maps to 121+ tests via static analysis, indicating it's a broadly imported component — most of those tests don't actually exercise staking yield UI. The FirmwareUpgradeNeededModal has no static test coverage and only indirect coverage through the custom firmware test; it likely needs dedicated test coverage for the upgrade-needed scenario.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx`
- `suite/firmware-upgrade/src/FirmwareUpgradeNeededModal.tsx`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `../../suite/e2e/tests/staking/eth/stake-more.test.ts` — EarnYieldAccountOpportunity.tsx is a dashboard/yield component in the earn/staking feature. This test directly exercises the ETH staking dashboard, including viewing staked amounts, rewards, pending sections, and staking progress indicators — all of which are rendered by earn dashboard yield components.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `../../suite/e2e/tests/staking/staking-form.test.ts` — This test navigates to the ETH staking tab and interacts with the staking form, which is accessed from the staking dashboard where EarnYieldAccountOpportunity is rendered. Changes to the yield opportunity component could affect the staking tab layout and navigation to the stake-more form.
- `../../suite/e2e/tests/staking/ada/stake.test.ts` — This test covers the Cardano staking flow including viewing staking dashboard state (inactive account, balance, staking buttons visibility). The EarnYieldAccountOpportunity component likely renders yield/staking opportunities across networks including ADA, so changes could affect the staking dashboard display.
- `../../suite/e2e/tests/staking/ada/unstake.test.ts` — This test validates the staked Cardano account dashboard display (balance, rewards, full balance staking indicator, button visibility) which relies on staking/yield dashboard components. Changes to EarnYieldAccountOpportunity could affect how staked account state is displayed.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `../../suite/e2e/tests/analytics/staking-events.test.ts` — This test navigates to staking from both the account menu and dashboard assets section. The EarnYieldAccountOpportunity component may render the dashboard staking entry point (stake button), so changes could affect the navigation flow that triggers StakingNavigate analytics events.
- `../../suite/e2e/tests/firmware/custom-firmware.test.ts` — FirmwareUpgradeNeededModal.tsx handles firmware upgrade prompts. While custom-firmware.test.ts covers custom firmware installation (not upgrade-needed modals), it is the closest firmware-related E2E test and could exercise related firmware modal infrastructure.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/firmware-upgrade/src/FirmwareUpgradeNeededModal.tsx`

_Updated: 2026-05-21T13:28:44.152Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/yield-firmware-update-disconnected&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/yield-firmware-update-disconnected&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 15 test(s)</summary>

| Test | Type |
|------|------|
| Metadata - switching between cloud providers > Start with one and switch to another | 🤖 auto |
| Metadata - address labeling > google provider | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Account metadata > dropbox - watches files over time | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Remembered device > google provider | 🤖 auto |
| Dropbox API errors > Malformed token | 🤖 auto |
| Dropbox API errors > Incomplete data returned from provider | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Account metadata > google - watches files over time | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-21T15:23:17.388Z • 15 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-22T07:08:07.548Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/yield-firmware-update-disconnected/web/](https://dev.suite.sldev.cz/suite-web/fix/yield-firmware-update-disconnected/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->