### PR TITLE
chore(jest): trap unexpected console.error in tests

### DIFF
--- a/JestCustomEnv.js
+++ b/JestCustomEnv.js
@@ -12,6 +12,21 @@ class CustomEnvironment extends NodeEnvironment {
                 );
             }
         });
+
+        // console.error trap: a real console.error during a test is almost always either an
+        // expected error path that the test forgot to assert on, or a missing mock that hides
+        // a real production issue. Tests that legitimately want to silence the error must
+        // jest.spyOn(console, 'error').mockImplementation(...) — the spy replaces this wrap.
+        const originalError = this.global.console.error;
+        this.global.console.error = (...args) => {
+            originalError.apply(this.global.console, args);
+            throw new Error(
+                `Unexpected console.error during test. If this is expected, mock it with ` +
+                    `jest.spyOn(console, 'error').mockImplementation(() => {}). Args: ${args
+                        .map(a => (a instanceof Error ? a.message : String(a)))
+                        .join(' ')}`,
+            );
+        };
     }
 
     async teardown() {


### PR DESCRIPTION
## Summary

Extends `JestCustomEnv` with a `console.error` trap. A real `console.error` during a test is almost always either an expected error path the test forgot to assert on, or a missing mock that hides a real production issue. Tests that legitimately want to silence the error must use `jest.spyOn(console, 'error').mockImplementation(() => {})` — the spy replaces this wrap.

Split out of #27990. Sibling PR: #28050 (timeout traps).

## Implementation

Wraps `this.global.console.error` in env setup. Original call is preserved (so the message still appears in test output), then an `Error` is thrown to fail the test with a clear message and an instruction on how to mock.

## Findings from running all 29 wired packages

**0 hits across ~6000 tests.** 15 test files already mock `console.error`/`console.warn`/`console.log` via `jest.spyOn(...).mockImplementation(...)`. Other tests either don't exercise console-logging error paths or the paths don't produce log calls.

Trap verified to fire via a synthetic test file with an explicit `console.error(...)`.

## Risk

The `console.error` wrap interacts with any test that exercises a third-party lib that logs errors. None encountered in the 29 wired packages, but the surface exists. Easy escape valve: tests can mock `console.error` in `beforeEach` if a new code path triggers it.

## Test plan

- [ ] CI green on develop merge
- [ ] No flakiness introduced in the 29 wired packages over the next few CI runs
- [ ] If the trap surfaces an unexpected case in CI, evaluate whether it's a real signal or a false positive that needs a per-test mock