### PR TITLE
chore(nx): include all root jest files in test:unit cache inputs

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -46,7 +46,10 @@
                 "^production",
                 "default",
                 "{workspaceRoot}/jest.config.base.js",
-                "{workspaceRoot}/jest.config.native.js"
+                "{workspaceRoot}/jest.config.base.swc.js",
+                "{workspaceRoot}/jest.config.native.js",
+                "{workspaceRoot}/jest.config.swc-transform.js",
+                "{workspaceRoot}/JestCustomEnv.js"
             ],
             "cache": true
         },


### PR DESCRIPTION
## Summary

Adds three workspace-root files used by virtually every package's `test:unit` target to the Nx cache inputs:

- `jest.config.base.swc.js` — transitive base config used by ~30 packages
- `jest.config.swc-transform.js` — used by `jest.config.base.swc.js`
- `JestCustomEnv.js` — custom `testEnvironment` for the wired packages (currently 6, will be 29 after #27987)

## Why this matters

Without these inputs, Nx serves cached test results even when one of these files changes. The cache hash is computed from `inputs`; if a file isn't listed, modifying it doesn't bust the cache.

Concrete failure mode: a PR that only edits `JestCustomEnv.js` (e.g. to add a new warning trap) can pass CI with the new environment never actually executing. Nx Cloud returns the previous run's stdout/stderr because the cache hash is unchanged — the trap never runs, and any test that should have failed under the new env passes silently.

## How this was found

While reviewing whether `test:unit` re-runs on changes to `JestCustomEnv.js` between iterations of the exploratory PRs (#27988, #27990), it became clear the file was outside the cache key. The same gap applies to `jest.config.base.swc.js` and `jest.config.swc-transform.js` — both are required by every package using the SWC transform pipeline and neither is currently tracked.

Local `yarn workspace @trezor/X test:unit` invocations are unaffected because they call Jest directly and bypass Nx. The gap only surfaces on CI / Nx Cloud paths.

## Prerequisite for

- #27988 — adds DeprecationWarning trap to `JestCustomEnv.js`. Without this fix, CI may serve cached results from before the trap was added.
- #27990 — adds `console.error` + Timeout traps to `JestCustomEnv.js`. Same risk.
- Any future PR that modifies `JestCustomEnv.js` or the shared SWC jest configs.

## Test plan

- [ ] CI green on develop merge
- [ ] After merge, the next PR that touches `JestCustomEnv.js` actually re-runs `test:unit` for all dependent projects (verify via the run summary in the Nx Cloud link)

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is nx.json, which is a build/workspace configuration file for the Nx monorepo tooling. It does not contain application logic, UI components, or business rules that would be exercised by E2E tests. Changes to nx.json typically affect task orchestration, caching, and project graph configuration rather than runtime behavior. No E2E tests are recommended for this change.

<details><summary><b>Changed files (1)</b></summary>

- `nx.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `nx.json`

_Updated: 2026-05-24T13:20:21.463Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/nx-jest-cache-inputs&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/nx-jest-cache-inputs&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 16 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox - watches files over time | 🤖 auto |
| Dropbox API errors > Incomplete data returned from provider | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Metadata - switching between cloud providers > Start with one and switch to another | 🤖 auto |
| Metadata - address labeling > google provider | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Remembered device > google provider | 🤖 auto |
| Dropbox API errors > Malformed token | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Account metadata > google - watches files over time | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-24T13:26:21.955Z • 16 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-24T13:23:55.959Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/nx-jest-cache-inputs/web/](https://dev.suite.sldev.cz/suite-web/chore/nx-jest-cache-inputs/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->