### PR TITLE
fix(suite-native): accept localhost URLs in analytics URL validation

### DIFF
--- a/suite-native/module-dev-utils/src/components/AnalyticsLogging.tsx
+++ b/suite-native/module-dev-utils/src/components/AnalyticsLogging.tsx
@@ -15,7 +15,9 @@ import { useToast } from '@suite-native/toasts';
 const DEFAULT_CUSTOM_URL = '';
 
 const urlSchema = yup.object({
-    analyticsUrl: yup.string().url('Please enter a valid URL'),
+    analyticsUrl: yup
+        .string()
+        .test('url', 'Please enter a valid URL', value => !value || URL.canParse(value)),
 });
 
 type FormValues = yup.InferType<typeof urlSchema>;


### PR DESCRIPTION
## Description

`localhost` URL were not accepted as analytics backend custom URL. This PR fixes that.

- Replace `yup.string().url()` with a `URL.canParse()` based validator in `AnalyticsLogging`
- `yup`'s built-in `.url()` rejects `localhost` URLs (requires a TLD); `URL.canParse` uses the native URL parser which correctly accepts them

## Notes for QA

- In dev utils → Analytics URL, entering `http://localhost:5181/log` should now pass validation and save


## Screenshots:

<img width="406" height="848" alt="Screenshot 2026-05-25 at 14 59 47" src="https://github.com/user-attachments/assets/ea545545-ccea-456e-9c2a-099bf9e6d9fe" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/analytics-url-localhost-validation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->