### PR TITLE
chore(jest): console.error and TimeoutNegative/Overflow traps

### DIFF
--- a/JestCustomEnv.js
+++ b/JestCustomEnv.js
@@ -11,7 +11,32 @@ class CustomEnvironment extends NodeEnvironment {
                     'MaxListenersExceededWarning detected. If you need more, use events.setMaxListeners(desiredNumber)',
                 );
             }
+
+            // TimeoutNegativeWarning / TimeoutOverflowWarning fire from setTimeout when ms is
+            // negative or > 2^31-1. Almost always a date-arithmetic bug (e.g. `deadline - now`
+            // where deadline is in the past). Near-zero false-positive surface.
+            if (
+                warning.name === 'TimeoutNegativeWarning' ||
+                warning.name === 'TimeoutOverflowWarning'
+            ) {
+                throw warning;
+            }
         });
+
+        // console.error trap: a real console.error during a test is almost always either an
+        // expected error path that the test forgot to assert on, or a missing mock that hides
+        // a real production issue. Tests that legitimately want to silence the error must
+        // jest.spyOn(console, 'error').mockImplementation(...) — the spy replaces this wrap.
+        const originalError = this.global.console.error;
+        this.global.console.error = (...args) => {
+            originalError.apply(this.global.console, args);
+            throw new Error(
+                `Unexpected console.error during test. If this is expected, mock it with ` +
+                    `jest.spyOn(console, 'error').mockImplementation(() => {}). Args: ${args
+                        .map(a => (a instanceof Error ? a.message : String(a)))
+                        .join(' ')}`,
+            );
+        };
     }
 
     async teardown() {

--- a/packages/address-validator/jest.config.cjs
+++ b/packages/address-validator/jest.config.cjs
@@ -2,5 +2,6 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
+    testEnvironment: '../../JestCustomEnv.js',
     transformIgnorePatterns: ['/node_modules/(?!@scure/base/)'],
 };

--- a/packages/analytics-docs/jest.config.cjs
+++ b/packages/analytics-docs/jest.config.cjs
@@ -2,4 +2,5 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
+    testEnvironment: '../../JestCustomEnv.js',
 };

--- a/packages/analytics-uploader/jest.config.js
+++ b/packages/analytics-uploader/jest.config.js
@@ -2,5 +2,5 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
-    testEnvironment: 'node',
+    testEnvironment: '../../JestCustomEnv.js',
 };

--- a/packages/blockchain-link-types/jest.config.cjs
+++ b/packages/blockchain-link-types/jest.config.cjs
@@ -1,3 +1,6 @@
 const baseConfig = require('../../jest.config.base.swc');
 
-module.exports = { ...baseConfig };
+module.exports = {
+    ...baseConfig,
+    testEnvironment: '../../JestCustomEnv.js',
+};

--- a/packages/blockchain-link-utils/jest.config.cjs
+++ b/packages/blockchain-link-utils/jest.config.cjs
@@ -2,5 +2,5 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
-    testEnvironment: 'node',
+    testEnvironment: '../../JestCustomEnv.js',
 };

--- a/packages/bundler-security/jest.config.js
+++ b/packages/bundler-security/jest.config.js
@@ -8,4 +8,5 @@ const { ...baseConfig } = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
+    testEnvironment: '../../JestCustomEnv.js',
 };

--- a/packages/coinjoin/jest.config.js
+++ b/packages/coinjoin/jest.config.js
@@ -2,5 +2,5 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
-    testEnvironment: 'node',
+    testEnvironment: '../../JestCustomEnv.js',
 };

--- a/packages/connect-plugin-stellar/jest.config.cjs
+++ b/packages/connect-plugin-stellar/jest.config.cjs
@@ -2,4 +2,5 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
+    testEnvironment: '../../JestCustomEnv.js',
 };

--- a/packages/connect-web/jest.config.cjs
+++ b/packages/connect-web/jest.config.cjs
@@ -2,4 +2,5 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
+    testEnvironment: '../../JestCustomEnv.js',
 };

--- a/packages/connect/jest.config.cjs
+++ b/packages/connect/jest.config.cjs
@@ -2,7 +2,7 @@ const { testPathIgnorePatterns, ...baseConfig } = require('../../jest.config.bas
 
 module.exports = {
     ...baseConfig,
-    testEnvironment: 'node',
+    testEnvironment: '../../JestCustomEnv.js',
     collectCoverage: true,
     setupFiles: ['<rootDir>/setupJest.ts'],
     testPathIgnorePatterns: [...testPathIgnorePatterns, 'e2e'],

--- a/packages/env-utils/jest.config.cjs
+++ b/packages/env-utils/jest.config.cjs
@@ -2,4 +2,5 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
+    testEnvironment: '../../JestCustomEnv.js',
 };

--- a/packages/node-utils/jest.config.js
+++ b/packages/node-utils/jest.config.js
@@ -2,5 +2,5 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
-    testEnvironment: 'node',
+    testEnvironment: '../../JestCustomEnv.js',
 };

--- a/packages/protobuf/jest.config.cjs
+++ b/packages/protobuf/jest.config.cjs
@@ -2,4 +2,5 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
+    testEnvironment: '../../JestCustomEnv.js',
 };

--- a/packages/protocol/jest.config.cjs
+++ b/packages/protocol/jest.config.cjs
@@ -2,5 +2,5 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
-    testEnvironment: 'node',
+    testEnvironment: '../../JestCustomEnv.js',
 };

--- a/packages/request-manager/jest.config.js
+++ b/packages/request-manager/jest.config.js
@@ -2,5 +2,6 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
+    testEnvironment: '../../JestCustomEnv.js',
     testRetryTimes: 3,
 };

--- a/packages/requirements/jest.config.cjs
+++ b/packages/requirements/jest.config.cjs
@@ -2,4 +2,5 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
+    testEnvironment: '../../JestCustomEnv.js',
 };

--- a/packages/schema-utils/jest.config.cjs
+++ b/packages/schema-utils/jest.config.cjs
@@ -2,7 +2,7 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
-    testEnvironment: 'node',
+    testEnvironment: '../../JestCustomEnv.js',
     collectCoverage: true,
     collectCoverageFrom: ['src/**/*.ts'],
 };

--- a/packages/styles-common/jest.config.js
+++ b/packages/styles-common/jest.config.js
@@ -2,4 +2,5 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
+    testEnvironment: '../../JestCustomEnv.js',
 };

--- a/packages/suite-desktop-core/jest.config.js
+++ b/packages/suite-desktop-core/jest.config.js
@@ -2,6 +2,7 @@ const { ...baseConfig } = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
+    testEnvironment: '../../JestCustomEnv.js',
     roots: ['<rootDir>/src'],
     modulePathIgnorePatterns: ['node_modules', '<rootDir>/lib', '<rootDir>/libDev'],
     watchPathIgnorePatterns: ['<rootDir>/libDev', '<rootDir>/lib'],

--- a/packages/transport-bridge/jest.config.js
+++ b/packages/transport-bridge/jest.config.js
@@ -2,5 +2,5 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
-    testEnvironment: 'node',
+    testEnvironment: '../../JestCustomEnv.js',
 };

--- a/packages/urls/jest.config.js
+++ b/packages/urls/jest.config.js
@@ -2,4 +2,5 @@ const { ...baseConfig } = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
+    testEnvironment: '../../JestCustomEnv.js',
 };

--- a/packages/utxo-lib/jest.config.cjs
+++ b/packages/utxo-lib/jest.config.cjs
@@ -2,7 +2,7 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
-    testEnvironment: 'node',
+    testEnvironment: '../../JestCustomEnv.js',
     collectCoverage: true,
     collectCoverageFrom: ['src/**/*.ts'],
 };

--- a/packages/websocket-client/jest.config.cjs
+++ b/packages/websocket-client/jest.config.cjs
@@ -2,5 +2,5 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
-    testEnvironment: 'node',
+    testEnvironment: '../../JestCustomEnv.js',
 };


### PR DESCRIPTION
## Summary

> **Prerequisite:** #27991 must land first so that Nx Cloud properly invalidates `test:unit` cache when `JestCustomEnv.js` changes; otherwise CI may serve stale cached results from runs before the trap was added.
**Experimental, exploratory PR.** Extends `JestCustomEnv.js` with two additional failure conditions on top of the existing `MaxListenersExceededWarning` trap, then runs the experiment across all 29 wired packages to see what surfaces.

Independent of and unrelated to the listener-leak audit series — this PR explores a different class of warnings: test-quality and timer-arithmetic bugs.

Stacks on **#27987** (the safety-net PR that wired `JestCustomEnv` across all node-env packages). Land that first, then evaluate this one.

## New traps

| Trap | What it catches | Implementation |
|---|---|---|
| Unexpected `console.error` during test | Tests that exercise an error path the test forgot to assert on, or a missing mock that hides a real production issue (silent error logging from third-party libs that the test exercises) | Wraps `this.global.console.error` in env setup. Tests that legitimately silence errors must use `jest.spyOn(console, 'error').mockImplementation(...)` — the spy replaces the wrap. |
| `TimeoutNegativeWarning` / `TimeoutOverflowWarning` | `setTimeout(fn, < 0)` or `setTimeout(fn, > 2^31-1)`. Almost always a date-arithmetic bug (e.g. `deadline - now` where `deadline` is in the past) | Piggy-backs on the existing `process.on('warning', ...)` listener. |

## Findings from running all 29 wired packages

**Both traps: 0 hits across ~6000 tests.** Codebase is currently clean.

| Trap | Hits | Notes |
|---|---|---|
| `console.error` wrap | 0 | 15 test files already mock `console.error`/`console.warn`/`console.log` via `jest.spyOn(...).mockImplementation(...)`. Other tests either don't exercise console-logging error paths or the paths don't produce log calls. |
| `TimeoutNegativeWarning` | 0 | No test exercises `setTimeout(fn, < 0)`. |
| `TimeoutOverflowWarning` | 0 | No test exercises `setTimeout(fn, > 2^31-1)`. |

Both traps verified to fire via synthetic test files (one explicit `console.error(...)`, one `setTimeout(() => {}, -1)`).

## Verdict

Cheap insurance for future regressions:

- `console.error` trap costs nothing today (zero false positives) and will catch the next time someone adds an error-logging code path without an asserting test or mock.
- `TimeoutNegativeWarning` / `TimeoutOverflowWarning` are near-impossible to produce false positives on; they only fire on genuinely buggy `setTimeout` arguments.

Recommended path: **ship as-is**. Both traps are safe additions; their value compounds over time as the codebase grows.

## Risk

- `console.error` wrap interacts with any test that exercises a third-party lib that logs errors. None encountered in the 29 wired packages, but the surface exists. Easy escape valve: tests can mock console.error in `beforeEach` if a new code path triggers it.
- Timer warnings are Node-level and surface in unrelated tests if any of them happen to do bad timer arithmetic. None encountered.

## Test plan

- [ ] CI green on develop merge
- [ ] No flakiness introduced in the 29 wired packages over the next few CI runs
- [ ] If `console.error` trap surfaces an unexpected case in CI, evaluate whether it's a real signal or a false positive that needs a per-test mock

