### PR TITLE
refactor(utxo-lib): replace "bn.js" with BigInt

### DIFF
--- a/packages/utxo-lib/package.json
+++ b/packages/utxo-lib/package.json
@@ -53,7 +53,6 @@
         "@scure/base": "^2.0.0",
         "@sinclair/typebox": "^0.34.49",
         "@trezor/utils": "workspace:*",
-        "bn.js": "5.2.3",
         "cashaddrjs": "0.4.4",
         "int64-buffer": "^1.1.0",
         "varuint-bitcoin": "2.0.0",
@@ -61,7 +60,6 @@
     },
     "devDependencies": {
         "@trezor/eslint": "workspace:*",
-        "@types/bn.js": "^5.2.0",
         "minimaldata": "^1.0.2"
     },
     "peerDependencies": {

--- a/packages/utxo-lib/src/bufferutils.ts
+++ b/packages/utxo-lib/src/bufferutils.ts
@@ -5,7 +5,6 @@
 // - added `BufferWritter` "writeInt64", "writeUInt16" methods.
 // - `BufferWritter.writeUInt64` is accepting string or number.
 
-import BN from 'bn.js';
 import { Int64LE } from 'int64-buffer';
 import * as varuint from 'varuint-bitcoin';
 
@@ -41,11 +40,10 @@ export function readUInt64LEasString(buffer: Buffer, offset: number) {
     } catch {
         const aUint = buffer.readUInt32LE(offset);
         const bUint = buffer.readUInt32LE(offset + 4);
-        const m = new BN(0x100000000);
-        const a = new BN(aUint);
-        const b = new BN(bUint).mul(m);
+        const a = BigInt(aUint);
+        const b = BigInt(bUint) * 0x100000000n;
 
-        return a.add(b).toString();
+        return (a + b).toString();
     }
 }
 

--- a/packages/utxo-lib/src/coinselect/coinselectUtils.ts
+++ b/packages/utxo-lib/src/coinselect/coinselectUtils.ts
@@ -133,12 +133,12 @@ export function getDustAmount(
     return Math.max(dustThreshold || 0, getFeeForBytes(dustRelayFeeRate, inputSize));
 }
 
-export function bignumberOrNaN(v?: bigint | string): bigint | undefined;
-export function bignumberOrNaN<F extends boolean>(
+export function parseBigInt(v?: bigint | string): bigint | undefined;
+export function parseBigInt<F extends boolean>(
     v?: bigint | string,
     forgiving?: F,
 ): F extends true ? bigint : bigint | undefined;
-export function bignumberOrNaN(v?: bigint | string, forgiving = false) {
+export function parseBigInt(v?: bigint | string, forgiving = false) {
     if (typeof v === 'bigint') return v;
     const defaultValue = forgiving ? ZERO : undefined;
     if (!v || typeof v !== 'string' || !/^\d+$/.test(v)) return defaultValue;
@@ -158,7 +158,7 @@ export function sumOrNaN<F extends boolean>(
 export function sumOrNaN(range: { value?: bigint }[], forgiving = false) {
     return range.reduce((a: bigint | undefined, x) => {
         if (a === undefined) return a;
-        const value = bignumberOrNaN(x.value);
+        const value = parseBigInt(x.value);
         if (value === undefined) return forgiving ? a : undefined;
 
         return value + a;

--- a/packages/utxo-lib/src/coinselect/coinselectUtils.ts
+++ b/packages/utxo-lib/src/coinselect/coinselectUtils.ts
@@ -1,5 +1,3 @@
-import BN from 'bn.js';
-
 import { type Network, isNetworkType } from '../networks';
 import {
     type CoinSelectAlgorithm,
@@ -10,7 +8,7 @@ import {
     type CoinSelectPaymentType,
 } from '../types';
 
-export const ZERO = new BN(0);
+export const ZERO = 0n;
 
 // TODO: p2ms, external, p2wsh. currently not used in suite/connect.
 export const INPUT_SCRIPT_LENGTH: Record<CoinSelectPaymentType, number> = {
@@ -135,35 +133,35 @@ export function getDustAmount(
     return Math.max(dustThreshold || 0, getFeeForBytes(dustRelayFeeRate, inputSize));
 }
 
-export function bignumberOrNaN(v?: BN | string): BN | undefined;
+export function bignumberOrNaN(v?: bigint | string): bigint | undefined;
 export function bignumberOrNaN<F extends boolean>(
-    v?: BN | string,
+    v?: bigint | string,
     forgiving?: F,
-): F extends true ? BN : BN | undefined;
-export function bignumberOrNaN(v?: BN | string, forgiving = false) {
-    if (BN.isBN(v)) return v;
+): F extends true ? bigint : bigint | undefined;
+export function bignumberOrNaN(v?: bigint | string, forgiving = false) {
+    if (typeof v === 'bigint') return v;
     const defaultValue = forgiving ? ZERO : undefined;
     if (!v || typeof v !== 'string' || !/^\d+$/.test(v)) return defaultValue;
 
     try {
-        return new BN(v);
+        return BigInt(v);
     } catch {
         return defaultValue;
     }
 }
 
-export function sumOrNaN(range: { value?: BN }[]): BN | undefined;
+export function sumOrNaN(range: { value?: bigint }[]): bigint | undefined;
 export function sumOrNaN<F extends boolean>(
-    range: { value?: BN }[],
+    range: { value?: bigint }[],
     forgiving: F,
-): F extends true ? BN : BN | undefined;
-export function sumOrNaN(range: { value?: BN }[], forgiving = false) {
-    return range.reduce((a: BN | undefined, x) => {
-        if (!a) return a;
+): F extends true ? bigint : bigint | undefined;
+export function sumOrNaN(range: { value?: bigint }[], forgiving = false) {
+    return range.reduce((a: bigint | undefined, x) => {
+        if (a === undefined) return a;
         const value = bignumberOrNaN(x.value);
-        if (!value) return forgiving ? ZERO.add(a) : undefined;
+        if (value === undefined) return forgiving ? a : undefined;
 
-        return value.add(a);
+        return value + a;
     }, ZERO);
 }
 
@@ -201,8 +199,10 @@ function getDogeFee(
     const fee = getBitcoinFee(inputs, outputs, feeRate, options);
 
     // find all outputs below dust limit
-    const limit = new BN(dustThreshold);
-    const dustOutputsCount = outputs.filter(({ value }) => value?.lt(limit)).length;
+    const limit = BigInt(dustThreshold);
+    const dustOutputsCount = outputs.filter(
+        ({ value }) => value !== undefined && value < limit,
+    ).length;
 
     // increase for every output below dustThreshold
     return fee + dustOutputsCount * dustThreshold;
@@ -267,18 +267,22 @@ export function finalize(
     // if sum inputs/outputs is NaN
     // or `fee` is greater than sum of inputs reduced by sum of outputs (use case: baseFee)
     // no further calculation required (not enough funds)
-    if (!sumInputs || !sumOutputs || sumInputs.sub(sumOutputs).lt(new BN(fee))) {
+    if (
+        sumInputs === undefined ||
+        sumOutputs === undefined ||
+        sumInputs - sumOutputs < BigInt(fee)
+    ) {
         return { fee };
     }
 
-    const remainderAfterExtraOutput = sumInputs.sub(sumOutputs.add(new BN(feeAfterExtraOutput)));
+    const remainderAfterExtraOutput = sumInputs - (sumOutputs + BigInt(feeAfterExtraOutput));
     const dustAmount = getDustAmount(feeRate, options);
 
     // it's verified that output have value (sumOutputs)
     const finalOutputs = [...(outputs as CoinSelectOutputFinal[])];
 
     // is it worth a change output?
-    if (remainderAfterExtraOutput.gte(new BN(dustAmount))) {
+    if (remainderAfterExtraOutput >= BigInt(dustAmount)) {
         finalOutputs.push({
             ...changeOutput,
             value: remainderAfterExtraOutput,
@@ -288,7 +292,7 @@ export function finalize(
     return {
         inputs,
         outputs: finalOutputs,
-        fee: sumInputs.sub(sumOrNaN(finalOutputs, true)).toNumber(),
+        fee: Number(sumInputs - sumOrNaN(finalOutputs, true)),
     };
 }
 
@@ -309,17 +313,17 @@ export function anyOf(algorithms: CoinSelectAlgorithm[]): CoinSelectAlgorithm {
 }
 
 export function utxoScore(x: CoinSelectInput, feeRate: number) {
-    return x.value.sub(new BN(getFeeForBytes(feeRate, inputBytes(x))));
+    return x.value - BigInt(getFeeForBytes(feeRate, inputBytes(x)));
 }
 
 export function sortByScore(feeRate: number) {
     return (a: CoinSelectInput, b: CoinSelectInput) => {
-        const difference = utxoScore(a, feeRate).sub(utxoScore(b, feeRate));
-        if (difference.eq(ZERO)) {
+        const difference = utxoScore(a, feeRate) - utxoScore(b, feeRate);
+        if (difference === ZERO) {
             return a.i - b.i;
         }
 
-        return difference.isNeg() ? 1 : -1;
+        return difference < ZERO ? 1 : -1;
     };
 }
 

--- a/packages/utxo-lib/src/coinselect/inputs/accumulative.ts
+++ b/packages/utxo-lib/src/coinselect/inputs/accumulative.ts
@@ -1,11 +1,11 @@
 import { type CoinSelectAlgorithm, type CoinSelectInput, type CoinSelectResult } from '../../types';
 import {
     ZERO,
-    bignumberOrNaN,
     finalize,
     getFee,
     getFeeForBytes,
     inputBytes,
+    parseBigInt,
     sumOrNaN,
 } from '../coinselectUtils';
 
@@ -27,7 +27,7 @@ export const accumulative: CoinSelectAlgorithm = (
     utxos0.forEach(u => {
         if (u.required) {
             requiredUtxos.push(u);
-            const utxoValue = bignumberOrNaN(u.value, true); // use forgiving (0)
+            const utxoValue = parseBigInt(u.value, true); // use forgiving (0)
             inAccum = inAccum + utxoValue;
             inputs.push(u);
         } else {
@@ -48,7 +48,7 @@ export const accumulative: CoinSelectAlgorithm = (
         const utxo = utxos[i];
         const utxoBytes = inputBytes(utxo);
         const utxoFee = getFeeForBytes(feeRate, utxoBytes);
-        const utxoValue = bignumberOrNaN(utxo.value);
+        const utxoValue = parseBigInt(utxo.value);
 
         // skip detrimental input
         if (utxoValue === undefined || utxoValue < BigInt(utxoFee)) {

--- a/packages/utxo-lib/src/coinselect/inputs/accumulative.ts
+++ b/packages/utxo-lib/src/coinselect/inputs/accumulative.ts
@@ -1,5 +1,3 @@
-import BN from 'bn.js';
-
 import { type CoinSelectAlgorithm, type CoinSelectInput, type CoinSelectResult } from '../../types';
 import {
     ZERO,
@@ -30,7 +28,7 @@ export const accumulative: CoinSelectAlgorithm = (
         if (u.required) {
             requiredUtxos.push(u);
             const utxoValue = bignumberOrNaN(u.value, true); // use forgiving (0)
-            inAccum = inAccum.add(utxoValue);
+            inAccum = inAccum + utxoValue;
             inputs.push(u);
         } else {
             utxos.push(u);
@@ -53,21 +51,21 @@ export const accumulative: CoinSelectAlgorithm = (
         const utxoValue = bignumberOrNaN(utxo.value);
 
         // skip detrimental input
-        if (!utxoValue || utxoValue.lt(new BN(utxoFee))) {
+        if (utxoValue === undefined || utxoValue < BigInt(utxoFee)) {
             if (i === utxos.length - 1) {
                 const fee = getFee([...inputs, utxo], outputs, feeRate, options);
 
                 return { fee };
             }
         } else {
-            inAccum = inAccum.add(utxoValue);
+            inAccum = inAccum + utxoValue;
             inputs.push(utxo);
 
             const fee = getFee(inputs, outputs, feeRate, options);
-            const outAccumWithFee = outAccum ? outAccum.add(new BN(fee)) : ZERO;
+            const outAccumWithFee = outAccum !== undefined ? outAccum + BigInt(fee) : ZERO;
 
             // go again?
-            if (inAccum.gte(outAccumWithFee)) {
+            if (inAccum >= outAccumWithFee) {
                 return finalize(inputs, outputs, feeRate, options);
             }
         }

--- a/packages/utxo-lib/src/coinselect/inputs/branchAndBound.ts
+++ b/packages/utxo-lib/src/coinselect/inputs/branchAndBound.ts
@@ -1,5 +1,3 @@
-import BN from 'bn.js';
-
 import { type CoinSelectAlgorithm, type CoinSelectInput, type CoinSelectResult } from '../../types';
 import {
     OUTPUT_SCRIPT_LENGTH,
@@ -19,14 +17,14 @@ const MAX_TRIES = 1000000;
 function calculateEffectiveValues(utxos: CoinSelectInput[], feeRate: number) {
     return utxos.map(utxo => {
         const value = bignumberOrNaN(utxo.value);
-        if (!value) {
+        if (value === undefined) {
             return {
                 utxo,
                 effectiveValue: ZERO,
             };
         }
         const effectiveFee = getFeeForBytes(feeRate, inputBytes(utxo));
-        const effectiveValue = value.sub(new BN(effectiveFee));
+        const effectiveValue = value - BigInt(effectiveFee);
 
         return {
             utxo,
@@ -39,8 +37,8 @@ function calculateEffectiveValues(utxos: CoinSelectInput[], feeRate: number) {
 // Inclusion branch first (Largest First Exploration), then exclusion branch
 function search(
     effectiveUtxos: ReturnType<typeof calculateEffectiveValues>,
-    target: BN,
-    costRange: BN,
+    target: bigint,
+    costRange: bigint,
 ) {
     if (effectiveUtxos.length === 0) {
         return null;
@@ -54,7 +52,7 @@ function search(
     let done = false;
     let backtrack = false;
 
-    let remaining = effectiveUtxos.reduce((a, x) => x.effectiveValue.add(a), ZERO);
+    let remaining = effectiveUtxos.reduce((a, x) => x.effectiveValue + a, ZERO);
 
     let depth = 0;
     while (!done) {
@@ -63,16 +61,16 @@ function search(
             return null;
         }
 
-        if (selectedAccum.gt(costRange)) {
+        if (selectedAccum > costRange) {
             // Selected value is out of range, go back and try other branch
             backtrack = true;
-        } else if (selectedAccum.gte(target)) {
+        } else if (selectedAccum >= target) {
             // Selected value is within range
             done = true;
         } else if (depth >= effectiveUtxos.length) {
             // Reached a leaf node, no solution here
             backtrack = true;
-        } else if (selectedAccum.add(remaining).lt(target)) {
+        } else if (selectedAccum + remaining < target) {
             // Cannot possibly reach target with amount remaining
             if (depth === 0) {
                 // At the first utxo, no possible selections, so exit
@@ -82,10 +80,10 @@ function search(
         } else {
             // Continue down this branch
             // Remove this utxo from the remaining utxo amount
-            remaining = remaining.sub(effectiveUtxos[depth].effectiveValue);
+            remaining = remaining - effectiveUtxos[depth].effectiveValue;
             // Inclusion branch first (Largest First Exploration)
             selected[depth] = true;
-            selectedAccum = selectedAccum.add(effectiveUtxos[depth].effectiveValue);
+            selectedAccum = selectedAccum + effectiveUtxos[depth].effectiveValue;
             depth++;
         }
 
@@ -96,7 +94,7 @@ function search(
 
             // Walk backwards to find the first utxo which has not has its second branch traversed
             while (!selected[depth]) {
-                remaining = remaining.add(effectiveUtxos[depth].effectiveValue);
+                remaining = remaining + effectiveUtxos[depth].effectiveValue;
 
                 // Step back one
                 depth--;
@@ -110,7 +108,7 @@ function search(
 
             // Now traverse the second branch of the utxo we have arrived at.
             selected[depth] = false;
-            selectedAccum = selectedAccum.sub(effectiveUtxos[depth].effectiveValue);
+            selectedAccum = selectedAccum - effectiveUtxos[depth].effectiveValue;
             depth++;
         }
         tries--;
@@ -152,19 +150,19 @@ export const branchAndBound: CoinSelectAlgorithm = (
     const outputsBytes = transactionBytes([], outputs);
     const outputsFee = getFeeForBytes(feeRate, outputsBytes);
     const outputsTotalValue = sumOrNaN(outputs);
-    if (!outputsTotalValue) return { fee: 0 };
+    if (outputsTotalValue === undefined) return { fee: 0 };
 
     // target = total amount that needs to be covered (all outputs + fee)
-    const target = outputsTotalValue.add(new BN(outputsFee));
-    const targetRange = target.add(new BN(costOfChange));
+    const target = outputsTotalValue + BigInt(outputsFee);
+    const targetRange = target + BigInt(costOfChange);
 
     // use only effective utxos which:
     // - value is greater than its cost (effectiveValue > 0)
     // - value is lower or equal than target range (will not produce change output)
     const effectiveUtxos = calculateEffectiveValues(utxos, feeRate)
-        .filter(({ effectiveValue }) => effectiveValue.gt(ZERO) && effectiveValue.lte(targetRange))
+        .filter(({ effectiveValue }) => effectiveValue > ZERO && effectiveValue <= targetRange)
         .sort((a, b) => {
-            const subtract = b.effectiveValue.sub(a.effectiveValue).toNumber();
+            const subtract = Number(b.effectiveValue - a.effectiveValue);
             if (subtract !== 0) {
                 return subtract;
             }
@@ -174,10 +172,10 @@ export const branchAndBound: CoinSelectAlgorithm = (
 
     // check if sum of all effective utxos is greater than target (if transaction is even possible with remaining subset)
     const utxosTotalEffectiveValue = effectiveUtxos.reduce(
-        (total, { effectiveValue }) => total.add(effectiveValue),
+        (total, { effectiveValue }) => total + effectiveValue,
         ZERO,
     );
-    if (utxosTotalEffectiveValue.lt(target)) {
+    if (utxosTotalEffectiveValue < target) {
         return { fee: 0 };
     }
 

--- a/packages/utxo-lib/src/coinselect/inputs/branchAndBound.ts
+++ b/packages/utxo-lib/src/coinselect/inputs/branchAndBound.ts
@@ -2,12 +2,12 @@ import { type CoinSelectAlgorithm, type CoinSelectInput, type CoinSelectResult }
 import {
     OUTPUT_SCRIPT_LENGTH,
     ZERO,
-    bignumberOrNaN,
     finalize,
     getDustAmount,
     getFeeForBytes,
     inputBytes,
     outputBytes,
+    parseBigInt,
     sumOrNaN,
     transactionBytes,
 } from '../coinselectUtils';
@@ -16,7 +16,7 @@ const MAX_TRIES = 1000000;
 
 function calculateEffectiveValues(utxos: CoinSelectInput[], feeRate: number) {
     return utxos.map(utxo => {
-        const value = bignumberOrNaN(utxo.value);
+        const value = parseBigInt(utxo.value);
         if (value === undefined) {
             return {
                 utxo,

--- a/packages/utxo-lib/src/coinselect/outputs/split.ts
+++ b/packages/utxo-lib/src/coinselect/outputs/split.ts
@@ -1,5 +1,3 @@
-import BN from 'bn.js';
-
 import {
     type CoinSelectInput,
     type CoinSelectOptions,
@@ -32,26 +30,29 @@ export function split(
 
     const inAccum = sumOrNaN(utxos);
     const outAccum = sumOrNaN(outputs, true);
-    if (!inAccum) return { fee };
+    if (inAccum === undefined) return { fee };
 
-    const remaining = inAccum.sub(outAccum).sub(new BN(fee));
-    if (remaining.lt(ZERO)) return { fee };
+    const remaining = inAccum - outAccum - BigInt(fee);
+    if (remaining < ZERO) return { fee };
 
-    const unspecified = outputs.reduce((a, x) => a + (!bignumberOrNaN(x.value) ? 1 : 0), 0);
+    const unspecified = outputs.reduce(
+        (a, x) => a + (bignumberOrNaN(x.value) === undefined ? 1 : 0),
+        0,
+    );
 
-    if (remaining.isZero() || unspecified === 0) {
+    if (remaining === ZERO || unspecified === 0) {
         return finalize(utxos, outputs, feeRate, options);
     }
 
-    const splitValue = remaining.div(new BN(unspecified));
+    const splitValue = remaining / BigInt(unspecified);
     const dustAmount = getDustAmount(feeRate, options);
 
     // ensure every output is either user defined, or over the threshold
-    if (unspecified && splitValue.lt(new BN(dustAmount))) return { fee };
+    if (unspecified && splitValue < BigInt(dustAmount)) return { fee };
 
     // assign splitValue to outputs not user defined
     const outputsSplit = outputs.map(output => {
-        if (output.value) return output;
+        if (output.value !== undefined) return output;
 
         return {
             ...output,

--- a/packages/utxo-lib/src/coinselect/outputs/split.ts
+++ b/packages/utxo-lib/src/coinselect/outputs/split.ts
@@ -7,11 +7,11 @@ import {
 import {
     MINIMAL_COINBASE_CONFIRMATIONS,
     ZERO,
-    bignumberOrNaN,
     filterCoinbase,
     finalize,
     getDustAmount,
     getFee,
+    parseBigInt,
     sumOrNaN,
 } from '../coinselectUtils';
 
@@ -36,7 +36,7 @@ export function split(
     if (remaining < ZERO) return { fee };
 
     const unspecified = outputs.reduce(
-        (a, x) => a + (bignumberOrNaN(x.value) === undefined ? 1 : 0),
+        (a, x) => a + (parseBigInt(x.value) === undefined ? 1 : 0),
         0,
     );
 

--- a/packages/utxo-lib/src/compose/request.ts
+++ b/packages/utxo-lib/src/compose/request.ts
@@ -4,10 +4,10 @@ import { toOutputScript } from '../address';
 import {
     INPUT_SCRIPT_LENGTH,
     OUTPUT_SCRIPT_LENGTH,
-    bignumberOrNaN,
     getFeePolicy,
     inputWeight,
     outputWeight,
+    parseBigInt,
 } from '../coinselect/coinselectUtils';
 import type { Network } from '../networks';
 import { p2data } from '../payments/embed';
@@ -55,7 +55,7 @@ function transformInput(
         throw new Error('Missing confirmations');
     }
 
-    const value = bignumberOrNaN(utxo.amount);
+    const value = parseBigInt(utxo.amount);
     if (value === undefined) {
         throw new Error('Invalid amount');
     }
@@ -106,19 +106,19 @@ function transformOutput(
     const script = { length: OUTPUT_SCRIPT_LENGTH[txType] };
     if (output.type === 'payment') {
         return {
-            value: bignumberOrNaN(output.amount) ?? throwError('Invalid amount'),
+            value: parseBigInt(output.amount) ?? throwError('Invalid amount'),
             script: toOutputScript(output.address, network),
         };
     }
     if (output.type === 'payment-noaddress') {
         return {
-            value: bignumberOrNaN(output.amount) ?? throwError('Invalid amount'),
+            value: parseBigInt(output.amount) ?? throwError('Invalid amount'),
             script,
         };
     }
     if (output.type === 'opreturn') {
         return {
-            value: bignumberOrNaN('0', true),
+            value: parseBigInt('0', true),
             script: p2data({ data: [Buffer.from(output.dataHex, 'hex')] }).output as Buffer,
         };
     }

--- a/packages/utxo-lib/src/compose/request.ts
+++ b/packages/utxo-lib/src/compose/request.ts
@@ -56,7 +56,7 @@ function transformInput(
     }
 
     const value = bignumberOrNaN(utxo.amount);
-    if (!value) {
+    if (value === undefined) {
         throw new Error('Invalid amount');
     }
 
@@ -106,13 +106,13 @@ function transformOutput(
     const script = { length: OUTPUT_SCRIPT_LENGTH[txType] };
     if (output.type === 'payment') {
         return {
-            value: bignumberOrNaN(output.amount) || throwError('Invalid amount'),
+            value: bignumberOrNaN(output.amount) ?? throwError('Invalid amount'),
             script: toOutputScript(output.address, network),
         };
     }
     if (output.type === 'payment-noaddress') {
         return {
-            value: bignumberOrNaN(output.amount) || throwError('Invalid amount'),
+            value: bignumberOrNaN(output.amount) ?? throwError('Invalid amount'),
             script,
         };
     }

--- a/packages/utxo-lib/src/compose/result.ts
+++ b/packages/utxo-lib/src/compose/result.ts
@@ -1,5 +1,3 @@
-import BN from 'bn.js';
-
 import { createTransaction } from './transaction';
 import { transactionBytes } from '../coinselect/coinselectUtils';
 import {
@@ -60,11 +58,11 @@ export function getResult<
 
     const totalSpent = result.outputs.reduce((total, output, index) => {
         if (request.outputs[index]) {
-            return total.add(output.value);
+            return total + output.value;
         }
 
         return total;
-    }, new BN(result.fee));
+    }, BigInt(result.fee));
 
     const max =
         sendMaxOutputIndex >= 0 ? result.outputs[sendMaxOutputIndex].value.toString() : undefined;

--- a/packages/utxo-lib/src/compose/sorting/bip69SortingStrategy.ts
+++ b/packages/utxo-lib/src/compose/sorting/bip69SortingStrategy.ts
@@ -7,12 +7,15 @@ function inputComparator(a: ComposeInput, b: ComposeInput) {
 }
 
 function outputComparator(a: CoinSelectOutputFinal, b: CoinSelectOutputFinal) {
-    return (
-        a.value.cmp(b.value) ||
-        (Buffer.isBuffer(a.script) && Buffer.isBuffer(b.script)
-            ? a.script.compare(b.script)
-            : a.script.length - b.script.length)
-    );
+    if (a.value < b.value) {
+        return -1;
+    } else if (a.value > b.value) {
+        return 1;
+    }
+
+    return Buffer.isBuffer(a.script) && Buffer.isBuffer(b.script)
+        ? a.script.compare(b.script)
+        : a.script.length - b.script.length;
 }
 
 export const bip69SortingStrategy: SortingStrategy = ({ result, request, convertedInputs }) => {

--- a/packages/utxo-lib/src/types/coinselect.ts
+++ b/packages/utxo-lib/src/types/coinselect.ts
@@ -1,5 +1,3 @@
-import type BN from 'bn.js';
-
 import { type TransactionInputOutputSortingStrategy } from './compose';
 
 export type CoinSelectPaymentType = 'p2pkh' | 'p2sh' | 'p2tr' | 'p2wpkh' | 'p2wsh';
@@ -33,7 +31,7 @@ export interface CoinSelectInput {
     type: CoinSelectPaymentType;
     i: number;
     script: { length: number };
-    value: BN;
+    value: bigint;
     confirmations: number;
     coinbase?: boolean;
     required?: boolean;
@@ -43,13 +41,13 @@ export interface CoinSelectInput {
 
 export interface CoinSelectOutput {
     script: { length: number };
-    value?: BN;
+    value?: bigint;
     weight?: number;
 }
 
 export interface CoinSelectOutputFinal {
     script: { length: number };
-    value: BN;
+    value: bigint;
 }
 
 export interface CoinSelectRequest extends CoinSelectOptions {

--- a/packages/utxo-lib/tests/coinselect/branchAndBound.test.ts
+++ b/packages/utxo-lib/tests/coinselect/branchAndBound.test.ts
@@ -23,4 +23,27 @@ describe('coinselect: branchAndBound (bnb)', () => {
             }
         });
     });
+
+    it('with options.baseFee set returns { fee: 0 } (bnb disabled for DOGE)', () => {
+        const inputs = utils.expand(['102001'], true);
+        const outputs = utils.expand(['100000'], false);
+        const options = {
+            txType: 'p2pkh',
+            dustThreshold: 546,
+            baseFee: 100,
+        } as CoinSelectOptions;
+
+        expect(branchAndBound(inputs, outputs, 10, options)).toEqual({ fee: 0 });
+    });
+
+    it('with an unparseable utxo value treats it as ZERO effective value (filtered out)', () => {
+        const inputs = utils.expand([{}], true);
+        const outputs = utils.expand(['100000'], false);
+        const options = {
+            txType: 'p2pkh',
+            dustThreshold: 546,
+        } as CoinSelectOptions;
+
+        expect(branchAndBound(inputs, outputs, 10, options)).toEqual({ fee: 0 });
+    });
 });

--- a/packages/utxo-lib/tests/coinselect/coinselectUtils.test.ts
+++ b/packages/utxo-lib/tests/coinselect/coinselectUtils.test.ts
@@ -1,4 +1,11 @@
-import { bignumberOrNaN, getDustAmount, getFee } from '../../src/coinselect/coinselectUtils';
+import {
+    bignumberOrNaN,
+    getDustAmount,
+    getFee,
+    getFeePolicy,
+    sumOrNaN,
+} from '../../src/coinselect/coinselectUtils';
+import { zcash as zcashNetwork } from '../../src/networks';
 
 describe('coinselectUtils', () => {
     it('bignumberOrNaN', () => {
@@ -36,6 +43,19 @@ describe('coinselectUtils', () => {
         expect(
             getFee([], [{ script: { length: 181 } }], 1, { baseFee: 1000, floorBaseFee: true }),
         ).toEqual(1000);
+    });
+
+    it('getFeePolicy returns "zcash" for the zcash network', () => {
+        expect(getFeePolicy(zcashNetwork)).toEqual('zcash');
+    });
+
+    it('sumOrNaN short-circuits subsequent items once accumulator becomes undefined', () => {
+        expect(sumOrNaN([{}, { value: 10n }])).toBeUndefined();
+    });
+
+    it('getDogeFee with no dustThreshold option uses 0 default and adds no dust surcharge', () => {
+        // bytes = ceil(224/4) = 56, defaultFee = ceil(1.33 * 56) = 75
+        expect(getFee([], [{ script: { length: 37 } }], 1.33, { feePolicy: 'doge' })).toEqual(75);
     });
 
     it('getDogeFee', () => {

--- a/packages/utxo-lib/tests/coinselect/coinselectUtils.test.ts
+++ b/packages/utxo-lib/tests/coinselect/coinselectUtils.test.ts
@@ -1,36 +1,36 @@
 import {
-    bignumberOrNaN,
     getDustAmount,
     getFee,
     getFeePolicy,
+    parseBigInt,
     sumOrNaN,
 } from '../../src/coinselect/coinselectUtils';
 import { zcash as zcashNetwork } from '../../src/networks';
 
 describe('coinselectUtils', () => {
-    it('bignumberOrNaN', () => {
-        expect(bignumberOrNaN('1')).not.toBeUndefined();
-        expect(bignumberOrNaN('1.1')).toBeUndefined();
-        expect(bignumberOrNaN('-1')).toBeUndefined();
-        expect(bignumberOrNaN('')).toBeUndefined();
-        expect(bignumberOrNaN('deadbeef')).toBeUndefined();
-        expect(bignumberOrNaN('0x dead beef')).toBeUndefined();
-        expect(bignumberOrNaN('1.1')).toBeUndefined();
-        expect(bignumberOrNaN()).toBeUndefined();
+    it('parseBigInt', () => {
+        expect(parseBigInt('1')).not.toBeUndefined();
+        expect(parseBigInt('1.1')).toBeUndefined();
+        expect(parseBigInt('-1')).toBeUndefined();
+        expect(parseBigInt('')).toBeUndefined();
+        expect(parseBigInt('deadbeef')).toBeUndefined();
+        expect(parseBigInt('0x dead beef')).toBeUndefined();
+        expect(parseBigInt('1.1')).toBeUndefined();
+        expect(parseBigInt()).toBeUndefined();
         // @ts-expect-error invalid arg
-        expect(bignumberOrNaN(1)).toBeUndefined();
+        expect(parseBigInt(1)).toBeUndefined();
         // @ts-expect-error invalid arg
-        expect(bignumberOrNaN(-1, true)).not.toBeUndefined();
+        expect(parseBigInt(-1, true)).not.toBeUndefined();
         // @ts-expect-error invalid arg
-        expect(bignumberOrNaN(Infinity)).toBeUndefined();
+        expect(parseBigInt(Infinity)).toBeUndefined();
         // @ts-expect-error invalid arg
-        expect(bignumberOrNaN(NaN)).toBeUndefined();
+        expect(parseBigInt(NaN)).toBeUndefined();
         // @ts-expect-error invalid arg
-        expect(bignumberOrNaN(1.1)).toBeUndefined();
+        expect(parseBigInt(1.1)).toBeUndefined();
         // @ts-expect-error invalid arg
-        expect(bignumberOrNaN(-1)).toBeUndefined();
+        expect(parseBigInt(-1)).toBeUndefined();
         // @ts-expect-error invalid arg
-        expect(bignumberOrNaN({})).toBeUndefined();
+        expect(parseBigInt({})).toBeUndefined();
     });
 
     it('getBaseFee', () => {

--- a/packages/utxo-lib/tests/coinselect/coinselectUtils.test.ts
+++ b/packages/utxo-lib/tests/coinselect/coinselectUtils.test.ts
@@ -1,5 +1,3 @@
-import BN from 'bn.js';
-
 import { bignumberOrNaN, getDustAmount, getFee } from '../../src/coinselect/coinselectUtils';
 
 describe('coinselectUtils', () => {
@@ -45,8 +43,8 @@ describe('coinselectUtils', () => {
             getFee(
                 [],
                 [
-                    { value: new BN('8'), script: { length: 49 } },
-                    { value: new BN('7'), script: { length: 50 } },
+                    { value: 8n, script: { length: 49 } },
+                    { value: 7n, script: { length: 50 } },
                 ],
                 2,
                 { feePolicy: 'doge', baseFee: 1000, dustThreshold: 1000 },
@@ -56,8 +54,8 @@ describe('coinselectUtils', () => {
             getFee(
                 [],
                 [
-                    { value: new BN('8'), script: { length: 500 } },
-                    { value: new BN('7'), script: { length: 472 } },
+                    { value: 8n, script: { length: 500 } },
+                    { value: 7n, script: { length: 472 } },
                 ],
                 2,
                 { feePolicy: 'doge', baseFee: 1000, dustThreshold: 1000, floorBaseFee: true },
@@ -69,7 +67,7 @@ describe('coinselectUtils', () => {
         const IN = {
             type: 'p2pkh',
             i: 0,
-            value: new BN('1000'),
+            value: 1000n,
             confirmations: 0,
             script: { length: 108 },
         } as const;

--- a/packages/utxo-lib/tests/coinselect/split.test.ts
+++ b/packages/utxo-lib/tests/coinselect/split.test.ts
@@ -1,6 +1,7 @@
 import * as utils from './test.utils';
+import { INPUT_SCRIPT_LENGTH, OUTPUT_SCRIPT_LENGTH } from '../../src/coinselect/coinselectUtils';
 import { split } from '../../src/coinselect/outputs/split';
-import type { CoinSelectOptions } from '../../src/types';
+import type { CoinSelectInput, CoinSelectOptions, CoinSelectOutput } from '../../src/types';
 import fixtures from '../__fixtures__/coinselect/split';
 
 describe('coinselect split', () => {
@@ -25,5 +26,29 @@ describe('coinselect split', () => {
                 expect(utils.serialize(feedback)).toEqual(expected);
             }
         });
+    });
+
+    it('returns fee-only result when input value is non-numeric (sumOrNaN→undefined drives !inAccum branch)', () => {
+        const inputs = [
+            {
+                i: 0,
+                type: 'p2pkh',
+                value: 'not_a_number',
+                script: { length: INPUT_SCRIPT_LENGTH.p2pkh },
+            },
+        ] as unknown as CoinSelectInput[];
+        const outputs = [
+            { script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh } },
+        ] as unknown as CoinSelectOutput[];
+        const options = {
+            txType: 'p2pkh',
+            dustThreshold: 546,
+        } as CoinSelectOptions;
+
+        const result = split(inputs, outputs, 10, options);
+
+        expect(result.inputs).toBeUndefined();
+        expect(result.outputs).toBeUndefined();
+        expect(typeof result.fee).toBe('number');
     });
 });

--- a/packages/utxo-lib/tests/coinselect/test.utils.ts
+++ b/packages/utxo-lib/tests/coinselect/test.utils.ts
@@ -1,5 +1,3 @@
-import BN from 'bn.js';
-
 import { INPUT_SCRIPT_LENGTH, OUTPUT_SCRIPT_LENGTH } from '../../src/coinselect/coinselectUtils';
 
 function addScriptLength(values: any[], scriptLength: number) {
@@ -13,10 +11,10 @@ function addScriptLength(values: any[], scriptLength: number) {
     });
 }
 
-function valueToBN(vinVout: VinVoutFixture) {
-    if (typeof vinVout === 'string') return { value: new BN(vinVout) };
+function valueToBigInt(vinVout: VinVoutFixture) {
+    if (typeof vinVout === 'string') return { value: BigInt(vinVout) };
     if (vinVout.value) {
-        return { ...vinVout, value: new BN(vinVout.value) };
+        return { ...vinVout, value: BigInt(vinVout.value) };
     }
 
     return vinVout;
@@ -66,16 +64,16 @@ export function expand(values: VinVoutFixture[], indices: boolean) {
             values.map((x, i) => ({
                 i,
                 type: 'p2pkh',
-                ...valueToBN(x),
+                ...valueToBigInt(x),
             })),
             INPUT_SCRIPT_LENGTH.p2pkh,
         );
     }
 
-    return addScriptLength(values.map(valueToBN), OUTPUT_SCRIPT_LENGTH.p2pkh);
+    return addScriptLength(values.map(valueToBigInt), OUTPUT_SCRIPT_LENGTH.p2pkh);
 }
 
-type VinVoutResult = { value: BN };
+type VinVoutResult = { value: bigint };
 
 export function serialize(result: { inputs?: VinVoutResult[]; outputs?: VinVoutResult[] }) {
     return {

--- a/packages/utxo-lib/tests/compose.test.ts
+++ b/packages/utxo-lib/tests/compose.test.ts
@@ -2,9 +2,11 @@ import { getRandomInt } from '@trezor/utils';
 
 import { verifyTxBytes } from './compose.utils';
 import { composeTx } from '../src/compose';
-import * as NETWORKS from '../src/networks';
 import { composeTxFixture } from './__fixtures__/compose';
 import { fixturesCrossCheck } from './__fixtures__/compose.crosscheck';
+import { getErrorResult } from '../src/compose/result';
+import { bip69SortingStrategy } from '../src/compose/sorting/bip69SortingStrategy';
+import * as NETWORKS from '../src/networks';
 
 jest.mock('@trezor/utils', () => ({
     ...jest.requireActual('@trezor/utils'),
@@ -40,6 +42,149 @@ describe(composeTx.name, () => {
                 verifyTxBytes(tx, f.request.txType, network);
             }
         });
+    });
+});
+
+describe('composeTx request validation errors', () => {
+    it('returns MISSING-UTXOS when utxos array is empty', () => {
+        const tx = composeTx({
+            utxos: [],
+            outputs: [{ type: 'send-max-noaddress' }],
+            feeRate: 10,
+            network: NETWORKS.bitcoin,
+            changeAddress: { address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT' },
+            dustThreshold: 546,
+            sortingStrategy: 'bip69',
+        });
+
+        expect(tx).toEqual({ type: 'error', error: 'MISSING-UTXOS' });
+    });
+
+    it('returns INCORRECT-OUTPUT when changeAddress.address is not a valid Bitcoin address', () => {
+        const tx = composeTx({
+            utxos: [
+                {
+                    vout: 0,
+                    txid: '0000000000000000000000000000000000000000000000000000000000000000',
+                    coinbase: false,
+                    own: true,
+                    confirmations: 100,
+                    amount: '50000',
+                },
+            ],
+            outputs: [{ type: 'send-max-noaddress' }],
+            feeRate: 10,
+            network: NETWORKS.bitcoin,
+            changeAddress: { address: 'not-a-valid-address' },
+            dustThreshold: 546,
+            sortingStrategy: 'bip69',
+        });
+
+        expect(tx).toEqual({
+            type: 'error',
+            error: 'INCORRECT-OUTPUT',
+            message: 'not-a-valid-address has no matching Script',
+        });
+    });
+
+    it('returns INCORRECT-OUTPUT when a payment output has an unparseable amount', () => {
+        const tx = composeTx({
+            utxos: [
+                {
+                    vout: 0,
+                    txid: '0000000000000000000000000000000000000000000000000000000000000000',
+                    coinbase: false,
+                    own: true,
+                    confirmations: 100,
+                    amount: '50000',
+                },
+            ],
+            outputs: [
+                {
+                    type: 'payment',
+                    address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT',
+                    amount: 'not-a-number',
+                },
+            ],
+            feeRate: 10,
+            network: NETWORKS.bitcoin,
+            changeAddress: { address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT' },
+            dustThreshold: 546,
+            sortingStrategy: 'bip69',
+        });
+
+        expect(tx).toEqual({
+            type: 'error',
+            error: 'INCORRECT-OUTPUT',
+            message: 'Invalid amount at index 0',
+        });
+    });
+
+    it('returns the validateAndParseRequest error result directly (does not enter coinselect)', () => {
+        const tx = composeTx({
+            utxos: [
+                {
+                    vout: 0,
+                    txid: '0000000000000000000000000000000000000000000000000000000000000000',
+                    coinbase: false,
+                    own: true,
+                    confirmations: 100,
+                    amount: '50000',
+                },
+            ],
+            outputs: [{ type: 'send-max-noaddress' }],
+            feeRate: 0,
+            network: NETWORKS.bitcoin,
+            changeAddress: { address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT' },
+            dustThreshold: 546,
+            sortingStrategy: 'bip69',
+        });
+
+        expect(tx).toEqual({ type: 'error', error: 'INCORRECT-FEE-RATE' });
+    });
+});
+
+describe('getErrorResult', () => {
+    it('maps a thrown Error whose message matches a COMPOSE_ERROR_TYPES entry to the typed error object (no message field)', () => {
+        expect(getErrorResult(new Error('NOT-ENOUGH-FUNDS'))).toEqual({
+            type: 'error',
+            error: 'NOT-ENOUGH-FUNDS',
+        });
+    });
+
+    it('stringifies a non-Error thrown value and routes unknown messages to the COINSELECT branch with a message field', () => {
+        expect(getErrorResult('unexpected failure')).toEqual({
+            type: 'error',
+            error: 'COINSELECT',
+            message: 'unexpected failure',
+        });
+    });
+});
+
+describe('bip69SortingStrategy', () => {
+    it('falls back to script.length comparison when at least one output script is not a Buffer', () => {
+        const value = 1000n;
+        const result = {
+            inputs: [],
+            outputs: [
+                { value, script: Buffer.alloc(34, 0xff) }, // idx 0 — Buffer, length 34
+                { value, script: { length: 22 } }, // idx 1 — non-Buffer, length 22 (shorter)
+            ],
+            fee: 0,
+        };
+        const request = {
+            outputs: [{ type: 'payment', address: 'addr-a', amount: '1000' }],
+            changeAddress: { address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT' },
+        };
+
+        const composed = bip69SortingStrategy({
+            result: result as any,
+            request: request as any,
+            convertedInputs: [],
+        });
+
+        // idx 1 (non-Buffer, length 22) sorts before idx 0 (Buffer, length 34) by length.
+        expect(composed.outputsPermutation).toEqual([1, 0]);
     });
 });
 

--- a/scripts/list-outdated-dependencies/wallet-dependencies.txt
+++ b/scripts/list-outdated-dependencies/wallet-dependencies.txt
@@ -22,14 +22,12 @@
 @testing-library/react
 @testing-library/react-native
 @testing-library/user-event
-@types/bn.js
 @types/redux-logger
 @types/redux-mock-store
 @whatwg-node/events
 abortcontroller-polyfill
 ajv
 bignumber.js
-bn.js
 cashaddrjs
 event-target-shim
 golomb

--- a/yarn.lock
+++ b/yarn.lock
@@ -16689,8 +16689,6 @@ __metadata:
     "@sinclair/typebox": "npm:^0.34.49"
     "@trezor/eslint": "workspace:*"
     "@trezor/utils": "workspace:*"
-    "@types/bn.js": "npm:^5.2.0"
-    bn.js: "npm:5.2.3"
     cashaddrjs: "npm:0.4.4"
     int64-buffer: "npm:^1.1.0"
     minimaldata: "npm:^1.0.2"
@@ -16856,15 +16854,6 @@ __metadata:
   dependencies:
     "@babel/types": "npm:^7.28.2"
   checksum: 10/371c5e1b40399ef17570e630b2943617b84fafde2860a56f0ebc113d8edb1d0534ade0175af89eda1ae35160903c33057ed42457e165d4aa287fedab2c82abcf
-  languageName: node
-  linkType: hard
-
-"@types/bn.js@npm:^5.2.0":
-  version: 5.2.0
-  resolution: "@types/bn.js@npm:5.2.0"
-  dependencies:
-    "@types/node": "npm:*"
-  checksum: 10/06c93841f74e4a5e5b81b74427d56303b223c9af36389b4cd3c562bda93f43c425c7e241aee1b0b881dde57238dc2e07f21d30d412b206a7dae4435af4c054e8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Prerequisite for https://github.com/trezor/trezor-suite/pull/26298

replace "bn.js" with BigInt - mostly used by coinselect/compose modules, but not only

partial https://github.com/trezor/trezor-suite/issues/27403

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/utxo-lib-bigint&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/utxo-lib-bigint&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-27T16:15:54.563Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-26T10:06:41.290Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/utxo-lib-bigint/web/](https://dev.suite.sldev.cz/suite-web/refactor/utxo-lib-bigint/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->