### PR TITLE
fix(suite): Make settings responsive again

### DIFF
--- a/packages/product-components/src/components/Settings/SettingsSection.tsx
+++ b/packages/product-components/src/components/Settings/SettingsSection.tsx
@@ -9,7 +9,7 @@ type SettingsSectionProps = {
     className?: string;
     children?: ReactNode;
     tooltipText?: ReactNode;
-    isBelowLaptop?: boolean;
+    hasVerticalLayout?: boolean;
 };
 
 export const SettingsSection = ({
@@ -17,14 +17,14 @@ export const SettingsSection = ({
     icon,
     children,
     tooltipText,
-    isBelowLaptop,
+    hasVerticalLayout,
 }: SettingsSectionProps) => {
-    const width = isBelowLaptop ? '100%' : 250;
+    const width = hasVerticalLayout ? '100%' : 250;
 
     return (
         <InfoItem
             ellipsisLineCount={0}
-            direction={isBelowLaptop ? 'column' : 'row'}
+            direction={hasVerticalLayout ? 'column' : 'row'}
             labelWidth={width}
             iconName={icon}
             label={

--- a/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
+++ b/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
@@ -16,14 +16,15 @@ import {
 import { Button, Column, Tooltip, motionEasing } from '@trezor/components';
 import { hasBitcoinOnlyFirmware, isBitcoinOnlyDevice } from '@trezor/device-utils';
 import { SectionItem, SettingsSection } from '@trezor/product-components';
-import { spacingsPx } from '@trezor/theme';
+import { breakpoints, spacingsPx } from '@trezor/theme';
 
 import { DeviceBanner } from 'src/components/settings/DeviceBanner';
 import { SettingsLayout } from 'src/components/settings/SettingsLayout';
 import { CoinGroup } from 'src/components/suite';
 import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
 import { useNetworkSupport } from 'src/hooks/settings/useNetworkSupport';
-import { useDiscovery, useDispatch, useLayoutSize, useSelector } from 'src/hooks/suite';
+import { useDiscovery, useDispatch, useSelector } from 'src/hooks/suite';
+import { useIsContentBelowBreakpoint } from 'src/support/suite/ContentFlex';
 import { isCoinjoinSupportedSymbol } from 'src/utils/wallet/coinjoinUtils';
 
 import { FirmwareTypeSuggestion } from './FirmwareTypeSuggestion';
@@ -74,7 +75,7 @@ const getDiscoveryButtonAnimationConfig = (isConfirmed: boolean): MotionProps =>
 });
 
 export const SettingsCoins = () => {
-    const { isBelowLaptop } = useLayoutSize();
+    const hasContentBelowTabletWidth = useIsContentBelowBreakpoint(breakpoints.tablet);
     const { firmwareTypeBannerClosed } = useSelector(selectFlags);
     const enabledNetworks = useSelector(selectEnabledNetworks);
     const { showUnsupportedCoins, supportedMainnets, unsupportedMainnets, supportedTestnets } =
@@ -130,7 +131,7 @@ export const SettingsCoins = () => {
             </Column>
 
             <SettingsSection
-                isBelowLaptop={isBelowLaptop}
+                hasVerticalLayout={hasContentBelowTabletWidth}
                 title={<Translation id="TR_COINS" />}
                 icon="coin"
             >
@@ -152,7 +153,7 @@ export const SettingsCoins = () => {
 
             {useTestnetNetworks && (
                 <SettingsSection
-                    isBelowLaptop={isBelowLaptop}
+                    hasVerticalLayout={hasContentBelowTabletWidth}
                     tooltipText={<Translation id="TR_TESTNET_COINS_DESCRIPTION" />}
                     title={<Translation id="TR_TESTNET_COINS" />}
                     icon="coin"
@@ -176,7 +177,7 @@ export const SettingsCoins = () => {
 
             {showUnsupportedCoins && (
                 <SettingsSection
-                    isBelowLaptop={isBelowLaptop}
+                    hasVerticalLayout={hasContentBelowTabletWidth}
                     tooltipText={<Translation id="TR_UNSUPPORTED_COINS_DESCRIPTION" />}
                     title={<Translation id="TR_UNSUPPORTED_COINS" />}
                     icon="coin"

--- a/packages/suite/src/views/settings/SettingsDebug/PlatformEncryption.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/PlatformEncryption.tsx
@@ -4,16 +4,16 @@ import { useServices } from '@suite-common/dependency-injection';
 import { type PlatformEncryptionDep, asEncryptedHex } from '@suite-common/platform-encryption';
 import { Button, ButtonGroup, Column, Textarea } from '@trezor/components';
 import { SectionItem, SettingsSection } from '@trezor/product-components';
-import { spacings } from '@trezor/theme';
+import { breakpoints, spacings } from '@trezor/theme';
 import { type Branded } from '@trezor/type-utils';
 
-import { useLayoutSize } from 'src/hooks/suite';
+import { useIsContentBelowBreakpoint } from 'src/support/suite/ContentFlex';
 
 type Value = string & Branded<'Value'>;
 const asValue = (value: string) => value as Value;
 
 export const PlatformEncryption = () => {
-    const { isBelowLaptop } = useLayoutSize();
+    const isBelowLaptop = useIsContentBelowBreakpoint(breakpoints.laptop);
     const [plaintext, setPlaintext] = useState(asValue(''));
     const [ciphertext, setCiphertext] = useState(asEncryptedHex<Value>(''));
 
@@ -40,7 +40,7 @@ export const PlatformEncryption = () => {
     };
 
     return (
-        <SettingsSection isBelowLaptop={isBelowLaptop} title="Platform Encryption">
+        <SettingsSection hasVerticalLayout={isBelowLaptop} title="Platform Encryption">
             <SectionItem>
                 <Column gap={spacings.md} flex="1">
                     <Textarea

--- a/packages/suite/src/views/settings/SettingsDebug/QuotaManagerSettings.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/QuotaManagerSettings.tsx
@@ -14,15 +14,16 @@ import {
 } from '@suite-common/suite-sync-quota-manager';
 import { Button, ButtonGroup, Checkbox, Code, Column, Input, Text } from '@trezor/components';
 import { ActionColumn, SectionItem, SettingsSection, TextColumn } from '@trezor/product-components';
-import { spacings } from '@trezor/theme';
+import { breakpoints, spacings } from '@trezor/theme';
 
-import { useDispatch, useLayoutSize, useSelector } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import { useIsContentBelowBreakpoint } from 'src/support/suite/ContentFlex';
 
 const LOCAL_QUOTA_MANAGER_URL = 'http://127.0.0.1:4001/';
 
 export const QuotaManagerSettings = () => {
     const dispatch = useDispatch();
-    const { isBelowLaptop } = useLayoutSize();
+    const hasContentBelowTabletWidth = useIsContentBelowBreakpoint(breakpoints.laptop);
     const quotaManagerBaseUrl = useSelector(selectQuotaManagerBaseUrl);
     const registeredDevices = useSelector(selectRegisteredDevices);
     const ownersAllowance = useSelector(selectOwnersAllowance);
@@ -60,7 +61,7 @@ export const QuotaManagerSettings = () => {
         );
 
     return (
-        <SettingsSection isBelowLaptop={isBelowLaptop} title="Quota Manager">
+        <SettingsSection hasVerticalLayout={hasContentBelowTabletWidth} title="Quota Manager">
             <SectionItem>
                 <TextColumn title="Quota Manager URL" />
                 <ActionColumn>

--- a/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
@@ -7,10 +7,12 @@ import { type EnsureWalletSuiteSyncOnErrors } from '@suite-common/suite-sync-typ
 import { type StaticSessionId } from '@trezor/connect';
 import { isDesktop } from '@trezor/env-utils';
 import { SettingsSection } from '@trezor/product-components';
+import { breakpoints } from '@trezor/theme';
 
 import { SettingsLayout } from 'src/components/settings/SettingsLayout';
 import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
-import { useDispatch, useLayoutSize, useSelector } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import { useIsContentBelowBreakpoint } from 'src/support/suite/ContentFlex';
 
 import { AnalyticsLogging } from './AnalyticsLogging';
 import { Backends } from './Backends';
@@ -46,7 +48,7 @@ import { WipeData } from './WipeData';
 
 export const SettingsDebug = () => {
     const dispatch = useDispatch();
-    const { isBelowLaptop } = useLayoutSize();
+    const hasContentBelowTabletWidth = useIsContentBelowBreakpoint(breakpoints.laptop);
     const flags = useSelector(selectFlags);
 
     const handleWipeSuiteSyncLabelsError = ({
@@ -67,25 +69,25 @@ export const SettingsDebug = () => {
         <SettingsLayout>
             <ContextMessage context={Context.getSettings('debug')} />
 
-            <SettingsSection isBelowLaptop={isBelowLaptop} title="Debug">
+            <SettingsSection hasVerticalLayout={hasContentBelowTabletWidth} title="Debug">
                 <GithubIssue />
                 {isDesktop() && <WipeData />}
                 <TriggerHighlight />
                 <TriggerToast />
             </SettingsSection>
-            <SettingsSection isBelowLaptop={isBelowLaptop} title="Analytics">
+            <SettingsSection hasVerticalLayout={hasContentBelowTabletWidth} title="Analytics">
                 <AnalyticsLogging />
             </SettingsSection>
-            <SettingsSection isBelowLaptop={isBelowLaptop} title="Trade">
+            <SettingsSection hasVerticalLayout={hasContentBelowTabletWidth} title="Trade">
                 <TradeApi />
             </SettingsSection>
-            <SettingsSection isBelowLaptop={isBelowLaptop} title="OAuth">
+            <SettingsSection hasVerticalLayout={hasContentBelowTabletWidth} title="OAuth">
                 <OAuthApi />
             </SettingsSection>
-            <SettingsSection isBelowLaptop={isBelowLaptop} title="Coinjoin">
+            <SettingsSection hasVerticalLayout={hasContentBelowTabletWidth} title="Coinjoin">
                 <CoinjoinApi />
             </SettingsSection>
-            <SettingsSection isBelowLaptop={isBelowLaptop} title="Device">
+            <SettingsSection hasVerticalLayout={hasContentBelowTabletWidth} title="Device">
                 <DeviceAuthenticity />
                 <Devkit />
                 <CheckFirmwareAuthenticity />
@@ -93,52 +95,67 @@ export const SettingsDebug = () => {
                 <N4w1Backup />
                 <PingDevice />
             </SettingsSection>
-            <SettingsSection isBelowLaptop={isBelowLaptop} title="Testing">
+            <SettingsSection hasVerticalLayout={hasContentBelowTabletWidth} title="Testing">
                 <ThrowTestingError />
             </SettingsSection>
             {isDesktop() && (
-                <SettingsSection isBelowLaptop={isBelowLaptop} title="Transport backends">
+                <SettingsSection
+                    hasVerticalLayout={hasContentBelowTabletWidth}
+                    title="Transport backends"
+                >
                     <TransportBackends />
                 </SettingsSection>
             )}
-            <SettingsSection isBelowLaptop={isBelowLaptop} title="Transport clients">
+            <SettingsSection
+                hasVerticalLayout={hasContentBelowTabletWidth}
+                title="Transport clients"
+            >
                 <Transport />
             </SettingsSection>
             {isDesktop() && (
-                <SettingsSection isBelowLaptop={isBelowLaptop} title="Tor">
+                <SettingsSection hasVerticalLayout={hasContentBelowTabletWidth} title="Tor">
                     <Tor />
                 </SettingsSection>
             )}
-            <SettingsSection isBelowLaptop={isBelowLaptop} title="Backends">
+            <SettingsSection hasVerticalLayout={hasContentBelowTabletWidth} title="Backends">
                 <Backends />
             </SettingsSection>
-            <SettingsSection isBelowLaptop={isBelowLaptop} title="Flags JSON">
+            <SettingsSection hasVerticalLayout={hasContentBelowTabletWidth} title="Flags JSON">
                 <PreField>{JSON.stringify(flags)}</PreField>
             </SettingsSection>
-            <SettingsSection isBelowLaptop={isBelowLaptop} title="Metadata">
+            <SettingsSection hasVerticalLayout={hasContentBelowTabletWidth} title="Metadata">
                 <Metadata />
             </SettingsSection>
-            <SettingsSection isBelowLaptop={isBelowLaptop} title="Message system info">
+            <SettingsSection
+                hasVerticalLayout={hasContentBelowTabletWidth}
+                title="Message system info"
+            >
                 <MessageSystemConfigSourceSelect />
                 <MessageSystemDebug />
             </SettingsSection>
             {isDesktop() && (
                 <SettingsSection
-                    isBelowLaptop={isBelowLaptop}
+                    hasVerticalLayout={hasContentBelowTabletWidth}
                     title={<Translation id="TR_BLUETOOTH" />}
                 >
                     <ShowBluetoothDebugInfo />
                     <ForgetAllDevicesButton />
                 </SettingsSection>
             )}
-            <SettingsSection isBelowLaptop={isBelowLaptop} title="Trezor Host Protocol">
+            <SettingsSection
+                hasVerticalLayout={hasContentBelowTabletWidth}
+                title="Trezor Host Protocol"
+            >
                 <ResetThpCredentials />
             </SettingsSection>
-            <SettingsSection isBelowLaptop={isBelowLaptop} title="TrezorConnect">
+            <SettingsSection hasVerticalLayout={hasContentBelowTabletWidth} title="TrezorConnect">
                 <TrezorConnectLogs />
                 {isDesktop() && <ConnectPopup />}
             </SettingsSection>
-            <SettingsSection isBelowLaptop={isBelowLaptop} title="Firmware channel">
+            <SettingsSection
+                hasVerticalLayout={hasContentBelowTabletWidth}
+                title="Firmware channel"
+            >
                 <FirmwareUpdateEnvironmentSelect />
             </SettingsSection>
             <SuiteSyncSettings onError={handleWipeSuiteSyncLabelsError} />

--- a/packages/suite/src/views/settings/SettingsDevice/SettingsDevice.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/SettingsDevice.tsx
@@ -7,13 +7,15 @@ import { getIsDeviceRemembered } from '@suite-common/suite-utils';
 import { Banner } from '@trezor/components';
 import { isBitcoinOnlyDevice } from '@trezor/device-utils';
 import { SettingsSection } from '@trezor/product-components';
+import { breakpoints } from '@trezor/theme';
 
 import { setConnectionModal } from 'src/actions/device/deviceSlice';
 import { DeviceBanner } from 'src/components/settings/DeviceBanner';
 import { SettingsLayout } from 'src/components/settings/SettingsLayout';
 import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
-import { useDispatch, useLayoutSize, useSelector } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectHasActiveTransport } from 'src/selectors/suite/suiteSelectors';
+import { useIsContentBelowBreakpoint } from 'src/support/suite/ContentFlex';
 import type { TrezorDevice } from 'src/types/suite';
 import { getHowToGetFromBootloaderInstructionsMap } from 'src/utils/device/bootloader';
 
@@ -55,7 +57,7 @@ const deviceSettingsUnavailable = (device?: TrezorDevice) => {
 
 export const SettingsDevice = () => {
     const dispatch = useDispatch();
-    const { isBelowLaptop } = useLayoutSize();
+    const hasContentBelowTabletWidth = useIsContentBelowBreakpoint(breakpoints.tablet);
     const { device, isLocked } = useDevice();
     const noTransportAvailable = !useSelector(selectHasActiveTransport);
     const deviceUnavailable = !device?.features;
@@ -138,7 +140,7 @@ export const SettingsDevice = () => {
 
             {isNormalMode && (
                 <SettingsSection
-                    isBelowLaptop={isBelowLaptop}
+                    hasVerticalLayout={hasContentBelowTabletWidth}
                     title={<Translation id="TR_BACKUP" />}
                     icon="newspaper"
                 >
@@ -155,7 +157,7 @@ export const SettingsDevice = () => {
             )}
 
             <SettingsSection
-                isBelowLaptop={isBelowLaptop}
+                hasVerticalLayout={hasContentBelowTabletWidth}
                 title={<Translation id="TR_PASSPHRASE" />}
                 icon="password"
             >
@@ -163,7 +165,7 @@ export const SettingsDevice = () => {
             </SettingsSection>
 
             <SettingsSection
-                isBelowLaptop={isBelowLaptop}
+                hasVerticalLayout={hasContentBelowTabletWidth}
                 title={<Translation id="TR_FIRMWARE" />}
                 icon="puzzlePiece"
             >
@@ -176,7 +178,7 @@ export const SettingsDevice = () => {
 
             {isSecuritySectionVisible && (
                 <SettingsSection
-                    isBelowLaptop={isBelowLaptop}
+                    hasVerticalLayout={hasContentBelowTabletWidth}
                     title={<Translation id="TR_DEVICE_SECURITY" />}
                     icon="shieldCheck"
                 >
@@ -195,7 +197,7 @@ export const SettingsDevice = () => {
 
             {isNormalMode && (
                 <SettingsSection
-                    isBelowLaptop={isBelowLaptop}
+                    hasVerticalLayout={hasContentBelowTabletWidth}
                     title={<Translation id="TR_PERSONALIZATION" />}
                     icon="palette"
                 >
@@ -209,7 +211,7 @@ export const SettingsDevice = () => {
             )}
 
             <SettingsSection
-                isBelowLaptop={isBelowLaptop}
+                hasVerticalLayout={hasContentBelowTabletWidth}
                 title={<Translation id="TR_DEVICE_CONNECTION" />}
                 icon="plugs"
             >
@@ -218,7 +220,7 @@ export const SettingsDevice = () => {
             </SettingsSection>
 
             <SettingsSection
-                isBelowLaptop={isBelowLaptop}
+                hasVerticalLayout={hasContentBelowTabletWidth}
                 title={<Translation id="TR_ADVANCED" />}
                 icon="ghost"
             >

--- a/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
@@ -14,10 +14,12 @@ import {
 } from '@suite-common/wallet-core';
 import { isDesktop, isLinux, isWeb } from '@trezor/env-utils';
 import { SettingsSection } from '@trezor/product-components';
+import { breakpoints } from '@trezor/theme';
 
 import { SettingsLayout } from 'src/components/settings/SettingsLayout';
 import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
-import { useLayoutSize, useSelector } from 'src/hooks/suite';
+import { useSelector } from 'src/hooks/suite';
+import { useIsContentBelowBreakpoint } from 'src/support/suite/ContentFlex';
 import { TorStatus } from 'src/types/suite';
 
 import { AddressDisplay } from './AddressDisplay';
@@ -58,7 +60,8 @@ export const SettingsGeneral = () => {
     const enabledNetworks = useSelector(selectEnabledNetworks);
     const desktopUpdate = useSelector(state => state.desktopUpdate);
     const isLegacyLabelingVisible = useSelector(selectIsLegacyLabelingVisible);
-    const { isBelowLaptop, isBelowTablet } = useLayoutSize();
+    const hasContentBelowTabletWidth = useIsContentBelowBreakpoint(breakpoints.tablet);
+    const hasContentBelowMobileWidth = useIsContentBelowBreakpoint(breakpoints.mobile);
 
     const hasBitcoinNetworks = enabledNetworks.some(symbol => {
         const networkFeatures = getNetwork(symbol).features;
@@ -86,12 +89,12 @@ export const SettingsGeneral = () => {
             <ContextMessage context={Context.getSettings('general')} />
 
             <div>
-                {isWeb() && !isBelowTablet && shouldShowSettingsDesktopAppPromoBanner && (
-                    <DesktopSuiteBanner />
-                )}
+                {isWeb() &&
+                    !hasContentBelowMobileWidth &&
+                    shouldShowSettingsDesktopAppPromoBanner && <DesktopSuiteBanner />}
 
                 <SettingsSection
-                    isBelowLaptop={isBelowLaptop}
+                    hasVerticalLayout={hasContentBelowTabletWidth}
                     title={<Translation id="TR_PRIVACY" />}
                     icon="lock"
                 >
@@ -110,7 +113,7 @@ export const SettingsGeneral = () => {
             </div>
 
             <SettingsSection
-                isBelowLaptop={isBelowLaptop}
+                hasVerticalLayout={hasContentBelowTabletWidth}
                 title={<Translation id="TR_LOCALIZATION" />}
                 icon="flag"
             >
@@ -120,7 +123,7 @@ export const SettingsGeneral = () => {
             </SettingsSection>
 
             <SettingsSection
-                isBelowLaptop={isBelowLaptop}
+                hasVerticalLayout={hasContentBelowTabletWidth}
                 title={<Translation id="TR_LABELING" />}
                 icon="tag"
             >
@@ -135,7 +138,7 @@ export const SettingsGeneral = () => {
             </SettingsSection>
 
             <SettingsSection
-                isBelowLaptop={isBelowLaptop}
+                hasVerticalLayout={hasContentBelowTabletWidth}
                 title={<Translation id="TR_APPLICATION" />}
                 icon="appWindow"
             >
@@ -152,7 +155,7 @@ export const SettingsGeneral = () => {
                 <SettingsSection
                     title={<Translation id="TR_SECURITY" />}
                     icon="shield"
-                    isBelowLaptop={isBelowLaptop}
+                    hasVerticalLayout={hasContentBelowTabletWidth}
                 >
                     {isMevProtectionSettingsVisible && <MevProtection />}
                     {isDustPhishingThresholdSettingsVisible && <DustPhishing />}
@@ -161,7 +164,7 @@ export const SettingsGeneral = () => {
 
             {isNetworkReserveSettingsVisible && (
                 <SettingsSection
-                    isBelowLaptop={isBelowLaptop}
+                    hasVerticalLayout={hasContentBelowTabletWidth}
                     title={<Translation id="TR_NETWORKS" />}
                     icon="graph"
                 >
@@ -171,7 +174,7 @@ export const SettingsGeneral = () => {
 
             {isDesktop() && (
                 <SettingsSection
-                    isBelowLaptop={isBelowLaptop}
+                    hasVerticalLayout={hasContentBelowTabletWidth}
                     title={<Translation id="TR_TREZOR_CONNECT" />}
                     icon="plugs"
                 >
@@ -181,7 +184,7 @@ export const SettingsGeneral = () => {
             )}
 
             <SettingsSection
-                isBelowLaptop={isBelowLaptop}
+                hasVerticalLayout={hasContentBelowTabletWidth}
                 title={<Translation id="TR_EXPERIMENTAL_FEATURES" />}
                 icon="atom"
             >
@@ -191,7 +194,7 @@ export const SettingsGeneral = () => {
 
             {mcpServerEnabled && isDesktop() && (
                 <SettingsSection
-                    isBelowLaptop={isBelowLaptop}
+                    hasVerticalLayout={hasContentBelowTabletWidth}
                     title={<Translation id="TR_EXPERIMENTAL_MCP_SERVER" />}
                     icon="plugs"
                 >

--- a/suite/suite-sync/src/SuiteSyncSettings.tsx
+++ b/suite/suite-sync/src/SuiteSyncSettings.tsx
@@ -14,8 +14,7 @@ import {
 import { type SuiteSyncDep } from '@suite-common/suite-sync-types';
 import { Button, ButtonGroup, Checkbox, Code, Column, Input, Text } from '@trezor/components';
 import { ActionColumn, SectionItem, SettingsSection, TextColumn } from '@trezor/product-components';
-import { type BreakpointFlags } from '@trezor/theme';
-import { spacings } from '@trezor/theme';
+import { type BreakpointFlags, spacings } from '@trezor/theme';
 
 import { WipeSuiteSyncLabels, type WipeSuiteSyncLabelsOnError } from './WipeSuiteSyncLabels';
 
@@ -65,7 +64,7 @@ export const SuiteSyncSettings = ({ onError }: SuiteSyncSettingsProps) => {
     if (!isSuiteSyncFeatureEnabled) return null;
 
     return (
-        <SettingsSection title="Suite Sync" isBelowLaptop={isBelowLaptop}>
+        <SettingsSection title="Suite Sync" hasVerticalLayout={isBelowLaptop}>
             <SectionItem>
                 <TextColumn title="Relay URL" />
                 <ActionColumn>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- settings section responsiveness reacts to the width of the content, not whole page

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=make-settings-responsible-again&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=make-settings-responsible-again&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 16 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox - watches files over time | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Dropbox API errors > Incomplete data returned from provider | 🤖 auto |
| Metadata - switching between cloud providers > Start with one and switch to another | 🤖 auto |
| Metadata - address labeling > google provider | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Remembered device > google provider | 🤖 auto |
| Dropbox API errors > Malformed token | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Account metadata > google - watches files over time | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-25T19:14:52.105Z • 16 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-25T19:11:53.041Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/make-settings-responsible-again/web/](https://dev.suite.sldev.cz/suite-web/make-settings-responsible-again/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->