### PR TITLE
test: document event listener leaks across transport/node-utils/ipc-proxy

### DIFF
--- a/packages/ipc-proxy/src/__tests__/proxy.test.ts
+++ b/packages/ipc-proxy/src/__tests__/proxy.test.ts
@@ -189,4 +189,51 @@ describe('proxy', () => {
 
         expect(ipcMain.eventNames().length).toEqual(0);
     });
+
+    // CURRENTLY LEAKS — see PR #27978 for the fix.
+    //
+    // ipcMain.handle() registers invoke handlers under per-instance prefixes
+    // (`<prefix>/invoke`). The unregister() function returned by createIpcProxyHandler
+    // currently iterates ipcMain.eventNames() and removes 'on' listeners, then calls
+    // removeHandler() for the channel-level `<channel>/create` only. Per-instance
+    // `<prefix>/invoke` handlers leak — they're not on eventNames() and the handler does
+    // not track instance prefixes.
+    //
+    // Note: the existing 'unregister proxy handler' test above passes because
+    // mockedElectron's removeHandler() is a no-op and the test only asserts on
+    // eventNames() (which lists 'on' channels, not 'invoke' handlers). This test instead
+    // spies on ipcMain.removeHandler to observe call patterns directly.
+    //
+    // When the fix lands, unregister() must track instance prefixes and call
+    // removeHandler(`${prefix}/invoke`) for each, plus removeHandler(`${channel}/create`).
+    it('unregister does not call removeHandler for per-instance invoke prefixes (TODO: fix in #27978)', async () => {
+        exposeInMainWorld(
+            ...exposeIpcProxy(ipcRenderer, ['LeakApi'], { proxyName: 'leakIpcProxy' }),
+        );
+
+        const api = new TestApi();
+        const unregister = createIpcProxyHandler<TestApi>(ipcMain, 'LeakApi', {
+            onCreateInstance: () => ({
+                onRequest: (method, params) => (api[method] as any)(...params),
+            }),
+        });
+
+        // Two instances → two `<prefix>/invoke` handlers registered via ipcMain.handle()
+        await createIpcProxy<TestApi>('LeakApi', { proxyName: 'leakIpcProxy' });
+        await createIpcProxy<TestApi>('LeakApi', { proxyName: 'leakIpcProxy' });
+
+        const removeHandlerSpy = jest.spyOn(ipcMain, 'removeHandler');
+        unregister();
+
+        // TODO(#27978): after the fix lands, removeHandler must be called 3 times:
+        //   once with 'LeakApi/create' (already done today)
+        //   plus once with each '<prefix>/invoke' (currently missing)
+        //
+        // Current broken behavior: only 'LeakApi/create' is cleaned up.
+        expect(removeHandlerSpy).toHaveBeenCalledTimes(1);
+        expect(removeHandlerSpy).toHaveBeenCalledWith('LeakApi/create');
+        expect(removeHandlerSpy).not.toHaveBeenCalledWith(expect.stringMatching(/\/invoke$/));
+
+        removeHandlerSpy.mockRestore();
+    });
 });

--- a/packages/node-utils/src/tests/http.test.ts
+++ b/packages/node-utils/src/tests/http.test.ts
@@ -510,6 +510,42 @@ describe('HttpServer', () => {
         await server.stop();
     });
 
+    // CURRENTLY LEAKS — see PR #27978 for the fix.
+    //
+    // HttpServer.start() registers 'connection' and 'error' listeners on the underlying
+    // http.Server instance. HttpServer.stop() calls removeAllListeners() on the
+    // TypedEmitter wrapper (this.emitter) but does not touch listeners on the underlying
+    // http.Server itself. Because the same http.Server is reused across start/stop cycles
+    // (created once in the constructor), every cycle accumulates one fresh listener per
+    // event. On the multi-port retry path each accumulated 'error' listener triggers a
+    // parallel stop().then(start()) chain — a quadratic blow-up in flight.
+    //
+    // When the fix lands, stop() must call this.server.removeAllListeners('connection')
+    // and ('error') so each cycle nets zero accumulation.
+    test('stop() leaks connection/error listeners on the underlying http.Server (TODO: fix in #27978)', async () => {
+        const underlyingServer = (server as any).server;
+
+        // Node's http.Server keeps one built-in 'connection' listener by default; start()
+        // adds one more, error starts at 0 and start() adds one.
+        const connectionBaseline = underlyingServer.listenerCount('connection');
+        const errorBaseline = underlyingServer.listenerCount('error');
+
+        await server.start();
+        expect(underlyingServer.listenerCount('connection')).toBe(connectionBaseline + 1);
+        expect(underlyingServer.listenerCount('error')).toBe(errorBaseline + 1);
+
+        await server.stop();
+
+        // TODO(#27978): after the fix lands, the assertions below must be:
+        //   listenerCount('connection') === 0   (PR removes all 'connection' listeners,
+        //       including the built-in baseline)
+        //   listenerCount('error')      === 0
+        //
+        // Current broken behavior: stop() leaves both listeners attached to the underlying server.
+        expect(underlyingServer.listenerCount('connection')).toBe(connectionBaseline + 1);
+        expect(underlyingServer.listenerCount('error')).toBe(errorBaseline + 1);
+    });
+
     test('port negotiation - even when started using random port, the resulting port is stored for future use', async () => {
         server = new HttpServer<Events>({ logger: muteLogger, ports: [0] });
         await server.start();

--- a/packages/transport-common/tests/abstractUsb.test.ts
+++ b/packages/transport-common/tests/abstractUsb.test.ts
@@ -333,6 +333,45 @@ describe('Usb', () => {
             });
         });
 
+        // CURRENTLY LEAKS — see PR #27978 for the fix.
+        //
+        // AbstractApiTransport.listen() registers three event handlers (one on the api emitter,
+        // two on the sessionsClient) but stop() does not remove them. Every listen()/stop()
+        // cycle therefore adds one fresh closure per event to the same emitters, which is
+        // exactly the kind of accumulation that trips Node's MaxListenersExceededWarning trap
+        // around the 11th cycle.
+        //
+        // This test pins the current broken behavior so the leak is visible in CI and the
+        // assertions auto-flip the moment the fix lands. When updating: each call to stop()
+        // must leave the targeted listener counts at 0 (api may keep a single one-shot
+        // 'transport-interface-change' listener registered by stop() itself, so assert
+        // listenerCount('transport-interface-change') <= 1).
+        it('listen()/stop() leaks listeners on api and sessionsClient (TODO: fix in #27978)', async () => {
+            const { transport, testUsbApi } = await initTest();
+            const { sessionsClient } = transport as any;
+
+            transport.listen();
+            // listen() registers one handler on the api and one each on the sessionsClient
+            expect(testUsbApi.listenerCount('transport-interface-change')).toBe(1);
+            expect(sessionsClient.listenerCount('descriptors')).toBe(1);
+            expect(sessionsClient.listenerCount('releaseRequest')).toBe(1);
+
+            transport.stop();
+
+            // TODO(#27978): after the fix lands, expected counts are:
+            //   testUsbApi.listenerCount('transport-interface-change')  <= 1   (only the
+            //       one-shot 'goodbye' listener registered inside stop() may remain)
+            //   sessionsClient.listenerCount('descriptors')             === 0
+            //   sessionsClient.listenerCount('releaseRequest')          === 0
+            //
+            // Current broken behavior:
+            //   - api keeps the listener added in listen() AND gains the one-shot from stop()
+            //   - sessionsClient keeps both listeners added in listen()
+            expect(testUsbApi.listenerCount('transport-interface-change')).toBe(2);
+            expect(sessionsClient.listenerCount('descriptors')).toBe(1);
+            expect(sessionsClient.listenerCount('releaseRequest')).toBe(1);
+        });
+
         it('call - with use abort', async () => {
             const { transport } = await initTest();
             await transport.enumerate();

--- a/packages/transport-common/tests/sessions.test.ts
+++ b/packages/transport-common/tests/sessions.test.ts
@@ -1,5 +1,6 @@
 import { SessionsBackground } from '../src/sessions/background';
 import { SessionsClient } from '../src/sessions/client';
+import { type SessionsBackgroundInterface } from '../src/sessions/types';
 import { PathInternal, PathPublic, Session } from '../src/types';
 
 describe('sessions', () => {
@@ -196,5 +197,50 @@ describe('sessions', () => {
                 ],
             },
         });
+    });
+
+    // CURRENTLY LEAKS — see PR #27978 for the fix.
+    //
+    // SessionsClient subscribes to 'descriptors' and 'releaseRequest' on the background in
+    // its constructor. SessionsClient.dispose() removes its own listeners and triggers a
+    // 'dispose' request to the background, but it does not call background.off() to remove
+    // the constructor-registered handlers from the background itself. A real shared
+    // SessionsBackground masks this via its destructive dispose() (which calls
+    // removeAllListeners() unconditionally) — so this test uses a minimal mock to isolate
+    // the SessionsClient -> SessionsBackgroundInterface contract.
+    //
+    // When the fix lands SessionsBackgroundInterface gains an off() method and
+    // SessionsClient.dispose() uses it to remove its own handler refs.
+    test('client.dispose() leaks listeners on shared background (TODO: fix in #27978)', () => {
+        const listeners = {
+            descriptors: [] as ((d: any) => void)[],
+            releaseRequest: [] as ((d: any) => void)[],
+        };
+        const mockBackground = {
+            on: (event: 'descriptors' | 'releaseRequest', listener: (d: any) => void) => {
+                listeners[event].push(listener);
+            },
+            // off() is not part of the current SessionsBackgroundInterface; included on the
+            // mock so the test can detect whether dispose() reaches for it once the fix lands.
+            off: (event: 'descriptors' | 'releaseRequest', listener: (d: any) => void) => {
+                const idx = listeners[event].indexOf(listener);
+                if (idx >= 0) listeners[event].splice(idx, 1);
+            },
+            handleMessage: () =>
+                Promise.resolve({ success: true, payload: undefined, id: 0 } as any),
+            dispose: () => {},
+        } as unknown as SessionsBackgroundInterface;
+
+        const client = new SessionsClient(mockBackground);
+        expect(listeners.descriptors.length).toBe(1);
+        expect(listeners.releaseRequest.length).toBe(1);
+
+        client.dispose();
+
+        // TODO(#27978): after the fix lands, both counts must be 0 here because
+        // SessionsClient.dispose() will call background.off() for each handler it
+        // registered in the constructor. Update the expectations below.
+        expect(listeners.descriptors.length).toBe(1); // leaked: dispose() does not call background.off
+        expect(listeners.releaseRequest.length).toBe(1); // leaked
     });
 });


### PR DESCRIPTION
## Summary

Tests-only PR that pins the current broken behavior for four event listener leaks. Each test passes against develop today and contains a TODO that auto-flips the moment the corresponding fix lands.

Goal: land the regression net first so the fixes in #27978 can be reviewed in isolation, and so any future regression on these specific code paths gets caught by CI without needing a forensic audit.

## Tests added

| Package | File | Documents |
|---|---|---|
| `@trezor/transport-common` | `tests/abstractUsb.test.ts` | `AbstractApiTransport.listen()/stop()` does not remove the listeners registered by `listen()` on `api` and `sessionsClient` |
| `@trezor/transport-common` | `tests/sessions.test.ts` | `SessionsClient.dispose()` does not call `background.off()` for its constructor-registered handlers — uses an isolated mock to bypass the destructive `SessionsBackground.dispose()` that masks the leak |
| `@trezor/node-utils` | `src/tests/http.test.ts` | `HttpServer.stop()` removes listeners from the TypedEmitter wrapper but does not touch the underlying `http.Server`, so each `start()/stop()` cycle leaks one `connection` + one `error` listener |
| `@trezor/ipc-proxy` | `src/__tests__/proxy.test.ts` | `createIpcProxyHandler`'s `unregister()` does not call `removeHandler` for per-instance `<prefix>/invoke` channels — spy-based so no shared-mock change is required |

## Notes

- Each test body opens with a header comment describing the leak and a `TODO(#27978)` block describing the post-fix expectation. When the fix lands, the assertions break and the TODO points the implementer at the exact lines to update.
- No source code, no mock infrastructure, no jest config touched. Tests-only.

## Related PRs

Part of the listener-leak audit series:

- #27978 — `fix: audit and patch event listener leaks across transport/connect/desktop packages` (original fix series, covers 14 leaks in 12 atomic commits)
- #27980 — `fix(node-utils): remove HttpServer listeners on stop` (split-out single-package fix with its own regression test)
- #27981 — `test: document event listener leaks across transport/node-utils/ipc-proxy` (tests-only, pins the current broken state with `TODO` markers that auto-flip once the fix lands)
- #27982 — `feat(utils): introduce listener disposer helper for Connect/transport sites` (alternative angle: reusable `addEventListener` / `combineDisposers` helper in `@trezor/utils` plus migration of overlapping Connect/transport sites)
- #27987 — `chore(jest): wire JestCustomEnv into all node-env packages as a leak safety net` (extends the existing `MaxListenersExceededWarning` trap from 6 to 29 packages)
- #27989 — `fix(utils): cleanup both abort listeners in scheduleAction.rejectWhenAborted` (root cause for the bulk of multipleResolves events)

## Test plan

- [ ] CI green on develop merge
- [ ] After #27978 (or its equivalent) lands, this file's expectations need to be inverted — see each `TODO(#27978)` comment for the target values

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All four changed files are unit test files (not source files), located in __tests__ or tests directories within packages/ipc-proxy, packages/node-utils, and packages/transport-common. Since only test files were modified, the risk of regression in production behavior is very low — these changes likely reflect updates to test assertions, fixtures, or test infrastructure rather than functional code changes. No E2E tests have static coverage mappings to these files. A few E2E tests are tangentially related to the transport and bridge infrastructure being tested, but the risk is minimal. Running the recommended tests is precautionary.

<details><summary><b>Changed files (4)</b></summary>

- `packages/ipc-proxy/src/__tests__/proxy.test.ts`
- `packages/node-utils/src/tests/http.test.ts`
- `packages/transport-common/tests/abstractUsb.test.ts`
- `packages/transport-common/tests/sessions.test.ts`

</details>

**Recommended tests (3)**

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `../../suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — The changes to transport-common (abstractUsb, sessions) and node-utils (http) could affect bridge/transport infrastructure. This test exercises the bundled bridge spawning, bridge API responses, and device reconnection after bridge restart — all of which depend on transport session management and HTTP utilities.
- `../../suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — This test validates node-bridge daemon spawning and lifecycle, which relies on node-utils HTTP utilities and transport infrastructure. Changes to node-utils HTTP tests and transport-common sessions could indicate changes in the underlying transport/bridge behavior.
- `../../suite/e2e/tests/suite/multiple-sessions.test.ts` — This test explicitly validates Bridge session stealing and reclamation via BridgeTransport session acquire/enumerate. Changes to transport-common sessions tests suggest possible changes to session management logic that this test directly exercises.

</details>

⚠️ **Changes with no test coverage (4)**
- `packages/ipc-proxy/src/__tests__/proxy.test.ts`
- `packages/node-utils/src/tests/http.test.ts`
- `packages/transport-common/tests/abstractUsb.test.ts`
- `packages/transport-common/tests/sessions.test.ts`

_Updated: 2026-05-23T16:12:01.640Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/leak-detection-tests&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/leak-detection-tests&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 16 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox - watches files over time | 🤖 auto |
| Dropbox API errors > Incomplete data returned from provider | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Metadata - switching between cloud providers > Start with one and switch to another | 🤖 auto |
| Metadata - address labeling > google provider | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Remembered device > google provider | 🤖 auto |
| Dropbox API errors > Malformed token | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Account metadata > google - watches files over time | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-24T08:10:45.292Z • 16 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-23T16:15:20.366Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/leak-detection-tests/web/](https://dev.suite.sldev.cz/suite-web/chore/leak-detection-tests/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->







