### PR TITLE
chore(jest): add own-code DeprecationWarning trap to JestCustomEnv

### DIFF
--- a/JestCustomEnv.js
+++ b/JestCustomEnv.js
@@ -1,6 +1,21 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const NodeEnvironment = require('jest-environment-node').default;
 
+// Heuristic: a frame is "ours" when it points at /packages/* outside node_modules.
+// Used to keep DeprecationWarning trap from firing on warnings raised by third-party deps
+// (which we can't fix anyway). Returns the offending own-code frame, or null.
+const findOwnCodeFrame = stack => {
+    if (typeof stack !== 'string') return null;
+    for (const line of stack.split('\n')) {
+        if (line.includes('/node_modules/')) continue;
+        if (line.includes('/packages/') || line.includes('/suite-common/')) {
+            return line.trim();
+        }
+    }
+
+    return null;
+};
+
 class CustomEnvironment extends NodeEnvironment {
     async setup() {
         await super.setup();
@@ -10,6 +25,17 @@ class CustomEnvironment extends NodeEnvironment {
                 throw new Error(
                     'MaxListenersExceededWarning detected. If you need more, use events.setMaxListeners(desiredNumber)',
                 );
+            }
+
+            if (warning.name === 'DeprecationWarning') {
+                // Only fail on deprecations triggered by our own code — third-party deps
+                // emit deprecations we cannot fix, and we don't want to gate tests on them.
+                const ourFrame = findOwnCodeFrame(warning.stack);
+                if (ourFrame) {
+                    throw new Error(
+                        `DeprecationWarning from own code: ${warning.message}\nAt: ${ourFrame}`,
+                    );
+                }
             }
         });
     }


### PR DESCRIPTION
## Summary

> **Prerequisite:** #27991 must land first so that Nx Cloud properly invalidates `test:unit` cache when `JestCustomEnv.js` changes; otherwise CI may serve stale cached results from runs before the trap was added.
Extends `JestCustomEnv.js` with one additional failure condition on top of the existing `MaxListenersExceededWarning` trap:

| Trap | What it catches |
|---|---|
| `DeprecationWarning` (own code only) | Deprecated Node API used from code under `/packages/*` or `/suite-common/*`. Catches drift to APIs that will be removed (e.g. `Buffer()` constructor, `crypto.createCipher`, `url.parse`, `fs.exists`). |

Stack heuristic skips frames inside `/node_modules/` so third-party deps (which we cannot fix) do not gate tests. Verified to fire on synthetic `process.emitWarning('x', 'DeprecationWarning')` from a test file.

This stacks on **#27987** (the safety-net PR that wired `JestCustomEnv` across all node-env packages). Land that first, then this one.

## Findings from the original experiment

An earlier iteration of this PR also added a `multipleResolves` trap. It was removed from this PR because the trap was too noisy in practice, but the experiment surfaced real signal:

| Pattern | Verdict | Outcome |
|---|---|---|
| `Error: Aborted by signal` (~1500 fires in `@trezor/coinjoin`) | **Real bug** in `scheduleAction.rejectWhenAborted` — two abort listeners, neither removed the other on fire → second fire double-rejects already-settled promise | Fixed separately in **#27989** |
| `socket hang up`, `AbortError`, `[object Object]` resolved twice | **False positives** — `Promise.race` + slow racer pattern in `scheduleAction` produces phantom multipleResolves at the V8 level even though Promise semantics are correct | Endemic; would need significant filtering to be useful as a trap |
| Assertion failure surfaced via multipleResolves | Same family as the above — async assertion failures travel through `Promise.race` | Same |

Conclusion: `multipleResolves` is too noisy without a non-trivial filter that whitelists known-safe `scheduleAction` shapes. Dropped from this PR; revisit later if/when there is appetite to fix the `Promise.race` cleanup pattern at the source.

## DeprecationWarning trap — coverage

Ran all 29 wired packages: **0 hits**. Either the codebase genuinely avoids deprecated Node APIs on tested paths, or the tested paths simply don't exercise them. The trap is verified to work via a synthetic test (`process.emitWarning('test deprecation', 'DeprecationWarning')` from a test file fires).


## Test plan

- [ ] CI green on develop merge
- [ ] No regression: 29 wired packages still pass with the env active


