### PR TITLE
Reduce spam in Dev Tools (Network tab)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Local `.env` setup (optional):
 
 - Rename `env.local.example` to `.env.local` in the repo root.
 - Set `TANSTACK_REACT_QUERY_DEV_TOOLS=true` to enable TanStack React Query Devtools on localhost.
+- Set `TRANSPORT_BROWSER_PING=false` to disable transport period ping.
 
 ## **Trezor Suite Mobile** @suite-native/app
 

--- a/env.local.example
+++ b/env.local.example
@@ -1,2 +1,5 @@
 # Rename this file to ".env.local" to enable the devtools locally.
 TANSTACK_REACT_QUERY_DEV_TOOLS=true
+
+# Disable transport periodic ping
+TRANSPORT_BROWSER_PING=false

--- a/packages/suite-build/configs/base.webpack.config.ts
+++ b/packages/suite-build/configs/base.webpack.config.ts
@@ -16,6 +16,7 @@ import {
     isTanstackReactQueryDevTools,
     project,
     sentryAuthToken,
+    transportBrowserPing,
 } from '../utils/env';
 import { getRevision } from '../utils/git';
 import { getPathForProject } from '../utils/path';
@@ -203,6 +204,7 @@ const config: webpack.Configuration = {
             'process.env.TANSTACK_REACT_QUERY_DEV_TOOLS': JSON.stringify(
                 isTanstackReactQueryDevTools,
             ),
+            'process.env.TRANSPORT_BROWSER_PING': JSON.stringify(transportBrowserPing),
             __SENTRY_DEBUG__: isDev,
             __SENTRY_TRACING__: false, // needs to be removed when we introduce performance monitoring in trezor-suite
         }),

--- a/packages/suite-build/utils/env.ts
+++ b/packages/suite-build/utils/env.ts
@@ -17,6 +17,7 @@ const {
     SENTRY_AUTH_TOKEN,
     TEST_BUILD,
     TANSTACK_REACT_QUERY_DEV_TOOLS,
+    TRANSPORT_BROWSER_PING,
 } = process.env;
 
 const project = PROJECT as Project;
@@ -28,6 +29,7 @@ const assetPrefix = ASSET_PREFIX || '';
 const sentryAuthToken = SENTRY_AUTH_TOKEN;
 const isTestBuild = TEST_BUILD === 'true';
 const isTanstackReactQueryDevTools = TANSTACK_REACT_QUERY_DEV_TOOLS === 'true';
+const transportBrowserPing = TRANSPORT_BROWSER_PING !== 'false';
 
 export {
     isAnalyzing,
@@ -39,4 +41,5 @@ export {
     sentryAuthToken,
     isTestBuild,
     isTanstackReactQueryDevTools,
+    transportBrowserPing,
 };

--- a/packages/suite-build/vite.config.mts
+++ b/packages/suite-build/vite.config.mts
@@ -9,7 +9,12 @@ import { Plugin, ViteDevServer, build, defineConfig } from 'vite';
 import wasm from 'vite-plugin-wasm';
 
 import { suiteVersion } from '../suite/package.json';
-import { assetPrefix, isTanstackReactQueryDevTools, project } from './utils/env';
+import {
+    assetPrefix,
+    isTanstackReactQueryDevTools,
+    project,
+    transportBrowserPing,
+} from './utils/env';
 
 const require = createRequire(import.meta.url);
 
@@ -629,6 +634,7 @@ export default defineConfig({
         'process.env.NODE_ENV': JSON.stringify('development'),
         'process.env.ASSET_PREFIX': JSON.stringify(assetPrefix),
         'process.env.TANSTACK_REACT_QUERY_DEV_TOOLS': JSON.stringify(isTanstackReactQueryDevTools),
+        'process.env.TRANSPORT_BROWSER_PING': JSON.stringify(transportBrowserPing),
         global: 'globalThis',
         __DEV__: true,
         ENABLE_REDUX_LOGGER: true,

--- a/packages/transport/src/pinger/ping.browser.ts
+++ b/packages/transport/src/pinger/ping.browser.ts
@@ -12,6 +12,7 @@ const init = async () => {
 
     await new Promise<void>((resolve, reject) => {
         setTimeout(() => reject(new Error('worker_timeout')), 5000);
+
         worker.onmessage = message => {
             if (message?.data?.payload?.success) {
                 resolve();
@@ -46,6 +47,20 @@ const init = async () => {
     return { post };
 };
 
-const lazy = createLazy(init);
+type InitResult = Awaited<ReturnType<typeof init>>;
 
-export const ping = (url: string) => lazy.getOrInit().then(({ post }) => post(url));
+let lazy: ReturnType<typeof createLazy<InitResult, any[]>>;
+
+export const ping = async (url: string) => {
+    if (String(process.env.TRANSPORT_BROWSER_PING) === 'false') {
+        return false;
+    }
+
+    if (!lazy) {
+        lazy = createLazy(init);
+    }
+
+    const { post } = await lazy.getOrInit();
+
+    return post(url);
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add optional env var to disable transport browser ping. It must be explicitly set to false.

`.env.local`:
```ts
TRANSPORT_BROWSER_PING=false
```

Fixes this:
<img width="1169" height="411" alt="Snímek obrazovky 2026-05-25 v 10 14 46" src="https://github.com/user-attachments/assets/cfda82b4-cd58-4830-9bf0-4ffb84c3b178" />

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set touches two files: a build utility (suite-build/utils/env.ts) and a browser-side transport pinger (transport/src/pinger/ping.browser.ts). The env.ts file is a build-time utility with no direct test coverage. The ping.browser.ts file is a low-level transport dependency that maps to 121+ tests, indicating it's a broadly shared infrastructure component. Since most E2E tests only transitively depend on the pinger without directly exercising its behavior, only the bridge/transport lifecycle tests and session management tests are meaningfully affected. The risk is low-to-moderate: the pinger change could affect transport keepalive behavior, but most application-level tests are unlikely to surface regressions from this specific component.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite-build/utils/env.ts`
- `packages/transport/src/pinger/ping.browser.ts`

</details>

**Recommended tests (3)**

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `../../suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — This test directly exercises bridge/transport lifecycle (spawning, stopping, reconnecting). The ping.browser.ts change in @trezor/transport could affect how the bridge transport layer maintains connectivity, which this test validates by checking bridge status after restarts and reloads.
- `../../suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — This test validates bridge daemon spawning and lifecycle management. Changes to the transport pinger could affect how the bridge connection is monitored and maintained, which this test checks via bridge running/stopped status assertions.
- `../../suite/e2e/tests/suite/multiple-sessions.test.ts` — This test validates Bridge session management including session stealing, recovery, and multi-tab behavior. The browser pinger in transport directly affects how session liveness is monitored, which is central to detecting stolen sessions and the 'Use Here' vs 'Connected' status transitions tested here.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite-build/utils/env.ts`

_Updated: 2026-05-25T08:35:55.962Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/ping-spam&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/ping-spam&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 15 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox - watches files over time | 🤖 auto |
| Dropbox API errors > Incomplete data returned from provider | 🤖 auto |
| Metadata - switching between cloud providers > Start with one and switch to another | 🤖 auto |
| Metadata - address labeling > google provider | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Remembered device > google provider | 🤖 auto |
| Dropbox API errors > Malformed token | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Account metadata > google - watches files over time | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-25T08:41:30.445Z • 15 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-25T09:38:53.056Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/ping-spam/web/](https://dev.suite.sldev.cz/suite-web/fix/ping-spam/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->