### PR TITLE
test(e2e-suite): stabilize label tests by hiding notification banners

### DIFF
--- a/packages/product-components/src/components/SidebarBanner/SidebarBanner.tsx
+++ b/packages/product-components/src/components/SidebarBanner/SidebarBanner.tsx
@@ -103,6 +103,7 @@ export const SidebarBanner = ({
                             intent="neutral"
                             priority="secondary"
                             type="button"
+                            data-testid={`${dataTestId}/close-button`}
                             onClick={onClose}
                             size="small"
                         >

--- a/suite/e2e/support/pageObjects/metadata/metadataPage.ts
+++ b/suite/e2e/support/pageObjects/metadata/metadataPage.ts
@@ -24,6 +24,10 @@ export class MetadataPage {
     readonly suiteSyncBannerButton: Locator;
     readonly metadataProviderButton = (provider: MetadataProvider) =>
         this.page.getByTestId(`@modal/metadata-provider/${provider}-button`);
+    readonly legacyNotification: Locator;
+    readonly closeLegacyNotificationButton: Locator;
+    readonly suiteSyncNotification: Locator;
+    readonly closeSuiteSyncNotificationButton: Locator;
 
     constructor(
         private readonly page: Page,
@@ -40,6 +44,14 @@ export class MetadataPage {
         this.copyAddressButton = page.getByTestId('@metadata/copy-address-button');
         this.suiteSyncBanner = page.getByTestId('@notification/suite-sync-keys');
         this.suiteSyncBannerButton = page.getByTestId('@notification/suite-sync-keys/button');
+        this.legacyNotification = this.page.getByTestId('@notification/legacy-labeling-upgrade');
+        this.closeLegacyNotificationButton = this.page.getByTestId(
+            '@notification/legacy-labeling-upgrade/close-button',
+        );
+        this.suiteSyncNotification = this.page.getByTestId('@notification/feedback-banner');
+        this.closeSuiteSyncNotificationButton = this.page.getByTestId(
+            '@notification/feedback-banner/close-button',
+        );
     }
 
     @step()
@@ -83,6 +95,13 @@ export class MetadataPage {
             this.settingsPage.metadataSelectInputOption('legacy'),
         );
         await this.passThroughInitMetadata(provider);
+        await this.closeLegacyUpgradeNotification();
+    }
+
+    @step()
+    async closeLegacyUpgradeNotification() {
+        await expect(this.legacyNotification).toBeVisible();
+        await this.closeLegacyNotificationButton.click();
     }
 
     @step()

--- a/suite/e2e/tests/metadata/legacy/dropbox-api-errors.test.ts
+++ b/suite/e2e/tests/metadata/legacy/dropbox-api-errors.test.ts
@@ -36,6 +36,7 @@ test.describe('Dropbox API errors', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () 
             );
 
             await metadataPage.passThroughInitMetadata(MetadataProvider.DROPBOX);
+            await metadataPage.closeLegacyUpgradeNotification();
 
             await walletPage.openAccount();
 
@@ -163,6 +164,7 @@ test.describe('Dropbox API errors', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () 
             );
 
             await metadataPage.passThroughInitMetadata(MetadataProvider.DROPBOX);
+            await metadataPage.closeLegacyUpgradeNotification();
 
             await walletPage.openAccount();
             // just enter some label, this indicates that app did not crash

--- a/suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts
@@ -66,6 +66,11 @@ test.describe('Suite Sync - Labelling', { tag: ['@T3W1', '@T3T1'] }, () => {
                 .toHaveText(expectedAddress.label);
         });
 
+        await test.step('Close Suite Sync feedback notification', async () => {
+            await expect(metadataPage.suiteSyncNotification).toBeVisible();
+            await metadataPage.closeSuiteSyncNotificationButton.click();
+        });
+
         await test.step('Change output label', async () => {
             await walletPage.openAccount({ symbol: 'btc', type: 'normal', atIndex: 0 });
             await metadataPage.output.changeLabel({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies three files: a Suite Sync create-new-labels test, the metadataPage page object used across all metadata/labeling tests, and a SidebarBanner UI component. The metadataPage change carries the highest risk as it's a shared page object used by all 14+ metadata tests (both legacy and suite-sync). The test file change itself needs validation. The SidebarBanner component has no direct E2E test coverage. The recommended strategy focuses on running all Suite Sync tests at high priority (since both the page object and test were changed) and all legacy metadata tests at medium priority (since they share the modified page object).

<details><summary><b>Changed files (3)</b></summary>

- `packages/product-components/src/components/SidebarBanner/SidebarBanner.tsx`
- `suite/e2e/support/pageObjects/metadata/metadataPage.ts`
- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts`

</details>

**Recommended tests (15)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `../../suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — This test file itself was directly changed, so it must be run to verify the test modifications are correct and passing. It also exercises metadataPage which was also changed.
- `../../suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts` — This test directly uses metadataPage page object (enableSuiteSync, account.removeLabel, wallet.removeLabel, address.removeLabel, output.removeLabel) which was changed. Any modifications to metadataPage could break label removal flows.
- `../../suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — This test uses metadataPage extensively (setupQuotaManager, initiateSuiteSyncSetup, wallet.walletLabel, address.label, output.outputLabel) for Suite Sync label syncing. Changes to metadataPage could break these interactions.
- `../../suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — This test relies on metadataPage for enabling Suite Sync and managing labels across multiple passphrase wallets. Changes to metadataPage methods directly impact this test's flows.

</details>

<details><summary>🟡 <b>Medium priority (11)</b></summary>

- `../../suite/e2e/tests/metadata/legacy/account-metadata.test.ts` — Uses metadataPage page object extensively for account label editing (clickEditLabelButton, metadataInput, changeLabel, successIconIsVisible, enableLegacyLabeling). Changes to metadataPage could affect legacy labeling flows.
- `../../suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — Uses metadataPage for output label editing and submission workflows. Changes to metadataPage output-related methods could break output labeling and CSV export assertions.
- `../../suite/e2e/tests/metadata/legacy/metadata-lifecycle.test.ts` — Uses metadataPage for enabling/disabling legacy labeling and adding labels to accounts. The metadata lifecycle flow depends on metadataPage methods for provider management.
- `../../suite/e2e/tests/metadata/legacy/remembered-device.test.ts` — Uses metadataPage for legacy labeling enable/disable and provider selection modal interactions. Changes to metadataPage could affect remembered device label persistence flows.
- `../../suite/e2e/tests/metadata/legacy/wallet-metadata.test.ts` — Uses metadataPage wallet label editing methods (wallet.clickEditLabel, wallet.fillLabelInput, wallet.successIconIsVisible, wallet.walletLabel). Changes to metadataPage wallet sub-object could break this test.
- `../../suite/e2e/tests/metadata/legacy/address-metadata.test.ts` — Uses metadataPage for address label editing and Google metadata provider enablement. Changes to metadataPage address-related methods could break address labeling assertions.
- `../../suite/e2e/tests/metadata/legacy/switching-providers.test.ts` — Uses metadataPage for enabling legacy labeling and editing account labels when switching between Dropbox and Google providers. Changes to metadataPage could affect provider switching flows.
- `../../suite/e2e/tests/metadata/legacy/dropbox-api-errors.test.ts` — Uses metadataPage for metadata initialization and account label editing in error scenarios. Changes to metadataPage could affect error handling label interactions.
- `../../suite/e2e/tests/metadata/legacy/interval-fetching.test.ts` — Uses metadataPage.enableLegacyLabeling to set up metadata provider before verifying interval-based label fetching. Changes to metadataPage enablement methods could break this.
- `../../suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts` — Uses metadataPage for both legacy Dropbox labeling enablement and Suite Sync migration verification. Changes to metadataPage affect the migration test path directly.
- `../../suite/e2e/tests/metadata/legacy/google-api-errors.test.ts` — Uses metadataPage for Google metadata provider initialization. Changes to metadataPage could affect provider connection error handling flows.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/product-components/src/components/SidebarBanner/SidebarBanner.tsx`

_Updated: 2026-05-25T14:13:06.738Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-fixes-5-25&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-fixes-5-25&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 15 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Dropbox API errors > Incomplete data returned from provider | 🤖 auto |
| Metadata - switching between cloud providers > Start with one and switch to another | 🤖 auto |
| Metadata - address labeling > google provider | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Remembered device > google provider | 🤖 auto |
| Dropbox API errors > Malformed token | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Account metadata > google - watches files over time | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-25T14:18:44.229Z • 15 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-25T14:16:06.692Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test-fixes-5-25/web/](https://dev.suite.sldev.cz/suite-web/test-fixes-5-25/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->