### PR TITLE
fix(suite): suite popup UI details improvements

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectAddressConfirmation.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectAddressConfirmation.tsx
@@ -155,8 +155,13 @@ export const ConnectAddressConfirmation = () => {
                                     justifyContent="space-between"
                                     gap={spacings.sm}
                                 >
-                                    <Row gap={spacings.sm} alignItems="center" flex="1">
-                                        <Paragraph overflowWrap="break-word">
+                                    <Row
+                                        gap={spacings.sm}
+                                        alignItems="center"
+                                        flex="1"
+                                        minWidth={0}
+                                    >
+                                        <Paragraph overflowWrap="anywhere">
                                             {address.address}
                                         </Paragraph>
                                         {address.validated === 'valid' && (

--- a/packages/suite/src/views/settings/SettingsConnectedApps/SettingsConnectedApps.tsx
+++ b/packages/suite/src/views/settings/SettingsConnectedApps/SettingsConnectedApps.tsx
@@ -59,7 +59,7 @@ export const SettingsConnectedApps = () => {
                             </SubTabs.Item>
                         ))}
                     </SubTabs>
-                    <WalletConnectButton handleOpened={() => setActiveItemId('walletconnect')} />
+                    {activeItemdId === 'walletconnect' && <WalletConnectButton />}
                 </Row>
                 {tabs.find(tab => tab.id === activeItemdId)?.component}
             </Column>

--- a/packages/suite/src/views/settings/SettingsConnectedApps/WalletConnectButton.tsx
+++ b/packages/suite/src/views/settings/SettingsConnectedApps/WalletConnectButton.tsx
@@ -7,11 +7,7 @@ import { Button, Input, Modal } from '@trezor/components';
 
 import { useDispatch } from 'src/hooks/suite';
 
-interface WalletConnectButtonProps {
-    handleOpened: () => void;
-}
-
-export const WalletConnectButton = ({ handleOpened }: WalletConnectButtonProps) => {
+export const WalletConnectButton = () => {
     const dispatch = useDispatch();
     const [connectionUrl, setConnectionUrl] = useState('');
     const [modalOpened, setModalOpened] = useState(false);
@@ -34,10 +30,7 @@ export const WalletConnectButton = ({ handleOpened }: WalletConnectButtonProps) 
         setLoading(false);
         setModalOpened(false);
     };
-    const handleOpen = () => {
-        setModalOpened(true);
-        handleOpened();
-    };
+    const handleOpen = () => setModalOpened(true);
     const onCancel = () => setModalOpened(false);
 
     return (


### PR DESCRIPTION



<!--- Provide a general summary of your changes in the Title above -->

## Description

1. In popup when address are longer like in Cardano they get overflow and they are not visible by the user.

* Currently
<img width="1435" height="812" alt="image" src="https://github.com/user-attachments/assets/efd55f0c-af45-4c7e-bc3b-a1febd812c2e" />
* After the fix
<img width="1435" height="812" alt="image" src="https://github.com/user-attachments/assets/11a450a1-8635-4565-87ac-cfd899c95088" />


2. Add wallet connect button should only be visible when WalletConnect tab is active. It seams to me a but that when TrezorConenct tab is active, we still see button to add WalletConnect, it is confusing.
* Currently
<img width="2249" height="647" alt="image" src="https://github.com/user-attachments/assets/0e8786ee-aea8-4bd7-a8cc-85f49058d900" />

* After the fix
<img width="2249" height="647" alt="image" src="https://github.com/user-attachments/assets/671fe000-78e5-4ef1-a20b-3cf76aa61c25" />



## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=popup-ui-impr&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=popup-ui-impr&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-26T14:51:26.190Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-26T14:48:47.827Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/popup-ui-impr/web/](https://dev.suite.sldev.cz/suite-web/popup-ui-impr/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->