### PR TITLE
fix(suite-native): simplify animations in HistoryButton and Footer components

### DIFF
--- a/suite-native/module-trading/src/components/general/Footer.tsx
+++ b/suite-native/module-trading/src/components/general/Footer.tsx
@@ -68,7 +68,7 @@ export const Footer = ({ isFormMountedRecently }: FooterProps) => {
             <AnimatedBox
                 entering={isFormMountedRecently ? undefined : FadeInDown}
                 exiting={FadeOutDown}
-                layout={isFormMountedRecently ? undefined : LinearTransition}
+                layout={LinearTransition}
             >
                 <VStack alignItems="center">
                     <FooterProviderContent provider={providerInfo} />

--- a/suite-native/module-trading/src/components/general/HistoryButton.tsx
+++ b/suite-native/module-trading/src/components/general/HistoryButton.tsx
@@ -51,7 +51,7 @@ const HistoryButtonMemoized = memo(({ isFormMountedRecently }: HistoryButtonProp
         <AnimatedBox
             entering={isFormMountedRecently ? undefined : FadeInDown}
             exiting={FadeOutDown}
-            layout={isFormMountedRecently ? undefined : LinearTransition}
+            layout={LinearTransition}
         >
             <Pressable onPress={handleOnPress} testID={TRADE_HISTORY_BUTTON_TEST_ID}>
                 <HStack style={applyStyle(buttonStyle)}>


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Another try to get rid of that ghost view.

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve 27152

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=27152-mobile-continue-button-becomes-unresponsive-in-trade-form&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->