### PR TITLE
refactor(suite): Mandatory tooltips in icon button

### DIFF
--- a/packages/analytics-docs/src/App.tsx
+++ b/packages/analytics-docs/src/App.tsx
@@ -13,7 +13,6 @@ import {
     ResizableBox,
     Row,
     Spinner,
-    Tooltip,
     useMediaQuery,
     variables,
 } from '@trezor/components';
@@ -271,63 +270,58 @@ export const App = ({ theme }: AppProps) => {
                                     {(isFiltering || isSidebarLoading) && <Spinner size={20} />}
                                 </Row>
                                 <Row gap={8} alignItems="center">
-                                    <Tooltip isActive={isMobile} content="Add event">
-                                        {isMobile ? (
-                                            <IconButton icon="plus" {...addButtonProps} />
-                                        ) : (
-                                            <Button iconLeft="plus" {...addButtonProps}>
-                                                Add event
-                                            </Button>
-                                        )}
-                                    </Tooltip>
+                                    {isMobile ? (
+                                        <IconButton
+                                            tooltip={{ content: 'Add event' }}
+                                            icon="plus"
+                                            {...addButtonProps}
+                                        />
+                                    ) : (
+                                        <Button iconLeft="plus" {...addButtonProps}>
+                                            Add event
+                                        </Button>
+                                    )}
                                     <ThemeSwitch />
                                     <ButtonGroup intent="neutral" priority="secondary" size="small">
-                                        <Tooltip
-                                            content={
-                                                isLiveLogOpen
+                                        <IconButton
+                                            tooltip={{
+                                                content: isLiveLogOpen
                                                     ? 'Hide live log'
-                                                    : 'Show live analytics log'
-                                            }
-                                        >
-                                            <IconButton
-                                                icon="broadcast"
-                                                onClick={() => {
-                                                    startTransition(() => {
-                                                        const next = !isLiveLogOpen;
-                                                        setIsLiveLogOpen(next);
-                                                        if (next) setIsSidebarOpen(false);
-                                                    });
-                                                }}
-                                                intent={isLiveLogOpen ? 'brand' : 'neutral'}
-                                                priority={isLiveLogOpen ? 'primary' : 'secondary'}
-                                            />
-                                        </Tooltip>
-                                        <Tooltip
-                                            content={
-                                                isSidebarOpen
+                                                    : 'Show live analytics log',
+                                            }}
+                                            icon="broadcast"
+                                            onClick={() => {
+                                                startTransition(() => {
+                                                    const next = !isLiveLogOpen;
+                                                    setIsLiveLogOpen(next);
+                                                    if (next) setIsSidebarOpen(false);
+                                                });
+                                            }}
+                                            intent={isLiveLogOpen ? 'brand' : 'neutral'}
+                                            priority={isLiveLogOpen ? 'primary' : 'secondary'}
+                                        />
+
+                                        <IconButton
+                                            tooltip={{
+                                                content: isSidebarOpen
                                                     ? 'Hide changelog'
-                                                    : 'Show versions by changelog'
-                                            }
-                                        >
-                                            <IconButton
-                                                icon="clockCounterClockwise"
-                                                onClick={() => {
-                                                    setIsSidebarLoading(true);
-                                                    if (isSidebarOpen) {
-                                                        startTransition(() =>
-                                                            setIsSidebarOpen(false),
-                                                        );
-                                                    } else {
-                                                        startTransition(() => {
-                                                            setIsLiveLogOpen(false);
-                                                            setIsSidebarOpen(true);
-                                                        });
-                                                    }
-                                                }}
-                                                intent={isSidebarOpen ? 'brand' : 'neutral'}
-                                                priority={isSidebarOpen ? 'primary' : 'secondary'}
-                                            />
-                                        </Tooltip>
+                                                    : 'Show versions by changelog',
+                                            }}
+                                            icon="clockCounterClockwise"
+                                            onClick={() => {
+                                                setIsSidebarLoading(true);
+                                                if (isSidebarOpen) {
+                                                    startTransition(() => setIsSidebarOpen(false));
+                                                } else {
+                                                    startTransition(() => {
+                                                        setIsLiveLogOpen(false);
+                                                        setIsSidebarOpen(true);
+                                                    });
+                                                }
+                                            }}
+                                            intent={isSidebarOpen ? 'brand' : 'neutral'}
+                                            priority={isSidebarOpen ? 'primary' : 'secondary'}
+                                        />
                                     </ButtonGroup>
                                 </Row>
                             </Row>

--- a/packages/analytics-docs/src/components/AddEventModal/AttributeEditor.tsx
+++ b/packages/analytics-docs/src/components/AddEventModal/AttributeEditor.tsx
@@ -108,19 +108,18 @@ export const AttributeEditor = ({
                     </Checkbox>
                     {canRemove && (
                         <Row flex="1" justifyContent="flex-end">
-                            <Tooltip
-                                content="Delete attribute"
-                                appendTo={document.body}
-                                zIndex={zIndices.windowControls}
-                            >
-                                <IconButton
-                                    icon="trash"
-                                    size="small"
-                                    intent="critical"
-                                    priority="secondary"
-                                    onClick={onRemove}
-                                />
-                            </Tooltip>
+                            <IconButton
+                                icon="trash"
+                                size="small"
+                                intent="critical"
+                                priority="secondary"
+                                onClick={onRemove}
+                                tooltip={{
+                                    content: 'Delete attribute',
+                                    appendTo: document.body,
+                                    zIndex: zIndices.windowControls,
+                                }}
+                            />
                         </Row>
                     )}
                 </Row>

--- a/packages/analytics-docs/src/components/AddEventModal/ChangelogEntriesEditor.tsx
+++ b/packages/analytics-docs/src/components/AddEventModal/ChangelogEntriesEditor.tsx
@@ -56,6 +56,7 @@ export const ChangelogEntriesEditor = ({
                     onClick={() => onChange(entries.filter((_, i) => i !== idx))}
                     aria-label="Remove entry"
                     priority="secondary"
+                    tooltip={{ content: 'Remove entry' }}
                 />
             </Row>
         ))}

--- a/packages/analytics-docs/src/components/LiveLogSidebar.tsx
+++ b/packages/analytics-docs/src/components/LiveLogSidebar.tsx
@@ -20,7 +20,6 @@ import {
     TOOLTIP_DELAY_LONG,
     Table,
     Text,
-    Tooltip,
     variables,
 } from '@trezor/components';
 import { zIndices } from '@trezor/theme';
@@ -156,18 +155,20 @@ const LiveLogEventItem = ({
                         </Row>
                     </Column>
                     {hasPayload && (
-                        <Tooltip content="Find event" delayShow={TOOLTIP_DELAY_LONG}>
-                            <IconButton
-                                icon="magnifyingGlass"
-                                size="small"
-                                intent="neutral"
-                                priority="secondary"
-                                onClick={e => {
-                                    onEventClick(event.type);
-                                    e.stopPropagation();
-                                }}
-                            />
-                        </Tooltip>
+                        <IconButton
+                            icon="magnifyingGlass"
+                            size="small"
+                            intent="neutral"
+                            priority="secondary"
+                            onClick={e => {
+                                onEventClick(event.type);
+                                e.stopPropagation();
+                            }}
+                            tooltip={{
+                                content: 'Find event',
+                                delayShow: TOOLTIP_DELAY_LONG,
+                            }}
+                        />
                     )}
                 </Row>
                 <EventPayload
@@ -277,33 +278,31 @@ export const LiveLogSidebar = ({ onEventClick, filterQuery }: LiveLogSidebarProp
                             <H3 margin={{ bottom: 0 }}>Live log</H3>
                             <Row gap={8}>
                                 {events.length > 0 && (
-                                    <Tooltip content="Clear log">
-                                        <IconButton
-                                            size="small"
-                                            priority="secondary"
-                                            intent="critical"
-                                            onClick={async () => {
-                                                await clear();
-                                                seenEventIdsRef.current.clear();
-                                                for (const timeoutId of timeoutsRef.current.values()) {
-                                                    window.clearTimeout(timeoutId);
-                                                }
-                                                timeoutsRef.current.clear();
-                                                setNewEventIds({});
-                                            }}
-                                            icon="prohibit"
-                                        />
-                                    </Tooltip>
-                                )}
-                                <Tooltip content="Settings">
                                     <IconButton
-                                        icon="gear"
                                         size="small"
-                                        intent="neutral"
                                         priority="secondary"
-                                        onClick={() => setIsSettingsOpen(true)}
+                                        intent="critical"
+                                        onClick={async () => {
+                                            await clear();
+                                            seenEventIdsRef.current.clear();
+                                            for (const timeoutId of timeoutsRef.current.values()) {
+                                                window.clearTimeout(timeoutId);
+                                            }
+                                            timeoutsRef.current.clear();
+                                            setNewEventIds({});
+                                        }}
+                                        icon="prohibit"
+                                        tooltip={{ content: 'Clear log' }}
                                     />
-                                </Tooltip>
+                                )}
+                                <IconButton
+                                    icon="gear"
+                                    size="small"
+                                    intent="neutral"
+                                    priority="secondary"
+                                    onClick={() => setIsSettingsOpen(true)}
+                                    tooltip={{ content: 'Settings' }}
+                                />
                             </Row>
                         </Row>
                         <Box margin={{ bottom: 8 }}>

--- a/packages/analytics-docs/src/components/ThemeSwitch.tsx
+++ b/packages/analytics-docs/src/components/ThemeSwitch.tsx
@@ -1,4 +1,4 @@
-import { IconButton, Tooltip } from '@trezor/components';
+import { IconButton } from '@trezor/components';
 
 import { type ThemePreference, useTheme } from '../contexts/ThemeContext';
 
@@ -24,15 +24,14 @@ export const ThemeSwitch = () => {
     const tooltipContent = `Switch to ${PREFERENCE_TOOLTIP[nextPreference]}`;
 
     return (
-        <Tooltip content={tooltipContent}>
-            <IconButton
-                icon={PREFERENCE_ICON[preference]}
-                size="small"
-                intent="neutral"
-                priority="secondary"
-                onClick={() => setPreference(nextPreference)}
-                aria-label={tooltipContent}
-            />
-        </Tooltip>
+        <IconButton
+            icon={PREFERENCE_ICON[preference]}
+            size="small"
+            intent="neutral"
+            priority="secondary"
+            onClick={() => setPreference(nextPreference)}
+            aria-label={tooltipContent}
+            tooltip={{ content: tooltipContent }}
+        />
     );
 };

--- a/packages/analytics-docs/src/utils/useChangelogButton.tsx
+++ b/packages/analytics-docs/src/utils/useChangelogButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { IconButton, Tooltip } from '@trezor/components';
+import { IconButton } from '@trezor/components';
 
 export const useChangelogButton = () => {
     const [isChangelogOpened, setIsChangelogOpened] = React.useState<boolean>(false);
@@ -8,17 +8,16 @@ export const useChangelogButton = () => {
     return {
         isChangelogOpened,
         ChangelogButton: () => (
-            <Tooltip content={`${isChangelogOpened ? 'Hide' : 'Show'} changelog`}>
-                <IconButton
-                    onClick={() => {
-                        setIsChangelogOpened(!isChangelogOpened);
-                    }}
-                    icon="clockCounterClockwise"
-                    intent={isChangelogOpened ? 'brand' : 'neutral'}
-                    size="small"
-                    priority="secondary"
-                />
-            </Tooltip>
+            <IconButton
+                onClick={() => {
+                    setIsChangelogOpened(!isChangelogOpened);
+                }}
+                icon="clockCounterClockwise"
+                intent={isChangelogOpened ? 'brand' : 'neutral'}
+                size="small"
+                priority="secondary"
+                tooltip={{ content: `${isChangelogOpened ? 'Hide' : 'Show'} changelog` }}
+            />
         ),
     };
 };

--- a/packages/components/src/components/Banner/Banner.stories.tsx
+++ b/packages/components/src/components/Banner/Banner.stories.tsx
@@ -43,14 +43,24 @@ export const Banner: StoryObj<typeof meta> = {
                 combinedButtons: (
                     <Row gap={10}>
                         <BannerComponent.Button>Button</BannerComponent.Button>
-                        <BannerComponent.IconButton icon="x" priority="secondary" />
+                        <BannerComponent.IconButton
+                            icon="x"
+                            priority="secondary"
+                            tooltip={{ content: 'Dismiss' }}
+                        />
                     </Row>
                 ),
-                iconButton: <BannerComponent.IconButton icon="x" />,
+                iconButton: (
+                    <BannerComponent.IconButton icon="x" tooltip={{ content: 'Dismiss' }} />
+                ),
                 iconButtons: (
                     <Row gap={10}>
-                        <BannerComponent.IconButton icon="x" />
-                        <BannerComponent.IconButton icon="asterisk" priority="secondary" />
+                        <BannerComponent.IconButton icon="x" tooltip={{ content: 'Dismiss' }} />
+                        <BannerComponent.IconButton
+                            icon="asterisk"
+                            priority="secondary"
+                            tooltip={{ content: 'Details' }}
+                        />
                     </Row>
                 ),
             },

--- a/packages/components/src/components/ComponentWithSubIcon/ComponentWithSubIcon.stories.tsx
+++ b/packages/components/src/components/ComponentWithSubIcon/ComponentWithSubIcon.stories.tsx
@@ -26,6 +26,7 @@ export const ComponentWithSubIcon: StoryObj<ComponentWithSubIconProps> = {
                 size="large"
                 intent="neutral"
                 priority="secondary"
+                tooltip={{ content: 'Air traffic control' }}
             />
         ),
         iconPadding: 2,

--- a/packages/components/src/components/Dropdown/Dropdown.tsx
+++ b/packages/components/src/components/Dropdown/Dropdown.tsx
@@ -5,7 +5,7 @@ import { type IconName } from '../Icon/Icon';
 import { type DropdownMenuItemProps, Menu, type MenuProps } from '../Menu/Menu';
 import { Popover, type PopoverRef } from '../Popover/Popover';
 import { type PopoverPlacement } from '../Popover/utils';
-import { IconButton } from '../buttons/IconButton/IconButton';
+import { IconButton, type IconButtonProps } from '../buttons/IconButton/IconButton';
 import { type ButtonSize } from '../buttons/types';
 
 export const allowedDropdownFrameProps = ['width', 'minWidth'] as const satisfies FramePropsKeys[];
@@ -19,6 +19,7 @@ export type DropdownProps = Omit<MenuProps, 'onClose'> &
         isLoading?: boolean;
         iconName?: IconName;
         className?: string;
+        tooltip?: IconButtonProps['tooltip'];
         'data-testid'?: string;
     };
 
@@ -43,6 +44,7 @@ export const Dropdown = forwardRef(
             minWidth,
             maxWidth,
             width,
+            tooltip = { isActive: false },
         }: DropdownProps,
         ref,
     ) => {
@@ -83,6 +85,7 @@ export const Dropdown = forwardRef(
                     isDisabled={isDisabled}
                     isLoading={isLoading}
                     data-testid={dataTest}
+                    tooltip={tooltip}
                 />
             </Popover>
         );

--- a/packages/components/src/components/Modal/Modal.tsx
+++ b/packages/components/src/components/Modal/Modal.tsx
@@ -57,6 +57,8 @@ type ModalProps = AllowedFrameProps & {
     bottomContent?: ReactNode;
     onBackClick?: () => void;
     onCancel?: () => void;
+    backButtonTooltip?: ReactNode;
+    closeButtonTooltip?: ReactNode;
     isBackdropCancelable?: boolean;
     alignment?: ModalAlignment;
     width?: ModalWidth;
@@ -76,6 +78,8 @@ const InnerModalBase = ({
     iconName,
     onBackClick,
     onCancel,
+    backButtonTooltip,
+    closeButtonTooltip,
     isBackdropCancelable,
     height,
     maxHeight = '85vh',
@@ -114,6 +118,11 @@ const InnerModalBase = ({
                                         icon="caretLeft"
                                         data-testid="@modal/back-button"
                                         onClick={onBackClick}
+                                        tooltip={
+                                            backButtonTooltip
+                                                ? { content: backButtonTooltip }
+                                                : { isActive: false }
+                                        }
                                     />
                                 )}
 
@@ -143,6 +152,11 @@ const InnerModalBase = ({
                                         data-testid="@modal/close-button"
                                         onClick={onCancel}
                                         margin={{ left: 'auto' }}
+                                        tooltip={
+                                            closeButtonTooltip
+                                                ? { content: closeButtonTooltip }
+                                                : { isActive: false }
+                                        }
                                     />
                                 )}
                             </ElevationUp>

--- a/packages/components/src/components/Toast/Toast.tsx
+++ b/packages/components/src/components/Toast/Toast.tsx
@@ -60,6 +60,7 @@ export type ToastProps = {
     actions?: ToastAction[];
     dataTestId?: string;
     dismissible?: boolean;
+    dismissTooltip?: ReactNode;
     onDismiss?: () => void;
 };
 
@@ -70,6 +71,7 @@ export const Toast = ({
     actions,
     dismissible = true,
     dataTestId,
+    dismissTooltip,
     onDismiss,
 }: ToastProps) => {
     const dataTestBase = `@toast/${dataTestId ?? intent}`;
@@ -124,6 +126,7 @@ export const Toast = ({
                         onClick={onDismiss}
                         data-testid={`${dataTestBase}/close`}
                         aria-label="Close toast"
+                        tooltip={dismissTooltip ? { content: dismissTooltip } : { isActive: false }}
                     />
                 )}
             </Row>

--- a/packages/components/src/components/buttons/IconButton/IconButton.stories.tsx
+++ b/packages/components/src/components/buttons/IconButton/IconButton.stories.tsx
@@ -28,6 +28,7 @@ export const IconButton: StoryObj<IconButtonProps> = {
         isLoading: false,
         isInverse: false,
         isFloating: false,
+        tooltip: { content: 'Address book' },
         ...getFramePropsStory(allowedIconButtonFrameProps).args,
     },
     argTypes: {

--- a/packages/components/src/components/buttons/IconButton/IconButton.tsx
+++ b/packages/components/src/components/buttons/IconButton/IconButton.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 
+import { mapSizeToPadding } from './utils';
 import {
     type FrameProps,
     type FramePropsKeys,
@@ -9,8 +10,8 @@ import {
 import { type TransientProps } from '../../../utils/transientProps';
 import { Box } from '../../Box/Box';
 import { Icon, type IconName } from '../../Icon/Icon';
+import { Tooltip, type UnmanagedTooltipProps } from '../../Tooltip/Tooltip';
 import { Spinner } from '../../loaders/Spinner/Spinner';
-import { Tooltip, TooltipProps } from '../../Tooltip/Tooltip';
 import {
     type ButtonIntent,
     type ButtonPriority,
@@ -25,7 +26,6 @@ import {
     mapSizeToIconSize,
     pickButtonProps,
 } from '../utils';
-import { mapSizeToPadding } from './utils';
 
 export const allowedIconButtonFrameProps = ['margin'] as const satisfies FramePropsKeys[];
 export type AllowedIconButtonFrameProps = Pick<
@@ -57,7 +57,7 @@ export type IconButtonProps = CommonButtonProps &
     AllowedIconButtonFrameProps & {
         size?: ButtonSize;
         icon: IconName;
-        tooltip: Partial<TooltipProps>;
+        tooltip: Partial<UnmanagedTooltipProps>;
         'data-testid'?: string;
         'aria-label'?: string;
     };
@@ -92,8 +92,8 @@ export const IconButton = ({
             {...buttonProps}
             {...frameProps}
         >
-            <Box padding={mapSizeToPadding(size)}>
-                <Tooltip {...tooltip}>
+            <Tooltip {...(tooltip as UnmanagedTooltipProps)}>
+                <Box padding={mapSizeToPadding(size)}>
                     {props.isLoading ? (
                         <Spinner
                             isDisabled={true}
@@ -103,8 +103,8 @@ export const IconButton = ({
                     ) : (
                         <Icon name={icon} {...iconProps} />
                     )}
-                </Tooltip>
-            </Box>
+                </Box>
+            </Tooltip>
         </Container>
     );
 };

--- a/packages/components/src/components/buttons/IconButton/IconButton.tsx
+++ b/packages/components/src/components/buttons/IconButton/IconButton.tsx
@@ -1,6 +1,5 @@
 import styled from 'styled-components';
 
-import { mapSizeToPadding } from './utils';
 import {
     type FrameProps,
     type FramePropsKeys,
@@ -11,6 +10,7 @@ import { type TransientProps } from '../../../utils/transientProps';
 import { Box } from '../../Box/Box';
 import { Icon, type IconName } from '../../Icon/Icon';
 import { Tooltip, type UnmanagedTooltipProps } from '../../Tooltip/Tooltip';
+import { TOOLTIP_DELAY_NORMAL } from '../../Tooltip/TooltipDelay';
 import { Spinner } from '../../loaders/Spinner/Spinner';
 import {
     type ButtonIntent,
@@ -26,6 +26,7 @@ import {
     mapSizeToIconSize,
     pickButtonProps,
 } from '../utils';
+import { mapSizeToPadding } from './utils';
 
 export const allowedIconButtonFrameProps = ['margin'] as const satisfies FramePropsKeys[];
 export type AllowedIconButtonFrameProps = Pick<
@@ -92,7 +93,7 @@ export const IconButton = ({
             {...buttonProps}
             {...frameProps}
         >
-            <Tooltip {...(tooltip as UnmanagedTooltipProps)}>
+            <Tooltip delayShow={TOOLTIP_DELAY_NORMAL} {...(tooltip as UnmanagedTooltipProps)}>
                 <Box padding={mapSizeToPadding(size)}>
                     {props.isLoading ? (
                         <Spinner

--- a/packages/components/src/components/buttons/IconButton/IconButton.tsx
+++ b/packages/components/src/components/buttons/IconButton/IconButton.tsx
@@ -54,11 +54,15 @@ const Container = styled.button<ButtonContainerProps>`
     ${withFrameProps}
 `;
 
+export type IconButtonTooltipProps = Omit<UnmanagedTooltipProps, 'children' | 'content'> & {
+    content?: UnmanagedTooltipProps['content'];
+};
+
 export type IconButtonProps = CommonButtonProps &
     AllowedIconButtonFrameProps & {
         size?: ButtonSize;
         icon: IconName;
-        tooltip: Partial<UnmanagedTooltipProps>;
+        tooltip: IconButtonTooltipProps;
         'data-testid'?: string;
         'aria-label'?: string;
     };
@@ -93,7 +97,7 @@ export const IconButton = ({
             {...buttonProps}
             {...frameProps}
         >
-            <Tooltip delayShow={TOOLTIP_DELAY_NORMAL} {...(tooltip as UnmanagedTooltipProps)}>
+            <Tooltip delayShow={TOOLTIP_DELAY_NORMAL} content={null} {...tooltip}>
                 <Box padding={mapSizeToPadding(size)}>
                     {props.isLoading ? (
                         <Spinner

--- a/packages/components/src/components/buttons/IconButton/IconButton.tsx
+++ b/packages/components/src/components/buttons/IconButton/IconButton.tsx
@@ -10,6 +10,7 @@ import { type TransientProps } from '../../../utils/transientProps';
 import { Box } from '../../Box/Box';
 import { Icon, type IconName } from '../../Icon/Icon';
 import { Spinner } from '../../loaders/Spinner/Spinner';
+import { Tooltip, TooltipProps } from '../../Tooltip/Tooltip';
 import {
     type ButtonIntent,
     type ButtonPriority,
@@ -56,6 +57,7 @@ export type IconButtonProps = CommonButtonProps &
     AllowedIconButtonFrameProps & {
         size?: ButtonSize;
         icon: IconName;
+        tooltip: Partial<TooltipProps>;
         'data-testid'?: string;
         'aria-label'?: string;
     };
@@ -66,6 +68,7 @@ export const IconButton = ({
     icon,
     size = 'medium',
     isFloating = false,
+    tooltip,
     ...props
 }: IconButtonProps) => {
     const frameProps = pickAndPrepareFrameProps(props, allowedIconButtonFrameProps);
@@ -90,15 +93,17 @@ export const IconButton = ({
             {...frameProps}
         >
             <Box padding={mapSizeToPadding(size)}>
-                {props.isLoading ? (
-                    <Spinner
-                        isDisabled={true}
-                        size={mapSizeToIconSize(size)}
-                        data-testid={`${dataTestId}/spinner`}
-                    />
-                ) : (
-                    <Icon name={icon} {...iconProps} />
-                )}
+                <Tooltip {...tooltip}>
+                    {props.isLoading ? (
+                        <Spinner
+                            isDisabled={true}
+                            size={mapSizeToIconSize(size)}
+                            data-testid={`${dataTestId}/spinner`}
+                        />
+                    ) : (
+                        <Icon name={icon} {...iconProps} />
+                    )}
+                </Tooltip>
             </Box>
         </Container>
     );

--- a/packages/connect-explorer/src/components/Method.tsx
+++ b/packages/connect-explorer/src/components/Method.tsx
@@ -294,6 +294,7 @@ export const Method = () => {
                                     intent="neutral"
                                     priority="secondary"
                                     onClick={() => actions.onCancelCall()}
+                                    tooltip={{ isActive: false }}
                                 />
                             )}
                         </Row>
@@ -320,6 +321,7 @@ export const Method = () => {
                                         priority="secondary"
                                         data-testid="@cancel-button"
                                         onClick={() => actions.onCancelCall()}
+                                        tooltip={{ isActive: false }}
                                     />
                                 )}
                             </Row>

--- a/packages/product-components/src/components/ConfirmOnDevice/ConfirmOnDevicePillContent.tsx
+++ b/packages/product-components/src/components/ConfirmOnDevice/ConfirmOnDevicePillContent.tsx
@@ -99,6 +99,7 @@ export const ConfirmOnDevicePillContent = ({
                     intent="neutral"
                     priority="secondary"
                     size="small"
+                    tooltip={{ isActive: false }}
                 />
             )}
         </Row>

--- a/packages/product-components/src/components/EditableText/ActionsContainer.tsx
+++ b/packages/product-components/src/components/EditableText/ActionsContainer.tsx
@@ -3,7 +3,7 @@ import { FormattedMessage } from 'react-intl';
 
 import styled, { css } from 'styled-components';
 
-import { IconButton, type IconButtonProps, Spinner, Tooltip } from '@trezor/components';
+import { IconButton, type IconButtonProps, Spinner } from '@trezor/components';
 
 import type { SavingStatus } from './types';
 
@@ -85,22 +85,21 @@ export const ActionsContainer = ({
 
         if (savingStatus === 'error') {
             return (
-                <Tooltip
-                    content={
-                        <FormattedMessage
-                            id="TR_LABELING_ERROR"
-                            defaultMessage="There was an error saving the label. Please try again."
-                        />
-                    }
-                    delayShow={0}
-                >
-                    <IconButton
-                        intent="critical"
-                        icon="arrowsClockwise"
-                        onClick={onError}
-                        {...commonProps}
-                    />
-                </Tooltip>
+                <IconButton
+                    intent="critical"
+                    icon="arrowsClockwise"
+                    onClick={onError}
+                    tooltip={{
+                        content: (
+                            <FormattedMessage
+                                id="TR_LABELING_ERROR"
+                                defaultMessage="There was an error saving the label. Please try again."
+                            />
+                        ),
+                        delayShow: 0,
+                    }}
+                    {...commonProps}
+                />
             );
         }
 
@@ -112,6 +111,7 @@ export const ActionsContainer = ({
                             data-testid="@metadata/submit"
                             icon="check"
                             onClick={onSubmit}
+                            tooltip={{ isActive: false }}
                             {...commonProps}
                         />
                     )}
@@ -120,6 +120,7 @@ export const ActionsContainer = ({
                         icon="x"
                         intent="neutral"
                         onClick={onCancel}
+                        tooltip={{ isActive: false }}
                         {...commonProps}
                     />
                 </>
@@ -127,38 +128,39 @@ export const ActionsContainer = ({
         } else {
             return (
                 <>
-                    <Tooltip
-                        content={
-                            <FormattedMessage id="TR_LABELING_EDIT_LABEL" defaultMessage="Edit" />
-                        }
-                        delayShow={1000}
-                    >
+                    <IconButton
+                        data-testid="@metadata/edit"
+                        intent="neutral"
+                        icon="pencilSimple"
+                        onClick={onEdit}
+                        tooltip={{
+                            content: (
+                                <FormattedMessage
+                                    id="TR_LABELING_EDIT_LABEL"
+                                    defaultMessage="Edit"
+                                />
+                            ),
+                            delayShow: 1000,
+                        }}
+                        {...commonProps}
+                    />
+                    {isDeleteButtonVisible && (
                         <IconButton
-                            data-testid="@metadata/edit"
-                            intent="neutral"
-                            icon="pencilSimple"
-                            onClick={onEdit}
+                            data-testid="@metadata/delete"
+                            intent="critical"
+                            icon="trash"
+                            onClick={onDelete}
+                            tooltip={{
+                                content: (
+                                    <FormattedMessage
+                                        id="TR_LABELING_REMOVE_LABEL"
+                                        defaultMessage="Remove"
+                                    />
+                                ),
+                                delayShow: 1000,
+                            }}
                             {...commonProps}
                         />
-                    </Tooltip>
-                    {isDeleteButtonVisible && (
-                        <Tooltip
-                            content={
-                                <FormattedMessage
-                                    id="TR_LABELING_REMOVE_LABEL"
-                                    defaultMessage="Remove"
-                                />
-                            }
-                            delayShow={1000}
-                        >
-                            <IconButton
-                                data-testid="@metadata/delete"
-                                intent="critical"
-                                icon="trash"
-                                onClick={onDelete}
-                                {...commonProps}
-                            />
-                        </Tooltip>
                     )}
                 </>
             );

--- a/packages/product-components/src/components/EditableText/ActionsContainer.tsx
+++ b/packages/product-components/src/components/EditableText/ActionsContainer.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import styled, { css } from 'styled-components';

--- a/packages/suite/src/components/dashboard/DashboardSection.tsx
+++ b/packages/suite/src/components/dashboard/DashboardSection.tsx
@@ -7,6 +7,7 @@ import {
     useState,
 } from 'react';
 
+import { Translation } from '@suite/intl';
 import { Collapsible, Column, H3, IconButton, Row, Text } from '@trezor/components';
 import { useCurrentRef } from '@trezor/react-utils';
 
@@ -72,6 +73,17 @@ export const DashboardSection = forwardRef(
                                                     icon={collapsed ? 'caretDown' : 'caretUp'}
                                                     intent="neutral"
                                                     priority="secondary"
+                                                    tooltip={{
+                                                        content: (
+                                                            <Translation
+                                                                id={
+                                                                    collapsed
+                                                                        ? 'TR_EXPAND'
+                                                                        : 'TR_COLLAPSE'
+                                                                }
+                                                            />
+                                                        ),
+                                                    }}
                                                 />
                                             </Collapsible.Toggle>
                                         )}

--- a/packages/suite/src/components/earn/yield/claim/YieldClaimPageHeader.tsx
+++ b/packages/suite/src/components/earn/yield/claim/YieldClaimPageHeader.tsx
@@ -43,6 +43,7 @@ export const YieldClaimPageHeader = ({ account }: YieldClaimPageHeaderProps) => 
                     size="large"
                     onClick={onBackClick}
                     data-testid="@account-subpage/back"
+                    tooltip={{ content: <Translation id="TR_BACK" /> }}
                 />
                 {account ? (
                     <Row gap={12} alignItems="center" flex="1" overflow="hidden">

--- a/packages/suite/src/components/earn/yield/common/YieldApprovedAmountCard.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldApprovedAmountCard.tsx
@@ -47,6 +47,7 @@ export const YieldApprovedAmountCard = ({
                         intent="neutral"
                         priority="secondary"
                         onClick={onRevoke}
+                        tooltip={{ content: <Translation id="TR_REVOKE_DATA_TITLE" /> }}
                     />
                 )}
             </Row>

--- a/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
@@ -111,6 +111,7 @@ export const YieldPageHeader = ({
                     size="large"
                     onClick={onBackClick}
                     data-testid="@account-subpage/back"
+                    tooltip={{ content: <Translation id="TR_BACK" /> }}
                 />
 
                 {account && vaultName ? (
@@ -158,6 +159,7 @@ export const YieldPageHeader = ({
                             aria-label={translationString('TR_EARN_HOW_IT_WORKS')}
                             onClick={onHowItWorksClick}
                             isDisabled={!account || !routeParams}
+                            tooltip={{ content: <Translation id="TR_EARN_HOW_IT_WORKS" /> }}
                         />
                     ) : (
                         <Button

--- a/packages/suite/src/components/guide/GuideButton.tsx
+++ b/packages/suite/src/components/guide/GuideButton.tsx
@@ -3,7 +3,7 @@ import { FreeFocusInside } from 'react-focus-lock';
 import styled from 'styled-components';
 
 import { Translation } from '@suite/intl';
-import { IconButton, TOOLTIP_DELAY_LONG, Tooltip } from '@trezor/components';
+import { IconButton, TOOLTIP_DELAY_LONG } from '@trezor/components';
 import { zIndices } from '@trezor/theme';
 import { hexToRgba } from '@trezor/utils';
 
@@ -27,20 +27,19 @@ export const GuideButton = () => {
     return (
         <FreeFocusInside>
             <Wrapper $isGuideOpen={isGuideOpen}>
-                <Tooltip
-                    content={<Translation id="TR_GUIDE_SUPPORT_AND_FEEDBACK" />}
-                    placement="top"
-                    delayShow={TOOLTIP_DELAY_LONG}
-                >
-                    <IconButton
-                        data-testid="@guide/button-open"
-                        onClick={openGuide}
-                        icon="lifebuoy"
-                        intent="neutral"
-                        priority="secondary"
-                        size="large"
-                    />
-                </Tooltip>
+                <IconButton
+                    data-testid="@guide/button-open"
+                    onClick={openGuide}
+                    icon="lifebuoy"
+                    intent="neutral"
+                    priority="secondary"
+                    size="large"
+                    tooltip={{
+                        content: <Translation id="TR_GUIDE_SUPPORT_AND_FEEDBACK" />,
+                        placement: 'top',
+                        delayShow: TOOLTIP_DELAY_LONG,
+                    }}
+                />
             </Wrapper>
         </FreeFocusInside>
     );

--- a/packages/suite/src/components/guide/GuideHeader.tsx
+++ b/packages/suite/src/components/guide/GuideHeader.tsx
@@ -3,6 +3,7 @@ import { type JSX, useContext } from 'react';
 import styled, { css } from 'styled-components';
 
 import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
 import { H3, IconButton, Paragraph, useElevation } from '@trezor/components';
 import { type Elevation, mapElevationToBorder, zIndices } from '@trezor/theme';
@@ -83,6 +84,7 @@ export const GuideHeader = ({ back, label, useBreadcrumb }: GuideHeaderProps) =>
                         intent="neutral"
                         priority="secondary"
                         data-testid="@guide/button-back"
+                        tooltip={{ content: <Translation id="TR_BACK" /> }}
                     />
 
                     {label && (
@@ -113,6 +115,7 @@ export const GuideHeader = ({ back, label, useBreadcrumb }: GuideHeaderProps) =>
                 priority="secondary"
                 onClick={handleClose}
                 data-testid="@guide/button-close"
+                tooltip={{ content: <Translation id="TR_CLOSE" /> }}
             />
         </HeaderWrapper>
     );

--- a/packages/suite/src/components/suite/CoinGroup/CoinGroupHeader.tsx
+++ b/packages/suite/src/components/suite/CoinGroup/CoinGroupHeader.tsx
@@ -35,6 +35,13 @@ export const CoinGroupHeader = ({
                     intent="neutral"
                     priority="secondary"
                     margin={{ left: 'auto' }}
+                    tooltip={{
+                        content: settingsMode ? (
+                            <Translation id="TR_CLOSE" />
+                        ) : (
+                            <Translation id="TR_SETTINGS" />
+                        ),
+                    }}
                 />
             )}
         </Row>

--- a/packages/suite/src/components/suite/FindBar/FindBar.tsx
+++ b/packages/suite/src/components/suite/FindBar/FindBar.tsx
@@ -13,7 +13,6 @@ import {
     Paragraph,
     Row,
     TOOLTIP_DELAY_LONG,
-    Tooltip,
 } from '@trezor/components';
 import { borders, zIndices } from '@trezor/theme';
 
@@ -119,31 +118,34 @@ export const FindBarForm = ({ setIsVisible }: FindBarFormProps) => {
                     />
                     <Row gap={8} justifyContent="flex-end">
                         <ButtonGroup intent="neutral" priority="secondary" size="small">
-                            <Tooltip
-                                content={<Translation id="TR_FIND_PREV" />}
-                                delayShow={TOOLTIP_DELAY_LONG}
-                            >
-                                <IconButton icon="arrowUp" onClick={prev} />
-                            </Tooltip>
-                            <Tooltip
-                                content={<Translation id="TR_FIND_NEXT" />}
-                                delayShow={TOOLTIP_DELAY_LONG}
-                            >
-                                <IconButton icon="arrowDown" onClick={next} />
-                            </Tooltip>
-                        </ButtonGroup>
-                        <Tooltip
-                            content={<Translation id="TR_FIND_CLOSE" />}
-                            delayShow={TOOLTIP_DELAY_LONG}
-                        >
                             <IconButton
-                                icon="x"
-                                size="small"
-                                intent="neutral"
-                                priority="secondary"
-                                onClick={handleCloseFindBar}
+                                icon="arrowUp"
+                                onClick={prev}
+                                tooltip={{
+                                    content: <Translation id="TR_FIND_PREV" />,
+                                    delayShow: TOOLTIP_DELAY_LONG,
+                                }}
                             />
-                        </Tooltip>
+                            <IconButton
+                                icon="arrowDown"
+                                onClick={next}
+                                tooltip={{
+                                    content: <Translation id="TR_FIND_NEXT" />,
+                                    delayShow: TOOLTIP_DELAY_LONG,
+                                }}
+                            />
+                        </ButtonGroup>
+                        <IconButton
+                            icon="x"
+                            size="small"
+                            intent="neutral"
+                            priority="secondary"
+                            onClick={handleCloseFindBar}
+                            tooltip={{
+                                content: <Translation id="TR_FIND_CLOSE" />,
+                                delayShow: TOOLTIP_DELAY_LONG,
+                            }}
+                        />
                     </Row>
                 </Row>
             </Wrapper>

--- a/packages/suite/src/components/suite/PinMatrix/PinMatrix.tsx
+++ b/packages/suite/src/components/suite/PinMatrix/PinMatrix.tsx
@@ -152,6 +152,7 @@ export const PinMatrix = ({
                                     onClick={() => onPinAdd(value)}
                                     isDisabled={isDisabled}
                                     data-testid={`@pin/input/${value}`}
+                                    tooltip={{ isActive: false }}
                                 />
                             ))
                         }

--- a/packages/suite/src/components/suite/WordInputAdvanced.tsx
+++ b/packages/suite/src/components/suite/WordInputAdvanced.tsx
@@ -137,6 +137,7 @@ export const WordInputAdvanced = ({ count }: WordInputAdvancedProps) => {
                                 intent="neutral"
                                 priority="secondary"
                                 size="large"
+                                tooltip={{ isActive: false }}
                             />
                         ))}
                     </Grid>

--- a/packages/suite/src/components/suite/banners/MessageSystemBanner.tsx
+++ b/packages/suite/src/components/suite/banners/MessageSystemBanner.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 
+import { Translation } from '@suite/intl';
 import { selectLanguage } from '@suite/settings';
 import { messageSystemActions, resolveMessageContent } from '@suite-common/message-system';
 import { type Message } from '@suite-common/suite-types';
@@ -45,6 +46,7 @@ export const MessageSystemBanner = ({ message, margin, width }: MessageSystemBan
                             onClick={dismissalConfig.onClick}
                             priority="secondary"
                             data-testid={dismissalConfig['data-testid']}
+                            tooltip={{ content: <Translation id="TR_DISMISS" /> }}
                         />
                     )}
                 </>

--- a/packages/suite/src/components/suite/banners/SuiteBanners/OutOfQuotaBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/OutOfQuotaBanner.tsx
@@ -41,6 +41,7 @@ export const OutOfQuotaBanner = () => {
                         intent="info"
                         priority="secondary"
                         onClick={handleDismiss}
+                        tooltip={{ content: <Translation id="TR_DISMISS" /> }}
                     />
                 </>
             }

--- a/packages/suite/src/components/suite/banners/SuiteBanners/SafetyChecksBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/SafetyChecksBanner.tsx
@@ -37,6 +37,7 @@ export const SafetyChecksBanner = ({ onDismiss }: SafetyChecksBannerProps) => {
                             icon="x"
                             onClick={onDismiss}
                             data-testid="@banner/safety-checks/dismiss"
+                            tooltip={{ content: <Translation id="TR_DISMISS" /> }}
                         />
                     )}
                 </>

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderActionButton.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderActionButton.tsx
@@ -30,6 +30,7 @@ export const HeaderActionButton = ({
                 size={size}
                 isDisabled={isDisabled}
                 priority={priority}
+                tooltip={{ content: children }}
             />
         </ConditionalRender>
         <ConditionalRender container="content" minWidth={breakpoints.mobile}>

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderDropdown.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderDropdown.tsx
@@ -130,6 +130,7 @@ export const HeaderDropdown = ({
                     placement={{ position: 'bottom', alignment: 'start' }}
                     isDisabled={isDisabled}
                     data-testid="@wallet/menu/extra-dropdown"
+                    tooltip={{ content: <Translation id="TR_SHOW_MORE" />, placement: 'left' }}
                     items={visibleAdditionalActions.map<DropdownMenuItemProps>(item => ({
                         key: item.id,
                         onClick: isDisabled ? undefined : item.callback,

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountSubpageName.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountSubpageName.tsx
@@ -1,3 +1,4 @@
+import { Translation } from '@suite/intl';
 import { goto, selectSettingsBackRoute } from '@suite/router';
 import { type Account } from '@suite-common/wallet-types';
 import { IconButton, Row } from '@trezor/components';
@@ -26,6 +27,7 @@ export const AccountSubpageName = ({ selectedAccount }: AccountSubpageNameProps)
                 size="large"
                 onClick={handleBackClick}
                 data-testid="@account-subpage/back"
+                tooltip={{ content: <Translation id="TR_BACK" /> }}
             />
             <AccountDetails selectedAccount={selectedAccount} isBalanceShown />
         </Row>

--- a/packages/suite/src/components/suite/layouts/WelcomeLayout/NavSettings.tsx
+++ b/packages/suite/src/components/suite/layouts/WelcomeLayout/NavSettings.tsx
@@ -1,6 +1,6 @@
 import { Translation } from '@suite/intl';
 import { goto } from '@suite/router';
-import { IconButton, Tooltip } from '@trezor/components';
+import { IconButton } from '@trezor/components';
 
 import { useDispatch } from 'src/hooks/suite';
 
@@ -10,14 +10,13 @@ export const NavSettings = () => {
     const handleClick = () => dispatch(goto({ routeName: 'settings-index' }));
 
     return (
-        <Tooltip content={<Translation id="TR_SETTINGS" />}>
-            <IconButton
-                icon="gear"
-                intent="neutral"
-                priority="secondary"
-                onClick={handleClick}
-                data-testid="@suite/menu/settings"
-            />
-        </Tooltip>
+        <IconButton
+            icon="gear"
+            intent="neutral"
+            priority="secondary"
+            onClick={handleClick}
+            data-testid="@suite/menu/settings"
+            tooltip={{ content: <Translation id="TR_SETTINGS" /> }}
+        />
     );
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
@@ -166,6 +166,9 @@ export const TransactionReviewSummary = ({
                                 intent="neutral"
                                 priority="secondary"
                                 icon="info"
+                                tooltip={{
+                                    content: <Translation id="TR_TRANSACTION_DETAILS" />,
+                                }}
                             />
                         </Box>
                     )}

--- a/packages/suite/src/components/suite/notifications/Notifications/Notifications.tsx
+++ b/packages/suite/src/components/suite/notifications/Notifications/Notifications.tsx
@@ -47,7 +47,13 @@ export const Notifications = (props: NotificationsProps) => {
                     </Tabs.Item>
                 </Tabs>
                 {props.onCancel && (
-                    <IconButton intent="neutral" priority="secondary" icon="x" onClick={onCancel} />
+                    <IconButton
+                        intent="neutral"
+                        priority="secondary"
+                        icon="x"
+                        onClick={onCancel}
+                        tooltip={{ content: <Translation id="TR_CLOSE" /> }}
+                    />
                 )}
             </Row>
             <Divider margin={{ top: 0, bottom: spacings.md }} />

--- a/packages/suite/src/components/suite/notifications/Toaster/ToastNotificationView.tsx
+++ b/packages/suite/src/components/suite/notifications/Toaster/ToastNotificationView.tsx
@@ -47,6 +47,7 @@ export const ToastNotificationView = ({
             dataTestId={notification.type}
             actions={mapNotificationActionsToToastActions(action, translationString)}
             onDismiss={handleDismiss}
+            dismissTooltip={<Translation id="TR_DISMISS" />}
         />
     );
 };

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/ContextMessage.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/ContextMessage.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 
 import { getTorUrlIfAvailable } from '@suite/external-links';
+import { Translation } from '@suite/intl';
 import { goto } from '@suite/router';
 import { selectLanguage, selectTorOnionLinks } from '@suite/settings';
 import { selectTorState } from '@suite/tor';
@@ -79,6 +80,7 @@ export const ContextMessage = ({ context }: ContextMessageProps) => {
                             onClick={dismissalConfig.onClick}
                             priority="secondary"
                             data-testid={dismissalConfig['data-testid']}
+                            tooltip={{ content: <Translation id="TR_DISMISS" /> }}
                         />
                     )}
                 </>

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakingBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakingBanner.tsx
@@ -172,6 +172,7 @@ export const StakingBanner = ({ account }: StakingBannerProps) => {
                         priority="secondary"
                         icon="x"
                         onClick={closeBanner}
+                        tooltip={{ content: <Translation id="TR_DISMISS" /> }}
                     />
                 </>
             }

--- a/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetRow.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetRow.tsx
@@ -23,13 +23,13 @@ import {
 import { TokenIconSetWrapper } from 'src/components/wallet/TokenIconSetWrapper';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
+import { AssetActionButton } from '../AssetActionButton';
 import { AssetCoinLogo } from '../AssetCoinLogo';
 import { AssetCoinName } from '../AssetCoinName';
+import { handleTokensAndStakingData } from '../assetsViewUtils';
 import { AssetStakingRow } from './AssetStakingRow';
 import { AssetTableExtraRowsSection as Section } from './AssetTableExtraRowsSection';
 import { AssetTokenRow } from './AssetTokenRow';
-import { AssetActionButton } from '../AssetActionButton';
-import { handleTokensAndStakingData } from '../assetsViewUtils';
 
 export interface AssetTableRowProps {
     network: Network;
@@ -211,7 +211,7 @@ export const AssetRow = memo(
                                 icon="arrowRight"
                                 intent="neutral"
                                 priority="secondary"
-                                tooltip={{ isActive: false }}
+                                tooltip={{ content: <Translation id="TR_SHOW_MORE" /> }}
                             />
                         </Row>
                     </Table.Cell>

--- a/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetRow.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetRow.tsx
@@ -207,7 +207,12 @@ export const AssetRow = memo(
                                     <Translation id="TR_BUY_BUY" />
                                 </AssetActionButton>
                             )}
-                            <IconButton icon="arrowRight" intent="neutral" priority="secondary" />
+                            <IconButton
+                                icon="arrowRight"
+                                intent="neutral"
+                                priority="secondary"
+                                tooltip={{ isActive: false }}
+                            />
                         </Row>
                     </Table.Cell>
                 </Table.Row>

--- a/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
@@ -38,7 +38,6 @@ import {
     LoadingContent,
     Row,
     TOOLTIP_DELAY_LONG,
-    Tooltip,
 } from '@trezor/components';
 import { spacingsPx, typography } from '@trezor/theme';
 import { type PartialRecord } from '@trezor/type-utils';
@@ -213,25 +212,28 @@ export const AssetsView = () => {
                                 <Translation id="TR_ENABLE_MORE_COINS" />
                             </Button>
                         )}
-                        <Tooltip
-                            content={<Translation id="TR_MY_ASSETS_CHANGE_VIEW" />}
-                            delayShow={TOOLTIP_DELAY_LONG}
-                        >
-                            <ButtonGroup intent="neutral" priority="secondary">
-                                <IconButton
-                                    icon="rowsFilled"
-                                    data-testid="@dashboard/assets/table-icon"
-                                    onClick={setTable}
-                                    intent={dashboardAssetsGridMode ? 'neutral' : 'brand'}
-                                />
-                                <IconButton
-                                    icon="gridNineFilled"
-                                    data-testid="@dashboard/assets/grid-icon"
-                                    onClick={setGrid}
-                                    intent={dashboardAssetsGridMode ? 'brand' : 'neutral'}
-                                />
-                            </ButtonGroup>
-                        </Tooltip>
+                        <ButtonGroup intent="neutral" priority="secondary">
+                            <IconButton
+                                icon="rowsFilled"
+                                data-testid="@dashboard/assets/table-icon"
+                                onClick={setTable}
+                                intent={dashboardAssetsGridMode ? 'neutral' : 'brand'}
+                                tooltip={{
+                                    content: <Translation id="TR_MY_ASSETS_CHANGE_VIEW" />,
+                                    delayShow: TOOLTIP_DELAY_LONG,
+                                }}
+                            />
+                            <IconButton
+                                icon="gridNineFilled"
+                                data-testid="@dashboard/assets/grid-icon"
+                                onClick={setGrid}
+                                intent={dashboardAssetsGridMode ? 'brand' : 'neutral'}
+                                tooltip={{
+                                    content: <Translation id="TR_MY_ASSETS_CHANGE_VIEW" />,
+                                    delayShow: TOOLTIP_DELAY_LONG,
+                                }}
+                            />
+                        </ButtonGroup>
                     </Row>
                 )
             }

--- a/packages/suite/src/views/dashboard/DashboardPromoBanner/CommonPromoBannerComponents.tsx
+++ b/packages/suite/src/views/dashboard/DashboardPromoBanner/CommonPromoBannerComponents.tsx
@@ -2,6 +2,7 @@ import { AnimatePresence, motion } from 'framer-motion';
 import styled from 'styled-components';
 
 import { type FlagsState, setFlag } from '@suite/flags';
+import { Translation } from '@suite/intl';
 import { IconButton } from '@trezor/components';
 import { borders, spacingsPx } from '@trezor/theme';
 
@@ -28,6 +29,7 @@ export const CloseButton = ({ onClose, isInverse = false }: CloseButtonProps) =>
             priority="secondary"
             onClick={onClose}
             isInverse={isInverse}
+            tooltip={{ content: <Translation id="TR_CLOSE" /> }}
         />
     </CloseButtonContainer>
 );

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
@@ -2,6 +2,7 @@ import { memo, useMemo } from 'react';
 
 import { useDevice } from '@suite/device';
 import { selectFlags, setFlag } from '@suite/flags';
+import { Translation } from '@suite/intl';
 import { networksCollection } from '@suite-common/wallet-config';
 import {
     selectAllAccountsToList,
@@ -144,6 +145,11 @@ export const PortfolioCard = memo(() => {
                     }),
                 )
             }
+            tooltip={{
+                content: (
+                    <Translation id={dashboardGraphHidden ? 'TR_GRAPH_SHOW' : 'TR_GRAPH_HIDE'} />
+                ),
+            }}
         />
     ) : null;
 

--- a/packages/suite/src/views/settings/SettingsConnectedApps/ConnectPermissions.tsx
+++ b/packages/suite/src/views/settings/SettingsConnectedApps/ConnectPermissions.tsx
@@ -94,6 +94,10 @@ export const ConnectPermissions = () => {
                         <Dropdown
                             data-testid={`@settings/connect-apps/${index}/dropdown`}
                             placement={{ position: 'bottom', alignment: 'end' }}
+                            tooltip={{
+                                content: <Translation id="TR_SHOW_MORE" />,
+                                placement: 'left',
+                            }}
                             items={[
                                 ...(isDebugModeActive
                                     ? [

--- a/packages/suite/src/views/settings/SettingsConnectedApps/WalletConnectList.tsx
+++ b/packages/suite/src/views/settings/SettingsConnectedApps/WalletConnectList.tsx
@@ -74,6 +74,10 @@ export const WalletConnectList = () => {
 
                         <Dropdown
                             placement={{ position: 'bottom', alignment: 'end' }}
+                            tooltip={{
+                                content: <Translation id="TR_SHOW_MORE" />,
+                                placement: 'left',
+                            }}
                             items={[
                                 {
                                     icon: 'xCircle',

--- a/packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemExperiment/MessageSystemExperimentToolbar.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemExperiment/MessageSystemExperimentToolbar.tsx
@@ -116,7 +116,12 @@ export const MessageSystemExperimentToolbar = ({
                     }
                     zIndex={zIndices.tooltip}
                 >
-                    <IconButton icon="question" intent="neutral" priority="secondary" />
+                    <IconButton
+                        icon="question"
+                        intent="neutral"
+                        priority="secondary"
+                        tooltip={{ content: 'Manual' }}
+                    />
                 </Popover>
             </Row>
         </Row>

--- a/packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemManager/MessageSystemManagerToolbar.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemManager/MessageSystemManagerToolbar.tsx
@@ -136,7 +136,12 @@ export const MessageSystemManagerToolbar = ({
                     }
                     zIndex={zIndices.tooltip}
                 >
-                    <IconButton icon="question" intent="neutral" priority="secondary" />
+                    <IconButton
+                        icon="question"
+                        intent="neutral"
+                        priority="secondary"
+                        tooltip={{ content: 'Manual' }}
+                    />
                 </Popover>
             </Row>
         </Row>

--- a/packages/suite/src/views/settings/SettingsGeneral/DesktopSuiteBanner.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/DesktopSuiteBanner.tsx
@@ -91,6 +91,7 @@ export const DesktopSuiteBanner = () => {
                                 intent="neutral"
                                 priority="secondary"
                                 isInverse
+                                tooltip={{ content: <Translation id="TR_CLOSE" /> }}
                             />
                         </Box>
 

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/AddWalletButton.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/AddWalletButton.tsx
@@ -94,6 +94,7 @@ export const AddWalletButton = ({ device, instances, onCancel }: AddWalletButton
                         onClick={() => {
                             setIsPassphraseExpanded(false);
                         }}
+                        tooltip={{ content: <Translation id="TR_CLOSE" /> }}
                     />
                 </Row>
                 <Column gap={8}>

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceHeader.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceHeader.tsx
@@ -2,7 +2,7 @@ import { type ReactNode } from 'react';
 
 import { Translation } from '@suite/intl';
 import { getDeviceInternalModel } from '@suite-common/suite-utils';
-import { IconButton, Row, TOOLTIP_DELAY_LONG, Tooltip } from '@trezor/components';
+import { IconButton, Row, TOOLTIP_DELAY_LONG } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { DeviceStatus } from 'src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceStatus';
@@ -45,6 +45,7 @@ export const DeviceHeader = ({
                     intent="neutral"
                     priority="secondary"
                     data-testid="@switch-device/back-button"
+                    tooltip={{ content: <Translation id="TR_BACK" /> }}
                 />
             )}
 
@@ -58,15 +59,17 @@ export const DeviceHeader = ({
 
             <Row gap={spacings.xxs} margin={{ left: 'auto' }}>
                 {isDefaultCancelVisible && (
-                    <Tooltip delayShow={TOOLTIP_DELAY_LONG} content={<Translation id="TR_CLOSE" />}>
-                        <IconButton
-                            icon="x"
-                            intent="neutral"
-                            priority="secondary"
-                            onClick={() => onCancel()}
-                            data-testid="@switch-device/close-button"
-                        />
-                    </Tooltip>
+                    <IconButton
+                        icon="x"
+                        intent="neutral"
+                        priority="secondary"
+                        onClick={() => onCancel()}
+                        data-testid="@switch-device/close-button"
+                        tooltip={{
+                            delayShow: TOOLTIP_DELAY_LONG,
+                            content: <Translation id="TR_CLOSE" />,
+                        }}
+                    />
                 )}
                 {actions}
             </Row>

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
@@ -206,34 +206,33 @@ export const WalletInstance = ({
                                 )}
                             </Text>
                             <Collapsible.Toggle>
-                                <Tooltip
-                                    delayShow={TOOLTIP_DELAY_LONG}
-                                    content={
-                                        <Translation
-                                            id={
-                                                isEjecting
-                                                    ? 'TR_CANCEL'
-                                                    : 'TR_SWITCH_DEVICE_EJECT_TOOLTIP'
-                                            }
-                                        />
+                                <IconButton
+                                    data-testid={
+                                        isEjecting
+                                            ? `@switch-device/cancelEject`
+                                            : `${dataTestBase}/eject-button`
                                     }
-                                >
-                                    <IconButton
-                                        data-testid={
-                                            isEjecting
-                                                ? `@switch-device/cancelEject`
-                                                : `${dataTestBase}/eject-button`
-                                        }
-                                        icon={isEjecting ? 'x' : 'eject'}
-                                        size="small"
-                                        intent="neutral"
-                                        priority="secondary"
-                                        onClick={e => {
-                                            e.stopPropagation();
-                                            setIsEjecting(prev => !prev);
-                                        }}
-                                    />
-                                </Tooltip>
+                                    icon={isEjecting ? 'x' : 'eject'}
+                                    size="small"
+                                    intent="neutral"
+                                    priority="secondary"
+                                    onClick={e => {
+                                        e.stopPropagation();
+                                        setIsEjecting(prev => !prev);
+                                    }}
+                                    tooltip={{
+                                        delayShow: TOOLTIP_DELAY_LONG,
+                                        content: (
+                                            <Translation
+                                                id={
+                                                    isEjecting
+                                                        ? 'TR_CANCEL'
+                                                        : 'TR_SWITCH_DEVICE_EJECT_TOOLTIP'
+                                                }
+                                            />
+                                        ),
+                                    }}
+                                />
                             </Collapsible.Toggle>
                         </Row>
 

--- a/packages/suite/src/views/wallet/nfts/NftsTable/NftsRow.tsx
+++ b/packages/suite/src/views/wallet/nfts/NftsTable/NftsRow.tsx
@@ -91,6 +91,10 @@ const NftsRow = ({
                     <Row gap={8}>
                         <Dropdown
                             placement={{ position: 'bottom', alignment: 'start' }}
+                            tooltip={{
+                                content: <Translation id="TR_SHOW_MORE" />,
+                                placement: 'left',
+                            }}
                             content={
                                 <Card paddingType="small">
                                     <Column gap={16}>

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/Locktime/Locktime.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/Locktime/Locktime.tsx
@@ -114,6 +114,7 @@ export const Locktime = ({ close }: LocktimeProps) => {
                         priority="secondary"
                         size="small"
                         onClick={close}
+                        tooltip={{ content: <Translation id="TR_CLOSE" /> }}
                     />
                 </Row>
                 {locktimeOption == 'block' ? (

--- a/packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumData.tsx
+++ b/packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumData.tsx
@@ -96,6 +96,7 @@ export const EthereumData = ({ close }: EthereumDataProps) => {
                         size="small"
                         data-testid="send/close-ethereum-data"
                         onClick={handleClose}
+                        tooltip={{ content: <Translation id="TR_CLOSE" /> }}
                     />
                 </Row>
                 <Row gap={16}>

--- a/packages/suite/src/views/wallet/send/Options/SolanaOptions/SolanaMemo.tsx
+++ b/packages/suite/src/views/wallet/send/Options/SolanaOptions/SolanaMemo.tsx
@@ -46,6 +46,7 @@ export const SolanaMemo = ({ close }: SolanaMemoProps) => {
                         icon="x"
                         size="small"
                         onClick={handleClose}
+                        tooltip={{ content: <Translation id="TR_CLOSE" /> }}
                     />
                 </Row>
                 <Textarea

--- a/packages/suite/src/views/wallet/send/Options/TronOptions/TronNote.tsx
+++ b/packages/suite/src/views/wallet/send/Options/TronOptions/TronNote.tsx
@@ -75,6 +75,7 @@ export const TronNote = ({ close }: TronNoteProps) => {
                         icon="x"
                         size="small"
                         onClick={handleClose}
+                        tooltip={{ content: <Translation id="TR_CLOSE" /> }}
                     />
                 </Row>
 

--- a/packages/suite/src/views/wallet/send/Outputs/Address.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Address.tsx
@@ -557,6 +557,7 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                                 // compose by first Output
                                 composeTransaction();
                             }}
+                            tooltip={{ content: <Translation id="TR_REMOVE" /> }}
                         />
                     )}
                 </Row>

--- a/packages/suite/src/views/wallet/send/Outputs/OpReturn.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/OpReturn.tsx
@@ -75,6 +75,7 @@ export const OpReturn = ({ outputId }: { outputId: number }) => {
                     icon="x"
                     size="small"
                     onClick={() => removeOpReturn(outputId)}
+                    tooltip={{ content: <Translation id="TR_REMOVE" /> }}
                 />
             </Row>
             <Flex direction={isBelowTablet ? 'column' : 'row'} gap={16} alignItems="center">

--- a/packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx
@@ -206,7 +206,12 @@ export const TokenSelect = ({ outputId }: TokenSelectProps) => {
                         </Column>
                     </Row>
                     {!hasNoStandardTokens && (
-                        <IconButton icon="caretDown" intent="neutral" priority="secondary" />
+                        <IconButton
+                            icon="caretDown"
+                            intent="neutral"
+                            priority="secondary"
+                            tooltip={{ isActive: false }}
+                        />
                     )}
                 </Row>
 

--- a/packages/suite/src/views/wallet/send/SendHeader.tsx
+++ b/packages/suite/src/views/wallet/send/SendHeader.tsx
@@ -117,6 +117,7 @@ export const SendHeader = () => {
                 <Dropdown
                     placement={{ position: 'bottom', alignment: 'start' }}
                     data-testid="@send/header-dropdown"
+                    tooltip={{ content: <Translation id="TR_SHOW_MORE" />, placement: 'left' }}
                     items={options}
                 />
             </WalletSubpageHeading>

--- a/packages/suite/src/views/wallet/send/SendRaw.tsx
+++ b/packages/suite/src/views/wallet/send/SendRaw.tsx
@@ -92,7 +92,13 @@ export const SendRaw = ({ account }: SendRawProps) => {
                     </Tooltip>
                 </H3>
 
-                <IconButton intent="neutral" priority="secondary" icon="x" onClick={cancel} />
+                <IconButton
+                    intent="neutral"
+                    priority="secondary"
+                    icon="x"
+                    onClick={cancel}
+                    tooltip={{ content: <Translation id="TR_CLOSE" /> }}
+                />
             </Row>
 
             <Textarea

--- a/packages/suite/src/views/wallet/tokens/TokensNavigation.tsx
+++ b/packages/suite/src/views/wallet/tokens/TokensNavigation.tsx
@@ -183,6 +183,7 @@ export const TokensNavigation = ({
                         intent="neutral"
                         priority="secondary"
                         onClick={handleAddToken}
+                        tooltip={{ content: <Translation id="TR_ADD_TOKEN_SUBMIT" /> }}
                     />
                 )}
             </Row>

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
@@ -322,6 +322,7 @@ const TokenRowBasicActions = ({
         <Row gap={8}>
             <Dropdown
                 placement={{ position: 'bottom', alignment: 'start' }}
+                tooltip={{ content: <Translation id="TR_SHOW_MORE" />, placement: 'left' }}
                 content={
                     <Card paddingType="small">
                         <Column gap={16}>

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
@@ -45,7 +45,6 @@ import {
     InfoItem,
     Link,
     Row,
-    Tooltip,
 } from '@trezor/components';
 
 import { SUITE } from 'src/actions/suite/constants';
@@ -451,24 +450,21 @@ const TokenRowBasicActions = ({
             />
 
             {type !== 'defi' && !isBelowTablet && (
-                <Tooltip
-                    content={
-                        canSwapToken ? (
+                <IconButton
+                    isDisabled={!canSwapToken}
+                    key="swap"
+                    intent="neutral"
+                    priority="secondary"
+                    icon="repeat"
+                    onClick={onSwapButtonClick}
+                    tooltip={{
+                        content: canSwapToken ? (
                             <Translation id="TR_TRADING_SWAP" />
                         ) : (
                             <Translation id="TR_TRADING_SWAP_UNAVAILABLE" />
-                        )
-                    }
-                >
-                    <IconButton
-                        isDisabled={!canSwapToken}
-                        key="swap"
-                        intent="neutral"
-                        priority="secondary"
-                        icon="repeat"
-                        onClick={onSwapButtonClick}
-                    />
-                </Tooltip>
+                        ),
+                    }}
+                />
             )}
 
             {!isBelowTablet &&
@@ -501,57 +497,55 @@ const TokenRowBasicActions = ({
                     <>
                         {type === 'defi' ? (
                             <ButtonGroup intent="neutral" priority="secondary">
-                                <Tooltip
-                                    content={<Translation id="TR_DEFI_NO_VAULT_TOOLTIP" />}
-                                    isActive={isSupplyButtonDisabled}
-                                >
-                                    <IconButton
-                                        icon="plus"
-                                        isDisabled={isSupplyButtonDisabled}
-                                        onClick={navigateToYieldSupply}
-                                    />
-                                </Tooltip>
+                                <IconButton
+                                    icon="plus"
+                                    isDisabled={isSupplyButtonDisabled}
+                                    onClick={navigateToYieldSupply}
+                                    tooltip={{
+                                        content: <Translation id="TR_DEFI_NO_VAULT_TOOLTIP" />,
+                                        isActive: isSupplyButtonDisabled,
+                                    }}
+                                />
 
-                                <Tooltip
-                                    content={<Translation id="TR_DEFI_NO_VAULT_TOOLTIP" />}
-                                    isActive={isWithdrawButtonDisabled}
-                                >
-                                    <IconButton
-                                        icon="minus"
-                                        isDisabled={isWithdrawButtonDisabled}
-                                        onClick={navigateToYieldWithdraw}
-                                    />
-                                </Tooltip>
+                                <IconButton
+                                    icon="minus"
+                                    isDisabled={isWithdrawButtonDisabled}
+                                    onClick={navigateToYieldWithdraw}
+                                    tooltip={{
+                                        content: <Translation id="TR_DEFI_NO_VAULT_TOOLTIP" />,
+                                        isActive: isWithdrawButtonDisabled,
+                                    }}
+                                />
                             </ButtonGroup>
                         ) : (
                             <ButtonGroup intent="neutral" priority="secondary">
-                                <Tooltip
-                                    content={
-                                        <Translation
-                                            id={
-                                                isDeviceCompromised
-                                                    ? 'TR_RECEIVE_ADDRESS_SECURITY_CHECK_FAILED'
-                                                    : 'TR_NAV_RECEIVE'
-                                            }
-                                        />
-                                    }
-                                >
-                                    <IconButton
-                                        key="token-receive"
-                                        icon="arrowDown"
-                                        isDisabled={!canReceiveToken}
-                                        onClick={onReceiveButtonClick}
-                                    />
-                                </Tooltip>
+                                <IconButton
+                                    key="token-receive"
+                                    icon="arrowDown"
+                                    isDisabled={!canReceiveToken}
+                                    onClick={onReceiveButtonClick}
+                                    tooltip={{
+                                        content: (
+                                            <Translation
+                                                id={
+                                                    isDeviceCompromised
+                                                        ? 'TR_RECEIVE_ADDRESS_SECURITY_CHECK_FAILED'
+                                                        : 'TR_NAV_RECEIVE'
+                                                }
+                                            />
+                                        ),
+                                    }}
+                                />
 
-                                <Tooltip content={<Translation id="TR_NAV_SEND" />}>
-                                    <IconButton
-                                        isDisabled={token.balance === '0'}
-                                        key="token-send"
-                                        icon="arrowUp"
-                                        onClick={onSendButtonClick}
-                                    />
-                                </Tooltip>
+                                <IconButton
+                                    isDisabled={token.balance === '0'}
+                                    key="token-send"
+                                    icon="arrowUp"
+                                    onClick={onSendButtonClick}
+                                    tooltip={{
+                                        content: <Translation id="TR_NAV_SEND" />,
+                                    }}
+                                />
                             </ButtonGroup>
                         )}
                     </>

--- a/packages/suite/src/views/wallet/trading/common/TradingLayout/TradingLayoutHeader.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingLayout/TradingLayoutHeader.tsx
@@ -44,6 +44,7 @@ const TradingPageHeader = ({ fallbackTitle }: TradingPageHeaderProps) => {
                     size="large"
                     onClick={goToRoute(getBackRoute(currentRouteName, activeSection))}
                     data-testid="@account-subpage/back"
+                    tooltip={{ content: <Translation id="TR_BACK" /> }}
                 />
                 <BasicName>
                     <Translation id={fallbackTitle} />

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/ExportAction.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/ExportAction.tsx
@@ -9,7 +9,7 @@ import { getNetwork } from '@suite-common/wallet-config';
 import { fetchAllTransactionsForAccountThunk } from '@suite-common/wallet-core';
 import { type ExportFileType } from '@suite-common/wallet-types';
 import { getTitleForCoinjoinAccount } from '@suite-common/wallet-utils';
-import { Dropdown, Note, Tooltip } from '@trezor/components';
+import { Dropdown, Note } from '@trezor/components';
 
 import { exportTransactionsThunk } from 'src/actions/wallet/exportTransactionsActions';
 import { useDispatch } from 'src/hooks/suite';
@@ -99,36 +99,35 @@ export const ExportAction = ({ account, searchQuery }: ExportActionProps) => {
     const exportTypes = ['csv', 'pdf', 'json'] as const;
 
     return (
-        <Tooltip content={<Translation id="TR_EXPORT_TO_FILE" />}>
-            <Dropdown
-                placement={{ position: 'bottom', alignment: 'start' }}
-                content={
-                    searchQuery ? (
-                        <Note iconName="checks">
-                            <Translation
-                                id={
-                                    searchQuery
-                                        ? 'TR_EXPORT_SEARCH_FILTER_ACTIVE'
-                                        : 'TR_EXPORT_SEARCH_FILTER_INACTIVE'
-                                }
-                            />
-                        </Note>
-                    ) : (
-                        <Note iconName="info" priority="secondary">
-                            <Translation id="TR_EXPORT_SEARCH_FILTER_INACTIVE" />
-                        </Note>
-                    )
-                }
-                items={exportTypes.map(type => ({
-                    label: <Translation id="TR_EXPORT_AS" values={{ as: `.${type}` }} />,
-                    onClick: () => runExport(type),
-                    'data-testid': `${dataTest}/${type}`,
-                }))}
-                minWidth={240}
-                iconName="fileArrowDown"
-                isLoading={isExportRunning}
-                data-testid={`${dataTest}/dropdown`}
-            />
-        </Tooltip>
+        <Dropdown
+            placement={{ position: 'bottom', alignment: 'start' }}
+            content={
+                searchQuery ? (
+                    <Note iconName="checks">
+                        <Translation
+                            id={
+                                searchQuery
+                                    ? 'TR_EXPORT_SEARCH_FILTER_ACTIVE'
+                                    : 'TR_EXPORT_SEARCH_FILTER_INACTIVE'
+                            }
+                        />
+                    </Note>
+                ) : (
+                    <Note iconName="info" priority="secondary">
+                        <Translation id="TR_EXPORT_SEARCH_FILTER_INACTIVE" />
+                    </Note>
+                )
+            }
+            items={exportTypes.map(type => ({
+                label: <Translation id="TR_EXPORT_AS" values={{ as: `.${type}` }} />,
+                onClick: () => runExport(type),
+                'data-testid': `${dataTest}/${type}`,
+            }))}
+            minWidth={240}
+            iconName="fileArrowDown"
+            isLoading={isExportRunning}
+            data-testid={`${dataTest}/dropdown`}
+            tooltip={{ content: <Translation id="TR_EXPORT_TO_FILE" />, placement: 'left' }}
+        />
     );
 };

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/FilterAction.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/FilterAction.tsx
@@ -80,58 +80,55 @@ export const FilterAction = () => {
                 </Row>
             }
         >
-            <Tooltip content={<Translation id="TR_FILTER" />} placement="top">
-                <Dropdown
-                    iconName="funnelSimple"
-                    ref={dropdownRef}
-                    placement={{ position: 'bottom', alignment: 'end' }}
-                    isDisabled={false}
-                    content={
-                        <Column maxWidth={250} padding={spacings.xxs} gap={spacings.md}>
-                            {options.map(option => (
-                                <Radio
-                                    key={option.id}
-                                    isChecked={
-                                        Boolean(suspiciousTransactionsHidden) === Boolean(option.id)
-                                    }
-                                    onChange={() => {
-                                        handleToggleSuspiciousTransactionsRequest(
-                                            Boolean(option.id),
-                                        );
-                                    }}
-                                    data-testid={dataTest}
-                                    verticalAlignment="center"
-                                >
-                                    <Column>
-                                        <Text
-                                            typographyStyle="body-sm-strong"
-                                            intent={
-                                                Boolean(suspiciousTransactionsHidden) ===
-                                                Boolean(option.id)
-                                                    ? 'brand'
-                                                    : 'neutral'
-                                            }
+            <Dropdown
+                iconName="funnelSimple"
+                ref={dropdownRef}
+                placement={{ position: 'bottom', alignment: 'end' }}
+                isDisabled={false}
+                tooltip={{ content: <Translation id="TR_FILTER" />, placement: 'left' }}
+                content={
+                    <Column maxWidth={250} padding={spacings.xxs} gap={spacings.md}>
+                        {options.map(option => (
+                            <Radio
+                                key={option.id}
+                                isChecked={
+                                    Boolean(suspiciousTransactionsHidden) === Boolean(option.id)
+                                }
+                                onChange={() => {
+                                    handleToggleSuspiciousTransactionsRequest(Boolean(option.id));
+                                }}
+                                data-testid={dataTest}
+                                verticalAlignment="center"
+                            >
+                                <Column>
+                                    <Text
+                                        typographyStyle="body-sm-strong"
+                                        intent={
+                                            Boolean(suspiciousTransactionsHidden) ===
+                                            Boolean(option.id)
+                                                ? 'brand'
+                                                : 'neutral'
+                                        }
+                                    >
+                                        {option.label}
+                                    </Text>
+                                    {'description' in option && option.description && (
+                                        <Paragraph
+                                            typographyStyle="body-xs"
+                                            intent="neutral"
+                                            priority="secondary"
+                                            textWrap="pretty"
                                         >
-                                            {option.label}
-                                        </Text>
-                                        {'description' in option && option.description && (
-                                            <Paragraph
-                                                typographyStyle="body-xs"
-                                                intent="neutral"
-                                                priority="secondary"
-                                                textWrap="pretty"
-                                            >
-                                                {option.description}
-                                            </Paragraph>
-                                        )}
-                                    </Column>
-                                </Radio>
-                            ))}
-                        </Column>
-                    }
-                    data-testid={`${dataTest}/dropdown`}
-                />
-            </Tooltip>
+                                            {option.description}
+                                        </Paragraph>
+                                    )}
+                                </Column>
+                            </Radio>
+                        ))}
+                    </Column>
+                }
+                data-testid={`${dataTest}/dropdown`}
+            />
         </Tooltip>
     );
 };

--- a/suite/address/src/Address.tsx
+++ b/suite/address/src/Address.tsx
@@ -128,6 +128,7 @@ export const Address = ({
                                 dispatch(copyAddressToClipboard(value));
                             }
                         }}
+                        tooltip={{ isActive: false }}
                     />
                 </Row>
             }

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -6827,6 +6827,22 @@ export const messages = defineMessages({
         defaultMessage:
             "All token and staking amounts are included in your portfolio balance, but aren't currently supported in graph view.",
     },
+    TR_GRAPH_SHOW: {
+        id: 'TR_GRAPH_SHOW',
+        defaultMessage: 'Show graph',
+    },
+    TR_GRAPH_HIDE: {
+        id: 'TR_GRAPH_HIDE',
+        defaultMessage: 'Hide graph',
+    },
+    TR_EXPAND: {
+        id: 'TR_EXPAND',
+        defaultMessage: 'Expand',
+    },
+    TR_COLLAPSE: {
+        id: 'TR_COLLAPSE',
+        defaultMessage: 'Collapse',
+    },
     METADATA_PROVIDER_NOT_FOUND_ERROR: {
         id: 'METADATA_PROVIDER_NOT_FOUND_ERROR',
         defaultMessage: 'Failed to find metadata in cloud provider.',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mandatory-tooltips-in-icon-button&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mandatory-tooltips-in-icon-button&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 16 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox - watches files over time | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Dropbox API errors > Incomplete data returned from provider | 🤖 auto |
| Metadata - switching between cloud providers > Start with one and switch to another | 🤖 auto |
| Metadata - address labeling > google provider | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Remembered device > google provider | 🤖 auto |
| Dropbox API errors > Malformed token | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Account metadata > google - watches files over time | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-25T21:01:03.587Z • 16 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-25T20:58:25.588Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mandatory-tooltips-in-icon-button/web/](https://dev.suite.sldev.cz/suite-web/mandatory-tooltips-in-icon-button/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->