### PR TITLE
feat(trading): update KYC warnings and provider CTA

### DIFF
--- a/packages/suite/src/views/wallet/trading/buy/TradingFormOfferBuyActions.tsx
+++ b/packages/suite/src/views/wallet/trading/buy/TradingFormOfferBuyActions.tsx
@@ -10,6 +10,7 @@ import { useSelector } from 'src/hooks/suite';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { useTradingStellarActivation } from 'src/hooks/wallet/trading/useTradingStellarActivation';
 import { TradingFormOfferConfirmButton } from 'src/views/wallet/trading/common/TradingForm/TradingFormOffer/components/TradingFormOfferConfirmButton';
+import { TradingFormOfferKYCWarning } from 'src/views/wallet/trading/common/TradingForm/TradingFormOffer/components/TradingFormOfferKYCWarning';
 import { TradingFormOfferOTC } from 'src/views/wallet/trading/common/TradingForm/TradingFormOffer/components/TradingFormOfferOTC';
 import { useTradingFormOfferCommon } from 'src/views/wallet/trading/common/TradingForm/TradingFormOffer/hooks/useTradingFormOfferCommon';
 import { useReceiveAddressModalControls } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/useReceiveAddressModalControls';
@@ -31,8 +32,7 @@ export const TradingFormOfferBuyActions = () => {
     const {
         quote,
         areFeesLoading,
-        isConfirmButtonLoading,
-        confirmButtonTranslationId,
+        confirmButtonData,
         selectedAssetCryptoId,
         isBaseButtonDisabled,
     } = useTradingFormOfferCommon<'buy'>();
@@ -76,10 +76,9 @@ export const TradingFormOfferBuyActions = () => {
 
         return (
             <TradingFormOfferConfirmButton
+                {...confirmButtonData}
                 onClick={onSelectQuote}
                 isDisabled={isButtonDisabled}
-                isLoading={isConfirmButtonLoading}
-                translationId={confirmButtonTranslationId}
                 testId="@trading/form/buy-button"
             />
         );
@@ -88,6 +87,7 @@ export const TradingFormOfferBuyActions = () => {
     return (
         <>
             {renderActionButton()}
+            {quote && <TradingFormOfferKYCWarning />}
             {stellarActivateModal}
             <TradingFormOfferOTC />
         </>

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchangeSidebar.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchangeSidebar.tsx
@@ -15,7 +15,7 @@ import { TradingExchangeMinimumReceivedInfoItem } from 'src/views/wallet/trading
 import { TradingExchangeRateInfoItem } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingExchangeRateInfoItem';
 import { TradingExchangeSlippageInfoItem } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingExchangeSlippageInfoItem';
 import { TradingInfoItem } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem';
-import { TradingUtilsKyc } from 'src/views/wallet/trading/common/TradingUtils/TradingUtilsKyc';
+import { TradingUtilsProviderKyc } from 'src/views/wallet/trading/common/TradingUtils/TradingUtilsProviderKyc';
 import { formatCryptoAmountAsAmount } from 'src/views/wallet/trading/common/formatCryptoAmountAsAmount';
 
 type TradingDetailExchangeSidebarProps = {
@@ -104,7 +104,7 @@ export const TradingDetailExchangeSidebar = ({
 
                     {!trade.isDex && <TradingExchangeRateInfoItem rateType={rateType} />}
                 </Column>
-                <TradingUtilsKyc exchange={trade.exchange} providers={providers} />
+                <TradingUtilsProviderKyc exchange={trade.exchange} providers={providers} />
             </Column>
         </Card>
     );

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer/TradingFormOffer.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer/TradingFormOffer.tsx
@@ -35,7 +35,7 @@ export const TradingFormOffer = () => {
     } = useTradingFormOfferCommon();
 
     return (
-        <Column gap={20}>
+        <Column gap={12}>
             <TradingFormOfferAmount
                 amount={receiveAmount}
                 sendAmount={sendAmount}

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer/components/TradingFormOfferConfirmButton.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer/components/TradingFormOfferConfirmButton.tsx
@@ -1,5 +1,5 @@
 import { Translation, type TranslationKey } from '@suite/intl';
-import { Button } from '@trezor/components';
+import { Button, type IconName } from '@trezor/components';
 import { breakpoints } from '@trezor/theme';
 
 import { useIsContentBelowBreakpoint } from 'src/support/suite/ContentFlex';
@@ -9,6 +9,8 @@ interface TradingFormOfferConfirmButtonProps {
     isDisabled: boolean;
     isLoading: boolean;
     translationId: TranslationKey;
+    translationValues?: Record<string, string>;
+    iconRight?: IconName;
     testId: string;
 }
 
@@ -17,6 +19,8 @@ export const TradingFormOfferConfirmButton = ({
     isDisabled,
     isLoading,
     translationId,
+    translationValues,
+    iconRight,
     testId,
 }: TradingFormOfferConfirmButtonProps) => {
     const isContentBelowBreakpoint = useIsContentBelowBreakpoint(breakpoints.tablet);
@@ -32,8 +36,9 @@ export const TradingFormOfferConfirmButton = ({
             data-testid={testId}
             minWidth={160}
             width={isContentBelowBreakpoint ? undefined : '100%'}
+            iconRight={iconRight}
         >
-            <Translation id={translationId} />
+            <Translation id={translationId} values={translationValues} />
         </Button>
     );
 };

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer/components/TradingFormOfferKYCWarning.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer/components/TradingFormOfferKYCWarning.tsx
@@ -1,0 +1,11 @@
+import { Translation } from '@suite/intl';
+import { Banner } from '@trezor/components';
+
+export const TradingFormOfferKYCWarning = () => (
+    <Banner
+        intent="warning"
+        icon="identificationCard"
+        description={<Translation id="TR_TRADING_KYC_REQUIRED_WARNING" />}
+        data-testid="@trading/form/kyc-warning"
+    />
+);

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer/hooks/useTradingFormOfferCommon.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer/hooks/useTradingFormOfferCommon.ts
@@ -1,8 +1,10 @@
 import type { BuyTrade, ExchangeTrade, SellFiatTrade } from 'invity-api';
 
+import { type TranslationKey } from '@suite/intl';
 import { selectTorState } from '@suite/tor';
-import type { TradingType } from '@suite-common/trading';
+import { type TradingType, selectTradingProviderCompanyName } from '@suite-common/trading';
 import { selectAreFeesLoading, selectHasRunningDiscovery } from '@suite-common/wallet-core';
+import { type IconName } from '@trezor/components';
 
 import { useSelector } from 'src/hooks/suite';
 import { useTradingDeviceDisconnected } from 'src/hooks/wallet/trading/form/common/useTradingDeviceDisconnected';
@@ -58,11 +60,33 @@ export const useTradingFormOfferCommon = <T extends TradingType>() => {
             : selectedCryptoId;
 
     const noOffersWithTor = isTorEnabled && !quote && !state.isFormLoading;
-    const isConfirmButtonLoading = areFeesLoading || (state.isFormLoading && !isAmountEmpty);
-    const confirmButtonTranslationId =
-        state.isFormLoading && !isAmountEmpty
-            ? ('TR_TRADING_OFFER_LOOKING' as const)
-            : tradingGetSectionActionLabel(type);
+    const isLookingForQuote = state.isFormLoading && !isAmountEmpty;
+
+    const providerName = useSelector(suiteState =>
+        selectTradingProviderCompanyName(suiteState, quote?.exchange, type),
+    );
+
+    const confirmButtonData: {
+        translationId: TranslationKey;
+        translationValues?: Record<string, string>;
+        iconRight?: IconName;
+        isLoading: boolean;
+    } = {
+        translationId: tradingGetSectionActionLabel(type),
+        isLoading: areFeesLoading || isLookingForQuote,
+    };
+
+    if (isLookingForQuote) {
+        confirmButtonData.translationId = 'TR_TRADING_OFFER_LOOKING';
+    } else if (providerName && type === 'buy') {
+        confirmButtonData.translationId = 'TR_TRADING_BUY_VIA';
+        confirmButtonData.translationValues = { providerName };
+        confirmButtonData.iconRight = 'arrowSquareOut';
+    } else if (providerName && type === 'sell') {
+        confirmButtonData.translationId = 'TR_TRADING_SELL_VIA';
+        confirmButtonData.translationValues = { providerName };
+        confirmButtonData.iconRight = 'arrowSquareOut';
+    }
 
     const amountLabels = tradingGetAmountLabels({ type, amountInCrypto: !!amountInCrypto });
 
@@ -78,8 +102,7 @@ export const useTradingFormOfferCommon = <T extends TradingType>() => {
         quoteAmounts,
         areFeesLoading,
         noOffersWithTor,
-        isConfirmButtonLoading,
-        confirmButtonTranslationId,
+        confirmButtonData,
         sendAmount,
         receiveAmount,
         selectedAssetCryptoId,

--- a/packages/suite/src/views/wallet/trading/common/TradingOffers/TradingOffersModalItem.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingOffers/TradingOffersModalItem.tsx
@@ -14,8 +14,8 @@ import {
 } from 'src/utils/wallet/trading/tradingTypingUtils';
 
 import { useTradingOfferRate } from './useTradingOfferRate';
-import { TradingUtilsKyc } from '../TradingUtils/TradingUtilsKyc';
 import { TradingUtilsProvider } from '../TradingUtils/TradingUtilsProvider';
+import { TradingUtilsProviderKyc } from '../TradingUtils/TradingUtilsProviderKyc';
 
 type TradingOffersModalItemProps = {
     quote: TradingTradeType;
@@ -64,13 +64,15 @@ export const TradingOffersModalItem = ({ quote, onSelect }: TradingOffersModalIt
                 <Row justifyContent="space-between" alignItems="center" width="100%">
                     <ProviderWrapper>
                         <TradingUtilsProvider providers={providers} exchange={exchange} />
-                        {exchangeComparatorProps && (
-                            <TradingUtilsKyc
+                        {exchangeComparatorProps ? (
+                            <TradingUtilsProviderKyc
                                 exchange={exchange}
                                 providers={exchangeComparatorProps.providers}
                                 isForComparator
                                 isDex={exchangeComparatorProps.isDex}
                             />
+                        ) : (
+                            <TradingUtilsProviderKyc isForComparator isBuySell />
                         )}
                     </ProviderWrapper>
 

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeDetails.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeDetails.tsx
@@ -23,7 +23,7 @@ import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingC
 import { type TradingExchangeProvidersInfoProps } from 'src/types/trading/trading';
 import { formatCryptoAmountAsAmount } from 'src/views/wallet/trading/common/formatCryptoAmountAsAmount';
 
-import { TradingUtilsKyc } from '../../TradingUtils/TradingUtilsKyc';
+import { TradingUtilsProviderKyc } from '../../TradingUtils/TradingUtilsProviderKyc';
 import { TradingExchangeMevProtectionInfoItem } from '../TradingInfo/TradingExchangeMevProtectionInfoItem';
 import { TradingExchangeMinimumReceivedInfoItem } from '../TradingInfo/TradingExchangeMinimumReceivedInfoItem';
 import { TradingExchangeRateInfoItem } from '../TradingInfo/TradingExchangeRateInfoItem';
@@ -136,12 +136,8 @@ export const TradingOfferExchangeDetails = ({
                         </Tooltip>
                     </Text>
                 </InfoItem>
+                <TradingUtilsProviderKyc exchange={exchange} providers={providers} />
             </Column>
-
-            <TradingUtilsKyc
-                exchange={exchange}
-                providers={providers as TradingExchangeProvidersInfoProps}
-            />
 
             {formStep === 'SIGN_DATA' && (
                 <Card>

--- a/packages/suite/src/views/wallet/trading/common/TradingUtils/TradingUtilsKyc.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingUtils/TradingUtilsKyc.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 
 import { Translation } from '@suite/intl';
 import { Banner, Icon, Row, Text, Tooltip } from '@trezor/components';
+import { exhaustive } from '@trezor/type-utils';
 
 import {
     KYC_DEX,
@@ -11,49 +12,40 @@ import {
     KYC_REQUIRED,
     KYC_YES_REFUND,
 } from 'src/constants/wallet/trading/kyc';
-import { type TradingExchangeProvidersInfoProps } from 'src/types/trading/trading';
 
 const TooltipText = styled.span`
     text-decoration: underline dotted;
 `;
 
-interface TradingUtilsProviderProps {
-    exchange?: string;
-    providers?: TradingExchangeProvidersInfoProps;
+interface TradingUtilsKycProps {
+    kycType?: ExchangeKYCType;
     isForComparator?: boolean;
-    isDex?: boolean;
 }
 
-const getKycPolicy = (kycPolicyType: ExchangeKYCType | undefined) => {
-    if (kycPolicyType === KYC_REQUIRED) {
-        return <Translation id="TR_TRADING_KYC_REQUIRED" />;
-    }
-
-    if (kycPolicyType === KYC_NO_REFUND) {
-        return <Translation id="TR_TRADING_KYC_NO_REFUND" />;
-    }
-
-    if (kycPolicyType === KYC_YES_REFUND) {
-        return <Translation id="TR_TRADING_KYC_YES_REFUND" />;
-    }
-
-    if (kycPolicyType === KYC_NO_KYC) {
-        return <Translation id="TR_TRADING_KYC_NO_KYC" />;
+const getKycPolicyTranslation = (kycType: ExchangeKYCType) => {
+    switch (kycType) {
+        case KYC_REQUIRED:
+            return <Translation id="TR_TRADING_KYC_REQUIRED" />;
+        case KYC_NO_REFUND:
+            return <Translation id="TR_TRADING_KYC_NO_REFUND" />;
+        case KYC_YES_REFUND:
+            return <Translation id="TR_TRADING_KYC_YES_REFUND" />;
+        case KYC_NO_KYC:
+            return <Translation id="TR_TRADING_KYC_NO_KYC" />;
+        case KYC_DEX:
+            return null;
+        default:
+            return exhaustive(kycType);
     }
 };
 
-export const TradingUtilsKyc = ({
-    exchange,
-    providers,
-    isForComparator,
-    isDex,
-}: TradingUtilsProviderProps) => {
-    const provider = providers && exchange ? providers[exchange] : null;
-    const kycPolicyType = provider?.kycPolicyType;
-    const kycPolicyTranslation = getKycPolicy(kycPolicyType);
+export const TradingUtilsKyc = ({ kycType, isForComparator }: TradingUtilsKycProps) => {
+    if (!kycType) {
+        return null;
+    }
 
     if (isForComparator) {
-        if (isDex) {
+        if (kycType === KYC_DEX) {
             return (
                 <Row alignItems="center" gap={4}>
                     <Icon
@@ -69,13 +61,16 @@ export const TradingUtilsKyc = ({
             );
         }
 
-        if (!kycPolicyType || !kycPolicyTranslation) {
+        const kycPolicyTranslation = getKycPolicyTranslation(kycType);
+
+        if (!kycPolicyTranslation) {
             return null;
         }
 
-        const kycTitle = [KYC_NO_KYC, KYC_DEX].includes(kycPolicyType)
-            ? 'TR_TRADING_KYC_POLICY_NEVER_REQUIRED'
-            : 'TR_TRADING_KYC_POLICY';
+        const kycTitle =
+            kycType === KYC_NO_KYC
+                ? 'TR_TRADING_KYC_POLICY_NEVER_REQUIRED'
+                : 'TR_TRADING_KYC_POLICY';
 
         return (
             <Tooltip content={kycPolicyTranslation} placement="bottom">
@@ -91,9 +86,11 @@ export const TradingUtilsKyc = ({
         );
     }
 
-    if (!kycPolicyType || !kycPolicyTranslation) {
+    const kycPolicyTranslation = getKycPolicyTranslation(kycType);
+
+    if (!kycPolicyTranslation) {
         return null;
     }
 
-    return <Banner icon description={kycPolicyTranslation} />;
+    return <Banner intent="neutral" icon="identificationCard" description={kycPolicyTranslation} />;
 };

--- a/packages/suite/src/views/wallet/trading/common/TradingUtils/TradingUtilsPrice.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingUtils/TradingUtilsPrice.tsx
@@ -23,7 +23,7 @@ import { tradingGetAmountLabels } from 'src/utils/wallet/trading/tradingUtils';
 import { TradingCryptoAmount } from 'src/views/wallet/trading/common/TradingCryptoAmount';
 import { TradingFiatAmount } from 'src/views/wallet/trading/common/TradingFiatAmount';
 
-import { TradingUtilsKyc } from './TradingUtilsKyc';
+import { TradingUtilsProviderKyc } from './TradingUtilsProviderKyc';
 
 const PriceValue = styled.div`
     ${typography['headline-sm']}
@@ -157,7 +157,7 @@ export const TradingUtilsPrice = ({
                         </PriceValue>
                         {exchangeComparatorProps && (
                             <Row margin={{ top: spacings.xs }}>
-                                <TradingUtilsKyc
+                                <TradingUtilsProviderKyc
                                     exchange={exchangeComparatorProps.exchange}
                                     providers={exchangeComparatorProps.providers}
                                     isForComparator

--- a/packages/suite/src/views/wallet/trading/common/TradingUtils/TradingUtilsProviderKyc.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingUtils/TradingUtilsProviderKyc.tsx
@@ -1,0 +1,47 @@
+import { type ExchangeKYCType } from 'invity-api';
+
+import { KYC_DEX, KYC_REQUIRED } from 'src/constants/wallet/trading/kyc';
+import { type TradingExchangeProvidersInfoProps } from 'src/types/trading/trading';
+
+import { TradingUtilsKyc } from './TradingUtilsKyc';
+
+interface TradingUtilsProviderKycProps {
+    exchange?: string;
+    providers?: TradingExchangeProvidersInfoProps;
+    isForComparator?: boolean;
+    isDex?: boolean;
+    isBuySell?: boolean;
+}
+
+const getKycType = ({
+    exchange,
+    providers,
+    isDex,
+    isBuySell,
+}: Pick<TradingUtilsProviderKycProps, 'exchange' | 'providers' | 'isDex' | 'isBuySell'>):
+    | ExchangeKYCType
+    | undefined => {
+    // Buy and sell providers always require KYC and do not expose a kyc policy.
+    if (isBuySell) {
+        return KYC_REQUIRED;
+    }
+
+    if (isDex) {
+        return KYC_DEX;
+    }
+
+    return providers && exchange ? providers[exchange]?.kycPolicyType : undefined;
+};
+
+export const TradingUtilsProviderKyc = ({
+    exchange,
+    providers,
+    isForComparator,
+    isDex,
+    isBuySell,
+}: TradingUtilsProviderKycProps) => (
+    <TradingUtilsKyc
+        kycType={getKycType({ exchange, providers, isDex, isBuySell })}
+        isForComparator={isForComparator}
+    />
+);

--- a/packages/suite/src/views/wallet/trading/exchange/TradingFormOfferExchangeActions.tsx
+++ b/packages/suite/src/views/wallet/trading/exchange/TradingFormOfferExchangeActions.tsx
@@ -50,8 +50,7 @@ export const TradingFormOfferExchangeActions = () => {
         quote,
         quoteAmounts,
         areFeesLoading,
-        isConfirmButtonLoading,
-        confirmButtonTranslationId,
+        confirmButtonData,
         selectedAssetCryptoId,
         isBaseButtonDisabled,
     } = useTradingFormOfferCommon<'exchange'>();
@@ -146,10 +145,9 @@ export const TradingFormOfferExchangeActions = () => {
 
         return (
             <TradingFormOfferConfirmButton
+                {...confirmButtonData}
                 onClick={onSelectQuote}
                 isDisabled={isButtonDisabled}
-                isLoading={isConfirmButtonLoading}
-                translationId={confirmButtonTranslationId}
                 testId="@trading/form/exchange-button"
             />
         );

--- a/packages/suite/src/views/wallet/trading/sell/TradingFormOfferSellActions.tsx
+++ b/packages/suite/src/views/wallet/trading/sell/TradingFormOfferSellActions.tsx
@@ -5,6 +5,7 @@ import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { getTradingFirstOutput } from 'src/utils/wallet/trading/tradingUtils';
 import { TradingFormOfferConfirmButton } from 'src/views/wallet/trading/common/TradingForm/TradingFormOffer/components/TradingFormOfferConfirmButton';
+import { TradingFormOfferKYCWarning } from 'src/views/wallet/trading/common/TradingForm/TradingFormOffer/components/TradingFormOfferKYCWarning';
 import { TradingFormOfferOTC } from 'src/views/wallet/trading/common/TradingForm/TradingFormOffer/components/TradingFormOfferOTC';
 import { useTradingFormOfferCommon } from 'src/views/wallet/trading/common/TradingForm/TradingFormOffer/hooks/useTradingFormOfferCommon';
 
@@ -36,8 +37,7 @@ export const TradingFormOfferSellActions = () => {
         areSatsUsed,
     });
 
-    const { quote, isConfirmButtonLoading, confirmButtonTranslationId, isBaseButtonDisabled } =
-        useTradingFormOfferCommon<'sell'>();
+    const { quote, confirmButtonData, isBaseButtonDisabled } = useTradingFormOfferCommon<'sell'>();
 
     const isButtonDisabled =
         isBaseButtonDisabled ||
@@ -62,12 +62,13 @@ export const TradingFormOfferSellActions = () => {
     return (
         <>
             <TradingFormOfferConfirmButton
+                {...confirmButtonData}
                 onClick={onSelectQuote}
                 isDisabled={isButtonDisabled}
-                isLoading={isConfirmButtonLoading}
-                translationId={confirmButtonTranslationId}
                 testId="@trading/form/sell-button"
             />
+
+            {quote && <TradingFormOfferKYCWarning />}
 
             <TradingFormOfferOTC />
         </>

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -316,6 +316,12 @@ export const selectTradingProviderKycPolicy = (
     return undefined;
 };
 
+export const selectTradingProviderCompanyName = (
+    state: TradingRootState,
+    name: string | undefined,
+    type: TradingType,
+) => selectTradingProviderByNameAndTradeType(state, name, type)?.companyName ?? name;
+
 export const selectTradingBuyQuotesRequest = (state: TradingRootState) =>
     state.wallet.trading.buy.quotesRequest;
 

--- a/suite/e2e/support/pageObjects/trading/tradingPage.ts
+++ b/suite/e2e/support/pageObjects/trading/tradingPage.ts
@@ -34,6 +34,7 @@ export class TradingPage {
     readonly buyBestOfferButton: Locator;
     readonly sellBestOfferButton: Locator;
     readonly swapBestOfferButton: Locator;
+    readonly kycWarning: Locator;
     readonly proceedToPayButton: Locator;
     readonly backToAccountButton = (type: 'Buy' | 'Sell' | 'Swap') =>
         this.page.getByRole('button', { name: `Make another ${type}` });
@@ -74,6 +75,7 @@ export class TradingPage {
         this.buyBestOfferButton = this.page.getByTestId('@trading/form/buy-button');
         this.sellBestOfferButton = this.page.getByTestId('@trading/form/sell-button');
         this.swapBestOfferButton = this.page.getByTestId('@trading/form/exchange-button');
+        this.kycWarning = this.page.getByTestId('@trading/form/kyc-warning');
         this.proceedToPayButton = this.page.getByRole('button', { name: 'Proceed to pay' });
 
         // Swap

--- a/suite/e2e/tests/trading/buy-bitcoin.test.ts
+++ b/suite/e2e/tests/trading/buy-bitcoin.test.ts
@@ -1,12 +1,19 @@
 import { localizeNumber } from '@suite-common/wallet-utils';
 import { capitalizeFirstLetter } from '@trezor/utils';
 
-import { buyQuotesBTC, buyTradeBTC, invityEndpoint, invityRequest } from '../../fixtures/invity';
+import {
+    buyQuotesBTC,
+    buyTradeBTC,
+    getCompanyNameFromList,
+    invityEndpoint,
+    invityRequest,
+} from '../../fixtures/invity';
 import { expect, test } from '../../support/fixtures';
 
 // Expected values based on our mocked responses
 const fiatAmount = buyQuotesBTC[0].fiatStringAmount;
 const bestBuyProvider = capitalizeFirstLetter(buyQuotesBTC[0].exchange);
+const bestBuyProviderCompanyName = getCompanyNameFromList(buyQuotesBTC[0].exchange, 'buyList');
 const bestBuyCryptoAmount = `${buyQuotesBTC[0].receiveStringAmount} BTC`;
 const formattedFiatAmount = `CZK ${localizeNumber(fiatAmount, 'en-US', 2)}`;
 const { receiveAddress } = buyTradeBTC.trade;
@@ -57,6 +64,14 @@ test.describe('Trading - Buy BTC', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () =
                     await tradingPage.receiveAccount.selectSuiteReceiveAccount(0, 'btc');
                 },
             });
+        });
+
+        await test.step('Confirm button shows provider name and KYC warning is visible', async () => {
+            await expect(tradingPage.buyBestOfferButton).toHaveTranslation('TR_TRADING_BUY_VIA', {
+                values: { providerName: bestBuyProviderCompanyName },
+            });
+            await expect(tradingPage.buyBestOfferButton.locator('svg')).toBeVisible();
+            await expect(tradingPage.kycWarning).toBeVisible();
         });
 
         await page.clock.install();

--- a/suite/e2e/tests/trading/sell-bitcoin.test.ts
+++ b/suite/e2e/tests/trading/sell-bitcoin.test.ts
@@ -53,6 +53,14 @@ test.describe('Trading - Sell BTC', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () 
             await tradingPage.fees.expectBitcoinFeeCalculated();
         });
 
+        await test.step('Confirm button shows provider name and KYC warning is visible', async () => {
+            await expect(tradingPage.sellBestOfferButton).toHaveTranslation('TR_TRADING_SELL_VIA', {
+                values: { providerName: provider },
+            });
+            await expect(tradingPage.sellBestOfferButton.locator('svg')).toBeVisible();
+            await expect(tradingPage.kycWarning).toBeVisible();
+        });
+
         await test.step('Confirm sell', async () => {
             const tradeRequestPromise = page.waitForRequest(invityEndpoint.sellTrade);
             await tradingPage.sellBestOfferButton.click();

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -1127,6 +1127,18 @@ export const messages = defineMessages({
         id: 'TR_TRADING_SELL',
         defaultMessage: 'Sell',
     },
+    TR_TRADING_BUY_VIA: {
+        id: 'TR_TRADING_BUY_VIA',
+        defaultMessage: 'Buy via {providerName}',
+    },
+    TR_TRADING_SELL_VIA: {
+        id: 'TR_TRADING_SELL_VIA',
+        defaultMessage: 'Sell via {providerName}',
+    },
+    TR_TRADING_KYC_REQUIRED_WARNING: {
+        id: 'TR_TRADING_KYC_REQUIRED_WARNING',
+        defaultMessage: 'Identity verification will be required.',
+    },
     TR_TRADING_RATE: {
         id: 'TR_TRADING_RATE',
         defaultMessage: 'Rate',


### PR DESCRIPTION
## Description

- Show the selected provider name in Buy and Sell main CTAs after a quote is chosen.
- Add the external-link icon to Buy and Sell main CTAs when they redirect to the provider.
- Show an identity-verification warning banner under the Buy and Sell main CTA for selected quotes.
- Keep the KYC policy tooltip visible in Compare offers for Buy and Sell even when comparator provider metadata is missing.

## Notes for QA

- In Trading Buy and Trading Sell, select an offer and verify the main CTA shows the provider name, the external-link icon, and the identity-verification warning below it.
- In Compare offers for Buy or Sell, open the offers list and verify the KYC policy tooltip is still visible on offer rows that do not have comparator provider metadata.

## Related Issue

Resolve #26243

## Screenshots:

<img width="471" height="633" alt="image" src="https://github.com/user-attachments/assets/86613628-87df-45ea-96fd-83a65f9d1915" />
<img width="1200" height="640" alt="image" src="https://github.com/user-attachments/assets/f465afa7-89dd-4907-9612-61b4107a80b7" />
<img width="773" height="744" alt="image" src="https://github.com/user-attachments/assets/b9f4b867-6b1b-4f48-91ea-b424e9563cc2" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/trading-26243-kyc-warning-provider-cta&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/trading-26243-kyc-warning-provider-cta&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/trading-26243-kyc-warning-provider-cta&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-28T12:51:28.534Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-26T07:32:18.901Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/trading-26243-kyc-warning-provider-cta/web/](https://dev.suite.sldev.cz/suite-web/feat/trading-26243-kyc-warning-provider-cta/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->