### PR TITLE
feat(address-validator)!: drop groestl-hash-js dependency

### DIFF
--- a/packages/address-validator/package.json
+++ b/packages/address-validator/package.json
@@ -31,7 +31,6 @@
         "@scure/base": "^2.0.0",
         "cbor": "^10.0.12",
         "crc": "^3.8.0",
-        "groestl-hash-js": "1.0.0",
         "jssha": "2.3.1"
     },
     "devDependencies": {

--- a/packages/address-validator/src/bitcoin_validator.ts
+++ b/packages/address-validator/src/bitcoin_validator.ts
@@ -28,8 +28,6 @@ function getChecksum(hashFunction: HashFunction, payload: string): string {
             return cryptoUtils.blake256Checksum(payload);
         case 'keccak256':
             return cryptoUtils.keccak256Checksum(payload);
-        case 'groestl512x2':
-            return cryptoUtils.groestl512x2(payload);
         case 'sha256':
             return cryptoUtils.sha256Checksum(payload);
     }

--- a/packages/address-validator/src/crypto/utils.ts
+++ b/packages/address-validator/src/crypto/utils.ts
@@ -1,4 +1,3 @@
-import groestl from 'groestl-hash-js';
 import jsSHA from 'jssha';
 
 import * as base32Module from './base32';
@@ -139,12 +138,6 @@ export function keccak256Checksum(payload: string | Buffer | Uint8Array): string
 
 export function blake2b256(hexString: string): string {
     return new (Blake2B as any)(32).update(Buffer.from(hexString, 'hex'), 32).digest('hex');
-}
-
-export function groestl512x2(hexString: string): string {
-    const result = groestl.groestl_2(Buffer.from(hexString, 'hex'), 1, 0).substr(0, 8);
-
-    return result;
 }
 
 export function bigNumberToBuffer(bignumber: number | string, size?: number): Buffer {

--- a/packages/address-validator/src/currency-types.ts
+++ b/packages/address-validator/src/currency-types.ts
@@ -2,12 +2,7 @@ import type { addressType } from './crypto/utils';
 
 type AddressType = (typeof addressType)[keyof typeof addressType];
 
-export type HashFunction =
-    | 'sha256'
-    | 'blake256'
-    | 'blake256keccak256'
-    | 'keccak256'
-    | 'groestl512x2';
+export type HashFunction = 'sha256' | 'blake256' | 'blake256keccak256' | 'keccak256';
 
 export type NetworkEnvironment =
     | 'prod'

--- a/packages/address-validator/src/types.d.ts
+++ b/packages/address-validator/src/types.d.ts
@@ -1,3 +1,2 @@
 declare module 'crc';
-declare module 'groestl-hash-js';
 declare module 'jssha';

--- a/scripts/list-outdated-dependencies/connect-dependencies.txt
+++ b/scripts/list-outdated-dependencies/connect-dependencies.txt
@@ -44,7 +44,6 @@ escape-string-regexp
 flexsearch
 focus-visible
 git-url-parse
-groestl-hash-js
 html-inline-script-webpack-plugin
 http-server
 intersection-observer

--- a/yarn.lock
+++ b/yarn.lock
@@ -15252,7 +15252,6 @@ __metadata:
     "@trezor/eslint": "workspace:*"
     cbor: "npm:^10.0.12"
     crc: "npm:^3.8.0"
-    groestl-hash-js: "npm:1.0.0"
     jssha: "npm:2.3.1"
   peerDependencies:
     tslib: ^2.6.2
@@ -28748,13 +28747,6 @@ __metadata:
     section-matter: "npm:^1.0.0"
     strip-bom-string: "npm:^1.0.0"
   checksum: 10/9a8f146a7a918d2524d5d60e0b4d45729f5bca54aa41247f971d9e4bc984943fda58159435763d463ec2abc8a0e238e807bd9b05e3a48f4a613a325c9dd5ad0c
-  languageName: node
-  linkType: hard
-
-"groestl-hash-js@npm:1.0.0":
-  version: 1.0.0
-  resolution: "groestl-hash-js@npm:1.0.0"
-  checksum: 10/ef5598adb70863cc7bca6137e464ae1743b38e03f63210a0c58e4ee2518a25e44e55f80d236708c810fcec0bffdba6d4c8623086eb35a83bf78bc7d0d8e84a9d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Stacked on #28091 — please review/merge that one first; this PR's base will retarget to `develop` automatically once the parent lands.

## Summary

- Drop `'groestl512x2'` from the `HashFunction` union and remove the corresponding `case` branch in `getChecksum` (now unreachable thanks to the typed union from #28091).
- Remove `groestl512x2()` helper and its `import groestl from 'groestl-hash-js'` from `crypto/utils.ts`.
- Remove `declare module 'groestl-hash-js'` from `src/types.d.ts`.
- Drop the `groestl-hash-js` dependency from `package.json` + matching `yarn.lock` entries.
- Remove `groestl-hash-js` from `scripts/list-outdated-dependencies/connect-dependencies.txt`.

## Why

iz dead

<img width="657" height="257" alt="image" src="https://github.com/user-attachments/assets/acda72a7-faef-43b7-8be7-331c25bf0b8e" />


## Breaking change

`'groestl512x2'` is no longer a valid `Currency.hashFunction`. The package is `private: true` in this monorepo, but if any external consumer constructed a `Currency` with that value, it will now fail to type-check.

## Scope clarification: does this affect Groestlcoin support elsewhere?

No — this PR is scoped strictly to `@trezor/address-validator`'s `groestl-hash-js` dependency. Concretely:

- **Suite UI** never surfaced Groestlcoin. `suite-common/wallet-config/src/networksConfig.ts` enumerates supported networks explicitly and Groestlcoin is not in it. Grepping `groestl`/`GRS` (case-insensitive) across the repo turns up only generated artifacts (`packages/connect-data/files/coins.json`, firmware changelog JSONs, generated protobuf) plus false positives — no hand-written Suite code references it.
- **`@trezor/connect`** does not depend on `@trezor/address-validator` (consumers are only `suite-common/trading`, `suite-common/wallet-utils`, `packages/suite`). `groestl-hash-js` is not imported anywhere under `packages/connect/**`. Any Groestlcoin code path in connect (e.g. `getAddress`, `signTransaction` for BTC-like coins) is driven by firmware via the device protocol, not by this JS dependency — so dropping it here does not change connect's behavior for Groestlcoin.

## Test plan

- [ ] `yarn workspace @trezor/address-validator type-check`
- [ ] `yarn workspace @trezor/address-validator test:unit`
- [ ] CI green on parent PR #28091 first


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/address-validator-drop-groestl&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/address-validator-drop-groestl&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-27T09:53:12.901Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-27T11:38:32.506Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/address-validator-drop-groestl/web/](https://dev.suite.sldev.cz/suite-web/mroz22/address-validator-drop-groestl/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->