### PR TITLE
refactor(suite): unify service selection for suite sync

### DIFF
--- a/packages/analytics-docs/src/utils/eventFileUtils.ts
+++ b/packages/analytics-docs/src/utils/eventFileUtils.ts
@@ -92,25 +92,34 @@ export const getEventsIndexExportSnippet = (eventName: string): string => {
 
 const PLATFORM_USAGE_IMPORTS: Record<
     string,
-    { events: string; services: string; analyticsImport: string; analyticsDep: string }
+    {
+        events: string;
+        services: string;
+        analyticsImport: string;
+        analyticsDep: string;
+        analyticsDepSelector: string;
+    }
 > = {
     desktop: {
         events: '@suite/analytics',
         services: '@suite-common/dependency-injection',
         analyticsImport: '@suite/analytics',
         analyticsDep: 'DesktopAnalyticsDep',
+        analyticsDepSelector: 'selectDesktopAnalyticsDep',
     },
     mobile: {
         events: '@suite-native/analytics',
         services: '@suite-common/dependency-injection',
         analyticsImport: '@suite-native/analytics',
         analyticsDep: 'NativeAnalyticsDep',
+        analyticsDepSelector: 'selectNativeAnalyticsDep',
     },
     shared: {
         events: '@suite/analytics',
         services: '@suite-common/dependency-injection',
         analyticsImport: '@suite/analytics',
         analyticsDep: 'DesktopAnalyticsDep',
+        analyticsDepSelector: 'selectDesktopAnalyticsDep',
     },
 };
 
@@ -123,10 +132,10 @@ export const getUsageExampleSnippet = (platform: string, eventName: string): str
 
     return `import { events } from '${imports.events}';
 import { useServices } from '${imports.services}';
-    import { select${imports.analyticsDep.replace('Dep', '')}Dep } from '${imports.analyticsImport}';
+import { ${imports.analyticsDepSelector} } from '${imports.analyticsImport}';
 
 // inside component:
-    const { analytics } = useServices(select${imports.analyticsDep.replace('Dep', '')}Dep);
+const { analytics } = useServices(${imports.analyticsDepSelector});
 analytics.report({
     type: events.${baseName}.name,
     payload: {

--- a/packages/analytics-docs/src/utils/eventFileUtils.ts
+++ b/packages/analytics-docs/src/utils/eventFileUtils.ts
@@ -123,10 +123,10 @@ export const getUsageExampleSnippet = (platform: string, eventName: string): str
 
     return `import { events } from '${imports.events}';
 import { useServices } from '${imports.services}';
-import { type ${imports.analyticsDep} } from '${imports.analyticsImport}';
+    import { select${imports.analyticsDep.replace('Dep', '')}Dep } from '${imports.analyticsImport}';
 
 // inside component:
-const { analytics } = useServices<${imports.analyticsDep}>();
+    const { analytics } = useServices(select${imports.analyticsDep.replace('Dep', '')}Dep);
 analytics.report({
     type: events.${baseName}.name,
     payload: {

--- a/packages/suite-desktop-ui/src/support/DesktopUpdater.tsx
+++ b/packages/suite-desktop-ui/src/support/DesktopUpdater.tsx
@@ -1,7 +1,11 @@
 import { type JSX, useCallback, useEffect } from 'react';
 
-import { AppUpdateEventStatus, asTypedDesktopAnalytics, events } from '@suite/analytics';
-import { type DesktopAnalyticsDep } from '@suite/analytics';
+import {
+    AppUpdateEventStatus,
+    asTypedDesktopAnalytics,
+    events,
+    selectDesktopAnalyticsDep,
+} from '@suite/analytics';
 import {
     UpdateState,
     availableThunk,
@@ -39,7 +43,7 @@ const alwaysOpenStates = [
 export const DesktopUpdater = () => {
     const dispatch = useDispatch();
     const desktopUpdate = useSelector(selectDesktopUpdate);
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const desktopUpdateState = desktopUpdate.state;
 
     useEffect(() => {

--- a/packages/suite-desktop-ui/src/support/DesktopUpdater/EarlyAccessDisable.tsx
+++ b/packages/suite-desktop-ui/src/support/DesktopUpdater/EarlyAccessDisable.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
 import { Column, H3, Modal, Paragraph } from '@trezor/components';
@@ -14,7 +14,7 @@ interface EarlyAccessDisableProps {
 
 export const EarlyAccessDisable = ({ hideWindow }: EarlyAccessDisableProps) => {
     const [enabled, setEnabled] = useState(true);
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     const allowPrerelease = useCallback(() => {
         analytics.report({

--- a/packages/suite-desktop-ui/src/support/DesktopUpdater/EarlyAccessEnable.tsx
+++ b/packages/suite-desktop-ui/src/support/DesktopUpdater/EarlyAccessEnable.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
 import { Card, Column, H3, Modal, Paragraph, Tooltip } from '@trezor/components';
@@ -16,7 +16,7 @@ interface EarlyAccessEnableProps {
 export const EarlyAccessEnable = ({ hideWindow }: EarlyAccessEnableProps) => {
     const [understood, setUnderstood] = useState(false);
     const [enabled, setEnabled] = useState(false);
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const allowPrerelease = useCallback(() => {
         analytics.report({
             type: events.settingsGeneralEarlyAccessEvent.name,

--- a/packages/suite/src/components/connection/BluetoothConnectionModal.tsx
+++ b/packages/suite/src/components/connection/BluetoothConnectionModal.tsx
@@ -1,4 +1,4 @@
-import { type DesktopAnalyticsDep } from '@suite/analytics';
+import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
@@ -19,7 +19,7 @@ type BluetoothConnectionModalProps = {
 const selectedDeviceConnectionTypes = ['connecting', 'pairing'];
 
 export const BluetoothConnectionModal = ({ onClose }: BluetoothConnectionModalProps) => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { handlePairingCancel, onReScanClick, selectedDevice } =
         useConnectionGlobalModalContext();
     const connectingDevices = useSelector(selectConnectingDevices);

--- a/packages/suite/src/components/connection/CantSeeTrezorModal.tsx
+++ b/packages/suite/src/components/connection/CantSeeTrezorModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo } from 'react';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
 import { Column, H3, Modal, Paragraph } from '@trezor/components';
@@ -34,7 +34,7 @@ const commonCableTips = [
 ];
 
 export const CantSeeTrezorModal = ({ onClose }: DontSeeYourTrezorModalProps) => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const {
         isBluetoothMode,
         toggleShouldPairAgain,

--- a/packages/suite/src/components/connection/ConnectDeviceGlobalModal.tsx
+++ b/packages/suite/src/components/connection/ConnectDeviceGlobalModal.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import { AnimatePresence, motion } from 'framer-motion';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { selectAdapterStatus, selectIsDeviceOsUnpairingRequired } from '@suite-common/bluetooth';
 import { useServices } from '@suite-common/dependency-injection';
@@ -202,7 +202,7 @@ const ViaCableCard = ({ onClick }: ConnectionModeCardProps) => (
 );
 
 export const ConnectDeviceGlobalModal = ({ onCancel }: { onCancel: () => void }) => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const [isModeSelected, setIsModeSelected] = useState(false);
     const isWebUsbTransport = useSelector(selectHasTransportOfType('WebUsbTransport'));
     const {

--- a/packages/suite/src/components/connection/hook/useBluetoothConnection.tsx
+++ b/packages/suite/src/components/connection/hook/useBluetoothConnection.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 
-import { type DesktopAnalyticsDep } from '@suite/analytics';
+import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { events } from '@suite-common/analytics';
 import { selectKnownDevices } from '@suite-common/bluetooth';
 import { useServices } from '@suite-common/dependency-injection';
@@ -30,7 +30,7 @@ export const useBluetoothConnection = ({
     devices,
     onReScanClick,
 }: UseBluetoothConnectionProps): UseBluetoothConnectionReturn => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const dispatch = useDispatch();
     const [selectedDeviceId, setSelectedDeviceId] = useState<string | null>(null);
 

--- a/packages/suite/src/components/earn/dashboard/staking/EarnStakingAccountRow.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/EarnStakingAccountRow.tsx
@@ -1,4 +1,4 @@
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
 import { goto } from '@suite/router';
@@ -45,7 +45,7 @@ export const EarnStakingAccountRow = ({
 }) => {
     const dispatch = useDispatch();
     const { CryptoAmountFormatter } = useFormatters();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { isBelowMobile } = useLayoutSize();
     const apy = useSelector(state => selectPoolStatsApy(state, { account }));
     const displaySymbol = getDisplaySymbol(account.symbol);

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { FirmwareUpgradeNeededModal } from '@suite/firmware-upgrade';
 import { useTranslation } from '@suite/intl';
 import { openModal } from '@suite/modal';
@@ -43,7 +43,7 @@ export const EarnYieldAccountOpportunity = ({
     isCardLayout,
 }: EarnYieldAccountOpportunityProps) => {
     const dispatch = useDispatch();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { CryptoAmountFormatter } = useFormatters();
     const { translationString } = useTranslation();
     const { isBelowMobile } = useLayoutSize();

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyTooltip.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyTooltip.tsx
@@ -2,7 +2,7 @@ import { type ReactNode, useEffect, useRef } from 'react';
 
 import styled from 'styled-components';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { type YieldDto } from '@suite-common/earn-stablecoin-api';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
@@ -34,7 +34,7 @@ export const EarnYieldApyTooltip = ({
     networkSymbol,
     children,
 }: EarnYieldApyTooltipProps) => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const reportTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     useEffect(

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBanner.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBanner.tsx
@@ -1,4 +1,4 @@
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
 import { useFormatters } from '@suite-common/formatters';
@@ -22,7 +22,7 @@ export const EarnYieldClaimRewardsBanner = ({
     claimDisabledTooltip,
     onClaim,
 }: EarnYieldClaimRewardsBannerProps) => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { BaseCurrencyAmountFormatter } = useFormatters();
 
     const handleOnClaim = () => {

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimSelectAccountModal.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimSelectAccountModal.tsx
@@ -1,5 +1,5 @@
 import { Address } from '@suite/address';
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { selectIsDebugModeActive } from '@suite/settings';
 import { useServices } from '@suite-common/dependency-injection';
@@ -25,7 +25,7 @@ export const EarnYieldClaimSelectAccountModal = ({
     onSelect,
     onClose,
 }: EarnYieldClaimSelectAccountModalProps) => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { BaseCurrencyAmountFormatter } = useFormatters();
     const isDebugModeActive = useSelector(selectIsDebugModeActive);
     const baseCurrency = useSelector(selectBaseCurrency);

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { EarnAnchor, goto, useAnchor } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
@@ -31,7 +31,7 @@ export const EarnYieldTable = () => {
     const { isBelowLaptop } = useLayoutSize();
     const isCardLayout = isBelowLaptop;
     const dispatch = useDispatch();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const [isClaimModalOpen, setIsClaimModalOpen] = useState(false);
     const claimMessageSystem = useMessageSystemYield('claim');
 

--- a/packages/suite/src/components/earn/modals/EarnClaimModal/EarnClaimModal.tsx
+++ b/packages/suite/src/components/earn/modals/EarnClaimModal/EarnClaimModal.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { FormProvider } from 'react-hook-form';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
@@ -31,7 +31,7 @@ type EarnClaimModalProps = {
 export const EarnClaimModal = ({ onCancel, account }: EarnClaimModalProps) => {
     const dispatch = useDispatch();
     const { device, isLocked } = useDevice();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { isClaimingDisabled, claimingMessageContent } = useMessageSystemStaking(account.symbol);
 
     const {

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/EarnInANutshellModal.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/EarnInANutshellModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 
-import { type DesktopAnalyticsDep } from '@suite/analytics';
+import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import {
     type EarnAnalyticsStep,
@@ -47,7 +47,7 @@ export const EarnInANutshellModal = ({
     yieldContext,
     onCancel,
 }: EarnInANutshellModalProps) => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     useEffect(() => {
         switch (flow) {

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/YieldEarnInANutshellModal.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/YieldEarnInANutshellModal.tsx
@@ -1,4 +1,4 @@
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
 import { RewardDtoYieldSource } from '@suite-common/earn-stablecoin-api';
@@ -39,7 +39,7 @@ export const YieldEarnInANutshellModal = ({
     actionType,
     yieldContext,
 }: YieldEarnInANutshellModalProps) => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     const { handleAction, onCancelClick, vault } = useEarnInANutshell({
         flow: EarnFlow.Yield,

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/hooks/useEarnInANutshell.ts
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/hooks/useEarnInANutshell.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { type DesktopAnalyticsDep } from '@suite/analytics';
+import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { openModal } from '@suite/modal';
 import { useServices } from '@suite-common/dependency-injection';
 import { type YieldDto, useAllYieldOpportunities } from '@suite-common/earn-stablecoin-api';
@@ -47,7 +47,7 @@ export const useEarnInANutshell = ({
     );
 
     const dispatch = useDispatch();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     const handleAction = () => {
         onCancel();

--- a/packages/suite/src/components/earn/modals/EarnProviderConsent/YieldEarnProviderConsentModal.tsx
+++ b/packages/suite/src/components/earn/modals/EarnProviderConsent/YieldEarnProviderConsentModal.tsx
@@ -1,4 +1,4 @@
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { TrezorLink } from '@suite/external-links';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
@@ -34,7 +34,7 @@ export const YieldEarnProviderConsentModal = ({
     provider,
     yieldContext,
 }: YieldEarnProviderConsentModalProps) => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     const tokenContractAddress = yieldContext?.tokenContractAddress;
     const normalizedTokenContractAddress = tokenContractAddress

--- a/packages/suite/src/components/earn/modals/EarnProviderConsent/hooks/useEarnProviderConsentActions.ts
+++ b/packages/suite/src/components/earn/modals/EarnProviderConsent/hooks/useEarnProviderConsentActions.ts
@@ -1,4 +1,4 @@
-import { type DesktopAnalyticsDep } from '@suite/analytics';
+import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { openModal } from '@suite/modal';
 import { goto } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
@@ -38,7 +38,7 @@ export const useEarnProviderConsentActions = ({
     yieldContext,
 }: UseEarnProviderConsentActionsProps) => {
     const dispatch = useDispatch();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const selectedVotingDelegation = useSelector(selectVotingDelegationOption);
 
     const report = (action: EarnModalAction) => {

--- a/packages/suite/src/components/earn/modals/StakeModal/StakeForm/ConfirmStakeModal.tsx
+++ b/packages/suite/src/components/earn/modals/StakeModal/StakeForm/ConfirmStakeModal.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 
-import { type DesktopAnalyticsDep } from '@suite/analytics';
+import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
 import { useServices } from '@suite-common/dependency-injection';
@@ -37,7 +37,7 @@ export const ConfirmStakeModal = ({
     onCancel,
     flow,
 }: ConfirmStakeModalProps) => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const dispatch = useDispatch();
     const [hasAgreed, setHasAgreed] = useState(false);
     const validatorsQueue = useSelector(selectEthValidatorsQueue);

--- a/packages/suite/src/components/earn/modals/StakeModal/StakeForm/StakeButton.tsx
+++ b/packages/suite/src/components/earn/modals/StakeModal/StakeForm/StakeButton.tsx
@@ -1,4 +1,4 @@
-import { type DesktopAnalyticsDep } from '@suite/analytics';
+import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
@@ -31,7 +31,7 @@ export const StakeButton = ({ flow }: StakeButtonProps) => {
         currency,
         isStakingDisabled: isCardanoStakingDisabled,
     } = useSupplyFormContext();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { isStakingDisabled, stakingMessageContent } = useMessageSystemStaking(network.symbol);
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
     const areFeesLoading = useSelector(state => selectAreFeesLoading(state, network.symbol));

--- a/packages/suite/src/components/earn/modals/StakeModal/StakeForm/StakeInputs.tsx
+++ b/packages/suite/src/components/earn/modals/StakeModal/StakeForm/StakeInputs.tsx
@@ -1,4 +1,4 @@
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation, useTranslation } from '@suite/intl';
 import { selectLanguage } from '@suite/settings';
 import { useServices } from '@suite-common/dependency-injection';
@@ -29,7 +29,7 @@ export const StakeInputs = () => {
     const { translationString } = useTranslation();
     const { CryptoAmountFormatter } = useFormatters();
     const locale = useSelector(selectLanguage);
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     const {
         control,

--- a/packages/suite/src/components/earn/modals/StakeModal/StakeModal.tsx
+++ b/packages/suite/src/components/earn/modals/StakeModal/StakeModal.tsx
@@ -1,4 +1,4 @@
-import { type DesktopAnalyticsDep } from '@suite/analytics';
+import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
 import { type StakeModalFlow } from '@suite-common/suite-types/src/staking';
@@ -22,7 +22,7 @@ type StakeModalProps = {
 };
 
 export const StakeModal = ({ onCancel, account, flow }: StakeModalProps) => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const supplyContextValues = useSupplyForm({ account });
     const { isBelowTablet } = useLayoutSize();
 

--- a/packages/suite/src/components/earn/modals/UnstakeModal/UnstakeForm/UnstakeButton.tsx
+++ b/packages/suite/src/components/earn/modals/UnstakeModal/UnstakeForm/UnstakeButton.tsx
@@ -1,4 +1,4 @@
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
@@ -19,7 +19,7 @@ export const UnstakeButton = () => {
     const { isUnstakingDisabled, unstakingMessageContent } = useMessageSystemStaking(
         network.symbol,
     );
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { isSubmitting, errors } = formState;
     const hasValues = Boolean(watch(FIAT_INPUT) || watch(CRYPTO_INPUT));
     // used instead of formState.isValid, which is sometimes returning false even if there are no errors

--- a/packages/suite/src/components/earn/modals/UnstakeModal/UnstakeModal.tsx
+++ b/packages/suite/src/components/earn/modals/UnstakeModal/UnstakeModal.tsx
@@ -1,4 +1,4 @@
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
 import { EarnFlow } from '@suite-common/suite-types/src/staking';
@@ -19,7 +19,7 @@ type UnstakeModalProps = {
 };
 
 export const UnstakeModal = ({ onCancel, account }: UnstakeModalProps) => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const withdrawalContextValues = useWithdrawalForm({ account });
     const { isBelowTablet } = useLayoutSize();
 

--- a/packages/suite/src/components/earn/yield/claim/YieldClaim.tsx
+++ b/packages/suite/src/components/earn/yield/claim/YieldClaim.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect } from 'react';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
@@ -32,7 +32,7 @@ type YieldClaimProps = {
 };
 
 export const YieldClaim = ({ account }: YieldClaimProps) => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const dispatch = useDispatch();
     const { device } = useDevice();
     const flowKey = account.key;

--- a/packages/suite/src/components/earn/yield/claim/YieldClaimPageHeader.tsx
+++ b/packages/suite/src/components/earn/yield/claim/YieldClaimPageHeader.tsx
@@ -1,4 +1,4 @@
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { goto } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
@@ -17,7 +17,7 @@ type YieldClaimPageHeaderProps = {
 
 export const YieldClaimPageHeader = ({ account }: YieldClaimPageHeaderProps) => {
     const dispatch = useDispatch();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     const onBackClick = () => {
         analytics.report({

--- a/packages/suite/src/components/earn/yield/common/YieldApproveModal.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldApproveModal.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react';
 
 import { type DexApprovalType } from 'invity-api';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { KNOWN_VAULTS } from '@suite-common/suite-constants';
 import { parseCryptoId, toTokenCryptoId } from '@suite-common/trading';
@@ -37,7 +37,7 @@ export const YieldApproveModal = ({
     onCancel,
     onSuccess,
 }: YieldApproveModalProps) => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     const {
         state: { isApproveModalOpen, isRevokeModalOpen, openApproveModal, openRevokeModal },

--- a/packages/suite/src/components/earn/yield/common/YieldFlowComplete.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldFlowComplete.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode } from 'react';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation, useTranslation } from '@suite/intl';
 import { goto } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
@@ -29,7 +29,7 @@ export const YieldFlowComplete = ({
     children,
 }: YieldFlowCompleteProps) => {
     const dispatch = useDispatch();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { translationString } = useTranslation();
     const { isBelowMobile } = useLayoutSize();
 

--- a/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation, type TranslationKey, useTranslation } from '@suite/intl';
 import { openModal } from '@suite/modal';
 import { type EarnParams, goto } from '@suite/router';
@@ -34,7 +34,7 @@ export const YieldPageHeader = ({
     routeParams,
 }: YieldPageHeaderProps) => {
     const dispatch = useDispatch();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { translationString } = useTranslation();
     const { isBelowMobile } = useLayoutSize();
     const { data: yieldOpportunities, isSuccess } = useAllYieldOpportunities();

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { type UseFormReturn, useForm } from 'react-hook-form';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { type TranslationKey } from '@suite/intl';
 import { openModal } from '@suite/modal';
@@ -119,7 +119,7 @@ export const useYieldFlow = ({
     flowType,
 }: UseYieldFlowProps): UseYieldFlowResult => {
     const dispatch = useDispatch();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { device } = useDevice();
     const methods = useForm<YieldFlowFormValues>({
         mode: 'onChange',

--- a/packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 
-import { type AnalyticsDesktopEvents, type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { type AnalyticsDesktopEvents, events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { type YieldDto } from '@suite-common/earn-stablecoin-api';
 import {
@@ -157,7 +157,7 @@ export const useYieldPendingTransactionTracking = ({
     vault,
 }: UseYieldPendingTransactionTrackingProps) => {
     const dispatch = useDispatch();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const pendingTransaction = useSelector(
         state => selectStablecoinYieldSession(state, flowType, flowKey).action.pendingTransaction,
     );

--- a/packages/suite/src/components/earn/yield/supply/YieldSupplyForm.tsx
+++ b/packages/suite/src/components/earn/yield/supply/YieldSupplyForm.tsx
@@ -1,4 +1,4 @@
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
 import { splitYieldPendingTransaction } from '@suite-common/wallet-core';
@@ -15,7 +15,7 @@ import { YieldFlowCompleteSupply } from '../common/YieldFlowCompleteSupply';
 import { getApyBreakdown } from '../yieldFlowUtils';
 
 export const YieldSupplyForm = () => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     const {
         account,

--- a/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
+++ b/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
 import { splitYieldPendingTransaction } from '@suite-common/wallet-core';
@@ -15,7 +15,7 @@ import { YieldFlowCompleteWithdraw } from '../common/YieldFlowCompleteWithdraw';
 import { getApyBreakdown } from '../yieldFlowUtils';
 
 export const YieldWithdrawForm = () => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     const {
         vault,

--- a/packages/suite/src/components/guide/Feedback.tsx
+++ b/packages/suite/src/components/guide/Feedback.tsx
@@ -2,7 +2,7 @@ import { type ChangeEvent, type ReactNode, useCallback, useState } from 'react';
 
 import styled from 'styled-components';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
@@ -57,7 +57,7 @@ type FeedbackProps = {
 
 export const Feedback = ({ type }: FeedbackProps) => {
     const { device } = useDevice();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const dispatch = useDispatch();
     const router = useSelector(state => state.router);
     const [description, setDescription] = useState('');

--- a/packages/suite/src/components/guide/Guide.tsx
+++ b/packages/suite/src/components/guide/Guide.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import styled from 'styled-components';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
 import { Button, Column, Divider } from '@trezor/components';
@@ -26,7 +26,7 @@ export const Guide = () => {
     const [searchActive, setSearchActive] = useState(false);
     const indexNode = useSelector(state => state.guide.indexNode);
     const dispatch = useDispatch();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const handleFeedbackButtonClick = () => {
         dispatch(setView('SUPPORT_FEEDBACK_SELECTION'));
         analytics.report({

--- a/packages/suite/src/components/guide/GuideHeader.tsx
+++ b/packages/suite/src/components/guide/GuideHeader.tsx
@@ -2,7 +2,7 @@ import { type JSX, useContext } from 'react';
 
 import styled, { css } from 'styled-components';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
 import { H3, IconButton, Paragraph, useElevation } from '@trezor/components';
@@ -50,7 +50,7 @@ interface GuideHeaderProps {
 }
 
 export const GuideHeader = ({ back, label, useBreadcrumb }: GuideHeaderProps) => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { elevation } = useElevation();
     const dispatch = useDispatch();
     const isScrolled = useContext(ContentScrolledContext);

--- a/packages/suite/src/components/guide/GuideNode.tsx
+++ b/packages/suite/src/components/guide/GuideNode.tsx
@@ -2,7 +2,7 @@ import { type ReactNode } from 'react';
 
 import styled from 'styled-components';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { selectLanguage } from '@suite/settings';
 import { useServices } from '@suite-common/dependency-injection';
 import { type GuideNode as GuideNodeType } from '@suite-common/suite-types';
@@ -68,7 +68,7 @@ type GuideNodeProps = {
 export const GuideNode = ({ node, description }: GuideNodeProps) => {
     const language = useSelector(selectLanguage);
     const dispatch = useDispatch();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     const navigateToNode = () => {
         dispatch(openNode(node));

--- a/packages/suite/src/components/guide/HeaderBreadcrumb.tsx
+++ b/packages/suite/src/components/guide/HeaderBreadcrumb.tsx
@@ -1,4 +1,4 @@
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { selectLanguage } from '@suite/settings';
 import { useServices } from '@suite-common/dependency-injection';
@@ -10,7 +10,7 @@ import { useDispatch, useSelector } from 'src/hooks/suite';
 import { findAncestorNodes, getNodeTitle } from 'src/utils/suite/guide';
 
 export const HeaderBreadcrumb = () => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const language = useSelector(selectLanguage);
     const indexNode = useSelector(state => state.guide.indexNode);
     const currentNode = useSelector(state => state.guide.currentNode);

--- a/packages/suite/src/components/guide/SupportFeedbackSelection.tsx
+++ b/packages/suite/src/components/guide/SupportFeedbackSelection.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { UpdateState } from '@suite/desktop-update';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
@@ -86,7 +86,7 @@ const LabelHeadline = styled.strong`
 `;
 
 export const SupportFeedbackSelection = () => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const desktopUpdate = useSelector(state => state.desktopUpdate);
     const device = useSelector(selectSelectedDevice);
     const dispatch = useDispatch();

--- a/packages/suite/src/components/suite/AppRouter.tsx
+++ b/packages/suite/src/components/suite/AppRouter.tsx
@@ -2,10 +2,10 @@ import { type ComponentType, createElement, memo } from 'react';
 
 import {
     type PageName,
-    type SuiteRouterHistoryDep,
     resolveEffectiveBackgroundRouteName,
     selectRoute,
     selectRouteName,
+    selectSuiteRouterHistoryDep,
     suiteRoutes,
 } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
@@ -19,7 +19,7 @@ type AppRouterProps = {
 export const AppRouter = memo(({ components }: AppRouterProps) => {
     const routeName = useSelector(selectRouteName);
     const route = useSelector(selectRoute);
-    const { suiteRouterHistory } = useServices<SuiteRouterHistoryDep>();
+    const { suiteRouterHistory } = useServices(selectSuiteRouterHistoryDep);
 
     const resolvedRouteName =
         resolveEffectiveBackgroundRouteName(route, suiteRouterHistory.getLocation()) ?? routeName;

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceConnect.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceConnect.tsx
@@ -1,4 +1,4 @@
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
 import { Button, Column } from '@trezor/components';
@@ -8,7 +8,7 @@ import { useDispatch } from 'src/hooks/suite';
 
 export const DeviceConnect = () => {
     const dispatch = useDispatch();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     const handleConnect = () => {
         dispatch(toggleConnectionModal());

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceInitialize.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceInitialize.tsx
@@ -1,6 +1,6 @@
 import { type MouseEvent } from 'react';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { goto } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
@@ -19,7 +19,7 @@ import { useStore } from 'src/hooks/suite/useStore';
 
 export const DeviceInitialize = () => {
     const dispatch = useDispatch();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { getState } = useStore();
 
     const handleCtaClick = (e: MouseEvent) => {

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceNoFirmware.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceNoFirmware.tsx
@@ -1,6 +1,6 @@
 import { type MouseEventHandler } from 'react';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { goto } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
@@ -14,7 +14,7 @@ import { useStore } from 'src/hooks/suite/useStore';
 
 export const DeviceNoFirmware = () => {
     const dispatch = useDispatch();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { getState } = useStore();
 
     const handleClick: MouseEventHandler = e => {

--- a/packages/suite/src/components/suite/banners/SuiteBanners/SuiteSyncBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/SuiteSyncBanner.tsx
@@ -11,7 +11,7 @@ import {
     selectHasDeviceSuiteSyncError,
     selectSuiteSyncInteraction,
 } from '@suite-common/suite-sync';
-import { type SuiteSyncDep } from '@suite-common/suite-sync-types';
+import { selectEnsureWalletSuiteSyncOnDep } from '@suite-common/suite-sync-types';
 import { Banner } from '@trezor/components';
 import { type StaticSessionId } from '@trezor/connect';
 
@@ -89,7 +89,8 @@ const SuiteSyncBannerContent = ({
 
 export const SuiteSyncBanner = ({ deviceStaticSessionId }: SuiteSyncBannerProps) => {
     const dispatch = useDispatch();
-    const { suiteSync } = useServices<SuiteSyncDep>();
+
+    const { ensureWalletSuiteSyncOn } = useServices(selectEnsureWalletSuiteSyncOnDep);
 
     const hasSuiteSyncError = useSelector((state: WithSuiteSyncAndDeviceState) =>
         selectHasDeviceSuiteSyncError(state, deviceStaticSessionId),
@@ -111,7 +112,7 @@ export const SuiteSyncBanner = ({ deviceStaticSessionId }: SuiteSyncBannerProps)
 
     const handlers: Record<SuiteSyncBannerInteraction, () => void | Promise<void>> = {
         'keys-needed': async () => {
-            const result = await suiteSync.ensureWalletSuiteSyncOn({
+            const result = await ensureWalletSuiteSyncOn({
                 deviceStaticSessionId,
                 isWriteMode: false,
             });

--- a/packages/suite/src/components/suite/bluetooth/BluetoothDeviceListItem.tsx
+++ b/packages/suite/src/components/suite/bluetooth/BluetoothDeviceListItem.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 
-import { type DesktopAnalyticsDep } from '@suite/analytics';
+import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation, type TranslationKey } from '@suite/intl';
 import { events } from '@suite-common/analytics';
 import {
@@ -79,7 +79,7 @@ const ActionButton = ({
 }: ActionButtonProps) => {
     const connectingDevicesIds = useSelector(selectConnectingDevices);
     const { onConnect } = useConnectionGlobalModalContext();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const isSuiteTryingToConnectToDevice = connectingDevicesIds.includes(device.id);
     const connectionStatus = connectionStatusMap[device.connectionStatus.type];
     const isClickable = connectionStatus?.component === 'button';

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal/GlobalReceiveModal.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal/GlobalReceiveModal.tsx
@@ -1,6 +1,6 @@
 import { useRef } from 'react';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
@@ -25,7 +25,7 @@ type GlobalReceiveModalProps = {
 };
 
 export const GlobalReceiveModal = ({ onCancel, onSubmit }: GlobalReceiveModalProps) => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { device } = useDevice();
     const { isDiscoveryRunning } = useDiscovery();
     const isAddAccountDisabled = isDiscoveryRunning || !device?.connected;

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendReceiveButtons.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendReceiveButtons.tsx
@@ -1,4 +1,4 @@
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
 import { type GlobalSendReceiveType } from '@suite-common/wallet-types';
@@ -16,7 +16,7 @@ export const GlobalSendReceiveButtons = ({
     intent,
     priority,
 }: GlobalSendReceiveButtonsProps) => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     return (
         <ButtonGroup intent={intent} priority={priority}>

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/hooks/useGlobalSendReceiveAnalytics.ts
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/hooks/useGlobalSendReceiveAnalytics.ts
@@ -3,13 +3,13 @@ import { useCallback } from 'react';
 import {
     type DashboardReceiveModalOptionsEventOption,
     type DashboardSendModalOptionsEventOption,
-    type DesktopAnalyticsDep,
     events,
+    selectDesktopAnalyticsDep,
 } from '@suite/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 
 export const useGlobalSendReceiveAnalytics = () => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const reportSend = useCallback(
         (option: DashboardSendModalOptionsEventOption, filledSearch: boolean) => {
             analytics.report({

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderDropdown.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderDropdown.tsx
@@ -1,7 +1,7 @@
 import { type JSX } from 'react';
 
 import { selectSelectedAccount } from '@suite/account';
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
 import { getTradingPrefilledFromAccountData, tradingActions } from '@suite-common/trading';
@@ -34,7 +34,7 @@ export const HeaderDropdown = ({
     isTradingDisabled,
     showSignAndVerify,
 }: HeaderDropdownProps) => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const dispatch = useDispatch();
     const goToWithAnalytics = useGoToWithAnalytics();
     const account = useSelector(selectSelectedAccount);

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageHeader.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageHeader.tsx
@@ -4,10 +4,10 @@ import styled, { css } from 'styled-components';
 
 import { selectSelectedAccountKey } from '@suite/account';
 import {
-    type SuiteRouterHistoryDep,
     isAccountTabRoute,
     resolveEffectiveBackgroundRouteName,
     selectRoute,
+    selectSuiteRouterHistoryDep,
 } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectAccounts } from '@suite-common/wallet-core';
@@ -67,7 +67,7 @@ interface PageHeaderProps {
 export const PageHeader = ({ children, expandable }: PageHeaderProps) => {
     const selectedAccountKey = useSelector(selectSelectedAccountKey);
     const route = useSelector(selectRoute);
-    const { suiteRouterHistory } = useServices<SuiteRouterHistoryDep>();
+    const { suiteRouterHistory } = useServices(selectSuiteRouterHistoryDep);
     const effectiveRouteName = resolveEffectiveBackgroundRouteName(
         route,
         suiteRouterHistory.getLocation(),

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/PageName.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/PageName.tsx
@@ -1,10 +1,10 @@
 import { selectSelectedAccount } from '@suite/account';
 import { Translation } from '@suite/intl';
 import {
-    type SuiteRouterHistoryDep,
     isAccountTabRoute,
     resolveEffectiveBackgroundRouteName,
     selectRoute,
+    selectSuiteRouterHistoryDep,
 } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectDeviceAccountForNetworkSymbolAndAccountTypeWithIndex } from '@suite-common/wallet-core';
@@ -18,7 +18,7 @@ import { SettingsName } from './SettingsName';
 
 export const PageName = () => {
     const route = useSelector(selectRoute);
-    const { suiteRouterHistory } = useServices<SuiteRouterHistoryDep>();
+    const { suiteRouterHistory } = useServices(selectSuiteRouterHistoryDep);
     const currentRoute = resolveEffectiveBackgroundRouteName(
         route,
         suiteRouterHistory.getLocation(),

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/TradeActions.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/TradeActions.tsx
@@ -1,4 +1,4 @@
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { goto, selectIsAccountTabPage, selectRouteName } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
@@ -19,7 +19,7 @@ interface TradeActionsProps {
 }
 
 export const TradeActions = ({ selectedAccount }: TradeActionsProps) => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const dispatch = useDispatch();
     const account = selectedAccount?.account;
     const device = useSelector(selectSelectedDevice);

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/useGoToWithAnalytics.ts
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/useGoToWithAnalytics.ts
@@ -1,5 +1,5 @@
 import { selectSelectedAccount } from '@suite/account';
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { goto } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { type Account } from '@suite-common/wallet-types';
@@ -7,7 +7,7 @@ import { type Account } from '@suite-common/wallet-types';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
 export const useGoToWithAnalytics = (account?: Account) => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const selectedAccount = useSelector(selectSelectedAccount);
     const accountToUse = account ?? selectedAccount;
     const dispatch = useDispatch();

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/NotificationDropdown.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/NotificationDropdown.tsx
@@ -2,7 +2,7 @@ import { useRef, useState } from 'react';
 
 import styled, { css } from 'styled-components';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { Box, Menu, Popover, type PopoverRef } from '@trezor/components';
@@ -22,7 +22,7 @@ const StyledNavigationItem = styled(NavigationItem)`
 `;
 
 export const NotificationDropdown = (props: NavigationItemProps) => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const [isOpen, setIsOpen] = useState(false);
     const { isBelowLaptop } = useLayoutSize();
     const popoverRef = useRef<PopoverRef>(null);

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode, useEffect, useState } from 'react';
 
 import { Address } from '@suite/address';
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { Translation, useTranslation } from '@suite/intl';
 import { Labeling } from '@suite/labeling';
@@ -80,7 +80,7 @@ export const ConfirmValueModal = ({
     const dispatch = useDispatch();
     const { openNodeById } = useGuideOpenNode();
     const { translationString } = useTranslation();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     const isSuiteSyncEnabled = useSelector(selectIsSuiteSyncEnabled);
     const isLegacyLabelingVisible = useSelector(selectIsLegacyLabelingVisible);

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBody.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBody.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { selectAccountIncludingChosenInTrading } from '@suite/account';
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { preserveModalOnTxTimeout } from '@suite/modal';
 import { selectRouterUrl } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
@@ -39,7 +39,7 @@ export const TransactionReviewModalBody = ({
     precomposedForm,
     isRbfConfirmedError,
 }: TransactionReviewModalBodyProps) => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const dispatch = useDispatch();
     const account = useSelector(selectAccountIncludingChosenInTrading);
     const device = useSelector(selectSelectedDevice);

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { closeModal } from '@suite/modal';
 import { useServices } from '@suite-common/dependency-injection';
@@ -102,7 +102,7 @@ export const TransactionReviewModalBodyInner = ({
     setIsSending,
     hasTxReviewExpired,
 }: TransactionReviewModalBodyInnerProps) => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const dispatch = useDispatch();
     const [areDetailsVisible, setAreDetailsVisible] = useState(false);
     const { symbol, networkType } = account;

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalBottomContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalBottomContent.tsx
@@ -1,9 +1,9 @@
 import { useDispatch, useSelector } from 'react-redux';
 
 import {
-    type DesktopAnalyticsDep,
     type TransactionCreatedEventAction,
     events,
+    selectDesktopAnalyticsDep,
 } from '@suite/analytics';
 import { type ExtendedMessageDescriptor, Translation } from '@suite/intl';
 import { selectConnectPopupCall } from '@suite-common/connect-popup';
@@ -63,7 +63,7 @@ export const TransactionReviewModalBottomContent = ({
     precomposedForm,
     outputs,
 }: TransactionReviewModalBottomContentProps) => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const dispatch = useDispatch();
     const connectPopupCall = useSelector(selectConnectPopupCall);
     const { precomposedTx, serializedTx } = txInfoState;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddAccountButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddAccountButton.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
@@ -71,7 +71,7 @@ const AddDefaultAccountButton = ({
 }: AddAccountButtonProps) => {
     const defaultAccount = scopedAccounts.at(-1);
     const device = useSelector(selectSelectedDevice);
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     const { setCoinFilter, setSearchString, coinFilter } = useAccountSearch();
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddTokenModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddTokenModal.tsx
@@ -1,7 +1,7 @@
 import { type ChangeEvent, useCallback, useEffect, useState } from 'react';
 
 import { selectSelectedAccount } from '@suite/account';
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation, useTranslation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
 import { isAddressValid, tryGetAccountIdentity } from '@suite-common/wallet-utils';
@@ -24,7 +24,7 @@ export const AddTokenModal = ({ onCancel }: AddTokenModalProps) => {
     const account = useSelector(selectSelectedAccount);
     const dispatch = useDispatch();
     const { translationString } = useTranslation();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     const loadTokenInfo = useCallback(
         async (acc: Account, contractAddress: string) => {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApplicationLogModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApplicationLogModal.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import styled from 'styled-components';
 
-import { type DesktopAnalyticsDep } from '@suite/analytics';
+import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
@@ -45,7 +45,7 @@ const LogWrapper = styled.pre`
 type ApplicationLogModalProps = { onCancel: () => void };
 
 export const ApplicationLogModal = ({ onCancel }: ApplicationLogModalProps) => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const [hideSensitiveInfo, setHideSensitiveInfo] = useState(false);
     const applicationLogs = useApplicationLogs({ hideSensitiveInfo });
     const { ShadowTop, ShadowBottom, ShadowContainer, onScroll, scrollElementRef } =

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApproveModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApproveModal.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { type DexApprovalType, type ExchangeTrade } from 'invity-api';
 import styled from 'styled-components';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { selectIsDebugModeActive } from '@suite/settings';
 import { useServices } from '@suite-common/dependency-injection';
@@ -59,7 +59,7 @@ export const ApproveModal = ({
     onCancel,
 }: ApproveModalProps) => {
     const dispatch = useDispatch();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const context = useTradingFormContext<TradingExchangeType>();
     const {
         form: {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AutoStartBeforeQuitModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AutoStartBeforeQuitModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { closeModal } from '@suite/modal';
 import { useServices } from '@suite-common/dependency-injection';
@@ -12,7 +12,7 @@ import { useDispatch } from 'src/hooks/suite';
 
 export const AutoStartBeforeQuitModal = () => {
     const dispatch = useDispatch();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const [dontAskAgain, setDontAskAgain] = useState(false);
     useEffect(() => {
         if (desktopApi.available) desktopApi.appAutoStartPopupAck();

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectPermissionsModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectPermissionsModal.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { type DesktopAnalyticsDep } from '@suite/analytics';
+import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { selectIsDebugModeActive } from '@suite/settings';
 import { events } from '@suite-common/analytics';
@@ -18,7 +18,7 @@ import { useDispatch, useSelector } from 'src/hooks/suite';
 import { getPermissionText } from 'src/views/settings/SettingsConnectedApps/ConnectPermissions';
 
 export const ConnectPermissionsModal = () => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const [isRemembered, setIsRemembered] = useState(false);
     const [isSilentMode, setIsSilentMode] = useState(false);
     const dispatch = useDispatch();

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/MultiShareBackupModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/MultiShareBackupModal.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { LearnMoreButton } from '@suite/external-links';
 import { Translation } from '@suite/intl';
 import { isAdditionalShamirBackupInProgress } from '@suite/recovery';
@@ -29,7 +29,7 @@ type MultiShareBackupModalProps = {
 type StepConfig = Partial<ModalProps>;
 
 export const MultiShareBackupModal = ({ onCancel }: MultiShareBackupModalProps) => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const device = useSelector(selectSelectedDevice);
 
     const isInBackupMode =

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/RevokeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/RevokeModal.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import styled from 'styled-components';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { selectIsDebugModeActive } from '@suite/settings';
 import { useServices } from '@suite-common/dependency-injection';
@@ -52,7 +52,7 @@ type RevokeModalProps = {
 };
 
 export const RevokeModal = ({ setIsWaitingForDevice, onCancel }: RevokeModalProps) => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const context = useTradingFormContext<TradingExchangeType>();
     const {
         form: {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StellarManageTokenModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StellarManageTokenModal.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { selectSelectedAccount } from '@suite/account';
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation, useTranslation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
 import { notificationsActions } from '@suite-common/toast-notifications';
@@ -48,7 +48,7 @@ type StellarManageTokenModalProps =
       };
 
 export const StellarManageTokenModal = (props: StellarManageTokenModalProps) => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { mode, symbol, contractAddress, onCancel } = props;
     const tokenBalance = mode === 'deactivate' ? props.tokenBalance : undefined;
     const dispatch = useDispatch();

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakingBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakingBanner.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { selectFlags, setFlag } from '@suite/flags';
 import { Translation } from '@suite/intl';
 import { goto } from '@suite/router';
@@ -28,7 +28,7 @@ type StakingBannerProps = {
 };
 
 export const StakingBanner = ({ account }: StakingBannerProps) => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const dispatch = useDispatch();
     const { CryptoAmountFormatter } = useFormatters();
     const { stakeEthBannerClosed, stakeSolBannerClosed, stakeCardanoBannerClosed } =

--- a/packages/suite/src/components/wallet/WalletLayout/AccountNavigation.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountNavigation.tsx
@@ -1,5 +1,5 @@
 import { selectSelectedAccount } from '@suite/account';
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { selectRouterParams } from '@suite/router';
 import { selectHasExperimentalFeature } from '@suite/settings';
@@ -13,7 +13,7 @@ import { useSelector } from 'src/hooks/suite';
 import { type WalletParams } from 'src/types/wallet';
 
 export const AccountNavigation = () => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const account = useSelector(selectSelectedAccount);
     const routerParams = useSelector(selectRouterParams) as WalletParams;
     const enabledNftSection = useSelector(selectHasExperimentalFeature('nft-section'));

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountItem.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountItem.tsx
@@ -1,4 +1,4 @@
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { type BaseCurrencyAmount } from '@suite-common/wallet-types';
 import { Box, Column, GhostContainer, TOOLTIP_DELAY_NORMAL, Tooltip } from '@trezor/components';
@@ -51,7 +51,7 @@ export const AccountItem = ({
     isFiatLoading,
     onClick,
 }: AccountItemProps) => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { accountType, index, symbol } = account;
 
     const goToWithAnalytics = useGoToWithAnalytics(account);

--- a/packages/suite/src/hooks/guide/useGuide.ts
+++ b/packages/suite/src/hooks/guide/useGuide.ts
@@ -1,4 +1,4 @@
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 
 import { close, open } from 'src/actions/suite/guideActions';
@@ -9,7 +9,7 @@ import { usePreferredModal } from '../suite';
 export const GUIDE_ANIMATION_DURATION_MS = 300;
 
 export const useGuide = () => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const isGuideOpen = useSelector(state => state.guide.open);
     const dispatch = useDispatch();
 

--- a/packages/suite/src/hooks/guide/useGuideOpenNode.ts
+++ b/packages/suite/src/hooks/guide/useGuideOpenNode.ts
@@ -1,4 +1,4 @@
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 
 import { openNode } from 'src/actions/suite/guideActions';
@@ -7,7 +7,7 @@ import { useDispatch, useSelector } from 'src/hooks/suite';
 import { getNodeById } from 'src/utils/suite/guide';
 
 export const useGuideOpenNode = () => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { isGuideOpen, openGuide } = useGuide();
 
     const indexNode = useSelector(state => state.guide.indexNode);

--- a/packages/suite/src/hooks/settings/backends/useBackendsForm.ts
+++ b/packages/suite/src/hooks/settings/backends/useBackendsForm.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useTranslation } from '@suite/intl';
 import { isOnionUrl } from '@suite/tor';
 import { useServices } from '@suite-common/dependency-injection';
@@ -110,7 +110,7 @@ const getStoredState = (
 });
 
 export const useBackendsForm = (symbol: NetworkSymbol) => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const backends = useSelector(state => state.wallet.blockchain[symbol].backends);
     const dispatch = useDispatch();
     const { translationString } = useTranslation();

--- a/packages/suite/src/hooks/suite/useChangeDeviceLabel.ts
+++ b/packages/suite/src/hooks/suite/useChangeDeviceLabel.ts
@@ -2,7 +2,7 @@ import { type UseFormReturn, useForm } from 'react-hook-form';
 
 import { yupResolver } from '@hookform/resolvers/yup';
 
-import { type DesktopAnalyticsDep } from '@suite/analytics';
+import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { type TranslationFunction, useTranslation } from '@suite/intl';
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
@@ -42,7 +42,7 @@ export const useChangeDeviceLabel = (): {
     >;
     handleSubmit: (onSuccess?: () => void) => void;
 } => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { translationString } = useTranslation();
     const deviceLabel = useSelector(selectSelectedDeviceLabelOrName);
     const dispatch = useDispatch();

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingBuyHandleChange.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingBuyHandleChange.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { type UseFormSetValue } from 'react-hook-form';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import {
     TRADING_FORM_PAYMENT_METHOD_SELECT,
@@ -40,7 +40,7 @@ export const useTradingBuyHandleChange = ({
 }: TradingBuyUseHandleChangeProps) => {
     const dispatch = useDispatch();
     const previousPromise = useRef<PromiseType>(null);
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const handleChange = useCallback(async () => {
         if (
             isCountrySubdivisionEmpty(

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingExchangeHandleChange.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingExchangeHandleChange.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef } from 'react';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import {
     type TradingExchangeFormProps,
@@ -38,7 +38,7 @@ export const useTradingExchangeHandleChange = ({
     setIsScheduledQuotesRefresh = noop,
 }: TradingExchangeUseHandleChangeProps) => {
     const dispatch = useDispatch();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const previousPromise = useRef<PromiseType>(null);
 
     const handleChange = useCallback(async () => {

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingSellHandleChange.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingSellHandleChange.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { type UseFormSetValue } from 'react-hook-form';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import {
     TRADING_FORM_PAYMENT_METHOD_SELECT,
@@ -42,7 +42,7 @@ export const useTradingSellHandleChange = ({
 }: TradingSellUseHandleChangeProps) => {
     const dispatch = useDispatch();
     const previousPromise = useRef<PromiseType>(null);
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const handleChange = useCallback(async () => {
         if (
             isCountrySubdivisionEmpty(

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
@@ -4,7 +4,7 @@ import { useForm, useWatch } from 'react-hook-form';
 import type { BuyTrade, BuyTradeResponse } from 'invity-api';
 import useDebounce from 'react-use/lib/useDebounce';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { goto } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import {
@@ -61,7 +61,7 @@ import { useTradingReceiveAddress } from './useTradingReceiveAddress';
 export const useTradingBuyForm = ({
     pageType = 'form',
 }: UseTradingFormCommonProps = {}): TradingBuyFormContextProps => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const type = 'buy';
     const isFormPage = pageType === 'form';
     const dispatch = useDispatch();

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -3,7 +3,7 @@ import { useForm, useWatch } from 'react-hook-form';
 
 import type { DexApprovalType, ExchangeTrade } from 'invity-api';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { type TranslationKey, useTranslation } from '@suite/intl';
 import { goto } from '@suite/router';
 import { selectHasExperimentalFeature } from '@suite/settings';
@@ -80,7 +80,7 @@ import { useTradingReceiveAddress } from './useTradingReceiveAddress';
 export const useTradingExchangeForm = ({
     pageType = 'form',
 }: UseTradingFormCommonProps): TradingExchangeFormContextProps => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const type = 'exchange';
     const isFormPage = pageType === 'form';
     const dispatch = useDispatch();

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
@@ -3,7 +3,7 @@ import { useForm, useWatch } from 'react-hook-form';
 
 import type { BankAccount, CryptoId, SellFiatTrade, SellFiatTradeResponse } from 'invity-api';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { type TranslationKey, useTranslation } from '@suite/intl';
 import { goto } from '@suite/router';
 import { selectHasExperimentalFeature } from '@suite/settings';
@@ -66,7 +66,7 @@ import { useTradingFormAccount } from './useTradingFormAccount';
 export const useTradingSellForm = ({
     pageType = 'form',
 }: UseTradingFormCommonProps = {}): TradingSellFormContextProps => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const type = 'sell';
     const isFormPage = pageType === 'form';
     const dispatch = useDispatch();

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -99,6 +99,8 @@ export type SuiteServices = CommonServices &
     MetadataMigrationDep &
     SuiteRouterHistoryDep;
 
+export const selectSuiteServices = (services: any): SuiteServices => services;
+
 export const createSuiteServicesCompositionRoot = (deps: SuiteAppDeps): SuiteServices => {
     const { ensureDelegatedIdentityKey } = delegatedIdentityKeyCompositionRoot({
         dispatch: deps.dispatch,

--- a/packages/suite/src/support/suite/RouterHandler.tsx
+++ b/packages/suite/src/support/suite/RouterHandler.tsx
@@ -3,10 +3,10 @@ import { useEffect } from 'react';
 import { Action } from 'history';
 
 import {
-    type SuiteRouterHistoryDep,
     onLocationChange,
     selectCanNavigate,
     selectRouterLoaded,
+    selectSuiteRouterHistoryDep,
 } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 
@@ -15,7 +15,7 @@ import { useDispatch, useSelector } from 'src/hooks/suite';
 export const RouterHandler = () => {
     const dispatch = useDispatch();
     const routerLoaded = useSelector(selectRouterLoaded);
-    const { suiteRouterHistory } = useServices<SuiteRouterHistoryDep>();
+    const { suiteRouterHistory } = useServices(selectSuiteRouterHistoryDep);
     const canGoBack = useSelector(selectCanNavigate);
 
     useEffect(() => {

--- a/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 
-import { type DesktopAnalyticsDep } from '@suite/analytics';
+import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { MODAL_CONTEXT_DEVICE, openModal } from '@suite/modal';
 import { events } from '@suite-common/analytics';
 import {
@@ -28,7 +28,7 @@ import { useDispatch, useSelector } from 'src/hooks/suite';
 
 export const useConnectPopupDesktop = () => {
     const dispatch = useDispatch();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const popupCall = useSelector(selectConnectPopupCall);
     const selectedDevice = useSelector(selectSelectedDevice);
     const selectedDeviceRef = useRef(selectedDevice);

--- a/packages/suite/src/views/dashboard/AssetsView/AssetCard/AssetCard.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetCard/AssetCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { goto } from '@suite/router';
 import { type AssetFiatBalance } from '@suite-common/assets';
@@ -98,7 +98,7 @@ export const AssetCard = ({
 }: AssetCardProps) => {
     const { symbol } = network;
     const dispatch = useDispatch();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { shallDisplayBaseCurrency } = useDisplayBaseCurrency(symbol);
 
     const handleCardClick = () => {

--- a/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetRow.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetRow.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { goto } from '@suite/router';
 import { type AssetFiatBalance } from '@suite-common/assets';
@@ -59,7 +59,7 @@ export const AssetRow = memo(
     }: AssetTableRowProps) => {
         const { symbol } = network;
         const dispatch = useDispatch();
-        const { analytics } = useServices<DesktopAnalyticsDep>();
+        const { analytics } = useServices(selectDesktopAnalyticsDep);
         const { shallDisplayBaseCurrency } = useDisplayBaseCurrency(symbol);
 
         const handleRowClick = () => {

--- a/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { selectFlags, setFlag } from '@suite/flags';
 import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
@@ -93,7 +93,7 @@ export const AssetsView = () => {
     const enabledNetworks = useSelector(selectEnabledNetworks);
 
     const dispatch = useDispatch();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { isDiscoveryRunning } = useDiscovery();
     const discoveryStatus = useSelector(selectDiscoveryOverallStatus);
     const accounts = useSelector(selectAllAccountsToList);

--- a/packages/suite/src/views/dashboard/DashboardFooter.tsx
+++ b/packages/suite/src/views/dashboard/DashboardFooter.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import styled from 'styled-components';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
 import {
@@ -68,7 +68,7 @@ const StoreBadgeWithQr = ({
 }: StoreBadgeWithQrProps) => {
     const { isBelowTablet } = useLayoutSize();
     const [isTooltipOpen, setIsTooltipOpen] = useState(false);
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     return (
         <Tooltip
@@ -152,7 +152,7 @@ const MobileAppPromo = ({ hasRightMargin }: { hasRightMargin: boolean }) => {
 };
 
 const ReferralButton = () => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const hasAtLeastOneRememberedWallet = useSelector(
         state =>
             selectRememberedStandardWalletsCount(state) > 0 ||
@@ -179,7 +179,7 @@ const ReferralButton = () => {
 };
 
 export const DashboardFooter = () => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { isBelowTablet } = useLayoutSize();
     const { contentWidth } = useResponsiveContext();
 

--- a/packages/suite/src/views/dashboard/DashboardPromoBanner/DashboardPromoBanner.tsx
+++ b/packages/suite/src/views/dashboard/DashboardPromoBanner/DashboardPromoBanner.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import {
     selectIsStablecoinYieldDashboardPromoBannerShown,
     selectIsTEXDashboardPromoBannerShown,
@@ -23,7 +23,7 @@ import { type DashboardBannerTypeWithNull, isDashboardBannerType } from './dashb
 
 export const DashboardPromoBanner = () => {
     const [isVisible, setIsVisible] = useState(true);
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const discoveryStatus = useSelector(selectDiscoveryOverallStatus);
     const isDiscoveryEmpty = discoveryStatus?.type === 'discovery-empty';
     const shouldShowTEXDashboardPromoBanner = useSelector(selectIsTEXDashboardPromoBannerShown);

--- a/packages/suite/src/views/dashboard/PortfolioCard/EmptyWallet.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/EmptyWallet.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { goto } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
@@ -20,7 +20,7 @@ const RoundedBorder = styled.div`
 
 export const EmptyWallet = () => {
     const dispatch = useDispatch();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const enabledNetworks = useSelector(selectEnabledNetworks);
     const isBitcoinOnlyFirmware = useSelector(selectHasBitcoinOnlyFirmware);
 

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardException.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardException.tsx
@@ -1,6 +1,6 @@
 import { type ComponentProps, type JSX } from 'react';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { Translation, type TranslationKey } from '@suite/intl';
 import { openModal } from '@suite/modal';
@@ -140,7 +140,7 @@ export const PortfolioCardException = ({
     failed,
 }: PortfolioCardExceptionProps) => {
     const dispatch = useDispatch();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     switch (exception.type) {
         case 'discovery-empty':

--- a/packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/SecurityCheck.tsx
+++ b/packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/SecurityCheck.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { TrezorLink } from '@suite/external-links';
 import { selectFlags } from '@suite/flags';
 import { Translation } from '@suite/intl';
@@ -112,7 +112,7 @@ const SecurityCheckContent = ({
     goToSuiteOrNextDevice,
     shouldAuthenticateSelectedDevice,
 }: SecurityCheckContentProps) => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { isBelowTablet } = useLayoutSize();
     const recoveryStatus = useSelector(selectRecoveryStatus);
     const device = useSelector(selectSelectedDevice);

--- a/packages/suite/src/views/settings/SettingsDebug/AnalyticsLogging.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/AnalyticsLogging.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { type DesktopAnalyticsDep } from '@suite/analytics';
+import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import {
     analyticsActions,
     selectCustomAnalyticsUrl,
@@ -18,7 +18,7 @@ export const AnalyticsLogging = () => {
     const loggerEnabled = useSelector(selectLoggerEnabled);
     const isAnalyticsEnabled = useSelector(selectIsAnalyticsEnabled);
     const dispatch = useDispatch();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     const [inputValue, setInputValue] = useState(customAnalyticsUrl ?? '');
 

--- a/packages/suite/src/views/settings/SettingsDebug/PlatformEncryption.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/PlatformEncryption.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import { useServices } from '@suite-common/dependency-injection';
-import { type PlatformEncryptionDep, asEncryptedHex } from '@suite-common/platform-encryption';
+import { asEncryptedHex, selectPlatformEncryptionDep } from '@suite-common/platform-encryption';
 import { Button, ButtonGroup, Column, Textarea } from '@trezor/components';
 import { SectionItem, SettingsSection } from '@trezor/product-components';
 import { breakpoints, spacings } from '@trezor/theme';
@@ -17,7 +17,7 @@ export const PlatformEncryption = () => {
     const [plaintext, setPlaintext] = useState(asValue(''));
     const [ciphertext, setCiphertext] = useState(asEncryptedHex<Value>(''));
 
-    const { platformEncryption } = useServices<PlatformEncryptionDep>();
+    const { platformEncryption } = useServices(selectPlatformEncryptionDep);
 
     const encrypt = async () => {
         const result = await platformEncryption.encrypt({ value: plaintext });

--- a/packages/suite/src/views/settings/SettingsDevice/AutoLock.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/AutoLock.tsx
@@ -1,6 +1,6 @@
 import type { Locale } from 'date-fns';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
 import { Anchor, SettingsAnchor } from '@suite/router';
@@ -33,7 +33,7 @@ export const AutoLock = ({ isDeviceLocked }: AutoLockProps) => {
     const dispatch = useDispatch();
     const { device } = useDevice();
     const locale = useLocales();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const autoLockDelay = device?.features?.auto_lock_delay_ms;
 
     if (typeof autoLockDelay !== 'number') {

--- a/packages/suite/src/views/settings/SettingsDevice/Brightness.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/Brightness.tsx
@@ -1,4 +1,4 @@
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
@@ -11,7 +11,7 @@ interface DeviceLabelProps {
 
 export const Brightness = ({ isDeviceLocked }: DeviceLabelProps) => {
     const { device } = useDevice();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const isSupportedDevice = device?.features?.capabilities?.includes('Capability_Brightness');
 
     if (!isSupportedDevice) {

--- a/packages/suite/src/views/settings/SettingsDevice/ChangePin.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/ChangePin.tsx
@@ -1,4 +1,4 @@
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { Anchor, SettingsAnchor } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
@@ -13,7 +13,7 @@ interface ChangePinProps {
 
 export const ChangePin = ({ isDeviceLocked }: ChangePinProps) => {
     const dispatch = useDispatch();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const handleClick = () => {
         dispatch(changePin({ remove: false }));
         analytics.report({

--- a/packages/suite/src/views/settings/SettingsDevice/DisplayRotation.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/DisplayRotation.tsx
@@ -1,6 +1,6 @@
 import { type JSX } from 'react';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
 import { Anchor, SettingsAnchor } from '@suite/router';
@@ -60,7 +60,7 @@ interface DisplayRotationProps {
 export const DisplayRotation = ({ isDeviceLocked }: DisplayRotationProps) => {
     const dispatch = useDispatch();
     const { device } = useDevice();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const isSupported =
         device?.features !== undefined &&
         DEVICES_SUPPORTING_ROTATION.includes(device.features.internal_model);

--- a/packages/suite/src/views/settings/SettingsDevice/ForgetDevice/useForgetDevice.ts
+++ b/packages/suite/src/views/settings/SettingsDevice/ForgetDevice/useForgetDevice.ts
@@ -1,4 +1,4 @@
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { notificationsActions } from '@suite-common/toast-notifications';
 
@@ -12,7 +12,7 @@ import { useDispatch } from 'src/hooks/suite';
  */
 export const useForgetDevice = () => {
     const dispatch = useDispatch();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     const forgetDevice = async ({
         skipToggleModalConnection,

--- a/packages/suite/src/views/settings/SettingsDevice/HapticFeedback.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/HapticFeedback.tsx
@@ -1,4 +1,4 @@
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
 import { Anchor, SettingsAnchor } from '@suite/router';
@@ -16,7 +16,7 @@ interface DeviceLabelProps {
 export const HapticFeedback = ({ isDeviceLocked }: DeviceLabelProps) => {
     const dispatch = useDispatch();
     const { device } = useDevice();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const isSupportedDevice = device?.features?.capabilities?.includes('Capability_Haptic');
 
     if (!isSupportedDevice) {

--- a/packages/suite/src/views/settings/SettingsDevice/MultiShareBackup.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/MultiShareBackup.tsx
@@ -1,4 +1,4 @@
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { LearnMoreButton } from '@suite/external-links';
 import { Translation } from '@suite/intl';
 import { goto } from '@suite/router';
@@ -30,7 +30,7 @@ const doesSupportMultiShare = (device: TrezorDevice | undefined): boolean => {
 };
 
 export const MultiShareBackup = ({ isDeviceLocked }: { isDeviceLocked: boolean }) => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const device = useSelector(selectSelectedDevice);
     const dispatch = useDispatch();
 

--- a/packages/suite/src/views/settings/SettingsDevice/Passphrase.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/Passphrase.tsx
@@ -1,4 +1,4 @@
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { LearnMoreButton } from '@suite/external-links';
 import { Translation } from '@suite/intl';
@@ -18,7 +18,7 @@ interface PassphraseProps {
 export const Passphrase = ({ isDeviceLocked }: PassphraseProps) => {
     const dispatch = useDispatch();
     const { device } = useDevice();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const passphraseProtection = !!device?.features?.passphrase_protection;
 
     const handleChange = () => {

--- a/packages/suite/src/views/settings/SettingsDevice/PinProtection.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/PinProtection.tsx
@@ -1,4 +1,4 @@
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
 import { Anchor, SettingsAnchor } from '@suite/router';
@@ -16,7 +16,7 @@ interface PinProtectionProps {
 export const PinProtection = ({ isDeviceLocked }: PinProtectionProps) => {
     const dispatch = useDispatch();
     const { device } = useDevice();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     const pinProtection = device?.features?.pin_protection ?? null;
 

--- a/packages/suite/src/views/settings/SettingsDevice/ThpAutoconnect.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/ThpAutoconnect.tsx
@@ -1,4 +1,4 @@
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
 import { Anchor, SettingsAnchor } from '@suite/router';
@@ -14,7 +14,7 @@ interface PinProtectionProps {
 }
 
 export const ThpAutoconnect = ({ isDeviceLocked }: PinProtectionProps) => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const dispatch = useDispatch();
 
     const { device } = useDevice();

--- a/packages/suite/src/views/settings/SettingsDevice/WipeCode.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/WipeCode.tsx
@@ -1,6 +1,6 @@
 import { useSelector } from 'react-redux';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { LearnMoreButton } from '@suite/external-links';
 import { Translation } from '@suite/intl';
 import { Anchor, SettingsAnchor } from '@suite/router';
@@ -18,7 +18,7 @@ interface Props {
 
 export const WipeCode = ({ isDeviceLocked }: Props) => {
     const dispatch = useDispatch();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const isDeviceProtectedByWipeCode = useSelector(selectIsDeviceProtectedByWipeCode);
 
     const enableWipeCode = () => {

--- a/packages/suite/src/views/settings/SettingsDevice/WipeDevice/WipeDeviceModal.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/WipeDevice/WipeDeviceModal.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import { isFulfilled } from '@reduxjs/toolkit';
 
-import { type DesktopAnalyticsDep } from '@suite/analytics';
+import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
 import { events } from '@suite-common/analytics';
@@ -19,7 +19,7 @@ type WipeDeviceModalProps = {
 };
 
 export const WipeDeviceModal = ({ onCancel }: WipeDeviceModalProps) => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const [isLoading, setIsLoading] = useState(false);
     const [isConfirmed, setIsConfirmed] = useState(false);
 

--- a/packages/suite/src/views/settings/SettingsGeneral/AddressDisplay.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/AddressDisplay.tsx
@@ -1,4 +1,4 @@
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { Anchor, SettingsAnchor } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
@@ -14,7 +14,7 @@ const getAddressDisplayType = (value: boolean) =>
 
 export const AddressDisplay = () => {
     const dispatch = useDispatch();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     const selectedAddressDisplay = useSelector(selectAddressDisplayType);
 

--- a/packages/suite/src/views/settings/SettingsGeneral/Analytics.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Analytics.tsx
@@ -2,7 +2,7 @@ import { useSelector } from 'react-redux';
 
 import styled from 'styled-components';
 
-import { type DesktopAnalyticsDep } from '@suite/analytics';
+import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { Anchor, SettingsAnchor } from '@suite/router';
 import { selectIsAnalyticsEnabled } from '@suite-common/analytics-redux';
@@ -16,7 +16,7 @@ const PositionedSwitch = styled.div`
 
 export const Analytics = () => {
     const isAnalyticsEnabled = useSelector(selectIsAnalyticsEnabled);
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     return (
         <Anchor anchorId={SettingsAnchor.Analytics}>

--- a/packages/suite/src/views/settings/SettingsGeneral/AutoEject.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/AutoEject.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { Anchor, SettingsAnchor } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
@@ -46,7 +46,7 @@ const AutoEjectConfirmationModal = ({
 };
 
 export const AutoEject = () => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const isAutoEjectEnabled = useSelector(selectIsDeviceAutoEjectEnabled);
     const dispatch = useDispatch();
     const [isConfirmationModalOpen, setIsConfirmationModalOpen] = useState(false);

--- a/packages/suite/src/views/settings/SettingsGeneral/BaseCurrency.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/BaseCurrency.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation, useTranslation } from '@suite/intl';
 import { Anchor, SettingsAnchor } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
@@ -17,7 +17,7 @@ import { typedObjectKeys } from '@trezor/utils';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
 export const BaseCurrency = () => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { translationString } = useTranslation();
     const baseCurrencyCode = useSelector(selectBaseCurrency);
     const dispatch = useDispatch();

--- a/packages/suite/src/views/settings/SettingsGeneral/BioAuthSettings.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/BioAuthSettings.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { Anchor, SettingsAnchor } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
@@ -14,7 +14,7 @@ const PositionedSwitch = styled.div`
 `;
 
 export const BioAuthSettings = () => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const {
         isBioAuthEnabled,
         isBioAuthAvailable,

--- a/packages/suite/src/views/settings/SettingsGeneral/DesktopSuiteBanner.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/DesktopSuiteBanner.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import styled from 'styled-components';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useExternalLink } from '@suite/external-links';
 import { setFlag } from '@suite/flags';
 import { Translation } from '@suite/intl';
@@ -55,7 +55,7 @@ const OSIcons = styled.div`
 `;
 
 export const DesktopSuiteBanner = () => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const [isVisible, setIsVisible] = useState(true);
 
     const dispatch = useDispatch();

--- a/packages/suite/src/views/settings/SettingsGeneral/Experimental.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Experimental.tsx
@@ -21,7 +21,7 @@ import { typedObjectKeys } from '@trezor/utils';
 
 import { EXPERIMENTAL_FEATURES } from 'src/constants/suite/experimental';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { type SuiteServices } from 'src/support/extraDependencies';
+import { selectSuiteServices } from 'src/support/extraDependencies';
 
 type FeatureLineProps = {
     feature: ExperimentalFeature;
@@ -30,7 +30,7 @@ type FeatureLineProps = {
 
 const FeatureLine = ({ feature, enabledFeatures }: FeatureLineProps) => {
     const dispatch = useDispatch();
-    const services = useServices<SuiteServices>();
+    const services = useServices(selectSuiteServices);
     const checked = enabledFeatures.includes(feature);
 
     const config = EXPERIMENTAL_FEATURES[feature];
@@ -123,7 +123,7 @@ export const Experimental = () => {
     const isDebug = useSelector(selectIsDebugModeActive);
 
     const dispatch = useDispatch();
-    const services = useServices<SuiteServices>();
+    const services = useServices(selectSuiteServices);
 
     const onSwitchExperimental = () => {
         enabledFeatures?.forEach(feature =>

--- a/packages/suite/src/views/settings/SettingsGeneral/Language.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Language.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { LearnMoreButton } from '@suite/external-links';
 import { Translation, useTranslation } from '@suite/intl';
 import { Anchor, SettingsAnchor } from '@suite/router';
@@ -60,7 +60,7 @@ const useLanguageOptions = () => {
 };
 
 export const Language = () => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const language = useSelector(selectLanguage);
     const autodetectLanguage = useSelector(selectAutodetectLanguage);
     const dispatch = useDispatch();

--- a/packages/suite/src/views/settings/SettingsGeneral/MevProtection.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/MevProtection.tsx
@@ -1,6 +1,6 @@
 import { FormattedList } from 'react-intl';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { Anchor, SettingsAnchor } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
@@ -12,7 +12,7 @@ import { ActionColumn, SectionItem, TextColumn } from '@trezor/product-component
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
 export const MevProtection = () => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const dispatch = useDispatch();
     const isMevProtectionEnabled = useSelector(selectIsMevProtectionEnabled);
 

--- a/packages/suite/src/views/settings/SettingsGeneral/NetworkReserve.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/NetworkReserve.tsx
@@ -1,6 +1,6 @@
 import { FormattedList } from 'react-intl';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { LearnMoreButton } from '@suite/external-links';
 import { Translation } from '@suite/intl';
 import { Anchor, SettingsAnchor } from '@suite/router';
@@ -14,7 +14,7 @@ import { NETWORK_RESERVE_URL } from '@trezor/urls';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
 export const NetworkReserve = () => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const dispatch = useDispatch();
     const isNetworkReserveEnabled = useSelector(selectIsNetworkReserveEnabled);
 

--- a/packages/suite/src/views/settings/SettingsGeneral/Theme.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Theme.tsx
@@ -1,4 +1,4 @@
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation, useTranslation } from '@suite/intl';
 import { Anchor, SettingsAnchor } from '@suite/router';
 import {
@@ -56,7 +56,7 @@ const useThemeOptions = () => {
 };
 
 export const Theme = () => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const theme = useSelector(selectThemeSettings);
     const autodetectTheme = useSelector(selectAutodetectTheme);
     const dispatch = useDispatch();

--- a/packages/suite/src/views/settings/SettingsGeneral/TorOnionLinks.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/TorOnionLinks.tsx
@@ -1,4 +1,4 @@
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { Anchor, SettingsAnchor } from '@suite/router';
 import { selectTorOnionLinks, suiteSettingsActions } from '@suite/settings';
@@ -13,7 +13,7 @@ import { useDispatch, useSelector } from 'src/hooks/suite';
 export const TorOnionLinks = () => {
     const torOnionLinks = useSelector(selectTorOnionLinks);
     const dispatch = useDispatch();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const handleChange = () => {
         dispatch(suiteSettingsActions.setOnionLinks(!torOnionLinks));
         analytics.report({

--- a/packages/suite/src/views/start/AnalyticsConsentScreen.tsx
+++ b/packages/suite/src/views/start/AnalyticsConsentScreen.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode } from 'react';
 
-import { type DesktopAnalyticsDep } from '@suite/analytics';
+import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { TrezorLink } from '@suite/external-links';
 import { useServices } from '@suite-common/dependency-injection';
 import { Column } from '@trezor/components';
@@ -10,7 +10,7 @@ import { DATA_TOS_URL, DOCS_ANALYTICS_URL } from '@trezor/urls';
 import { WelcomeLayoutWithoutModalSwitcher } from '../../components/suite/layouts/WelcomeLayout/WelcomeLayoutWithoutModalSwitcher';
 
 export const AnalyticsConsentScreen = () => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     const onConfirm = (trackingEnabled: boolean) => {
         if (trackingEnabled) {

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/EjectConfirmation.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/EjectConfirmation.tsx
@@ -1,6 +1,6 @@
 import { type MouseEventHandler } from 'react';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
 import { deviceActions } from '@suite-common/device';
@@ -17,7 +17,7 @@ type EjectConfirmationProps = {
 };
 
 export const EjectConfirmation = ({ onClick, onCancel, instance }: EjectConfirmationProps) => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const dispatch = useDispatch();
 
     const handleEject = () => {

--- a/packages/suite/src/views/suite/SwitchDevice/SwitchDevice.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/SwitchDevice.tsx
@@ -1,4 +1,4 @@
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { bluetoothActions, selectAdapterStatus } from '@suite-common/bluetooth';
 import { useServices } from '@suite-common/dependency-injection';
@@ -14,7 +14,7 @@ import { DeviceItem } from './DeviceItem/DeviceItem';
 import { SwitchDeviceModal } from './SwitchDeviceModal';
 
 export const SwitchDeviceContent = ({ cancelable, onCancel }: ForegroundAppProps) => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const dispatch = useDispatch();
     const bluetoothAdapterStatus = useSelector(selectAdapterStatus);
     const devices = useSelector(selectDevices);

--- a/packages/suite/src/views/wallet/labels/Bip329Labels.tsx
+++ b/packages/suite/src/views/wallet/labels/Bip329Labels.tsx
@@ -5,7 +5,7 @@ import { Translation } from '@suite/intl';
 import { selectIsMetadataEnabled } from '@suite/metadata';
 import { suiteSyncErrorHandler } from '@suite/suite-sync';
 import { shouldDisplayExportBip329Labels } from '@suite-common/bip329';
-import { type Bip329Dep, type Bip329Label, bip329LabelSchema } from '@suite-common/bip329-types';
+import { type Bip329Label, bip329LabelSchema, selectBip329Dep } from '@suite-common/bip329-types';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectIsSuiteSyncEnabled } from '@suite-common/suite-sync';
 import { notificationsActions } from '@suite-common/toast-notifications';
@@ -39,7 +39,7 @@ export const Bip329Labels = ({ account, isLoading }: Bip329LabelsProps) => {
     const isMetadataEnabled = useSelector(selectIsMetadataEnabled);
 
     const dispatch = useDispatch();
-    const { bip329 } = useServices<Bip329Dep>();
+    const { bip329 } = useServices(selectBip329Dep);
     const { getDefaultAccountLabel } = useDefaultAccountLabel();
     const isContentBelowBreakpoint = useIsContentBelowBreakpoint();
 

--- a/packages/suite/src/views/wallet/send/Outputs/Address.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Address.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { checkAddressCheckSum, toChecksumAddress } from 'web3-utils';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { Translation, useTranslation } from '@suite/intl';
 import { Labeling } from '@suite/labeling';
@@ -77,7 +77,7 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
         clearErrors,
     } = useSendFormContext();
     const { translationString } = useTranslation();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { descriptor, networkType, symbol } = account;
     const inputName = `outputs.${outputId}.address` as const;
     // NOTE: compose errors are always associated with the amount.

--- a/packages/suite/src/views/wallet/send/Outputs/Amount/Amount.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/Amount.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation, useTranslation } from '@suite/intl';
 import { selectLanguage } from '@suite/settings';
 import { useServices } from '@suite-common/dependency-injection';
@@ -46,7 +46,7 @@ interface AmountProps {
 
 export const Amount = ({ output, outputId }: AmountProps) => {
     const { translationString } = useTranslation();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const {
         account,
         network,

--- a/packages/suite/src/views/wallet/send/SendRaw.tsx
+++ b/packages/suite/src/views/wallet/send/SendRaw.tsx
@@ -1,6 +1,6 @@
 import { useForm } from 'react-hook-form';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation, useTranslation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectIsMevProtectionFeatureEnabled } from '@suite-common/mev';
@@ -37,7 +37,7 @@ export const SendRaw = ({ account }: SendRawProps) => {
     });
     const dispatch = useDispatch();
     const { translationString } = useTranslation();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const inputValue = watch(INPUT_NAME);
     const error = errors[INPUT_NAME];
     const hasError = !!error;

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/ClaimCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/ClaimCard.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef } from 'react';
 
 import { selectSelectedAccount } from '@suite/account';
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
 import { useServices } from '@suite-common/dependency-injection';
@@ -16,7 +16,7 @@ import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
 
 export const ClaimCard = () => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const selectedAccount = useSelector(selectSelectedAccount);
     const claimTxs = useSelector(state =>
         selectAccountClaimTransactions(state, selectedAccount?.key || null),

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/StakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/StakingCard.tsx
@@ -1,4 +1,4 @@
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
 import { useServices } from '@suite-common/dependency-injection';
@@ -94,7 +94,7 @@ export const StakingCard = ({
     daysToUnstake,
     account,
 }: StakingCardProps) => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { isBelowLaptop } = useLayoutSize();
 
     const cardanoStakingPools = useSelector(selectCardanoPoolsInfo);

--- a/packages/suite/src/views/wallet/tokens/TokensNavigation.tsx
+++ b/packages/suite/src/views/wallet/tokens/TokensNavigation.tsx
@@ -1,6 +1,6 @@
 import { type Dispatch, type SetStateAction, useEffect } from 'react';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation, type TranslationKey, useTranslation } from '@suite/intl';
 import { openModal } from '@suite/modal';
 import { type Route, goto, selectRouteName } from '@suite/router';
@@ -95,7 +95,7 @@ export const TokensNavigation = ({
 }: TokensNavigationProps) => {
     const { account } = selectedAccount;
     const routeName = useSelector(selectRouteName);
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const tokenDefinitions = useSelector(state =>
         isNft
             ? selectNftDefinitions(state, selectedAccount.account.symbol)

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode } from 'react';
 
 import { Address, copyAddressToClipboard, showCopyAddressModal } from '@suite/address';
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { selectIsDeviceCompromised } from '@suite/authenticity-checks';
 import { useDevice } from '@suite/device';
 import { useExternalLink } from '@suite/external-links';
@@ -77,7 +77,7 @@ const TokenRowBasicActions = ({
     setShowDeactivateModal,
 }: TokenRowBasicActionsProps) => {
     const dispatch = useDispatch();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const device = useSelector(selectSelectedDevice);
     const { isLocked } = useDevice();
     const { isBelowTablet } = useLayoutSize();

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailBuy/TradingDetailBuy.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailBuy/TradingDetailBuy.tsx
@@ -4,7 +4,7 @@ import { usePrevious } from 'react-use';
 import { type BuyTradeStatus } from 'invity-api';
 import styled from 'styled-components';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation, useTranslation } from '@suite/intl';
 import { goto } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
@@ -47,7 +47,7 @@ const getTradeStatusStep = (tradeStatus?: BuyTradeStatus) => {
 };
 
 export const TradingDetailBuy = () => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const accounts = useSelector(selectAccounts);
     const { trade, info, account } = useTradingDetailContext<TradingBuyType>();
     const dispatch = useDispatch();

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchange.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchange.tsx
@@ -4,7 +4,7 @@ import { usePrevious } from 'react-use';
 import { type ExchangeTradeStatus } from 'invity-api';
 import styled from 'styled-components';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation, useTranslation } from '@suite/intl';
 import { goto } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
@@ -55,7 +55,7 @@ const getTradeStatusStep = (tradeStatus: ExchangeTradeStatus) => {
 };
 
 export const TradingDetailExchange = () => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const accounts = useSelector(selectAccounts);
     const { trade, info } = useTradingDetailContext<TradingExchangeType>();
     const dispatch = useDispatch();

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSell/TradingDetailSell.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSell/TradingDetailSell.tsx
@@ -4,7 +4,7 @@ import { usePrevious } from 'react-use';
 import { type SellTradeStatus } from 'invity-api';
 import styled from 'styled-components';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation, useTranslation } from '@suite/intl';
 import { goto } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
@@ -40,7 +40,7 @@ const getTradeStatusStep = (tradeStatus: SellTradeStatus) => {
 };
 
 export const TradingDetailSell = () => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const accounts = useSelector(selectAccounts);
     const { trade, info } = useTradingDetailContext<TradingSellType>();
     const dispatch = useDispatch();

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingApproveModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingApproveModal.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from 'react';
 
 import { type CryptoId, type DexApprovalType } from 'invity-api';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Calldata } from '@suite-common/calldata';
 import { useServices } from '@suite-common/dependency-injection';
 import { useCurrentRef } from '@trezor/react-utils';
@@ -25,7 +25,7 @@ interface TradingApproveModalProps {
 export const TradingApproveModal = ({ amount, cryptoId }: TradingApproveModalProps) => {
     const { state } = useAllowanceContext();
     const context = useTradingFormContext();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const getCryptoInfo = useTradingExchangeCryptoAndProviderInfo();
 
     const contextRef = useCurrentRef(context);

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import {
     TRADING_FORM_OUTPUT_AMOUNT,
@@ -46,7 +46,7 @@ import { generateFractionButtons } from './tradingFormInputsUtils';
 
 export const TradingExchangeFormInputs = () => {
     const context = useTradingFormContext<TradingExchangeType>();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     const { isLoading } = useSelector(selectTradingLoadingAndTimestamp);
 

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx
@@ -1,7 +1,7 @@
 import styled, { type DefaultTheme } from 'styled-components';
 
 import { Address } from '@suite/address';
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
 import { useServices } from '@suite-common/dependency-injection';
@@ -36,7 +36,7 @@ const TextButton = styled.div<{ $disabled: boolean }>`
 export const TradingFormApproval = () => {
     const context = useTradingFormContext<TradingExchangeType>();
     const dispatch = useDispatch();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     const { tx, state: allowanceState } = useAllowanceContext();
 

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingRevokeModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingRevokeModal.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from 'react';
 
 import { type CryptoId } from 'invity-api';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Calldata } from '@suite-common/calldata';
 import { useServices } from '@suite-common/dependency-injection';
 
@@ -23,7 +23,7 @@ interface TradingRevokeModalProps {
 export const TradingRevokeModal = ({ cryptoId }: TradingRevokeModalProps) => {
     const { state } = useAllowanceContext();
     const context = useTradingFormContext();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const getCryptoInfo = useTradingExchangeCryptoAndProviderInfo();
 
     const handleCancel = useCallback(async () => {

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingSellFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingSellFormInputs.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import {
     TRADING_FORM_OUTPUT_AMOUNT,
@@ -40,7 +40,7 @@ import { generateFractionButtons } from './tradingFormInputsUtils';
 
 export const TradingSellFormInputs = () => {
     const context = useTradingFormContext<TradingSellType>();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     const {
         feeInfo,

--- a/packages/suite/src/views/wallet/trading/common/TradingLayout/TradingLayoutNavigation.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingLayout/TradingLayoutNavigation.tsx
@@ -1,4 +1,4 @@
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation, type TranslationKey } from '@suite/intl';
 import { type Route, goto } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
@@ -41,7 +41,7 @@ const navigationItems: NavigationItem[] = [
 
 export const TradingLayoutNavigation = ({ route }: TradingLayoutNavigationProps) => {
     const dispatch = useDispatch();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const goToRoute = (route: Route['name']) => () => {
         dispatch(goto({ routeName: route }));
 

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.tsx
@@ -1,6 +1,6 @@
 import { type CryptoId } from 'invity-api';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
 import {
@@ -31,7 +31,7 @@ export const TradingOfferExchange = ({
     quoteAmounts,
 }: TradingOfferExchangeProps) => {
     const { handleClick, disabled } = useAsyncClickHandler();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const formStep = useSelector(selectTradingExchangeFormStep);
     const receiveAccountKey = useSelector(selectTradingExchangeReceiveAccountKey);
     const receiveAccount = useSelector(

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferSell/TradingOfferSellTransaction.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferSell/TradingOfferSellTransaction.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
 import type { TradingSellType } from '@suite-common/trading';
@@ -46,7 +46,7 @@ const Row = styled.div`
 const Address = styled.div``;
 
 export const TradingSelectedOfferSellTransaction = () => {
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { handleClick, disabled } = useAsyncClickHandler();
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
     const {

--- a/packages/suite/src/views/wallet/transactions/TradeBox/TradeBox.tsx
+++ b/packages/suite/src/views/wallet/transactions/TradeBox/TradeBox.tsx
@@ -1,4 +1,4 @@
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
 import { type Route, goto } from '@suite/router';
@@ -28,7 +28,7 @@ export const TradeBox = ({ account }: TradeBoxProps) => {
     const { isBelowTablet, isBelowMobile } = useLayoutSize();
     const dispatch = useDispatch();
     const { device } = useDevice();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { shallDisplayBaseCurrency } = useDisplayBaseCurrency(account.symbol);
 
     const isStakeNetwork = hasNetworkFeatures(account, 'staking');

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/ExportAction.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/ExportAction.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react';
 
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation, useTranslation } from '@suite/intl';
 import { selectLabelingDataForSelectedAccount } from '@suite/metadata';
 import { useServices } from '@suite-common/dependency-injection';
@@ -24,7 +24,7 @@ export interface ExportActionProps {
 export const ExportAction = ({ account, searchQuery }: ExportActionProps) => {
     const [isExportRunning, setIsExportRunning] = useState(false);
     const dispatch = useDispatch();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { translationString } = useTranslation();
 
     const getAccountTitle = useCallback(() => {

--- a/packages/suite/src/views/wallet/transactions/components/AccountEmpty.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/AccountEmpty.tsx
@@ -1,4 +1,4 @@
-import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { goto } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
@@ -19,7 +19,7 @@ interface AccountEmptyProps {
 
 export const AccountEmpty = ({ account }: AccountEmptyProps) => {
     const dispatch = useDispatch();
-    const { analytics } = useServices<DesktopAnalyticsDep>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     const isTokensNetwork = getNetworkFeatures(account.symbol).includes('tokens');
 

--- a/suite-common/bip329-types/src/index.ts
+++ b/suite-common/bip329-types/src/index.ts
@@ -71,3 +71,7 @@ export type Bip329 = {
 export type Bip329Dep = {
     bip329: Bip329;
 };
+
+export const selectBip329Dep = (services: any): Bip329Dep => ({
+    bip329: services.bip329,
+});

--- a/suite-common/dependency-injection/jest.config.js
+++ b/suite-common/dependency-injection/jest.config.js
@@ -1,0 +1,6 @@
+const baseConfig = require('../../jest.config.base.swc');
+
+module.exports = {
+    ...baseConfig,
+    testEnvironment: 'jsdom',
+};

--- a/suite-common/dependency-injection/package.json
+++ b/suite-common/dependency-injection/package.json
@@ -13,5 +13,8 @@
     "dependencies": {
         "@trezor/type-utils": "workspace:*",
         "react": "19.2.4"
+    },
+    "devDependencies": {
+        "@testing-library/react": "^16.3.2"
     }
 }

--- a/suite-common/dependency-injection/src/__tests__/selectServices.test.ts
+++ b/suite-common/dependency-injection/src/__tests__/selectServices.test.ts
@@ -1,0 +1,36 @@
+import { selectServices } from '../useServices';
+
+const services = {
+    analytics: {
+        report: jest.fn(),
+    },
+    suiteSync: {
+        turnOffSuiteSync: jest.fn(),
+    },
+};
+
+type SelectedServices = {
+    analytics: typeof services.analytics;
+    turnOffSuiteSync: typeof services.suiteSync.turnOffSuiteSync;
+};
+
+const selectAnalyticsDep = (currentServices: any) => ({
+    analytics: currentServices.analytics,
+});
+
+const selectTurnOffSuiteSyncDep = (currentServices: any) => ({
+    turnOffSuiteSync: currentServices.suiteSync.turnOffSuiteSync,
+});
+
+describe(selectServices.name, () => {
+    it('selects and merges a subset of nested services', () => {
+        const selectedServices: SelectedServices = selectServices(
+            services,
+            selectAnalyticsDep,
+            selectTurnOffSuiteSyncDep,
+        );
+
+        expect(selectedServices.analytics).toBe(services.analytics);
+        expect(selectedServices.turnOffSuiteSync).toBe(services.suiteSync.turnOffSuiteSync);
+    });
+});

--- a/suite-common/dependency-injection/src/__tests__/useServices.test.tsx
+++ b/suite-common/dependency-injection/src/__tests__/useServices.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import React, { type PropsWithChildren } from 'react';
 
 import { renderHook } from '@testing-library/react';

--- a/suite-common/dependency-injection/src/__tests__/useServices.test.tsx
+++ b/suite-common/dependency-injection/src/__tests__/useServices.test.tsx
@@ -1,0 +1,37 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import React, { type PropsWithChildren } from 'react';
+
+import { renderHook } from '@testing-library/react';
+
+import { ServicesProvider, useServices } from '../useServices';
+
+const services = {
+    a: jest.fn(),
+    b: jest.fn(),
+};
+
+const selectADep = (currentServices: any) => ({
+    analytics: currentServices.analytics,
+});
+
+const selectBDep = (currentServices: any) => ({
+    turnOffSuiteSync: currentServices.suiteSync.turnOffSuiteSync,
+});
+
+describe(useServices.name, () => {
+    it('returns the same selected services reference across rerenders', () => {
+        const wrapper = ({ children }: PropsWithChildren) => (
+            <ServicesProvider services={services}>{children}</ServicesProvider>
+        );
+
+        const { result, rerender } = renderHook(() => useServices(selectADep, selectBDep), {
+            wrapper,
+        });
+
+        const firstSelectedServices = result.current;
+
+        rerender();
+
+        expect(result.current).toBe(firstSelectedServices);
+    });
+});

--- a/suite-common/dependency-injection/src/__tests__/useServices.test.tsx
+++ b/suite-common/dependency-injection/src/__tests__/useServices.test.tsx
@@ -5,23 +5,26 @@ import { renderHook } from '@testing-library/react';
 
 import { ServicesProvider, useServices } from '../useServices';
 
-const services = {
+type ADep = { a: () => void };
+type BDep = { b: () => void };
+
+const appServices: ADep & BDep = {
     a: jest.fn(),
     b: jest.fn(),
 };
 
-const selectADep = (currentServices: any) => ({
-    analytics: currentServices.analytics,
+const selectADep = (services: any): ADep => ({
+    a: services.a,
 });
 
-const selectBDep = (currentServices: any) => ({
-    turnOffSuiteSync: currentServices.suiteSync.turnOffSuiteSync,
+const selectBDep = (services: any): BDep => ({
+    b: services.b,
 });
 
 describe(useServices.name, () => {
     it('returns the same selected services reference across rerenders', () => {
         const wrapper = ({ children }: PropsWithChildren) => (
-            <ServicesProvider services={services}>{children}</ServicesProvider>
+            <ServicesProvider services={appServices}>{children}</ServicesProvider>
         );
 
         const { result, rerender } = renderHook(() => useServices(selectADep, selectBDep), {

--- a/suite-common/dependency-injection/src/__tests__/useServices.type-test.ts
+++ b/suite-common/dependency-injection/src/__tests__/useServices.type-test.ts
@@ -1,0 +1,17 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+import { useServices } from '../useServices';
+
+type ADep = { a: () => void };
+type BDep = { b: () => void };
+
+const selectADep = (services: any): ADep => ({ a: services.a });
+const selectBDep = (services: any): BDep => ({ b: services.b });
+
+const _selectedServices: ADep & BDep = useServices(selectADep, selectBDep);
+const _allServices: BDep = useServices<BDep>();
+
+// @ts-expect-error useServices requires an explicit generic type argument.
+useServices();
+
+void _selectedServices;
+void _allServices;

--- a/suite-common/dependency-injection/src/__tests__/useServices.type-test.ts
+++ b/suite-common/dependency-injection/src/__tests__/useServices.type-test.ts
@@ -8,10 +8,15 @@ const selectADep = (services: any): ADep => ({ a: services.a });
 const selectBDep = (services: any): BDep => ({ b: services.b });
 
 const _selectedServices: ADep & BDep = useServices(selectADep, selectBDep);
-const _allServices: BDep = useServices<BDep>();
 
-// @ts-expect-error useServices requires an explicit generic type argument.
+// @ts-expect-error useServices requires at least one selector.
 useServices();
 
+// @ts-expect-error useServices infers its return type from selectors.
+useServices<BDep>();
+
+// @ts-expect-error useServices returns type as narrow as the supplied selectors
+const _mismatchedService: ADep = useServices(selectBDep);
+
 void _selectedServices;
-void _allServices;
+void _mismatchedService;

--- a/suite-common/dependency-injection/src/useServices.tsx
+++ b/suite-common/dependency-injection/src/useServices.tsx
@@ -2,12 +2,29 @@ import React from 'react';
 
 const ServicesContext = React.createContext<any>(null);
 
+// This is intentional `any`. Services cannot be known in advance,
+// doing some global super type would create same complication as we
+// currently have in the `ExtraDependenciesStatic` type, where
+// we have central place where _everything_ must be imported.
+type Services = any;
+
+export type ServiceSelector<TSelected> = (services: Services) => TSelected;
+
+type SelectorResult<TSelector> =
+    TSelector extends ServiceSelector<infer TSelected> ? TSelected : never;
+
+type UnionToIntersection<TUnion> = (
+    TUnion extends unknown ? (value: TUnion) => void : never
+) extends (value: infer TIntersection) => void
+    ? TIntersection
+    : never;
+
+type SelectedServices<TSelectors extends readonly ServiceSelector<any>[]> = UnionToIntersection<
+    SelectorResult<TSelectors[number]>
+>;
+
 type ServicesProviderProps = {
-    // This is intentional `any`. Services cannot be known in advance,
-    // doing some global super type would create same complication as we
-    // currently have in the `ExtraDependenciesStatic` type, where
-    // we have central place where _everything_ must be imported.
-    services: any;
+    services: Services;
     children: React.ReactNode;
 };
 
@@ -20,14 +37,28 @@ ServicesProvider.displayName = 'ServicesProvider';
 type MissingUseServicesGenericError =
     'useServices<TServices>() requires an explicit service type argument';
 
-export const useServices = <TServices = never,>(
-    ..._enforceTypeArgument: [TServices] extends [never] ? [MissingUseServicesGenericError] : []
-): TServices => {
+export const selectServices = (services: Services, ...selectors: ServiceSelector<any>[]) => {
+    if (selectors.length === 0) {
+        return services;
+    }
+
+    return Object.assign({}, ...selectors.map(selector => selector(services)));
+};
+
+export function useServices<TServices = never>(
+    ...args: [TServices] extends [never] ? [MissingUseServicesGenericError] : []
+): TServices;
+
+export function useServices<
+    const TSelectors extends readonly [ServiceSelector<any>, ...ServiceSelector<any>[]],
+>(...selectors: TSelectors): SelectedServices<TSelectors>;
+
+export function useServices(...selectors: ServiceSelector<any>[]) {
     const services = React.useContext(ServicesContext);
 
     if (!services) {
         throw new Error('useServices must be used within a ServicesProvider');
     }
 
-    return services as TServices;
-};
+    return selectServices(services, ...selectors);
+}

--- a/suite-common/dependency-injection/src/useServices.tsx
+++ b/suite-common/dependency-injection/src/useServices.tsx
@@ -34,13 +34,8 @@ export const ServicesProvider = ({ services, children }: ServicesProviderProps) 
 
 ServicesProvider.displayName = 'ServicesProvider';
 
-export const selectServices = (services: Services, ...selectors: ServiceSelector<any>[]) => {
-    if (selectors.length === 0) {
-        return services;
-    }
-
-    return Object.assign({}, ...selectors.map(selector => selector(services)));
-};
+export const selectServices = (services: Services, ...selectors: ServiceSelector<any>[]) =>
+    Object.assign({}, ...selectors.map(selector => selector(services)));
 
 export function useServices<
     const TSelectors extends readonly [ServiceSelector<any>, ...ServiceSelector<any>[]],

--- a/suite-common/dependency-injection/src/useServices.tsx
+++ b/suite-common/dependency-injection/src/useServices.tsx
@@ -34,9 +34,6 @@ export const ServicesProvider = ({ services, children }: ServicesProviderProps) 
 
 ServicesProvider.displayName = 'ServicesProvider';
 
-type MissingUseServicesGenericError =
-    'useServices<TServices>() requires an explicit service type argument';
-
 export const selectServices = (services: Services, ...selectors: ServiceSelector<any>[]) => {
     if (selectors.length === 0) {
         return services;
@@ -44,10 +41,6 @@ export const selectServices = (services: Services, ...selectors: ServiceSelector
 
     return Object.assign({}, ...selectors.map(selector => selector(services)));
 };
-
-export function useServices<TServices = never>(
-    ...args: [TServices] extends [never] ? [MissingUseServicesGenericError] : []
-): TServices;
 
 export function useServices<
     const TSelectors extends readonly [ServiceSelector<any>, ...ServiceSelector<any>[]],

--- a/suite-common/dependency-injection/src/useServices.tsx
+++ b/suite-common/dependency-injection/src/useServices.tsx
@@ -60,5 +60,6 @@ export function useServices(...selectors: ServiceSelector<any>[]) {
         throw new Error('useServices must be used within a ServicesProvider');
     }
 
-    return selectServices(services, ...selectors);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    return React.useMemo(() => selectServices(services, ...selectors), [services, ...selectors]);
 }

--- a/suite-common/earn-stablecoin/tsconfig.json
+++ b/suite-common/earn-stablecoin/tsconfig.json
@@ -10,8 +10,6 @@
         {
             "path": "../../packages/connect-common"
         },
-        {
-            "path": "../../packages/utils"
-        }
+        { "path": "../../packages/utils" }
     ]
 }

--- a/suite-common/platform-encryption/src/index.ts
+++ b/suite-common/platform-encryption/src/index.ts
@@ -6,4 +6,4 @@ export type {
     EncryptionError,
 } from './platformEncryption';
 export { asEncryptedHex, EncryptionUnavailable, DecryptionFailed } from './platformEncryption';
-export type { PlatformEncryptionDep } from './platformEncryption';
+export { selectPlatformEncryptionDep, type PlatformEncryptionDep } from './platformEncryption';

--- a/suite-common/platform-encryption/src/platformEncryption.ts
+++ b/suite-common/platform-encryption/src/platformEncryption.ts
@@ -29,6 +29,10 @@ export type DecryptionError = EncryptionUnavailable | DecryptionFailed;
 
 export type PlatformEncryptionDep = { platformEncryption: PlatformEncryption };
 
+export const selectPlatformEncryptionDep = (services: any): PlatformEncryptionDep => ({
+    platformEncryption: services.platformEncryption,
+});
+
 export interface PlatformEncryption {
     encrypt: <T extends EncryptableBranded>(params: {
         value: T;

--- a/suite-common/suite-sync-types/src/SuiteSync.ts
+++ b/suite-common/suite-sync-types/src/SuiteSync.ts
@@ -26,3 +26,7 @@ export type SuiteSync = ChangeRelayUrlDep &
     };
 
 export type SuiteSyncDep = { suiteSync: SuiteSync };
+
+export const selectSuiteSyncDep = (services: any): SuiteSyncDep => ({
+    suiteSync: services.suiteSync,
+});

--- a/suite-common/suite-sync-types/src/data/dangerouslyWipeAllLabelsFromWallet.ts
+++ b/suite-common/suite-sync-types/src/data/dangerouslyWipeAllLabelsFromWallet.ts
@@ -24,3 +24,9 @@ export type DangerouslyWipeAllLabelsFromWallet = (
 export type DangerouslyWipeAllLabelsFromWalletDep = {
     dangerouslyWipeAllLabelsFromWallet: DangerouslyWipeAllLabelsFromWallet;
 };
+
+export const selectDangerouslyWipeAllLabelsFromWalletDep = (
+    services: any,
+): DangerouslyWipeAllLabelsFromWalletDep => ({
+    dangerouslyWipeAllLabelsFromWallet: services.suiteSync.dangerouslyWipeAllLabelsFromWallet,
+});

--- a/suite-common/suite-sync-types/src/data/updateAccountLabel.ts
+++ b/suite-common/suite-sync-types/src/data/updateAccountLabel.ts
@@ -16,3 +16,7 @@ export type UpdateAccountLabel = (
 ) => Promise<Result<void, EnsureWalletSuiteSyncOnErrors | SuiteSyncUpdateError>>;
 
 export type UpdateAccountLabelDep = { updateAccountLabel: UpdateAccountLabel };
+
+export const selectUpdateAccountLabelDep = (services: any): UpdateAccountLabelDep => ({
+    updateAccountLabel: services.suiteSync.labeling.updateAccountLabel,
+});

--- a/suite-common/suite-sync-types/src/data/updateAddressLabel.ts
+++ b/suite-common/suite-sync-types/src/data/updateAddressLabel.ts
@@ -19,3 +19,7 @@ export type UpdateAddressLabel = (
 ) => Promise<Result<void, EnsureWalletSuiteSyncOnErrors | SuiteSyncUpdateError>>;
 
 export type UpdateAddressLabelDep = { updateAddressLabel: UpdateAddressLabel };
+
+export const selectUpdateAddressLabelDep = (services: any): UpdateAddressLabelDep => ({
+    updateAddressLabel: services.suiteSync.labeling.updateAddressLabel,
+});

--- a/suite-common/suite-sync-types/src/data/updateOutputLabel.ts
+++ b/suite-common/suite-sync-types/src/data/updateOutputLabel.ts
@@ -20,3 +20,7 @@ export type UpdateOutputLabel = (
 ) => Promise<Result<void, EnsureWalletSuiteSyncOnErrors | SuiteSyncUpdateError>>;
 
 export type UpdateOutputLabelDep = { updateOutputLabel: UpdateOutputLabel };
+
+export const selectUpdateOutputLabelDep = (services: any): UpdateOutputLabelDep => ({
+    updateOutputLabel: services.suiteSync.labeling.updateOutputLabel,
+});

--- a/suite-common/suite-sync-types/src/data/updateWalletLabel.ts
+++ b/suite-common/suite-sync-types/src/data/updateWalletLabel.ts
@@ -14,3 +14,7 @@ export type UpdateWalletLabel = (
 ) => Promise<Result<void, EnsureWalletSuiteSyncOnErrors | SuiteSyncUpdateError>>;
 
 export type UpdateWalletLabelDep = { updateWalletLabel: UpdateWalletLabel };
+
+export const selectUpdateWalletLabelDep = (services: any): UpdateWalletLabelDep => ({
+    updateWalletLabel: services.suiteSync.labeling.updateWalletLabel,
+});

--- a/suite-common/suite-sync-types/src/index.ts
+++ b/suite-common/suite-sync-types/src/index.ts
@@ -1,4 +1,4 @@
-export type { SuiteSync, SuiteSyncDep } from './SuiteSync';
+export { type SuiteSync, type SuiteSyncDep, selectSuiteSyncDep } from './SuiteSync';
 
 export type {
     SuiteSyncStorageRepositoryDep,
@@ -12,10 +12,22 @@ export type {
     EnsureSuiteSyncKeysDep,
     EnsureSuiteSyncKeysResult,
 } from './ensureSuiteSyncKeys';
-export type { TurnOffSuiteSyncDep, TurnOffSuiteSync } from './turnOffSuiteSync';
-export type { TurnOnSuiteSyncDep, TurnOnSuiteSync } from './turnOnSuiteSync';
+export {
+    type TurnOffSuiteSyncDep,
+    type TurnOffSuiteSync,
+    selectTurnOffSuiteSyncDep,
+} from './turnOffSuiteSync';
+export {
+    type TurnOnSuiteSyncDep,
+    type TurnOnSuiteSync,
+    selectTurnOnSuiteSyncDep,
+} from './turnOnSuiteSync';
 export type { SuiteSyncUnavailableOnDeviceErrorType } from './ensureSuiteSyncKeys';
-export type { ChangeRelayUrl, ChangeRelayUrlDep } from './relay/changeRelayUrl';
+export {
+    type ChangeRelayUrl,
+    type ChangeRelayUrlDep,
+    selectChangeRelayUrlDep,
+} from './relay/changeRelayUrl';
 
 export type {
     EnsureSuiteSyncOwnerDep,
@@ -28,24 +40,28 @@ export type {
     SubscriptionStorage,
     SubscriptionStorageParams,
 } from './storage/subscriptionStorage';
-export type {
-    DangerouslyWipeAllLabelsFromWallet,
-    DangerouslyWipeAllLabelsFromWalletDep,
-    DangerouslyWipeAllLabelsFromWalletParams,
+export {
+    type DangerouslyWipeAllLabelsFromWallet,
+    type DangerouslyWipeAllLabelsFromWalletDep,
+    type DangerouslyWipeAllLabelsFromWalletParams,
+    selectDangerouslyWipeAllLabelsFromWalletDep,
 } from './data/dangerouslyWipeAllLabelsFromWallet';
-export type {
-    TurnOffSuiteSyncForWallet,
-    TurnOffSuiteSyncForWalletDep,
+export {
+    type TurnOffSuiteSyncForWallet,
+    type TurnOffSuiteSyncForWalletDep,
+    selectTurnOffSuiteSyncForWalletDep,
 } from './storage/turnOffSuiteSyncForWallet';
-export type {
-    EnsureWalletSuiteSyncOnAsync,
-    EnsureWalletSuiteSyncOnAsyncDep,
-    EnsureWalletSuiteSyncOn,
-    EnsureWalletSuiteSyncOnErrors,
-    EnsureWalletSuiteSyncOnDep,
-    EnsureWalletSuiteSyncOnParams,
-    SuiteSyncFirmwareUpgradeNeededDeviceErrorType,
-    SuiteSyncUserFacingErrorType,
+export {
+    type EnsureWalletSuiteSyncOnAsync,
+    type EnsureWalletSuiteSyncOnAsyncDep,
+    type EnsureWalletSuiteSyncOn,
+    type EnsureWalletSuiteSyncOnErrors,
+    type EnsureWalletSuiteSyncOnDep,
+    type EnsureWalletSuiteSyncOnParams,
+    type SuiteSyncFirmwareUpgradeNeededDeviceErrorType,
+    type SuiteSyncUserFacingErrorType,
+    selectEnsureWalletSuiteSyncOnAsyncDep,
+    selectEnsureWalletSuiteSyncOnDep,
 } from './storage/ensureWalletSuiteSyncOn';
 
 export type {
@@ -57,25 +73,29 @@ export type {
 } from './data/ensureSubscribedStorage';
 
 // Labeling
-export type {
-    UpdateAccountLabel,
-    UpdateAccountLabelDep,
-    UpdateAccountLabelParams,
+export {
+    type UpdateAccountLabel,
+    type UpdateAccountLabelDep,
+    type UpdateAccountLabelParams,
+    selectUpdateAccountLabelDep,
 } from './data/updateAccountLabel';
-export type {
-    UpdateAddressLabel,
-    UpdateAddressLabelDep,
-    UpdateAddressLabelParams,
+export {
+    type UpdateAddressLabel,
+    type UpdateAddressLabelDep,
+    type UpdateAddressLabelParams,
+    selectUpdateAddressLabelDep,
 } from './data/updateAddressLabel';
-export type {
-    UpdateOutputLabelDep,
-    UpdateOutputLabel,
-    UpdateOutputLabelParams,
+export {
+    type UpdateOutputLabelDep,
+    type UpdateOutputLabel,
+    type UpdateOutputLabelParams,
+    selectUpdateOutputLabelDep,
 } from './data/updateOutputLabel';
-export type {
-    UpdateWalletLabel,
-    UpdateWalletLabelDep,
-    UpdateWalletLabelParams,
+export {
+    type UpdateWalletLabel,
+    type UpdateWalletLabelDep,
+    type UpdateWalletLabelParams,
+    selectUpdateWalletLabelDep,
 } from './data/updateWalletLabel';
 
 export type {

--- a/suite-common/suite-sync-types/src/relay/changeRelayUrl.ts
+++ b/suite-common/suite-sync-types/src/relay/changeRelayUrl.ts
@@ -3,3 +3,7 @@ export type ChangeRelayUrl = (params: { relayUrl: string | null }) => Promise<vo
 export type ChangeRelayUrlDep = {
     changeRelayUrl: ChangeRelayUrl;
 };
+
+export const selectChangeRelayUrlDep = (services: any): ChangeRelayUrlDep => ({
+    changeRelayUrl: services.suiteSync.changeRelayUrl,
+});

--- a/suite-common/suite-sync-types/src/storage/ensureWalletSuiteSyncOn.ts
+++ b/suite-common/suite-sync-types/src/storage/ensureWalletSuiteSyncOn.ts
@@ -37,11 +37,21 @@ export type EnsureWalletSuiteSyncOn = (
 
 export type EnsureWalletSuiteSyncOnDep = { ensureWalletSuiteSyncOn: EnsureWalletSuiteSyncOn };
 
+export const selectEnsureWalletSuiteSyncOnDep = (services: any): EnsureWalletSuiteSyncOnDep => ({
+    ensureWalletSuiteSyncOn: services.suiteSync.ensureWalletSuiteSyncOn,
+});
+
 export type EnsureWalletSuiteSyncOnAsync = (params: EnsureWalletSuiteSyncOnParams) => Promise<void>;
 
 export type EnsureWalletSuiteSyncOnAsyncDep = {
     ensureWalletSuiteSyncOnAsync: EnsureWalletSuiteSyncOnAsync;
 };
+
+export const selectEnsureWalletSuiteSyncOnAsyncDep = (
+    services: any,
+): EnsureWalletSuiteSyncOnAsyncDep => ({
+    ensureWalletSuiteSyncOnAsync: services.suiteSync.ensureWalletSuiteSyncOnAsync,
+});
 
 export type SuiteSyncUserFacingErrorType =
     | 'SuiteSyncUnavailableOnDeviceError'

--- a/suite-common/suite-sync-types/src/storage/turnOffSuiteSyncForWallet.ts
+++ b/suite-common/suite-sync-types/src/storage/turnOffSuiteSyncForWallet.ts
@@ -7,3 +7,9 @@ export type TurnOffSuiteSyncForWallet = (params: {
 export type TurnOffSuiteSyncForWalletDep = {
     turnOffSuiteSyncForWallet: TurnOffSuiteSyncForWallet;
 };
+
+export const selectTurnOffSuiteSyncForWalletDep = (
+    services: any,
+): TurnOffSuiteSyncForWalletDep => ({
+    turnOffSuiteSyncForWallet: services.suiteSync.turnOffSuiteSyncForWallet,
+});

--- a/suite-common/suite-sync-types/src/turnOffSuiteSync.ts
+++ b/suite-common/suite-sync-types/src/turnOffSuiteSync.ts
@@ -4,3 +4,7 @@ export type TurnOffSuiteSync = (params?: {
 }) => Promise<void>;
 
 export type TurnOffSuiteSyncDep = { turnOffSuiteSync: TurnOffSuiteSync };
+
+export const selectTurnOffSuiteSyncDep = (services: any): TurnOffSuiteSyncDep => ({
+    turnOffSuiteSync: services.suiteSync.turnOffSuiteSync,
+});

--- a/suite-common/suite-sync-types/src/turnOnSuiteSync.ts
+++ b/suite-common/suite-sync-types/src/turnOnSuiteSync.ts
@@ -18,3 +18,7 @@ export type TurnOnSuiteSync = (
 ) => Promise<Result<void, EnsureWalletSuiteSyncOnErrors>>;
 
 export type TurnOnSuiteSyncDep = { turnOnSuiteSync: TurnOnSuiteSync };
+
+export const selectTurnOnSuiteSyncDep = (services: any): TurnOnSuiteSyncDep => ({
+    turnOnSuiteSync: services.suiteSync.turnOnSuiteSync,
+});

--- a/suite-native/address/src/AddressLabelEditable.tsx
+++ b/suite-native/address/src/AddressLabelEditable.tsx
@@ -2,7 +2,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { useServices } from '@suite-common/dependency-injection';
 import { type SuiteSyncDataRootState, selectSuiteSyncAddressLabel } from '@suite-common/suite-sync';
-import { type SuiteSyncDep } from '@suite-common/suite-sync-types';
+import { selectUpdateAddressLabelDep } from '@suite-common/suite-sync-types';
 import type { NetworkSymbol } from '@suite-common/wallet-config';
 import { type AccountDescriptor } from '@suite-common/wallet-types';
 import { featureUsed } from '@suite-native/feature-feedback';
@@ -31,7 +31,9 @@ export const AddressLabelEditable = ({
 }: AddressLabelEditableProps) => {
     const dispatch = useDispatch();
     const isLabellingAllowed = useSelector(selectIsLabellingAllowed);
-    const { suiteSync } = useServices<SuiteSyncDep>();
+
+    const { updateAddressLabel } = useServices(selectUpdateAddressLabelDep);
+
     const { handleSuiteSyncError } = useSuiteSyncErrorHandler();
 
     const label = useSelector((state: SuiteSyncDataRootState) =>
@@ -39,7 +41,7 @@ export const AddressLabelEditable = ({
     );
 
     const onSubmit = async (newLabel: string) => {
-        const result = await suiteSync.labeling.updateAddressLabel({
+        const result = await updateAddressLabel({
             deviceStaticSessionId,
             address,
             label: newLabel,

--- a/suite-native/analytics/src/createAnalytics.ts
+++ b/suite-native/analytics/src/createAnalytics.ts
@@ -7,6 +7,10 @@ export type NativeAnalyticsDep = {
     analytics: Analytics<AnalyticsNativeEvents>;
 };
 
+export const selectNativeAnalyticsDep = (services: any): NativeAnalyticsDep => ({
+    analytics: services.analytics,
+});
+
 const createAnalytics = (): Analytics<AnalyticsNativeEvents> => {
     const newAnalytics = new QueuedAnalytics<AnalyticsNativeEvents>({
         version: getSuiteVersion(),

--- a/suite-native/analytics/src/index.ts
+++ b/suite-native/analytics/src/index.ts
@@ -27,7 +27,7 @@ export { type DeviceSetupInfoLocation } from './events/deviceSetupInfoEvent';
 
 export type { AutoEjectModalValue } from './events/autoEjectModalEvent';
 export type { DemoAccountQuestionnaireLinkKey } from './events/demoAccountQuestionnaireLinksEvent';
-export { analytics, type NativeAnalyticsDep } from './createAnalytics';
+export { analytics, type NativeAnalyticsDep, selectNativeAnalyticsDep } from './createAnalytics';
 export { asTypedNativeAnalytics } from './asTypedNativeAnalytics';
 export type { AnalyticsNativeEvents } from './analyticsEvents';
 

--- a/suite-native/app/src/devtools/InitRoseniteDevTools.tsx
+++ b/suite-native/app/src/devtools/InitRoseniteDevTools.tsx
@@ -2,7 +2,7 @@ import { memo, useEffect, useState } from 'react';
 import { type MMKV } from 'react-native-mmkv';
 
 import { useServices } from '@suite-common/dependency-injection';
-import { type MMKVStorageDep } from '@suite-native/services';
+import { selectMMKVStorageDep } from '@suite-native/services';
 
 import { useRozenitePlugins } from '../hooks/useRozenitePlugins';
 
@@ -16,7 +16,7 @@ const InitRosenitePluginInternal = memo(({ mmkvStorage }: { mmkvStorage: MMKV })
 });
 
 export const InitRosenitePlugin = memo(() => {
-    const { getMMKVStorage } = useServices<MMKVStorageDep>();
+    const { getMMKVStorage } = useServices(selectMMKVStorageDep);
     const [mmkvStorage, setMMKVStorage] = useState<MMKV | null>(null);
 
     useEffect(() => {

--- a/suite-native/app/src/hooks/useReportAppInitToAnalytics.ts
+++ b/suite-native/app/src/hooks/useReportAppInitToAnalytics.ts
@@ -15,7 +15,7 @@ import {
     selectBitcoinAmountUnit,
     selectEnabledNetworks,
 } from '@suite-common/wallet-core';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { useDiscreetMode } from '@suite-native/atoms';
 import { useIsBiometricsEnabled } from '@suite-native/biometrics';
 import { selectLocale } from '@suite-native/intl';
@@ -26,7 +26,7 @@ import { useUserColorScheme } from '@suite-native/theme';
 export const useReportAppInitToAnalytics = (appLaunchTimestamp: number) => {
     const [loadDuration, setLoadDuration] = useState<number | null>(null);
     const [initWasReported, setInitWasReported] = useState(false);
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const isAppReady = useSelector(selectIsAppReady);
     const isOnboardingFinished = useSelector(selectIsOnboardingFinished);
     const { userColorScheme } = useUserColorScheme();

--- a/suite-native/app/src/navigation/AppTabNavigator.tsx
+++ b/suite-native/app/src/navigation/AppTabNavigator.tsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import { type BottomTabBarProps, createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 
 import { useServices } from '@suite-common/dependency-injection';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { AccountsStackNavigator } from '@suite-native/module-accounts-management';
 import { EarnStackNavigator } from '@suite-native/module-earn';
 import { HomeStackNavigator } from '@suite-native/module-home';
@@ -17,7 +17,7 @@ import { rootTabsOptions } from './routes';
 const Tab = createBottomTabNavigator<AppTabsParamList>();
 
 export const AppTabNavigator = () => {
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const isTradingEnabled = useSelector(selectIsTradingEnabled);
 
     const handleTradeTabPress = () => {

--- a/suite-native/biometrics/src/useBiometricsSettings.ts
+++ b/suite-native/biometrics/src/useBiometricsSettings.ts
@@ -2,7 +2,7 @@ import { useCallback } from 'react';
 
 import { useServices } from '@suite-common/dependency-injection';
 import { useAlert } from '@suite-native/alerts';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 
 import {
     useIsBiometricsEnabled,
@@ -19,7 +19,7 @@ export const useBiometricsSettings = () => {
     const { setIsUserAuthenticated } = useIsUserAuthenticated();
     const { isBiometricsOptionEnabled, setIsBiometricsOptionEnabled } = useIsBiometricsEnabled();
     const { setIsBiometricsOverlayVisible } = useIsBiometricsOverlayVisible();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const toggleBiometricsOption = useCallback(async (): Promise<BiometricsToggleResult> => {
         const isBiometricsAvailable = await getIsBiometricsFeatureAvailable();
 

--- a/suite-native/bluetooth/src/hooks/useBluetoothAdapter.ts
+++ b/suite-native/bluetooth/src/hooks/useBluetoothAdapter.ts
@@ -5,7 +5,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { events } from '@suite-common/analytics';
 import { bluetoothActions, parseManufacturerData } from '@suite-common/bluetooth';
 import { useServices } from '@suite-common/dependency-injection';
-import { type NativeAnalyticsDep } from '@suite-native/analytics';
+import { selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { useTranslate } from '@suite-native/intl';
 import { useToast } from '@suite-native/toasts';
 import { asBluetoothDeviceId } from '@trezor/connect';
@@ -32,7 +32,7 @@ const toBluetoothDevice = (device: TransportBluetoothDevice) => ({
 });
 
 export const useBluetoothAdapter = () => {
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const dispatch = useDispatch();
     const { showToast } = useToast();
     const { translate } = useTranslate();

--- a/suite-native/coin-enabling/src/components/CoinEnablingForm.tsx
+++ b/suite-native/coin-enabling/src/components/CoinEnablingForm.tsx
@@ -6,7 +6,7 @@ import { useNavigation } from '@react-navigation/native';
 import { useServices } from '@suite-common/dependency-injection';
 import { changeCoinVisibility } from '@suite-common/wallet-core';
 import { useAlert } from '@suite-native/alerts';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import {
     selectDeviceEnabledDiscoveryNetworkSymbols,
     selectDiscoveryNetworkSymbols,
@@ -23,7 +23,7 @@ import {
 export const CoinEnablingForm = () => {
     const dispatch = useDispatch();
     const navigation = useNavigation();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const enabledNetworkSymbols = useSelector(selectDeviceEnabledDiscoveryNetworkSymbols);
     const networkSymbols = useSelector(selectDiscoveryNetworkSymbols);
 

--- a/suite-native/coin-enabling/src/screens/CoinEnablingInitScreen.tsx
+++ b/suite-native/coin-enabling/src/screens/CoinEnablingInitScreen.tsx
@@ -6,7 +6,7 @@ import { useNavigation } from '@react-navigation/native';
 
 import { useServices } from '@suite-common/dependency-injection';
 import { changeCoinVisibility } from '@suite-common/wallet-core';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import {
     AnimatedBox,
     AnimatedInlineAlertBox,
@@ -43,7 +43,7 @@ type NavigationProps = StackToStackCompositeNavigationProps<
 
 export const CoinEnablingInitScreen = () => {
     const dispatch = useDispatch();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const navigation = useNavigation<NavigationProps>();
     useInterceptNativeNavigation();
 

--- a/suite-native/device-authorization/src/hooks/usePinAction.tsx
+++ b/suite-native/device-authorization/src/hooks/usePinAction.tsx
@@ -6,7 +6,7 @@ import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
 import { useAlert } from '@suite-native/alerts';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
 import { Translation, type TxKeyPath } from '@suite-native/intl';
 import { type PinActionType } from '@suite-native/navigation';
@@ -52,7 +52,7 @@ export const usePinAction = ({ type, onSuccess, onError }: PinActionProps) => {
     const navigation = useNavigation();
     const { showToast } = useToast();
     const { showAlert } = useAlert();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const showSuccess = useCallback(
         (messageKey: TxKeyPath) => {
             showToast({

--- a/suite-native/device-manager/src/components/AddHiddenWalletButton.tsx
+++ b/suite-native/device-manager/src/components/AddHiddenWalletButton.tsx
@@ -5,7 +5,7 @@ import { useNavigation } from '@react-navigation/native';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
 import { runDiscoveryThunk, startDiscoveryThunk } from '@suite-common/wallet-core';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Button } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
@@ -25,7 +25,7 @@ type NavigationProp = StackToStackCompositeNavigationProps<
 >;
 
 export const AddHiddenWalletButton = () => {
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const dispatch = useDispatch();
 
     const navigation = useNavigation<NavigationProp>();

--- a/suite-native/device-manager/src/components/ConnectButton.tsx
+++ b/suite-native/device-manager/src/components/ConnectButton.tsx
@@ -5,7 +5,7 @@ import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
 import { type TrezorDevice } from '@suite-common/suite-types';
 import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { AnimatedBox, Box, Button } from '@suite-native/atoms';
 import { useConnectDeviceHandler } from '@suite-native/device';
 import { Translation } from '@suite-native/intl';
@@ -30,7 +30,7 @@ const buttonSurfaceStyle = prepareNativeStyle(utils => ({
 export const ConnectButton = ({ onSelectDevice }: ConnectButtonProps) => {
     const { setIsDeviceManagerVisible } = useDeviceManager();
     const { applyStyle } = useNativeStyles();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const hasDiscovery = useSelector(selectHasRunningDiscovery);
     const device = useSelector(selectSelectedDevice);
 

--- a/suite-native/device-manager/src/components/DeviceManagerContent.tsx
+++ b/suite-native/device-manager/src/components/DeviceManagerContent.tsx
@@ -17,7 +17,7 @@ import {
 } from '@suite-common/device';
 import { type TrezorDevice } from '@suite-common/suite-types';
 import { selectDeviceThunk, selectHasRunningDiscovery } from '@suite-common/wallet-core';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { AnimatedVStack, VStack } from '@suite-native/atoms';
 import { selectShouldFactoryResetBeVisible } from '@suite-native/device';
 import {
@@ -56,7 +56,7 @@ type NavigationProp = TabNavigationProp<AppTabsParamList, AppTabsRoutes.HomeStac
 export const DeviceManagerContent = () => {
     const { applyStyle, utils } = useNativeStyles();
     const [isChangeDeviceRequested, setIsChangeDeviceRequested] = useState(false);
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
     const isPassphraseEnabledOnDevice = useSelector(selectIsDeviceProtectedByPassphrase);
     const shouldFactoryResetBeVisible = useSelector(selectShouldFactoryResetBeVisible);

--- a/suite-native/device-manager/src/components/DeviceSettingsButton.tsx
+++ b/suite-native/device-manager/src/components/DeviceSettingsButton.tsx
@@ -4,7 +4,7 @@ import { useNavigation } from '@react-navigation/native';
 
 import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Button } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
@@ -23,7 +23,7 @@ type NavigationProp = StackToStackCompositeNavigationProps<
 >;
 
 export const DeviceSettingsButton = () => {
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const navigation = useNavigation<NavigationProp>();
     const { setIsDeviceManagerVisible } = useDeviceManager();
     const selectedDevice = useSelector(selectSelectedDevice);

--- a/suite-native/device/src/hooks/useDetectDeviceError.tsx
+++ b/suite-native/device/src/hooks/useDetectDeviceError.tsx
@@ -17,7 +17,7 @@ import {
 } from '@suite-common/device';
 import { acquireDevice } from '@suite-common/wallet-core';
 import { useAlert } from '@suite-native/alerts';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { selectIsFirmwareInstallationRunning } from '@suite-native/firmware';
 import { Translation } from '@suite-native/intl';
 import { SUITE_MOBILE_SUPPORT_URL, useOpenLink } from '@suite-native/link';
@@ -52,7 +52,7 @@ type NavigationProps = StackToStackCompositeNavigationProps<
 
 export const useDetectDeviceError = () => {
     const [wasDeviceEjectedByUser, setWasDeviceEjectedByUser] = useState(false);
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const dispatch = useDispatch();
     const { hideAlert, showAlert } = useAlert();
     const openLink = useOpenLink();

--- a/suite-native/device/src/hooks/useDeviceAuthenticityCheck.ts
+++ b/suite-native/device/src/hooks/useDeviceAuthenticityCheck.ts
@@ -14,8 +14,8 @@ import {
 import { type StoredAuthenticateDeviceResult } from '@suite-common/suite-types';
 import {
     type DeviceAuthenticityCheckResult,
-    type NativeAnalyticsDep,
     events,
+    selectNativeAnalyticsDep,
 } from '@suite-native/analytics';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
 import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
@@ -47,7 +47,7 @@ export const useDeviceAuthenticityCheck = () => {
     const isMCURemotelyDisabled = useSelector((state: MessageSystemRootState) =>
         selectIsFeatureDisabled(state, Feature.deviceAuthenticityCheckMCU),
     );
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const device = useSelector(selectSelectedDevice);
     const isDeviceBootloaderUnlocked = !!device && !device?.features?.bootloader_locked;
     const reportCheckResult = useCallback(

--- a/suite-native/device/src/hooks/useWipeDevice.tsx
+++ b/suite-native/device/src/hooks/useWipeDevice.tsx
@@ -8,7 +8,7 @@ import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
 import { wipeDeviceThunk } from '@suite-common/wallet-core';
-import { type NativeAnalyticsDep } from '@suite-native/analytics';
+import { selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
 import { setWasDeviceOnboardingCancelled } from '@suite-native/device-onboarding';
 import {
@@ -25,7 +25,7 @@ type NavigationProps = StackNavigationProps<
 
 export const useWipeDevice = () => {
     const dispatch = useDispatch();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const navigation = useNavigation<NavigationProps>();
 
     const device = useSelector(selectSelectedDevice);

--- a/suite-native/firmware/src/hooks/useFirmwareAnalytics.ts
+++ b/suite-native/firmware/src/hooks/useFirmwareAnalytics.ts
@@ -7,8 +7,8 @@ import { type TrezorDevice } from '@suite-common/suite-types';
 import {
     type FirmwareUpdatePayload,
     type FirmwareUpdateStartType,
-    type NativeAnalyticsDep,
     events,
+    selectNativeAnalyticsDep,
 } from '@suite-native/analytics';
 import { type FirmwareType } from '@trezor/connect';
 import {
@@ -27,7 +27,7 @@ export const useFirmwareAnalytics = ({
     navigationLocation?: 'settings' | 'onboarding';
 }) => {
     const toFwVersion = useSelector(selectDeviceUpdateFirmwareVersion);
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const prepareAnalyticsPayload = useCallback(
         () => ({
             model: device?.features?.internal_model ?? DeviceModelInternal.UNKNOWN,

--- a/suite-native/graph/src/hooks.ts
+++ b/suite-native/graph/src/hooks.ts
@@ -23,7 +23,7 @@ import {
 } from '@suite-common/wallet-core';
 import { type BaseCurrencyAmount } from '@suite-common/wallet-types';
 import { tryGetAccountIdentity } from '@suite-common/wallet-utils';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 
 import { timeSwitchItems } from './components/TimeSwitch';
 import { selectPortfolioGraphAccountItems } from './selectors';
@@ -42,7 +42,7 @@ const useWatchTimeframeChangeForAnalytics = (
     symbol?: NetworkSymbol,
 ) => {
     const isFirstRender = useRef(true);
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     useEffect(() => {
         if (isFirstRender.current) {
             // Do not report default value on first render.

--- a/suite-native/module-accounts-import/src/components/AccountImportConfirmFormScreen.tsx
+++ b/suite-native/module-accounts-import/src/components/AccountImportConfirmFormScreen.tsx
@@ -17,7 +17,7 @@ import {
 } from '@suite-common/wallet-core';
 import { type TokenAddress, type TokenSymbol } from '@suite-common/wallet-types';
 import { type AccountFormValues, useAccountLabelForm } from '@suite-native/accounts';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Box, Button, Text } from '@suite-native/atoms';
 import { Form } from '@suite-native/forms';
 import { Translation } from '@suite-native/intl';
@@ -52,7 +52,7 @@ export const AccountImportConfirmFormScreen = ({
     accountInfo,
 }: AccountImportConfirmFormScreenProps) => {
     const dispatch = useDispatch();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const navigation = useNavigation<NavigationProp>();
     const navigateToInitialScreen = useNavigateToInitialScreen();
     const showImportError = useShowImportError(symbol, navigation);

--- a/suite-native/module-accounts-management/src/components/AccountAssets/AccountAssetsTabContent.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountAssets/AccountAssetsTabContent.tsx
@@ -6,7 +6,7 @@ import { useNavigation } from '@react-navigation/native';
 import { useServices } from '@suite-common/dependency-injection';
 import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import {
     type RootStackParamList,
     RootStackRoutes,
@@ -34,7 +34,7 @@ export const AccountAssetsTabContent = ({
 }: AccountAssetsTabContentProps) => {
     const navigation =
         useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes.AccountAssets>>();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
     );

--- a/suite-native/module-accounts-management/src/components/AccountRenameForm.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountRenameForm.tsx
@@ -3,7 +3,7 @@ import { useWatch } from 'react-hook-form';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { useServices } from '@suite-common/dependency-injection';
-import { type SuiteSyncDep } from '@suite-common/suite-sync-types';
+import { selectUpdateAccountLabelDep } from '@suite-common/suite-sync-types';
 import {
     type AccountsRootState,
     accountsActions,
@@ -31,7 +31,9 @@ type AccountRenameFormProps = {
 export const AccountRenameForm = ({ accountKey, onSubmit }: AccountRenameFormProps) => {
     const { translate } = useTranslate();
     const dispatch = useDispatch();
-    const { suiteSync } = useServices<SuiteSyncDep>();
+
+    const { updateAccountLabel } = useServices(selectUpdateAccountLabelDep);
+
     const { handleSuiteSyncError } = useSuiteSyncErrorHandler();
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
@@ -73,7 +75,7 @@ export const AccountRenameForm = ({ accountKey, onSubmit }: AccountRenameFormPro
         if (isLabellingAllowed) {
             if (!account.deviceState) return;
 
-            const result = await suiteSync.labeling.updateAccountLabel({
+            const result = await updateAccountLabel({
                 deviceStaticSessionId: account.deviceState,
                 accountKey,
                 label: formValues.accountLabel,

--- a/suite-native/module-accounts-management/src/components/TransactionListHeader.tsx
+++ b/suite-native/module-accounts-management/src/components/TransactionListHeader.tsx
@@ -14,7 +14,7 @@ import {
     useDisplayBaseCurrency,
 } from '@suite-common/wallet-core';
 import { type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Box, Button, HStack, Text, VStack } from '@suite-native/atoms';
 import { selectHasFirmwareAuthenticityCheckHardFailedForSelectedDevice } from '@suite-native/device';
 import { type FeatureFlagsRootState } from '@suite-native/feature-flags';
@@ -88,7 +88,7 @@ const TransactionListHeaderContent = ({
 
 export const TransactionListHeader = memo(
     ({ accountKey, tokenContract }: TransactionListHeaderProps) => {
-        const { analytics } = useServices<NativeAnalyticsDep>();
+        const { analytics } = useServices(selectNativeAnalyticsDep);
         const navigation = useNavigation<NavigationProp>();
 
         const account = useSelector((state: AccountsRootState) =>

--- a/suite-native/module-accounts-management/src/screens/AccountDetailContentScreen.tsx
+++ b/suite-native/module-accounts-management/src/screens/AccountDetailContentScreen.tsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 
 import { useServices } from '@suite-common/dependency-injection';
 import { type Account, type TokenAddress } from '@suite-common/wallet-types';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Screen } from '@suite-native/navigation';
 import { type TokensRootState, selectAccountTokenInfo } from '@suite-native/tokens';
 import { TransactionList } from '@suite-native/transactions';
@@ -21,7 +21,7 @@ export const AccountDetailContentScreen = ({
     account,
     tokenContract,
 }: AccountDetailContentScreenProps) => {
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const token = useSelector((state: TokensRootState) =>
         selectAccountTokenInfo(state, account.key, tokenContract),
     );

--- a/suite-native/module-authorize-device/src/screens/connect/ConnectBluetoothDeviceScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/connect/ConnectBluetoothDeviceScreen.tsx
@@ -5,7 +5,7 @@ import { useNavigation } from '@react-navigation/native';
 
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
-import { type NativeAnalyticsDep } from '@suite-native/analytics';
+import { selectNativeAnalyticsDep } from '@suite-native/analytics';
 import {
     type BluetoothDevice,
     BluetoothDeviceList,
@@ -31,7 +31,7 @@ type NavigationProps = StackNavigationProps<
 export const ConnectBluetoothDeviceScreen = () => {
     const { connectBluetoothDevice } = useBluetoothDevice();
     const navigation = useNavigation<NavigationProps>();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
 
     // Once a device is connected, it's added to known devices and thus disappears from the list
     // before the transition to the next screen finishes. This ensures it doesn't feel glitchy.

--- a/suite-native/module-authorize-device/src/screens/passphrase/PassphraseEnterOnTrezorScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/passphrase/PassphraseEnterOnTrezorScreen.tsx
@@ -1,5 +1,5 @@
 import { useServices } from '@suite-common/dependency-injection';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Text } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { AuthorizeDeviceStackRoutes, useNavigateToInitialScreen } from '@suite-native/navigation';
@@ -13,7 +13,7 @@ import { useHandleNavigateToInitialScreenOnIdle } from '../../hooks/useHandleNav
 
 export const PassphraseEnterOnTrezorScreen = () => {
     const navigateToInitialScreen = useNavigateToInitialScreen();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
 
     useHandleNavigateToInitialScreenOnIdle();
 

--- a/suite-native/module-check-backup/src/components/CheckBackupScreenWithExitButton.tsx
+++ b/suite-native/module-check-backup/src/components/CheckBackupScreenWithExitButton.tsx
@@ -4,7 +4,7 @@ import { useNavigation, useRoute } from '@react-navigation/native';
 
 import { useServices } from '@suite-common/dependency-injection';
 import { useAlert } from '@suite-native/alerts';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { useTranslate } from '@suite-native/intl';
 import {
     type DeviceCheckBackupStackParamList,
@@ -32,7 +32,7 @@ type NavigationProps = StackToStackCompositeNavigationProps<
 export const useHandleCheckBackupExitButtonPress = () => {
     const { showAlert } = useAlert();
     const { translate } = useTranslate();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const navigation = useNavigation<NavigationProps>();
     const route = useRoute();
 

--- a/suite-native/module-check-backup/src/hooks/useCheckBackupOnMount.tsx
+++ b/suite-native/module-check-backup/src/hooks/useCheckBackupOnMount.tsx
@@ -4,7 +4,7 @@ import { useDispatch } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 
 import { useServices } from '@suite-common/dependency-injection';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import {
     type DeviceCheckBackupStackParamList,
     DeviceCheckBackupStackRoutes,
@@ -25,7 +25,7 @@ const DEFINITIVE_ERRORS: ERRORS.ErrorCode[] = ['Method_Interrupted', 'Failure_Ac
 export const useCheckBackupOnMount = () => {
     const dispatch = useDispatch();
     const navigation = useNavigation<NavigationProps>();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     useEffect(() => {
         const startCheckBackup = async () => {
             const response = await dispatch(checkBackupThunk()).unwrap();

--- a/suite-native/module-check-backup/src/screens/DeviceCheckBackupSupportScreen.tsx
+++ b/suite-native/module-check-backup/src/screens/DeviceCheckBackupSupportScreen.tsx
@@ -3,7 +3,7 @@ import { useCallback } from 'react';
 import { useFocusEffect } from '@react-navigation/native';
 
 import { useServices } from '@suite-common/dependency-injection';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Box, Button, PictogramTitleHeader, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { useOpenLink } from '@suite-native/link';
@@ -15,7 +15,7 @@ const SUPPORT_URL = `${TREZOR_SUPPORT_RECOVERY_ISSUES_URL}#open-chat`;
 
 export const DeviceCheckBackupSupportScreen = () => {
     const openLink = useOpenLink();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const handleSupportButtonPress = () => {
         openLink(SUPPORT_URL);
     };

--- a/suite-native/module-check-backup/src/screens/DeviceCheckBackupTutorialScreen.tsx
+++ b/suite-native/module-check-backup/src/screens/DeviceCheckBackupTutorialScreen.tsx
@@ -4,7 +4,7 @@ import { useSharedValue } from 'react-native-reanimated';
 import { useFocusEffect } from '@react-navigation/native';
 
 import { useServices } from '@suite-common/dependency-injection';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Screen } from '@suite-native/navigation';
 import {
     SwipeableWalkthrough,
@@ -21,7 +21,7 @@ const WALLET_BACKUP_TUTORIAL_STEPS_COUNT = 2;
 export const DeviceCheckBackupTutorialScreen = () => {
     const handleExitButtonPress = useHandleCheckBackupExitButtonPress();
     const currentStepIndex = useSharedValue(0);
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
 
     useFocusEffect(
         useCallback(() => {

--- a/suite-native/module-demo-account-questionnaire/src/components/DemoAccountQuestionnaireScreenContent.tsx
+++ b/suite-native/module-demo-account-questionnaire/src/components/DemoAccountQuestionnaireScreenContent.tsx
@@ -7,8 +7,8 @@ import { useServices } from '@suite-common/dependency-injection';
 import {
     type DemoAccountQuestionnaireQuestion,
     type DemoAccountQuestionnaireQuestionOption,
-    type NativeAnalyticsDep,
     events,
+    selectNativeAnalyticsDep,
 } from '@suite-native/analytics';
 import { Button, HStack, ScreenFooterGradient, Text, VStack } from '@suite-native/atoms';
 import { type IconName } from '@suite-native/icons';
@@ -42,7 +42,7 @@ export const DemoAccountQuestionnaireScreenContent = ({
     answerOptions,
     nextRoute,
 }: DemoAccountQuestionnaireScreenContentProps) => {
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const navigation =
         useNavigation<
             StackNavigationProps<

--- a/suite-native/module-demo-account-questionnaire/src/screens/DemoAccountQuestionnaireIntroScreen.tsx
+++ b/suite-native/module-demo-account-questionnaire/src/screens/DemoAccountQuestionnaireIntroScreen.tsx
@@ -1,7 +1,7 @@
 import { useNavigation } from '@react-navigation/native';
 
 import { useServices } from '@suite-common/dependency-injection';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Button, InlineAlertBox, PictogramTitleHeader, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
@@ -13,7 +13,7 @@ import {
 } from '@suite-native/navigation';
 
 export const DemoAccountQuestionnaireIntroScreen = () => {
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const navigation =
         useNavigation<
             StackNavigationProps<

--- a/suite-native/module-demo-account-questionnaire/src/screens/DemoAccountQuestionnaireSuccessScreen.tsx
+++ b/suite-native/module-demo-account-questionnaire/src/screens/DemoAccountQuestionnaireSuccessScreen.tsx
@@ -3,8 +3,8 @@ import { useNavigation } from '@react-navigation/native';
 import { useServices } from '@suite-common/dependency-injection';
 import {
     type DemoAccountQuestionnaireLinkKey,
-    type NativeAnalyticsDep,
     events,
+    selectNativeAnalyticsDep,
 } from '@suite-native/analytics';
 import { Button, PictogramTitleHeader, TextDivider, VStack } from '@suite-native/atoms';
 import { type IconName } from '@suite-native/icons';
@@ -61,7 +61,7 @@ type NavigationProp = StackNavigationProps<
 export const DemoAccountQuestionnaireSuccessScreen = () => {
     const navigation = useNavigation<NavigationProp>();
     const openLink = useOpenLink();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const handleOpenUrl = (recommendation: Recommendation) => {
         analytics.report(
             {

--- a/suite-native/module-dev-utils/src/components/DangerZoneCard.tsx
+++ b/suite-native/module-dev-utils/src/components/DangerZoneCard.tsx
@@ -3,12 +3,12 @@ import { useDispatch } from 'react-redux';
 import { useServices } from '@suite-common/dependency-injection';
 import { deviceActions } from '@suite-common/device';
 import { Button, Card, Text, VStack } from '@suite-native/atoms';
-import { type MMKVStorageDep } from '@suite-native/services';
+import { selectMMKVStorageDep } from '@suite-native/services';
 import { clearStorage } from '@suite-native/storage';
 
 export const DangerZoneCard = () => {
     const dispatch = useDispatch();
-    const { getMMKVStorage } = useServices<MMKVStorageDep>();
+    const { getMMKVStorage } = useServices(selectMMKVStorageDep);
 
     return (
         <Card>

--- a/suite-native/module-dev-utils/src/components/SuiteSyncRelaySettings.tsx
+++ b/suite-native/module-dev-utils/src/components/SuiteSyncRelaySettings.tsx
@@ -7,7 +7,7 @@ import {
     selectSuiteSyncRelayUrl,
     updateSuiteSyncDebugEnabled,
 } from '@suite-common/suite-sync';
-import { type SuiteSyncDep } from '@suite-common/suite-sync-types';
+import { selectChangeRelayUrlDep } from '@suite-common/suite-sync-types';
 import { yup } from '@suite-common/validators';
 import { Button, Card, CheckBox, HStack, Text, VStack } from '@suite-native/atoms';
 import { Form, TextInputField, useForm } from '@suite-native/forms';
@@ -18,7 +18,9 @@ const DEFAULT_CUSTOM_RELAY_URL = '';
 export const SuiteSyncRelaySettings = () => {
     const suiteSyncRelayUrl = useSelector(selectSuiteSyncRelayUrl);
     const isSuiteSyncDebugEnabled = useSelector(selectIsSuiteSyncDebugEnabled);
-    const { suiteSync } = useServices<SuiteSyncDep>();
+
+    const { changeRelayUrl } = useServices(selectChangeRelayUrlDep);
+
     const { showToast } = useToast();
     const dispatch = useDispatch();
 
@@ -32,7 +34,7 @@ export const SuiteSyncRelaySettings = () => {
     });
 
     const onSubmit = form.handleSubmit(async values => {
-        await suiteSync.changeRelayUrl({ relayUrl: values.suiteSyncRelayUrl });
+        await changeRelayUrl({ relayUrl: values.suiteSyncRelayUrl });
         showToast({
             message: 'Suite Sync relay URL updated',
             intent: 'brand',
@@ -48,7 +50,7 @@ export const SuiteSyncRelaySettings = () => {
     };
 
     const handleResetToDefault = async () => {
-        await suiteSync.changeRelayUrl({ relayUrl: DEFAULT_SUITE_SYNC_RELAY_URL });
+        await changeRelayUrl({ relayUrl: DEFAULT_SUITE_SYNC_RELAY_URL });
         form.reset({ suiteSyncRelayUrl: DEFAULT_SUITE_SYNC_RELAY_URL });
         showToast({
             message: 'Suite Sync relay URL reset to default',

--- a/suite-native/module-device-onboarding/src/components/SecuritySealDescription.tsx
+++ b/suite-native/module-device-onboarding/src/components/SecuritySealDescription.tsx
@@ -2,7 +2,7 @@ import { useSelector } from 'react-redux';
 
 import { useServices } from '@suite-common/dependency-injection';
 import { selectDeviceModel } from '@suite-common/device';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import {
     BottomSheetModal,
     Box,
@@ -20,7 +20,7 @@ import { SecuritySealImages } from './SecuritySealImages';
 
 export const SecuritySealDescription = () => {
     const openLink = useOpenLink();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const { bottomSheetRef, openModal, closeModal } = useBottomSheetModal();
 
     const handleLinkPress = () => {

--- a/suite-native/module-device-onboarding/src/hooks/useReportOnboardingSuccessAnalytics.ts
+++ b/suite-native/module-device-onboarding/src/hooks/useReportOnboardingSuccessAnalytics.ts
@@ -10,7 +10,7 @@ import {
     selectIsDeviceBackupRequired,
     selectIsDeviceProtectedByPin,
 } from '@suite-common/device';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 
 import { onboardingAnalyticsAtom } from '../../atoms';
 
@@ -19,7 +19,7 @@ export const useReportOnboardingSuccessAnalytics = () => {
     const isDeviceBackupRequired = useSelector(selectIsDeviceBackupRequired);
     const isDeviceProtectedByPin = useSelector(selectIsDeviceProtectedByPin);
     const onboardingAnalytics = useAtomValue(onboardingAnalyticsAtom);
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
 
     return useCallback(() => {
         analytics.report({

--- a/suite-native/module-device-onboarding/src/screens/SecurityCheckScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/SecurityCheckScreen.tsx
@@ -1,8 +1,8 @@
 import { useServices } from '@suite-common/dependency-injection';
 import {
     type AnalyticsNativeEvents,
-    type NativeAnalyticsDep,
     events,
+    selectNativeAnalyticsDep,
 } from '@suite-native/analytics';
 import { CardStepper, type CardStepperMap, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
@@ -69,7 +69,7 @@ const cardStepperContentMap = (analytics: Analytics<AnalyticsNativeEvents>) =>
 export const SecurityCheckScreen = ({
     navigation,
 }: StackProps<DeviceOnboardingStackParamList, DeviceOnboardingStackRoutes.SecurityCheck>) => {
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const handleFinishStepper = () => {
         navigation.navigate(DeviceOnboardingStackRoutes.FirmwareInfo);
     };

--- a/suite-native/module-device-onboarding/src/screens/UninitializedDeviceLandingScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/UninitializedDeviceLandingScreen.tsx
@@ -11,7 +11,7 @@ import {
     selectSelectedDevice,
     selectShouldOfferUpdateFirmware,
 } from '@suite-common/device';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Box, Button, Text, TextButton, VStack } from '@suite-native/atoms';
 import { type SetupSupportingDeviceModel, useCoinLabel } from '@suite-native/device';
 import { Translation } from '@suite-native/intl';
@@ -68,7 +68,7 @@ export const UninitializedDeviceLandingScreen = ({
     RootStackParamList
 >) => {
     const dispatch = useDispatch();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const deviceModel = params.deviceModel as SetupSupportingDeviceModel;
     const hasDeviceFirmwareInstalled = useSelector(selectHasDeviceFirmwareInstalled);
     const shouldOfferUpdateFirmware = useSelector(selectShouldOfferUpdateFirmware);

--- a/suite-native/module-device-settings/src/hooks/useChangeDeviceName.ts
+++ b/suite-native/module-device-settings/src/hooks/useChangeDeviceName.ts
@@ -5,7 +5,7 @@ import { useNavigation } from '@react-navigation/native';
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
-import { type NativeAnalyticsDep } from '@suite-native/analytics';
+import { selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { useForm } from '@suite-native/forms';
 import { useTranslate } from '@suite-native/intl';
 import {
@@ -28,7 +28,7 @@ export const useChangeDeviceName = () => {
     const { translate } = useTranslate();
     const navigation = useNavigation<NavigationProps>();
     const device = useSelector(selectSelectedDevice);
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const form = useForm({
         validation: deviceNameFormValidationSchema(translate),
         defaultValues: {

--- a/suite-native/module-earn/src/components/StakingManagementReadyToClaimCard.tsx
+++ b/suite-native/module-earn/src/components/StakingManagementReadyToClaimCard.tsx
@@ -7,7 +7,7 @@ import { BASE_CRYPTO_MAX_DISPLAYED_DECIMALS, useFormatters } from '@suite-common
 import { selectAccountNetworkSymbol } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { isPositiveBalance } from '@suite-common/wallet-utils';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Box, Button, HStack, InlineAlertBox, Text, VStack } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
@@ -45,7 +45,7 @@ export const StakingManagementReadyToClaimCard = ({
     const { isPortfolioTrackerDevice, openPortfolioTrackerSheet } = useEarnPortfolioTrackerGuard();
     const navigation = useNavigation<NavigationProp>();
     const { CryptoAmountFormatter: amountFormatter } = useFormatters();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
 
     const symbol = useSelector((state: NativeStakingRootState) =>
         selectAccountNetworkSymbol(state, accountKey),

--- a/suite-native/module-earn/src/components/StakingManagementStakedCard.tsx
+++ b/suite-native/module-earn/src/components/StakingManagementStakedCard.tsx
@@ -4,7 +4,7 @@ import { useServices } from '@suite-common/dependency-injection';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { selectEthNextRewardPayout } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Badge, Button, Card, HStack, InlineAlertBox, Text, VStack } from '@suite-native/atoms';
 import { CryptoAmountFormatter, CryptoToFiatAmountFormatter } from '@suite-native/formatters';
 import { Translation } from '@suite-native/intl';
@@ -51,7 +51,7 @@ export const StakingManagementStakedCard = ({
     const { applyStyle } = useNativeStyles();
     const { isPortfolioTrackerDevice, openPortfolioTrackerSheet } = useEarnPortfolioTrackerGuard();
     const navigation = useNavigation<NavigationProp>();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
 
     const handleStake = () => {
         if (isPortfolioTrackerDevice) {

--- a/suite-native/module-earn/src/hooks/useHandleOnClaimTransactionReview.ts
+++ b/suite-native/module-earn/src/hooks/useHandleOnClaimTransactionReview.ts
@@ -7,7 +7,7 @@ import { isFulfilled, isRejected } from '@reduxjs/toolkit';
 import { useServices } from '@suite-common/dependency-injection';
 import { type AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import {
     type RootStackParamList,
     type RootStackRoutes,
@@ -47,7 +47,7 @@ export const useHandleOnClaimTransactionReview = ({
         selectAccountNetworkSymbol(state, accountKey),
     );
 
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
 
     const handleOnClaimTransactionReview = useCallback(async () => {
         if (!precomposedTransaction) return;

--- a/suite-native/module-earn/src/hooks/useHandleOnEarnTransactionReview.ts
+++ b/suite-native/module-earn/src/hooks/useHandleOnEarnTransactionReview.ts
@@ -7,7 +7,7 @@ import { isFulfilled, isRejected } from '@reduxjs/toolkit';
 import { useServices } from '@suite-common/dependency-injection';
 import { type AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import {
     type RootStackParamList,
     type RootStackRoutes,
@@ -47,7 +47,7 @@ export const useHandleOnEarnTransactionReview = ({
         selectAccountNetworkSymbol(state, accountKey),
     );
 
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
 
     const handleOnEarnTransactionReview = useCallback(async () => {
         if (!precomposedTransaction) return;

--- a/suite-native/module-earn/src/hooks/useHandleOnUnstakeTransactionReview.ts
+++ b/suite-native/module-earn/src/hooks/useHandleOnUnstakeTransactionReview.ts
@@ -7,7 +7,7 @@ import { isFulfilled, isRejected } from '@reduxjs/toolkit';
 import { useServices } from '@suite-common/dependency-injection';
 import { type AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import {
     type RootStackParamList,
     type RootStackRoutes,
@@ -47,7 +47,7 @@ export const useHandleOnUnstakeTransactionReview = ({
         selectAccountNetworkSymbol(state, accountKey),
     );
 
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
 
     const handleOnUnstakeTransactionReview = useCallback(async () => {
         if (!precomposedTransaction) return;

--- a/suite-native/module-earn/src/hooks/useNavigateBackAnalytics.ts
+++ b/suite-native/module-earn/src/hooks/useNavigateBackAnalytics.ts
@@ -3,10 +3,10 @@ import { useCallback, useEffect, useRef } from 'react';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 
 import { useServices } from '@suite-common/dependency-injection';
-import { type AnalyticsNativeEvents, type NativeAnalyticsDep } from '@suite-native/analytics';
+import { type AnalyticsNativeEvents, selectNativeAnalyticsDep } from '@suite-native/analytics';
 
 export const useNavigateBackAnalytics = (event: AnalyticsNativeEvents) => {
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const hasContinuedRef = useRef(false);
     const navigation = useNavigation();
     const eventRef = useRef(event);

--- a/suite-native/module-earn/src/hooks/useStakingNavigateAnalytics.ts
+++ b/suite-native/module-earn/src/hooks/useStakingNavigateAnalytics.ts
@@ -2,12 +2,12 @@ import { useCallback } from 'react';
 
 import { useServices } from '@suite-common/dependency-injection';
 import { type Account } from '@suite-common/wallet-types';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 
 import { getStakingAnalyticsNavigateFrom } from '../utils/getStakingAnalyticsNavigateFrom';
 
 export const useStakingNavigateAnalytics = () => {
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
 
     return useCallback(
         (account: Account) => {

--- a/suite-native/module-earn/src/hooks/useStakingPromoNavigation.ts
+++ b/suite-native/module-earn/src/hooks/useStakingPromoNavigation.ts
@@ -10,7 +10,7 @@ import { selectVisibleDeviceAccounts } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { isSupportedEthStakingNetworkSymbol } from '@suite-common/wallet-utils';
 import { useAccountAlerts } from '@suite-native/accounts';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { useBottomSheetModal } from '@suite-native/atoms';
 import {
     AddCoinAccountStackRoutes,
@@ -33,7 +33,7 @@ export const useStakingPromoNavigation = () => {
     const isDeviceInViewOnlyMode = useSelector(selectIsDeviceInViewOnlyMode);
     const { showViewOnlyAddAccountAlert } = useAccountAlerts();
     const { isPortfolioTrackerDevice, openPortfolioTrackerSheet } = useEarnPortfolioTrackerGuard();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
 
     const reportStakingNavigate = useStakingNavigateAnalytics();
 

--- a/suite-native/module-earn/src/screens/ClaimReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/ClaimReviewScreen.tsx
@@ -16,7 +16,7 @@ import {
     subunitsToUnits,
 } from '@suite-common/wallet-utils';
 import { AccountDetailsCard } from '@suite-native/accounts';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Box, Button, FullAlertBox, InlineAlertBox, Text, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
@@ -80,7 +80,7 @@ export const ClaimReviewScreen = () => {
         formDraftPrefix: 'claim',
     });
 
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const registerNavigateBackAnalytics = useNavigateBackAnalytics({
         type: events.stakingClaimEvent.name,
         payload: {

--- a/suite-native/module-earn/src/screens/EarnConsentsScreen.tsx
+++ b/suite-native/module-earn/src/screens/EarnConsentsScreen.tsx
@@ -5,7 +5,7 @@ import { type RouteProp, useNavigation, useRoute } from '@react-navigation/nativ
 
 import { useServices } from '@suite-common/dependency-injection';
 import { getNetwork } from '@suite-common/wallet-config';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Text, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
@@ -50,7 +50,7 @@ export const EarnConsentsScreen = () => {
     const { accountKey, amount, account } = route.params;
     const networkSymbol = account.symbol;
 
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const registerNavigateBackAnalytics = useNavigateBackAnalytics({
         type: events.stakingStakeEvent.name,
         payload: {

--- a/suite-native/module-earn/src/screens/EarnFormScreen.tsx
+++ b/suite-native/module-earn/src/screens/EarnFormScreen.tsx
@@ -6,7 +6,7 @@ import { type RouteProp, useNavigation, useRoute } from '@react-navigation/nativ
 import { useServices } from '@suite-common/dependency-injection';
 import { type AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
 import { AccountDetailsCard } from '@suite-native/accounts';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { type ActiveView, Box } from '@suite-native/atoms';
 import { Form } from '@suite-native/forms';
 import {
@@ -33,7 +33,7 @@ export const EarnFormScreen = () => {
     const networkSymbol = useSelector((state: AccountsRootState) =>
         selectAccountNetworkSymbol(state, accountKey),
     );
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const currencyRef = useRef<'crypto' | 'fiat' | undefined>(undefined);
     const handleCurrencyChange = useCallback((activeView: ActiveView) => {
         currencyRef.current = activeView === 'primary' ? 'crypto' : 'fiat';

--- a/suite-native/module-earn/src/screens/EarnScreen.tsx
+++ b/suite-native/module-earn/src/screens/EarnScreen.tsx
@@ -4,7 +4,7 @@ import { useFocusEffect } from '@react-navigation/native';
 import { FlashList } from '@shopify/flash-list';
 
 import { useServices } from '@suite-common/dependency-injection';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { ListItemSkeleton, TitleHeader, VStack, useBottomSheetModal } from '@suite-native/atoms';
 import { DeviceManagerScreenHeader } from '@suite-native/device-manager';
 import { Translation } from '@suite-native/intl';
@@ -33,7 +33,7 @@ const isSectionBoundaryItem = (item: EarnPromoListDataItem | undefined) =>
     item === undefined || typeof item === 'string' || item.type === 'provider';
 
 const EarnScreenContent = () => {
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const { bottomSheetRef: stablecoinYieldBottomSheetRef, openModal: openStablecoinYieldModal } =
         useBottomSheetModal();
 

--- a/suite-native/module-earn/src/screens/HowStakeWorksScreen.tsx
+++ b/suite-native/module-earn/src/screens/HowStakeWorksScreen.tsx
@@ -12,7 +12,7 @@ import {
     selectDeviceAccountsByNetworkSymbol,
 } from '@suite-common/wallet-core';
 import { calculateRewards } from '@suite-common/wallet-utils';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Button, InlineAlertBox, TimelineDetailsCard, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
@@ -52,7 +52,7 @@ export const HowStakeWorksScreen = () => {
 
     const resolvedAccountKey = accountKey || accounts[0]?.key;
 
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const registerNavigateBackAnalytics = useNavigateBackAnalytics({
         type: events.stakingStakeEvent.name,
         payload: {

--- a/suite-native/module-earn/src/screens/UnstakeFlowScreen.tsx
+++ b/suite-native/module-earn/src/screens/UnstakeFlowScreen.tsx
@@ -6,7 +6,7 @@ import { type RouteProp, useNavigation, useRoute } from '@react-navigation/nativ
 import { useServices } from '@suite-common/dependency-injection';
 import { type AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
 import { AccountDetailsCard } from '@suite-native/accounts';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import {
     type ActiveView,
     Box,
@@ -40,7 +40,7 @@ export const UnstakeFlowScreen = () => {
     const networkSymbol = useSelector((state: AccountsRootState) =>
         selectAccountNetworkSymbol(state, accountKey),
     );
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const currencyRef = useRef<'crypto' | 'fiat' | undefined>(undefined);
     const handleCurrencyChange = useCallback((activeView: ActiveView) => {
         currencyRef.current = activeView === 'primary' ? 'crypto' : 'fiat';

--- a/suite-native/module-home/src/screens/HomeScreen/components/EmptyPortfolioCrossroads.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/EmptyPortfolioCrossroads.tsx
@@ -9,7 +9,7 @@ import {
     type MessageSystemRootState,
     selectIsFeatureEnabled,
 } from '@suite-common/message-system';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Button, Card, CenteredTitleHeader, Text, VStack } from '@suite-native/atoms';
 import { useConnectDeviceHandler } from '@suite-native/device';
 import { Translation, type TxKeyPath } from '@suite-native/intl';
@@ -58,7 +58,7 @@ type SecondaryCardConfig = {
 };
 
 export const EmptyPortfolioCrossroads = () => {
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const navigation = useNavigation<NavigationProps>();
     const { applyStyle } = useNativeStyles();
 

--- a/suite-native/module-home/src/screens/HomeScreen/components/ReferralButton.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/ReferralButton.tsx
@@ -1,5 +1,5 @@
 import { useServices } from '@suite-common/dependency-injection';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Button } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { useOpenLink } from '@suite-native/link';
@@ -7,7 +7,7 @@ import { SUITE_REFERRAL } from '@trezor/urls';
 
 export const ReferralButton = () => {
     const openLink = useOpenLink();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const handleOpenLink = () => {
         analytics.report({
             type: events.referralButtonPressEvent.name,

--- a/suite-native/module-home/src/screens/HomeScreen/components/SuiteSyncKeysAlert.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/SuiteSyncKeysAlert.tsx
@@ -5,7 +5,7 @@ import { useNavigation } from '@react-navigation/native';
 
 import { useServices } from '@suite-common/dependency-injection';
 import { selectDeviceStaticSessionId, selectIsDeviceConnected } from '@suite-common/device';
-import { type SuiteSyncDep } from '@suite-common/suite-sync-types';
+import { selectEnsureWalletSuiteSyncOnDep } from '@suite-common/suite-sync-types';
 import { AnimatedFullAlertBox } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
@@ -26,7 +26,7 @@ type NavigationProp = StackToStackCompositeNavigationProps<
 >;
 
 export const SuiteSyncKeysAlert = () => {
-    const { suiteSync } = useServices<SuiteSyncDep>();
+    const { ensureWalletSuiteSyncOn } = useServices(selectEnsureWalletSuiteSyncOnDep);
 
     const isDeviceConnected = useSelector(selectIsDeviceConnected);
     const shouldDisplaySuiteSyncAlert = useSelector(selectShouldDisplaySuiteSyncAlert);
@@ -43,7 +43,7 @@ export const SuiteSyncKeysAlert = () => {
                 screen: AuthorizeDeviceStackRoutes.DeviceConnectionGuard,
             });
         } else {
-            const result = await suiteSync.ensureWalletSuiteSyncOn({
+            const result = await ensureWalletSuiteSyncOn({
                 deviceStaticSessionId,
                 isWriteMode: false,
             });
@@ -52,7 +52,13 @@ export const SuiteSyncKeysAlert = () => {
                 handleSuiteSyncError(result.error);
             }
         }
-    }, [deviceStaticSessionId, handleSuiteSyncError, isDeviceConnected, navigation, suiteSync]);
+    }, [
+        deviceStaticSessionId,
+        ensureWalletSuiteSyncOn,
+        handleSuiteSyncError,
+        isDeviceConnected,
+        navigation,
+    ]);
 
     if (!shouldDisplaySuiteSyncAlert) return null;
 

--- a/suite-native/module-home/src/screens/HomeScreen/useShowAutoEjectAlert.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/useShowAutoEjectAlert.tsx
@@ -6,7 +6,11 @@ import { useFocusEffect } from '@react-navigation/native';
 import { useServices } from '@suite-common/dependency-injection';
 import { toggleAutoEjectThunk } from '@suite-common/wallet-core';
 import { useAlert } from '@suite-native/alerts';
-import { type AutoEjectModalValue, type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import {
+    type AutoEjectModalValue,
+    events,
+    selectNativeAnalyticsDep,
+} from '@suite-native/analytics';
 import { CenteredTitleHeader, VStack } from '@suite-native/atoms';
 import { selectIsBluetoothDeviceOsUnpairingRequired } from '@suite-native/bluetooth';
 import { Translation } from '@suite-native/intl';
@@ -23,7 +27,7 @@ export const useShowAutoEjectAlert = () => {
     const dispatch = useDispatch();
     const { showAlert, hideAlert } = useAlert();
     const { showToast } = useToast();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const shouldShowAutoEjectAlert = useSelector(selectShouldShowAutoEjectAlert);
     const isBluetoothDeviceOsUnpairingRequired = useSelector(
         selectIsBluetoothDeviceOsUnpairingRequired,

--- a/suite-native/module-onboarding/src/screens/AnalyticsConsentScreen.tsx
+++ b/suite-native/module-onboarding/src/screens/AnalyticsConsentScreen.tsx
@@ -4,8 +4,8 @@ import { type AnalyticsSharedEvents } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import {
     type AnalyticsNativeEvents,
-    type NativeAnalyticsDep,
     events,
+    selectNativeAnalyticsDep,
 } from '@suite-native/analytics';
 import {
     Box,
@@ -59,7 +59,7 @@ const reportAnalyticsOnboardingCompleted = (
 export const AnalyticsConsentScreen = ({
     navigation,
 }: StackProps<OnboardingStackParamList, OnboardingStackRoutes.AnalyticsConsent>) => {
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const [isEnabled, setIsEnabled] = useState(true);
 
     const { applyStyle } = useNativeStyles();

--- a/suite-native/module-onboarding/src/screens/BiometricsScreen.tsx
+++ b/suite-native/module-onboarding/src/screens/BiometricsScreen.tsx
@@ -1,7 +1,7 @@
 import { useSelector } from 'react-redux';
 
 import { useServices } from '@suite-common/dependency-injection';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Box, Button, HStack, Text, VStack } from '@suite-native/atoms';
 import { BiometricsSvg, useBiometricsSettings } from '@suite-native/biometrics';
 import { Icon } from '@suite-native/icons';
@@ -30,7 +30,7 @@ const titleStyle = prepareNativeStyle(_ => ({
 
 export const BiometricsScreen = ({ navigation }: BiometricsScreenProps) => {
     const { applyStyle } = useNativeStyles();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const { toggleBiometricsOption } = useBiometricsSettings();
     const exitOnboardingFlow = useExitOnboardingFlow();
 

--- a/suite-native/module-passphrase/src/screens/PassphraseEmptyWalletScreen.tsx
+++ b/suite-native/module-passphrase/src/screens/PassphraseEmptyWalletScreen.tsx
@@ -7,7 +7,7 @@ import {
     runDiscoveryThunk,
     startDiscoveryThunk,
 } from '@suite-common/wallet-core';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import {
     Box,
     Button,
@@ -31,7 +31,7 @@ const cardStyle = prepareNativeStyle(utils => ({
 export const PassphraseEmptyWalletScreen = () => {
     const { applyStyle } = useNativeStyles();
     const { bottomSheetRef, openModal, closeModal } = useBottomSheetModal();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const dispatch = useDispatch();
 
     const device = useSelector(selectSelectedDevice);

--- a/suite-native/module-passphrase/src/screens/PassphraseFormScreen.tsx
+++ b/suite-native/module-passphrase/src/screens/PassphraseFormScreen.tsx
@@ -5,7 +5,7 @@ import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-na
 import { useNavigation } from '@react-navigation/native';
 
 import { useServices } from '@suite-common/dependency-injection';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Box, Button, HStack, Text, TitleHeader, VStack } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';
 import { Translation, useTranslate } from '@suite-native/intl';
@@ -57,7 +57,7 @@ type NavigationProp = StackToStackCompositeNavigationProps<
 
 export const PassphraseFormScreen = () => {
     const { applyStyle } = useNativeStyles();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const { translate } = useTranslate();
 
     const navigation = useNavigation<NavigationProp>();

--- a/suite-native/module-passphrase/src/screens/PassphraseLoadingScreen.tsx
+++ b/suite-native/module-passphrase/src/screens/PassphraseLoadingScreen.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import { useServices } from '@suite-common/dependency-injection';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Spinner, type SpinnerLoadingState, Text, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { Screen, useNavigateToInitialScreen } from '@suite-native/navigation';
@@ -11,7 +11,7 @@ import { PassphraseScreenHeader, selectPassphraseDeviceNotEmpty } from '@suite-n
 export const PassphraseLoadingScreen = () => {
     const isDeviceNotEmpty = useSelector(selectPassphraseDeviceNotEmpty);
     const navigateToInitialScreen = useNavigateToInitialScreen();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const [loadingResult, setLoadingResult] = useState<SpinnerLoadingState>('idle');
 
     useEffect(() => {

--- a/suite-native/module-send/src/components/AddressInput.tsx
+++ b/suite-native/module-send/src/components/AddressInput.tsx
@@ -13,7 +13,7 @@ import {
 import { type AccountKey } from '@suite-common/wallet-types';
 import { convertAmountSubunitsToUnits, isAddressValid } from '@suite-common/wallet-utils';
 import { type NativeAccountsRootState, selectFreshAccountAddress } from '@suite-native/accounts';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Button, HStack, Text, VStack } from '@suite-native/atoms';
 import { isDebugEnv } from '@suite-native/config';
 import { TextInputField, useFormContext } from '@suite-native/forms';
@@ -38,7 +38,7 @@ export const AddressInput = ({ index, accountKey }: AddressInputProps) => {
     const amountFieldName = getOutputFieldName(index, 'amount');
     const tokenFieldName = getOutputFieldName(index, 'token');
     const { setValue, watch } = useFormContext<SendOutputsFormValues>();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const symbol = useSelector((state: AccountsRootState) =>
         selectAccountNetworkSymbol(state, accountKey),
     );

--- a/suite-native/module-send/src/components/AmountInputs.tsx
+++ b/suite-native/module-send/src/components/AmountInputs.tsx
@@ -9,7 +9,7 @@ import {
     selectAccountNetworkSymbol,
     useDisplayBaseCurrency,
 } from '@suite-common/wallet-core';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { type ActiveView, AnimatedDoubleInput, HStack, Text, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
@@ -30,7 +30,7 @@ type AmountInputProps = {
 type RouteProps = StackProps<SendStackParamList, SendStackRoutes.SendOutputs>['route'];
 
 export const AmountInputs = ({ index }: AmountInputProps) => {
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const route = useRoute<RouteProps>();
     const { accountKey, tokenContract } = route.params;
 

--- a/suite-native/module-send/src/screens/SendAccountsScreen.tsx
+++ b/suite-native/module-send/src/screens/SendAccountsScreen.tsx
@@ -2,7 +2,7 @@ import { useNavigation } from '@react-navigation/native';
 
 import { useServices } from '@suite-common/dependency-injection';
 import { AccountsListWithFilter, type OnSelectAccount } from '@suite-native/accounts';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Translation } from '@suite-native/intl';
 import {
     type RootStackParamList,
@@ -22,7 +22,7 @@ type NavigationProps = StackToStackCompositeNavigationProps<
 
 export const SendAccountsScreen = () => {
     const navigateToInitialScreen = useNavigateToInitialScreen();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const navigation = useNavigation<NavigationProps>();
 
     const handleSelectAccount: OnSelectAccount = ({ account, hasAnyKnownTokens }) => {

--- a/suite-native/module-settings/src/components/BitcoinUnitsSelector.tsx
+++ b/suite-native/module-settings/src/components/BitcoinUnitsSelector.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useServices } from '@suite-common/dependency-injection';
 import { UNIT_ABBREVIATIONS } from '@suite-common/suite-constants';
 import { selectBitcoinAmountUnit, setBitcoinAmountUnits } from '@suite-common/wallet-core';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Select } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { PROTO } from '@trezor/connect';
@@ -18,7 +18,7 @@ const bitcoinUnitsItems = [
 export const BitcoinUnitsSelector = () => {
     const dispatch = useDispatch();
     const bitcoinUnit = useSelector(selectBitcoinAmountUnit);
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const handleSelectUnit = (value: PROTO.AmountUnit) => {
         dispatch(setBitcoinAmountUnits(value));
         analytics.report({

--- a/suite-native/module-settings/src/components/CurrencySelector.tsx
+++ b/suite-native/module-settings/src/components/CurrencySelector.tsx
@@ -2,7 +2,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { useServices } from '@suite-common/dependency-injection';
 import { selectBaseCurrency, setBaseCurrency } from '@suite-common/wallet-core';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Select } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
@@ -24,7 +24,7 @@ const fiatCurrencyItems = typedObjectValues(baseCurrencies).map(transformFiatCur
 export const CurrencySelector = () => {
     const selectedFiatCurrencyCode = useSelector(selectBaseCurrency);
     const dispatch = useDispatch();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const handleSelectCurrency = (baseCurrencyCode: BaseCurrencyCode) => {
         dispatch(setBaseCurrency(baseCurrencyCode));
         analytics.report({

--- a/suite-native/module-settings/src/components/EjectWallets/AutoEjectSwitch.tsx
+++ b/suite-native/module-settings/src/components/EjectWallets/AutoEjectSwitch.tsx
@@ -4,14 +4,14 @@ import { useServices } from '@suite-common/dependency-injection';
 import { selectIsNoPhysicalDeviceConnected } from '@suite-common/device';
 import { selectIsDeviceAutoEjectEnabled, toggleAutoEjectThunk } from '@suite-common/wallet-core';
 import { useAlert } from '@suite-native/alerts';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { TouchableSwitchRow } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { useToast } from '@suite-native/toasts';
 
 export const AutoEjectSwitch = () => {
     const dispatch = useDispatch();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const { showAlert, hideAlert } = useAlert();
 
     const { showToast } = useToast();

--- a/suite-native/module-settings/src/components/ToggleNetworkReserveCheckCard.tsx
+++ b/suite-native/module-settings/src/components/ToggleNetworkReserveCheckCard.tsx
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useServices } from '@suite-common/dependency-injection';
 import { networksCollection } from '@suite-common/wallet-config';
 import { selectIsNetworkReserveEnabled, setNetworkReserve } from '@suite-common/wallet-core';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { TouchableSwitchRow } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { useOpenLink } from '@suite-native/link';
@@ -14,7 +14,7 @@ export const ToggleNetworkReserveCheckCard = () => {
     const isNetworkReserveEnabled = useSelector(selectIsNetworkReserveEnabled);
 
     const dispatch = useDispatch();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const openLink = useOpenLink();
 
     const supportedNetworks = networksCollection

--- a/suite-native/module-settings/src/components/ToggleSuiteSyncCard.tsx
+++ b/suite-native/module-settings/src/components/ToggleSuiteSyncCard.tsx
@@ -5,19 +5,27 @@ import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
 import { selectIsSuiteSyncEnabled } from '@suite-common/suite-sync';
-import { type SuiteSyncDep } from '@suite-common/suite-sync-types';
+import {
+    selectTurnOffSuiteSyncDep,
+    selectTurnOnSuiteSyncDep,
+} from '@suite-common/suite-sync-types';
 import { useAlert } from '@suite-native/alerts';
-import { type NativeAnalyticsDep, events as nativeEvents } from '@suite-native/analytics';
+import { events as nativeEvents, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { TouchableSwitchRow } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { StorageContext } from '@suite-native/storage';
 import { useSuiteSyncErrorHandler } from '@suite-native/suite-sync';
 
 export const ToggleSuiteSyncCard = () => {
-    const { analytics } = useServices<NativeAnalyticsDep>();
-    const persistor = useContext(StorageContext);
+    const { analytics } = useServices(selectNativeAnalyticsDep);
+    const storageContext = useContext(StorageContext);
     const { showAlert } = useAlert();
-    const { suiteSync } = useServices<SuiteSyncDep>();
+
+    const { turnOffSuiteSync, turnOnSuiteSync } = useServices(
+        selectTurnOffSuiteSyncDep,
+        selectTurnOnSuiteSyncDep,
+    );
+
     const { handleSuiteSyncError } = useSuiteSyncErrorHandler();
     const isSuiteSyncEnabled = useSelector(selectIsSuiteSyncEnabled);
     const selectedDevice = useSelector(selectSelectedDevice);
@@ -28,8 +36,8 @@ export const ToggleSuiteSyncCard = () => {
             description: <Translation id="suiteSync.disableAlert.description" />,
             primaryButtonTitle: <Translation id="suiteSync.disableAlert.cta" />,
             onPressPrimaryButton: () => {
-                suiteSync.turnOffSuiteSync({
-                    ensureSettingsPersisted: () => persistor?.flush(),
+                turnOffSuiteSync({
+                    ensureSettingsPersisted: () => storageContext?.flush(),
                 });
 
                 analytics.report({
@@ -47,7 +55,7 @@ export const ToggleSuiteSyncCard = () => {
         if (isSuiteSyncEnabled) {
             showSuiteSyncDisableConfirmationAlert();
         } else {
-            const result = await suiteSync.turnOnSuiteSync({
+            const result = await turnOnSuiteSync({
                 deviceStaticSessionId: selectedDevice?.state?.staticSessionId,
             });
 

--- a/suite-native/module-settings/src/components/ToggleTestnetsCard.tsx
+++ b/suite-native/module-settings/src/components/ToggleTestnetsCard.tsx
@@ -1,14 +1,14 @@
 import { useDispatch, useSelector } from 'react-redux';
 
 import { useServices } from '@suite-common/dependency-injection';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { TouchableSwitchRow } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { selectAreTestnetsEnabled, toggleAreTestnetsEnabled } from '@suite-native/settings';
 
 export const ToggleTestnetsCard = () => {
     const dispatch = useDispatch();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const areTestnetsEnabled = useSelector(selectAreTestnetsEnabled);
 
     const handleToggleTestnets = (value: boolean) => {

--- a/suite-native/module-settings/src/components/ToggleTronCard.tsx
+++ b/suite-native/module-settings/src/components/ToggleTronCard.tsx
@@ -1,14 +1,14 @@
 import { useDispatch, useSelector } from 'react-redux';
 
 import { useServices } from '@suite-common/dependency-injection';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { TouchableSwitchRow } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { selectIsTronEnabled, toggleIsTronEnabled } from '@suite-native/settings';
 
 export const ToggleTronCard = () => {
     const dispatch = useDispatch();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const isTronEnabled = useSelector(selectIsTronEnabled);
 
     const handleToggleTron = (value: boolean) => {

--- a/suite-native/module-settings/src/hooks/useBackendServersForm.ts
+++ b/suite-native/module-settings/src/hooks/useBackendServersForm.ts
@@ -13,7 +13,7 @@ import {
     reconnectBlockchainThunk,
     selectNetworkBlockchainInfo,
 } from '@suite-common/wallet-core';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { type SelectItemType } from '@suite-native/atoms';
 import { useForm } from '@suite-native/forms';
 import { useTranslate } from '@suite-native/intl';
@@ -32,7 +32,7 @@ type FormValues = {
 export const useBackendServersForm = () => {
     const dispatch = useDispatch();
     const { translate } = useTranslate();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
 
     const {
         connected,

--- a/suite-native/module-settings/src/hooks/useSuiteSyncRelayUrlForm.ts
+++ b/suite-native/module-settings/src/hooks/useSuiteSyncRelayUrlForm.ts
@@ -9,7 +9,7 @@ import {
     createChangeSuiteSyncServerSchema,
     selectSuiteSyncCustomRelayUrl,
 } from '@suite-common/suite-sync';
-import { type SuiteSyncDep } from '@suite-common/suite-sync-types';
+import { selectChangeRelayUrlDep } from '@suite-common/suite-sync-types';
 import { type SelectItemType } from '@suite-native/atoms';
 import { useForm } from '@suite-native/forms';
 import { useTranslate } from '@suite-native/intl';
@@ -18,7 +18,9 @@ import { useToast } from '@suite-native/toasts';
 export const useSuiteSyncRelayUrlForm = () => {
     const { translate } = useTranslate();
     const customRelayUrl = useSelector(selectSuiteSyncCustomRelayUrl);
-    const { suiteSync } = useServices<SuiteSyncDep>();
+
+    const { changeRelayUrl } = useServices(selectChangeRelayUrlDep);
+
     const { showToast } = useToast();
 
     const serverTypes = useMemo<SelectItemType<SuiteSyncServerTypeSelectValue>[]>(
@@ -64,7 +66,7 @@ export const useSuiteSyncRelayUrlForm = () => {
                     ? null
                     : values.customRelayUrl;
 
-            await suiteSync.changeRelayUrl({ relayUrl });
+            await changeRelayUrl({ relayUrl });
             showToast({
                 intent: 'brand',
                 message: translate('moduleSettings.items.features.suiteSync.relayUrl.saved'),

--- a/suite-native/module-settings/src/screens/SettingsAppLogScreen.tsx
+++ b/suite-native/module-settings/src/screens/SettingsAppLogScreen.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { prettifyLog, useCommonApplicationLogs as useApplicationLogs } from '@suite-common/logger';
-import { type NativeAnalyticsDep } from '@suite-native/analytics';
+import { selectNativeAnalyticsDep } from '@suite-native/analytics';
 import {
     Button,
     Card,
@@ -20,7 +20,7 @@ import { DynamicScreenHeader, Screen } from '@suite-native/navigation';
 export const SettingsAppLogScreen = () => {
     const [includeSensitiveInfo, setIncludeSensitiveInfo] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
 
     const applicationLogs = useApplicationLogs(!includeSensitiveInfo);
     const stringifiedApplicationLogs = applicationLogs ? prettifyLog(applicationLogs) : '';

--- a/suite-native/module-settings/src/screens/SettingsPrivacyScreen.tsx
+++ b/suite-native/module-settings/src/screens/SettingsPrivacyScreen.tsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 
 import { selectIsAnalyticsEnabled } from '@suite-common/analytics-redux';
 import { useServices } from '@suite-common/dependency-injection';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import {
     Box,
     DiscreetCanvas,
@@ -35,7 +35,7 @@ const DiscreetTextExample = () => {
 
 const DiscreetModeSwitchRow = () => {
     const { isDiscreetMode, setIsDiscreetMode } = useDiscreetMode();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const handleSetDiscreetMode = (value: boolean) => {
         setIsDiscreetMode(value);
         analytics.report({
@@ -63,7 +63,7 @@ const DiscreetModeSwitchRow = () => {
 };
 
 const AnalyticsSwitchRow = () => {
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const isAnalyticsEnabled = useSelector(selectIsAnalyticsEnabled);
 
     const handleAnalyticsChange = (isEnabled: boolean) => {

--- a/suite-native/module-trading/src/components/buy/BuyPaymentMethodPicker.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyPaymentMethodPicker.tsx
@@ -4,7 +4,7 @@ import type { BuyTrade } from 'invity-api';
 
 import { useServices } from '@suite-common/dependency-injection';
 import { selectTradingBuyIsLoading } from '@suite-common/trading';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Text } from '@suite-native/atoms';
 import { Translation, useTranslate } from '@suite-native/intl';
 import { OverviewRow, OverviewValueSkeleton } from '@suite-native/trading-atoms';
@@ -61,7 +61,7 @@ const BuyPaymentMethodPickerRight = ({
 
 export const BuyPaymentMethodPicker = () => {
     const { translate } = useTranslate();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const form = useBuyFormContext();
     const quotes = useSelector(selectBuyBestQuotesForAvailablePaymentMethods);
     const isLoading = useSelector(selectTradingBuyIsLoading);

--- a/suite-native/module-trading/src/components/buy/BuyProviderPicker.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyProviderPicker.tsx
@@ -10,7 +10,7 @@ import {
     selectTradingBuyProviders,
     selectTradingProviderByNameAndTradeType,
 } from '@suite-common/trading';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { HStack, Text } from '@suite-native/atoms';
 import { useTranslate } from '@suite-native/intl';
 import { OverviewRow, OverviewValueSkeleton, ProviderLogo } from '@suite-native/trading-atoms';
@@ -66,7 +66,7 @@ export const BuyProviderPicker = () => {
     const form = useBuyFormContext();
     const providers = useSelector(selectTradingBuyProviders);
     const isLoading = useSelector(selectTradingBuyIsLoading);
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const { isSheetVisible, hideSheet, showSheet, setSelectedValue, selectedValue } =
         useSheetControls(form, 'quote');
     const { paymentMethod } = selectedValue ?? {};

--- a/suite-native/module-trading/src/components/exchange/ExchangeRateAndProviderPicker.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeRateAndProviderPicker.tsx
@@ -4,7 +4,7 @@ import type { ExchangeTrade } from 'invity-api';
 
 import { useServices } from '@suite-common/dependency-injection';
 import { selectTradingExchangeIsLoading } from '@suite-common/trading';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { selectGroupedExchangeQuotes } from '@suite-native/trading-state';
 
 import { ExchangeProviderPicker } from './ExchangeProviderPicker';
@@ -15,7 +15,7 @@ import { ProviderSheet } from '../general/ProviderSheet/ProviderSheet';
 export const ExchangeRateAndProviderPicker = () => {
     const isLoading = useSelector(selectTradingExchangeIsLoading);
     const quotes = useSelector(selectGroupedExchangeQuotes);
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const form = useExchangeFormContext();
 
     const { isSheetVisible, hideSheet, showSheet, setSelectedValue, selectedValue } =

--- a/suite-native/module-trading/src/components/general/Header/HeaderTabs.tsx
+++ b/suite-native/module-trading/src/components/general/Header/HeaderTabs.tsx
@@ -3,7 +3,7 @@ import { FlatList } from 'react-native-gesture-handler';
 
 import { useServices } from '@suite-common/dependency-injection';
 import { type TradingTypeWithConcierge } from '@suite-common/trading';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { HStack, IconButton, useBottomSheetModal } from '@suite-native/atoms';
 import { type IconName } from '@suite-native/icons';
 import { useTranslate } from '@suite-native/intl';
@@ -59,7 +59,7 @@ export const HeaderTabs = () => {
     const data = useTabsData();
     const { translate } = useTranslate();
     const { bottomSheetRef, openModal, closeModal } = useBottomSheetModal();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
 
     const activeTabIndex = useMemo(
         () => data.findIndex(tab => tab.key === activeTab),

--- a/suite-native/module-trading/src/components/sell/fiat/SellReceiveMethodPicker.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/SellReceiveMethodPicker.tsx
@@ -5,7 +5,7 @@ import type { SellFiatTrade } from 'invity-api';
 
 import { useServices } from '@suite-common/dependency-injection';
 import { selectTradingSellIsLoading } from '@suite-common/trading';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { AnimatedBox, Text } from '@suite-native/atoms';
 import { Translation, useTranslate } from '@suite-native/intl';
 import { OverviewRow, OverviewValueSkeleton } from '@suite-native/trading-atoms';
@@ -69,7 +69,7 @@ const SellReceiveMethodPickerRight = ({
 
 export const SellReceiveMethodPicker = () => {
     const { translate } = useTranslate();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const { applyStyle } = useNativeStyles();
     const form = useSellFormContext();
     const quotes = useSelector(selectSellBestQuotesForAvailablePaymentMethods);

--- a/suite-native/module-trading/src/components/sell/payment/SellProviderPicker.tsx
+++ b/suite-native/module-trading/src/components/sell/payment/SellProviderPicker.tsx
@@ -10,7 +10,7 @@ import {
     selectTradingSellIsLoading,
     selectTradingSellProviders,
 } from '@suite-common/trading';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { HStack, Text } from '@suite-native/atoms';
 import { useTranslate } from '@suite-native/intl';
 import { OverviewRow, OverviewValueSkeleton, ProviderLogo } from '@suite-native/trading-atoms';
@@ -63,7 +63,7 @@ const SellProviderPickerRight = ({ isLoading, selectedValue }: SellProviderPicke
 
 export const SellProviderPicker = () => {
     const { translate } = useTranslate();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const form = useSellFormContext();
     const providers = useSelector(selectTradingSellProviders);
     const isLoading = useSelector(selectTradingSellIsLoading);

--- a/suite-native/module-trading/src/hooks/buy/useBuyFlow.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyFlow.ts
@@ -12,7 +12,7 @@ import {
     selectTradingCoinInfoByCryptoId,
     tradingBuyActions,
 } from '@suite-common/trading';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import {
     type RootStackParamList,
     RootStackRoutes,
@@ -38,7 +38,7 @@ type NavigationProps = StackToStackCompositeNavigationProps<
 >;
 
 export const useBuyFlow = (form: BuyFormType) => {
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const dispatch = useDispatch();
     const isLoading = useSelector(selectTradingBuyIsLoading);
     const [asset, candidateQuote, receiveAccount] = form.watch([

--- a/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
@@ -9,7 +9,7 @@ import { type TradingAmountLimitProps, selectTradingBuyQuotesRequest } from '@su
 import { getNetwork } from '@suite-common/wallet-config';
 import { type WalletSettingsRootState, selectIsAmountInSats } from '@suite-common/wallet-core';
 import { convertAmountUnitsToSubunits } from '@suite-common/wallet-utils';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { useForm } from '@suite-native/forms';
 import { useTranslate } from '@suite-native/intl';
 import { getSymbolFromTradeableAsset } from '@suite-native/trading-atoms';
@@ -34,7 +34,7 @@ const useAmountAndCurrencyFieldsChangeEffect = ({ setValue, getValues, watch }: 
     const dispatch = useDispatch();
     const prevCryptoId = useRef<CryptoId | undefined>(undefined);
     const prevFiatCurrency = useRef<FiatCurrencyCode | undefined>(getValues('fiatCurrency'));
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     useEffect(() => {
         const { unsubscribe } = watch(
             ({ focusedValue, asset, amountInCrypto, fiatCurrency }, { name, type }) => {

--- a/suite-native/module-trading/src/hooks/buy/useBuyQuotes.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyQuotes.ts
@@ -17,7 +17,7 @@ import {
     useTradingRefetchScheduler,
 } from '@suite-common/trading';
 import { type WalletSettingsRootState, selectIsAmountInSats } from '@suite-common/wallet-core';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { getSymbolFromTradeableAsset } from '@suite-native/trading-atoms';
 import { buyActions, selectValidTradingBuyQuotesNative } from '@suite-native/trading-state';
 import { type AbortablePromise, type BuyFormType } from '@suite-native/trading-types';
@@ -135,7 +135,7 @@ const useBuyQuotesThunk = (
     debounce: ReturnType<typeof useDebounce>,
 ) => {
     const dispatch = useDispatch();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const asset = form.watch('asset');
     const symbol = getSymbolFromTradeableAsset(asset);
     const shouldSendInSats = useSelector((state: WalletSettingsRootState) =>

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeSelectQuote.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeSelectQuote.test.ts
@@ -3,7 +3,7 @@ import React from 'react';
 import { useServices } from '@suite-common/dependency-injection';
 import { tradingExchangeActions, tradingSettingsActions } from '@suite-common/trading';
 import { type AccountKey } from '@suite-common/wallet-types';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { type TestStore, act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
 import {
     btcAsset,
@@ -47,7 +47,7 @@ jest.mock('@react-navigation/native', () => ({
 type ReportSpy = jest.SpyInstance;
 
 const useExchangeSelectQuoteWithReportSpy = (exchangeForm: ExchangeFormType) => {
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
 
     const spyRef = React.useRef<ReportSpy | null>(null);
     if (!spyRef.current) {

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeFlow.tsx
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeFlow.tsx
@@ -10,7 +10,7 @@ import {
     exchangeThunks,
     selectTradingExchangeSelectedQuote,
 } from '@suite-common/trading';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import {
     type ExchangeFlowType,
     type RootStackParamList,
@@ -49,7 +49,7 @@ export const useExchangeFlow = ({ flowType }: UseExchangeFlowProps = {}) => {
             >
         >();
     const dispatch = useDispatch();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const quote = useSelector(selectTradingExchangeSelectedQuote);
 
     const sendAccount = useSelector(selectExchangeSelectedSendAccount);

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeForm.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeForm.ts
@@ -14,7 +14,7 @@ import {
 import { getNetwork } from '@suite-common/wallet-config';
 import { type WalletSettingsRootState, selectIsAmountInSats } from '@suite-common/wallet-core';
 import { convertAmountUnitsToSubunits } from '@suite-common/wallet-utils';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { useForm } from '@suite-native/forms';
 import { useTranslate } from '@suite-native/intl';
 import { getSymbolFromTradeableAsset } from '@suite-native/trading-atoms';
@@ -115,7 +115,7 @@ const useAmountAndCurrencyFieldsChangeEffect = ({ setValue, watch }: ExchangeFor
     const dispatch = useDispatch();
     const prevSendCryptoId = useRef<CryptoId | undefined>(undefined);
     const prevReceiveCryptoId = useRef<CryptoId | undefined>(undefined);
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
 
     useEffect(() => {
         const { unsubscribe } = watch(({ sendAsset, receiveAsset }, { name }) => {

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeQuotes.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeQuotes.ts
@@ -16,8 +16,8 @@ import {
 import { type WalletSettingsRootState, selectIsAmountInSats } from '@suite-common/wallet-core';
 import {
     type AnalyticsNativeEvents,
-    type NativeAnalyticsDep,
     events,
+    selectNativeAnalyticsDep,
 } from '@suite-native/analytics';
 import { useFormState } from '@suite-native/forms';
 import { getSymbolFromTradeableAsset } from '@suite-native/trading-atoms';
@@ -129,7 +129,7 @@ const useExchangeQuotesThunk = (
     quotesPromiseRef: RefObject<AbortablePromise | undefined>,
     debounce: ReturnType<typeof useDebounce>,
 ) => {
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const dispatch = useDispatch();
     const asset = getValues('sendAsset');
     const symbol = getSymbolFromTradeableAsset(asset);

--- a/suite-native/module-trading/src/hooks/general/__tests__/useTransactionStateChangeAnalyticsReporting.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useTransactionStateChangeAnalyticsReporting.test.ts
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { useServices } from '@suite-common/dependency-injection';
 import { type TradingTransaction } from '@suite-common/trading';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { renderHook, renderHookWithBasicProvider } from '@suite-native/test-utils';
 import { getBuyTrade, getExchangeTrade } from '@suite-native/trading-fixtures';
 
@@ -12,7 +12,7 @@ type Props = { trades: TradingTransaction[] };
 type ReportSpy = jest.SpyInstance;
 
 const useHookWithReportSpy = (trades: TradingTransaction[]) => {
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
 
     const spyRef = React.useRef<ReportSpy | null>(null);
 

--- a/suite-native/module-trading/src/hooks/general/__tests__/useWatchTrade.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useWatchTrade.test.ts
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { useServices } from '@suite-common/dependency-injection';
 import { type AccountKey } from '@suite-common/wallet-types';
-import { type NativeAnalyticsDep } from '@suite-native/analytics';
+import { selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { type TestStore } from '@suite-native/test-utils-store';
 import { getBuyTrade } from '@suite-native/trading-fixtures';
 
@@ -34,7 +34,7 @@ const useWatchTradeWithReportSpy = (props: {
     orderId?: string;
     isInProgress?: boolean;
 }) => {
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const spyRef = React.useRef<ReportSpy | null>(null);
 
     if (!spyRef.current) {

--- a/suite-native/module-trading/src/hooks/general/useTransactionStateChangeAnalyticsReporting.ts
+++ b/suite-native/module-trading/src/hooks/general/useTransactionStateChangeAnalyticsReporting.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react';
 
 import { useServices } from '@suite-common/dependency-injection';
 import { type TradingTransaction } from '@suite-common/trading';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 
 import { getTradeStatusStep } from '../../utils/general/utils';
 
@@ -11,7 +11,7 @@ export const useTransactionStateChangeAnalyticsReporting = (deviceTrades: Tradin
     const previousStatuses = useRef<Map<string, ReturnType<typeof getTradeStatusStep> | undefined>>(
         new Map(),
     );
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     // Report analytics for status changes
     useEffect(() => {
         deviceTrades.forEach(trade => {

--- a/suite-native/module-trading/src/hooks/general/useWatchTrade.ts
+++ b/suite-native/module-trading/src/hooks/general/useWatchTrade.ts
@@ -13,7 +13,7 @@ import {
 } from '@suite-common/trading';
 import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { type TradingRootState } from '@suite-native/trading-state';
 
 import { useReloadTimer } from './useReloadTimer';
@@ -38,7 +38,7 @@ export const shouldRefreshTrade = (trade: TradingTransaction | undefined) =>
 
 export const useWatchTrade = ({ accountKey, orderId, isInProgress }: TradingUseWatchTradeProps) => {
     const dispatch = useDispatch();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
     );

--- a/suite-native/module-trading/src/hooks/sell/useSellForm.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellForm.ts
@@ -12,7 +12,7 @@ import {
 import { getNetwork } from '@suite-common/wallet-config';
 import { type WalletSettingsRootState, selectIsAmountInSats } from '@suite-common/wallet-core';
 import { convertAmountUnitsToSubunits } from '@suite-common/wallet-utils';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { useForm } from '@suite-native/forms';
 import { useTranslate } from '@suite-native/intl';
 import { getSymbolFromTradeableAsset } from '@suite-native/trading-atoms';
@@ -37,7 +37,7 @@ const useAmountAndCurrencyFieldsChangeEffect = ({ setValue, getValues, watch }: 
     const dispatch = useDispatch();
     const prevCryptoId = useRef<CryptoId | undefined>(undefined);
     const prevFiatCurrency = useRef<FiatCurrencyCode | undefined>(getValues('fiatCurrency'));
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
 
     useEffect(() => {
         const { unsubscribe } = watch(

--- a/suite-native/module-trading/src/screens/TradingScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingScreen.tsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 
 import { useServices } from '@suite-common/dependency-injection';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { VStack } from '@suite-native/atoms';
 import { DeviceManagerScreenHeader } from '@suite-native/device-manager';
 import { RootStackRoutes, Screen } from '@suite-native/navigation';
@@ -30,7 +30,7 @@ const TradingScreenContent = () => {
     const navigation = useNavigation<NavigationProps>();
     const isScreenMountedRecently = useMountedRecentlyFlag(activeTradingType);
     useActiveTradingTypeReaction();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     useEffect(() => {
         if (tradeToBeOpened) {
             analytics.report({

--- a/suite-native/module-transactions/src/components/TransactionDetailSheet.tsx
+++ b/suite-native/module-transactions/src/components/TransactionDetailSheet.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode } from 'react';
 
 import { useServices } from '@suite-common/dependency-injection';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import {
     BottomSheetModal,
     Box,
@@ -71,7 +71,7 @@ export const TransactionDetailSheet = ({
     sheetName,
     sheetControls,
 }: TransactionDetailSheetProps) => {
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const internal = useBottomSheetModal();
     const { bottomSheetRef, openModal, closeModal } = sheetControls ?? internal;
 

--- a/suite-native/module-transactions/src/screens/TransactionDetailScreen.tsx
+++ b/suite-native/module-transactions/src/screens/TransactionDetailScreen.tsx
@@ -5,7 +5,7 @@ import { useNavigation, usePreventRemove } from '@react-navigation/native';
 import { useServices } from '@suite-common/dependency-injection';
 import { useFormatters } from '@suite-common/formatters';
 import { redactNumericalSubstring } from '@suite-common/wallet-utils';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Button, HStack, Text, VStack, useDiscreetMode } from '@suite-native/atoms';
 import { CryptoIconWithNetwork } from '@suite-native/icons';
 import { useInAppRating } from '@suite-native/in-app-rating';
@@ -33,7 +33,7 @@ export const TransactionDetailScreen = ({
 }: StackProps<TransactionDetailStackParamList, TransactionDetailStackRoutes.TransactionDetail>) => {
     const { askForRating } = useInAppRating();
     const navigation = useNavigation();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const { CryptoAmountFormatter: cryptoAmountFormatter } = useFormatters();
     const { isDiscreetMode } = useDiscreetMode();
     const { txid, accountKey, tokenContract, closeActionType = 'back', source } = route.params;

--- a/suite-native/navigation/src/components/NavigationContainerWithAnalytics.tsx
+++ b/suite-native/navigation/src/components/NavigationContainerWithAnalytics.tsx
@@ -9,7 +9,7 @@ import {
 import { useReactNavigationDevTools } from '@rozenite/react-navigation-plugin';
 
 import { useServices } from '@suite-common/dependency-injection';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { addSentryBreadcrumb, setSentryTag } from '@suite-native/sentry';
 import { useNativeStyles } from '@trezor/styles-native';
 
@@ -23,7 +23,7 @@ export const navigationContainerRef = createNavigationContainerRef<RootStackPara
 export const NavigationContainerWithAnalytics = ({ children }: { children: ReactNode }) => {
     const [isNavigationReady, setIsNavigationReady] = useState(false);
     const routeNameRef = useRef<string | undefined>(undefined);
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const {
         utils: { colors, isDarkColor },
     } = useNativeStyles();

--- a/suite-native/navigation/src/hooks/useReportSendFlowExitToAnalytics.ts
+++ b/suite-native/navigation/src/hooks/useReportSendFlowExitToAnalytics.ts
@@ -3,8 +3,8 @@ import { useCallback, useState } from 'react';
 import { useServices } from '@suite-common/dependency-injection';
 import {
     type AnalyticsSendFlowStep,
-    type NativeAnalyticsDep,
     events,
+    selectNativeAnalyticsDep,
 } from '@suite-native/analytics';
 import { isNotNullOrUndefined } from '@trezor/utils';
 
@@ -34,7 +34,7 @@ export const useReportSendFlowExitToAnalytics = () => {
     const [furthestSendStep, setFurthestSendStep] = useState<AnalyticsRelevantSendRoute | null>(
         null,
     );
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const reportSendFlowExitToAnalytics = useCallback(
         (nextScreenRoute?: string) => {
             // The user is still inside of the send flow.

--- a/suite-native/passphrase/src/components/EnterPassphraseOnTrezorButton.tsx
+++ b/suite-native/passphrase/src/components/EnterPassphraseOnTrezorButton.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectDeviceInternalModel, selectSelectedDevice } from '@suite-common/device';
 import { submitPassphrase } from '@suite-common/wallet-core';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Button } from '@suite-native/atoms';
 import { selectPassphraseRequestId } from '@suite-native/device-authorization';
 import { deviceModelToIconName } from '@suite-native/icons';
@@ -12,7 +12,7 @@ import { Translation } from '@suite-native/intl';
 export const EnterPassphraseOnTrezorButton = () => {
     const dispatch = useDispatch();
     const device = useSelector(selectSelectedDevice);
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const deviceModel = useSelector(selectDeviceInternalModel);
     const requestId = useSelector(selectPassphraseRequestId);
 

--- a/suite-native/passphrase/src/components/PassphraseDuplicateAlert.tsx
+++ b/suite-native/passphrase/src/components/PassphraseDuplicateAlert.tsx
@@ -6,7 +6,7 @@ import { useNavigation } from '@react-navigation/native';
 import { useServices } from '@suite-common/dependency-injection';
 import { switchToDuplicatedWallet } from '@suite-common/wallet-core';
 import { useAlert } from '@suite-native/alerts';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { useTranslate } from '@suite-native/intl';
 import {
     AppTabsRoutes,
@@ -26,7 +26,7 @@ type NavigationProp = StackToStackCompositeNavigationProps<
 
 export const PassphraseDuplicateAlert = ({ children }: { children: React.ReactNode }) => {
     const dispatch = useDispatch();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const { translate } = useTranslate();
 
     const navigation = useNavigation<NavigationProp>();

--- a/suite-native/passphrase/src/components/PassphraseForm.tsx
+++ b/suite-native/passphrase/src/components/PassphraseForm.tsx
@@ -14,7 +14,7 @@ import {
     passphraseFormSchema,
 } from '@suite-common/validators';
 import { submitPassphrase } from '@suite-common/wallet-core';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Button, Card, TextDivider, VStack } from '@suite-native/atoms';
 import { selectPassphraseRequestId } from '@suite-native/device-authorization';
 import { Form, SecureTextInputField, useForm } from '@suite-native/forms';
@@ -43,7 +43,7 @@ export const PassphraseForm = ({
     noPassphraseEnabled,
     onAfterSubmit,
 }: PassphraseFormProps) => {
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const dispatch = useDispatch();
     const formWrapperView = useRef<View>(null);
 

--- a/suite-native/passphrase/src/components/PassphraseMismatchAlert.tsx
+++ b/suite-native/passphrase/src/components/PassphraseMismatchAlert.tsx
@@ -11,7 +11,7 @@ import {
     startDiscoveryThunk,
 } from '@suite-common/wallet-core';
 import { useAlert } from '@suite-native/alerts';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Translation } from '@suite-native/intl';
 import {
     type AuthorizeDeviceStackParamList,
@@ -32,7 +32,7 @@ type NavigationProp = StackToStackCompositeNavigationProps<
 
 export const PassphraseMismatchAlert = ({ children }: { children?: React.ReactNode }) => {
     const dispatch = useDispatch();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const navigation = useNavigation<NavigationProp>();
     const device = useSelector(selectSelectedDevice);
     const navigateToInitialScreen = useNavigateToInitialScreen();

--- a/suite-native/passphrase/src/components/PassphraseScreenHeader.tsx
+++ b/suite-native/passphrase/src/components/PassphraseScreenHeader.tsx
@@ -7,7 +7,7 @@ import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
 import { cancelDiscoveryThunk } from '@suite-common/wallet-core';
 import { useAlert } from '@suite-native/alerts';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { IconButton, ScreenHeaderWrapper } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
@@ -35,7 +35,7 @@ export const PassphraseScreenHeader = () => {
     const navigation = useNavigation<NavigationProp>();
     const route = useRoute();
     const device = useSelector(selectSelectedDevice);
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const dispatch = useDispatch();
 
     const { showAlert } = useAlert();

--- a/suite-native/passphrase/src/useRedirectOnPassphraseCompletion.ts
+++ b/suite-native/passphrase/src/useRedirectOnPassphraseCompletion.ts
@@ -10,7 +10,7 @@ import {
     cancelDiscoveryThunk,
     selectDiscoveryByDevicePath,
 } from '@suite-common/wallet-core';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { useNavigateToInitialScreen } from '@suite-native/navigation';
 
 import {
@@ -25,7 +25,7 @@ export const useRedirectOnPassphraseCompletion = () => {
     const passphraseDiscoveryCompleted = useSelector(selectPassphraseDiscoveryCompleted);
     const hasPassphraseError = useSelector(selectHasPassphraseError);
     const hasVerificationCancelledError = useSelector(selectHasVerificationCancelledError);
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const dispatch = useDispatch();
     const store = useStore();
     const navigateToInitialScreen = useNavigateToInitialScreen();

--- a/suite-native/receive/src/hooks/useAccountReceiveAddress.tsx
+++ b/suite-native/receive/src/hooks/useAccountReceiveAddress.tsx
@@ -14,7 +14,7 @@ import {
 import { type AccountKey } from '@suite-common/wallet-types';
 import { type NativeAccountsRootState, selectFreshAccountAddress } from '@suite-native/accounts';
 import { useAlert } from '@suite-native/alerts';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
 import { Translation } from '@suite-native/intl';
 import { useToast } from '@suite-native/toasts';
@@ -27,7 +27,7 @@ export const useAccountReceiveAddress = (accountKey: AccountKey) => {
     const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
     const isDeviceInViewOnlyMode = useSelector(selectIsDeviceInViewOnlyMode);
     const navigation = useNavigation();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const { showToast } = useToast();
 
     const { showAlert } = useAlert();

--- a/suite-native/receive/src/screens/ReceiveAccountsScreen.tsx
+++ b/suite-native/receive/src/screens/ReceiveAccountsScreen.tsx
@@ -4,7 +4,7 @@ import { useNavigation } from '@react-navigation/native';
 
 import { useServices } from '@suite-common/dependency-injection';
 import { AccountsListWithFilter, type OnSelectAccount } from '@suite-native/accounts';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { selectHasFirmwareAuthenticityCheckHardFailedForSelectedDevice } from '@suite-native/device';
 import { Translation } from '@suite-native/intl';
 import {
@@ -22,7 +22,7 @@ type NavigationProp = StackNavigationProps<
 >;
 
 export const ReceiveAccountsScreen = () => {
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const navigation = useNavigation<NavigationProp>();
     const hasFirmwareAuthenticityCheckHardFailed = useSelector(
         selectHasFirmwareAuthenticityCheckHardFailedForSelectedDevice,

--- a/suite-native/services/src/index.ts
+++ b/suite-native/services/src/index.ts
@@ -1,1 +1,1 @@
-export type { MMKVStorageDep, NativeServices } from './nativeServices';
+export { type MMKVStorageDep, type NativeServices, selectMMKVStorageDep } from './nativeServices';

--- a/suite-native/services/src/nativeServices.ts
+++ b/suite-native/services/src/nativeServices.ts
@@ -7,4 +7,8 @@ export type MMKVStorageDep = {
     getMMKVStorage: () => Promise<MMKV>;
 };
 
+export const selectMMKVStorageDep = (services: any): MMKVStorageDep => ({
+    getMMKVStorage: services.getMMKVStorage,
+});
+
 export type NativeServices = CommonServices & NativeAnalyticsDep & MMKVStorageDep;

--- a/suite-native/suite-sync/src/useTurnOnSuiteSyncGuard.tsx
+++ b/suite-native/suite-sync/src/useTurnOnSuiteSyncGuard.tsx
@@ -9,7 +9,10 @@ import {
     type WithSuiteSyncAndDeviceState,
     selectSuiteSyncInteraction,
 } from '@suite-common/suite-sync';
-import { type SuiteSyncDep } from '@suite-common/suite-sync-types';
+import {
+    selectEnsureWalletSuiteSyncOnDep,
+    selectTurnOnSuiteSyncDep,
+} from '@suite-common/suite-sync-types';
 import { useAlert } from '@suite-native/alerts';
 import { Translation, useTranslate } from '@suite-native/intl';
 import {
@@ -26,7 +29,12 @@ import { suiteSyncErrorMessageMap } from './suiteSyncErrorMessages';
 
 export const useTurnOnSuiteSyncGuard = () => {
     const { showAlert } = useAlert();
-    const { suiteSync } = useServices<SuiteSyncDep>();
+
+    const { ensureWalletSuiteSyncOn, turnOnSuiteSync } = useServices(
+        selectEnsureWalletSuiteSyncOnDep,
+        selectTurnOnSuiteSyncDep,
+    );
+
     const { showToast } = useToast();
     const { translate } = useTranslate();
     const navigation =
@@ -66,10 +74,10 @@ export const useTurnOnSuiteSyncGuard = () => {
         });
     };
 
-    const turnOnSuiteSync = async (onSuccess: () => void) => {
+    const handleTurnOnSuiteSync = async (onSuccess: () => void) => {
         if (!deviceStaticSessionId) return;
 
-        const result = await suiteSync.turnOnSuiteSync({
+        const result = await turnOnSuiteSync({
             deviceStaticSessionId,
         });
 
@@ -113,7 +121,7 @@ export const useTurnOnSuiteSyncGuard = () => {
                 title: <Translation id="suiteSync.enableAlert.title" />,
                 description: <Translation id="suiteSync.enableAlert.description" />,
                 primaryButtonTitle: <Translation id="suiteSync.enableAlert.cta" />,
-                onPressPrimaryButton: () => turnOnSuiteSync(onSuccess),
+                onPressPrimaryButton: () => handleTurnOnSuiteSync(onSuccess),
                 secondaryButtonTitle: <Translation id="generic.buttons.cancel" />,
             });
         }
@@ -129,7 +137,7 @@ export const useTurnOnSuiteSyncGuard = () => {
                 break;
             case 'keys-needed':
                 if (deviceStaticSessionId) {
-                    const result = await suiteSync.ensureWalletSuiteSyncOn({
+                    const result = await ensureWalletSuiteSyncOn({
                         deviceStaticSessionId,
                         isWriteMode: false,
                     });

--- a/suite-native/theme/src/useUserColorScheme.ts
+++ b/suite-native/theme/src/useUserColorScheme.ts
@@ -1,7 +1,7 @@
 import { useAtom } from 'jotai';
 
 import { useServices } from '@suite-common/dependency-injection';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { atomWithUnecryptedStorage } from '@suite-native/storage';
 import { type ThemeColorVariant } from '@trezor/theme';
 export type AppColorScheme = ThemeColorVariant | 'system';
@@ -10,7 +10,7 @@ const userColorSchemeAtom = atomWithUnecryptedStorage<AppColorScheme>('colorSche
 
 export const useUserColorScheme = () => {
     const [userColorScheme, setUserColorScheme] = useAtom(userColorSchemeAtom);
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const handleSetUserColorScheme = (colorScheme: AppColorScheme) => {
         setUserColorScheme(colorScheme);
         analytics.report({

--- a/suite-native/trading-analytics/src/hooks/useExchangeAnalyticReportCallback.ts
+++ b/suite-native/trading-analytics/src/hooks/useExchangeAnalyticReportCallback.ts
@@ -12,10 +12,10 @@ import {
     selectTradingProviderByNameAndTradeType,
 } from '@suite-common/trading';
 import {
-    type NativeAnalyticsDep,
     type TradingExchangeAction,
     type TradingExchangeStep,
     events,
+    selectNativeAnalyticsDep,
 } from '@suite-native/analytics';
 import { coinInfoToTradeableAsset } from '@suite-native/trading-atoms';
 
@@ -84,7 +84,7 @@ export const useExchangeAnalyticReportCallback = (
 ): TradingExchangeAnalyticReportCallback => {
     const persistedQuote = useSelector(selectTradingExchangeSelectedQuote);
     const quote = candidateQuote || persistedQuote;
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const {
         exchangeName,
         exchangeType,

--- a/suite-native/trading-analytics/src/hooks/useSellAnalyticReportCallback.ts
+++ b/suite-native/trading-analytics/src/hooks/useSellAnalyticReportCallback.ts
@@ -10,10 +10,10 @@ import {
     selectTradingSellSelectedQuote,
 } from '@suite-common/trading';
 import {
-    type NativeAnalyticsDep,
     type TradingSellAction,
     type TradingSellStep,
     events,
+    selectNativeAnalyticsDep,
 } from '@suite-native/analytics';
 
 import { getAnalyticsTradingSellPayload } from '../utils/quotesUtils';
@@ -26,7 +26,7 @@ export type TradingSellAnalyticReportCallback = (
 export const useSellAnalyticReportCallback = (
     candidateQuote?: SellFiatTrade,
 ): TradingSellAnalyticReportCallback => {
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const persistedQuote = useSelector(selectTradingSellSelectedQuote);
     const quote = candidateQuote || persistedQuote;
 

--- a/suite-native/trading-residence/src/components/CountrySheet/CountryOfResidencePicker.tsx
+++ b/suite-native/trading-residence/src/components/CountrySheet/CountryOfResidencePicker.tsx
@@ -5,8 +5,8 @@ import { getCountryFlag } from '@suite-common/flags';
 import {
     type AnalyticsNativeEvents,
     type CountryChangeContext,
-    type NativeAnalyticsDep,
     events,
+    selectNativeAnalyticsDep,
 } from '@suite-native/analytics';
 import { Flag, HStack, Text } from '@suite-native/atoms';
 import { useFormContext } from '@suite-native/forms';
@@ -42,7 +42,7 @@ export const CountryOfResidencePicker = ({
     noBottomBorder = true,
 }: CountryOfResidencePickerProps) => {
     const { translate } = useTranslate();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const { isSheetVisible, hideSheet, showSheet } = useBottomSheetControls();
 
     const { watch, setValue } = useFormContext<TradingLocationFormValues>();

--- a/suite-native/trading-residence/src/hooks/useCountrySelectionAnalyticsReport.ts
+++ b/suite-native/trading-residence/src/hooks/useCountrySelectionAnalyticsReport.ts
@@ -1,13 +1,17 @@
 import { useCallback, useContext } from 'react';
 
 import { useServices } from '@suite-common/dependency-injection';
-import { type CountryChangeAction, type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import {
+    type CountryChangeAction,
+    events,
+    selectNativeAnalyticsDep,
+} from '@suite-native/analytics';
 
 import { CountryChangeContextCheckContext } from '../components/CountryChangeContextCheckContext';
 
 export const useCountrySelectionAnalyticsReport = () => {
     const type = useContext(CountryChangeContextCheckContext);
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
 
     return useCallback(
         (action: CountryChangeAction) => {

--- a/suite-native/transaction-management/src/hooks/fees/useFeeSelection.ts
+++ b/suite-native/transaction-management/src/hooks/fees/useFeeSelection.ts
@@ -3,7 +3,7 @@ import { useDispatch } from 'react-redux';
 
 import { useServices } from '@suite-common/dependency-injection';
 import { type AccountKey, type FeeLevelLabel, type TokenAddress } from '@suite-common/wallet-types';
-import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 
 import { type UpdateSelectedFeeLevelThunkParams } from '../../types';
 
@@ -28,7 +28,7 @@ export const useFeeSelection = ({
     formDraftKey,
 }: UseFeeSelectionParams) => {
     const dispatch = useDispatch();
-    const { analytics } = useServices<NativeAnalyticsDep>();
+    const { analytics } = useServices(selectNativeAnalyticsDep);
     const handleFeeLevelChange = useCallback(
         (
             feeLevel: FeeLevelLabel,

--- a/suite-native/transactions/src/components/TransactionOutputLabelEditable.tsx
+++ b/suite-native/transactions/src/components/TransactionOutputLabelEditable.tsx
@@ -2,7 +2,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { useServices } from '@suite-common/dependency-injection';
 import { type SuiteSyncDataRootState, selectSuiteSyncOutputLabel } from '@suite-common/suite-sync';
-import { type SuiteSyncDep } from '@suite-common/suite-sync-types';
+import { selectUpdateOutputLabelDep } from '@suite-common/suite-sync-types';
 import type { NetworkSymbol } from '@suite-common/wallet-config';
 import { isTokenTargetId } from '@suite-common/wallet-core';
 import { type AccountDescriptor, type TxTargetId } from '@suite-common/wallet-types';
@@ -32,7 +32,9 @@ export const TransactionOutputLabelEditable = ({
 }: TransactionOutputLabelEditableProps) => {
     const dispatch = useDispatch();
     const isLabellingAllowed = useSelector(selectIsLabellingAllowed);
-    const { suiteSync } = useServices<SuiteSyncDep>();
+
+    const { updateOutputLabel } = useServices(selectUpdateOutputLabelDep);
+
     const { handleSuiteSyncError } = useSuiteSyncErrorHandler();
     const isTokenTxTargetId = isTokenTargetId(txTargetId);
 
@@ -46,7 +48,7 @@ export const TransactionOutputLabelEditable = ({
     }
 
     const onSubmit = async (value: string) => {
-        const result = await suiteSync.labeling.updateOutputLabel({
+        const result = await updateOutputLabel({
             deviceStaticSessionId,
             txId,
             txTargetId,

--- a/suite/analytics/src/createAnalytics.ts
+++ b/suite/analytics/src/createAnalytics.ts
@@ -6,6 +6,10 @@ export type DesktopAnalyticsDep = {
     analytics: Analytics<AnalyticsDesktopEvents>;
 };
 
+export const selectDesktopAnalyticsDep = (services: any): DesktopAnalyticsDep => ({
+    analytics: services.analytics,
+});
+
 export const createAnalytics = (): Analytics<AnalyticsDesktopEvents> =>
     new QueuedAnalytics<AnalyticsDesktopEvents>({
         version: process.env.VERSION!,

--- a/suite/analytics/src/index.ts
+++ b/suite/analytics/src/index.ts
@@ -1,4 +1,8 @@
-export { createAnalytics, type DesktopAnalyticsDep } from './createAnalytics';
+export {
+    createAnalytics,
+    type DesktopAnalyticsDep,
+    selectDesktopAnalyticsDep,
+} from './createAnalytics';
 export {
     type OnboardingAnalytics,
     type AppUpdateEvent,

--- a/suite/labeling/src/Labeling.tsx
+++ b/suite/labeling/src/Labeling.tsx
@@ -24,7 +24,7 @@ import {
     type WithSuiteSyncAndDeviceState,
     selectIsSuiteSyncEnabled,
 } from '@suite-common/suite-sync';
-import { type SuiteSyncDep } from '@suite-common/suite-sync-types';
+import { selectEnsureWalletSuiteSyncOnDep } from '@suite-common/suite-sync-types';
 import { type DiscoveryRootState, selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { type StaticSessionId } from '@trezor/connect';
 import { EditableText, type EditableTextProps } from '@trezor/product-components';
@@ -55,7 +55,7 @@ export const Labeling = ({
     ...rest
 }: LabelingProps) => {
     const dispatch = useDispatch();
-    const { suiteSync } = useServices<SuiteSyncDep>();
+    const { ensureWalletSuiteSyncOn } = useServices(selectEnsureWalletSuiteSyncOnDep);
     const [showEnableSuiteSyncModal, setShowEnableSuiteSyncModal] = useState(false);
     const suiteSyncTurnOnEditResolveRef = useRef<((value: boolean) => void) | null>(null);
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
@@ -92,7 +92,7 @@ export const Labeling = ({
             if (suiteSyncInteraction !== null && suiteSyncInteraction !== 'unsupported') {
                 // Keys needed is not handled by the same modal, because it in DeviceInteraction context
                 if (suiteSyncInteraction === 'keys-needed') {
-                    const result = await suiteSync.ensureWalletSuiteSyncOn({
+                    const result = await ensureWalletSuiteSyncOn({
                         deviceStaticSessionId,
                         isWriteMode: false,
                     });
@@ -133,7 +133,7 @@ export const Labeling = ({
         isLegacyLabelingEnabled,
         isSuiteSyncEnabled,
         legacyMetadataState.initiating,
-        suiteSync,
+        ensureWalletSuiteSyncOn,
         suiteSyncInteraction,
     ]);
 

--- a/suite/labeling/src/LabelingSettings.tsx
+++ b/suite/labeling/src/LabelingSettings.tsx
@@ -2,7 +2,7 @@ import { type ReactNode, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { type OptionProps } from 'react-select';
 
-import { type DesktopAnalyticsDep } from '@suite/analytics';
+import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { LearnMoreButton } from '@suite/external-links';
 import { Translation, type TranslationKey, useTranslation } from '@suite/intl';
@@ -20,7 +20,10 @@ import {
     selectIsSuiteSyncEnabled,
     selectIsSuiteSyncFeatureAvailable,
 } from '@suite-common/suite-sync';
-import { type SuiteSyncDep } from '@suite-common/suite-sync-types';
+import {
+    selectTurnOffSuiteSyncDep,
+    selectTurnOnSuiteSyncDep,
+} from '@suite-common/suite-sync-types';
 import { Box, LoadingContent, Tooltip } from '@trezor/components';
 // eslint-disable-next-line local-rules/no-package-deep-imports
 import { Option as SelectOption } from '@trezor/components/src/components/form/Select/customComponents';
@@ -80,7 +83,13 @@ const LabelingOption = ({
 
 export const LabelingSettings = () => {
     const { translationString } = useTranslation();
-    const { suiteSync, analytics } = useServices<SuiteSyncDep & DesktopAnalyticsDep>();
+
+    const { analytics, turnOffSuiteSync, turnOnSuiteSync } = useServices(
+        selectDesktopAnalyticsDep,
+        selectTurnOffSuiteSyncDep,
+        selectTurnOnSuiteSyncDep,
+    );
+
     const dispatch = useDispatch();
     const [legacyModalWarningVisible, setLegacyModalWarningVisible] = useState(false);
     const { device } = useDevice();
@@ -105,7 +114,7 @@ export const LabelingSettings = () => {
     })).filter(option => option.value !== 'suite-sync' || showSuiteSync);
 
     const handleLegacyOptionSelect = async () => {
-        await suiteSync.turnOffSuiteSync();
+        await turnOffSuiteSync();
         if (legacyMetadataState.enabled === false) {
             dispatch(metadataLabelingActions.init(true));
         }
@@ -127,11 +136,11 @@ export const LabelingSettings = () => {
                     dispatch(metadataThunks.disableMetadata());
                 }
 
-                await suiteSync.turnOffSuiteSync();
+                await turnOffSuiteSync();
                 break;
 
             case 'suite-sync': {
-                const result = await suiteSync.turnOnSuiteSync({ deviceStaticSessionId });
+                const result = await turnOnSuiteSync({ deviceStaticSessionId });
                 if (!result.success && deviceStaticSessionId !== undefined) {
                     suiteSyncErrorHandler({ deviceStaticSessionId, dispatch, error: result.error });
                 }

--- a/suite/metadata-migration/src/LegacyLabelingMigrationModal.tsx
+++ b/suite/metadata-migration/src/LegacyLabelingMigrationModal.tsx
@@ -18,7 +18,7 @@ import { type AnyAction, type ExtraDependencies } from '@suite-common/redux-util
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { type StaticSessionId } from '@trezor/connect';
 
-import { type MetadataMigrationDep } from './createMetadataMigrationCompositionRoot';
+import { selectMetadataMigrationDep } from './createMetadataMigrationCompositionRoot';
 import type { MigrationError } from './legacyLabelsMigration';
 import { isMigratableDevice } from './migrationUtils';
 
@@ -39,7 +39,7 @@ export const LegacyLabelingMigrationModal = ({
     onSuiteSyncError,
 }: LegacyLabelingMigrationModalProps) => {
     const dispatch = useDispatch<MetadataDispatch>();
-    const { migrateLegacyLabelsToSuiteSync } = useServices<MetadataMigrationDep>();
+    const { migrateLegacyLabelsToSuiteSync } = useServices(selectMetadataMigrationDep);
     const selectedProvider = useSelector(selectSelectedProviderForLabels);
     const selectedDevice = useSelector(selectSelectedDevice);
     const [providerLoading, setProviderLoading] = useState<MetadataProviderType | null>(null);

--- a/suite/metadata-migration/src/createMetadataMigrationCompositionRoot.ts
+++ b/suite/metadata-migration/src/createMetadataMigrationCompositionRoot.ts
@@ -25,6 +25,10 @@ export type MetadataMigrationDep = {
     migrateLegacyLabelsToSuiteSync: MigrateLegacyLabelsToSuiteSync;
 };
 
+export const selectMetadataMigrationDep = (services: any): MetadataMigrationDep => ({
+    migrateLegacyLabelsToSuiteSync: services.migrateLegacyLabelsToSuiteSync,
+});
+
 type CreateMetadataMigrationCompositionRootDeps = {
     getAccountsByDeviceState: GetAccountsByDeviceState;
     getLegacyWalletLabels: GetLegacyWalletLabels;

--- a/suite/metadata-migration/src/index.ts
+++ b/suite/metadata-migration/src/index.ts
@@ -1,6 +1,7 @@
 export {
     createMetadataMigrationCompositionRoot,
     type MetadataMigrationDep,
+    selectMetadataMigrationDep,
 } from './createMetadataMigrationCompositionRoot';
 export {
     LegacyLabelingMigration,

--- a/suite/router/src/suiteRouterHistory.ts
+++ b/suite/router/src/suiteRouterHistory.ts
@@ -20,6 +20,10 @@ export type SuiteRouterHistoryDep = {
     suiteRouterHistory: SuiteRouterHistory;
 };
 
+export const selectSuiteRouterHistoryDep = (services: any): SuiteRouterHistoryDep => ({
+    suiteRouterHistory: services.suiteRouterHistory,
+});
+
 export type SuiteRouterHistoryDeps = {
     history: History;
 };

--- a/suite/suite-sync/src/SelectSuiteSyncServer.tsx
+++ b/suite/suite-sync/src/SelectSuiteSyncServer.tsx
@@ -13,7 +13,7 @@ import {
     createChangeSuiteSyncServerSchema,
     selectSuiteSyncCustomRelayUrl,
 } from '@suite-common/suite-sync';
-import { type SuiteSyncDep } from '@suite-common/suite-sync-types';
+import { selectChangeRelayUrlDep } from '@suite-common/suite-sync-types';
 import { Card, Column, Input, Modal, Select } from '@trezor/components';
 
 type SelectSuiteSyncServerProps = {
@@ -22,7 +22,9 @@ type SelectSuiteSyncServerProps = {
 
 export const SelectSuiteSyncServer = ({ onCancel }: SelectSuiteSyncServerProps) => {
     const { translationString } = useTranslation();
-    const { suiteSync } = useServices<SuiteSyncDep>();
+
+    const { changeRelayUrl } = useServices(selectChangeRelayUrlDep);
+
     const customRelayUrl = useSelector(selectSuiteSyncCustomRelayUrl);
 
     const formSchema = useMemo(
@@ -69,7 +71,7 @@ export const SelectSuiteSyncServer = ({ onCancel }: SelectSuiteSyncServerProps) 
                 ? null
                 : values.customRelayUrl;
 
-        await suiteSync.changeRelayUrl({ relayUrl });
+        await changeRelayUrl({ relayUrl });
         onCancel();
     });
 

--- a/suite/suite-sync/src/SuiteSyncSettings.tsx
+++ b/suite/suite-sync/src/SuiteSyncSettings.tsx
@@ -11,7 +11,7 @@ import {
     selectSuiteSyncRelayUrl,
     updateSuiteSyncDebugEnabled,
 } from '@suite-common/suite-sync';
-import { type SuiteSyncDep } from '@suite-common/suite-sync-types';
+import { selectChangeRelayUrlDep } from '@suite-common/suite-sync-types';
 import { Button, ButtonGroup, Checkbox, Code, Column, Input, Text } from '@trezor/components';
 import { ActionColumn, SectionItem, SettingsSection, TextColumn } from '@trezor/product-components';
 import { type BreakpointFlags, spacings } from '@trezor/theme';
@@ -28,7 +28,8 @@ type SuiteSyncSettingsProps = {
 
 export const SuiteSyncSettings = ({ onError }: SuiteSyncSettingsProps) => {
     const [isRelayUrlLoading, setIsRelayUrlLoading] = useState(false);
-    const { suiteSync } = useServices<SuiteSyncDep>();
+
+    const { changeRelayUrl } = useServices(selectChangeRelayUrlDep);
 
     const dispatch = useDispatch();
     const isBelowLaptop = useSelector(selectIsBelowLaptop);
@@ -48,7 +49,7 @@ export const SuiteSyncSettings = ({ onError }: SuiteSyncSettingsProps) => {
 
         setRelayUrl(url);
 
-        await suiteSync.changeRelayUrl({ relayUrl: url });
+        await changeRelayUrl({ relayUrl: url });
 
         // Fake it, to make some UI interaction for the user
         setTimeout(() => {

--- a/suite/suite-sync/src/SuiteSyncTurnOnModal.tsx
+++ b/suite/suite-sync/src/SuiteSyncTurnOnModal.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Translation, useTranslation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
 import { type DeviceRootState, selectDeviceByStaticSessionId } from '@suite-common/device';
-import { type SuiteSyncDep } from '@suite-common/suite-sync-types';
+import { selectTurnOnSuiteSyncDep } from '@suite-common/suite-sync-types';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { Card, Column, Icon, List, Modal, Paragraph } from '@trezor/components';
 import { type StaticSessionId } from '@trezor/connect';
@@ -24,7 +24,8 @@ export const SuiteSyncTurnOnModal = ({
 }: SuiteSyncTurnOnModalProps) => {
     const dispatch = useDispatch();
     const { translationString } = useTranslation();
-    const { suiteSync } = useServices<SuiteSyncDep>();
+
+    const { turnOnSuiteSync } = useServices(selectTurnOnSuiteSyncDep);
 
     const device = useSelector((state: DeviceRootState) =>
         selectDeviceByStaticSessionId(state, deviceStaticSessionId),
@@ -35,7 +36,7 @@ export const SuiteSyncTurnOnModal = ({
     }
 
     const onSwitch = async () => {
-        const result = await suiteSync.turnOnSuiteSync({
+        const result = await turnOnSuiteSync({
             deviceStaticSessionId: deviceStaticSessionId ?? undefined,
         });
 

--- a/suite/suite-sync/src/WipeSuiteSyncLabels.tsx
+++ b/suite/suite-sync/src/WipeSuiteSyncLabels.tsx
@@ -6,7 +6,7 @@ import { selectSelectedDevice } from '@suite-common/device';
 import { type SuiteSyncUpdateError } from '@suite-common/suite-sync-storage';
 import {
     type EnsureWalletSuiteSyncOnErrors,
-    type SuiteSyncDep,
+    selectDangerouslyWipeAllLabelsFromWalletDep,
 } from '@suite-common/suite-sync-types';
 import { parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
 import { Button } from '@trezor/components';
@@ -35,7 +35,10 @@ type WipeSuiteSyncLabelsStep = 'wipingLoading' | 'areYouSure' | 'confirmDeletion
 export const WipeSuiteSyncLabels = ({ onError }: WipeSuiteSyncLabelsProps) => {
     const [step, setStep] = useState<WipeSuiteSyncLabelsStep>('start');
     const [wipeConfirmationCountdown, setWipeConfirmationCountdown] = useState(0);
-    const { suiteSync } = useServices<SuiteSyncDep>();
+
+    const { dangerouslyWipeAllLabelsFromWallet } = useServices(
+        selectDangerouslyWipeAllLabelsFromWalletDep,
+    );
 
     const wipeConfirmationTimeoutRef = useRef<TimerId | null>(null);
     const wipeConfirmationIntervalRef = useRef<TimerId | null>(null);
@@ -117,7 +120,7 @@ export const WipeSuiteSyncLabels = ({ onError }: WipeSuiteSyncLabelsProps) => {
                     const { walletDescriptor } = parseDeviceStaticSessionId(
                         selectedDeviceStaticSessionId,
                     );
-                    const result = await suiteSync.dangerouslyWipeAllLabelsFromWallet({
+                    const result = await dangerouslyWipeAllLabelsFromWallet({
                         walletDescriptor,
                     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10339,6 +10339,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-common/dependency-injection@workspace:suite-common/dependency-injection"
   dependencies:
+    "@testing-library/react": "npm:^16.3.2"
     "@trezor/type-utils": "workspace:*"
     react: "npm:19.2.4"
   languageName: unknown


### PR DESCRIPTION
Introduces selector for services. This allow more precises dependency resolution so you do not need to pass whole SuiteSync for example if you only need one sub-dependency from it.

## Testing
Nothing if CI passes it shall be ok, its just code improvement

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=di-use-servicis-selector&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=di-use-servicis-selector&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=di-use-servicis-selector&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-27T14:35:01.865Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-28T05:46:50.320Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/di-use-servicis-selector/web/](https://dev.suite.sldev.cz/suite-web/di-use-servicis-selector/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->