### PR TITLE
fix(suite): prevent stake and trading layouts from stretching on huge fiat amounts

### DIFF
--- a/packages/product-components/src/components/InputWithOptions/InputWithOptions.tsx
+++ b/packages/product-components/src/components/InputWithOptions/InputWithOptions.tsx
@@ -10,7 +10,6 @@ import {
     Row,
     TextButton,
 } from '@trezor/components';
-import { spacings } from '@trezor/theme';
 
 import { NumberInput, type NumberInputProps } from '../NumberInput/NumberInput';
 
@@ -83,10 +82,10 @@ export const InputWithOptions = <TFieldValues extends FieldValues>({
 
     return (
         <InputWithOptionsContainer>
-            <Column gap={spacings.xs}>
+            <Column gap={8}>
                 {numberInputs}
-                <Row justifyContent="space-between">
-                    <Row gap={spacings.xs} data-testid={`${dataTest}/fraction-buttons`}>
+                <Row justifyContent="space-between" gap={12}>
+                    <Row gap={8} data-testid={`${dataTest}/fraction-buttons`}>
                         {options.map(button => (
                             <FractionButton key={button.id} {...button} />
                         ))}

--- a/packages/suite/src/components/earn/modals/StakeModal/StakeForm/StakeInputs.tsx
+++ b/packages/suite/src/components/earn/modals/StakeModal/StakeForm/StakeInputs.tsx
@@ -217,6 +217,7 @@ export const StakeInputs = () => {
                                     typographyStyle="body-xs"
                                     intent="neutral"
                                     priority="secondary"
+                                    overflowWrap="anywhere"
                                 >
                                     {value}
                                 </Text>

--- a/packages/suite/src/components/earn/modals/StakeModal/StakeModal.tsx
+++ b/packages/suite/src/components/earn/modals/StakeModal/StakeModal.tsx
@@ -61,7 +61,7 @@ export const StakeModal = ({ onCancel, account, flow }: StakeModalProps) => {
                 onCancel={onCancelClick}
                 bottomContent={<StakeButton flow={flow} />}
             >
-                <Grid columns={isBelowTablet ? 1 : 2} gap={32}>
+                <Grid columns={isBelowTablet ? 1 : 2} gap={32} forceEqualColumns>
                     <StakeForm flow={flow} />
                     <StakeInfoCards account={account} flow={flow} />
                 </Grid>

--- a/packages/suite/src/components/earn/modals/UnstakeModal/UnstakeForm/UnstakeInputs.tsx
+++ b/packages/suite/src/components/earn/modals/UnstakeModal/UnstakeForm/UnstakeInputs.tsx
@@ -152,6 +152,7 @@ export const UnstakeInputs = () => {
                                     typographyStyle="body-xs"
                                     intent="neutral"
                                     priority="secondary"
+                                    overflowWrap="anywhere"
                                 >
                                     {value}
                                 </Text>

--- a/packages/suite/src/components/earn/modals/UnstakeModal/UnstakeModal.tsx
+++ b/packages/suite/src/components/earn/modals/UnstakeModal/UnstakeModal.tsx
@@ -56,7 +56,7 @@ export const UnstakeModal = ({ onCancel, account }: UnstakeModalProps) => {
                 onCancel={onCancelClick}
                 bottomContent={<UnstakeButton />}
             >
-                <Grid columns={isBelowTablet ? 1 : 2} gap={32}>
+                <Grid columns={isBelowTablet ? 1 : 2} gap={32} forceEqualColumns>
                     <UnstakeForm />
                     <Column gap={20}>
                         <CollapsibleBox

--- a/packages/suite/src/views/wallet/trading/common/TradingBalance.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingBalance.tsx
@@ -48,7 +48,12 @@ export const TradingBalance = ({
         if (Number(balance) === 0 || isNaN(Number(balance))) return null;
 
         return (
-            <Text intent="neutral" priority="secondary" typographyStyle="body-xs">
+            <Text
+                intent="neutral"
+                priority="secondary"
+                typographyStyle="body-xs"
+                overflowWrap="anywhere"
+            >
                 {!amountInCrypto ? (
                     <HiddenPlaceholder>
                         &asymp; {formattedBalance} {balanceCurrency}

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
@@ -143,7 +143,7 @@ export const TradingExchangeFormInputs = () => {
                             cryptoCurrencyLabel={sendCryptoSelect?.id}
                         />
                         {amountInCrypto && (
-                            <Row justifyContent="space-between" alignItems="flex-start">
+                            <Row justifyContent="space-between" alignItems="center" gap={8}>
                                 <TradingFractionButtons />
                                 <TradingBalance
                                     balance={outputAmount}

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormLayout.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormLayout.tsx
@@ -32,7 +32,9 @@ export const TradingFormLayout = ({ children }: TradingFormLayoutProps) => {
             <form onSubmit={e => e.preventDefault()}>
                 <ReceiveAddressModalControlsProvider>
                     <ContentFlex gap={16} breakpoint={breakpoints.tablet} alignItems="stretch">
-                        <Box flex="2">{children}</Box>
+                        <Box flex="2" minWidth={0}>
+                            {children}
+                        </Box>
                         <Card flex="1">
                             <TradingFormOffer />
                         </Card>

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingSellFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingSellFormInputs.tsx
@@ -108,7 +108,7 @@ export const TradingSellFormInputs = () => {
                             cryptoCurrencyLabel={sendCryptoSelect?.id}
                         />
                         {amountInCrypto && (
-                            <Row justifyContent="space-between" alignItems="flex-start">
+                            <Row justifyContent="space-between" alignItems="center" gap={8}>
                                 <TradingFractionButtons />
                                 <TradingBalance
                                     balance={outputAmount}


### PR DESCRIPTION
## Description

Big crypto amounts produce an unbreakable fiat approximation that stretches the Stake / Unstake modal columns and the Trading (Swap / Sell) form panel.

Two-part fix:

1. Lock the containers so the inner content can't push them wider.
2. Long fiat amount is divided by a line break.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26585

## Screenshots:

<img width="1062" height="628" alt="image" src="https://github.com/user-attachments/assets/c705f302-c5be-432c-a56f-108c2a09e4dc" />

<img width="1216" height="638" alt="image" src="https://github.com/user-attachments/assets/c66fab3c-189d-4513-8b71-b11607e62bae" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/fiat-amount-truncate&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/fiat-amount-truncate&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-09T09:23:01.074Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add account types ada | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-09T09:21:09.835Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/fiat-amount-truncate/web/](https://dev.suite.sldev.cz/suite-web/fix/fiat-amount-truncate/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->