### PR TITLE
Merkle user rewards (stale data)

### DIFF
--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimSelectAccountModal.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimSelectAccountModal.tsx
@@ -1,12 +1,16 @@
 import { Address } from '@suite/address';
 import { type DesktopAnalyticsDep, events } from '@suite/analytics';
 import { Translation } from '@suite/intl';
+import { selectIsDebugModeActive } from '@suite/settings';
 import { useServices } from '@suite-common/dependency-injection';
 import { useFormatters } from '@suite-common/formatters';
-import { CardList, Column, Modal, Row, Text } from '@trezor/components';
+import { selectBaseCurrency } from '@suite-common/wallet-core';
+import { CardList, Column, Modal, Row, Text, Tooltip } from '@trezor/components';
 import { CoinLogo } from '@trezor/product-components';
 
 import { AccountLabel } from 'src/components/suite/AccountLabel';
+import { DebugOnlyBadge } from 'src/components/suite/DebugOnlyBadge';
+import { useSelector } from 'src/hooks/suite';
 
 import { type YieldAccountRewards, type YieldAccountsRewards } from '../../yield/claim/hooks';
 
@@ -23,6 +27,8 @@ export const EarnYieldClaimSelectAccountModal = ({
 }: EarnYieldClaimSelectAccountModalProps) => {
     const { analytics } = useServices<DesktopAnalyticsDep>();
     const { BaseCurrencyAmountFormatter } = useFormatters();
+    const isDebugModeActive = useSelector(selectIsDebugModeActive);
+    const baseCurrency = useSelector(selectBaseCurrency);
 
     const handleOnSelect = (account: YieldAccountRewards) => {
         analytics.report({
@@ -85,11 +91,25 @@ export const EarnYieldClaimSelectAccountModal = ({
                                 />
                             </Column>
                         </Row>
-                        <Text typographyStyle="body-md-strong">
-                            {BaseCurrencyAmountFormatter.format(
-                                accountRewards.totalClaimableFiatAmount,
-                            )}
-                        </Text>
+                        <Tooltip
+                            content={
+                                isDebugModeActive ? (
+                                    <Column gap={8} alignItems="flex-start">
+                                        <DebugOnlyBadge />
+                                        <Text>
+                                            {accountRewards.totalClaimableFiatAmount.toFixed()}{' '}
+                                            {baseCurrency.toUpperCase()}
+                                        </Text>
+                                    </Column>
+                                ) : undefined
+                            }
+                        >
+                            <Text typographyStyle="body-md-strong">
+                                {BaseCurrencyAmountFormatter.format(
+                                    accountRewards.totalClaimableFiatAmount,
+                                )}
+                            </Text>
+                        </Tooltip>
                     </CardList.Item>
                 ))}
             </CardList>

--- a/packages/suite/src/components/earn/yield/claim/YieldClaim.tsx
+++ b/packages/suite/src/components/earn/yield/claim/YieldClaim.tsx
@@ -6,7 +6,6 @@ import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
 import { useServices } from '@suite-common/dependency-injection';
 import { Context } from '@suite-common/message-system';
-import { commonQueryKeys, useQueryClient } from '@suite-common/react-query';
 import {
     selectStablecoinYieldSession,
     selectStablecoinYieldTxReview,
@@ -52,7 +51,7 @@ export const YieldClaim = ({ account }: YieldClaimProps) => {
     const { merkleRewardsQuery, missingRateTickersQuery } = useMerkleRewards(account);
     const accountRewards: YieldAccountRewards | undefined =
         merkleRewardsQuery.data?.accountsRewards[0];
-    const isRewardsLoading = merkleRewardsQuery.isLoading || missingRateTickersQuery.isFetching;
+    const isRewardsLoading = merkleRewardsQuery.isLoading || missingRateTickersQuery.isLoading;
 
     useEffect(() => {
         dispatch(stablecoinYieldActions.initSession({ flowType: 'claim', flowKey }));
@@ -66,9 +65,8 @@ export const YieldClaim = ({ account }: YieldClaimProps) => {
         account,
         flowType: 'claim',
         flowKey,
+        waitForMerkleToResolveClaim: merkleRewardsQuery.waitForMerkleToResolveClaim,
     });
-
-    const queryClient = useQueryClient();
 
     const handleClaim = async () => {
         if (!accountRewards) return;
@@ -96,12 +94,6 @@ export const YieldClaim = ({ account }: YieldClaimProps) => {
 
         try {
             await dispatch(claimMerkleRewardsThunk({ account, flowKey, rewards })).unwrap();
-
-            await merkleRewardsQuery.refetchBypassingCache();
-            await queryClient.invalidateQueries({
-                queryKey: commonQueryKeys.yieldOpportunities(),
-                exact: false,
-            });
         } catch {
             // cancelled or rejected — isClaiming resets via Redux (discardTransaction in finally)
         }
@@ -186,7 +178,7 @@ export const YieldClaim = ({ account }: YieldClaimProps) => {
                             isDisabled={
                                 isRewardsLoading || !accountRewards?.rewards.length || isClaiming
                             }
-                            isLoading={isClaimSubmitting}
+                            isLoading={isClaimSubmitting || merkleRewardsQuery.isLoading}
                             onClick={handleClaim}
                         >
                             <Translation id="TR_EARN_YIELD_CLAIM" />

--- a/packages/suite/src/components/earn/yield/claim/hooks/useMerkleRewards.ts
+++ b/packages/suite/src/components/earn/yield/claim/hooks/useMerkleRewards.ts
@@ -1,13 +1,12 @@
 import { useCallback, useMemo } from 'react';
 
-import { useQuery } from '@tanstack/react-query';
-
 import {
     ChainAddressKey,
     type MerkleRewardsByChainAndAddress,
+    getMerkleRewards,
     useGetMerkleRewards,
 } from '@suite-common/earn-stablecoin-api';
-import { commonQueryKeys, useQueryClient } from '@suite-common/react-query';
+import { commonQueryKeys, useQuery, useQueryClient } from '@suite-common/react-query';
 import { getNetworkByEvmChainId } from '@suite-common/wallet-config';
 import {
     selectBaseCurrency,
@@ -32,7 +31,8 @@ import {
     toFiatCurrency,
 } from '@suite-common/wallet-utils';
 import { type BaseCurrencyCode } from '@trezor/blockchain-link-types';
-import { BigNumber } from '@trezor/utils';
+import { useFreshRef } from '@trezor/react-utils';
+import { BigNumber, delay } from '@trezor/utils';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
@@ -182,24 +182,7 @@ export function useMerkleRewards(accounts: YieldRewardsAccounts) {
     }, [accounts]);
     const merkleRewardsQueryEntries = useMerkleRewardsQueryEntries(resolvedAccounts);
     const merkleRewardsQuery = useGetMerkleRewards(merkleRewardsQueryEntries);
-
     const queryClient = useQueryClient();
-    const refetchBypassingCache = useCallback(async () => {
-        const queryKey = commonQueryKeys.merkleRewards();
-        queryClient.setQueryDefaults(queryKey, {
-            meta: { bypassCache: true },
-        });
-        try {
-            await queryClient.refetchQueries(
-                { queryKey, exact: false },
-                { cancelRefetch: true, throwOnError: true },
-            );
-        } finally {
-            queryClient.setQueryDefaults(queryKey, {
-                meta: { bypassCache: false },
-            });
-        }
-    }, [queryClient]);
 
     const baseCurrency = useSelector(selectBaseCurrency);
     const currentFiatRates = useSelector(selectCurrentFiatRates);
@@ -273,10 +256,54 @@ export function useMerkleRewards(accounts: YieldRewardsAccounts) {
         return asBaseCurrencyAmount(new BigNumber(result.toFixed(2)));
     }, [rewardsWithFiat]);
 
+    const accountsRewardsRef = useFreshRef(accountsRewards);
+    const merkleRewardsQueryEntriesRef = useFreshRef(merkleRewardsQueryEntries);
+    /**
+     * - Force Merkle to return fresh rewards after claiming has completed and the tx is confirmed on-chain.
+     * - It resolves once Merkle return empty rewards = actually finished processing the claim.
+     */
+    const waitForMerkleToResolveClaim = useCallback(async () => {
+        let attempts = 30;
+
+        await queryClient.invalidateQueries({
+            queryKey: commonQueryKeys.merkleRewards(merkleRewardsQueryEntriesRef.current),
+            type: 'inactive',
+        });
+
+        const abortController = new AbortController();
+        const { signal } = abortController;
+
+        // Refetch until it returns no rewards (i.e. the claim was finalized by Merkle)
+        while (accountsRewardsRef.current.length > 0 && attempts > 0 && !signal.aborted) {
+            // Do direct API calls to avoid manipulating with React Query cache (because once the the endpoint returns empty rewards, the component would rerender with empty rewards state instead of successfull one)
+            const rewards = await getMerkleRewards({
+                queryEntries: merkleRewardsQueryEntriesRef.current,
+            });
+
+            if (Object.keys(rewards).length === 0) {
+                break;
+            }
+
+            await delay(2000, signal);
+            attempts--;
+        }
+
+        await queryClient.invalidateQueries({
+            queryKey: commonQueryKeys.merkleRewards(merkleRewardsQueryEntriesRef.current),
+            type: 'inactive',
+        });
+
+        return () => {
+            if (attempts > 0 && !signal.aborted) {
+                abortController.abort();
+            }
+        };
+    }, [accountsRewardsRef, merkleRewardsQueryEntriesRef, queryClient]);
+
     return {
         merkleRewardsQuery: {
             ...merkleRewardsQuery,
-            refetchBypassingCache,
+            waitForMerkleToResolveClaim,
             data: {
                 accountsRewards,
                 totalRewardsToClaim: {

--- a/packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts
@@ -130,13 +130,17 @@ type UseYieldPendingTransactionTrackingProps = {
     flowType: YieldFlowType;
     flowKey: string;
     vaultId?: string;
+    waitForMerkleToResolveClaim?: () => Promise<unknown>;
 };
+
+const stablePlaceholderPromise = () => Promise.resolve();
 
 export const useYieldPendingTransactionTracking = ({
     account,
     flowType,
     flowKey,
     vaultId,
+    waitForMerkleToResolveClaim = stablePlaceholderPromise,
 }: UseYieldPendingTransactionTrackingProps) => {
     const dispatch = useDispatch();
     const { analytics } = useServices<DesktopAnalyticsDep>();
@@ -242,13 +246,32 @@ export const useYieldPendingTransactionTracking = ({
         }
 
         if (pendingTransaction.type === flowType) {
-            dispatch(
-                stablecoinYieldActions.completeAction({
-                    flowType,
-                    flowKey,
-                    amount: pendingTransaction.amount,
-                }),
-            );
+            const completeAction = () => {
+                dispatch(
+                    stablecoinYieldActions.completeAction({
+                        flowType: 'claim',
+                        flowKey,
+                        amount: pendingTransaction.amount,
+                    }),
+                );
+            };
+
+            if (flowType !== 'claim') {
+                completeAction();
+
+                return;
+            }
+
+            analytics.report({
+                type: events.yieldClaimEvent.name,
+                payload: {
+                    action: 'continue',
+                    type: 'success',
+                    networkSymbol: account.symbol,
+                },
+            });
+
+            waitForMerkleToResolveClaim().then(completeAction);
 
             return;
         }
@@ -263,6 +286,7 @@ export const useYieldPendingTransactionTracking = ({
         analytics,
         account.symbol,
         vaultId,
+        waitForMerkleToResolveClaim,
     ]);
 
     // Emit `leftPending` if the component unmounts while a tx is still unresolved.

--- a/packages/utils/src/delay.ts
+++ b/packages/utils/src/delay.ts
@@ -1,0 +1,11 @@
+export function delay(ms: number, signal?: AbortSignal): Promise<void> {
+    return new Promise<void>(resolve => {
+        const timeoutId = setTimeout(resolve, ms);
+
+        if (signal) {
+            signal.addEventListener('abort', () => {
+                clearTimeout(timeoutId);
+            });
+        }
+    });
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -70,3 +70,4 @@ export * from './isInt';
 export * from './number';
 export * from './sanitizeFilename';
 export * from './isSafeObjectKey';
+export * from './delay';

--- a/suite-common/earn-stablecoin-api/src/config/index.ts
+++ b/suite-common/earn-stablecoin-api/src/config/index.ts
@@ -4,5 +4,5 @@ const minutes = (value: number) => value * 60 * 1000;
 
 export const queriesStaleTime = {
     getYieldOpportunities: minutes(5),
-    getMerkleRewards: minutes(5),
+    getMerkleRewards: minutes(1),
 } as const satisfies Record<string, number>;

--- a/suite-common/earn-stablecoin-api/src/hooks/useGetMerkleRewards.ts
+++ b/suite-common/earn-stablecoin-api/src/hooks/useGetMerkleRewards.ts
@@ -24,8 +24,47 @@ export class ChainAddressKey {
 export type MerkleRewardsParams<Address extends string> = {
     address: Address;
     chainId: number;
-    reloadChainId?: number;
 };
+
+interface GetMerkleRewardsProps {
+    queryEntries: MerkleRewardsParams<string>[];
+    signal?: AbortSignal;
+    meta?: {
+        bypassCache?: boolean;
+    };
+}
+
+export async function getMerkleRewards({ queryEntries, signal, meta }: GetMerkleRewardsProps) {
+    const requests = queryEntries.map(entry =>
+        getMerkleUserRewards({
+            routeParams: { address: entry.address },
+            params: {
+                chainId: entry.chainId,
+                claimableOnly: true,
+                // Force fresh data by default. Merkle API returns Cloudflare cache (<= 60s) if sent without `reloadChainId`.
+                reloadChainId: meta?.bypassCache === false ? undefined : entry.chainId,
+            },
+            signal,
+        }),
+    );
+
+    const usersChainRewards = await Promise.all(requests);
+
+    const usersRewardsByChainAndAddress = usersChainRewards.reduce<
+        Record<string, MerkleClaimableReward[]>
+    >((result, chainsRewards, index) => {
+        const { address, chainId } = queryEntries[index];
+        const key = ChainAddressKey.compose(chainId, address);
+
+        result[key] = chainsRewards.flatMap(chainRewards => chainRewards.rewards);
+
+        return result;
+    }, {});
+
+    return Object.fromEntries(
+        Object.entries(usersRewardsByChainAndAddress).filter(([, rewards]) => rewards.length > 0),
+    );
+}
 
 export function useGetMerkleRewards<Address extends string>(
     queryEntries: MerkleRewardsParams<Address>[],
@@ -33,33 +72,8 @@ export function useGetMerkleRewards<Address extends string>(
     return useQuery({
         queryKey: commonQueryKeys.merkleRewards(queryEntries),
         staleTime: queriesStaleTime.getMerkleRewards,
-        async queryFn({ signal, meta }) {
-            const requests = queryEntries.map(entry =>
-                getMerkleUserRewards({
-                    routeParams: { address: entry.address },
-                    params: {
-                        chainId: entry.chainId,
-                        claimableOnly: true,
-                        // Force fresh data by default. This will be improved later, but for now it seems that Merkle sends obsolete data (reloadChainId).
-                        reloadChainId: meta?.bypassCache === false ? undefined : entry.chainId,
-                    },
-                    signal,
-                }),
-            );
-
-            const usersChainRewards = await Promise.all(requests);
-
-            return usersChainRewards.reduce<Record<string, MerkleClaimableReward[]>>(
-                (result, chainsRewards, index) => {
-                    const { address, chainId } = queryEntries[index];
-                    const key = ChainAddressKey.compose(chainId, address);
-
-                    result[key] = chainsRewards.flatMap(chainRewards => chainRewards.rewards);
-
-                    return result;
-                },
-                {},
-            );
+        queryFn({ signal, meta }) {
+            return getMerkleRewards({ queryEntries, signal, meta });
         },
     });
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

**Context:**
__TLDR: The Merkle user rewards endpoint (`useGetMerkleRewards`) returns stale data (even with `reloadChainId` query param) for unknown period of time (usally it's about ~10s).__ 
The yield rewards issue is caused by Merkle API sending stale data. Even with the reloadChainId (that should force refresh data in response). Without sending reloadChainId the Merkle endpoint cache user rewards up to 60s. 
If I do polling of the endpoint once the reward claiming finishes (i.e. the tx has been broadcast to blockchain), it takes ~10-12s than the Merkle API starts sending fresh data.

There're no http cache, nor Cloudflare cache at our end. It just can't go faster than that. 

**Solution**
Once a claim rewards tx has been successfully broadcasted to blockchain, it starts polling the user rewards endpoint (30 attempts with 2s delay) until it starts returning empty rewards, i.e. the claim has resolved. 
- The polling is intentionally done outside of Tanstack Query hook to avoid manipulating its cache, thus given component' state. Once the endpoint returns empty rewards, `useGetMerkleRewards` is invalidate (but again only inactive one to prevent `YieldClaim` showing empty rewards state).


https://github.com/user-attachments/assets/9e01e732-8f51-4eeb-86a5-32d2c311842e



## Notes for QA

Yield: rewards after claim should disappear. 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27317

## Screenshots:

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are focused on stablecoin yield functionality (deposit, withdraw, claim thunks), an earn-specific tx simulation modal component, a shared TxSimulationFooter, a merkle rewards hook, and modal type definitions. No E2E tests exist that directly cover stablecoin yield features, indicating this is likely a new or not-yet-E2E-tested feature area. The closest existing tests are the ETH staking tests which share analogous earn/deposit/withdraw/claim patterns and may be affected by the modal.ts type changes. The risk is moderate — most changes are isolated to new stablecoin yield code paths, but the modal.ts change could have broader impact on modal rendering across the app.

<details><summary><b>Changed files (7)</b></summary>

- `packages/suite/src/actions/wallet/stablecoin-yield/claimMerkleRewardsThunk.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts`
- `packages/suite/src/components/tx-simulation/earn-stablecoin/EarnYieldTxSimulationModalInner.tsx`
- `suite-common/earn-stablecoin-api/src/hooks/useGetMerkleRewards.ts`
- `suite-common/suite-types/src/modal.ts`
- `suite/tx-simulation/src/common/components/TxSimulationFooter.tsx`

</details>

**Recommended tests (4)**

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `../../suite/e2e/tests/staking/eth/initial-stake.test.ts` — The changed files include stablecoin yield deposit/withdraw/claim thunks and an earn-related tx simulation modal. ETH staking tests exercise the closest earn/staking flow infrastructure, including deposit confirmation, device prompts, and transaction lifecycle. While stablecoin yield is distinct from ETH staking, they share earn-related UI patterns, modal types (suite-types/modal.ts), and potentially the TxSimulationFooter component.
- `../../suite/e2e/tests/staking/eth/unstake.test.ts` — The unstake test covers withdraw and claim flows for ETH staking, which are analogous to the stablecoin yield withdraw and claim merkle rewards thunks being changed. The modal.ts type changes could affect modal rendering in the unstake/claim confirmation flow. This test exercises the closest existing claim-after-unstake pattern.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `../../suite/e2e/tests/staking/eth/stake-more.test.ts` — Stake-more exercises additional deposit flows and transaction confirmation modals that share infrastructure with the stablecoin yield deposit thunk. Changes to modal.ts types could impact the confirmation modal rendering in this flow.
- `../../suite/e2e/tests/staking/staking-form.test.ts` — The staking form test validates input validation, amount calculation, and form submission for ETH staking. The stablecoin yield deposit thunk likely follows similar form submission patterns, and modal type changes could affect the form's confirmation modal.

</details>

⚠️ **Changes with no test coverage (6)**
- `packages/suite/src/actions/wallet/stablecoin-yield/claimMerkleRewardsThunk.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts`
- `packages/suite/src/components/tx-simulation/earn-stablecoin/EarnYieldTxSimulationModalInner.tsx`
- `suite-common/earn-stablecoin-api/src/hooks/useGetMerkleRewards.ts`
- `suite/tx-simulation/src/common/components/TxSimulationFooter.tsx`

_Updated: 2026-05-22T15:26:04.834Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/merkle-stale-data-after-claim&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/merkle-stale-data-after-claim&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/merkle-stale-data-after-claim&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 16 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox - watches files over time | 🤖 auto |
| Dropbox API errors > Incomplete data returned from provider | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Metadata - switching between cloud providers > Start with one and switch to another | 🤖 auto |
| Metadata - address labeling > google provider | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Remembered device > google provider | 🤖 auto |
| Dropbox API errors > Malformed token | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Account metadata > google - watches files over time | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-22T15:42:04.834Z • 16 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-22T15:40:37.974Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/merkle-stale-data-after-claim/web/](https://dev.suite.sldev.cz/suite-web/fix/merkle-stale-data-after-claim/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->