### PR TITLE
RBF tx review modal fix + allowance spender label

### DIFF
--- a/packages/suite/src/components/earn/yield/common/YieldApproveModal.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldApproveModal.tsx
@@ -52,7 +52,7 @@ export const YieldApproveModal = ({
             contractAddress: parsedContract,
             size: 80,
         }),
-        isActive: true,
+        label: 'TR_EARN_YIELD_VAULT' as const,
     };
 
     useEffect(() => {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/AllowanceModalProviderInfo.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/AllowanceModalProviderInfo.tsx
@@ -1,7 +1,6 @@
-import { type ProviderMetadata } from 'invity-api';
 import styled from 'styled-components';
 
-import { Translation } from '@suite/intl';
+import { Translation, type TranslationKey } from '@suite/intl';
 import { invityAPI } from '@suite-common/trading';
 import { Box, Column, Row, Text } from '@trezor/components';
 import { borders } from '@trezor/theme';
@@ -9,8 +8,15 @@ import { exhaustive } from '@trezor/type-utils';
 
 export type ProviderLogoSourceType = 'invity-api-path' | 'url';
 
+export type AllowanceModalProvider = {
+    name?: string;
+    companyName?: string;
+    logo?: string;
+    label?: TranslationKey;
+};
+
 interface AllowanceModalProviderInfoProps {
-    provider: ProviderMetadata;
+    provider: AllowanceModalProvider;
     spender: string;
     logoSourceType?: ProviderLogoSourceType;
 }
@@ -51,7 +57,7 @@ export const AllowanceModalProviderInfo = ({
         <Box padding={12} borderWidth={borders.widths.large} borderRadius={borders.radii.sm}>
             <Column gap={12}>
                 <Text>
-                    <Translation id="TR_EXCHANGE_APPROVAL_PROVIDER" />
+                    <Translation id={provider.label ?? 'TR_EXCHANGE_APPROVAL_PROVIDER'} />
                 </Text>
                 <Row gap={8}>
                     {providerLogoSource && <ProviderLogo src={providerLogoSource} alt="" />}

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModal.tsx
@@ -1,6 +1,6 @@
 import { FormProvider } from 'react-hook-form';
 
-import { type CryptoId, type DexApprovalType, type ProviderMetadata } from 'invity-api';
+import { type CryptoId, type DexApprovalType } from 'invity-api';
 
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
@@ -16,6 +16,7 @@ import { Fees } from 'src/components/wallet/Fees/Fees';
 import { useAllowanceModal } from 'src/hooks/wallet/allowance';
 
 import {
+    type AllowanceModalProvider,
     AllowanceModalProviderInfo,
     type ProviderLogoSourceType,
 } from './AllowanceModalProviderInfo';
@@ -25,7 +26,7 @@ interface ApproveModalProps {
     amount: string;
     cryptoId: CryptoId;
     account: Account;
-    provider: ProviderMetadata;
+    provider: AllowanceModalProvider;
     spender: string;
     logoSourceType?: ProviderLogoSourceType;
     onSelectApprovalType?: (type: DexApprovalType) => void;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModalTypeSelector.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModalTypeSelector.tsx
@@ -1,4 +1,4 @@
-import { type CryptoId, type DexApprovalType, type ProviderMetadata } from 'invity-api';
+import { type CryptoId, type DexApprovalType } from 'invity-api';
 import styled from 'styled-components';
 
 import { Translation } from '@suite/intl';
@@ -13,13 +13,15 @@ import { DebugOnlyBadge } from 'src/components/suite/DebugOnlyBadge';
 import { useSelector } from 'src/hooks/suite';
 import { TradingCoinLogo } from 'src/views/wallet/trading/common/TradingCoinLogo';
 
+import { type AllowanceModalProvider } from './AllowanceModalProviderInfo';
+
 interface ApproveModalTypeSelectorProps {
     approvalType: DexApprovalType;
     isLoading: boolean;
     data: string;
     cryptoId: CryptoId;
     onSelect: (type: DexApprovalType) => void;
-    provider: ProviderMetadata;
+    provider: AllowanceModalProvider;
     token: TokenInfo;
     displayAmount: AmountSubunit;
 }

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/RevokeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/RevokeModal.tsx
@@ -1,6 +1,6 @@
 import { FormProvider } from 'react-hook-form';
 
-import { type CryptoId, type ProviderMetadata } from 'invity-api';
+import { type CryptoId } from 'invity-api';
 
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
@@ -18,6 +18,7 @@ import { useAllowanceModal } from 'src/hooks/wallet/allowance';
 import { TradingCoinLogo } from 'src/views/wallet/trading/common/TradingCoinLogo';
 
 import {
+    type AllowanceModalProvider,
     AllowanceModalProviderInfo,
     type ProviderLogoSourceType,
 } from './AllowanceModalProviderInfo';
@@ -25,7 +26,7 @@ import {
 interface RevokeModalProps {
     cryptoId: CryptoId;
     account: Account;
-    provider: ProviderMetadata;
+    provider: AllowanceModalProvider;
     spender: string;
     logoSourceType?: ProviderLogoSourceType;
     preapprovedAmount?: string;

--- a/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
@@ -16,6 +16,7 @@ const SIGN_TX_ROUTES = [
     'wallet-trading-sell-confirm',
     'earn-deposit',
     'earn-withdraw',
+    'earn-claim',
 ] as const;
 
 const SIGN_TX_CONNECT_METHODS = [
@@ -28,9 +29,13 @@ const getAccountForButtonRequest = (state: AppState) => {
     const { account } = state.wallet.selectedAccount;
     if (account) return account;
 
-    const { accountKey } = state.wallet.stablecoinYield.txReview;
+    const yieldAccountKey = state.wallet.stablecoinYield.txReview.accountKey;
+    if (yieldAccountKey) return selectAccountByKey(state, yieldAccountKey);
 
-    return selectAccountByKey(state, accountKey);
+    const sendAccountKey = state.wallet.send.accountKey;
+    if (sendAccountKey) return selectAccountByKey(state, sendAccountKey);
+
+    return undefined;
 };
 
 const shouldRemapToSignTx = (

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -78,6 +78,10 @@ export const messages = defineMessages({
         defaultMessage: "Token doesn't exist",
         id: 'TR_EARN_YIELD_TOKEN_NOT_EXIST',
     },
+    TR_EARN_YIELD_VAULT: {
+        defaultMessage: 'Vault',
+        id: 'TR_EARN_YIELD_VAULT',
+    },
     TR_ACCOUNT_OUT_OF_SYNC: {
         defaultMessage: 'Account sync in progress.',
         id: 'TR_ACCOUNT_OUT_OF_SYNC',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Two small UX fixes for yield approve and RBF:
- Tx review modal stays open during yield RBF (no longer interrupted by the generic "Confirm action on your Trezor" modal)
- Yield approve/revoke modals show "Vault" instead of "Provider"

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #27815
Resolve #27943

## Screenshots:

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes primarily affect AllowanceModals (Approve, Revoke, TypeSelector, ProviderInfo), the YieldApproveModal for staking, buttonRequestMiddleware for device prompt handling, and the shared messages.ts translation file. The AllowanceModals are most likely triggered during token swap/sell flows requiring ERC-20/SPL token approvals, while YieldApproveModal is specific to staking yield flows. buttonRequestMiddleware is extremely broad (121 tests), so only tests that specifically exercise device confirmation prompts in staking or trading contexts are recommended. The messages.ts file is a global dependency and alone doesn't warrant broad test inclusion. Focus testing on token-involving trading flows and ETH staking flows.

<details><summary><b>Changed files (7)</b></summary>

- `packages/suite/src/components/earn/yield/common/YieldApproveModal.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/AllowanceModalProviderInfo.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModal.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModalTypeSelector.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/RevokeModal.tsx`
- `packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (10)**

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `../../suite/e2e/tests/staking/eth/initial-stake.test.ts` — YieldApproveModal.tsx is part of the earn/staking flow. ETH initial staking involves device confirmation prompts handled by buttonRequestMiddleware and may trigger yield approval modals. This test exercises the closest user-facing path to the changed YieldApproveModal component.
- `../../suite/e2e/tests/staking/eth/stake-more.test.ts` — Stake-more flow for ETH involves device confirmation prompts (buttonRequestMiddleware) and could trigger the YieldApproveModal for additional staking. Changes to approval modal UI or button request handling could affect this flow.
- `../../suite/e2e/tests/staking/eth/unstake.test.ts` — ETH unstake and claim flows involve device confirmation prompts managed by buttonRequestMiddleware and may involve approval/revoke modals. Changes to these components could affect the unstaking confirmation flow.
- `../../suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Swapping SOL to USDC token likely triggers token allowance/approval modals (ApproveModal) when the swap involves an ERC-20/SPL token on the receive side. The AllowanceModals components are directly changed and this test exercises a token swap flow end-to-end.
- `../../suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Swapping a token (USDT) to a coin (BTC) is a scenario where token allowance approval is most likely needed before the swap can proceed. The ApproveModal and related AllowanceModals components are directly changed.
- `../../suite/e2e/tests/trading/swap-tokens.test.ts` — Token-to-token swaps (USDT to USDC on Solana) are the primary scenario requiring token allowance approval. The changed AllowanceModals components directly support this user flow.
- `../../suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Selling an ERC-20 token (USDC) may require token allowance approval before the sell transaction can proceed. The ApproveModal and AllowanceModalProviderInfo components are directly relevant to this flow.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `../../suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — ETH-to-BTC swap with custom fees involves the trading modal flow where AllowanceModals could appear. The buttonRequestMiddleware changes also affect device confirmation prompts used in this test's fee verification flow.
- `../../suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — BTC-to-ETH swap with custom fees exercises the device prompt confirmation flow affected by buttonRequestMiddleware changes, though this native coin swap is less likely to trigger allowance modals.
- `../../suite/e2e/tests/staking/staking-form.test.ts` — The staking form validation test for ETH exercises the staking UI that shares infrastructure with YieldApproveModal. Changes to messages.ts could affect validation error translations used in the staking form.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/components/earn/yield/common/YieldApproveModal.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/RevokeModal.tsx`

_Updated: 2026-05-21T14:15:21.535Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/rbf-tx-review-modal&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/rbf-tx-review-modal&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-21T14:20:55.904Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-21T14:18:37.439Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/rbf-tx-review-modal/web/](https://dev.suite.sldev.cz/suite-web/fix/rbf-tx-review-modal/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->