### PR TITLE
Add account type badges in suite native earn module

### DIFF
--- a/suite-native/accounts/src/components/AccountLabel.tsx
+++ b/suite-native/accounts/src/components/AccountLabel.tsx
@@ -1,44 +1,104 @@
 import { useSelector } from 'react-redux';
 
 import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { type Account, type AccountDescriptor } from '@suite-common/wallet-types';
-import { Text, type TextProps } from '@suite-native/atoms';
+import {
+    type Account,
+    type AccountDescriptor,
+    type AccountKey,
+    createAccountKey,
+} from '@suite-common/wallet-types';
+import { HStack, Text, type TextProps } from '@suite-native/atoms';
 import { type CombinedLabelingState } from '@suite-native/labeling';
 import { type StaticSessionId } from '@trezor/connect';
 
 import { selectAccountLabel } from '../selectors';
+import { AccountTypeBadge } from './AccountTypeBadge';
 
-type AccountLabelProps = {
+type AccountTypeBadgeOptions = {
+    showAccountTypeBadge?: boolean;
+};
+
+type AccountLabelDescriptorProps = {
     deviceStaticSessionId: StaticSessionId;
     accountDescriptor: AccountDescriptor;
     networkSymbol: NetworkSymbol;
-} & TextProps;
+} & TextProps &
+    AccountTypeBadgeOptions;
 
-export type AccountLabelPropsWithAccount = AccountLabelProps | ({ account: Account } & TextProps);
+type AccountLabelAccountProps = { account: Account } & TextProps & AccountTypeBadgeOptions;
 
-const normalizeProps = (props: AccountLabelPropsWithAccount): AccountLabelProps => {
+export type AccountLabelPropsWithAccount = AccountLabelDescriptorProps | AccountLabelAccountProps;
+
+type NormalizedAccountLabelProps = {
+    accountKey: AccountKey;
+    deviceStaticSessionId: StaticSessionId;
+    accountDescriptor: AccountDescriptor;
+    networkSymbol: NetworkSymbol;
+    showAccountTypeBadge: boolean;
+    textProps: TextProps;
+};
+
+const normalizeProps = (props: AccountLabelPropsWithAccount): NormalizedAccountLabelProps => {
     if ('account' in props) {
-        const { account, ...textProps } = props;
+        const { account, showAccountTypeBadge = false, ...textProps } = props;
 
         return {
+            accountKey: account.key,
             deviceStaticSessionId: account.deviceState,
             networkSymbol: account.symbol,
             accountDescriptor: account.descriptor,
-            ...textProps,
+            showAccountTypeBadge,
+            textProps,
         };
     }
 
-    return props;
+    const {
+        deviceStaticSessionId,
+        accountDescriptor,
+        networkSymbol,
+        showAccountTypeBadge = false,
+        ...textProps
+    } = props;
+
+    return {
+        accountKey: createAccountKey({ accountDescriptor, networkSymbol, deviceStaticSessionId }),
+        deviceStaticSessionId,
+        accountDescriptor,
+        networkSymbol,
+        showAccountTypeBadge,
+        textProps,
+    };
 };
 
 export const AccountLabel = (props: AccountLabelPropsWithAccount) => {
-    const { accountDescriptor, deviceStaticSessionId, networkSymbol, ...textProps } =
-        normalizeProps(props);
+    const {
+        accountKey,
+        accountDescriptor,
+        deviceStaticSessionId,
+        networkSymbol,
+        showAccountTypeBadge,
+        textProps,
+    } = normalizeProps(props);
 
     // This selector already handles the Suite Sync Feature & Legacy Label fallback
     const accountLabel = useSelector((state: CombinedLabelingState) =>
         selectAccountLabel(state, deviceStaticSessionId, accountDescriptor, networkSymbol),
     );
 
-    return accountLabel ? <Text {...textProps}>{accountLabel}</Text> : null;
+    if (!accountLabel) {
+        return null;
+    }
+
+    if (!showAccountTypeBadge) {
+        return <Text {...textProps}>{accountLabel}</Text>;
+    }
+
+    return (
+        <HStack alignItems="center" spacing="sp4">
+            <Text {...textProps} style={{ flexShrink: 1, ...textProps.style }}>
+                {accountLabel}
+            </Text>
+            <AccountTypeBadge accountKey={accountKey} />
+        </HStack>
+    );
 };

--- a/suite-native/accounts/src/components/AccountTypeBadge.tsx
+++ b/suite-native/accounts/src/components/AccountTypeBadge.tsx
@@ -1,0 +1,21 @@
+import { useSelector } from 'react-redux';
+
+import { type AccountsRootState, selectFormattedAccountType } from '@suite-common/wallet-core';
+import { type AccountKey } from '@suite-common/wallet-types';
+import { Badge, type BadgeProps } from '@suite-native/atoms';
+
+type AccountTypeBadgeProps = {
+    accountKey: AccountKey;
+} & Pick<BadgeProps, 'alignSelf'>;
+
+export const AccountTypeBadge = ({ accountKey, alignSelf }: AccountTypeBadgeProps) => {
+    const formattedAccountType = useSelector((state: AccountsRootState) =>
+        selectFormattedAccountType(state, accountKey),
+    );
+
+    if (!formattedAccountType) {
+        return null;
+    }
+
+    return <Badge label={formattedAccountType} size="small" alignSelf={alignSelf} />;
+};

--- a/suite-native/accounts/src/components/__tests__/AccountLabel.test.tsx
+++ b/suite-native/accounts/src/components/__tests__/AccountLabel.test.tsx
@@ -30,6 +30,18 @@ describe('AccountLabel', () => {
         visible: true,
     });
 
+    const ethLedgerAccount = mockWalletAccount({
+        symbol: 'eth',
+        accountLabel: 'ETH Ledger Account',
+        deviceState: MOCK_ACCOUNT_DEVICE_SESSION_ID,
+
+        accountType: 'ledger',
+        descriptor: asAccountDescriptor('eth1-ledger'),
+        visible: true,
+    });
+
+    const accounts = [ethAccount, ethLedgerAccount];
+
     const reducer = {
         locale: localeReducer,
         device: createStaticReducer(deviceInitialState),
@@ -38,7 +50,7 @@ describe('AccountLabel', () => {
         suiteSyncData: createStaticReducer(initialSuiteSyncDataState),
         wallet: combineReducers({
             settings: createStaticReducer(initialWalletSettingsState),
-            accounts: createStaticReducer([ethAccount]),
+            accounts: createStaticReducer(accounts),
         }),
     } as const;
 
@@ -49,7 +61,7 @@ describe('AccountLabel', () => {
                 preloadedState: {
                     wallet: {
                         settings: initialWalletSettingsState,
-                        accounts: [ethAccount],
+                        accounts,
                     },
                 } satisfies PreloadedStatePartial<StateFromReducersMapObject<typeof reducer>>,
             }),
@@ -88,5 +100,34 @@ describe('AccountLabel', () => {
         });
 
         expect(getByText('ETH Account #1')).toHaveProp('accessibilityLabel', 'ACCESSIBILITY_LABEL');
+    });
+
+    it('should render account type badge when showAccountTypeBadge is set', () => {
+        const { getByText } = renderAccountLabel({
+            account: ethLedgerAccount,
+            showAccountTypeBadge: true,
+        });
+
+        expect(getByText('ETH Ledger Account')).toBeOnTheScreen();
+        expect(getByText('Ledger')).toBeOnTheScreen();
+    });
+
+    it('should render account type badge for the descriptor variant when showAccountTypeBadge is set', () => {
+        const { getByText } = renderAccountLabel({
+            deviceStaticSessionId: ethLedgerAccount.deviceState,
+            networkSymbol: ethLedgerAccount.symbol,
+            accountDescriptor: ethLedgerAccount.descriptor,
+            showAccountTypeBadge: true,
+        });
+
+        expect(getByText('ETH Ledger Account')).toBeOnTheScreen();
+        expect(getByText('Ledger')).toBeOnTheScreen();
+    });
+
+    it('should not render account type badge when showAccountTypeBadge is not set', () => {
+        const { getByText, queryByText } = renderAccountLabel({ account: ethLedgerAccount });
+
+        expect(getByText('ETH Ledger Account')).toBeOnTheScreen();
+        expect(queryByText('Ledger')).not.toBeOnTheScreen();
     });
 });

--- a/suite-native/accounts/src/components/__tests__/AccountTypeBadge.test.tsx
+++ b/suite-native/accounts/src/components/__tests__/AccountTypeBadge.test.tsx
@@ -1,0 +1,51 @@
+import { type AccountKey, asAccountDescriptor } from '@suite-common/wallet-types';
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+import { renderWithStoreProvider } from '@suite-native/test-utils-store';
+import type { StaticSessionId } from '@trezor/connect';
+
+import { AccountTypeBadge } from '../AccountTypeBadge';
+
+const MOCK_ACCOUNT_DEVICE_SESSION_ID: StaticSessionId = '1@2:3';
+
+describe('AccountTypeBadge', () => {
+    const ethNormalAccount = mockWalletAccount({
+        symbol: 'eth',
+        deviceState: MOCK_ACCOUNT_DEVICE_SESSION_ID,
+        accountType: 'normal',
+        descriptor: asAccountDescriptor('eth1-normal'),
+        visible: true,
+    });
+
+    const ethLedgerAccount = mockWalletAccount({
+        symbol: 'eth',
+        deviceState: MOCK_ACCOUNT_DEVICE_SESSION_ID,
+        accountType: 'ledger',
+        descriptor: asAccountDescriptor('eth1-ledger'),
+        visible: true,
+    });
+
+    const accounts = [ethNormalAccount, ethLedgerAccount];
+
+    const renderAccountTypeBadge = (accountKey: AccountKey) =>
+        renderWithStoreProvider(<AccountTypeBadge accountKey={accountKey} />, {
+            preloadedState: { wallet: { accounts } },
+        });
+
+    it('should render the formatted account type', () => {
+        const { getByText } = renderAccountTypeBadge(ethLedgerAccount.key);
+
+        expect(getByText('Ledger')).toBeOnTheScreen();
+    });
+
+    it('should render nothing for an account type without a formatted name', () => {
+        const { toJSON } = renderAccountTypeBadge(ethNormalAccount.key);
+
+        expect(toJSON()).toBeNull();
+    });
+
+    it('should render nothing for an unknown account key', () => {
+        const { toJSON } = renderAccountTypeBadge('unknown-eth-1@2:3' as AccountKey);
+
+        expect(toJSON()).toBeNull();
+    });
+});

--- a/suite-native/accounts/src/index.ts
+++ b/suite-native/accounts/src/index.ts
@@ -1,6 +1,7 @@
 export * from './components/AddAccountsButton';
 export * from './components/AccountSelectBottomSheet';
 export * from './components/AccountLabel';
+export * from './components/AccountTypeBadge';
 export * from './components/AccountsList/AccountsList';
 export * from './components/AccountsList/AccountsListItem';
 export * from './components/AccountsList/AccountsListItemBase';

--- a/suite-native/module-earn/src/components/EarnAccountCard.tsx
+++ b/suite-native/module-earn/src/components/EarnAccountCard.tsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import { selectIsPortfolioTrackerDevice } from '@suite-common/device';
 import { getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
 import { isSupportedEthStakingNetworkSymbol } from '@suite-common/wallet-utils';
+import { AccountTypeBadge } from '@suite-native/accounts';
 import { Box, Card, PressableOpacity, Text, VStack } from '@suite-native/atoms';
 import { CryptoIconWithNetwork, Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
@@ -110,6 +111,7 @@ export const EarnAccountCard = ({ item, onPress, onClaimPress }: EarnAccountCard
                             {secondaryDescription}
                         </Text>
                     )}
+                    <AccountTypeBadge accountKey={item.accountKey} alignSelf="flex-start" />
                 </VStack>
 
                 <VStack spacing="sp2" style={applyStyle(valuesStyle)}>

--- a/suite-native/module-earn/src/components/StakingDetailScreenHeader.tsx
+++ b/suite-native/module-earn/src/components/StakingDetailScreenHeader.tsx
@@ -45,13 +45,14 @@ export const StakingDetailScreenHeader = () => {
                             <Translation id="earn.stakingDetailScreen.title" />
                         </Text>
                     </HStack>
-                    <Text variant="body-sm" color="contentSecondary">
-                        <AccountLabel
-                            accountDescriptor={accountDescriptor}
-                            networkSymbol={networkSymbol}
-                            deviceStaticSessionId={deviceStaticSessionId}
-                        />
-                    </Text>
+                    <AccountLabel
+                        accountDescriptor={accountDescriptor}
+                        networkSymbol={networkSymbol}
+                        deviceStaticSessionId={deviceStaticSessionId}
+                        variant="body-sm"
+                        color="contentSecondary"
+                        showAccountTypeBadge
+                    />
                 </>
             }
             closeActionType="back"

--- a/suite-native/module-earn/src/components/StakingManagementScreenHeader.tsx
+++ b/suite-native/module-earn/src/components/StakingManagementScreenHeader.tsx
@@ -38,15 +38,16 @@ export const StakingManagementScreenHeader = () => {
                         <Text variant="body-md-strong" ellipsizeMode="tail" numberOfLines={1}>
                             <Translation id="earn.stakingDetailScreen.title" />
                         </Text>
-                        <Text variant="body-sm" numberOfLines={1} ellipsizeMode="tail">
-                            <AccountLabel
-                                accountDescriptor={accountDescriptor}
-                                networkSymbol={networkSymbol}
-                                deviceStaticSessionId={deviceStaticSessionId}
-                                color="contentSecondary"
-                                variant="body-sm"
-                            />
-                        </Text>
+                        <AccountLabel
+                            accountDescriptor={accountDescriptor}
+                            networkSymbol={networkSymbol}
+                            deviceStaticSessionId={deviceStaticSessionId}
+                            color="contentSecondary"
+                            variant="body-sm"
+                            numberOfLines={1}
+                            ellipsizeMode="tail"
+                            showAccountTypeBadge
+                        />
                     </Box>
                 </HStack>
             }


### PR DESCRIPTION
## Description

Added the formatted account type badge beside the account label on staking detail and management headers. Matched earn staking headers with earn account cards for account-type visibility.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27616
