### PR TITLE
Properly extend no-restricted-imports rule in connect eslint

### DIFF
--- a/packages/connect/eslint.config.mjs
+++ b/packages/connect/eslint.config.mjs
@@ -1,4 +1,4 @@
-import { eslint } from '@trezor/eslint';
+import { eslint, restrictedImportsPatterns } from '@trezor/eslint';
 
 export default [
     ...eslint,
@@ -22,15 +22,7 @@ export default [
                 'error',
                 {
                     paths: [{ name: '.' }, { name: '..' }, { name: '../..' }],
-                    patterns: [
-                        '@trezor/*/lib',
-                        '@trezor/*/lib/**',
-                        '@trezor/*/libDev',
-                        '@trezor/*/libDev/**',
-                        '@suite-common/**',
-                        '@suite-native/**',
-                        '**/exports',
-                    ],
+                    patterns: [...restrictedImportsPatterns, { group: ['**/exports'] }],
                 },
             ],
         },

--- a/packages/eslint/src/index.mjs
+++ b/packages/eslint/src/index.mjs
@@ -9,12 +9,12 @@ import { javascriptNodejsConfig } from './javascriptNodejsConfig.mjs';
 import { jestConfig } from './jestConfig.mjs';
 import { localRulesConfig } from './localRulesConfig.mjs';
 import { reactConfig } from './reactConfig.mjs';
-import { typescriptConfig } from './typescriptConfig.mjs';
+import { restrictedImportsPatterns, typescriptConfig } from './typescriptConfig.mjs';
 /**
  * @typedef {import('eslint').Linter.Config} Config
  */
 
-export { globalNoExtraneousDependenciesDevDependencies };
+export { globalNoExtraneousDependenciesDevDependencies, restrictedImportsPatterns };
 
 /** @type {Config[]} */
 export const eslint = [

--- a/packages/eslint/src/typescriptConfig.mjs
+++ b/packages/eslint/src/typescriptConfig.mjs
@@ -52,6 +52,13 @@ const suiteInternalPatterns = {
         '@suite-common/* and @suite-native/* packages are private to the suite apps and must not be imported by other workspace packages.',
 };
 
+export const restrictedImportsPatterns = [
+    buildArtifactPatterns,
+    suiteInternalPatterns,
+    coinsPackagePatterns,
+    ...connectDeepImportPatterns,
+];
+
 /** @type {import('typescript-eslint').ConfigArray} */
 export const typescriptConfig = [
     ...tseslint.configs.recommended,
@@ -110,12 +117,7 @@ export const typescriptConfig = [
                 'error',
                 {
                     paths: [{ name: '.' }, { name: '..' }, { name: '../..' }],
-                    patterns: [
-                        buildArtifactPatterns,
-                        suiteInternalPatterns,
-                        coinsPackagePatterns,
-                        ...connectDeepImportPatterns,
-                    ],
+                    patterns: restrictedImportsPatterns,
                 },
             ],
         },


### PR DESCRIPTION
## Description

In `@trezor/connect`'s eslint config, `@typescript-eslint/no-restricted-imports` was defined in order to restrict imports from `../exports` path. That unfortunately overrid the same rule from global eslint config. I've basically redefined it again, and added exports.

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** No relevant source file changes detected against origin/develop.

_No test recommendations found._

_Updated: 2026-05-21T14:52:59.111Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/fix-ts-eslint&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/fix-ts-eslint&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/fix-ts-eslint&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Metadata - switching between cloud providers > Start with one and switch to another | 🤖 auto |
| Metadata - address labeling > google provider | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Remembered device > google provider | 🤖 auto |
| Dropbox API errors > Malformed token | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Account metadata > google - watches files over time | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-22T07:18:48.637Z • 14 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-22T07:16:13.619Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/fix-ts-eslint/web/](https://dev.suite.sldev.cz/suite-web/chore/fix-ts-eslint/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->