### PR TITLE
fix(suite-common): prevent setDeviceState from matching device by path

### DIFF
--- a/packages/suite/src/reducers/suite/__fixtures__/deviceReducer.ts
+++ b/packages/suite/src/reducers/suite/__fixtures__/deviceReducer.ts
@@ -3,7 +3,7 @@ import {
     deviceActions,
     deviceReducerInitialState,
 } from '@suite-common/device';
-import { type TrezorDevice } from '@suite-common/suite-types';
+import { type AcquiredDevice, type TrezorDevice } from '@suite-common/suite-types';
 import { mockConnectDevice, mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { DEVICE } from '@trezor/connect';
 import { type DeepPartial } from '@trezor/type-utils';
@@ -1114,6 +1114,46 @@ const remember: Fixture<ReturnType<typeof deviceActions.setRememberDevice>>[] = 
     },
 ];
 
+const setDeviceState: Fixture<ReturnType<typeof deviceActions.setDeviceState>>[] = [
+    {
+        description:
+            'does not assign state to a device that only matches by path when device IDs differ',
+        // Regression: setDeviceState used path as a fallback match when device.id didn't match.
+        // A stale dispatch for Device A (path '1') would incorrectly set state on Device B
+        // (different ID, same path '1') if Device A had already disconnected.
+        initialState: {
+            ...deviceReducerInitialState,
+            devices: [
+                // Device A: remembered but disconnected, path cleared to ''
+                mockSuiteDevice(
+                    { connected: false, available: false, path: '', remember: true },
+                    { device_id: 'old-device-id' },
+                ),
+                // Device B: connected via the same physical path as Device A was
+                mockSuiteDevice({ connected: true, available: true, path: '1' }),
+            ],
+        },
+        actions: [
+            // Stale setDeviceState for Device A (id='old-device-id', path='1') dispatched
+            // after Device A disconnected and Device B connected on path '1'.
+            deviceActions.setDeviceState({
+                device: mockSuiteDevice(
+                    { connected: true, path: '1' },
+                    { device_id: 'old-device-id' },
+                ) as AcquiredDevice,
+                state: { staticSessionId: '1stTestnet@old-device-id:0' },
+                useEmptyPassphrase: true,
+            }),
+        ],
+        result: [
+            // Device A: still no state (it's disconnected, nothing should match)
+            { connected: false, features: { device_id: 'old-device-id' }, state: undefined },
+            // Device B: must not receive Device A's state via the path fallback
+            { connected: true, features: { device_id: 'device-id' }, state: undefined },
+        ],
+    },
+];
+
 export default {
     connect,
     disconnect,
@@ -1121,4 +1161,5 @@ export default {
     selectDevice,
     forget,
     remember,
+    setDeviceState,
 };

--- a/packages/suite/src/reducers/suite/__tests__/deviceReducer.test.ts
+++ b/packages/suite/src/reducers/suite/__tests__/deviceReducer.test.ts
@@ -106,3 +106,18 @@ describe('SUITE.REMEMBER_DEVICE', () => {
         });
     });
 });
+
+describe('DEVICE.SET_STATE', () => {
+    fixtures.setDeviceState.forEach(f => {
+        it(f.description, () => {
+            let state: State = f.initialState;
+            f.actions.forEach(a => {
+                state = deviceReducer(state, a);
+            });
+            expect(state.devices.length).toEqual(f.result.length);
+            state.devices.forEach((device, i) => {
+                expect(device).toMatchObject(f.result[i]);
+            });
+        });
+    });
+});

--- a/suite-common/device/src/deviceReducer.ts
+++ b/suite-common/device/src/deviceReducer.ts
@@ -342,11 +342,7 @@ const setDeviceState = (
     if (!device.features) return;
 
     const affectedDevice = draft.devices.filter(
-        d =>
-            d.features &&
-            d.connected &&
-            d.instance === device.instance &&
-            (d.id === device.id || (d.path.length > 0 && d.path === device.path)),
+        d => d.features && d.connected && d.instance === device.instance && d.id === device.id,
     );
 
     if (affectedDevice.length > 1) {
@@ -354,6 +350,8 @@ const setDeviceState = (
 
         return;
     }
+
+    if (affectedDevice.length === 0) return;
 
     affectedDevice[0].state = state;
     affectedDevice[0].useEmptyPassphrase = useEmptyPassphrase;


### PR DESCRIPTION
## Description

The \`setDeviceState\` filter used \`d.path === device.path\` as a fallback when \`d.id \!== device.id\`. This caused a race condition where a stale \`setDeviceState\` dispatch (authorization completing after a device disconnected) would assign the wrong \`staticSessionId\` to a different device that happened to be connected on the same physical path. The fix removes the path fallback so only the hardware device ID is used for matching, and adds the missing \`affectedDevice.length === 0\` guard that the path fallback was previously masking.

## Notes for QA

**USB:** Authorize Device A, unplug it (so it becomes remembered with an empty path), plug Device B into the same USB port, then verify Device B's \`state.staticSessionId\` does not contain Device A's hardware ID.

**Bluetooth (factory reset):** The device path in Redux is a sequential integer assigned by \`SessionsBackground\`, not the BT UUID. When a factory-reset device (same BT UUID, new hardware ID) reconnects unacquired, the remembered Device A record is temporarily updated with \`connected=true\` and Device B's path — creating a window where a stale \`setDeviceState\` for Device A matches Device B via the path fallback.

Automated regression test is included.

## Related Issue

Resolve #27203

## Screenshots:

N/A

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=milan&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->