### PR TITLE
feat(trading): move sell network fees into secondary params

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingSellFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingSellFormInputs.tsx
@@ -154,14 +154,14 @@ export const TradingSellFormInputs = () => {
                         />
                     )}
                 </TradingFormSection>
+            </TradingFormCard>
+            <TradingFormCard>
                 <TradingFormFees
                     feeInfo={feeInfo}
                     account={account}
                     composedLevels={composedLevels}
                     changeFeeLevel={changeFeeLevel}
                 />
-            </TradingFormCard>
-            <TradingFormCard>
                 {!!quotes.length && (
                     <TradingFormInputPaymentMethod label="TR_TRADING_RECEIVE_METHOD" />
                 )}
@@ -173,6 +173,7 @@ export const TradingSellFormInputs = () => {
                         country={selectedCountry}
                     />
                 )}
+
                 <TradingSelectedOfferProvider />
             </TradingFormCard>
         </Column>


### PR DESCRIPTION
## Description

- Move sell network fees into the secondary params card.
- Show network fees before payment method, country, subdivision, and selected offer details.
- Keep the primary sell asset and amount inputs in the top card.

## Notes for QA

- Open Wallet > Trading > Sell and confirm the network fees section is rendered in the secondary params card below the main sell inputs.
- Verify payment method, country, subdivision, and selected offer still render below the fees section when quotes are available.
- Verify the sell form still renders correctly when there are no quotes.

## Related Issue

Resolve #27886

## Screenshots:

<img width="777" height="605" alt="image" src="https://github.com/user-attachments/assets/a92364b1-4ca7-48e3-a6d0-1450466f6857" />

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is scoped to a single UI component (TradingSellFormInputs.tsx) within the trading sell form. This is a focused change with clear test coverage from three statically mapped tests. The highest risk is in the sell-inputs test which directly validates the form input behavior. The sell-solana test provides secondary coverage for a specific coin flow, while the navigation test has only tangential relevance.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingSellFormInputs.tsx`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/trading/sell-inputs.test.ts` — This test directly exercises the sell form inputs, which is exactly what TradingSellFormInputs.tsx renders. Any change to this component's input fields, validation, or layout would be caught by this test.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/trading/sell-solana.test.ts` — This test covers the sell flow for Solana, which uses the same TradingSellFormInputs component. Changes to input handling or form behavior could manifest differently with Solana-specific logic.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — This test covers trading navigation which may render the sell form inputs during navigation between trading views. A regression is possible if the component change causes a render error that blocks navigation.

</details>

_Updated: 2026-05-25T10:25:27.392Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/trading-sell-network-fees-secondary-params&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/trading-sell-network-fees-secondary-params&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 15 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox - watches files over time | 🤖 auto |
| Dropbox API errors > Incomplete data returned from provider | 🤖 auto |
| Metadata - switching between cloud providers > Start with one and switch to another | 🤖 auto |
| Metadata - address labeling > google provider | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Remembered device > google provider | 🤖 auto |
| Dropbox API errors > Malformed token | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Account metadata > google - watches files over time | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-25T10:31:02.756Z • 15 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-25T10:28:07.296Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/trading-sell-network-fees-secondary-params/web/](https://dev.suite.sldev.cz/suite-web/feat/trading-sell-network-fees-secondary-params/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->