### PR TITLE
Defer staking-only transaction empty state until load completes

### DIFF
--- a/suite-native/transactions/src/components/TransactionList.tsx
+++ b/suite-native/transactions/src/components/TransactionList.tsx
@@ -11,6 +11,7 @@ import {
     fetchAndUpdateAccountThunk,
     fetchTransactionsPageThunk,
     selectAccountByKey,
+    selectAreAllAccountTransactionsLoaded,
     selectBaseCurrency,
     selectIsLoadingAccountTransactions,
     selectIsPageAlreadyFetched,
@@ -145,6 +146,10 @@ export const TransactionList = ({
     );
     const isLoadingTransactions = useSelector((state: TransactionsRootState) =>
         selectIsLoadingAccountTransactions(state, accountKey),
+    );
+    const shouldDeferEmptyState = useSelector(
+        (state: TransactionsRootState & AccountsRootState) =>
+            stakingOnly && !selectAreAllAccountTransactionsLoaded(state, accountKey),
     );
 
     const transactions = useSelector((state: TransactionsRootState & TokensRootState) =>
@@ -294,7 +299,11 @@ export const TransactionList = ({
                 data={data}
                 renderItem={renderItem}
                 contentContainerStyle={applyStyle(sectionListContainerStyle)}
-                ListEmptyComponent={<TransactionsEmptyState accountKey={accountKey} />}
+                ListEmptyComponent={
+                    shouldDeferEmptyState ? null : (
+                        <TransactionsEmptyState accountKey={accountKey} />
+                    )
+                }
                 ListHeaderComponent={listHeaderComponent}
                 ListFooterComponent={
                     <TransactionsListFooter


### PR DESCRIPTION
## Description

Fetched the full account history before applying the staking filter, so older stakes stayed visible, and hid the empty state until loading finished, so the list never flashed a false empty state.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27609
