### PR TITLE
fix(suite): timeout and retry for yield allowance fetch

### DIFF
--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -98,6 +98,7 @@ export type UseYieldFlowResult = {
     handleApproveModalCancel: () => Promise<void>;
     handleApproveSuccessTxid: (txid: string) => void;
     openPendingTransaction: (txid: string) => void;
+    retryInitAllowance: () => void;
     methods: UseFormReturn<YieldFlowFormValues>;
     flow: UseYieldFlowStepsResult;
 };
@@ -190,8 +191,8 @@ export const useYieldFlow = ({
         [flowKey],
     );
 
-    useEffect(() => {
-        if (flowType !== 'deposit' || allowanceStatus !== 'idle') {
+    const runInitAllowance = useCallback(() => {
+        if (flowType !== 'deposit') {
             return;
         }
 
@@ -210,25 +211,31 @@ export const useYieldFlow = ({
         );
 
         initAllowancePromiseRef.current = promise;
-        void promise.finally(() => {
-            if (initAllowancePromiseRef.current === promise) {
-                initAllowancePromiseRef.current = null;
-            }
-        });
-    }, [
-        account.descriptor,
-        account.key,
-        account.symbol,
-        allowanceFlowDataRef,
-        allowanceStatus,
-        dispatch,
-        flowKey,
-        flowType,
-        receiptToken?.contractAddress,
-        token?.contractAddress,
-        token?.decimals,
-        vault?.id,
-    ]);
+        void promise
+            .unwrap()
+            .catch(() => {
+                analytics.report({
+                    type: events.yieldInteractionEvent.name,
+                    payload: {
+                        element: 'allowance-error-banner',
+                        networkSymbol: token.networkSymbol,
+                        vaultId: vault.id,
+                    },
+                });
+            })
+            .finally(() => {
+                if (initAllowancePromiseRef.current === promise) {
+                    initAllowancePromiseRef.current = null;
+                }
+            });
+    }, [allowanceFlowDataRef, analytics, dispatch, flowKey, flowType]);
+
+    useEffect(() => {
+        if (allowanceStatus !== 'idle') {
+            return;
+        }
+        runInitAllowance();
+    }, [allowanceStatus, runInitAllowance]);
 
     useYieldPendingTransactionTracking({
         account,
@@ -588,6 +595,7 @@ export const useYieldFlow = ({
         handleApproveModalCancel,
         handleApproveSuccessTxid,
         openPendingTransaction,
+        retryInitAllowance: runInitAllowance,
         methods,
         flow,
     };

--- a/packages/suite/src/components/earn/yield/supply/YieldSupplyForm.tsx
+++ b/packages/suite/src/components/earn/yield/supply/YieldSupplyForm.tsx
@@ -46,6 +46,7 @@ export const YieldSupplyForm = () => {
         handleApproveModalCancel,
         handleApproveSuccessTxid,
         openPendingTransaction,
+        retryInitAllowance,
         flow,
     } = useYieldSupplyContext();
 
@@ -127,6 +128,19 @@ export const YieldSupplyForm = () => {
         setAmountInput(maxAmount);
     };
 
+    const handleRetryAllowance = () => {
+        analytics.report({
+            type: events.yieldInteractionEvent.name,
+            payload: {
+                element: 'allowance-retry',
+                networkSymbol: token.networkSymbol,
+                vaultId: vault.id,
+            },
+        });
+
+        retryInitAllowance();
+    };
+
     return (
         <>
             <Column width="100%" alignItems="center">
@@ -155,6 +169,21 @@ export const YieldSupplyForm = () => {
                                 <Banner
                                     intent="warning"
                                     description={<Translation id={errorMessage} />}
+                                />
+                            )}
+
+                            {allowanceStatus === 'error' && (
+                                <Banner
+                                    icon
+                                    intent="warning"
+                                    description={
+                                        <Translation id="TR_EARN_YIELD_ALLOWANCE_FETCH_FAILED" />
+                                    }
+                                    rightContent={
+                                        <Banner.Button onClick={handleRetryAllowance}>
+                                            <Translation id="TR_RETRY" />
+                                        </Banner.Button>
+                                    }
                                 />
                             )}
 

--- a/suite-common/wallet-core/src/allowance/fetchAllowance.ts
+++ b/suite-common/wallet-core/src/allowance/fetchAllowance.ts
@@ -4,6 +4,8 @@ import { asAmountSubunit } from '@suite-common/wallet-utils';
 import TrezorConnect from '@trezor/connect';
 import { BigNumber } from '@trezor/utils';
 
+const ALLOWANCE_FETCH_TIMEOUT_MS = 15_000;
+
 type FetchAllowanceParams = {
     owner: string;
     spender: string;
@@ -23,12 +25,20 @@ export const fetchAllowance = async ({
         throw new Error('Allowance calldata could not be built.');
     }
 
-    const response = await TrezorConnect.blockchainEvmRpcCall({
-        coin,
-        from: owner,
-        to: tokenContractAddress,
-        data: allowanceCalldata.data,
-    });
+    const response = await Promise.race([
+        TrezorConnect.blockchainEvmRpcCall({
+            coin,
+            from: owner,
+            to: tokenContractAddress,
+            data: allowanceCalldata.data,
+        }),
+        new Promise<never>((_, reject) =>
+            setTimeout(
+                () => reject(new Error('Allowance fetch timed out')),
+                ALLOWANCE_FETCH_TIMEOUT_MS,
+            ),
+        ),
+    ]);
 
     if (!response.success) {
         throw new Error(response.error.message);

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.ts
@@ -336,8 +336,9 @@ export const initYieldAllowanceThunk = createThunk<void, InitYieldAllowancePaylo
             if (amount !== '0') {
                 dispatch(stablecoinYieldActions.skipApprovalStep({ flowType, flowKey }));
             }
-        } catch {
+        } catch (error) {
             dispatch(stablecoinYieldActions.setAllowanceError({ flowType, flowKey }));
+            throw error;
         } finally {
             dispatch(stablecoinYieldActions.finishInitializingAllowance({ flowType, flowKey }));
         }

--- a/suite/analytics/src/events/yieldInteractionEvent.ts
+++ b/suite/analytics/src/events/yieldInteractionEvent.ts
@@ -14,6 +14,8 @@ type Attributes = {
         | 'show-more-accounts'
         | 'feedback-submit'
         | 'insufficient-funds-banner'
+        | 'allowance-error-banner'
+        | 'allowance-retry'
     >;
     value?: AttributeDef<string>;
     networkSymbol?: AttributeDef<string>;

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -9588,6 +9588,10 @@ export const messages = defineMessages({
         id: 'TR_EARN_YIELD_APPROVED_AMOUNT',
         defaultMessage: 'Approved amount',
     },
+    TR_EARN_YIELD_ALLOWANCE_FETCH_FAILED: {
+        id: 'TR_EARN_YIELD_ALLOWANCE_FETCH_FAILED',
+        defaultMessage: 'Failed to fetch approved amount.',
+    },
     TR_EARN_YIELD_SUPPLY_COMPLETE: {
         id: 'TR_EARN_YIELD_SUPPLY_COMPLETE',
         defaultMessage: 'Deposit complete',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Add 15s timeout to `fetchAllowance` to surface stuck RPC calls instead of spinning indefinitely
- Add retry mechanism: warning banner in the supply flow with a Retry button when allowance fetch fails

New `yieldInteractionEvent` elements:
  - `allowance-error-banner` — fires when allowance fetch fails
  - `allowance-retry` — fires when user clicks retry on the error banner

## Notes for QA

Update `ALLOWANCE_FETCH_TIMEOUT_MS` in order to simulate stuck call.

## Related Issue

Resolve #27957

## Screenshots:

<img width="863" height="804" alt="image" src="https://github.com/user-attachments/assets/5996d0d1-3acc-4de9-9ce1-d57e8f9750a0" />

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes primarily affect the stablecoin yield/supply feature: the YieldSupplyForm component, its useYieldFlow hook, allowance fetching, approval thunks, a yield analytics event, and intl messages. There are no dedicated E2E tests for stablecoin yield supply flows, so the primary risk is untested. The closest tests are the staking/earn tests which share UI infrastructure (form inputs, confirmation flows, device prompts) with the yield supply feature. The recommended strategy is to run all ETH staking form tests at high priority since they most closely exercise the shared earn flow infrastructure, plus broader staking tests at medium priority to catch regressions in the earn module.

<details><summary><b>Changed files (6)</b></summary>

- `packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts`
- `packages/suite/src/components/earn/yield/supply/YieldSupplyForm.tsx`
- `suite-common/wallet-core/src/allowance/fetchAllowance.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.ts`
- `suite/analytics/src/events/yieldInteractionEvent.ts`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `../../suite/e2e/tests/staking/eth/initial-stake.test.ts` — The changed files include useYieldFlow.ts, YieldSupplyForm.tsx, and stablecoinYieldApprovalThunks.ts which are part of the earn/yield supply flow. ETH staking tests exercise the staking form, confirmation, and transaction signing flows that share UI infrastructure with yield supply. The staking form validation and submission paths are closely related to yield supply flows.
- `../../suite/e2e/tests/staking/eth/stake-more.test.ts` — Stake-more exercises the staking form input, confirmation modal, device prompt, and transaction sending flow — the same component infrastructure that YieldSupplyForm.tsx and useYieldFlow.ts build upon. Changes to the yield supply form could affect shared earn/staking UI components.
- `../../suite/e2e/tests/staking/staking-form.test.ts` — This test validates staking form input validation (min amounts, decimals, insufficient funds), percentage buttons, max button, and crypto/fiat switching. The YieldSupplyForm likely shares form validation infrastructure and input components with the staking form. Changes to YieldSupplyForm.tsx could affect shared form logic.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `../../suite/e2e/tests/staking/eth/unstake.test.ts` — The unstake flow tests the earn/staking UI components including the staking dashboard, transaction confirmation, and claim flows. Changes to the yield supply form and yield flow hook could affect shared earn module infrastructure used in unstaking.
- `../../suite/e2e/tests/staking/sol/initial-stake.test.ts` — SOL initial staking tests the earn staking flow on a different network. Changes to useYieldFlow.ts could affect shared earn flow hooks. The staking form and confirmation UI may share components with the yield supply form.
- `../../suite/e2e/tests/staking/ada/stake.test.ts` — ADA staking tests the earn staking flow including the staking info modal, Everstake terms acknowledgment, and transaction confirmation — UI patterns shared with the yield supply flow. Changes to earn components could propagate.
- `../../suite/e2e/tests/staking/sol/stake-more.test.ts` — SOL stake-more exercises the staking form with amount input and confirmation flow on Solana. Shared earn/staking UI components and hooks (useYieldFlow) could be affected by changes.
- `../../suite/e2e/tests/analytics/staking-events.test.ts` — This test verifies StakingNavigate analytics events when navigating to staking. The changed yieldInteractionEvent.ts is a sibling analytics event definition, and changes to suite/intl/src/messages.ts could affect translated UI text in the staking navigation flow.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `../../suite/e2e/tests/staking/ada/claim.test.ts` — ADA claim tests the reward claiming flow which uses earn UI components. While not directly testing yield supply, changes to shared earn module infrastructure (useYieldFlow hook) could affect the claim flow's UI rendering.
- `../../suite/e2e/tests/staking/sol/unstake.test.ts` — SOL unstake tests exercise the earn module's unstake and claim flows. Changes to yield flow hooks could affect shared earn infrastructure used in SOL unstaking UI.
- `../../suite/e2e/tests/staking/sol/rewards.test.ts` — SOL rewards test displays staking dashboard amounts which use shared earn module components. Changes to yield supply components could have minor side effects on the staking dashboard rendering.

</details>

⚠️ **Changes with no test coverage (3)**
- `suite-common/wallet-core/src/allowance/fetchAllowance.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.ts`
- `suite/analytics/src/events/yieldInteractionEvent.ts`

_Updated: 2026-05-22T08:03:01.599Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/allowance-timeout-banner&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/allowance-timeout-banner&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/allowance-timeout-banner&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 15 test(s)</summary>

| Test | Type |
|------|------|
| Dropbox API errors > Incomplete data returned from provider | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Metadata - switching between cloud providers > Start with one and switch to another | 🤖 auto |
| Metadata - address labeling > google provider | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Remembered device > google provider | 🤖 auto |
| Dropbox API errors > Malformed token | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Account metadata > google - watches files over time | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-22T08:08:14.601Z • 15 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-22T08:05:35.185Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/allowance-timeout-banner/web/](https://dev.suite.sldev.cz/suite-web/feat/allowance-timeout-banner/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->