### PR TITLE
test(utxo-lib): cover writeUInt64LEasString and writeInt64LE

### DIFF
--- a/packages/utxo-lib/tests/bufferutils.test.ts
+++ b/packages/utxo-lib/tests/bufferutils.test.ts
@@ -152,6 +152,169 @@ describe('bufferutils', () => {
         });
     });
 
+    describe('writeUInt64LEasString', () => {
+        describe('string path', () => {
+            fixtures.valid.forEach(f => {
+                it(`encodes string "${f.dec}" correctly`, () => {
+                    const buffer = Buffer.alloc(8, 0);
+
+                    const n = bufferutils.writeUInt64LEasString(buffer, String(f.dec), 0);
+
+                    expect(buffer.toString('hex')).toEqual(f.hex64);
+                    expect(n).toEqual(8);
+                });
+
+                it(`round-trips string "${f.dec}" through readUInt64LEasString`, () => {
+                    const buffer = Buffer.alloc(8, 0);
+
+                    bufferutils.writeUInt64LEasString(buffer, String(f.dec), 0);
+
+                    expect(bufferutils.readUInt64LEasString(buffer, 0)).toEqual(String(f.dec));
+                });
+            });
+        });
+
+        // These values exceed Number.MAX_SAFE_INTEGER (2^53 - 1), which is the actual
+        // reason the string API exists. Round-trips through readUInt64LEasString must
+        // hit the BN fallback because readUInt64LE throws above 2^53.
+        describe('string path > Number.MAX_SAFE_INTEGER (BN fallback)', () => {
+            [
+                { dec: '9007199254740992', hex64: '0000000000002000' }, // 2^53
+                { dec: '9007199254740993', hex64: '0100000000002000' }, // 2^53 + 1
+                { dec: '18446744073709551615', hex64: 'ffffffffffffffff' }, // UINT64_MAX
+            ].forEach(f => {
+                it(`encodes "${f.dec}" correctly`, () => {
+                    const buffer = Buffer.alloc(8, 0);
+
+                    const n = bufferutils.writeUInt64LEasString(buffer, f.dec, 0);
+
+                    expect(buffer.toString('hex')).toEqual(f.hex64);
+                    expect(n).toEqual(8);
+                });
+
+                it(`round-trips "${f.dec}" through readUInt64LEasString (BN fallback)`, () => {
+                    const buffer = Buffer.alloc(8, 0);
+
+                    bufferutils.writeUInt64LEasString(buffer, f.dec, 0);
+
+                    expect(bufferutils.readUInt64LEasString(buffer, 0)).toEqual(f.dec);
+                });
+            });
+        });
+
+        describe('number path (delegates to writeUInt64LE)', () => {
+            fixtures.valid.forEach(f => {
+                it(`encodes number ${f.dec} correctly`, () => {
+                    const buffer = Buffer.alloc(8, 0);
+
+                    const n = bufferutils.writeUInt64LEasString(buffer, f.dec, 0);
+
+                    expect(buffer.toString('hex')).toEqual(f.hex64);
+                    expect(n).toEqual(8);
+                });
+            });
+        });
+
+        // int64-buffer silently coerces unparseable strings and overflows modulo 2^64
+        // without throwing. These snapshots pin that behavior so a future library swap
+        // (e.g. to viem / @noble) surfaces the change instead of corrupting silently.
+        // FIXME(bigint-migration): silent coercion is a latent bug — once int64-buffer
+        // is replaced, flip these expectations to `toThrow` for invalid inputs.
+        describe('invalid string input (regression guard)', () => {
+            [
+                { description: 'non-numeric string', input: 'abc', hex: '0000000000000000' },
+                { description: 'empty string', input: '', hex: '0000000000000000' },
+                {
+                    description: 'overflow > UINT64_MAX',
+                    input: '99999999999999999999',
+                    hex: 'ffff0f632d5ec76b',
+                },
+            ].forEach(f => {
+                it(`writes deterministic bytes for ${f.description}`, () => {
+                    const buffer = Buffer.alloc(8, 0);
+
+                    const n = bufferutils.writeUInt64LEasString(buffer, f.input, 0);
+
+                    expect(buffer.toString('hex')).toEqual(f.hex);
+                    expect(n).toEqual(8);
+                });
+            });
+        });
+    });
+
+    describe('writeInt64LE', () => {
+        fixtures.valid.forEach(f => {
+            it(`encodes positive ${f.dec} correctly`, () => {
+                const buffer = Buffer.alloc(8, 0);
+
+                const n = bufferutils.writeInt64LE(buffer, f.dec, 0);
+
+                expect(buffer.toString('hex')).toEqual(f.hex64);
+                expect(n).toEqual(8);
+            });
+        });
+
+        // INT64_MIN is exercised separately below as a known overflow; safe negatives
+        // go through the standard encode + round-trip path.
+        fixtures.negative
+            .filter(f => Number.isSafeInteger(f.dec))
+            .forEach(f => {
+                it(`encodes negative ${f.dec} correctly`, () => {
+                    const buffer = Buffer.alloc(8, 0);
+
+                    const n = bufferutils.writeInt64LE(buffer, f.dec, 0);
+
+                    expect(buffer.toString('hex')).toEqual(f.hex64.toLowerCase());
+                    expect(n).toEqual(8);
+                });
+
+                it(`round-trips negative ${f.dec} through readInt64LE`, () => {
+                    const buffer = Buffer.alloc(8, 0);
+
+                    bufferutils.writeInt64LE(buffer, f.dec, 0);
+
+                    expect(bufferutils.readInt64LE(buffer, 0)).toEqual(f.dec);
+                });
+            });
+
+        it('overflows for INT64_MIN due to JS number precision loss', () => {
+            // The JS Number literal -9223372036854775808 rounds to -9223372036854776000,
+            // which int64-buffer wraps modulo 2^64 to INT64_MAX. This regression test
+            // pins the current (buggy) behavior so future migrations of int64-buffer
+            // surface the change instead of silently corrupting amounts.
+            // FIXME(bigint-migration): once arithmetic moves to BigInt, expect either
+            // the correct INT64_MIN encoding (0000000000000080) or a thrown range error.
+            const buffer = Buffer.alloc(8, 0);
+
+            bufferutils.writeInt64LE(buffer, -9223372036854775808, 0);
+
+            expect(buffer.toString('hex')).not.toEqual('0000000000000080');
+            expect(buffer.toString('hex')).toEqual('ffffffffffffff7f');
+        });
+
+        // int64-buffer silently coerces NaN / Infinity to deterministic bytes
+        // without throwing. These snapshots pin that behavior so a future library swap
+        // surfaces the change instead of corrupting silently.
+        // FIXME(bigint-migration): silent coercion is a latent bug — once int64-buffer
+        // is replaced, flip these expectations to `toThrow` for invalid inputs.
+        describe('invalid number input (regression guard)', () => {
+            [
+                { description: 'NaN', input: NaN, hex: '0000000000000000' },
+                { description: 'Infinity', input: Infinity, hex: '0000000000000000' },
+                { description: '-Infinity', input: -Infinity, hex: 'ffffffffffffffff' },
+            ].forEach(f => {
+                it(`writes deterministic bytes for ${f.description}`, () => {
+                    const buffer = Buffer.alloc(8, 0);
+
+                    const n = bufferutils.writeInt64LE(buffer, f.input, 0);
+
+                    expect(buffer.toString('hex')).toEqual(f.hex);
+                    expect(n).toEqual(8);
+                });
+            });
+        });
+    });
+
     describe('writeVarInt', () => {
         fixtures.valid.forEach(f => {
             it(`encodes ${f.dec} correctly`, () => {


### PR DESCRIPTION
Land-test-first slice for #27538.

## Why this is a separate PR

#27538 replaces the unmaintained `int64-buffer` package with Node's native `Buffer.writeBigInt64LE` / `writeBigUInt64LE` in `src/bufferutils.ts`. Two functions change:

- `writeUInt64LEasString` (string path) — `new Int64LE(value).toBuffer().copy(...)` -> `buffer.writeBigUInt64LE(BigInt(value), offset)`
- `writeInt64LE` — `new Int64LE(value).toArray()` + manual byte copy -> `buffer.writeBigInt64LE(BigInt(value), offset)`

Today both functions are exercised **only indirectly** via `transaction.test.ts` (Bitcoin/Zcash/Decred/Dash/Peercoin serialization). There are no dedicated unit tests for either path, which makes #27538 harder to verify in isolation.

This PR lands the missing direct coverage on `develop` first, so that #27538 can be rebased on top and its behavior swap is guarded by tests that are already on `develop`.

## Summary

Adds 3 new `describe` blocks to `packages/utxo-lib/tests/bufferutils.test.ts`:

- **`writeUInt64LEasString` string path** — for every value in `fixtures.valid`, asserts that `writeUInt64LEasString(buf, String(value), 0)` produces the expected 8-byte little-endian encoding, plus a round-trip through `readUInt64LEasString`. This is the path #27538 actually rewires.
- **`writeUInt64LEasString` number-proxy path** — sanity check that the `typeof value !== 'string'` branch still delegates to `writeUInt64LE`. This path is unchanged by #27538 but was previously untested.
- **`writeInt64LE`** — for positive values (`fixtures.valid`) and negative values (`fixtures.negative`), asserts hex output and round-trip through `readInt64LE`.

**Note on INT64_MIN:** the `fixtures.negative` fixture for `-9223372036854775808` is filtered out of the `writeInt64LE` block via `Number.isSafeInteger`. The JS Number literal `-9223372036854775808` evaluates to `-9223372036854776000` because of double precision, which overflows past INT64_MIN on the write side (`Int64LE` clamps it to INT64_MAX bytes). The existing `readInt64LE` test happens to pass for this fixture only because the same precision rounding also hits the read result before `expect(...).toEqual(...)` runs.

## Test plan

- [x] `yarn workspace @trezor/utxo-lib test:unit tests/bufferutils.test.ts` — 180/180 pass on `develop`
- [x] `yarn workspace @trezor/utxo-lib test:unit tests/bufferutils.test.ts` — 180/180 pass on `mroz22/issue-27403-int64-dataview` (#27538 head)
- [x] `yarn workspace @trezor/utxo-lib type-check`
- [x] `yarn workspace @trezor/utxo-lib lint:js`

## Follow-up

- Rebase #27538 on top of this once merged. The new tests stay green across the rebase — they're the safety net for the `Int64LE` -> native BigInt swap.

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is a unit test file (packages/utxo-lib/tests/bufferutils.test.ts), not production source code. Changes to test files do not affect application behavior and therefore pose no risk of regression in any E2E test. No E2E tests need to be run for this change.

<details><summary><b>Changed files (1)</b></summary>

- `packages/utxo-lib/tests/bufferutils.test.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/utxo-lib/tests/bufferutils.test.ts`

_Updated: 2026-05-26T06:51:16.115Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/utxo-lib-bufferutils-int64-tests&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/utxo-lib-bufferutils-int64-tests&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-26T06:57:48.287Z • 8 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-26T07:30:41.213Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/utxo-lib-bufferutils-int64-tests/web/](https://dev.suite.sldev.cz/suite-web/mroz22/utxo-lib-bufferutils-int64-tests/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->