### PR TITLE
feat(trading): split swap form into two containers

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
@@ -121,92 +121,96 @@ export const TradingExchangeFormInputs = () => {
     const exchangeSellSupportedCryptoIds = useSelector(selectTradingExchangeSellCryptoIds);
 
     return (
-        <TradingFormCard>
-            <TradingFormSection>
-                <TradingFormInputSellAsset
-                    inputName={TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT}
-                    inputLabel="TR_FROM"
-                    inputBottomText={
-                        <AssetPickerInputBalance
-                            name={TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT}
-                            showOnlyAmount
-                        />
-                    }
-                    includedCryptoIds={exchangeSellSupportedCryptoIds}
-                    excludedCryptoId={receiveCryptoSelect?.id}
-                    onAssetSelect={handleSellAssetSelect}
-                />
-                <Column gap={8}>
-                    <TradingFormInputFiatCrypto
-                        cryptoInputName={TRADING_FORM_OUTPUT_AMOUNT}
-                        fiatInputName={TRADING_FORM_OUTPUT_FIAT}
-                        cryptoSelectName={TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT}
-                        currencySelectLabel={currencySelect.value.toUpperCase()}
-                        cryptoCurrencyLabel={sendCryptoSelect?.id}
-                    />
-                    {amountInCrypto && (
-                        <Row justifyContent="space-between" alignItems="flex-start">
-                            <Row gap={8} data-testid="@trading/form/fraction-buttons">
-                                {generateFractionButtons(helpers).map(button => {
-                                    const { percentValue, ...buttonProps } = button;
-
-                                    return (
-                                        <FractionButton
-                                            key={buttonProps.id}
-                                            {...buttonProps}
-                                            onClick={() => {
-                                                analytics.report({
-                                                    type: events.appFormPercentButtonsEvent.name,
-                                                    payload: {
-                                                        type: 'swap',
-                                                        value: percentValue,
-                                                    },
-                                                });
-                                                button.onClick();
-                                                context.resetSelectedOffer();
-                                            }}
-                                        />
-                                    );
-                                })}
-                            </Row>
-                            <TradingBalance
-                                balance={outputAmount}
-                                displaySymbol={sendCryptoSelect?.displaySymbol}
-                                symbol={account.symbol}
-                                tokenAddress={tokenAddress}
+        <Column gap={20}>
+            <TradingFormCard>
+                <TradingFormSection>
+                    <TradingFormInputSellAsset
+                        inputName={TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT}
+                        inputLabel="TR_FROM"
+                        inputBottomText={
+                            <AssetPickerInputBalance
+                                name={TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT}
                                 showOnlyAmount
-                                amountInCrypto={amountInCrypto}
-                                decimals={sendAssetDecimals}
                             />
-                        </Row>
-                    )}
-                </Column>
-
-                {showReserveBanner && (
-                    <TradingNetworkReserveBanner
-                        symbol={account.symbol}
-                        contractAddress={tokenAddress}
+                        }
+                        includedCryptoIds={exchangeSellSupportedCryptoIds}
+                        excludedCryptoId={receiveCryptoSelect?.id}
+                        onAssetSelect={handleSellAssetSelect}
                     />
-                )}
+                    <Column gap={8}>
+                        <TradingFormInputFiatCrypto
+                            cryptoInputName={TRADING_FORM_OUTPUT_AMOUNT}
+                            fiatInputName={TRADING_FORM_OUTPUT_FIAT}
+                            cryptoSelectName={TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT}
+                            currencySelectLabel={currencySelect.value.toUpperCase()}
+                            cryptoCurrencyLabel={sendCryptoSelect?.id}
+                        />
+                        {amountInCrypto && (
+                            <Row justifyContent="space-between" alignItems="flex-start">
+                                <Row gap={8} data-testid="@trading/form/fraction-buttons">
+                                    {generateFractionButtons(helpers).map(button => {
+                                        const { percentValue, ...buttonProps } = button;
 
-                <TradingFormInputBuyAsset
-                    inputPlaceholder="TR_SELECT_TOKEN"
-                    inputLabel="TR_TO"
-                    inputName={TRADING_FORM_RECEIVE_CRYPTO_CURRENCY_SELECT}
-                    includedCryptoIds={exchangeBuySupportedCryptoIds}
-                    excludedCryptoId={sendCryptoSelect?.id}
-                    onAssetSelect={handleReceiveAssetSelect}
+                                        return (
+                                            <FractionButton
+                                                key={buttonProps.id}
+                                                {...buttonProps}
+                                                onClick={() => {
+                                                    analytics.report({
+                                                        type: events.appFormPercentButtonsEvent
+                                                            .name,
+                                                        payload: {
+                                                            type: 'swap',
+                                                            value: percentValue,
+                                                        },
+                                                    });
+                                                    button.onClick();
+                                                    context.resetSelectedOffer();
+                                                }}
+                                            />
+                                        );
+                                    })}
+                                </Row>
+                                <TradingBalance
+                                    balance={outputAmount}
+                                    displaySymbol={sendCryptoSelect?.displaySymbol}
+                                    symbol={account.symbol}
+                                    tokenAddress={tokenAddress}
+                                    showOnlyAmount
+                                    amountInCrypto={amountInCrypto}
+                                    decimals={sendAssetDecimals}
+                                />
+                            </Row>
+                        )}
+                    </Column>
+
+                    {showReserveBanner && (
+                        <TradingNetworkReserveBanner
+                            symbol={account.symbol}
+                            contractAddress={tokenAddress}
+                        />
+                    )}
+
+                    <TradingFormInputBuyAsset
+                        inputPlaceholder="TR_SELECT_TOKEN"
+                        inputLabel="TR_TO"
+                        inputName={TRADING_FORM_RECEIVE_CRYPTO_CURRENCY_SELECT}
+                        includedCryptoIds={exchangeBuySupportedCryptoIds}
+                        excludedCryptoId={sendCryptoSelect?.id}
+                        onAssetSelect={handleReceiveAssetSelect}
+                    />
+                </TradingFormSection>
+            </TradingFormCard>
+            <TradingFormCard>
+                {receiveCryptoSelect && !isLoading && <TradingReceiveAddress />}
+                <TradingFormFees
+                    feeInfo={feeInfo}
+                    account={account}
+                    composedLevels={composedLevels}
+                    changeFeeLevel={changeFeeLevel}
                 />
-            </TradingFormSection>
-
-            {receiveCryptoSelect && !isLoading && <TradingReceiveAddress />}
-            <TradingFormFees
-                feeInfo={feeInfo}
-                account={account}
-                composedLevels={composedLevels}
-                changeFeeLevel={changeFeeLevel}
-            />
-            <TradingSelectedOfferProvider />
-        </TradingFormCard>
+                <TradingSelectedOfferProvider />
+            </TradingFormCard>
+        </Column>
     );
 };


### PR DESCRIPTION
## Description

- Split the swap exchange form into two stacked cards.
- Keep the asset selectors, amount input, fraction buttons, reserve banner, and receive asset selector in the top card.
- Move the receive address, fee selection, and selected provider block into the lower card.
- Keep the swap logic unchanged; this PR is layout-only for the exchange form.

## Notes for QA

- In Wallet > Trade > Swap, select source and destination assets and verify the receive address, network fee, and provider render together in a separate lower card.
- In Wallet > Trade > Swap, change the sell amount and assets and verify the top card layout stays intact and the lower card still updates correctly.

## Related Issue

Resolve #27885

## Screenshots:

N/A

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to TradingExchangeFormInputs.tsx, which is a core form component used across all swap/exchange trading flows. Since no LLM analysis data is available for the tests, prioritization is based on how directly each test exercises the exchange form input functionality. The recommended strategy is to run the three core swap direction tests (coin-to-token, coins, token-to-coin) at high priority for maximum confidence, with fee and edge-case tests at medium priority. Live tests are omitted as they likely require external service connectivity and the non-live equivalents provide sufficient coverage.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — This test directly exercises the swap exchange form flow (coin to token), which renders TradingExchangeFormInputs. Any change to form inputs would be immediately visible in this core swap scenario.
- `suite/e2e/tests/trading/swap-coins.test.ts` — This test covers the basic coin-to-coin swap flow, directly rendering the exchange form inputs component. It validates a fundamental swap path that would catch regressions in the changed component.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — This test exercises the reverse direction (token to coin) swap flow, ensuring the exchange form inputs work correctly when the source is a token. Complements swap-coin-to-token for full bidirectional coverage.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/trading/swap-tokens.test.ts` — Covers token-to-token swaps, another variant of the exchange form inputs. While similar to coin swap tests, it validates token-specific behavior in the form inputs component.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Tests fee-related behavior in the Bitcoin swap flow. Changes to TradingExchangeFormInputs could affect how fee options are displayed or interacted with alongside form inputs.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests fee-related behavior in the Ethereum swap flow. Similar rationale to Bitcoin fees test — changes to form inputs could affect fee display/interaction for EVM chains.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — Tests an edge case where the target network is disabled. The exchange form inputs component would be involved in rendering this scenario and changes could affect error/validation behavior.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — Navigation test likely only briefly renders the exchange form when navigating to the swap tab. Changes to form inputs are unlikely to break navigation, but the component is rendered in the flow.

</details>

_Updated: 2026-05-26T06:14:03.211Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/trading-split-swap-form-containers&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/trading-split-swap-form-containers&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Metadata - switching between cloud providers > Start with one and switch to another | 🤖 auto |
| Metadata - address labeling > google provider | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Remembered device > google provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-26T06:20:47.547Z • 12 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-26T06:16:54.063Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/trading-split-swap-form-containers/web/](https://dev.suite.sldev.cz/suite-web/feat/trading-split-swap-form-containers/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->