### PR TITLE
Nightly agent fixer 5

### DIFF
--- a/.github/workflows/test-suite-nightly-fix-agent.yml
+++ b/.github/workflows/test-suite-nightly-fix-agent.yml
@@ -1,0 +1,16 @@
+name: "[Test] Nightly Suite Fix Agent"
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  hello-world:
+    runs-on: ubuntu-latest
+    if: github.repository == 'trezor/trezor-suite'
+    timeout-minutes: 5
+    steps:
+      - run: echo "Hello, fix bot!"

--- a/packages/e2e-utils/package.json
+++ b/packages/e2e-utils/package.json
@@ -15,7 +15,8 @@
         "analyze-tests": "tsx ./src/llmTestAnalyzer/index.ts",
         "select-tests-llm": "tsx ./src/llmTestSelector/index.ts",
         "generate-usage-dashboard": "tsx ./src/llmUsageDashboard/index.ts",
-        "fix-bot:analyze": "tsx src/fixBot/analyze.ts"
+        "fix-bot:analyze": "tsx src/fixBot/analyze.ts",
+        "fix-bot:fix": "tsx src/fixBot/fix.ts"
     },
     "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",

--- a/packages/e2e-utils/package.json
+++ b/packages/e2e-utils/package.json
@@ -24,7 +24,8 @@
         "@trezor/utils": "workspace:*",
         "dotenv": "17.2.3",
         "express": "^5.2.1",
-        "ws": "^8.20.0"
+        "ws": "^8.20.0",
+        "zod": "4.3.6"
     },
     "devDependencies": {
         "@anthropic-ai/claude-code": "^2.1.89",

--- a/packages/e2e-utils/src/fixBot/FIX_AGENT.md
+++ b/packages/e2e-utils/src/fixBot/FIX_AGENT.md
@@ -1,0 +1,182 @@
+# Trezor Suite — Nightly Test Fix Agent
+
+You are implementing fixes for failing Trezor Suite nightly e2e tests.
+Your fix task is embedded at the bottom of this prompt. Read it before doing anything else.
+
+## Context
+
+- **Working directory:** the repo root (a git worktree already on the fix branch — do not switch branches)
+- **Test location:** `suite/e2e/tests/`
+- **Web playwright config:** `suite/e2e/playwright-config/playwright-web.config.ts`
+- **Desktop playwright config:** `suite/e2e/playwright-config/playwright-desktop.config.ts`
+- **Test runner commands (run from repo root):**
+
+    ```bash
+    (cd suite/e2e && yarn xvfb-maybe -- playwright test \
+      --config=./playwright-config/playwright-<web|desktop>.config.ts \
+      --project=<group> \
+      <spec>)
+    ```
+
+- **Spec path:** the `spec` field in validations is relative to the repo root (e.g. `suite/e2e/tests/wallet/send.ts`).
+  Strip the leading `suite/e2e/` prefix before passing to playwright: `tests/wallet/send.ts`.
+
+## Fix Constraints
+
+Allowed changes depend on the fix task's `fix_scope`:
+
+- `TEST_CODE` — only files inside `suite/e2e/`
+- `LOCATOR_ADD` — files inside `suite/e2e/` AND `data-testid` attributes in product source files. No other product code changes.
+
+## Environment
+
+**Desktop build:** `packages/suite-desktop/dist` and `packages/suite-desktop/build` are present.
+For `LOCATOR_ADD` fixes that modify a product component, remove them and rebuild before running
+desktop tests:
+
+```bash
+TEST_BUILD=true yarn workspace @trezor/suite-desktop build:ui
+yarn workspace @trezor/suite-desktop build:app
+```
+
+---
+
+## Step 1 — Read context
+
+Read the `diagnosis` field from the fix task. It contains the full analysis from the analyst agent:
+error messages, stack traces, visual evidence, and root cause reasoning.
+
+Then read the source files mentioned in the diagnosis — spec files, page objects, helpers, and
+(for `LOCATOR_ADD`) the product component containing the element to tag.
+
+---
+
+## Step 2 — Pre-flight
+
+Confirm each validation actually fails before attempting any fix.
+
+```bash
+touch /tmp/preflight-marker
+
+# For each validation — select config by platform:
+(cd suite/e2e && yarn xvfb-maybe -- playwright test \
+  --config=./playwright-config/playwright-<web|desktop>.config.ts \
+  --project=<group> \
+  <spec-without-suite-e2e-prefix>)
+```
+
+Exit code 0 = already passing — record as passed in the final status.
+Non-zero = failing — read the trace before deciding anything further (see below).
+
+**If all validations already pass:** write the status block (Step 4) and stop.
+
+### Reading traces after pre-flight and any test run
+
+```bash
+find suite/e2e/test-results -name 'trace.zip' -newer /tmp/preflight-marker
+```
+
+Unzip and read the last 10 screenshots (closest to the failure):
+
+```bash
+unzip -q <path/to/trace.zip> -d /tmp/trace-preflight/
+ls /tmp/trace-preflight/resources/page@*.jpeg | sort | tail -10
+```
+
+### Check the failure matches the diagnosis
+
+After reading the trace: if the test fails due to an infrastructure or environment error
+(emulator crash, transport failure, bridge error, process startup issue) rather than the
+test assertion described in `diagnosis` — retry once. If the retry shows the same
+infrastructure or environment error, write the result files (Step 4) with `result: "fail"` and
+`iterations: 0`, and stop. Do not enter the fix loop.
+
+---
+
+## Step 3 — Fix loop
+
+Your iteration budget comes from the fix task's `confidence` field: `HIGH` = 3, `MEDIUM` = 2, `LOW` = 1.
+
+Track your current iteration number starting at 1. Stop when budget is exhausted or all validations pass.
+
+### Per iteration
+
+**1. Make changes** according to `fix_scope`. For `LOCATOR_ADD`: only add or modify `data-testid`
+attributes — no logic changes in product code.
+
+**2. Run all validations that are still failing:**
+
+```bash
+touch /tmp/iter-<N>-marker
+
+# Run each failing validation separately so you get one trace per spec.
+# Select config by platform:
+(cd suite/e2e && yarn xvfb-maybe -- playwright test \
+  --config=./playwright-config/playwright-<web|desktop>.config.ts \
+  --project=<group> \
+  <spec>)
+```
+
+**3. Read traces for any that still fail:**
+
+```bash
+find suite/e2e/test-results -name 'trace.zip' -newer /tmp/iter-<N>-marker
+unzip -q <trace.zip> -d /tmp/trace-iter-<N>/
+ls /tmp/trace-iter-<N>/resources/page@*.jpeg | sort | tail -10
+```
+
+**4. Commit all changes from this iteration:**
+
+```bash
+git add <all files you changed in this iteration>
+
+# Iteration 1 — regular commit:
+git commit -m "test(e2e): <short description of fix>"
+
+# Iterations 2+ — fixup the first commit:
+git commit --fixup <SHA of the iteration-1 commit>
+```
+
+Save the iteration-1 commit SHA after the first commit: `git rev-parse HEAD`
+
+Then use `git commit --fixup $FIRST_SHA` for all subsequent iterations.
+
+**5. If all validations (web and desktop) pass → stop.**
+
+---
+
+## Step 4 — Write result files
+
+Write two files to the repo root (current directory) using the Write tool.
+
+**`fix-result.json`** — machine-readable status for the caller:
+
+```json
+{
+  "task_id": "<id from fix task>",
+  "result": "<pass | partial | fail>",
+  "iterations": <number of fix iterations performed, 0 if none needed>,
+  "passed": ["<platform>/<group>/<spec>"],
+  "failed": ["<platform>/<group>/<spec>"],
+  "pr_title": "<string up to 100 chars>"
+}
+```
+
+`pr_title` must be the full PR title including the `Nightly fix <YY-MM-DD> - ` prefix. Base it on the fix you just made.
+`pass` — all validations pass.
+`partial` — at least one passes, at least one fails.
+`fail` — zero validations pass.
+
+List every validation exactly once in either `passed` or `failed`.
+Use `<platform>/<group>/<spec>` format with the `spec` value as-is (repo-root-relative path).
+
+**`pr-description.md`** — PR body for GitHub. Include these sections in order:
+
+1. `## Nightly fix — <YYYY-MM-DD>`
+2. `**Task:**`, `**Scope:**`, `**Result:**` (✅ pass / ⚠️ partial / ❌ fail)
+3. `### Root cause` — `root_cause` from the fix task
+4. `### Fix` — `fix_description` from the fix task
+5. `### Validations` — markdown table with Status (✅/❌), Platform, Group, Spec for every validation
+6. `### Commits` — output of `git log --oneline origin/develop..HEAD`
+7. `### Prompt gaps` — one bullet per ambiguity or missing instruction you encountered,
+   or `_None._` if everything was clear

--- a/packages/e2e-utils/src/fixBot/analyze.ts
+++ b/packages/e2e-utils/src/fixBot/analyze.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { error, log } from '../logger';
-import { reportTokenUsage } from './reportTokenUsage';
+import { logAgentResult, reportTokenUsage } from './reportTokenUsage';
 
 function main(): void {
     const root = execFileSync('git', ['rev-parse', '--show-toplevel'], {
@@ -38,8 +38,8 @@ function main(): void {
     const result = spawnSync(
         join(root, 'node_modules/.bin/claude'),
         [
-            '--verbose',
             '--print',
+            '--verbose',
             '--output-format',
             'json',
             '--settings',
@@ -70,6 +70,7 @@ function main(): void {
     const reportJson = join(reportDir, `${date}.json`);
 
     reportTokenUsage(claudeOutput, join(reportDir, 'token_usage.txt'), 'analysis');
+    logAgentResult(claudeOutput, 'analysis');
 
     const missing = [reportMd, reportJson].filter(f => !existsSync(f));
 

--- a/packages/e2e-utils/src/fixBot/docs.md
+++ b/packages/e2e-utils/src/fixBot/docs.md
@@ -36,7 +36,8 @@ After completing its work, the fix agent writes two files to the **worktree root
         "result": "pass | partial | fail",
         "iterations": 2,
         "passed": ["web/T3W1/suite/e2e/tests/wallet/send.ts"],
-        "failed": []
+        "failed": [],
+        "pr_title": "Nightly fix 26-05-19 - send-button locator"
     }
     ```
 - **`pr-description.md`** — ready-to-post PR body, passed directly to `gh pr create --body-file`
@@ -60,7 +61,7 @@ Extends the existing `AGENT.md`. The existing Steps 1–6 stay as-is. The cluste
 | Value         | Meaning                                                     | Automatable       |
 | ------------- | ----------------------------------------------------------- | ----------------- |
 | `TEST_CODE`   | Only test files need to change                              | ✅                |
-| `LOCATOR_ADD` | Add/modify `data-testid` in product component + update test | ✅                |
+| `LOCATOR_ADD` | Add/modify `data-testid` in product component + update test | ✅                |
 | `PRODUCT_BUG` | Actual product logic needs fixing                           | ❌ human required |
 | `INFRA`       | CI/environment issue                                        | ❌ human required |
 
@@ -136,7 +137,7 @@ Loop:
 
 Fix constraints
 
-- May only change test files and `data-testid` attributes in product components
+- May only change test files and `data-testid` attributes in product components
 - Must run ALL validations listed in the fix task
 - A fix task is "done" when every validation passes or the iteration budget is exhausted
 
@@ -148,8 +149,8 @@ Fix constraints
 
 Every iteration commits locally. First iteration is a regular commit, subsequent ones are `--fixup`.
 
-- First commit: generic message, e.g. `test(e2e): fix send-button locator`
-- Subsequent iterations: `git commit --fixup HEAD` (no custom message, auto-generated)
+- First commit: generic message, e.g. `test(e2e): fix send-button locator` — save its SHA
+- Subsequent iterations: `git commit --fixup <SHA of the iteration-1 commit>` (no custom message, auto-generated)
 
 | Result    | Action                                           |
 | --------- | ------------------------------------------------ |
@@ -159,14 +160,9 @@ Every iteration commits locally. First iteration is a regular commit, subsequent
 
 ### Git strategy
 
-- One branch per fix task, name prepared by the analysis agent and included in `report.json` as `branch`: `fix/nightly-YYYY-MM-DD-<root-cause-slug>`
+- One branch and worktree per fix task, name prepared by the analysis agent and included in `report.json` as `branch`: `fix/nightly-YYYY-MM-DD-<root-cause-slug>`
 - PRs are created only when ≥1 validation passes
 
-### PR description structure
+### PR description
 
-## Nightly Fix — 2026-04-23
-
-✅ Fixed (3 tasks — 8 tests)
-⚠️ Partially fixed (1 task — 2/3 tests passing, see attempt log)
-❌ Failed to fix (1 task — see attempt log)
-🚫 Human required (2 tasks — PRODUCT_BUG, INFRA)
+The fix agent writes a per-task `pr-description.md` covering: root cause, fix applied, a validation status table (✅/❌ per platform/group/spec), the commit log, and any prompt gaps encountered. See `FIX_AGENT.md` Step 4 for the authoritative structure.

--- a/packages/e2e-utils/src/fixBot/fix.ts
+++ b/packages/e2e-utils/src/fixBot/fix.ts
@@ -1,0 +1,167 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import {
+    closeSync,
+    cpSync,
+    existsSync,
+    mkdirSync,
+    openSync,
+    readFileSync,
+    readdirSync,
+    symlinkSync,
+    unlinkSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { error, log } from '../logger';
+import { publishPR } from './publish';
+import { logAgentResult, reportTokenUsage } from './reportTokenUsage';
+import { type FixTask, ReportSchema } from './schemas';
+
+const AUTOMATABLE = new Set<FixTask['fix_scope']>(['TEST_CODE', 'LOCATOR_ADD']);
+
+function isAutomatable(task: FixTask): boolean {
+    return AUTOMATABLE.has(task.fix_scope) && task.validations.length > 0;
+}
+
+function latestReport(reportDir: string): string {
+    const files = readdirSync(reportDir)
+        .filter(f => /^\d{4}-\d{2}-\d{2}\.json$/.test(f))
+        .sort();
+    if (!files.length) throw new Error(`No report files in ${reportDir}`);
+
+    return join(reportDir, files[files.length - 1]);
+}
+
+function setupWorktree(root: string, task: FixTask, worktreePath: string): void {
+    if (existsSync(worktreePath)) {
+        execFileSync('git', ['worktree', 'remove', worktreePath, '--force']);
+    }
+    try {
+        execFileSync('git', ['branch', '-D', '--', task.branch]);
+    } catch {
+        // branch doesn't exist yet on first run
+    }
+
+    execFileSync('git', ['worktree', 'add', worktreePath, '-b', task.branch, 'origin/develop']);
+    symlinkSync(join(root, 'node_modules'), join(worktreePath, 'node_modules'));
+
+    execFileSync('git', [
+        '-C',
+        worktreePath,
+        'submodule',
+        'update',
+        '--init',
+        'submodules/trezor-common',
+    ]);
+    // use default git hooks instead of personal custom ones
+    execFileSync('git', [
+        '-C',
+        worktreePath,
+        'config',
+        'core.hooksPath',
+        join(worktreePath, '.husky'),
+    ]);
+
+    const envFile = join(root, 'suite/e2e/.env');
+    if (existsSync(envFile)) {
+        cpSync(envFile, join(worktreePath, 'suite/e2e/.env'));
+    }
+
+    for (const dir of ['packages/suite-desktop/dist', 'packages/suite-desktop/build'] as const) {
+        const src = join(root, dir);
+        if (existsSync(src)) {
+            mkdirSync(join(worktreePath, dirname(dir)), { recursive: true });
+            symlinkSync(src, join(worktreePath, dir));
+        }
+    }
+}
+
+function runAgent(
+    root: string,
+    fixAgentDir: string,
+    reportDir: string,
+    task: FixTask,
+    worktreePath: string,
+): void {
+    const prompt = `${readFileSync(join(fixAgentDir, 'FIX_AGENT.md'), 'utf-8')}\n\n---\n\n## Fix Task\n\n\`\`\`json\n${JSON.stringify(task, null, 2)}\n\`\`\`\n`;
+
+    // Write stdout to a temp file to avoid spawnSync's in-memory buffer limit (ENOBUFS).
+    const tmpFile = join(tmpdir(), `claude-fix-${task.id}-${Date.now()}.json`);
+    const stdoutFd = openSync(tmpFile, 'w');
+
+    const env = { ...process.env };
+    // Prevents an internal Claude Code setting from accidentally being inherited by the subprocess and breaking it
+    delete env['MCP_CONNECTION_NONBLOCKING'];
+
+    const result = spawnSync(
+        join(root, 'node_modules/.bin/claude'),
+        [
+            '--print',
+            '--verbose',
+            '--output-format',
+            'json',
+            '--settings',
+            join(fixAgentDir, 'settings.json'),
+        ],
+        { input: prompt, cwd: worktreePath, env, stdio: ['pipe', stdoutFd, 'inherit'] },
+    );
+
+    closeSync(stdoutFd);
+
+    const output = readFileSync(tmpFile, 'utf-8');
+    unlinkSync(tmpFile);
+
+    reportTokenUsage(output, join(reportDir, 'token_usage.txt'), `fix:${task.id}`);
+    logAgentResult(output, `fix:${task.id}`);
+
+    if (result.error) throw result.error;
+    if (result.status !== 0 || result.signal) {
+        log(`Agent exited with status=${result.status ?? '?'} signal=${result.signal ?? 'none'}`);
+    }
+}
+
+function runTask(root: string, fixAgentDir: string, reportDir: string, task: FixTask): void {
+    const sanitizedWorktreeName = task.branch.replaceAll('/', '-').replace(/[^a-zA-Z0-9_-]/g, '_');
+    const worktreePath = join(tmpdir(), sanitizedWorktreeName);
+
+    const webCount = task.validations.filter(v => v.platform === 'web').length;
+    const desktopCount = task.validations.filter(v => v.platform === 'desktop').length;
+
+    log(`━━━ Task ${task.id} ━━━`);
+    log(`Scope:   ${task.fix_scope}`);
+    log(`Branch:  ${task.branch}`);
+    log(`Web:     ${webCount}  Desktop: ${desktopCount}`);
+
+    setupWorktree(root, task, worktreePath);
+    log('Worktree ready.\n');
+
+    runAgent(root, fixAgentDir, reportDir, task, worktreePath);
+    log(`Agent done. Processing results.`);
+
+    publishPR({ worktreePath, branch: task.branch });
+}
+
+function main(): void {
+    const root = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+        encoding: 'utf-8',
+    }).trim();
+    const fixAgentDir = join(root, 'packages/e2e-utils/src/fixBot');
+    const reportDir = join(fixAgentDir, 'reports');
+
+    const reportPath = process.argv[2] ?? latestReport(reportDir);
+    const report = ReportSchema.parse(JSON.parse(readFileSync(reportPath, 'utf-8')));
+
+    const tasks = report.fix_tasks.filter(isAutomatable);
+    log(`${tasks.length} automatable task(s) in ${reportPath}\n`);
+
+    for (const task of tasks) {
+        try {
+            runTask(root, fixAgentDir, reportDir, task);
+        } catch (err) {
+            error(`Task ${task.id} failed: ${err}`);
+        }
+    }
+}
+
+main();

--- a/packages/e2e-utils/src/fixBot/publish.ts
+++ b/packages/e2e-utils/src/fixBot/publish.ts
@@ -1,0 +1,78 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { log } from '../logger';
+import { type FixResult, FixResultSchema } from './schemas';
+
+export interface PublishOptions {
+    worktreePath: string;
+    branch: string;
+    base?: string;
+    remote?: string;
+}
+
+const ICONS: Record<FixResult['result'], string> = {
+    pass: '✅',
+    partial: '⚠️',
+    fail: '❌',
+};
+
+export function publishPR({
+    worktreePath,
+    branch,
+    base = 'develop',
+    remote = 'origin',
+}: PublishOptions): void {
+    const resultFile = join(worktreePath, 'fix-result.json');
+
+    if (!existsSync(worktreePath)) {
+        log(`Result: ❌  worktree not found: ${worktreePath}`);
+
+        return;
+    }
+
+    if (!existsSync(resultFile)) {
+        log(`Result: ❌  fix-result.json missing — agent did not complete`);
+        log(`         expected at: ${resultFile}`);
+
+        return;
+    }
+
+    const { result, passed, failed, iterations, pr_title } = FixResultSchema.parse(
+        JSON.parse(readFileSync(resultFile, 'utf-8')),
+    );
+
+    log(
+        `Result: ${ICONS[result] ?? '?'} ${result}  passed=${passed.length}  failed=${failed.length}  iterations=${iterations}`,
+    );
+
+    if (result === 'fail') {
+        log('  → No branch pushed (zero validations pass).');
+
+        return;
+    }
+
+    log(`  → Pushing ${branch} to ${remote}...`);
+    execFileSync('git', ['-C', worktreePath, 'push', '--', remote, branch], { stdio: 'inherit' });
+
+    const prDescriptionFile = join(worktreePath, 'pr-description.md');
+    const prArgs = ['pr', 'create', '--title', pr_title, '--head', branch, '--base', base];
+
+    if (existsSync(prDescriptionFile)) prArgs.push('--body-file', prDescriptionFile);
+
+    const prUrl = execFileSync('gh', prArgs, { encoding: 'utf-8' }).trim();
+    log(`PR: ${prUrl}`);
+}
+
+// Entry point when called directly by GHA matrix jobs:
+// tsx publish.ts <worktreePath> <branch> [base]
+const isMain = /publish\.[jt]s$/.test(process.argv[1] ?? '');
+if (isMain) {
+    const [worktreePath, branch, base] = process.argv.slice(2);
+    if (!worktreePath || !branch) {
+        process.stderr.write('Usage: tsx publish.ts <worktreePath> <branch> [base]\n');
+        process.exit(1);
+    }
+    publishPR({ worktreePath, branch, base });
+}

--- a/packages/e2e-utils/src/fixBot/reportTokenUsage.ts
+++ b/packages/e2e-utils/src/fixBot/reportTokenUsage.ts
@@ -2,32 +2,24 @@
 // when implementation gets to GHA stage
 import { appendFileSync } from 'node:fs';
 
-interface ClaudeUsage {
-    input_tokens?: number;
-    output_tokens?: number;
-    cache_creation_input_tokens?: number;
-    cache_read_input_tokens?: number;
-}
-
-interface ClaudeResult {
-    type?: string;
-    num_turns?: number;
-    usage?: ClaudeUsage;
-    total_cost_usd?: number;
-    duration_ms?: number;
-}
+import { type ClaudeResult, ClaudeResultSchema } from './schemas';
 
 function parseClaudeOutput(raw: string): ClaudeResult {
-    const parsed: unknown = JSON.parse(raw.trim());
-    if (Array.isArray(parsed)) {
-        return (parsed as ClaudeResult[]).find(entry => entry.type === 'result') ?? {};
+    const unsafeParsed: unknown = JSON.parse(raw.trim());
+    const entries = Array.isArray(unsafeParsed) ? unsafeParsed : [unsafeParsed];
+    const resultEntry = entries
+        .map(entry => ClaudeResultSchema.safeParse(entry))
+        .find(parsed => parsed.success && parsed.data.type === 'result');
+
+    if (!resultEntry?.success) {
+        throw new Error('No result entry found in Claude output');
     }
 
-    return parsed as ClaudeResult;
+    return resultEntry.data;
 }
 
 function formatIntegerWithCommas(value: number): string {
-    return value.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+    return new Intl.NumberFormat('en-US').format(value);
 }
 
 function formatTimestamp(date: Date): string {
@@ -40,12 +32,36 @@ function formatTimestamp(date: Date): string {
     return `${year}-${month}-${day} ${hours}:${minutes}Z`;
 }
 
+export function logAgentResult(rawOutput: string, agentName: string): void {
+    let entry: ClaudeResult = {};
+    try {
+        entry = parseClaudeOutput(rawOutput);
+    } catch {
+        process.stderr.write(
+            `[${agentName}] agent output unparsable (${rawOutput.length} bytes)\n`,
+        );
+
+        return;
+    }
+
+    const subtype = entry.subtype ?? '?';
+    const text = entry.result ?? '';
+    const preview = text.length > 800 ? `${text.slice(0, 800)}…` : text;
+
+    process.stderr.write(`[${agentName}] subtype=${subtype}\n`);
+    if (preview) process.stderr.write(`${preview}\n`);
+}
+
 export function reportTokenUsage(rawOutput: string, logFilePath: string, agentName: string): void {
     let result: ClaudeResult = {};
     try {
         result = parseClaudeOutput(rawOutput);
     } catch {
-        // malformed — fall through with empty result (zeroed/blank line)
+        process.stderr.write(
+            `[${agentName}] agent output unparsable (${rawOutput.length} bytes)\n`,
+        );
+
+        return;
     }
 
     const timestamp = formatTimestamp(new Date());
@@ -54,22 +70,24 @@ export function reportTokenUsage(rawOutput: string, logFilePath: string, agentNa
     const turnsField = result.num_turns != null ? String(result.num_turns).padStart(3) : 'N/A';
 
     const formatTokenCount = (tokenCount: number | undefined) =>
-        formatIntegerWithCommas(tokenCount ?? 0).padStart(9);
+        tokenCount != null ? formatIntegerWithCommas(tokenCount).padStart(9) : 'N/A'.padStart(9);
 
     const inputTokens = formatTokenCount(result.usage?.input_tokens);
     const outputTokens = formatTokenCount(result.usage?.output_tokens);
     const cacheWriteTokens = formatTokenCount(result.usage?.cache_creation_input_tokens);
     const cacheReadTokens = formatTokenCount(result.usage?.cache_read_input_tokens);
 
+    const COST_FIELD_WIDTH = 9; // '$' + 8-char number
     const costField =
         result.total_cost_usd != null
             ? `$${result.total_cost_usd.toFixed(4).padStart(8)}`
-            : '         ';
+            : 'N/A'.padStart(COST_FIELD_WIDTH);
 
+    const DURATION_FIELD_WIDTH = 6; // 5-char number + 's'
     const durationField =
         result.duration_ms != null
             ? `${String(Math.round(result.duration_ms / 1000)).padStart(5)}s`
-            : '      ';
+            : 'N/A'.padStart(DURATION_FIELD_WIDTH);
 
     const line = `${timestamp}  ${paddedAgentName}  turns=${turnsField}  in=${inputTokens}  out=${outputTokens}  cache_w=${cacheWriteTokens}  cache_r=${cacheReadTokens}  ${costField}  ${durationField}`;
 

--- a/packages/e2e-utils/src/fixBot/schemas.ts
+++ b/packages/e2e-utils/src/fixBot/schemas.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+
+export const TestToValidateSchema = z.object({
+    platform: z.enum(['web', 'desktop']),
+    group: z.string(),
+    spec: z.string(),
+});
+
+export const FixTaskSchema = z.object({
+    id: z.string(),
+    branch: z.string(),
+    root_cause: z.string(),
+    fix_scope: z.enum(['TEST_CODE', 'LOCATOR_ADD', 'PRODUCT_BUG', 'INFRA']),
+    confidence: z.enum(['HIGH', 'MEDIUM', 'LOW']),
+    fix_description: z.string(),
+    diagnosis: z.string(),
+    validations: z.array(TestToValidateSchema),
+});
+
+export const ReportSchema = z.object({
+    fix_tasks: z.array(FixTaskSchema),
+});
+
+export const FixResultSchema = z.object({
+    task_id: z.string(),
+    result: z.enum(['pass', 'partial', 'fail']),
+    passed: z.array(z.string()),
+    failed: z.array(z.string()),
+    iterations: z.number().int().nonnegative(),
+    pr_title: z.string(),
+});
+
+export const ClaudeUsageSchema = z.object({
+    input_tokens: z.number().optional(),
+    output_tokens: z.number().optional(),
+    cache_creation_input_tokens: z.number().optional(),
+    cache_read_input_tokens: z.number().optional(),
+});
+
+export const ClaudeResultSchema = z.object({
+    type: z.string().optional(),
+    subtype: z.string().optional(),
+    result: z.string().optional(),
+    num_turns: z.number().optional(),
+    usage: ClaudeUsageSchema.optional(),
+    total_cost_usd: z.number().optional(),
+    duration_ms: z.number().optional(),
+});
+
+export type FixTask = z.infer<typeof FixTaskSchema>;
+export type Report = z.infer<typeof ReportSchema>;
+export type FixResult = z.infer<typeof FixResultSchema>;
+export type ClaudeResult = z.infer<typeof ClaudeResultSchema>;

--- a/packages/e2e-utils/src/fixBot/settings.json
+++ b/packages/e2e-utils/src/fixBot/settings.json
@@ -1,4 +1,5 @@
 {
+    "model": "claude-sonnet-4-6",
     "permissions": {
         "defaultMode": "auto"
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15565,6 +15565,7 @@ __metadata:
     express: "npm:^5.2.1"
     tsx: "npm:^4.21.0"
     ws: "npm:^8.20.0"
+    zod: "npm:4.3.6"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
update to docs and hello world wf so I can test it from the branch

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=nightly-agent-fixer-5&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-26T04:14:59.765Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/nightly-agent-fixer-5/web/](https://dev.suite.sldev.cz/suite-web/nightly-agent-fixer-5/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->