### PR TITLE
style(suite): Polish UI according to design critique

### DIFF
--- a/packages/components/src/components/skeletons/SkeletonRectangle.stories.tsx
+++ b/packages/components/src/components/skeletons/SkeletonRectangle.stories.tsx
@@ -15,6 +15,8 @@ import {
     SkeletonRectangle as SkeletonRectangleComponent,
     type SkeletonRectangleProps,
 } from './SkeletonRectangle';
+import { allowedSkeletonFrameProps } from './utils';
+import { getFramePropsStory } from '../../utils/frameProps';
 import { ElevationContext, ElevationUp, useElevation } from '../ElevationContext/ElevationContext';
 
 const UiBox = styled.div<{ $elevation: Elevation }>`
@@ -61,9 +63,13 @@ export const SkeletonRectangle: StoryObj<SkeletonRectangleProps> = {
         </ElevationContext>
     ),
     args: {
-        width: 120,
-        height: 20,
-        borderRadius: 4,
         animate: true,
+        ...getFramePropsStory(allowedSkeletonFrameProps).args,
+    },
+    argTypes: {
+        animate: {
+            type: 'boolean',
+        },
+        ...getFramePropsStory(allowedSkeletonFrameProps).argTypes,
     },
 };

--- a/packages/components/src/components/skeletons/SkeletonRectangle.tsx
+++ b/packages/components/src/components/skeletons/SkeletonRectangle.tsx
@@ -3,23 +3,19 @@ import styled, { css } from 'styled-components';
 import { type Elevation, borders, mapElevationToBackground } from '@trezor/theme';
 
 import { type SkeletonBaseProps } from './types';
-import { getValue, shimmerEffect } from './utils';
+import { type AllowedFrameProps, allowedSkeletonFrameProps, shimmerEffect } from './utils';
+import { pickAndPrepareFrameProps, withFrameProps } from '../../utils/frameProps';
 import { type TransientProps } from '../../utils/transientProps';
 import { useElevation } from '../ElevationContext/ElevationContext';
 
-export type SkeletonRectangleProps = SkeletonBaseProps & {
-    width?: string | number;
-    height?: string | number;
-    borderRadius?: string | number;
-};
+export type SkeletonRectangleProps = SkeletonBaseProps & AllowedFrameProps;
 
 const StyledSkeletonRectangle = styled.div<
-    TransientProps<SkeletonRectangleProps> & { $elevation: Elevation }
+    TransientProps<SkeletonRectangleProps> & {
+        $elevation: Elevation;
+    } & TransientProps<AllowedFrameProps>
 >`
-    width: ${({ $width }) => getValue($width) ?? '80px'};
-    height: ${({ $height }) => getValue($height) ?? '20px'};
     background: ${({ $background, ...props }) => $background ?? mapElevationToBackground(props)};
-    border-radius: ${({ $borderRadius }) => getValue($borderRadius) ?? borders.radii.xs};
     background-size: 200%;
 
     ${props =>
@@ -27,19 +23,29 @@ const StyledSkeletonRectangle = styled.div<
         css<{ $elevation: Elevation }>`
             ${shimmerEffect}
         `}
+
+    ${withFrameProps}
 `;
 
-export const SkeletonRectangle = (props: SkeletonRectangleProps) => {
+export const SkeletonRectangle = ({ animate, background, ...rest }: SkeletonRectangleProps) => {
     const { elevation } = useElevation();
+
+    const frameProps = pickAndPrepareFrameProps(
+        {
+            width: 80,
+            height: 20,
+            borderRadius: borders.radii.xs,
+            ...rest,
+        },
+        allowedSkeletonFrameProps,
+    );
 
     return (
         <StyledSkeletonRectangle
             $elevation={elevation}
-            $borderRadius={props.borderRadius}
-            $width={props.width}
-            $height={props.height}
-            $animate={props.animate}
-            $background={props.background}
+            $animate={animate}
+            $background={background}
+            {...frameProps}
         />
     );
 };

--- a/packages/components/src/components/skeletons/utils.ts
+++ b/packages/components/src/components/skeletons/utils.ts
@@ -3,6 +3,15 @@ import { css, keyframes } from 'styled-components';
 import { type Elevation, mapElevationToBackground } from '@trezor/theme';
 
 import { mapElevationToSkeletonForeground } from './colors';
+import { type FrameProps, type FramePropsKeys } from '../../utils/frameProps';
+
+export const allowedSkeletonFrameProps = [
+    'margin',
+    'width',
+    'height',
+    'borderRadius',
+] as const satisfies FramePropsKeys[];
+export type AllowedFrameProps = Pick<FrameProps, (typeof allowedSkeletonFrameProps)[number]>;
 
 const SHINE = keyframes`
     from {

--- a/packages/suite/src/components/guide/GuideViewWrapper.tsx
+++ b/packages/suite/src/components/guide/GuideViewWrapper.tsx
@@ -3,10 +3,11 @@ import { type ReactNode, type UIEventHandler, createContext, useCallback, useSta
 import styled from 'styled-components';
 
 import { variables } from '@trezor/components';
-import { type Elevation, mapElevationToBackground } from '@trezor/theme';
+import { type Elevation, mapElevationToBackground, mapElevationToBorder } from '@trezor/theme';
 
 const Wrapper = styled.div<{ $elevation: Elevation }>`
     background: ${mapElevationToBackground};
+    border-left: 1px solid ${mapElevationToBorder};
     display: flex;
     height: 100%;
     flex-direction: column;

--- a/packages/suite/src/components/suite/graph/GraphSkeleton.tsx
+++ b/packages/suite/src/components/suite/graph/GraphSkeleton.tsx
@@ -20,7 +20,7 @@ const SkeletonWrapper = styled.div`
 `;
 
 const SkeletonBar = (props: ComponentProps<typeof SkeletonRectangle>) => (
-    <SkeletonRectangle borderRadius="4px 4px 0px 0px" {...props} />
+    <SkeletonRectangle borderRadius={2} {...props} />
 );
 
 interface GraphSkeletonProps {

--- a/packages/suite/src/components/wallet/AccountExceptionLayout.tsx
+++ b/packages/suite/src/components/wallet/AccountExceptionLayout.tsx
@@ -38,7 +38,7 @@ export const AccountExceptionLayout = (props: AccountExceptionLayoutProps) => (
             <Paragraph
                 intent="neutral"
                 priority="secondary"
-                typographyStyle="body-sm"
+                typographyStyle="body-md"
                 margin={{ top: spacings.xs }}
                 align="center"
             >

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItemSkeleton.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItemSkeleton.tsx
@@ -22,13 +22,9 @@ export const AccountItemSkeleton = () => {
     }
 
     return (
-        <Row
-            gap={spacings.md}
-            margin={{ left: spacings.xs }}
-            data-testid="@account-menu/account-item-skeleton"
-        >
-            <SkeletonCircle size="24px" />
-            <Column alignItems="flex-start" gap={spacings.xs}>
+        <Row gap={spacings.md} margin={8} data-testid="@account-menu/account-item-skeleton">
+            <SkeletonCircle size="24px" animate={shouldAnimate} />
+            <Column alignItems="flex-start" gap={2}>
                 <SkeletonRectangle width="140px" animate={shouldAnimate} />
                 <SkeletonRectangle animate={shouldAnimate} />
             </Column>

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
@@ -205,11 +205,11 @@ export const AccountsList = ({
 
     if (isSidebarCollapsed) return <AccountsMenuNotice />;
 
+    if (!searchString) return null;
+
     return (
         <AccountsMenuNotice>
-            <Translation
-                id={!searchString ? 'TR_ACCOUNT_NO_ACCOUNTS' : 'TR_ACCOUNT_SEARCH_NO_RESULTS'}
-            />
+            <Translation id="TR_ACCOUNT_SEARCH_NO_RESULTS" />
         </AccountsMenuNotice>
     );
 };

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenuHeader.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenuHeader.tsx
@@ -55,7 +55,7 @@ export const AccountsMenuHeader = () => {
                 <ExpandedSidebarOnly>
                     <Row gap={12} padding={{ right: !isEmpty ? 10 : 0 }}>
                         {isDiscoveryRunning ? (
-                            <SkeletonRectangle animate width="100%" height={38} />
+                            <SkeletonRectangle animate width="100%" height={20} />
                         ) : (
                             <>
                                 {!isEmpty && <AccountSearchBox />}

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenuHeader.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenuHeader.tsx
@@ -55,7 +55,12 @@ export const AccountsMenuHeader = () => {
                 <ExpandedSidebarOnly>
                     <Row gap={12} padding={{ right: !isEmpty ? 10 : 0 }}>
                         {isDiscoveryRunning ? (
-                            <SkeletonRectangle animate width="100%" height={20} />
+                            <SkeletonRectangle
+                                animate
+                                width="100%"
+                                height={20}
+                                margin={{ left: 4 }}
+                            />
                         ) : (
                             <>
                                 {!isEmpty && <AccountSearchBox />}

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenuHeader.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenuHeader.tsx
@@ -87,7 +87,7 @@ export const AccountsMenuHeader = () => {
                                     </Tooltip>
                                 )}
 
-                                <AddAccountButton isIconOnly={!isEmpty} device={device} />
+                                {!isEmpty && <AddAccountButton device={device} />}
                             </>
                         )}
                     </Row>
@@ -95,7 +95,7 @@ export const AccountsMenuHeader = () => {
                 </ExpandedSidebarOnly>
                 <CollapsedSidebarOnly>
                     <Column alignItems="center" margin={{ bottom: 12 }}>
-                        <AddAccountButton isIconOnly={true} device={device} />
+                        {!isEmpty && <AddAccountButton device={device} />}
                     </Column>
                 </CollapsedSidebarOnly>
             </Box>

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AddAccountButton.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AddAccountButton.tsx
@@ -1,6 +1,6 @@
 import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
-import { Button, Icon, TOOLTIP_DELAY_NORMAL, Tooltip } from '@trezor/components';
+import { Icon, TOOLTIP_DELAY_NORMAL, Tooltip } from '@trezor/components';
 
 import { useDiscovery, useDispatch } from 'src/hooks/suite';
 import { type TrezorDevice } from 'src/types/suite';
@@ -15,10 +15,9 @@ const getExplanationMessage = (device: TrezorDevice | undefined, discoveryIsRunn
 
 type AddAccountButtonProps = {
     device: TrezorDevice | undefined;
-    isIconOnly?: boolean;
 };
 
-export const AddAccountButton = ({ device, isIconOnly }: AddAccountButtonProps) => {
+export const AddAccountButton = ({ device }: AddAccountButtonProps) => {
     const { isDiscoveryRunning } = useDiscovery();
     const dispatch = useDispatch();
 
@@ -40,7 +39,7 @@ export const AddAccountButton = ({ device, isIconOnly }: AddAccountButtonProps) 
         );
     };
 
-    const ButtonComponent = isIconOnly ? (
+    const ButtonComponent = (
         <Tooltip isActive={!tooltipMessage} content={<Translation id="TR_ADD_ACCOUNT" />}>
             <Icon
                 onClick={device ? handleOnClick : undefined}
@@ -52,18 +51,6 @@ export const AddAccountButton = ({ device, isIconOnly }: AddAccountButtonProps) 
                 data-testid={dataTestId}
             />
         </Tooltip>
-    ) : (
-        <Button
-            onClick={device ? handleOnClick : undefined}
-            iconLeft="plus"
-            isDisabled={addAccountDisabled}
-            intent="neutral"
-            priority="secondary"
-            width="100%"
-            data-testid={dataTestId}
-        >
-            <Translation id="TR_ADD_ACCOUNT" />
-        </Button>
     );
 
     return (
@@ -74,7 +61,6 @@ export const AddAccountButton = ({ device, isIconOnly }: AddAccountButtonProps) 
             placement="bottom"
             cursor="not-allowed"
             delayShow={TOOLTIP_DELAY_NORMAL}
-            width={isIconOnly ? undefined : '100%'}
         >
             {ButtonComponent}
         </Tooltip>

--- a/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetRowSkeleton.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetRowSkeleton.tsx
@@ -32,8 +32,8 @@ export const AssetRowSkeleton = ({ isAnimating }: AssetRowSkeletonProps) => {
             </Table.Cell>
             <Table.Cell colSpan={2}>
                 <Row gap={16}>
-                    <SkeletonRectangle animate={animate} width={58} height={38} borderRadius={19} />
-                    <SkeletonRectangle animate={animate} width={38} height={38} borderRadius={25} />
+                    <SkeletonRectangle animate={animate} width={58} height={38} borderRadius={20} />
+                    <SkeletonRectangle animate={animate} width={38} height={38} borderRadius={24} />
                 </Row>
             </Table.Cell>
         </Table.Row>

--- a/packages/suite/src/views/dashboard/PortfolioCard/EmptyWallet.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/EmptyWallet.tsx
@@ -53,7 +53,7 @@ export const EmptyWallet = () => {
             <Paragraph
                 intent="neutral"
                 priority="secondary"
-                typographyStyle="body-sm"
+                typographyStyle="body-md"
                 maxWidth={500}
                 align="center"
             >
@@ -81,7 +81,7 @@ export const EmptyWallet = () => {
                 <Button
                     intent="brand"
                     iconLeft="currencyCircleDollar"
-                    size="large"
+                    size="medium"
                     onClick={handleBuy}
                     data-testid="@dashboard/empty-wallet/buy"
                 >
@@ -90,7 +90,7 @@ export const EmptyWallet = () => {
                 <Button
                     intent="brand"
                     iconLeft="arrowDown"
-                    size="large"
+                    size="medium"
                     onClick={handleReceive}
                     data-testid="@dashboard/empty-wallet/receive"
                 >

--- a/packages/suite/src/views/wallet/transactions/components/AccountEmpty.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/AccountEmpty.tsx
@@ -79,6 +79,7 @@ export const AccountEmpty = ({ account }: AccountEmptyProps) => {
                     key: '1',
                     onClick: handleNavigateToBuyPage,
                     iconLeft: 'currencyCircleDollar',
+                    size: 'medium',
                     children: isTokensNetwork ? (
                         <Translation id="TR_BUY" />
                     ) : (
@@ -93,6 +94,7 @@ export const AccountEmpty = ({ account }: AccountEmptyProps) => {
                     key: '2',
                     onClick: handleNavigateToReceivePage,
                     iconLeft: 'arrowDown',
+                    size: 'medium',
                     children: isTokensNetwork ? (
                         <Translation id="TR_RECEIVE" />
                     ) : (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

https://www.figma.com/design/7XszcGNCeQS7AGpH6rmoSe/Assets?node-id=3649-46841&t=btLsKryAV63eB8MZ-0

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies UI components in the wallet layout sidebar (AccountsMenu: AccountsList, AccountsMenuHeader, AccountItemSkeleton), wallet exception handling layout (AccountExceptionLayout), and two empty-state views (EmptyWallet on dashboard, AccountEmpty on transactions). Since all changed files are broadly imported UI components (each mapping to 59-121 tests), the risk is primarily visual/rendering regressions rather than logic errors. The recommended strategy focuses on tests that directly exercise these specific views: wallet discovery (which shows accounts loading and empty states), dashboard rendering, and wallet navigation flows where these components are visible.

<details><summary><b>Changed files (6)</b></summary>

- `packages/suite/src/components/wallet/AccountExceptionLayout.tsx`
- `packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItemSkeleton.tsx`
- `packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx`
- `packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenuHeader.tsx`
- `packages/suite/src/views/dashboard/PortfolioCard/EmptyWallet.tsx`
- `packages/suite/src/views/wallet/transactions/components/AccountEmpty.tsx`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/general/wallet-discovery.test.ts` — This test directly exercises wallet discovery, which renders the AccountsMenu (AccountsList, AccountsMenuHeader, AccountItemSkeleton), the EmptyWallet dashboard view, and AccountEmpty transaction view — all of which are changed. A rendering regression in any of these components would be caught here.
- `suite/e2e/tests/dashboard/assets.test.ts` — The dashboard assets test directly renders the dashboard portfolio view which includes EmptyWallet.tsx and exercises the accounts menu sidebar with AccountsList and AccountsMenuHeader. Changes to these UI components could break dashboard rendering.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/wallet/send-form/send-bitcoin.test.ts` — Send form tests navigate through wallet views where AccountExceptionLayout and the AccountsMenu components are rendered. Changes to these layout components could affect navigation and rendering of wallet transaction views.
- `suite/e2e/tests/wallet/receive/bitcoin-address.test.ts` — Receive address tests navigate the wallet layout where AccountsMenu components (AccountsList, AccountsMenuHeader) and AccountExceptionLayout are actively rendered. UI changes to these could break the wallet receive flow.
- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — Discreet mode test renders dashboard views including the EmptyWallet component and exercises account-related UI. Changes to EmptyWallet.tsx or AccountsMenu components could affect how discreet mode renders these elements.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — Passphrase tests navigate into wallet views with empty accounts, directly exercising AccountEmpty.tsx and the accounts menu sidebar. Changes to these empty-state components could break the passphrase wallet flow.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — Custom backend settings test interacts with account views that may show AccountExceptionLayout when backend is misconfigured, and navigates through AccountsMenu. Changes to exception layout rendering could affect this flow.

</details>

_Updated: 2026-05-27T08:47:38.982Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=polish-ui-according-to-dcq&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=polish-ui-according-to-dcq&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-27T10:42:05.561Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-27T12:26:20.809Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/polish-ui-according-to-dcq/web/](https://dev.suite.sldev.cz/suite-web/polish-ui-according-to-dcq/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->