### PR TITLE
feat(trading): add swap to main navigation

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderDropdown.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderDropdown.tsx
@@ -116,7 +116,7 @@ export const HeaderDropdown = ({
                 });
             },
             title: <Translation id="TR_TRADING_SWAP" />,
-            icon: 'arrowsLeftRight',
+            icon: 'repeat',
             isHidden: isSwapVisible || isTradingDisabled,
         },
     ];

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/TradeActions.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/TradeActions.tsx
@@ -108,7 +108,7 @@ export const TradeActions = ({ selectedAccount }: TradeActionsProps) => {
                 {!hasBitcoinOnlyFirmware(device) && (
                     <ConditionalRender container="content" minWidth={breakpoints.tablet}>
                         <HeaderActionButton
-                            icon="arrowsLeftRight"
+                            icon="repeat"
                             onClick={onSwapClick}
                             data-testid="@wallet/menu/wallet-trading-exchange"
                             intent="neutral"

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Navigation.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Navigation.tsx
@@ -43,6 +43,12 @@ export const Navigation = ({ children }: NavigationProps) => {
                 ...(!isBtcOnly
                     ? [
                           {
+                              nameId: 'TR_TRADING_SWAP',
+                              icon: 'repeat',
+                              goToRoute: 'wallet-trading-exchange',
+                              routes: ['wallet-trading-exchange'],
+                          } as NavigationItemProps,
+                          {
                               nameId: 'TR_EARN',
                               icon: 'piggyBank',
                               goToRoute: 'suite-earn',

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
@@ -372,7 +372,7 @@ const TokenRowBasicActions = ({
                     {
                         label: <Translation id="TR_TRADING_SWAP" />,
                         'data-testid': '@trading/tokens/swap-button',
-                        icon: 'arrowsLeftRight',
+                        icon: 'repeat',
                         onClick: onSwapButtonClick,
                         isHidden: type === 'defi' ? false : !isBelowTablet,
                         isDisabled: !canSwapToken,
@@ -465,7 +465,7 @@ const TokenRowBasicActions = ({
                         key="swap"
                         intent="neutral"
                         priority="secondary"
-                        icon="arrowsLeftRight"
+                        icon="repeat"
                         onClick={onSwapButtonClick}
                     />
                 </Tooltip>

--- a/packages/suite/src/views/wallet/trading/common/TradingLayout/TradingLayoutNavigation.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingLayout/TradingLayoutNavigation.tsx
@@ -18,6 +18,11 @@ type NavigationItem = {
 
 const navigationItems: NavigationItem[] = [
     {
+        id: 'wallet-trading-exchange',
+        icon: 'repeat',
+        translationId: 'TR_TRADING_SWAP',
+    },
+    {
         id: 'wallet-trading-buy',
         icon: 'plus',
         translationId: 'TR_NAV_BUY',
@@ -26,11 +31,6 @@ const navigationItems: NavigationItem[] = [
         id: 'wallet-trading-sell',
         icon: 'minus',
         translationId: 'TR_NAV_SELL',
-    },
-    {
-        id: 'wallet-trading-exchange',
-        icon: 'arrowsLeftRight',
-        translationId: 'TR_TRADING_SWAP',
     },
     {
         id: 'wallet-trading-concierge',


### PR DESCRIPTION
## Description

- Add a SWAP entry to the main sidebar navigation.
- Move SWAP to the first position in the trading sub-navigation, before BUY and SELL.
- Use the Repeat icon for SWAP across the sidebar, trading tabs, header actions, and token row actions.
- Route the new SWAP navigation entry to the existing exchange screen entry point.

## Notes for QA

- Open the main sidebar, click SWAP, and verify the exchange screen opens with the default swap form state.
- Open the Trade screen, verify SWAP is the first tab with the Repeat icon, then switch to BUY and SELL and verify both tabs still navigate normally.
- In a token row action menu, verify the Swap action uses the same Repeat icon as the trading navigation and header action.

## Related Issue

Resolve #28057

## Screenshots:

<img width="1259" height="676" alt="image" src="https://github.com/user-attachments/assets/326bb8a1-b814-477d-9758-4e4be476ccbb" />

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect UI layout and navigation components: the page header dropdown, trade action buttons, sidebar navigation, token row actions, and trading layout tab navigation. The highest risk is in trading navigation flows since TradeActions.tsx, TradingLayoutNavigation.tsx, and TokenRowActions.tsx are directly involved in how users enter and navigate between buy/sell/swap/staking flows. HeaderDropdown.tsx and Navigation.tsx are very broad shared components (121 tests each), so only tests that specifically exercise header-level actions (global send/receive, discreet mode) are recommended. TokenRowActions.tsx has no static test coverage, representing a gap for token-specific trade actions.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderDropdown.tsx`
- `packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/TradeActions.tsx`
- `packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Navigation.tsx`
- `packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingLayout/TradingLayoutNavigation.tsx`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `../../suite/e2e/tests/trading/navigation.test.ts` — This test directly exercises navigation to Buy/Sell/Swap trading forms from multiple entry points including the global header, account trade sections, and token-level navigation. Changes to TradeActions.tsx (global header trade buttons), TradingLayoutNavigation.tsx (trading tab navigation), and TokenRowActions.tsx (token-level trade actions) are all directly exercised by this test's navigation flows.
- `../../suite/e2e/tests/wallet/global-receive-send.test.ts` — This test exercises global receive and send flows via header buttons (@wallet/menu/wallet-global-receive, @wallet/menu/wallet-global-send), which are rendered by TradeActions.tsx and HeaderDropdown.tsx. Changes to these components could break the global send/receive modal entry points.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `../../suite/e2e/tests/trading/buy-bitcoin.test.ts` — This test navigates to the trading buy form via walletPage.openTrading, which relies on TradeActions.tsx for the trading entry point, and uses TradingLayoutNavigation.tsx for tab navigation within the trading flow. A regression in either component could prevent reaching the buy form.
- `../../suite/e2e/tests/trading/sell-inputs.test.ts` — This test opens the sell trading tab via walletPage.openTrading and tradingPage.sellTabButton, directly exercising TradeActions.tsx for entry and TradingLayoutNavigation.tsx for switching to the sell tab. It also tests navigating to SOL sell via walletPage.sellButton.
- `../../suite/e2e/tests/trading/swap-coins.test.ts` — This test opens the swap trading form via walletPage.openSwapTrading, exercising TradeActions.tsx for the swap entry point. The swap flow uses TradingLayoutNavigation.tsx for the swap tab selection within the trading layout.
- `../../suite/e2e/tests/dashboard/discreet-mode.test.ts` — This test clicks the 'hide balance' button on the dashboard which is rendered in the page header area (HeaderDropdown.tsx). Changes to the header dropdown could affect the discreet mode toggle button's visibility or functionality.
- `../../suite/e2e/tests/analytics/staking-events.test.ts` — This test navigates to staking from dashboard assets and account menu, which uses Navigation.tsx sidebar links. It also uses walletPage.stakingButton which may be rendered as a trade action in TradeActions.tsx.
- `../../suite/e2e/tests/trading/sell-solana.test.ts` — This test navigates to the sell tab within the trading layout, directly exercising TradingLayoutNavigation.tsx for tab switching. It enters via walletPage.openTrading which uses TradeActions.tsx.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `../../suite/e2e/tests/trading/swap-history.test.ts` — This test navigates to swap trading via walletPage.openSwapTrading and views transaction history within the trading layout. Changes to TradingLayoutNavigation.tsx could affect the transactions/history tab navigation.
- `../../suite/e2e/tests/trading/buy-negative.test.ts` — This test opens the trading buy form via the global trading button, exercising TradeActions.tsx for initial navigation. However the core test logic is about form validation, not navigation components.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx`

_Updated: 2026-05-26T10:22:23.115Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/trading-add-swap-main-navigation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/trading-add-swap-main-navigation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-26T10:27:54.128Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-26T10:25:20.438Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/trading-add-swap-main-navigation/web/](https://dev.suite.sldev.cz/suite-web/feat/trading-add-swap-main-navigation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->