### PR TITLE
fix(node-utils): remove HttpServer listeners on stop

### DIFF
--- a/packages/node-utils/src/http.ts
+++ b/packages/node-utils/src/http.ts
@@ -97,6 +97,8 @@ export class HttpServer<T extends EventMap> extends TypedEmitter<T & BaseEvents>
     private port: number | undefined;
     private address: string;
     private sockets: Record<number, net.Socket> = {};
+    private onConnection?: (socket: net.Socket) => void;
+    private onError?: (e: Error) => void;
 
     constructor({
         logger,
@@ -180,7 +182,7 @@ export class HttpServer<T extends EventMap> extends TypedEmitter<T & BaseEvents>
               }
         >(resolve => {
             let nextSocketId = 0;
-            this.server.on('connection', socket => {
+            this.onConnection = socket => {
                 // Add a newly connected socket
                 const socketId = nextSocketId++;
                 this.sockets[socketId] = socket;
@@ -188,9 +190,10 @@ export class HttpServer<T extends EventMap> extends TypedEmitter<T & BaseEvents>
                 socket.on('close', () => {
                     delete this.sockets[socketId];
                 });
-            });
+            };
+            this.server.on('connection', this.onConnection);
 
-            this.server.on('error', async e => {
+            this.onError = async e => {
                 this.server.close();
                 // @ts-expect-error - type is missing
                 const errorCode: string = e.code;
@@ -222,7 +225,8 @@ export class HttpServer<T extends EventMap> extends TypedEmitter<T & BaseEvents>
                     error: 'other error',
                     message: `Start error code: ${errorCode}`,
                 };
-            });
+            };
+            this.server.on('error', this.onError);
 
             this.server.listen(port, this.address, undefined, () => {
                 this.logger.info('Server started, listening on port: ', port);
@@ -241,6 +245,14 @@ export class HttpServer<T extends EventMap> extends TypedEmitter<T & BaseEvents>
     public stop() {
         // note that this method only stops listening but keeps existing connections open and thus port blocked
         this.emitter.removeAllListeners();
+        if (this.onConnection) {
+            this.server.off('connection', this.onConnection);
+            this.onConnection = undefined;
+        }
+        if (this.onError) {
+            this.server.off('error', this.onError);
+            this.onError = undefined;
+        }
 
         return new Promise<void>(resolve => {
             this.emitter.emit('server/closing');

--- a/packages/node-utils/src/tests/http.test.ts
+++ b/packages/node-utils/src/tests/http.test.ts
@@ -510,40 +510,59 @@ describe('HttpServer', () => {
         await server.stop();
     });
 
-    // CURRENTLY LEAKS — see PR #27978 for the fix.
-    //
-    // HttpServer.start() registers 'connection' and 'error' listeners on the underlying
-    // http.Server instance. HttpServer.stop() calls removeAllListeners() on the
-    // TypedEmitter wrapper (this.emitter) but does not touch listeners on the underlying
-    // http.Server itself. Because the same http.Server is reused across start/stop cycles
-    // (created once in the constructor), every cycle accumulates one fresh listener per
-    // event. On the multi-port retry path each accumulated 'error' listener triggers a
-    // parallel stop().then(start()) chain — a quadratic blow-up in flight.
-    //
-    // When the fix lands, stop() must call this.server.removeAllListeners('connection')
-    // and ('error') so each cycle nets zero accumulation.
-    test('stop() leaks connection/error listeners on the underlying http.Server (TODO: fix in #27978)', async () => {
+    // Previously this test pinned the leak (see #27981): `HttpServer.stop()` did not
+    // remove the 'connection'/'error' listeners that `start()` attached to the underlying
+    // `http.Server`, only the TypedEmitter wrapper ones. The fix removes them surgically
+    // (`server.off(event, handler)`) so Node's built-in `connectionListener` — attached
+    // once by `http.createServer` and responsible for HTTP parsing — is preserved across
+    // start/stop cycles. Two cycles cover both halves: cleanup after stop() and
+    // non-accumulation across the next start().
+    test('repeated start()/stop() does not leak connection/error listeners on the underlying http.Server', async () => {
         const underlyingServer = (server as any).server;
-
-        // Node's http.Server keeps one built-in 'connection' listener by default; start()
-        // adds one more, error starts at 0 and start() adds one.
         const connectionBaseline = underlyingServer.listenerCount('connection');
-        const errorBaseline = underlyingServer.listenerCount('error');
 
         await server.start();
         expect(underlyingServer.listenerCount('connection')).toBe(connectionBaseline + 1);
-        expect(underlyingServer.listenerCount('error')).toBe(errorBaseline + 1);
+        expect(underlyingServer.listenerCount('error')).toBe(1);
 
         await server.stop();
+        expect(underlyingServer.listenerCount('connection')).toBe(connectionBaseline);
+        expect(underlyingServer.listenerCount('error')).toBe(0);
 
-        // TODO(#27978): after the fix lands, the assertions below must be:
-        //   listenerCount('connection') === 0   (PR removes all 'connection' listeners,
-        //       including the built-in baseline)
-        //   listenerCount('error')      === 0
-        //
-        // Current broken behavior: stop() leaves both listeners attached to the underlying server.
+        await server.start();
         expect(underlyingServer.listenerCount('connection')).toBe(connectionBaseline + 1);
-        expect(underlyingServer.listenerCount('error')).toBe(errorBaseline + 1);
+        expect(underlyingServer.listenerCount('error')).toBe(1);
+
+        await server.stop();
+        expect(underlyingServer.listenerCount('connection')).toBe(connectionBaseline);
+        expect(underlyingServer.listenerCount('error')).toBe(0);
+    });
+
+    // Regression for an earlier iteration of the fix that called
+    // `this.server.removeAllListeners('connection')` in stop(). That wiped out Node's
+    // built-in `connectionListener` (the one `http.createServer` attaches), so the next
+    // start() accepted TCP connections without ever parsing them as HTTP and clients
+    // got `socket hang up`. The surgical `.off(event, storedHandler)` cleanup leaves
+    // Node's parser listener intact across cycles.
+    test('HTTP requests still work after a stop()/start() cycle', async () => {
+        server.get('/ping', [
+            (_request, response) => {
+                response.end('pong');
+            },
+        ]);
+
+        await server.start();
+        const firstAddr = server.getServerAddress();
+        const firstRes = await fetch(`http://${firstAddr.address}:${firstAddr.port}/ping`);
+        expect(firstRes.status).toBe(200);
+        expect(await firstRes.text()).toBe('pong');
+
+        await server.stop();
+        await server.start();
+        const secondAddr = server.getServerAddress();
+        const secondRes = await fetch(`http://${secondAddr.address}:${secondAddr.port}/ping`);
+        expect(secondRes.status).toBe(200);
+        expect(await secondRes.text()).toBe('pong');
     });
 
     test('port negotiation - even when started using random port, the resulting port is stored for future use', async () => {


### PR DESCRIPTION
## Summary

`HttpServer.stop()` in `packages/node-utils/src/http.ts` now removes the `connection` and `error` listeners that `start()` attached to the underlying `http.Server`. Without this cleanup, every `stop()` + `start()` cycle (including the internal multi-port retry path on `EADDRINUSE`) accumulated a fresh set of listeners on the same `http.Server` instance, causing duplicate socket tracking and duplicate error handling on each restart.

The cleanup is surgical (`server.off(event, storedHandler)` against references captured in `start()`) rather than `removeAllListeners(event)`. The blunt variant would also wipe Node's built-in `connectionListener` — the one `http.createServer` attaches once and which is responsible for HTTP parsing — leaving the next `start()` cycle accepting TCP connections but never parsing them as HTTP (clients see `socket hang up`). The surgical variant preserves Node's parser listener across cycles.

- `packages/node-utils/src/http.ts`: store `onConnection` / `onError` handler refs on the instance, register them in `start()`, and `server.off()` them in `stop()`.
- `packages/node-utils/src/tests/http.test.ts`: two regression tests — listener counts return to baseline across two `start/stop` cycles, and a real HTTP request still succeeds after a `stop → start` cycle (covers the `removeAllListeners` regression).

Part of the broader listener-cleanup audit (related to #27978).

## Related PRs

Part of the listener-leak audit series:

- #27978 — `fix: audit and patch event listener leaks across transport/connect/desktop packages` (original fix series, covers 14 leaks in 12 atomic commits)
- #27980 — `fix(node-utils): remove HttpServer listeners on stop` (split-out single-package fix with its own regression test)
- #27981 — `test: document event listener leaks across transport/node-utils/ipc-proxy` (tests-only, pins the current broken state with `TODO` markers that auto-flip once the fix lands)
- #27982 — `feat(utils): introduce listener disposer helper for Connect/transport sites` (alternative angle: reusable `addEventListener` / `combineDisposers` helper in `@trezor/utils` plus migration of overlapping Connect/transport sites)
- #27987 — `chore(jest): wire JestCustomEnv into all node-env packages as a leak safety net` (extends the existing `MaxListenersExceededWarning` trap from 6 to 29 packages)
- #27989 — `fix(utils): cleanup both abort listeners in scheduleAction.rejectWhenAborted` (root cause for the bulk of multipleResolves events)

## Test plan

- [x] `yarn workspace @trezor/node-utils test:unit src/tests/http.test.ts` — 41/41 pass
- [x] Reverted the fix locally and re-ran the new test — fails on `listenerCount` assertion (regression coverage confirmed)

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are limited to `packages/node-utils/src/http.ts` and its unit test. This is a Node.js HTTP utility module with no static test mapping to any E2E tests. The unit test (`http.test.ts`) provides direct coverage of the changed code. The most plausible E2E impact is on the bridge-related tests that rely on HTTP-based bridge status checking and the node-bridge daemon, which likely uses node-utils HTTP infrastructure. All other E2E tests are browser/UI-focused and unlikely to exercise node-level HTTP utilities directly. The risk is low overall since the unit test covers the changed module directly.

<details><summary><b>Changed files (2)</b></summary>

- `packages/node-utils/src/http.ts`
- `packages/node-utils/src/tests/http.test.ts`

</details>

**Recommended tests (2)**

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `../../suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — This test exercises bridge HTTP status endpoint checking and bridge API responses (version field). The changed `packages/node-utils/src/http.ts` likely provides HTTP utilities used by the node-bridge module for serving or querying the bridge API. A regression in HTTP handling could cause bridge status checks or version queries to fail.
- `../../suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — This test checks bridge daemon spawning and HTTP-based bridge status verification (expectBridgeToBeRunning/expectBridgeToBeStopped). The node-bridge module likely depends on node-utils HTTP utilities for serving its HTTP endpoint or checking bridge liveness.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/node-utils/src/tests/http.test.ts`

_Updated: 2026-05-23T15:38:33.359Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/node-utils-http-server-listener-cleanup&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/node-utils-http-server-listener-cleanup&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 16 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox - watches files over time | 🤖 auto |
| Dropbox API errors > Incomplete data returned from provider | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Metadata - switching between cloud providers > Start with one and switch to another | 🤖 auto |
| Metadata - address labeling > google provider | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Remembered device > google provider | 🤖 auto |
| Dropbox API errors > Malformed token | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Account metadata > google - watches files over time | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-23T15:44:28.916Z • 16 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-23T16:11:47.069Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/node-utils-http-server-listener-cleanup/web/](https://dev.suite.sldev.cz/suite-web/fix/node-utils-http-server-listener-cleanup/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->






