### PR TITLE
fix(protobuf): add esm .js extension to generated definitions

### DIFF
--- a/packages/protobuf/scripts/protobuf-build.sh
+++ b/packages/protobuf/scripts/protobuf-build.sh
@@ -56,7 +56,7 @@ perl -0777 -pi -e 's{/\*.*?\*/}{}gs; s/^\s*\n//mg' src/definitions/*.js
 
 # generated source JS is inside a package with "type": "module", so relative JS imports
 # need explicit extensions for strict ESM resolution in bundlers
-perl -pi -e "s{from '(\\./[^']+_pb)';}{from '\$1.js';}g" src/definitions/*.js
+perl -pi -e 's{from (["'"'"'])(\.\/[^"'"'"']+)\1;}{from $1$2.js$1;}g' src/definitions/*.js
 
 yarn workspace @trezor/protobuf g:eslint --fix src/definitions/*
 yarn workspace @trezor/protobuf g:prettier --write src/definitions/*


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

perl script replaces by pattern `*_pb'` (single quota) at at build time (before the eslint) it has a format `*_pb"` (double quota). now it accepts both

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** No relevant source file changes detected against origin/develop.

_No test recommendations found._

_Updated: 2026-05-21T16:37:48.753Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/protobuf-esm-build&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/protobuf-esm-build&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 15 test(s)</summary>

| Test | Type |
|------|------|
| Metadata - switching between cloud providers > Start with one and switch to another | 🤖 auto |
| Metadata - address labeling > google provider | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Account metadata > dropbox - watches files over time | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Remembered device > google provider | 🤖 auto |
| Dropbox API errors > Malformed token | 🤖 auto |
| Dropbox API errors > Incomplete data returned from provider | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Account metadata > google - watches files over time | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-21T16:44:09.575Z • 15 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-21T16:41:31.015Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/protobuf-esm-build/web/](https://dev.suite.sldev.cz/suite-web/fix/protobuf-esm-build/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->