### PR TITLE
chore(jest): wire JestCustomEnv into all node-env packages as a leak safety net

### DIFF
--- a/packages/address-validator/jest.config.cjs
+++ b/packages/address-validator/jest.config.cjs
@@ -2,5 +2,6 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
+    testEnvironment: '../../JestCustomEnv.js',
     transformIgnorePatterns: ['/node_modules/(?!@scure/base/)'],
 };

--- a/packages/analytics-docs/jest.config.cjs
+++ b/packages/analytics-docs/jest.config.cjs
@@ -2,4 +2,5 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
+    testEnvironment: '../../JestCustomEnv.js',
 };

--- a/packages/analytics-uploader/jest.config.js
+++ b/packages/analytics-uploader/jest.config.js
@@ -2,5 +2,5 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
-    testEnvironment: 'node',
+    testEnvironment: '../../JestCustomEnv.js',
 };

--- a/packages/blockchain-link-types/jest.config.cjs
+++ b/packages/blockchain-link-types/jest.config.cjs
@@ -1,3 +1,6 @@
 const baseConfig = require('../../jest.config.base.swc');
 
-module.exports = { ...baseConfig };
+module.exports = {
+    ...baseConfig,
+    testEnvironment: '../../JestCustomEnv.js',
+};

--- a/packages/blockchain-link-utils/jest.config.cjs
+++ b/packages/blockchain-link-utils/jest.config.cjs
@@ -2,5 +2,5 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
-    testEnvironment: 'node',
+    testEnvironment: '../../JestCustomEnv.js',
 };

--- a/packages/bundler-security/jest.config.js
+++ b/packages/bundler-security/jest.config.js
@@ -8,4 +8,5 @@ const { ...baseConfig } = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
+    testEnvironment: '../../JestCustomEnv.js',
 };

--- a/packages/coinjoin/jest.config.js
+++ b/packages/coinjoin/jest.config.js
@@ -2,5 +2,5 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
-    testEnvironment: 'node',
+    testEnvironment: '../../JestCustomEnv.js',
 };

--- a/packages/connect-plugin-stellar/jest.config.cjs
+++ b/packages/connect-plugin-stellar/jest.config.cjs
@@ -2,4 +2,5 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
+    testEnvironment: '../../JestCustomEnv.js',
 };

--- a/packages/connect-web/jest.config.cjs
+++ b/packages/connect-web/jest.config.cjs
@@ -2,4 +2,5 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
+    testEnvironment: '../../JestCustomEnv.js',
 };

--- a/packages/connect/jest.config.cjs
+++ b/packages/connect/jest.config.cjs
@@ -2,7 +2,7 @@ const { testPathIgnorePatterns, ...baseConfig } = require('../../jest.config.bas
 
 module.exports = {
     ...baseConfig,
-    testEnvironment: 'node',
+    testEnvironment: '../../JestCustomEnv.js',
     collectCoverage: true,
     setupFiles: ['<rootDir>/setupJest.ts'],
     testPathIgnorePatterns: [...testPathIgnorePatterns, 'e2e'],

--- a/packages/env-utils/jest.config.cjs
+++ b/packages/env-utils/jest.config.cjs
@@ -2,4 +2,5 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
+    testEnvironment: '../../JestCustomEnv.js',
 };

--- a/packages/node-utils/jest.config.js
+++ b/packages/node-utils/jest.config.js
@@ -2,5 +2,5 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
-    testEnvironment: 'node',
+    testEnvironment: '../../JestCustomEnv.js',
 };

--- a/packages/protobuf/jest.config.cjs
+++ b/packages/protobuf/jest.config.cjs
@@ -2,4 +2,5 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
+    testEnvironment: '../../JestCustomEnv.js',
 };

--- a/packages/protocol/jest.config.cjs
+++ b/packages/protocol/jest.config.cjs
@@ -2,5 +2,5 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
-    testEnvironment: 'node',
+    testEnvironment: '../../JestCustomEnv.js',
 };

--- a/packages/request-manager/jest.config.js
+++ b/packages/request-manager/jest.config.js
@@ -2,5 +2,6 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
+    testEnvironment: '../../JestCustomEnv.js',
     testRetryTimes: 3,
 };

--- a/packages/requirements/jest.config.cjs
+++ b/packages/requirements/jest.config.cjs
@@ -2,4 +2,5 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
+    testEnvironment: '../../JestCustomEnv.js',
 };

--- a/packages/schema-utils/jest.config.cjs
+++ b/packages/schema-utils/jest.config.cjs
@@ -2,7 +2,7 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
-    testEnvironment: 'node',
+    testEnvironment: '../../JestCustomEnv.js',
     collectCoverage: true,
     collectCoverageFrom: ['src/**/*.ts'],
 };

--- a/packages/styles-common/jest.config.js
+++ b/packages/styles-common/jest.config.js
@@ -2,4 +2,5 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
+    testEnvironment: '../../JestCustomEnv.js',
 };

--- a/packages/suite-desktop-core/jest.config.js
+++ b/packages/suite-desktop-core/jest.config.js
@@ -2,6 +2,7 @@ const { ...baseConfig } = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
+    testEnvironment: '../../JestCustomEnv.js',
     roots: ['<rootDir>/src'],
     modulePathIgnorePatterns: ['node_modules', '<rootDir>/lib', '<rootDir>/libDev'],
     watchPathIgnorePatterns: ['<rootDir>/libDev', '<rootDir>/lib'],

--- a/packages/transport-bridge/jest.config.js
+++ b/packages/transport-bridge/jest.config.js
@@ -2,5 +2,5 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
-    testEnvironment: 'node',
+    testEnvironment: '../../JestCustomEnv.js',
 };

--- a/packages/urls/jest.config.js
+++ b/packages/urls/jest.config.js
@@ -2,4 +2,5 @@ const { ...baseConfig } = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
+    testEnvironment: '../../JestCustomEnv.js',
 };

--- a/packages/utxo-lib/jest.config.cjs
+++ b/packages/utxo-lib/jest.config.cjs
@@ -2,7 +2,7 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
-    testEnvironment: 'node',
+    testEnvironment: '../../JestCustomEnv.js',
     collectCoverage: true,
     collectCoverageFrom: ['src/**/*.ts'],
 };

--- a/packages/websocket-client/jest.config.cjs
+++ b/packages/websocket-client/jest.config.cjs
@@ -2,5 +2,5 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
-    testEnvironment: 'node',
+    testEnvironment: '../../JestCustomEnv.js',
 };


### PR DESCRIPTION
## Summary

Extends the existing `JestCustomEnv.js` (which throws on Node's `MaxListenersExceededWarning`) from 6 packages to 29 by swapping (or injecting) the `testEnvironment` in every node-env `jest.config.*` under `packages/*`.

The env is unchanged. This PR only widens its coverage.

## What the env does

`JestCustomEnv.js` extends `jest-environment-node` and listens for `process.on('warning', ...)`. When Node emits a `MaxListenersExceededWarning` (default threshold: 11 listeners on a single emitter+event) it throws and the offending test fails with a stack pointing at the emitter. This catches the classic per-cycle listener accumulation pattern automatically — no per-package regression test required.

## Coverage matrix

| Status | Count | Packages |
|---|---|---|
| **Already wired** (no-op for this PR) | 6 | `utils`, `transport`, `transport-common`, `device-utils`, `device-authenticity`, `blockchain-link/unit` |
| **Newly wired by this PR** | 23 | `address-validator`, `analytics-docs`, `analytics-uploader`, `blockchain-link-types`, `blockchain-link-utils`, `bundler-security`, `coinjoin`, `connect`, `connect-plugin-stellar`, `connect-web`, `env-utils`, `node-utils`, `protobuf`, `protocol`, `request-manager`, `requirements`, `schema-utils`, `styles-common`, `suite-desktop-core`, `transport-bridge`, `urls`, `utxo-lib`, `websocket-client` |
| **Out of scope (jsdom)** | 6 | `suite`, `components`, `connect-common`, `ipc-proxy`, `react-utils`, `suite-desktop-api` — would need a parallel jsdom-based env (separate PR) |
| **Skipped (no jest config)** | 1 | `transport-native-bluetooth` |

## Verification

- Ran `yarn workspace @trezor/<pkg> test:unit` on every newly wired package locally — all green (~4900 tests across 23 packages, zero failures).
- No latent listener leaks surfaced by the env trap.
- Tested transitivity: `transport-common` (already wired) keeps its existing passing test count.

## Risk and limitations

- **What it catches**: per-cycle listener accumulation on a single emitter+event that crosses 10 listeners. The classic class of leaks in long-running services.
- **What it does NOT catch**: single-shot leaks (1 listener left behind after dispose), leaks across per-instance emitters (each starts at 0), and leaks on DOM `EventTarget` / `chrome.runtime.*` (these are not Node EventEmitters).
- **False-positive surface**: any test that legitimately attaches >10 listeners to the same emitter+event (loops, fixtures with many subscribers) would fail. Such tests must call `events.setMaxListeners(N)` on the specific emitter. None encountered in this PR's verification run.

## Related PRs

Part of the listener-leak audit series:

- #27978 — `fix: audit and patch event listener leaks across transport/connect/desktop packages` (original fix series, covers 14 leaks in 12 atomic commits)
- #27980 — `fix(node-utils): remove HttpServer listeners on stop` (split-out single-package fix with its own regression test)
- #27981 — `test: document event listener leaks across transport/node-utils/ipc-proxy` (tests-only, pins the current broken state with `TODO` markers that auto-flip once the fix lands)
- #27982 — `feat(utils): introduce listener disposer helper for Connect/transport sites` (alternative angle: reusable `addEventListener` / `combineDisposers` helper in `@trezor/utils` plus migration of overlapping Connect/transport sites)
- #27987 — `chore(jest): wire JestCustomEnv into all node-env packages as a leak safety net` (extends the existing `MaxListenersExceededWarning` trap from 6 to 29 packages)
- #27989 — `fix(utils): cleanup both abort listeners in scheduleAction.rejectWhenAborted`

## Test plan

- [ ] CI green on develop merge
- [ ] No flakiness introduced in newly wired packages over the next few CI runs

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/jest-leak-detection-env&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/jest-leak-detection-env&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-24T08:27:38.020Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/jest-leak-detection-env/web/](https://dev.suite.sldev.cz/suite-web/chore/jest-leak-detection-env/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->





