### PR TITLE
test(utxo-lib): cover script.compile/toStack/decompile edge cases

### DIFF
--- a/packages/utxo-lib/tests/script.test.ts
+++ b/packages/utxo-lib/tests/script.test.ts
@@ -100,6 +100,33 @@ describe('script', () => {
         });
     });
 
+    describe('compile (Buffer passthrough)', () => {
+        it('returns the same Buffer unchanged when given a Buffer input', () => {
+            const buf = Buffer.from('51', 'hex');
+            expect(bscript.compile(buf)).toBe(buf);
+        });
+    });
+
+    describe('toStack (non-push-only rejection)', () => {
+        it('throws "Expected push-only script" for a script containing OP_CHECKSIG', () => {
+            const script = Buffer.from([bscript.OPS.OP_CHECKSIG]);
+            expect(() => bscript.toStack(script)).toThrow('Expected push-only script');
+        });
+    });
+
+    describe('compile (non-array, non-buffer rejection)', () => {
+        it('throws "Expected Array" when called with a non-Buffer non-Array input', () => {
+            expect(() => bscript.compile({} as unknown as Buffer)).toThrow('Expected Array');
+        });
+    });
+
+    describe('decompile (truncated pushdata header)', () => {
+        it('returns [] when buffer contains OP_PUSHDATA1 alone (pushdata.decode returns null)', () => {
+            const truncated = Buffer.from([bscript.OPS.OP_PUSHDATA1]);
+            expect(bscript.decompile(truncated)).toEqual([]);
+        });
+    });
+
     describe('decompile', () => {
         fixtures.valid.forEach(f => {
             it(`decompiles ${f.asm}`, () => {


### PR DESCRIPTION
Land-test-first slice for #27537.

## Why this is a separate PR

#27537 inlines `bitcoin-ops` and `pushdata-bitcoin` into `@trezor/utxo-lib`. The most consequential behavioral detail is that the new `src/script/pushdata.ts` returns `... | null` from `decode` for truncated PUSHDATA headers — the previous `pushdata-bitcoin` JS already behaved this way, but the `declare module` type signature hid it.

To make #27537 a true refactor (logic unchanged, types tightened), we want the truncated-header / null branch already covered on `develop` *before* the implementation swap lands. That way:

1. **This PR** merges first. The new tests pass against today's `develop` because the underlying JS behavior of `pushdata-bitcoin` already matches.
2. **#27537** is rebased on `develop` after this lands. The same tests then guard the inlined `src/script/pushdata.ts`, with no behavior change between the two states.

## Summary

Adds 4 unit tests to `packages/utxo-lib/tests/script.test.ts`:

- `compile (Buffer passthrough)` — `bscript.compile(Buffer)` returns the input by reference.
- `compile (non-array, non-buffer rejection)` — throws `Expected Array` for `{}`.
- `toStack (non-push-only rejection)` — throws `Expected push-only script` for a script containing `OP_CHECKSIG`.
- `decompile (truncated pushdata header)` — returns `[]` when the buffer is a lone `OP_PUSHDATA1` (this is the case the `pushdata.decode` -> `null` branch must handle).

Tests are lifted from #28007 (broader stryker / coverage PR), narrowed to only what's relevant to the code #27537 actually touches (`src/script/pushdata.ts`, `src/script/ops.ts`, `src/script/index.ts`).

## Test plan

- [x] `yarn workspace @trezor/utxo-lib test:unit tests/script.test.ts` — 713/713 pass against `develop`
- [x] `yarn workspace @trezor/utxo-lib type-check`
- [x] `yarn workspace @trezor/utxo-lib lint:js`

## Follow-up

- Rebase #27537 on top of this once merged. The new tests stay green across the rebase — they're the safety net for the inlined `pushdata.decode` returning `... | null`.

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is a unit test file (packages/utxo-lib/tests/script.test.ts), not production source code. Changes to test files do not affect application behavior and therefore pose no risk of regression in any E2E test. No E2E tests need to be run for this change.

<details><summary><b>Changed files (1)</b></summary>

- `packages/utxo-lib/tests/script.test.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/utxo-lib/tests/script.test.ts`

_Updated: 2026-05-26T06:34:38.020Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/utxo-lib-script-tests&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/utxo-lib-script-tests&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-26T06:40:50.191Z • 8 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-26T06:37:24.987Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/utxo-lib-script-tests/web/](https://dev.suite.sldev.cz/suite-web/mroz22/utxo-lib-script-tests/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->