### PR TITLE
Feat/connect authenticity proof streaming

### DIFF
--- a/packages/connect-cli/src/args.ts
+++ b/packages/connect-cli/src/args.ts
@@ -35,6 +35,7 @@ export const HELP = `@trezor/connect CLI arguments:
                                                 --method=get-account-info
                                                 --method=get-features
                                                 --method=apply-settings
+                                                --method=authenticate-device
     --params=<json>                           Extra params passed to the method (JSON object)
                                                 --params='{"use_passphrase": true}'
 `;

--- a/packages/connect-cli/src/index.ts
+++ b/packages/connect-cli/src/index.ts
@@ -135,6 +135,12 @@ const runTestCase = async (device: Device) => {
                 // button_protection: true,
             });
             break;
+        case 'authenticate-device':
+            result = await TrezorConnect.authenticateDevice({
+                device,
+                allowDebugKeys: true,
+            });
+            break;
         default:
             result = await TrezorConnect.getAddress({ device, path: "m/44'/0'/0'/0/0", ...params });
     }

--- a/packages/connect-common/src/types/firmware.ts
+++ b/packages/connect-common/src/types/firmware.ts
@@ -27,6 +27,7 @@ export type FirmwareCapability =
     | 'tutorial'
     | 'tropicDeviceAuthentication'
     | 'mcuDeviceAuthentication'
+    | 'authenticityProofChunk'
     | 'getFirmwareHash'
     | 'chunkify'
     | 'entropyCheck'

--- a/packages/connect/src/api/authenticateDevice.ts
+++ b/packages/connect/src/api/authenticateDevice.ts
@@ -10,6 +10,7 @@ import {
     validateSerialNumbers,
     verifyAuthenticityProof,
 } from '@trezor/device-authenticity';
+import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
 import type { MethodMessage } from '../core/AbstractMethod';
@@ -40,14 +41,123 @@ export default class AuthenticateDevice extends AbstractMethod<
         return ['management'];
     }
 
-    async run() {
-        const challenge = getRandomChallenge();
+    async streamAuthenticityProofs(challenge: Buffer) {
+        const cmd = this.getDevice().getCommands();
+        const MAX_CHUNK_SIZE = 500;
 
+        this.getDevice().startPiggybackAck();
+
+        // 1. Start streaming authenticity proofs
+        // Device will respond with sizes of proofs and certificates, which will be used to fetch subsequent chunks.
+        const { message: proofSizes } = await cmd.typedCall(
+            'AuthenticateDevice',
+            'AuthenticityProofSizes',
+            {
+                challenge: challenge.toString('hex'),
+                stream: true,
+            },
+        );
+
+        const proofTypes = [
+            {
+                name: 'optiga',
+                type: PROTO.AuthenticityProofType.OPTIGA,
+                certSizes: proofSizes.optiga_certificates,
+                sigSize: proofSizes.optiga_signature,
+            },
+            {
+                name: 'tropic',
+                type: PROTO.AuthenticityProofType.TROPIC,
+                certSizes: proofSizes.tropic_certificates,
+                sigSize: proofSizes.tropic_signature,
+            },
+            {
+                name: 'mcu',
+                type: PROTO.AuthenticityProofType.MCU,
+                certSizes: proofSizes.mcu_certificates,
+                sigSize: proofSizes.mcu_signature,
+            },
+        ] as const;
+
+        const authenticityProof: PROTO.AuthenticityProof = {
+            optiga_certificates: [],
+            optiga_signature: '',
+            tropic_certificates: [],
+            tropic_signature: undefined,
+            mcu_certificates: [],
+            mcu_signature: undefined,
+        };
+
+        const getChunk = async (
+            params: { proof_type: number; index?: number },
+            chunkSize: number,
+        ) => {
+            const chunks: string[] = [];
+            let offset = 0;
+            while (offset < chunkSize) {
+                const size = Math.min(MAX_CHUNK_SIZE, chunkSize - offset);
+                const { message } = await cmd.typedCall(
+                    'GetAuthenticityProofChunk',
+                    'AuthenticityProofChunk',
+                    {
+                        ...params,
+                        offset,
+                        size,
+                    },
+                );
+                chunks.push(message.chunk);
+                offset += size;
+            }
+
+            return chunks.join('');
+        };
+
+        // 2. Fetch all certificates and signatures based on sizes received in the first response.
+        for (const { name, type, certSizes, sigSize } of proofTypes) {
+            for (let i = 0; i < certSizes.length; i++) {
+                const cert = await getChunk({ proof_type: type, index: i }, certSizes[i]);
+                (authenticityProof[`${name}_certificates`] as string[]).push(cert);
+            }
+
+            if (sigSize) {
+                (authenticityProof[`${name}_signature`] as string) = await getChunk(
+                    { proof_type: type },
+                    sigSize,
+                );
+            }
+        }
+
+        // 3. Stop streaming.
+        await cmd.typedCall('GetAuthenticityProofChunk', 'Success', {
+            offset: 0,
+            size: 0,
+        });
+
+        await this.getDevice().stopPiggybackAck();
+
+        return authenticityProof;
+    }
+
+    async getAuthenticityProofs(challenge: Buffer) {
         const { message } = await this.getDevice()
             .getCommands()
             .typedCall('AuthenticateDevice', 'AuthenticityProof', {
                 challenge: challenge.toString('hex'),
             });
+
+        return message;
+    }
+
+    async run() {
+        const challenge = getRandomChallenge();
+        const { unavailableCapabilities } = this.getDevice();
+
+        // authenticityProofChunk and mcuDeviceAuthentication are strictly connected as MCU proofs are too large to be retrieved without chunking.
+        // if streaming is unavailable device will not return MCU proofs.
+        // see: https://github.com/trezor/trezor-firmware/pull/6961
+        const authenticityProof = !unavailableCapabilities['authenticityProofChunk']
+            ? await this.streamAuthenticityProofs(challenge)
+            : await this.getAuthenticityProofs(challenge);
 
         const config = this.params.config || deviceAuthenticityConfig;
         const blacklistConfig = this.params.blacklistConfig || deviceAuthenticityBlacklistConfig;
@@ -60,8 +170,9 @@ export default class AuthenticateDevice extends AbstractMethod<
         };
 
         const getOptigaResult = async (): Promise<VerifyAuthenticityProofResult> => {
-            const { optiga_signature: signature, optiga_certificates: certificates } = message;
-            const isAvailable = signature !== undefined && certificates.length > 0;
+            const { optiga_signature: signature, optiga_certificates: certificates } =
+                authenticityProof;
+            const isAvailable = signature && certificates.length > 0;
             if (isAvailable) {
                 return await verifyAuthenticityProof({ ...commonParams, certificates, signature });
             }
@@ -70,12 +181,11 @@ export default class AuthenticateDevice extends AbstractMethod<
             return { valid: false, error: 'RESPONSE_PAYLOAD_MISSING' };
         };
 
-        const hasTropicAbility =
-            !this.getDevice().unavailableCapabilities['tropicDeviceAuthentication'];
-
+        const hasTropicAbility = !unavailableCapabilities['tropicDeviceAuthentication'];
         const getTropicResult = async (): Promise<VerifyAuthenticityProofResult | null> => {
-            const { tropic_signature: signature, tropic_certificates: certificates } = message;
-            const isAvailable = signature !== undefined && certificates.length > 0;
+            const { tropic_signature: signature, tropic_certificates: certificates } =
+                authenticityProof;
+            const isAvailable = signature && certificates.length > 0;
             const isRequired = hasTropicAbility;
             if (isAvailable) {
                 return await verifyAuthenticityProof({ ...commonParams, certificates, signature });
@@ -85,9 +195,9 @@ export default class AuthenticateDevice extends AbstractMethod<
         };
 
         const getMCUResult = async (): Promise<VerifyAuthenticityProofResult | null> => {
-            const { mcu_signature: signature, mcu_certificates: certificates } = message;
-            const isAvailable = signature !== undefined && certificates.length > 0;
-            const isRequired = !this.getDevice().unavailableCapabilities['mcuDeviceAuthentication'];
+            const { mcu_signature: signature, mcu_certificates: certificates } = authenticityProof;
+            const isAvailable = signature && certificates.length > 0;
+            const isRequired = !unavailableCapabilities['mcuDeviceAuthentication'];
             if (isAvailable) {
                 return await verifyAuthenticityProof({
                     ...commonParams,
@@ -104,6 +214,7 @@ export default class AuthenticateDevice extends AbstractMethod<
             getTropicResult(),
             getMCUResult(),
         ]);
+
         const results = { optigaResult, tropicResult, mcuResult };
 
         // Only T3W1 and later have serialNumber (i.e. devices that support Tropic authentication), this validation is skipped for all older models.

--- a/packages/connect/src/data/config.ts
+++ b/packages/connect/src/data/config.ts
@@ -156,8 +156,7 @@ export const config: Config = {
                 T2B1: '0',
                 T3B1: '0',
                 T3T1: '0',
-                // TODO update this, when it is clear which version will support it https://github.com/trezor/trezor-suite/issues/27486
-                T3W1: '0',
+                T3W1: '2.12.1',
             },
         },
         {

--- a/packages/connect/src/data/config.ts
+++ b/packages/connect/src/data/config.ts
@@ -150,7 +150,7 @@ export const config: Config = {
             },
         },
         {
-            capabilities: ['mcuDeviceAuthentication'],
+            capabilities: ['mcuDeviceAuthentication', 'authenticityProofChunk'],
             min: {
                 // devices that don't support 'authenticateDevice' don't have to be listed here
                 T2B1: '0',

--- a/packages/connect/src/utils/__tests__/deviceFeaturesUtils.test.ts
+++ b/packages/connect/src/utils/__tests__/deviceFeaturesUtils.test.ts
@@ -223,6 +223,7 @@ describe('utils/deviceFeaturesUtils', () => {
                 thod: 'update-required',
                 tropicDeviceAuthentication: 'no-support',
                 mcuDeviceAuthentication: 'no-support',
+                authenticityProofChunk: 'no-support',
                 trx: 'no-capability',
                 ttrx: 'no-capability',
                 tsep: 'update-required',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

following https://github.com/trezor/trezor-firmware/pull/6961

add `stream` param to `AuthenticateDevice`.

add streamimg chunks: `GetAuthenticityProofChunk` => `AuthenticityProofChunk | Success` 

## Notes for QA
this could be tested only in limited setup.

EDIT: When production FW 2.12.1 is ready: 
- connect a production T3W1 with 2.12.1
- go through DAC → should pass ✔️ 


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/connect-authenticity-proof-streaming&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/connect-authenticity-proof-streaming&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/connect-authenticity-proof-streaming&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 15 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox - watches files over time | 🤖 auto |
| Dropbox API errors > Incomplete data returned from provider | 🤖 auto |
| Metadata - switching between cloud providers > Start with one and switch to another | 🤖 auto |
| Metadata - address labeling > google provider | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Remembered device > google provider | 🤖 auto |
| Dropbox API errors > Malformed token | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Account metadata > google - watches files over time | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-25T08:56:44.366Z • 15 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-26T09:20:21.166Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/connect-authenticity-proof-streaming/web/](https://dev.suite.sldev.cz/suite-web/feat/connect-authenticity-proof-streaming/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->