### PR TITLE
fix(suite-common): prevent setDeviceState from matching device by path

### DIFF
--- a/packages/suite/src/reducers/suite/__fixtures__/deviceReducer.ts
+++ b/packages/suite/src/reducers/suite/__fixtures__/deviceReducer.ts
@@ -3,7 +3,7 @@ import {
     deviceActions,
     deviceReducerInitialState,
 } from '@suite-common/device';
-import { type TrezorDevice } from '@suite-common/suite-types';
+import { type AcquiredDevice, type TrezorDevice } from '@suite-common/suite-types';
 import { mockConnectDevice, mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { DEVICE } from '@trezor/connect';
 import { type DeepPartial } from '@trezor/type-utils';
@@ -1114,6 +1114,46 @@ const remember: Fixture<ReturnType<typeof deviceActions.setRememberDevice>>[] = 
     },
 ];
 
+const setDeviceState: Fixture<ReturnType<typeof deviceActions.setDeviceState>>[] = [
+    {
+        description:
+            'does not assign state to a device that only matches by path when device IDs differ',
+        // Regression: setDeviceState used path as a fallback match when device.id didn't match.
+        // A stale dispatch for Device A (path '1') would incorrectly set state on Device B
+        // (different ID, same path '1') if Device A had already disconnected.
+        initialState: {
+            ...deviceReducerInitialState,
+            devices: [
+                // Device A: remembered but disconnected, path cleared to ''
+                mockSuiteDevice(
+                    { connected: false, available: false, path: '', remember: true },
+                    { device_id: 'old-device-id' },
+                ),
+                // Device B: connected via the same physical path as Device A was
+                mockSuiteDevice({ connected: true, available: true, path: '1' }),
+            ],
+        },
+        actions: [
+            // Stale setDeviceState for Device A (id='old-device-id', path='1') dispatched
+            // after Device A disconnected and Device B connected on path '1'.
+            deviceActions.setDeviceState({
+                device: mockSuiteDevice(
+                    { connected: true, path: '1' },
+                    { device_id: 'old-device-id' },
+                ) as AcquiredDevice,
+                state: { staticSessionId: '1stTestnet@old-device-id:0' },
+                useEmptyPassphrase: true,
+            }),
+        ],
+        result: [
+            // Device A: still no state (it's disconnected, nothing should match)
+            { connected: false, features: { device_id: 'old-device-id' }, state: undefined },
+            // Device B: must not receive Device A's state via the path fallback
+            { connected: true, features: { device_id: 'device-id' }, state: undefined },
+        ],
+    },
+];
+
 export default {
     connect,
     disconnect,
@@ -1121,4 +1161,5 @@ export default {
     selectDevice,
     forget,
     remember,
+    setDeviceState,
 };

--- a/packages/suite/src/reducers/suite/__tests__/deviceReducer.test.ts
+++ b/packages/suite/src/reducers/suite/__tests__/deviceReducer.test.ts
@@ -118,3 +118,18 @@ describe('SUITE.REMEMBER_DEVICE', () => {
         });
     });
 });
+
+describe('DEVICE.SET_STATE', () => {
+    fixtures.setDeviceState.forEach(f => {
+        it(f.description, () => {
+            let state: State = f.initialState;
+            f.actions.forEach(a => {
+                state = deviceReducer(state, a);
+            });
+            expect(state.devices.length).toEqual(f.result.length);
+            state.devices.forEach((device, i) => {
+                expect(device).toMatchObject(f.result[i]);
+            });
+        });
+    });
+});

--- a/suite-common/device/src/deviceReducer.ts
+++ b/suite-common/device/src/deviceReducer.ts
@@ -342,11 +342,7 @@ const setDeviceState = (
     if (!device.features) return;
 
     const affectedDevice = draft.devices.filter(
-        d =>
-            d.features &&
-            d.connected &&
-            d.instance === device.instance &&
-            (d.id === device.id || (d.path.length > 0 && d.path === device.path)),
+        d => d.features && d.connected && d.instance === device.instance && d.id === device.id,
     );
 
     if (affectedDevice.length > 1) {


### PR DESCRIPTION
## Description

The `setDeviceState` filter used `d.path === device.path` as a fallback when `d.id \!== device.id`. This caused a race condition where a stale `setDeviceState` dispatch (authorization completing after a device disconnected) would assign the wrong `staticSessionId` to a different device that happened to be connected on the same physical path. The fix removes the path fallback so only the hardware device ID is used for matching, and adds the missing `affectedDevice.length === 0` guard that the path fallback was previously masking.

## Notes for QA

**USB:** Authorize Device A, unplug it (so it becomes remembered with an empty path), plug Device B into the same USB port, then verify Device B's `state.staticSessionId` does not contain Device A's hardware ID.

**Bluetooth (factory reset):** The device path in Redux is a sequential integer assigned by `SessionsBackground`, not the BT UUID. When a factory-reset device (same BT UUID, new hardware ID) reconnects unacquired, the remembered Device A record is temporarily updated with `connected=true` and Device B's path — creating a window where a stale `setDeviceState` for Device A matches Device B via the path fallback.

Automated regression test is included.

## Related Issue

Resolve #27203

## Screenshots:

N/A

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes modify the core device reducer (deviceReducer.ts) along with its unit test fixtures and tests. Since deviceReducer.ts is a foundational piece of state management (mapping to 121+ E2E tests), the risk is broad but likely contained to device lifecycle operations. The recommended strategy focuses on tests that directly exercise device state transitions: connection/disconnection handling, session management, device forgetting, passphrase wallet management, and recovery persistence. The fixture and unit test file changes carry no E2E risk themselves but indicate the reducer logic is being actively modified.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/reducers/suite/__fixtures__/deviceReducer.ts`
- `packages/suite/src/reducers/suite/__tests__/deviceReducer.test.ts`
- `suite-common/device/src/deviceReducer.ts`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `../../suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts` — This test directly exercises deviceActions (setSimulatedEntropyCheckFail) from the device slice, dispatching actions through the device reducer. Changes to deviceReducer.ts could affect how device state transitions are handled during entropy check failures and the resulting UI behavior (compromised modal vs error toast).
- `../../suite/e2e/tests/settings/forget-device.test.ts` — This test directly exercises device forgetting logic (forget device modal, device state management, Bluetooth unpairing) which is core device reducer functionality. The deviceReducer manages device connection state, remembered devices, and forget flows that this test validates end-to-end.
- `../../suite/e2e/tests/suite/multiple-sessions.test.ts` — This test validates Bridge session management and device status transitions (connected, use-here, session stolen/reclaimed) which are directly managed by the device reducer's state handling for device connection and session acquire/release flows.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `../../suite/e2e/tests/backup/t2t1-fail.test.ts` — Tests device disconnect/reconnect handling during backup, which exercises device reducer state transitions for device power off/on and backup failure state. The reducer manages device mode and backup status flags.
- `../../suite/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts` — Tests device state persistence across page reloads and device reconnections during recovery mode. The device reducer manages recovery mode state and device reconnection handling that this test validates.
- `../../suite/e2e/tests/passphrase/passphrase.test.ts` — Tests hidden wallet creation with passphrase, wallet switching, and cached passphrase state - all managed through the device reducer's device state and wallet instance management. Changes could affect how passphrase wallets are tracked.
- `../../suite/e2e/tests/suite/db-migration.test.ts` — Tests database migration preserving remembered/passphrase wallet state and device connection status across versions. The device reducer's state shape and initialization logic directly affects whether migrated device state is correctly restored.
- `../../suite/e2e/tests/suite/initial-run.test.ts` — Tests device connection state persistence across reloads during onboarding. The device reducer manages the device connected status indicator (@deviceStatus-connected) that this test asserts on after completing onboarding.
- `../../suite/e2e/tests/wallet/without-device.test.ts` — Directly tests device disconnection handling (device disconnected status indicator, connection modal when device is missing). The device reducer manages the disconnected device state that drives these UI elements.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `../../suite/e2e/tests/analytics/events.test.ts` — DeviceConnect and DeviceDisconnect analytics events rely on device reducer state (device metadata like firmware version, model, pin/passphrase protection). Changes to how device state is structured could affect the event payload contents.
- `../../suite/e2e/tests/passphrase/passphrase-duplicate.test.ts` — Tests duplicate passphrase detection when adding hidden wallets, which depends on the device reducer's tracking of existing wallet instances per device. A change in how device instances are managed could affect duplicate detection.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/reducers/suite/__fixtures__/deviceReducer.ts`
- `packages/suite/src/reducers/suite/__tests__/deviceReducer.test.ts`

_Updated: 2026-05-26T09:11:55.221Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-common-set-device-state-path&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-common-set-device-state-path&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-common-set-device-state-path&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-15T12:46:59.380Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-15T12:45:42.862Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/suite-common-set-device-state-path/web/](https://dev.suite.sldev.cz/suite-web/fix/suite-common-set-device-state-path/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set modifies the core device reducer (suite-common/device/src/deviceReducer.ts) along with its unit test fixtures and tests. Since the device reducer is a foundational piece of state management used by 121+ E2E tests, the risk is broad but most tests only transitively depend on it. The recommended strategy focuses on tests that directly exercise device state management operations: device forget/disconnect/reconnect flows, passphrase wallet management (add/eject/numbering/duplication), session management, and remembered wallet loading. The unit test file and fixtures changes are covered by the unit tests themselves and don't need E2E coverage.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/reducers/suite/__fixtures__/deviceReducer.ts`
- `packages/suite/src/reducers/suite/__tests__/deviceReducer.test.ts`
- `suite-common/device/src/deviceReducer.ts`

</details>

**Recommended tests (13)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/settings/forget-device.test.ts` — The deviceReducer directly manages device state including forgetting devices, Bluetooth pairing state, and device connection status. This test exercises the forget device flow across multiple scenarios (connected, disconnected, with/without Bluetooth history), which are core behaviors governed by the device reducer.

</details>

<details><summary>🟡 <b>Medium priority (10)</b></summary>

- `suite/e2e/tests/backup/t2t1-fail.test.ts` — This test exercises device disconnect/reconnect during backup and verifies device status indicators and failed backup state, which are managed by the device reducer's handling of device connection state transitions and backup status flags.
- `suite/e2e/tests/backup/t2t1-misc.test.ts` — Tests backup behavior when device is disconnected but remembered — the remembered device state and disconnect detection are directly managed by the device reducer.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — Tests ejecting and re-adding standard wallets via the device switcher, which involves device reducer operations for removing and creating device instances.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — Tests device disconnect/reconnect with passphrase wallet preservation in the device switcher. The device reducer manages device instances, connection state, and passphrase caching across reconnections.
- `suite/e2e/tests/passphrase/passphrase-numbering.test.ts` — Tests sequential numbering of passphrase wallets during add/eject operations. The device reducer manages the device instances array and wallet indexing logic that determines numbering.
- `suite/e2e/tests/passphrase/passphrase-duplicate.test.ts` — Tests duplicate passphrase detection when adding hidden wallets. The device reducer likely contains logic for detecting duplicate device instances with the same passphrase.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — Tests Bridge session stealing/reclaiming and device connection status (TR_USE_HERE vs TR_CONNECTED). The device reducer manages session state and device status that drives these UI indicators.
- `suite/e2e/tests/suite/initial-run.test.ts` — Tests device connection state persistence across reloads during onboarding. The device reducer manages the connected device state that determines whether onboarding is shown or skipped.
- `suite/e2e/tests/wallet/without-device.test.ts` — Tests device disconnected state detection, connection modal display, and disconnected device banner — all driven by device state managed in the device reducer.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — Tests adding/switching between multiple hidden wallets, passphrase mismatch handling, and wallet caching. These are core device reducer operations for managing multiple device instances with different passphrases.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/settings/passphrase.test.ts` — Tests enabling passphrase protection on the device via settings. The device reducer handles the device features update when passphrase_protection is toggled.
- `suite/e2e/tests/trading/remembered-wallet-loading.test.ts` — Tests loading a remembered wallet from IndexedDB without a connected device. The device reducer manages remembered device state persistence and restoration.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/reducers/suite/__fixtures__/deviceReducer.ts`
- `packages/suite/src/reducers/suite/__tests__/deviceReducer.test.ts`

_Updated: 2026-06-15T12:42:10.006Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->