### PR TITLE
fix(suite): suppress sign-tx-error toast for invalid compose params

### DIFF
--- a/suite-common/wallet-core/src/send/sendFormBitcoinThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormBitcoinThunks.ts
@@ -135,12 +135,14 @@ export const composeBitcoinTransactionFeeLevelsThunk = createThunk<
         const response = await TrezorConnect.composeTransaction(params);
 
         if (!response.success) {
-            dispatch(
-                notificationsActions.addToast({
-                    type: 'sign-tx-error',
-                    error: response.error.message,
-                }),
-            );
+            if (response.error.code !== 'Method_InvalidParameter') {
+                dispatch(
+                    notificationsActions.addToast({
+                        type: 'sign-tx-error',
+                        error: response.error.message,
+                    }),
+                );
+            }
 
             return rejectWithValue({
                 error: 'fee-levels-compose-failed',

--- a/suite-common/wallet-core/src/send/sendFormCardanoThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormCardanoThunks.ts
@@ -70,12 +70,14 @@ export const composeCardanoTransactionFeeLevelsThunk = createThunk<
         });
 
         if (!response.success) {
-            dispatch(
-                notificationsActions.addToast({
-                    type: 'sign-tx-error',
-                    error: response.error.message,
-                }),
-            );
+            if (response.error.code !== 'Method_InvalidParameter') {
+                dispatch(
+                    notificationsActions.addToast({
+                        type: 'sign-tx-error',
+                        error: response.error.message,
+                    }),
+                );
+            }
 
             return rejectWithValue({
                 error: 'fee-levels-compose-failed',


### PR DESCRIPTION
## Summary

When the send form contains an invalid recipient address (e.g. a placeholder while waiting for the recipient to share their real address), Suite spams the user with `Transaction signing error: Invalid Bitcoin output address format` toasts.

<img width="828" height="809" alt="image" src="https://github.com/user-attachments/assets/da4a979a-4969-4377-ad79-6d4497a801fd" />

### Fix

Skip the toast when `response.error.code === 'Method_InvalidParameter'`. Form-level validators (`valid` in `Outputs/Address.tsx`) already surface this inline. Toast stays reserved for unexpected errors (network, firmware, …).

The reject value is unchanged, so loader teardown and `composedLevels` clearing in `useSendFormCompose` keep working as before.

I am honestly not sure if this is the right way to fix it. And this code is 100% vibecoded. 

## Test plan

- [ ] BTC send form: type a clearly invalid address (e.g. `placeholder`) → no toast, inline field error appears once the field is touched
- [ ] BTC send form: leave invalid address in draft, navigate away and back → no toast on load
- [ ] BTC send form: wait for periodic fee refresh with invalid address in draft → no toast spam
- [ ] BTC send form: valid address + insufficient funds → `AMOUNT_IS_NOT_ENOUGH` still surfaces inline (unchanged)
- [ ] BTC send form: trigger a real unexpected compose failure (e.g. backend offline) → toast still appears
- [ ] Cardano send form: same checks

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are scoped to two chain-specific send form thunk files: Bitcoin and Cardano transaction composition/signing logic. These are critical user-facing flows where regressions would directly impact the ability to send funds. Both files map to 121 tests via transitive imports, indicating they are bundled as part of the broader wallet-core package, but only send-related E2E tests directly exercise these code paths. The recommended strategy is to prioritize Bitcoin and Cardano send tests, with medium priority for related send variations (raw, multisig) that may share infrastructure.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/wallet-core/src/send/sendFormBitcoinThunks.ts`
- `suite-common/wallet-core/src/send/sendFormCardanoThunks.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/send/send-bitcoin.test.ts` — sendFormBitcoinThunks.ts contains the core logic for composing and sending Bitcoin transactions. A Bitcoin send test directly exercises this changed code path and any regression would be immediately user-visible.
- `suite/e2e/tests/send/send-cardano.test.ts` — sendFormCardanoThunks.ts contains the core logic for composing and sending Cardano transactions. A Cardano send test directly exercises this changed code path and any regression would be immediately user-visible.
- `suite/e2e/tests/send/send-form.test.ts` — A general send form test likely exercises the shared send form infrastructure that dispatches into chain-specific thunks like Bitcoin and Cardano, making it directly relevant to both changed files.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/send/send-raw.test.ts` — Raw send functionality may share transaction composition infrastructure with the Bitcoin thunks. Changes to sendFormBitcoinThunks could affect raw transaction handling if they share utility functions.
- `suite/e2e/tests/send/send-multisig.test.ts` — Multisig Bitcoin transactions go through the Bitcoin send form thunks. Changes to sendFormBitcoinThunks could affect how multisig transactions are composed and signed.

</details>

_Updated: 2026-05-22T10:53:05.324Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/invalid-address-toast-spam&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/invalid-address-toast-spam&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/invalid-address-toast-spam&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 16 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox - watches files over time | 🤖 auto |
| Dropbox API errors > Incomplete data returned from provider | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Metadata - switching between cloud providers > Start with one and switch to another | 🤖 auto |
| Metadata - address labeling > google provider | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Remembered device > google provider | 🤖 auto |
| Dropbox API errors > Malformed token | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Account metadata > google - watches files over time | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-22T10:57:53.361Z • 16 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-22T10:56:19.205Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/invalid-address-toast-spam/web/](https://dev.suite.sldev.cz/suite-web/mroz22/invalid-address-toast-spam/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->