### PR TITLE
chore(common): remove unwanted peer dep

### DIFF
--- a/suite-common/connect-popup/package.json
+++ b/suite-common/connect-popup/package.json
@@ -26,14 +26,6 @@
         "react": "19.2.4",
         "react-redux": "9.2.0"
     },
-    "peerDependencies": {
-        "@trezor/suite-desktop-api": "workspace:*"
-    },
-    "peerDependenciesMeta": {
-        "@trezor/suite-desktop-api": {
-            "optional": true
-        }
-    },
     "devDependencies": {
         "@types/react": "19.2.14"
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10307,11 +10307,6 @@ __metadata:
     "@types/react": "npm:19.2.14"
     react: "npm:19.2.4"
     react-redux: "npm:9.2.0"
-  peerDependencies:
-    "@trezor/suite-desktop-api": "workspace:*"
-  peerDependenciesMeta:
-    "@trezor/suite-desktop-api":
-      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Removed unwanted dep. 

Not testable, should fix Native build.

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is limited to suite-common/connect-popup/package.json, which likely involves a dependency version bump or metadata change. The connect-popup package provides the TrezorConnect permissions modal, address confirmation UI, error display, and popup lifecycle management. Since this is a package.json change (not source code), the risk is moderate — it could introduce breaking changes through dependency updates. The recommended strategy focuses on the trezor-connect test suite, which directly exercises the connect-popup functionality, with highest priority on tests that deeply interact with the permissions modal and popup state management.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/connect-popup/package.json`

</details>

**Recommended tests (8)**

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `../../suite/e2e/tests/trezor-connect/permissions.test.ts` — The connect-popup package directly implements the permissions modal and permission management logic used by TrezorConnect. Changes to its package.json (e.g., dependency version bumps) could affect the permissions modal rendering, remember/forget flow, and silent mode behavior. This test directly exercises connectPopup Redux state and the permissions modal component.
- `../../suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test exercises the full TrezorConnect popup flow including the permissions modal, address confirmation, and popup lifecycle management — all of which are implemented in or depend on the connect-popup package. A dependency change could break modal rendering or popup communication.
- `../../suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — Similar to the web popup test, this exercises the connect-popup permissions modal and address confirmation flows in a webextension context. The connect-popup package is central to this test's functionality.
- `../../suite/e2e/tests/trezor-connect/silentMode.test.ts` — This test directly exercises the connectPopup Redux slice (connectPopup.permissions state) and the silent mode checkbox within the permissions modal — both are part of the connect-popup package. Changes to dependencies could affect this behavior.

</details>

<details><summary>🟢 <b>Low priority (4)</b></summary>

- `../../suite/e2e/tests/trezor-connect/getAddress.test.ts` — This test uses the connect permissions modal (from connect-popup) and address confirmation UI. While less directly tied to the package internals than the permissions test, dependency changes could still affect the modal and confirmation components.
- `../../suite/e2e/tests/trezor-connect/error.test.ts` — This test verifies the connect-popup error display component (@connect-popup-error/message), which is implemented in the connect-popup package. A dependency change could affect error rendering.
- `../../suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts` — This test uses the connectPermissionsModal from the connect-popup package during the Ethereum sign message flow. Dependency changes could affect the modal confirmation step.
- `../../suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — This test exercises the connect permissions modal (confirmButton text assertion) which is part of the connect-popup package. A dependency change could affect the modal UI.

</details>

_Updated: 2026-05-25T15:02:53.683Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/remove-unwanted-peer-dep&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/remove-unwanted-peer-dep&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/remove-unwanted-peer-dep&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 16 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox - watches files over time | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Dropbox API errors > Incomplete data returned from provider | 🤖 auto |
| Metadata - switching between cloud providers > Start with one and switch to another | 🤖 auto |
| Metadata - address labeling > google provider | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Remembered device > google provider | 🤖 auto |
| Dropbox API errors > Malformed token | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Account metadata > google - watches files over time | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-25T19:40:43.735Z • 16 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-25T15:09:08.249Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/remove-unwanted-peer-dep/web/](https://dev.suite.sldev.cz/suite-web/chore/remove-unwanted-peer-dep/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->