### PR TITLE
chore: remove blake-hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,9 +190,6 @@
         "better-sqlite3": {
             "built": true
         },
-        "blake-hash": {
-            "built": true
-        },
         "detox": {
             "built": true
         },

--- a/packages/suite-desktop/.depcheckrc.json
+++ b/packages/suite-desktop/.depcheckrc.json
@@ -3,7 +3,6 @@
     "ignores": [
         "// Runtime deps for electron-main process. They must be in package.json, since electron-builder is hardwired for it.",
         "openpgp",
-        "usb",
-        "blake-hash"
+        "usb"
     ]
 }

--- a/packages/suite-desktop/electron-builder-config.js
+++ b/packages/suite-desktop/electron-builder-config.js
@@ -27,7 +27,6 @@ module.exports = {
         '!**/*.{md,js.map}', // exclude files unnecessary for runtime
         'build/release-notes.md', // this one is dynamically loaded in runtime
         '!build/static/**/{favicon,icons,bin,browsers}', // copied as extraResources instead, some are platform-specific
-        '!node_modules/blake-hash/**/{build,src}', // exclude files unnecessary for runtime
         '!node_modules/usb/**/{libusb,libusb_config,src}', // exclude files unnecessary for runtime
         '!node_modules/@trezor/**', // exclude @trezor/suite-desktop, which would recurse. Other @trezor packages are bundled by bundler.
     ],

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -28,7 +28,6 @@
         "_______ DO NOT REMOVE DEPENDENCIES unless you are sure of consequences! _______": "In this package they have special meaning, see core.webpack.config"
     },
     "dependencies": {
-        "blake-hash": "^2.0.0",
         "openpgp": "^6.3.0",
         "usb": "^2.17.0"
     },

--- a/packages/utxo-lib/src/types/blake-hash.d.ts
+++ b/packages/utxo-lib/src/types/blake-hash.d.ts
@@ -1,1 +1,0 @@
-declare module 'blake-hash';

--- a/scripts/list-outdated-dependencies/wallet-dependencies.txt
+++ b/scripts/list-outdated-dependencies/wallet-dependencies.txt
@@ -31,7 +31,6 @@ abortcontroller-polyfill
 ajv
 bignumber.js
 bitcoin-ops
-blake-hash
 bn.js
 cashaddrjs
 event-target-shim

--- a/yarn.lock
+++ b/yarn.lock
@@ -16230,7 +16230,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/suite-desktop@workspace:packages/suite-desktop"
   dependencies:
-    blake-hash: "npm:^2.0.0"
     electron: "npm:41.3.0"
     electron-builder: "npm:26.8.1"
     openpgp: "npm:^6.3.0"
@@ -20659,18 +20658,6 @@ __metadata:
     inherits: "npm:^2.0.4"
     readable-stream: "npm:^3.4.0"
   checksum: 10/b7904e66ed0bdfc813c06ea6c3e35eafecb104369dbf5356d0f416af90c1546de3b74e5b63506f0629acf5e16a6f87c3798f16233dcff086e9129383aa02ab55
-  languageName: node
-  linkType: hard
-
-"blake-hash@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "blake-hash@npm:2.0.0"
-  dependencies:
-    node-addon-api: "npm:^3.0.0"
-    node-gyp: "npm:latest"
-    node-gyp-build: "npm:^4.2.2"
-    readable-stream: "npm:^3.6.0"
-  checksum: 10/91cb584c2c98bfeb94f2fe01ab1663577fd8a69c330b03ea071ce53eda8e3e28293da891e3eacd78a95ad1275325cf7055e39294535c0474f297ada373083fd2
   languageName: node
   linkType: hard
 
@@ -36587,7 +36574,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-gyp-build@npm:^4.2.2, node-gyp-build@npm:^4.5.0":
+"node-gyp-build@npm:^4.5.0":
   version: 4.8.4
   resolution: "node-gyp-build@npm:4.8.4"
   bin:
@@ -44399,8 +44386,6 @@ __metadata:
     bcrypto:
       built: true
     better-sqlite3:
-      built: true
-    blake-hash:
       built: true
     detox:
       built: true


### PR DESCRIPTION
## Description

Remove `blake-hash` lib, which is unused after 19276ace9399278d1786988591977ffc4fa887c9
Because it was one of the electron-main runtime requires, it was depcheckignored, and that's why we didn't know it is no longer used!

[The current implementation](https://github.com/trezor/trezor-suite/blob/177f7b654cb173d7f2197bc07aed2ec44bd82eba/packages/utxo-lib/src/crypto.ts#L5) uses `@noble/hashes/blake1.js` instead. And as far as I can tell, it is only used for Decred networks ([here](https://github.com/trezor/trezor-suite/blob/47c184a8592e12f72d3d8f037c7aa18587262359/packages/utxo-lib/src/transaction/decred.ts), [here](https://github.com/trezor/trezor-suite/blob/19276ace9399278d1786988591977ffc4fa887c9/packages/utxo-lib/src/bip32.ts#L153), [here](https://github.com/trezor/trezor-suite/blob/19276ace9399278d1786988591977ffc4fa887c9/packages/utxo-lib/src/bip32.ts#L358)), so it is not even visible in Suite.

## QA notes

I am almost sure this is dead code and won't affect anything, but if I'm wrong, it would break address validation in Send Form, and BIP-32 derivations (deriving accounts and their addresses).

But that is covered by E2E `receive.test.ts, send.test.ts`, so IMO no QA needed.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set is low-risk, consisting primarily of configuration and build-related files: root package.json, suite-desktop depcheck config, electron-builder config, suite-desktop package.json, and a TypeScript type declaration for blake-hash. None of these files contain runtime application logic, so the risk of functional regression is minimal. The most plausible impact is on the Electron desktop build and packaging pipeline, which could affect bridge spawning behavior. The blake-hash type declaration change in utxo-lib is purely a TypeScript type fix with no runtime effect. A minimal set of desktop-specific bridge tests is recommended to verify the Electron app still builds and runs correctly.

<details><summary><b>Changed files (5)</b></summary>

- `package.json`
- `packages/suite-desktop/.depcheckrc.json`
- `packages/suite-desktop/electron-builder-config.js`
- `packages/suite-desktop/package.json`
- `packages/utxo-lib/src/types/blake-hash.d.ts`

</details>

**Recommended tests (3)**

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `../../suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — Changes to packages/suite-desktop/package.json and electron-builder-config.js could affect the Electron app build, packaging, and bundled dependencies including the node-bridge process. This test validates that the desktop app correctly spawns and manages the bridge process lifecycle, which is directly tied to the desktop packaging configuration.
- `../../suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — Changes to the suite-desktop package.json and electron-builder config could affect how the daemon mode bridge process is spawned and managed. This test specifically validates the bridge daemon lifecycle in the Electron app, which depends on correct desktop packaging and dependency configuration.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `../../suite/e2e/tests/trezor-connect/error.test.ts` — This test runs in the desktop Electron app with coreMode 'suite-desktop'. Changes to suite-desktop package.json and electron-builder config could affect the Electron app's ability to initialize TrezorConnect in desktop mode. The test validates basic error handling in the desktop connect flow.

</details>

⚠️ **Changes with no test coverage (3)**
- `package.json`
- `packages/suite-desktop/.depcheckrc.json`
- `packages/utxo-lib/src/types/blake-hash.d.ts`

_Updated: 2026-05-26T16:31:39.063Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=remove-blake-hash&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=remove-blake-hash&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-26T16:38:04.850Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-26T16:34:59.284Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/remove-blake-hash/web/](https://dev.suite.sldev.cz/suite-web/remove-blake-hash/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->