### PR TITLE
chore(transport): drop unused `configured` field from bridge info response

### DIFF
--- a/packages/transport/src/utils/bridgeApiResult.ts
+++ b/packages/transport/src/utils/bridgeApiResult.ts
@@ -24,10 +24,9 @@ export function info(res: UnknownPayload) {
     if (typeof version !== 'string') {
         return error({ code: ERRORS.WRONG_RESULT_TYPE });
     }
-    const configured = !!res.configured;
     const protocolMessages = !!res.protocolMessages;
 
-    return success({ version, configured, protocolMessages });
+    return success({ version, protocolMessages });
 }
 
 export function devices(res: UnknownPayload) {


### PR DESCRIPTION
## Description

The `configured` field on `bridgeApiResult.info`'s success payload is dead code: it is parsed from the node-bridge `/` response and re-emitted in the `info()` success payload, but no consumer in the monorepo ever reads `.configured` on that payload.

Grep across the repo for `\.configured\b` returned only the definition site itself (`packages/transport/src/utils/bridgeApiResult.ts`). `bridgeApiResult.info` has a single caller (`BridgeTransport` in `packages/transport/src/transports/bridge.ts`), which destructures only `version`.

Dropping the field shrinks the public surface of the bridge transport API. The TypeScript return shape of `info()` updates automatically — no downstream type fix-ups needed.

## Stack

Base of a 3-PR stack landing the legacy-bridge cleanup + Connect 10 DI rewrite:

1. **#27970 — this PR** — drop unused `configured` field from bridge `info()` response
2. **#27951** — drop legacy bridge port 21325 (rebased on top)
3. **#27842** — pure-DI transports in Connect (rebased on top of #27951)

Review/merge order: this PR → #27951 → #27842. Each downstream PR is rebased on top of the previous one, so once this lands the chain becomes a clean fast-forward.

## Test plan

- [ ] `yarn workspace @trezor/transport type-check` passes
- [ ] `yarn workspace @trezor/transport test` passes
- [ ] CI green

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file `packages/transport/src/utils/bridgeApiResult.ts` is a low-level transport utility used broadly across 116+ E2E tests, indicating it is a foundational/shared dependency. Without any LLM analysis data on candidate tests (the analysis object is empty), there is no specific evidence that any particular E2E test exercises the changed code path more directly than others. Since the broad-utility heuristic applies (≥10 tests mapped), and we lack concrete evidence to elevate any specific test, recommending zero tests is appropriate — unit/integration tests within the `packages/transport` package itself would be the proper coverage layer for this change. If no such unit tests exist, manual verification of bridge communication flows is advised.

<details><summary><b>Changed files (1)</b></summary>

- `packages/transport/src/utils/bridgeApiResult.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/transport/src/utils/bridgeApiResult.ts`

_Updated: 2026-05-22T12:09:33.502Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/configured-field-dead-code&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/configured-field-dead-code&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 16 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox - watches files over time | 🤖 auto |
| Dropbox API errors > Incomplete data returned from provider | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Metadata - switching between cloud providers > Start with one and switch to another | 🤖 auto |
| Metadata - address labeling > google provider | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Remembered device > google provider | 🤖 auto |
| Dropbox API errors > Malformed token | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Account metadata > google - watches files over time | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-22T12:15:07.437Z • 16 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-22T12:12:43.331Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/configured-field-dead-code/web/](https://dev.suite.sldev.cz/suite-web/mroz22/configured-field-dead-code/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->
