### PR TITLE
feat(suite-native): show unacquired devices in change device list

### DIFF
--- a/suite-common/device/src/deviceSelectors.ts
+++ b/suite-common/device/src/deviceSelectors.ts
@@ -560,9 +560,9 @@ export const selectNumberOfDeviceInstances = createMemoizedSelector(
 );
 
 export const selectInstacelessUnselectedDevices = createMemoizedSelector(
-    [selectSelectedDevice, selectDevices],
-    (device, allDevices) =>
-        pipe(getSortedDevicesWithoutInstances(allDevices, device?.id), returnStableArrayIfEmpty),
+    [selectDeviceId, selectDevices],
+    (deviceId, allDevices) =>
+        pipe(getSortedDevicesWithoutInstances(allDevices, deviceId), returnStableArrayIfEmpty),
 );
 
 export const selectHasBitcoinOnlyFirmware = createMemoizedSelector([selectSelectedDevice], device =>

--- a/suite-common/suite-utils/src/__fixtures__/device.ts
+++ b/suite-common/suite-utils/src/__fixtures__/device.ts
@@ -531,6 +531,58 @@ const getDeviceInstances = [
     },
 ];
 
+const getDeviceInstancesGroupedByDeviceId = [
+    { description: 'No devices', devices: [], result: [] },
+    {
+        description: 'Two acquired devices',
+        devices: [d({ id: '1', inst: 2 }), d({ id: '1', inst: 1 })],
+        result: [[d({ id: '1', inst: 1 }), d({ id: '1', inst: 2 })]],
+    },
+    {
+        description: 'One unacquired device, one acquired device',
+        devices: [d({ path: 'a' }), d({ id: '1', inst: 1 })],
+        result: [[d({ path: 'a' })], [d({ id: '1', inst: 1 })]],
+    },
+    {
+        description: 'Two unacquired devices, three acquired devices',
+        devices: [
+            d({ path: 'a' }),
+            d({ id: '1', inst: 2 }),
+            d({ path: 'b' }),
+            d({ id: '2', inst: 1 }),
+            d({ id: '1', inst: 1 }),
+        ],
+        result: [
+            [d({ path: 'a' })],
+            [d({ id: '1', inst: 1 }), d({ id: '1', inst: 2 })],
+            [d({ path: 'b' })],
+            [d({ id: '2', inst: 1 })],
+        ],
+    },
+];
+
+const getSortedDevicesWithoutInstances = [
+    { description: 'No devices', devices: [], excludedDeviceId: null, result: [] },
+    {
+        description: 'One unacquired device, one acquired device',
+        devices: [d({ path: 'a' }), d({ id: '1', inst: 1 })],
+        excludedDeviceId: null,
+        result: [d({ id: '1', inst: 1 }), d({ path: 'a' })],
+    },
+    {
+        description: 'Two unacquired devices, three acquired devices',
+        devices: [
+            d({ path: 'a' }),
+            d({ id: '1', inst: 2 }),
+            d({ path: 'b' }),
+            d({ id: '2', inst: 1 }),
+            d({ id: '1', inst: 1 }),
+        ],
+        excludedDeviceId: '2',
+        result: [d({ path: 'b' }), d({ id: '1', inst: 1 }), d({ path: 'a' })],
+    },
+];
+
 const getChangelogUrl = [
     {
         description: 'Revision set, core firmware',
@@ -632,6 +684,8 @@ export default {
     sortByTimestamp,
     getFirstDeviceInstance,
     getDeviceInstances,
+    getDeviceInstancesGroupedByDeviceId,
+    getSortedDevicesWithoutInstances,
     isDeviceRemembered,
     getChangelogUrl,
     getCheckBackupUrl,

--- a/suite-common/suite-utils/src/__tests__/device.test.ts
+++ b/suite-common/suite-utils/src/__tests__/device.test.ts
@@ -8,6 +8,7 @@ import {
     getChangelogUrl,
     getCheckBackupUrl,
     getDeviceInstances,
+    getDeviceInstancesGroupedByDeviceId,
     getFirmwareDowngradeUrl,
     getFirstDeviceInstance,
     getIsDeviceConnectedViaBluetooth,
@@ -19,6 +20,7 @@ import {
     getPhysicalDeviceCount,
     getPhysicalDeviceUniqueIds,
     getSelectedDevice,
+    getSortedDevicesWithoutInstances,
     getStatus,
     isDeviceWithButtonOnlyNoTouchscreen,
     isSelectedDevice,
@@ -126,6 +128,24 @@ describe(getDeviceInstances.name, () => {
         it(f.description, () => {
             const sort = getDeviceInstances(f.selected as any, f.devices as any, f.excluded);
             expect(sort).toEqual(f.result);
+        });
+    });
+});
+
+describe(getDeviceInstancesGroupedByDeviceId.name, () => {
+    fixtures.getDeviceInstancesGroupedByDeviceId.forEach(f => {
+        it(f.description, () => {
+            expect(getDeviceInstancesGroupedByDeviceId(f.devices as any)).toEqual(f.result);
+        });
+    });
+});
+
+describe(getSortedDevicesWithoutInstances.name, () => {
+    fixtures.getSortedDevicesWithoutInstances.forEach(f => {
+        it(f.description, () => {
+            expect(getSortedDevicesWithoutInstances(f.devices as any, f.excludedDeviceId)).toEqual(
+                f.result,
+            );
         });
     });
 });

--- a/suite-common/suite-utils/src/device.ts
+++ b/suite-common/suite-utils/src/device.ts
@@ -403,22 +403,23 @@ export const getDeviceInstances = (
  * * @param {TrezorDevice[]} devices
  * @returns {AcquiredDevice[][]}
  */
-export const getDeviceInstancesGroupedByDeviceId = (devices: TrezorDevice[]): AcquiredDevice[][] =>
+export const getDeviceInstancesGroupedByDeviceId = (devices: TrezorDevice[]): TrezorDevice[][] =>
     devices.reduce((deviceGroups, device) => {
         if (!isDeviceAcquired(device) || !device.id) {
-            return deviceGroups;
-        }
-        const existingGroupIndex = deviceGroups.findIndex(group => group[0].id === device.id);
-        if (existingGroupIndex === -1) {
-            // If the device ID is not yet in the accumulator, add a new group
-            const newGroup = getDeviceInstances(device, devices);
-            if (newGroup.length > 0) {
-                deviceGroups.push(newGroup);
+            deviceGroups.push([device]);
+        } else {
+            const existingGroupIndex = deviceGroups.findIndex(group => group[0].id === device.id);
+            if (existingGroupIndex === -1) {
+                // If the device ID is not yet in the accumulator, add a new group
+                const newGroup = getDeviceInstances(device, devices);
+                if (newGroup.length > 0) {
+                    deviceGroups.push(newGroup);
+                }
             }
         }
 
         return deviceGroups;
-    }, [] as AcquiredDevice[][]);
+    }, [] as TrezorDevice[][]);
 
 /**
  * Returns first available instance for each device sorted by priority
@@ -456,11 +457,11 @@ export const getPhysicalDeviceCount = (devices: TrezorDevice[]) =>
 
 export const getSortedDevicesWithoutInstances = (
     devices: TrezorDevice[],
-    excludedDeviceId?: string | null,
+    excludedDeviceId: string | null,
 ) =>
     getDeviceInstancesGroupedByDeviceId(devices)
         .flatMap(group => group[0])
-        .filter(d => d?.id !== excludedDeviceId && d?.id)
+        .filter(d => d?.id !== excludedDeviceId)
         .sort((a, b) => {
             if (!a.connected) return -1;
             if (!b.connected) return 1;

--- a/suite-native/device-manager/src/components/DeviceItem/DeviceItem.tsx
+++ b/suite-native/device-manager/src/components/DeviceItem/DeviceItem.tsx
@@ -8,7 +8,7 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 import { DeviceItemContent } from './DeviceItemContent';
 
 type DeviceItemProps = {
-    deviceState: NonNullable<TrezorDevice['state']>;
+    device: TrezorDevice;
     onPress: () => void;
 };
 
@@ -19,13 +19,13 @@ const deviceItemWrapperStyle = prepareNativeStyle(utils => ({
     paddingHorizontal: utils.spacings.sp16,
 }));
 
-export const DeviceItem = ({ deviceState, onPress }: DeviceItemProps) => {
+export const DeviceItem = ({ device, onPress }: DeviceItemProps) => {
     const { applyStyle } = useNativeStyles();
 
     return (
         <Pressable onPress={onPress}>
             <HStack style={applyStyle(deviceItemWrapperStyle)}>
-                <DeviceItemContent deviceState={deviceState} />
+                <DeviceItemContent device={device} />
                 <Icon name="caretRight" color="contentPrimary" size="mediumLarge" />
             </HStack>
         </Pressable>

--- a/suite-native/device-manager/src/components/DeviceItem/DeviceItemContent.tsx
+++ b/suite-native/device-manager/src/components/DeviceItem/DeviceItemContent.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import {
     type DeviceRootState,
     PORTFOLIO_TRACKER_DEVICE_ID,
-    selectDeviceByState,
     selectDeviceLabelOrNameById,
     selectSelectedDevice,
 } from '@suite-common/device';
@@ -27,7 +26,7 @@ const DEVICE_SWITCHER_ITEM_CONTENT_HEIGHT_LARGE = 56;
 export type DeviceItemContentVariant = 'simple' | 'walletDetail';
 
 export type DeviceItemContentProps = {
-    deviceState?: TrezorDevice['state'];
+    device?: TrezorDevice;
     headerTextVariant?: NativeTypographyStyle;
     variant?: DeviceItemContentVariant;
     isCompact?: boolean;
@@ -53,7 +52,7 @@ export const itemStyle = prepareNativeStyle<{ isCompact: boolean }>((utils, { is
 
 export const DeviceItemContent = React.memo(
     ({
-        deviceState,
+        device,
         headerTextVariant = 'body-md',
         variant = 'simple',
         isCompact = true,
@@ -62,9 +61,8 @@ export const DeviceItemContent = React.memo(
         const { translate } = useTranslate();
         const { applyStyle } = useNativeStyles();
 
-        const device = useSelectorDeepComparison((state: DeviceRootState) => {
-            // select only what is needed to avoid unnecessary rerenders
-            const d = selectDeviceByState(state, deviceState) ?? selectSelectedDevice(state);
+        const deviceItem = useSelectorDeepComparison((state: DeviceRootState) => {
+            const d = device ?? selectSelectedDevice(state);
 
             if (!d) return null;
 
@@ -77,26 +75,27 @@ export const DeviceItemContent = React.memo(
                 walletNumber: d.walletNumber,
                 isDeviceInBootloaderMode: !state && selectShouldFactoryResetBeVisible(state),
                 useEmptyPassphrase: d.useEmptyPassphrase,
+                staticSessionId: d.state?.staticSessionId,
             };
         });
 
-        const isPortfolioTrackerDevice = device?.id === PORTFOLIO_TRACKER_DEVICE_ID;
+        const isPortfolioTrackerDevice = deviceItem?.id === PORTFOLIO_TRACKER_DEVICE_ID;
 
         const deviceHeader =
-            (isPortfolioTrackerDevice ? device?.name : device?.label) ??
+            (isPortfolioTrackerDevice ? deviceItem?.name : deviceItem?.label) ??
             translate('deviceManager.defaultHeader');
 
         // todo: only makes sense device is already authorized (has state)
-        const fallbackLabel = device?.useEmptyPassphrase ? (
+        const fallbackLabel = deviceItem?.useEmptyPassphrase ? (
             <Translation id="deviceManager.wallet.standard" />
         ) : (
             <Translation
                 id="deviceManager.wallet.defaultPassphrase"
-                values={{ index: device?.walletNumber }}
+                values={{ index: deviceItem?.walletNumber }}
             />
         );
 
-        if (!device) {
+        if (!deviceItem) {
             return null;
         }
 
@@ -108,29 +107,29 @@ export const DeviceItemContent = React.memo(
                         : DEVICE_SWITCHER_ITEM_CONTENT_HEIGHT_LARGE,
                 })}
             >
-                <DeviceItemIcon deviceId={device.id} deviceModel={device.model} />
+                <DeviceItemIcon deviceId={deviceItem.id} deviceModel={deviceItem.model} />
                 <Box style={applyStyle(itemStyle, { isCompact })}>
                     {variant === 'simple' ? (
                         <SimpleDeviceItemContent
-                            isConnected={device.isConnected}
+                            isConnected={deviceItem.isConnected}
                             headerTextVariant={headerTextVariant}
                             header={deviceHeader}
-                            isDeviceInBootloader={device.isDeviceInBootloaderMode}
+                            isDeviceInBootloader={deviceItem.isDeviceInBootloaderMode}
                             isPortfolioTrackerDevice={isPortfolioTrackerDevice}
                             isSubHeaderForceHidden={isSubHeaderForceHidden}
                         />
                     ) : (
                         <WalletDetailDeviceItemContent
                             headerTextVariant={headerTextVariant}
-                            isConnected={device.isConnected}
+                            isConnected={deviceItem.isConnected}
                             header={deviceHeader}
                             subHeader={
                                 <WalletLabel
-                                    deviceStaticSessionId={deviceState?.staticSessionId}
+                                    deviceStaticSessionId={deviceItem.staticSessionId}
                                     fallbackLabel={fallbackLabel}
                                 />
                             }
-                            isDeviceInBootloader={device.isDeviceInBootloaderMode}
+                            isDeviceInBootloader={deviceItem.isDeviceInBootloaderMode}
                             isPortfolioTrackerDevice={isPortfolioTrackerDevice}
                         />
                     )}

--- a/suite-native/device-manager/src/components/DeviceList.tsx
+++ b/suite-native/device-manager/src/components/DeviceList.tsx
@@ -48,16 +48,9 @@ export const DeviceList = ({ onSelectDevice }: DeviceListProps) => {
             exiting={FadeOutUp.duration(ANIMATION_DURATION)}
         >
             <Box>
-                {notSelectedInstancelessDevices.map(
-                    d =>
-                        d.state && (
-                            <DeviceItem
-                                key={d.state.staticSessionId}
-                                deviceState={d.state}
-                                onPress={() => onSelectDevice(d)}
-                            />
-                        ),
-                )}
+                {notSelectedInstancelessDevices.map(d => (
+                    <DeviceItem key={d.id ?? d.path} device={d} onPress={() => onSelectDevice(d)} />
+                ))}
             </Box>
         </AnimatedBox>
     );

--- a/suite-native/module-settings/src/components/EjectWallets/DevicesManagement.tsx
+++ b/suite-native/module-settings/src/components/EjectWallets/DevicesManagement.tsx
@@ -30,7 +30,7 @@ export const DevicesManagement = () => {
                             )}
                             <Box>
                                 <Text variant="body-md-strong" color="contentPrimary">
-                                    {firstDevice.features.label || firstDevice.name}
+                                    {firstDevice.features?.label ?? firstDevice.name}
                                 </Text>
                                 <HStack alignItems="center" spacing="sp8">
                                     <ConnectionDot isConnected={firstDevice.connected} />


### PR DESCRIPTION
When user connects an uninitialized device to mobile Suite and then switches to _Porfolio tracker,_ there's no way to switch back to the connected device. Disconnecting the device or restarting the app fixes the issue but the UX sux.

## Related Issue

Discovered during #27770

## Screenshots:

| Before | After |
| --- | --- |
| <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/5c1590f8-3d2c-4a57-99c8-3a95736ba265" /> | <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/2949142d-28f8-4e42-aa18-08247b881c4b" /> |

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes span two domains: (1) suite-common/suite-utils/src/device.ts with its fixtures and tests — a broadly-used device utility module, and (2) suite-native/device-manager components (DeviceItem, DeviceItemContent, DeviceList) which are React Native mobile components with no web E2E test coverage. The device.ts utility maps to 121 tests, indicating it's a global dependency — most tests should NOT be run unless there's specific evidence the change affects their code path. The recommended strategy focuses on tests that directly exercise device state management, device switching, and device identity logic, where changes to device utility functions are most likely to cause regressions. The mobile components have no E2E test coverage in the web suite.

<details><summary><b>Changed files (6)</b></summary>

- `suite-common/suite-utils/src/__fixtures__/device.ts`
- `suite-common/suite-utils/src/__tests__/device.test.ts`
- `suite-common/suite-utils/src/device.ts`
- `suite-native/device-manager/src/components/DeviceItem/DeviceItem.tsx`
- `suite-native/device-manager/src/components/DeviceItem/DeviceItemContent.tsx`
- `suite-native/device-manager/src/components/DeviceList.tsx`

</details>

**Recommended tests (5)**

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `../../suite/e2e/tests/suite/multiple-sessions.test.ts` — This test exercises device switching, device status display (TR_USE_HERE, TR_CONNECTED), and wallet listing in the device switcher. Changes to suite-common/suite-utils/src/device.ts (a device utility module) could affect how device state is computed, displayed, or compared — which directly impacts session management and device status rendering in this test.
- `../../suite/e2e/tests/settings/forget-device.test.ts` — This test covers forgetting/unpairing devices, checking device connection status, and device state assertions (page.expectDeviceState). The device.ts utility likely provides helpers for device identity comparison or state checks that are exercised during the forget device flow.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `../../suite/e2e/tests/general/wallet-discovery.test.ts` — This test exercises device switching (eject wallet, add standard wallet) and wallet discovery. Changes to device utility functions could affect how devices/wallets are identified during the switching and discovery flow.
- `../../suite/e2e/tests/passphrase/passphrase.test.ts` — This test involves adding hidden wallets, switching between multiple passphrase wallets, and verifying wallet identity in the device switcher. Device utility changes could affect how passphrase wallet instances are compared or identified.
- `../../suite/e2e/tests/passphrase/passphrase-numbering.test.ts` — This test verifies sequential numbering of passphrase wallets after adding/ejecting. Device utility functions may be involved in wallet instance identity and ordering logic that determines numbering.

</details>

⚠️ **Changes with no test coverage (5)**
- `suite-common/suite-utils/src/__fixtures__/device.ts`
- `suite-common/suite-utils/src/__tests__/device.test.ts`
- `suite-native/device-manager/src/components/DeviceItem/DeviceItem.tsx`
- `suite-native/device-manager/src/components/DeviceItem/DeviceItemContent.tsx`
- `suite-native/device-manager/src/components/DeviceList.tsx`

_Updated: 2026-05-26T13:35:20.567Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/native/device-item-content&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/native/device-item-content&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/native/device-item-content&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-27T06:40:46.287Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-26T13:39:18.027Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/native/device-item-content/web/](https://dev.suite.sldev.cz/suite-web/refactor/native/device-item-content/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->