### PR TITLE
chore(connect-common): drop unused POPUP.CLOSE_WINDOW event

### DIFF
--- a/packages/connect-common/src/events/popup.ts
+++ b/packages/connect-common/src/events/popup.ts
@@ -14,8 +14,6 @@ export const POPUP = {
     // Event emitted from PopupManager at the end of popup closing process.
     // Sent from popup thru window.opener to an iframe because message channel between popup and iframe is no longer available
     CLOSED: 'popup-closed',
-    // Message called from inline element in popup.html (window.closeWindow), this is used only with webextensions to properly handle popup close event
-    CLOSE_WINDOW: 'window.close',
 } as const;
 
 export interface PopupInit {
@@ -43,14 +41,6 @@ export interface PopupClosedMessage {
     payload: { error: any } | null;
 }
 
-export interface PopupCloseWindow {
-    type: typeof POPUP.CLOSE_WINDOW;
-    // TODO: This field could be dropped entirely (no construction sites read it),
-    // but the same applies to other payload-less events in this file, so it's
-    // out of scope for this PR.
-    payload?: never;
-}
-
 export type PopupEvent =
     | {
           type: typeof POPUP.CORE_LOADED;
@@ -58,7 +48,6 @@ export type PopupEvent =
       }
     | PopupInit
     | PopupHandshake
-    | PopupCloseWindow
     | PopupClosedMessage;
 
 export type PopupEventMessage = PopupEvent & { event: typeof UI_EVENT };


### PR DESCRIPTION
## Summary

Follow-up to #27891. Removes the dead `POPUP.CLOSE_WINDOW` event from `@trezor/connect-common`.

`POPUP.CLOSE_WINDOW` (`'window.close'`) had **no construction or consumption sites** anywhere in the codebase — the only references were the constant, the `PopupCloseWindow` interface, and its variant in the `PopupEvent` discriminated union. The inline comment claimed it was dispatched from `window.closeWindow` in `popup.html` for webextensions, but no such sender exists in the repo today.

PR #27891 left a TODO suggesting the `payload` field could be dropped; this PR goes one step further and removes the entire dead branch, which is the cleaner fix.

## Changes

`packages/connect-common/src/events/popup.ts`:
- Remove `CLOSE_WINDOW: 'window.close'` from the `POPUP` constant
- Remove the `PopupCloseWindow` interface
- Remove the `PopupCloseWindow` variant from the `PopupEvent` union

## Verification

- `grep -r "CLOSE_WINDOW"` in TS/TSX/JS finds zero non-i18n references (the surviving `TR_CLOSE_WINDOW` matches are unrelated translation keys for modal buttons)
- `grep -r "PopupCloseWindow"` returns no matches after this PR
- `grep -r "'window.close'"` finds no usages as a message type

## Test plan

- [ ] `yarn nx run-many --target=lint:js`
- [ ] `yarn nx run-many --target=type-check`
- [ ] `yarn nx run-many --target=test:unit`
- [ ] `yarn nx run-many --target=build:lib`

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/connect-common-drop-close-window/web/](https://dev.suite.sldev.cz/suite-web/mroz22/connect-common-drop-close-window/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/connect-common-drop-close-window&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 16 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Account metadata > dropbox - watches files over time | 🤖 auto |
| Dropbox API errors > Incomplete data returned from provider | 🤖 auto |
| Metadata - switching between cloud providers > Start with one and switch to another | 🤖 auto |
| Metadata - address labeling > google provider | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Remembered device > google provider | 🤖 auto |
| Dropbox API errors > Malformed token | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Account metadata > google - watches files over time | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-25T12:41:58.123Z • 16 test(s) total_
<!-- QUARANTINE-LIST:web:END -->