### PR TITLE
Require `management` permission for setting custom backend

### DIFF
--- a/packages/connect-common/src/types/method.ts
+++ b/packages/connect-common/src/types/method.ts
@@ -9,7 +9,7 @@ import type { PrecomposeResultFinal } from './api/composeTransaction';
  * permissions by category and asks the user to grant access to a host (e.g.
  * read public data, sign a transaction, manage the device, push to network).
  */
-export type MethodPermission = 'read' | 'write' | 'management' | 'push_tx';
+export type MethodPermission = 'read' | 'write' | 'management' | 'push_tx' | 'internal';
 
 /**
  * Static and runtime metadata describing a `@trezor/connect` method call.

--- a/packages/connect/src/api/blockchainDisconnect.ts
+++ b/packages/connect/src/api/blockchainDisconnect.ts
@@ -41,7 +41,7 @@ export default class BlockchainDisconnect extends AbstractMethod<'blockchainDisc
     }
 
     get requiredPermissions(): MethodPermission[] {
-        return [];
+        return ['internal'];
     }
 
     get info() {

--- a/packages/connect/src/api/blockchainSetCustomBackend.ts
+++ b/packages/connect/src/api/blockchainSetCustomBackend.ts
@@ -41,7 +41,7 @@ export default class BlockchainSetCustomBackend extends AbstractMethod<
     }
 
     get requiredPermissions(): MethodPermission[] {
-        return [];
+        return ['internal'];
     }
 
     get info() {

--- a/packages/connect/src/api/blockchainSetCustomBackend.ts
+++ b/packages/connect/src/api/blockchainSetCustomBackend.ts
@@ -11,6 +11,10 @@ import { getCoinInfo } from '../data/coinInfo';
 
 type Params = {
     coinInfo: CoinInfo;
+    blockchainLink?: {
+        type: string;
+        url: string[];
+    };
 };
 
 export default class BlockchainSetCustomBackend extends AbstractMethod<
@@ -31,9 +35,11 @@ export default class BlockchainSetCustomBackend extends AbstractMethod<
             throw ERRORS.TypedError('Method_UnknownCoin');
         }
 
+        const { blockchainLink } = payload;
+
         setCustomBackend(coinInfo, payload.blockchainLink);
 
-        const params = { coinInfo };
+        const params = { coinInfo, blockchainLink };
 
         super(message, params);
         this.useDevice = false;
@@ -49,6 +55,8 @@ export default class BlockchainSetCustomBackend extends AbstractMethod<
     }
 
     async run() {
+        setCustomBackend(this.params.coinInfo, this.params.blockchainLink);
+
         await reconnectAllBackends(this.params.coinInfo);
 
         return true;

--- a/packages/connect/src/api/blockchainSubscribe.ts
+++ b/packages/connect/src/api/blockchainSubscribe.ts
@@ -54,7 +54,7 @@ export default class BlockchainSubscribe extends AbstractMethod<'blockchainSubsc
     }
 
     get requiredPermissions(): MethodPermission[] {
-        return [];
+        return ['internal'];
     }
 
     async run({ sendCoreMessage }: MethodContext) {

--- a/packages/connect/src/api/blockchainUnsubscribe.ts
+++ b/packages/connect/src/api/blockchainUnsubscribe.ts
@@ -54,7 +54,7 @@ export default class BlockchainUnsubscribe extends AbstractMethod<'blockchainUns
     }
 
     get requiredPermissions(): MethodPermission[] {
-        return [];
+        return ['internal'];
     }
 
     async run({ sendCoreMessage }: MethodContext) {

--- a/packages/connect/src/api/getSettings.ts
+++ b/packages/connect/src/api/getSettings.ts
@@ -13,7 +13,7 @@ export default class GetSettings extends AbstractMethod<'getSettings'> {
         this.useUi = false;
     }
     get requiredPermissions(): MethodPermission[] {
-        return ['management'];
+        return ['internal'];
     }
 
     run() {

--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -57,6 +57,7 @@ export const connectPopupCallThunkInner = createThunk<
             const methodInfoPayload = methodInfo.payload as MethodInfo;
             if (
                 methodInfoPayload.requiredPermissions.includes('management') ||
+                methodInfoPayload.requiredPermissions.includes('internal') ||
                 (methodInfoPayload.requiredPermissions.includes('push_tx') &&
                     source.type === 'deeplink')
             ) {

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -594,6 +594,7 @@ export const messages = {
             write: 'Permit transaction and data signing on Trezor',
             management: 'Change device settings',
             push_tx: 'Broadcast transactions to the blockchain',
+            internal: 'Internal use only',
         },
         simulation: {
             reviewTransaction: 'Review transaction',

--- a/suite-native/module-connect-popup/src/components/PermissionConfirmation.tsx
+++ b/suite-native/module-connect-popup/src/components/PermissionConfirmation.tsx
@@ -27,6 +27,7 @@ const permissionTranslationKeysMap = {
     write: 'moduleConnectPopup.permissions.write',
     management: 'moduleConnectPopup.permissions.management',
     push_tx: 'moduleConnectPopup.permissions.push_tx',
+    internal: 'moduleConnectPopup.permissions.internal',
 } as const satisfies Record<MethodPermission, TxKeyPath>;
 
 export const PermissionConfirmation = () => {


### PR DESCRIPTION
## Description

<strike>Now it's needed to have `management` permission to be able to set custom backend for any coin.</strike>

New `internal` permission was added and that one is now needed to set custom backend for any coin.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/custom-backend-permission/web/](https://dev.suite.sldev.cz/suite-web/fix/custom-backend-permission/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/custom-backend-permission&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/custom-backend-permission&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/custom-backend-permission&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-25T13:19:30.254Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 15 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox - watches files over time | 🤖 auto |
| Dropbox API errors > Incomplete data returned from provider | 🤖 auto |
| Metadata - switching between cloud providers > Start with one and switch to another | 🤖 auto |
| Metadata - address labeling > google provider | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Remembered device > google provider | 🤖 auto |
| Dropbox API errors > Malformed token | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Account metadata > google - watches files over time | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-25T12:10:48.976Z • 15 test(s) total_
<!-- QUARANTINE-LIST:web:END -->