### PR TITLE
test(bot): extract Zod schemas and improve analyze bot logging

### DIFF
--- a/packages/e2e-utils/package.json
+++ b/packages/e2e-utils/package.json
@@ -24,7 +24,8 @@
         "@trezor/utils": "workspace:*",
         "dotenv": "17.2.3",
         "express": "^5.2.1",
-        "ws": "^8.20.0"
+        "ws": "^8.20.0",
+        "zod": "4.3.6"
     },
     "devDependencies": {
         "@anthropic-ai/claude-code": "^2.1.89",

--- a/packages/e2e-utils/src/fixBot/analyze.ts
+++ b/packages/e2e-utils/src/fixBot/analyze.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { error, log } from '../logger';
-import { reportTokenUsage } from './reportTokenUsage';
+import { logAgentResult, reportTokenUsage } from './reportTokenUsage';
 
 function main(): void {
     const root = execFileSync('git', ['rev-parse', '--show-toplevel'], {
@@ -38,8 +38,8 @@ function main(): void {
     const result = spawnSync(
         join(root, 'node_modules/.bin/claude'),
         [
-            '--verbose',
             '--print',
+            '--verbose',
             '--output-format',
             'json',
             '--settings',
@@ -70,6 +70,7 @@ function main(): void {
     const reportJson = join(reportDir, `${date}.json`);
 
     reportTokenUsage(claudeOutput, join(reportDir, 'token_usage.txt'), 'analysis');
+    logAgentResult(claudeOutput, 'analysis');
 
     const missing = [reportMd, reportJson].filter(f => !existsSync(f));
 

--- a/packages/e2e-utils/src/fixBot/reportTokenUsage.ts
+++ b/packages/e2e-utils/src/fixBot/reportTokenUsage.ts
@@ -2,32 +2,24 @@
 // when implementation gets to GHA stage
 import { appendFileSync } from 'node:fs';
 
-interface ClaudeUsage {
-    input_tokens?: number;
-    output_tokens?: number;
-    cache_creation_input_tokens?: number;
-    cache_read_input_tokens?: number;
-}
-
-interface ClaudeResult {
-    type?: string;
-    num_turns?: number;
-    usage?: ClaudeUsage;
-    total_cost_usd?: number;
-    duration_ms?: number;
-}
+import { type ClaudeResult, ClaudeResultSchema } from './schemas';
 
 function parseClaudeOutput(raw: string): ClaudeResult {
-    const parsed: unknown = JSON.parse(raw.trim());
-    if (Array.isArray(parsed)) {
-        return (parsed as ClaudeResult[]).find(entry => entry.type === 'result') ?? {};
+    const unsafeParsed: unknown = JSON.parse(raw.trim());
+    const entries = Array.isArray(unsafeParsed) ? unsafeParsed : [unsafeParsed];
+    const resultEntry = entries
+        .map(entry => ClaudeResultSchema.safeParse(entry))
+        .find(parsed => parsed.success && parsed.data.type === 'result');
+
+    if (!resultEntry?.success) {
+        throw new Error('No result entry found in Claude output');
     }
 
-    return parsed as ClaudeResult;
+    return resultEntry.data;
 }
 
 function formatIntegerWithCommas(value: number): string {
-    return value.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+    return new Intl.NumberFormat('en-US').format(value);
 }
 
 function formatTimestamp(date: Date): string {
@@ -40,12 +32,36 @@ function formatTimestamp(date: Date): string {
     return `${year}-${month}-${day} ${hours}:${minutes}Z`;
 }
 
+export function logAgentResult(rawOutput: string, agentName: string): void {
+    let entry: ClaudeResult = {};
+    try {
+        entry = parseClaudeOutput(rawOutput);
+    } catch {
+        process.stderr.write(
+            `[${agentName}] agent output unparsable (${rawOutput.length} bytes)\n`,
+        );
+
+        return;
+    }
+
+    const subtype = entry.subtype ?? '?';
+    const text = entry.result ?? '';
+    const preview = text.length > 800 ? `${text.slice(0, 800)}…` : text;
+
+    process.stderr.write(`[${agentName}] subtype=${subtype}\n`);
+    if (preview) process.stderr.write(`${preview}\n`);
+}
+
 export function reportTokenUsage(rawOutput: string, logFilePath: string, agentName: string): void {
     let result: ClaudeResult = {};
     try {
         result = parseClaudeOutput(rawOutput);
     } catch {
-        // malformed — fall through with empty result (zeroed/blank line)
+        process.stderr.write(
+            `[${agentName}] agent output unparsable (${rawOutput.length} bytes)\n`,
+        );
+
+        return;
     }
 
     const timestamp = formatTimestamp(new Date());
@@ -54,22 +70,24 @@ export function reportTokenUsage(rawOutput: string, logFilePath: string, agentNa
     const turnsField = result.num_turns != null ? String(result.num_turns).padStart(3) : 'N/A';
 
     const formatTokenCount = (tokenCount: number | undefined) =>
-        formatIntegerWithCommas(tokenCount ?? 0).padStart(9);
+        tokenCount != null ? formatIntegerWithCommas(tokenCount).padStart(9) : 'N/A'.padStart(9);
 
     const inputTokens = formatTokenCount(result.usage?.input_tokens);
     const outputTokens = formatTokenCount(result.usage?.output_tokens);
     const cacheWriteTokens = formatTokenCount(result.usage?.cache_creation_input_tokens);
     const cacheReadTokens = formatTokenCount(result.usage?.cache_read_input_tokens);
 
+    const COST_FIELD_WIDTH = 9; // '$' + 8-char number
     const costField =
         result.total_cost_usd != null
             ? `$${result.total_cost_usd.toFixed(4).padStart(8)}`
-            : '         ';
+            : 'N/A'.padStart(COST_FIELD_WIDTH);
 
+    const DURATION_FIELD_WIDTH = 6; // 5-char number + 's'
     const durationField =
         result.duration_ms != null
             ? `${String(Math.round(result.duration_ms / 1000)).padStart(5)}s`
-            : '      ';
+            : 'N/A'.padStart(DURATION_FIELD_WIDTH);
 
     const line = `${timestamp}  ${paddedAgentName}  turns=${turnsField}  in=${inputTokens}  out=${outputTokens}  cache_w=${cacheWriteTokens}  cache_r=${cacheReadTokens}  ${costField}  ${durationField}`;
 

--- a/packages/e2e-utils/src/fixBot/schemas.ts
+++ b/packages/e2e-utils/src/fixBot/schemas.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+
+export const TestToValidateSchema = z.object({
+    platform: z.enum(['web', 'desktop']),
+    group: z.string(),
+    spec: z.string(),
+});
+
+export const FixTaskSchema = z.object({
+    id: z.string(),
+    branch: z.string(),
+    root_cause: z.string(),
+    fix_scope: z.enum(['TEST_CODE', 'LOCATOR_ADD', 'PRODUCT_BUG', 'INFRA']),
+    confidence: z.enum(['HIGH', 'MEDIUM', 'LOW']),
+    fix_description: z.string(),
+    diagnosis: z.string(),
+    validations: z.array(TestToValidateSchema),
+});
+
+export const ReportSchema = z.object({
+    fix_tasks: z.array(FixTaskSchema),
+});
+
+export const FixResultSchema = z.object({
+    task_id: z.string(),
+    result: z.enum(['pass', 'partial', 'fail']),
+    passed: z.array(z.string()),
+    failed: z.array(z.string()),
+    iterations: z.number().int().nonnegative(),
+    pr_title: z.string(),
+});
+
+export const ClaudeUsageSchema = z.object({
+    input_tokens: z.number().optional(),
+    output_tokens: z.number().optional(),
+    cache_creation_input_tokens: z.number().optional(),
+    cache_read_input_tokens: z.number().optional(),
+});
+
+export const ClaudeResultSchema = z.object({
+    type: z.string().optional(),
+    subtype: z.string().optional(),
+    result: z.string().optional(),
+    num_turns: z.number().optional(),
+    usage: ClaudeUsageSchema.optional(),
+    total_cost_usd: z.number().optional(),
+    duration_ms: z.number().optional(),
+});
+
+export type FixTask = z.infer<typeof FixTaskSchema>;
+export type Report = z.infer<typeof ReportSchema>;
+export type FixResult = z.infer<typeof FixResultSchema>;
+export type ClaudeResult = z.infer<typeof ClaudeResultSchema>;

--- a/packages/e2e-utils/src/fixBot/settings.json
+++ b/packages/e2e-utils/src/fixBot/settings.json
@@ -1,4 +1,5 @@
 {
+    "model": "claude-sonnet-4-6",
     "permissions": {
         "defaultMode": "auto"
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15565,6 +15565,7 @@ __metadata:
     express: "npm:^5.2.1"
     tsx: "npm:^4.21.0"
     ws: "npm:^8.20.0"
+    zod: "npm:4.3.6"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION


<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are all within `packages/e2e-utils/src/fixBot/` — a developer tooling module for analyzing and reporting on test fixes (schemas, settings, token usage reporting, analysis logic). These are internal CI/dev infrastructure files that are not part of the application runtime or test execution paths. None of the 120 candidate E2E tests reference or depend on the fixBot module in their behaviors, entry points, or source hints. There is no static coverage mapping linking any tests to these files. The risk of user-facing regression is negligible, and no E2E tests need to be run for this change.

<details><summary><b>Changed files (5)</b></summary>

- `packages/e2e-utils/package.json`
- `packages/e2e-utils/src/fixBot/analyze.ts`
- `packages/e2e-utils/src/fixBot/reportTokenUsage.ts`
- `packages/e2e-utils/src/fixBot/schemas.ts`
- `packages/e2e-utils/src/fixBot/settings.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (5)**
- `packages/e2e-utils/package.json`
- `packages/e2e-utils/src/fixBot/analyze.ts`
- `packages/e2e-utils/src/fixBot/reportTokenUsage.ts`
- `packages/e2e-utils/src/fixBot/schemas.ts`
- `packages/e2e-utils/src/fixBot/settings.json`

_Updated: 2026-05-25T15:35:29.916Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=nightl-agent-fixer-3&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-25T15:39:41.617Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/nightl-agent-fixer-3/web/](https://dev.suite.sldev.cz/suite-web/nightl-agent-fixer-3/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->