### PR TITLE
Fix/portfolio-card-layout

### DIFF
--- a/packages/components/src/components/form/SelectBar/SelectBar.tsx
+++ b/packages/components/src/components/form/SelectBar/SelectBar.tsx
@@ -36,6 +36,7 @@ const Options = styled.div<{ $elevation: Elevation }>`
     background: ${mapElevationToBackground};
     border-radius: ${borders.radii.lg};
     flex: 1;
+    min-width: 0;
 `;
 
 const Puck = styled.div<{
@@ -72,6 +73,9 @@ const Puck = styled.div<{
 
 const Option = styled.div<{ $isSelected: boolean; $isDisabled: boolean }>`
     position: relative;
+    width: 100%;
+    min-width: 0;
+    overflow: hidden;
     transition: color 0.175s;
 
     &:hover {
@@ -204,7 +208,7 @@ export const SelectBar = <V extends ValueTypes>({
                         tabIndex={0}
                         onKeyDown={handleKeyboardNav}
                     />
-                    <Grid columns={isVertical ? 1 : options.length} gap={GAP}>
+                    <Grid columns={isVertical ? 1 : options.length} gap={GAP} forceEqualColumns>
                         {options.map(option => {
                             const isSelected =
                                 selectedOptionIn !== undefined
@@ -222,6 +226,8 @@ export const SelectBar = <V extends ValueTypes>({
                                     textWrap="nowrap"
                                     as="div"
                                     cursor={isDisabled ? 'not-allowed' : 'pointer'}
+                                    minWidth={0}
+                                    overflow="hidden"
                                 >
                                     <Option
                                         onClick={handleOptionClick(option)}
@@ -232,9 +238,20 @@ export const SelectBar = <V extends ValueTypes>({
                                     >
                                         <Column
                                             padding={mapSizeToPadding(size)}
-                                            alignItems="center"
+                                            alignItems="stretch"
+                                            width="100%"
+                                            minWidth={0}
                                         >
-                                            {option.label}
+                                            <Text
+                                                as="div"
+                                                align="center"
+                                                width="100%"
+                                                maxWidth="100%"
+                                                minWidth={0}
+                                                ellipsisLineCount={1}
+                                            >
+                                                {option.label}
+                                            </Text>
                                             <Box height={0} overflow="hidden" aria-hidden>
                                                 <Text typographyStyle="body-md-strong">
                                                     {option.label}

--- a/packages/components/src/components/form/SelectBar/utils.ts
+++ b/packages/components/src/components/form/SelectBar/utils.ts
@@ -1,4 +1,4 @@
-import { type TypographyStyle, spacings } from '@trezor/theme';
+import { type TypographyStyle } from '@trezor/theme';
 
 import { type SelectBarSize } from './types';
 import { type Padding } from '../../../utils/frameProps';
@@ -19,12 +19,12 @@ export const mapSizeToTypographyStyle = (
 export const mapSizeToPadding = (size: SelectBarSize): Padding => {
     const paddingMap: Record<SelectBarSize, Padding> = {
         large: {
-            vertical: spacings.xs,
-            horizontal: spacings.xl,
+            vertical: 8,
+            horizontal: 24,
         },
         small: {
-            vertical: spacings.xxs,
-            horizontal: spacings.lg,
+            vertical: 4,
+            horizontal: 16,
         },
     };
 

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
@@ -15,17 +15,20 @@ import {
     Collapsible,
     Column,
     Divider,
+    Flex,
     Icon,
     IconButton,
     Paragraph,
     Row,
 } from '@trezor/components';
+import { breakpoints } from '@trezor/theme';
 
 import { updateGraphData } from 'src/actions/wallet/graphActions';
 import { DashboardSection } from 'src/components/dashboard';
 import { GraphRangeSelector, GraphSkeleton } from 'src/components/suite';
 import { useDiscovery, useDispatch, useSelector } from 'src/hooks/suite';
 import { useTotalFiatBalance } from 'src/hooks/wallet/useTotalFiatBalance';
+import { useIsContentBelowBreakpoint } from 'src/support/suite/ContentFlex';
 import { isNetworkWithGraphFeature } from 'src/utils/wallet/graph';
 import { selectDiscoveryOverallStatus } from 'src/utils/wallet/selectDiscoveryOverallStatus';
 
@@ -47,6 +50,7 @@ export const PortfolioCard = memo(() => {
     const { dashboardGraphHidden } = useSelector(selectFlags);
     const dispatch = useDispatch();
     const { device } = useDevice();
+    const isBelowLaptop = useIsContentBelowBreakpoint(breakpoints.laptop);
     const isDeviceEmpty = useMemo(() => accounts.every(a => a.empty), [accounts]);
     const failedAccounts = useMemo(() => accounts.filter(isAccountFailed), [accounts]);
 
@@ -169,15 +173,25 @@ export const PortfolioCard = memo(() => {
                                     {body}
                                 </Column>
                                 {showGraphControls && (
-                                    <Row gap={32} justifyContent="space-between">
+                                    <Flex
+                                        gap={16}
+                                        direction={isBelowLaptop ? 'column' : 'row'}
+                                        justifyContent="space-between"
+                                        alignItems={isBelowLaptop ? 'flex-start' : 'center'}
+                                    >
                                         <GraphRangeSelector onSelectedRange={onSelectedRange} />
                                         {showMissingDataTooltip && (
-                                            <Row gap={12} flex="1 1">
+                                            <Row
+                                                gap={12}
+                                                flex={isBelowLaptop ? undefined : '1 1 240px'}
+                                                minWidth={0}
+                                                isReversed={isBelowLaptop}
+                                            >
                                                 <Paragraph
                                                     typographyStyle="body-xs"
                                                     intent="neutral"
                                                     priority="secondary"
-                                                    align="end"
+                                                    align={isBelowLaptop ? 'start' : 'end'}
                                                     textWrap="balance"
                                                 >
                                                     <UnsupportedAssetsMessage
@@ -193,7 +207,7 @@ export const PortfolioCard = memo(() => {
                                                 />
                                             </Row>
                                         )}
-                                    </Row>
+                                    </Flex>
                                 )}
                             </Column>
                         </Collapsible.Content>


### PR DESCRIPTION
## Notes for QA

- fixed SelectBar behavior on small screens
- fixed dashboard chart responsiveness

## Screenshots:
<img width="835" height="582" alt="image" src="https://github.com/user-attachments/assets/343f8cb9-5cbe-4afc-9d97-0623bfd285fa" />

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies the SelectBar form component (a shared UI component used across 121 tests) and the PortfolioCard on the dashboard. The SelectBar changes carry broad risk but are likely utility/styling changes, so testing should focus on views where SelectBar is most prominently used. The PortfolioCard change is more targeted to the dashboard. The recommended strategy is to prioritize dashboard-specific tests that directly render the PortfolioCard and use SelectBar, with medium-priority coverage for settings and analytics flows that also exercise SelectBar interactions.

<details><summary><b>Changed files (3)</b></summary>

- `packages/components/src/components/form/SelectBar/SelectBar.tsx`
- `packages/components/src/components/form/SelectBar/utils.ts`
- `packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — This test directly exercises the dashboard view where PortfolioCard is rendered. Changes to PortfolioCard.tsx could affect the dashboard layout, portfolio graph rendering, or asset display. The SelectBar component may also be used on the dashboard for toggling views.
- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — Discreet mode test operates on the dashboard where PortfolioCard is prominently displayed. Changes to PortfolioCard could affect how values are hidden/shown in discreet mode, and SelectBar may be used for time-range or view toggles within the card.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/general/wallet-discovery.test.ts` — Wallet discovery navigates through the dashboard where the PortfolioCard is displayed after accounts are discovered. A broken PortfolioCard could cause visible regressions during the discovery flow.
- `suite/e2e/tests/analytics/events.test.ts` — Analytics events test likely covers interactions with dashboard components including PortfolioCard and potentially SelectBar toggles that emit analytics events. Changes to these components could alter event firing.
- `suite/e2e/tests/settings/general.test.ts` — Settings pages commonly use SelectBar for toggling between options (e.g., fiat currency, theme). Changes to SelectBar.tsx and its utils could break settings form controls.

</details>

_Updated: 2026-05-25T12:10:34.711Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/portfolio-card-layout&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/portfolio-card-layout&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 15 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Dropbox API errors > Incomplete data returned from provider | 🤖 auto |
| Metadata - switching between cloud providers > Start with one and switch to another | 🤖 auto |
| Metadata - address labeling > google provider | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Remembered device > google provider | 🤖 auto |
| Dropbox API errors > Malformed token | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Account metadata > google - watches files over time | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-25T14:40:42.815Z • 15 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-25T14:38:27.729Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/portfolio-card-layout/web/](https://dev.suite.sldev.cz/suite-web/fix/portfolio-card-layout/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->