### PR TITLE
fix(suite): remove copy-pasted data-testid from Cardano staking banner

### DIFF
--- a/packages/suite/src/components/suite/banners/SuiteBanners/CardanoOutdatedStakingBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/CardanoOutdatedStakingBanner.tsx
@@ -24,10 +24,7 @@ export const CardanoOutdatedStakingBanner = () => {
             icon
             intent="warning"
             rightContent={
-                <Banner.Button
-                    onClick={() => dispatch(goto({ routeName: 'suite-earn' }))}
-                    data-testid="@notification/bridge-deprecated/button"
-                >
+                <Banner.Button onClick={() => dispatch(goto({ routeName: 'suite-earn' }))}>
                     <Translation id="TR_STAKING_MODAL_OUTDATED_BUTTON" />
                 </Banner.Button>
             }


### PR DESCRIPTION
## Summary

`CardanoOutdatedStakingBanner` had a `data-testid="@notification/bridge-deprecated/button"` copy-pasted from `BridgeDeprecatedBanner`. Removed it — the Cardano banner doesn't need its own test id at the moment, and keeping the duplicated one would clash with selectors targeting the actual bridge-deprecated banner.

## Test plan

- [ ] Verify Cardano outdated staking banner still renders and the button navigates to `suite-earn`
- [ ] Verify the bridge-deprecated banner test selector `@notification/bridge-deprecated/button` is now unique

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to a single Cardano-specific staking banner component (CardanoOutdatedStakingBanner.tsx). This file maps to 121 tests via the shared SuiteBanners parent component, making it a broad transitive dependency — the vast majority of those tests are unlikely to actually render or interact with this specific Cardano banner. The risk is low since the change is scoped to a niche banner, but staking-related and Cardano-account-related tests are the most relevant to validate. No LLM analysis data was available for the candidate tests, so recommendations are conservative.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/suite/banners/SuiteBanners/CardanoOutdatedStakingBanner.tsx`

</details>

**Recommended tests (2)**

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/analytics/staking-events.test.ts` — The changed file is CardanoOutdatedStakingBanner, which is specifically related to Cardano staking. The staking-events analytics test is the most likely test to exercise a code path that renders or interacts with staking-related banners, potentially triggering the Cardano outdated staking banner.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — Wallet discovery may involve loading Cardano accounts, which could trigger the outdated staking banner to appear. This test is more likely than most to exercise the banner rendering path during account discovery.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/components/suite/banners/SuiteBanners/CardanoOutdatedStakingBanner.tsx`

_Updated: 2026-05-21T14:43:06.020Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/fix-cardano-banner-testid&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/fix-cardano-banner-testid&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Metadata - address labeling > google provider | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Account metadata > dropbox - watches files over time | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Remembered device > google provider | 🤖 auto |
| Dropbox API errors > Malformed token | 🤖 auto |
| Dropbox API errors > Incomplete data returned from provider | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Account metadata > google - watches files over time | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-21T14:49:05.631Z • 14 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-21T14:46:13.694Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/fix-cardano-banner-testid/web/](https://dev.suite.sldev.cz/suite-web/mroz22/fix-cardano-banner-testid/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->