### PR TITLE
fix(suite): allow Max button in fiat input mode on stake/unstake form

### DIFF
--- a/packages/suite/src/utils/suite/validation.ts
+++ b/packages/suite/src/utils/suite/validation.ts
@@ -142,7 +142,7 @@ export const validateFiatLimits =
         translationString: TranslationFunction,
         { amountLimits, localCurrency, formatter, decimals, rate }: ValidateFiatLimitsOptions,
     ) =>
-    (value: string) => {
+    (value: string, formValues?: { setMaxOutputId?: number }) => {
         if (value && amountLimits) {
             const currency = amountLimits.currency.toLowerCase();
             const cryptoAmount = fromBaseCurrencyToCryptoUnit({ fiatAmount: value, rate })?.toFixed(
@@ -168,6 +168,9 @@ export const validateFiatLimits =
                     }),
                 });
             }
+
+            // crypto field is source-of-truth in Max mode (fiat round-trip is lossy at the boundary)
+            if (formValues?.setMaxOutputId !== undefined) return;
 
             if (amountLimits.maxFiat && new BigNumber(value).gt(amountLimits.maxFiat)) {
                 if (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The `setMaxOutputId` flag already exists in form state (set on Max click). This change makes `validateFiatLimits` skip its fiat max-check when set - crypto field validates max separately, fiat round-trip is lossy at the boundary, which previously surfaced as a false `Maximum is X ETH` error.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/25756

## Screenshots:

https://github.com/user-attachments/assets/2adf06a8-060e-4a80-ac22-ef8dc5d3c11b

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file `packages/suite/src/utils/suite/validation.ts` is a broad utility mapped to 121 tests, indicating it is a shared validation helper used across the entire Suite application. Without any LLM analysis of candidate tests (the analysis is empty) and no specific information about what was changed within the file, there is no concrete evidence to tie any particular test to the change more than any other. Running all 121 tests would be wasteful, and no single test can be confidently prioritized without understanding the nature of the validation change. If the change is narrow (e.g., a single validation rule fix), a targeted manual review of which forms/flows use that rule would be needed to select tests. In the absence of that information, we recommend no specific tests and flag the file as effectively uncovered by targeted E2E selection.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/utils/suite/validation.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/utils/suite/validation.ts`

_Updated: 2026-05-26T14:56:35.866Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/stake-form-max-fiat-validation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/stake-form-max-fiat-validation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-26T15:02:31.807Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-26T15:00:16.816Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/stake-form-max-fiat-validation/web/](https://dev.suite.sldev.cz/suite-web/fix/stake-form-max-fiat-validation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->