### PR TITLE
chore: remove react-native-get-random-values

### DIFF
--- a/scripts/list-outdated-dependencies/trade-dependencies.txt
+++ b/scripts/list-outdated-dependencies/trade-dependencies.txt
@@ -60,7 +60,6 @@ react
 react-dom
 react-error-boundary
 react-native
-react-native-get-random-values
 react-native-launch-arguments
 react-native-performance
 react-native-permissions

--- a/suite-native/app/globalPolyfills.js
+++ b/suite-native/app/globalPolyfills.js
@@ -15,7 +15,6 @@ import isSubsetOf from 'set.prototype.issubsetof';
 import isSupersetOf from 'set.prototype.issupersetof';
 import symmetricDifference from 'set.prototype.symmetricdifference';
 import union from 'set.prototype.union';
-import 'react-native-get-random-values';
 
 // Event, EventTarget and CustomEvent are needed for @solana/kit to work
 globalThis.Event = Event;

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -145,7 +145,6 @@
         "react-native-ble-plx": "3.5.1",
         "react-native-edge-to-edge": "1.7.0",
         "react-native-gesture-handler": "2.31.1",
-        "react-native-get-random-values": "^2.0.0",
         "react-native-keyboard-controller": "1.20.7",
         "react-native-launch-arguments": "^4.1.1",
         "react-native-mmkv": "~4.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11602,7 +11602,6 @@ __metadata:
     react-native-ble-plx: "npm:3.5.1"
     react-native-edge-to-edge: "npm:1.7.0"
     react-native-gesture-handler: "npm:2.31.1"
-    react-native-get-random-values: "npm:^2.0.0"
     react-native-keyboard-controller: "npm:1.20.7"
     react-native-launch-arguments: "npm:^4.1.1"
     react-native-mmkv: "npm:~4.3.0"
@@ -27220,13 +27219,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-base64-decode@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "fast-base64-decode@npm:1.0.0"
-  checksum: 10/4c59eb1775a7f132333f296c5082476fdcc8f58d023c42ed6d378d2e2da4c328c7a71562f271181a725dd17cdaa8f2805346cc330cdbad3b8e4b9751508bd0a3
-  languageName: node
-  linkType: hard
-
 "fast-content-type-parse@npm:^2.0.0":
   version: 2.0.1
   resolution: "fast-content-type-parse@npm:2.0.1"
@@ -39871,17 +39863,6 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 10/0f02d989fddae1a59f3595b8039da04e8332206e0e8f7e05548b1ab2e57b6efa1b37d634ac8e5cc85b1844363a78f2f1400ace26164319b2140e994b0e779ea3
-  languageName: node
-  linkType: hard
-
-"react-native-get-random-values@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "react-native-get-random-values@npm:2.0.0"
-  dependencies:
-    fast-base64-decode: "npm:^1.0.0"
-  peerDependencies:
-    react-native: ">=0.81"
-  checksum: 10/f55218ac9710f9d329f0cfb1d8dce9765b4d06fdd2b9f966ed0476298f8373875679caf68b44f4e3b363abe81d1cb6f4c47b45f58b87eae63bd54776beeded46
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Remove `react-native-get-random-values` which is overwritten by later `react-native-quick-crypto` and does nothing.

See globalPolyfills file:
The `react-native-get-random-values` executes the global polyfills [as a side-effect](https://github.com/LinusU/react-native-get-random-values/blob/d1262246e6fdd7a73e12f22ccaa6e38606ae8890/index.js#L75-L81), while quick-crypto exposes [an install function that does it](https://github.com/margelo/react-native-quick-crypto/blob/ecedb805ae21358aa45efc9624bc6dfaca87f672/packages/react-native-quick-crypto/src/index.ts#L73-L94). The install function is called later at L30, so it overwrites the side-effect on L18.

I have verified this experimentally, that when you call `crypto.getRandomValues` in react-native, it is indeed the quick-crypto function that is called :heavy_check_mark: 

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=remove-react-native-get-random-values&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=remove-react-native-get-random-values&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=remove-react-native-get-random-values&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-26T17:39:43.536Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-26T17:36:29.652Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/remove-react-native-get-random-values/web/](https://dev.suite.sldev.cz/suite-web/remove-react-native-get-random-values/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->