### PR TITLE
Format crypto amounts with localizeNumber for precision

### DIFF
--- a/suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.ts
+++ b/suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.ts
@@ -1,5 +1,6 @@
 import { A, pipe } from '@mobily/ts-belt';
 
+import { LANGUAGES, type Locale } from '@suite-common/suite-types';
 import {
     type NetworkSymbol,
     getNetworkOptional,
@@ -10,6 +11,7 @@ import { type TokenSymbol } from '@suite-common/wallet-types';
 import {
     convertAmountSubunitsToUnits,
     convertAmountUnitsToSubunits,
+    localizeNumber,
     redactNumericalSubstring,
 } from '@suite-common/wallet-utils';
 import { PROTO } from '@trezor/connect';
@@ -30,6 +32,10 @@ export type CryptoAmountFormatterDataContext = {
 };
 
 export const BASE_CRYPTO_MAX_DISPLAYED_DECIMALS = 8;
+
+const DEFAULT_LOCALE: Locale = 'en-US';
+
+const isLocale = (value: string): value is Locale => Object.hasOwn(LANGUAGES, value);
 
 const appendEllipsis = ({
     value,
@@ -58,12 +64,11 @@ const localizedNumber = ({
     config: FormatterConfig;
     formatterContext: Partial<CryptoAmountFormatterDataContext>;
 }) => {
-    const { intl } = config;
+    const { locale } = config;
     const { maxDisplayedDecimals = BASE_CRYPTO_MAX_DISPLAYED_DECIMALS } = formatterContext;
 
-    const formattedValue = intl.formatNumber(Number(value), {
-        maximumFractionDigits: maxDisplayedDecimals,
-    });
+    const safeLocale: Locale = isLocale(locale) ? locale : DEFAULT_LOCALE;
+    const formattedValue = localizeNumber(value, safeLocale, 0, maxDisplayedDecimals);
 
     const [_, unformattedDecimalsPart] = value.split('.');
     const wasResultRounded = (unformattedDecimalsPart?.length ?? 0) > maxDisplayedDecimals;

--- a/suite-common/formatters/src/formatters/tests/prepareCryptoAmountFormatter.test.ts
+++ b/suite-common/formatters/src/formatters/tests/prepareCryptoAmountFormatter.test.ts
@@ -89,6 +89,16 @@ describe('CryptoAmountFormatter', () => {
             ).toBe('0.00014899… ETH');
         });
 
+        it('ETH fee preserves all 18 decimals without Number precision loss', () => {
+            expect(
+                CryptoAmountFormatter.format('1005309106970022', {
+                    symbol: 'eth',
+                    isBalance: false,
+                    maxDisplayedDecimals: 18,
+                }),
+            ).toBe('0.001005309106970022 ETH');
+        });
+
         describe('Formats correctly to Sats units', () => {
             it('BTC sats with symbol', () => {
                 expect(


### PR DESCRIPTION
## Description

Switched crypto amount localization to string-based localizeNumber with a validated locale, so high-precision ETH amounts no longer lose digits through Number conversion.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27615