### PR TITLE
chore(transport): drop unused useAbortEndpoint version probe

### DIFF
--- a/packages/transport-common/src/transports/bridge.ts
+++ b/packages/transport-common/src/transports/bridge.ts
@@ -4,8 +4,6 @@ import {
     type TransportProtocol,
     v1 as protocolV1,
 } from '@trezor/protocol';
-import { versionUtils } from '@trezor/utils';
-
 import * as ERRORS from '../errors';
 import {
     AbstractTransport,
@@ -76,7 +74,6 @@ type BridgeReadWriteError =
     | typeof PROTOCOL_MALFORMED;
 
 export class BridgeTransport extends AbstractTransport {
-    private useAbortEndpoint: boolean = false;
     /**
      * url of trezord server.
      */
@@ -106,7 +103,6 @@ export class BridgeTransport extends AbstractTransport {
                 }
 
                 this.version = response.payload.version;
-                this.useAbortEndpoint = versionUtils.isNewerOrEqual(this.version, '3.2.1');
 
                 this.stopped = false;
 
@@ -202,10 +198,6 @@ export class BridgeTransport extends AbstractTransport {
     // abort signal is also meant to resolve immediately but it could take a while to process it on the server
     // try to abort pending process through the server and fallback to local signal only if that fails
     private createAbortSignal = (session: Session, signal?: AbortSignal) => {
-        if (!this.useAbortEndpoint) {
-            return signal;
-        }
-
         const abortController = new AbortController();
         signal?.addEventListener('abort', async () => {
             const result = await this.post('/abort', { params: session });

--- a/packages/transport/src/transports/bridge.ts
+++ b/packages/transport/src/transports/bridge.ts
@@ -21,7 +21,6 @@ import {
     receiveAndParse,
     success,
 } from '@trezor/transport-common';
-import { versionUtils } from '@trezor/utils';
 
 import { ping } from '../pinger/ping';
 import { bridgeApiCall } from '../utils/bridgeApiCall';
@@ -63,7 +62,6 @@ type IncompleteRequestOptions = {
 type BridgeConstructorParameters = AbstractTransportParams & { port?: number };
 
 export class BridgeTransport extends AbstractTransport {
-    private useAbortEndpoint: boolean = false;
     /**
      * url of trezord server.
      */
@@ -93,7 +91,6 @@ export class BridgeTransport extends AbstractTransport {
                 }
 
                 this.version = response.payload.version;
-                this.useAbortEndpoint = versionUtils.isNewerOrEqual(this.version, '3.2.1');
 
                 this.stopped = false;
 
@@ -189,10 +186,6 @@ export class BridgeTransport extends AbstractTransport {
     // abort signal is also meant to resolve immediately but it could take a while to process it on the server
     // try to abort pending process through the server and fallback to local signal only if that fails
     private createAbortSignal = (session: Session, signal?: AbortSignal) => {
-        if (!this.useAbortEndpoint) {
-            return signal;
-        }
-
         const abortController = new AbortController();
         signal?.addEventListener('abort', async () => {
             const result = await this.post('/abort', { params: session });


### PR DESCRIPTION
## Summary

`BridgeTransport.useAbortEndpoint` was set from a runtime probe checking whether the bridge daemon version is `>= 3.2.1`. With the legacy trezord-go port 21325 server dropped in 1774c788cb2, the only bridge we talk to is the bundled `@trezor/transport-bridge` node server, which hardcodes `version = '3.2.1'` (`http.ts:83`). The probe is therefore always true.

This PR drops the dead code:
- the field
- the version probe in `init()`
- the early-return branch in `createAbortSignal` that skipped the server-side abort when the probe was false
- the now-unused `versionUtils` import

No behavior change.

Part of the cleanup series tracked in #23794. This is **PR 1A** of five small cleanup PRs (1A–1E).

- PR 1A: #28095
- PR 1B: #28102
- PR 1C: #28104
- PR 1D: #28136
- PR 1E: #28137 (stacked on #28136)

- PR 1B: #28102

## Test plan

- [x] `yarn workspace @trezor/transport type-check`
- [x] `yarn workspace @trezor/transport lint:js`
- [x] `yarn workspace @trezor/transport test:unit`
- [x] `yarn workspace @trezor/transport depcheck`
- [ ] E2E bridge tests pass (`yarn workspace @trezor/transport-test test:e2e`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is to packages/transport/src/transports/bridge.ts, which is a foundational transport layer file mapped to 121 tests — indicating it is a core shared dependency. Because the LLM analysis contains no test metadata (0 candidates analyzed), there is no specific evidence that any particular test's code path is more affected than others. The recommended strategy is to run a small representative set of tests that exercise device communication through the bridge transport across different user flows (discovery, backup, settings) as a smoke test. If any of these fail, a broader regression sweep across the full 121-test set would be warranted.

<details><summary><b>Changed files (1)</b></summary>

- `packages/transport/src/transports/bridge.ts`

</details>

**Recommended tests (3)**

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/general/wallet-discovery.test.ts` — Wallet discovery requires active bridge transport communication to detect and connect to hardware devices. Changes to bridge.ts could affect device enumeration and connection, which is core to this test's flow.
- `suite/e2e/tests/backup/t2t1-success.test.ts` — Backup flows rely heavily on sustained bridge transport sessions with the device. A regression in bridge communication could break the multi-step backup interaction, making this a reasonable smoke test for transport stability.
- `suite/e2e/tests/settings/general.test.ts` — General settings tests typically exercise basic device communication through the bridge transport (e.g., reading device info, applying settings). This provides a lightweight check that the bridge transport initializes and communicates correctly.

</details>

_Updated: 2026-05-27T09:18:21.173Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mvarmuza/transport-drop-useabortendpoint-probe&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mvarmuza/transport-drop-useabortendpoint-probe&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-21T14:33:27.543Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect.ethereumSignTransaction > TrezorConnect.ethereumSignTransaction | 🤖 auto |
| TrezorConnect > Permissions - add and forget | 🤖 auto |
| TrezorConnect silent mode > Silent mode suppresses Suite focus on subsequent calls | 🤖 auto |
| TrezorConnect.getAddress > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect.selectAccount > cancelling returns a Method_Cancel error | 🤖 auto |
| TrezorConnect.selectAccount > returns a single account (single) | 🤖 auto |
| TrezorConnect.selectAccount > selects and verifies an account (multi) | 🤖 auto |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-21T14:32:51.320Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mvarmuza/transport-drop-useabortendpoint-probe/web/](https://dev.suite.sldev.cz/suite-web/mvarmuza/transport-drop-useabortendpoint-probe/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->
