### PR TITLE
chore(jest): trap TimeoutNegative/Overflow warnings in tests

### DIFF
--- a/JestCustomEnv.js
+++ b/JestCustomEnv.js
@@ -11,6 +11,16 @@ class CustomEnvironment extends NodeEnvironment {
                     'MaxListenersExceededWarning detected. If you need more, use events.setMaxListeners(desiredNumber)',
                 );
             }
+
+            // TimeoutNegativeWarning / TimeoutOverflowWarning fire from setTimeout when ms is
+            // negative or > 2^31-1. Almost always a date-arithmetic bug (e.g. `deadline - now`
+            // where deadline is in the past). Near-zero false-positive surface.
+            if (
+                warning.name === 'TimeoutNegativeWarning' ||
+                warning.name === 'TimeoutOverflowWarning'
+            ) {
+                throw warning;
+            }
         });
     }
 


### PR DESCRIPTION
## Summary

Extends `JestCustomEnv` to throw on `TimeoutNegativeWarning` and `TimeoutOverflowWarning` from Node's `process.on('warning')` stream. These warnings fire from `setTimeout` when `ms` is negative or larger than `2^31-1`, almost always a date-arithmetic bug (e.g. `deadline - now` where `deadline` is in the past). Piggy-backs on the existing warning listener; near-zero false-positive surface.

Split out of #27990. Sibling PR: #28049 (`console.error` trap).

## Implementation

Adds two extra branches inside the existing `process.on('warning', ...)` listener that already handles `MaxListenersExceededWarning`. The warning itself is rethrown so the stack points back to the offending `setTimeout` call.

## Findings from running all 29 wired packages

**0 hits across ~6000 tests.** No test exercises `setTimeout(fn, < 0)` or `setTimeout(fn, > 2^31-1)`. Both traps verified to fire via a synthetic test file with `setTimeout(() => {}, -1)`.

## Risk

Near-impossible to produce false positives; the warnings only fire on genuinely buggy `setTimeout` arguments. Timer warnings are Node-level and surface in unrelated tests if any of them happen to do bad timer arithmetic. None encountered.

## Test plan

- [ ] CI green on develop merge
- [ ] No flakiness introduced in the 29 wired packages over the next few CI runs