### PR TITLE
[nitpick]: fix(utils): cleanup both abort listeners in scheduleAction.rejectWhenAborted

### DIFF
--- a/packages/utils/src/scheduleAction.ts
+++ b/packages/utils/src/scheduleAction.ts
@@ -74,14 +74,18 @@ const rejectWhenAborted = (signal: AbortSignal | undefined, clear: AbortSignal) 
         const errorSignal = new RejectWhenAbortedError();
         if (clear.aborted) return reject(errorSignal);
         if (signal?.aborted) return reject(errorSignal);
-        const onAbort = () => reject(errorSignal);
-        signal?.addEventListener('abort', onAbort);
-        const onClear = () => {
-            signal?.removeEventListener('abort', onAbort);
-            clear.removeEventListener('abort', onClear);
+        // One shared handler attached to both signals so the first abort detaches both
+        // listeners before rejecting. Two separate listeners that each removed only
+        // themselves would leave the surviving one to call reject() a second time when the
+        // other AbortSignal later fires, producing a Node 'multipleResolves' event for the
+        // same already-settled promise.
+        function rejectAndCleanup() {
+            signal?.removeEventListener('abort', rejectAndCleanup);
+            clear.removeEventListener('abort', rejectAndCleanup);
             reject(errorSignal);
-        };
-        clear.addEventListener('abort', onClear);
+        }
+        signal?.addEventListener('abort', rejectAndCleanup);
+        clear.addEventListener('abort', rejectAndCleanup);
     });
 
 const resolveAction = async <T>(action: ScheduledAction<T>, clear: AbortSignal) => {

--- a/packages/utils/tests/scheduleAction.test.ts
+++ b/packages/utils/tests/scheduleAction.test.ts
@@ -226,6 +226,51 @@ describe('scheduleAction', () => {
         expect(checkListeners()).toBeUndefined();
     });
 
+    it('rejectWhenAborted does not double-reject when both signal and clear abort', async () => {
+        // The double-reject is invisible to Promise consumers (reject is idempotent), so
+        // asserting on the rejection value alone passes for both broken and fixed code.
+        // Instead observe the direct mechanical cause — onAbort leaving its own listener
+        // attached on the user signal — in the synchronous window between ac.abort() and
+        // scheduleAction's finally block aborting its internal clear signal (which would
+        // otherwise incidentally remove the leaked listener, calling reject() a second
+        // time on the way).
+        const ac = new AbortController();
+        const abortListeners = new Set<EventListenerOrEventListenerObject>();
+        const origAdd = ac.signal.addEventListener.bind(ac.signal);
+        const origRemove = ac.signal.removeEventListener.bind(ac.signal);
+        (ac.signal as any).addEventListener = (type: string, fn: any, opts?: any) => {
+            if (type === 'abort') abortListeners.add(fn);
+            origAdd(type as any, fn, opts);
+        };
+        (ac.signal as any).removeEventListener = (type: string, fn: any, opts?: any) => {
+            if (type === 'abort') abortListeners.delete(fn);
+            origRemove(type as any, fn, opts);
+        };
+
+        const action = (signal?: AbortSignal) =>
+            new Promise((_resolve, reject) => {
+                signal?.addEventListener('abort', () => reject(new Error('action-abort')));
+            });
+
+        // Explicit graceful: false so a future flip of the default doesn't silently bypass
+        // rejectWhenAborted (which is only on the non-graceful branch in scheduleAction).
+        const promise = scheduleAction(action, { signal: ac.signal, graceful: false });
+        // Eager handler so a failing synchronous assertion below cannot leave `promise` as
+        // an unhandled rejection (which would crash the jest worker before the assertion
+        // failure is reported).
+        promise.catch(() => {});
+        expect(abortListeners.size).toBe(1);
+
+        ac.abort();
+        // Fixed code removes onAbort before calling reject(). Broken code leaves it
+        // attached, which is exactly what allows onClear (still attached on the internal
+        // clear signal) to call reject() again once scheduleAction's finally block runs
+        // clearAborter.abort().
+        expect(abortListeners.size).toBe(0);
+
+        await expect(promise).rejects.toThrow(ERR_SIGNAL);
+    });
+
     it("don't abort after success", async () => {
         let signal: AbortSignal | undefined;
         const action = (sig?: AbortSignal) => {


### PR DESCRIPTION
## Summary

`scheduleAction.rejectWhenAborted` attached two abort listeners — `onAbort` on the user signal and `onClear` on the internal clear signal — but neither removed the other when it fired. The double-fire path:

1. User signal aborts → `onAbort` calls `reject(errorSignal)` on the inner promise (settled).
2. `scheduleAction`'s `finally` aborts the clear signal → surviving `onClear` listener calls `reject(errorSignal)` a second time on the already-settled promise.
3. Node reports the spurious second settle as a `multipleResolves` event.

Refactored to a single shared listener (`rejectAndCleanup`) attached to both signals so the first abort detaches both before rejecting.

## Repro

```js
const ac = new AbortController();
const action = signal => new Promise((_, reject) => {
    signal.addEventListener('abort', () => reject(new Error('action-abort')));
});

const p = scheduleAction(action, { signal: ac.signal });
ac.abort();
// Node fires: multipleResolves type=reject reason=Error: Aborted by signal
```

A hermetic regression test (wires its own `multipleResolves` handler) lives next to the existing scheduleAction tests and asserts the event is not produced for the `Aborted by signal` reason.

## How this was found

Surfaced during an exploratory experiment that wires Node's `multipleResolves` into `JestCustomEnv`. The trap fired ~1500 times in `@trezor/coinjoin` test runs, all with `Error: Aborted by signal` — this fix is the root cause for that bulk.

Other multipleResolves events that the experiment surfaced (`socket hang up`, `[object Object]`, `AbortError`) appear to be `Promise.race` + slow racer false positives from Node and are not addressed by this PR.

## Related PRs

Part of the listener-leak audit series:

- #27978 — `fix: audit and patch event listener leaks across transport/connect/desktop packages` (original fix series, covers 14 leaks in 12 atomic commits)
- #27980 — `fix(node-utils): remove HttpServer listeners on stop` (split-out single-package fix with its own regression test)
- #27981 — `test: document event listener leaks across transport/node-utils/ipc-proxy` (tests-only, pins the current broken state with `TODO` markers that auto-flip once the fix lands)
- #27982 — `feat(utils): introduce listener disposer helper for Connect/transport sites` (alternative angle: reusable `addEventListener` / `combineDisposers` helper in `@trezor/utils` plus migration of overlapping Connect/transport sites)
- #27987 — `chore(jest): wire JestCustomEnv into all node-env packages as a leak safety net` (extends the existing `MaxListenersExceededWarning` trap from 6 to 29 packages)

## Test plan

- [ ] CI green on develop merge
- [ ] `yarn workspace @trezor/utils test:unit` stays green

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are limited to `packages/utils/src/scheduleAction.ts` and its unit test file `packages/utils/tests/scheduleAction.test.ts`. `scheduleAction` is a very broad utility used transitively by 121+ E2E tests, meaning it is a low-level shared dependency rather than a feature-specific module. The unit test file provides direct coverage of the changed logic. None of the 38 candidate E2E tests have specific behavior that would be uniquely sensitive to changes in `scheduleAction` — they all use it indirectly through higher-level abstractions (discovery, trading, device communication, etc.). Without evidence that the change alters the function's contract or introduces breaking behavioral changes (which the unit test should catch), running E2E tests provides negligible additional signal. The recommended strategy is to rely on the unit test for direct validation and skip E2E tests unless the unit test reveals issues.

<details><summary><b>Changed files (2)</b></summary>

- `packages/utils/src/scheduleAction.ts`
- `packages/utils/tests/scheduleAction.test.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/utils/tests/scheduleAction.test.ts`

_Updated: 2026-05-24T11:15:46.103Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/scheduleAction-rejectWhenAborted-double-reject&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/scheduleAction-rejectWhenAborted-double-reject&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 16 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox - watches files over time | 🤖 auto |
| Dropbox API errors > Incomplete data returned from provider | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Metadata - switching between cloud providers > Start with one and switch to another | 🤖 auto |
| Metadata - address labeling > google provider | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Remembered device > google provider | 🤖 auto |
| Dropbox API errors > Malformed token | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Account metadata > google - watches files over time | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-24T12:20:00.638Z • 16 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-24T11:19:11.661Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/scheduleAction-rejectWhenAborted-double-reject/web/](https://dev.suite.sldev.cz/suite-web/fix/scheduleAction-rejectWhenAborted-double-reject/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

