### PR TITLE
refactor(address-validator): strongly type Currency.hashFunction

### DIFF
--- a/packages/address-validator/src/bitcoin_validator.ts
+++ b/packages/address-validator/src/bitcoin_validator.ts
@@ -2,7 +2,7 @@ import * as base58 from './crypto/base58';
 import * as bech32 from './crypto/bech32';
 import * as cryptoUtils from './crypto/utils';
 import { addressType } from './crypto/utils';
-import type { Currency, NetworkEnvironment } from './currency-types';
+import type { Currency, HashFunction, NetworkEnvironment } from './currency-types';
 
 const DEFAULT_NETWORK: NetworkEnvironment = 'prod';
 
@@ -15,7 +15,7 @@ function getDecoded(address: string): number[] | null {
     }
 }
 
-function getChecksum(hashFunction: string | undefined, payload: string): string {
+function getChecksum(hashFunction: HashFunction, payload: string): string {
     // Each currency may implement different hashing algorithm
     switch (hashFunction) {
         // blake then keccak hash chain
@@ -31,7 +31,6 @@ function getChecksum(hashFunction: string | undefined, payload: string): string 
         case 'groestl512x2':
             return cryptoUtils.groestl512x2(payload);
         case 'sha256':
-        default:
             return cryptoUtils.sha256Checksum(payload);
     }
 }
@@ -40,7 +39,7 @@ function getAddressTypeHex(address: string, currency: any): string | null {
     currency = currency || {};
     // should be 25 bytes per btc address spec and 26 decred
     const expectedLength = currency.expectedLength || 25;
-    const hashFunction = currency.hashFunction || 'sha256';
+    const hashFunction: HashFunction = currency.hashFunction || 'sha256';
     const decoded = getDecoded(address);
     if (decoded) {
         const { length } = decoded;

--- a/packages/address-validator/src/currency-types.ts
+++ b/packages/address-validator/src/currency-types.ts
@@ -2,6 +2,13 @@ import type { addressType } from './crypto/utils';
 
 type AddressType = (typeof addressType)[keyof typeof addressType];
 
+export type HashFunction =
+    | 'sha256'
+    | 'blake256'
+    | 'blake256keccak256'
+    | 'keccak256'
+    | 'groestl512x2';
+
 export type NetworkEnvironment =
     | 'prod'
     | 'testnet'
@@ -33,6 +40,6 @@ export interface Currency {
     iAddressTypes?: Record<string, (string | number)[]>;
     subAddressTypes?: Record<string, (string | number)[]>;
     expectedLength?: number;
-    hashFunction?: string;
+    hashFunction?: HashFunction;
     regex?: RegExp;
 }


### PR DESCRIPTION
Prerequisite for #27403 (dropping the `groestl-hash-js` dependency).

Follow-up that does the actual drop: #28092 (stacked on this PR).

## Summary

- Introduce `HashFunction` string-literal union: `'sha256' | 'blake256' | 'blake256keccak256' | 'keccak256' | 'groestl512x2'`.
- Type `Currency.hashFunction` and `getChecksum`'s parameter with it.
- Drop the `default:` fallback in `getChecksum` — switch is now exhaustive over the union.
- Move the `'sha256'` default to the call site in `getAddressTypeHex`.
- Re-export `HashFunction` from the package entrypoint.

## Why

Type-level only — no `Currency` in `currencies.ts` currently sets `hashFunction`, and no monorepo consumer passes it (verified via grep), so the runtime behavior and the public surface are unchanged.

Tightening the type now means dropping `'groestl512x2'` in the follow-up PR will surface as a compile error on the single `case 'groestl512x2'` branch in `getChecksum`, making the removal mechanical.

## Test plan

- [ ] `yarn workspace @trezor/address-validator type-check`
- [ ] `yarn workspace @trezor/address-validator test:unit`

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are in the address-validator package, specifically targeting the Bitcoin validator, currency type definitions, and the package's main index/export file. This is a moderate-risk change because address validation is critical for send flows across multiple cryptocurrencies — an incorrect validation could either block legitimate transactions or allow invalid addresses. The highest risk is to Bitcoin send flows (regtest, CSV import, pending transactions) since bitcoin_validator.ts was directly modified. Secondary risk extends to BTC-like coins (LTC, DOGE) and trading flows involving BTC addresses. Non-Bitcoin chains (ETH, SOL) are lower risk unless the index.ts or currency-types.ts changes affected the shared validation API.

<details><summary><b>Changed files (3)</b></summary>

- `packages/address-validator/src/bitcoin_validator.ts`
- `packages/address-validator/src/currency-types.ts`
- `packages/address-validator/src/index.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `../../suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test exercises the Bitcoin send form with recipient address inputs on regtest. The address-validator package validates Bitcoin addresses entered in send forms, so changes to bitcoin_validator.ts could cause address validation failures or false acceptances in the send flow.
- `../../suite/e2e/tests/wallet/pending-transactions.test.ts` — This test sends Bitcoin transactions with multiple outputs on regtest, requiring valid BTC address entry in the send form. Changes to the Bitcoin address validator directly impact whether recipient addresses are accepted or rejected during the send flow.
- `../../suite/e2e/tests/wallet/import-btc-csv.test.ts` — This test imports a CSV file with BTC addresses into the send form. The address-validator is used to validate imported Bitcoin addresses, so changes to bitcoin_validator.ts or currency-types.ts could break CSV import address parsing/validation.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `../../suite/e2e/tests/wallet/send-doge.test.ts` — DOGE uses Bitcoin-like address formats. Changes to currency-types.ts (which likely defines supported currency types) and the address validator index could affect DOGE address validation in the send form.
- `../../suite/e2e/tests/wallet/send-form-ltc.test.ts` — LTC uses Bitcoin-derived address formats. Changes to bitcoin_validator.ts (which may handle BTC-like address validation for LTC) and currency-types.ts could affect LTC address validation in the send form.
- `../../suite/e2e/tests/trading/sell-bitcoin.test.ts` — This test involves a Bitcoin sell flow where destination addresses are validated. Changes to bitcoin_validator.ts could affect how the trading sell confirmation validates BTC addresses from the provider.
- `../../suite/e2e/tests/trading/buy-bitcoin.test.ts` — The buy BTC flow involves selecting a receive address and confirming trade details with BTC addresses. Address validation changes could affect the buy flow's address handling.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `../../suite/e2e/tests/wallet/send-sol.test.ts` — Changes to currency-types.ts and the validator index module could affect non-Bitcoin currency validation if the refactoring altered the exported API or type definitions used by Solana address validation.
- `../../suite/e2e/tests/wallet/send-eth.test.ts` — Changes to currency-types.ts and index.ts could affect Ethereum address validation if the module's exported interface or currency type registry was modified.
- `../../suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test configures custom backends for BTC and ETH and triggers discovery. If address validation is involved in backend URL or account address validation, changes could have an indirect effect.

</details>

_Updated: 2026-05-27T08:58:18.552Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/address-validator-hashfunction-typed&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/address-validator-hashfunction-typed&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-27T09:06:39.161Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-27T09:04:05.958Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/address-validator-hashfunction-typed/web/](https://dev.suite.sldev.cz/suite-web/mroz22/address-validator-hashfunction-typed/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->
