### PR TITLE
fix(ci): Fixed paths generated by the LLM analysis

### DIFF
--- a/packages/e2e-utils/src/llmTestAnalyzer/index.ts
+++ b/packages/e2e-utils/src/llmTestAnalyzer/index.ts
@@ -46,6 +46,28 @@ ${testSource}
 
 const hashContent = (content: string): string => createHash('sha256').update(content).digest('hex');
 
+/**
+ * Returns the git root containing `fromDir`, or falls back to `process.cwd()` when git is
+ * unavailable or `fromDir` is outside a git worktree. Using `fromDir` (derived from the test
+ * input path) rather than `process.cwd()` keeps the tool working when invoked from outside the
+ * worktree.
+ */
+const getGitRoot = (fromDir: string): string => {
+    const result = spawnSync('git', ['-C', fromDir, 'rev-parse', '--show-toplevel'], {
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    if (result.error || result.status !== 0) {
+        log(
+            `Could not determine git root from ${fromDir} (${result.error?.message ?? result.stderr.trim()}); falling back to process.cwd()`,
+        );
+
+        return process.cwd();
+    }
+
+    return result.stdout.trim();
+};
+
 const requiredKeys: (keyof ClaudeAnalysis)[] = [
     'behaviors',
     'entry_points',
@@ -359,11 +381,12 @@ const main = async () => {
     }
 
     if (buildCache) {
+        const gitRoot = getGitRoot(path.dirname(testFiles[0]));
         const cache = readCache(cacheFile);
         let failed = 0;
         for (const testFile of testFiles) {
             try {
-                const relPath = path.relative(process.cwd(), testFile);
+                const relPath = path.relative(gitRoot, testFile);
                 const testSource = fs.readFileSync(testFile, 'utf8');
                 const currentHash = hashContent(testSource);
                 const cached = cache[relPath];
@@ -387,10 +410,14 @@ const main = async () => {
             output(JSON.stringify(analysis, null, 2));
         } else {
             const results: Record<string, TestAnalysis> = {};
+            const gitRoot = getGitRoot(path.dirname(testFiles[0]));
             let failed = 0;
             for (const testFile of testFiles) {
                 try {
-                    results[testFile] = await analyzeTestFile(testFile, apiKey);
+                    results[path.relative(gitRoot, testFile)] = await analyzeTestFile(
+                        testFile,
+                        apiKey,
+                    );
                 } catch (err) {
                     error(
                         `Failed to analyze ${testFile}:`,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is `packages/e2e-utils/src/llmTestAnalyzer/index.ts`, which is a meta-tool used for analyzing tests themselves (likely the LLM-based test analysis infrastructure). It is not part of the application runtime, nor is it referenced by any E2E test's execution path based on both static mapping (no coverage found) and LLM analysis of all 51 candidate tests (none mention `llmTestAnalyzer` in their source hints or behaviors). This change carries virtually zero risk of causing any E2E test regression, so no tests are recommended.

<details><summary><b>Changed files (1)</b></summary>

- `packages/e2e-utils/src/llmTestAnalyzer/index.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/e2e-utils/src/llmTestAnalyzer/index.ts`

_Updated: 2026-05-26T14:04:25.484Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-ci-llm-test-analysis-correct-paths&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-ci-llm-test-analysis-correct-paths&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-26T14:10:14.948Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-26T14:08:06.963Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-ci-llm-test-analysis-correct-paths/web/](https://dev.suite.sldev.cz/suite-web/fix-ci-llm-test-analysis-correct-paths/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->