### PR TITLE
fix(transport-bridge): restore protocolMessages flag in /info response

### DIFF
--- a/packages/transport-bridge/src/http.ts
+++ b/packages/transport-bridge/src/http.ts
@@ -215,6 +215,12 @@ export class TrezordNode {
             res,
             str({
                 version: this.version,
+                // Kept for compatibility with released Suite versions whose BridgeTransport
+                // toggles wire format based on this flag. Missing / falsy makes those clients
+                // fall back to the legacy raw-hex bridge mode, which our /call /post /read
+                // handlers still accept but which we are working to retire — see #23794.
+                // Always true: this server always understands the v1 / v2 envelope.
+                protocolMessages: true,
                 githash: 'not provided',
             }),
         );

--- a/packages/transport-bridge/tests/http.test.ts
+++ b/packages/transport-bridge/tests/http.test.ts
@@ -477,6 +477,8 @@ describe('http', () => {
             }
             expect(response.payload).toMatchObject({
                 version: trezordNode.version,
+                // legacy field used by released Suite clients to choose wire format; see http.ts
+                protocolMessages: true,
             });
             await trezordNode.stop();
         });


### PR DESCRIPTION
## Summary

Restore the `protocolMessages: true` flag in the bridge daemon's `POST /` response.

## What broke

Released Suite versions still ship a `BridgeTransport` that reads `response.payload.protocolMessages` from `POST /` and toggles the wire format on it:

- flag truthy → use the v1/v2 envelope (`{ protocol, data, thpState }`)
- flag missing / falsy → fall back to the legacy raw-hex `bridge` mode

[1774c788cb2](https://github.com/trezor/trezor-suite/commit/1774c788cb2) dropped the flag from the response. The released Suite then falls into the legacy bridge mode when it connects to the nightly `trezor-user-env` build that exposes the node-bridge. The server-side `writeUtil` / `readUtil` in `packages/transport-bridge/src/core.ts` still accept the raw-hex bridge mode, but the round trip breaks somewhere in released Suite — production is incompatible with the new bridge in practice.

## Fix

- Hardcode `protocolMessages: true` back into `handleInfo`. The flag is **always true** now — this server always understands the v1/v2 envelope.
- Comment in the source explains the compat reason and points at #23794 for the longer-term cleanup.
- Extend the `POST /` unit test in `transport-bridge/tests/http.test.ts` to assert the flag is present so a future cleanup doesn't accidentally remove it again.

## When can this go for good?

When both:
1. The released Suite no longer reads the flag (i.e. all clients in the wild are post-1774c788cb2).
2. We drop the legacy `protocol === 'bridge'` mode entirely from the server (`writeUtil` / `readUtil` branches in `core.ts`). That's PR 1E in the cleanup series tracked by #23794.

## Test plan

- [x] `yarn workspace @trezor/transport-bridge type-check`
- [x] `yarn workspace @trezor/transport-bridge lint:js`
- [x] `yarn workspace @trezor/transport-bridge test:unit` (18 tests pass, including the new `POST /` assertion)
- [ ] Manual: released Suite Desktop against nightly `trezor-user-env` node-bridge — verify it no longer falls into legacy bridge mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are in the transport-bridge HTTP server module and its unit tests. The HTTP layer is the core communication interface for the node-bridge process that Suite uses to communicate with Trezor devices. The highest risk is to tests that directly exercise bridge lifecycle, HTTP endpoints, and session management. The unit test file change (http.test.ts) has no E2E coverage implications but the http.ts source change could affect any flow that depends on bridge communication. The recommended strategy focuses on bridge-specific tests first, then session management, with lower priority for tests that only interact with the bridge indirectly during reconnection scenarios.

<details><summary><b>Changed files (2)</b></summary>

- `packages/transport-bridge/src/http.ts`
- `packages/transport-bridge/tests/http.test.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `../../suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — This test directly exercises the bundled bridge process lifecycle (spawning, HTTP API responses, restart/reconnect scenarios). Changes to transport-bridge/src/http.ts could affect the bridge's HTTP server behavior, version endpoint responses, and connection handling that this test validates.
- `../../suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — This test validates the bridge daemon mode lifecycle including HTTP status endpoint checks. Changes to the transport-bridge HTTP layer could affect bridge startup detection, health checks, and process management that this test relies on.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `../../suite/e2e/tests/suite/bridge.test.ts` — This test navigates to the Bridge page and tests WebUSB fallback flow. Changes to the transport-bridge HTTP module could affect how the bridge page interacts with or detects the bridge service.
- `../../suite/e2e/tests/suite/multiple-sessions.test.ts` — This test validates Bridge session acquire/steal/reclaim behavior across multiple tabs. The transport-bridge HTTP layer handles session management endpoints, so changes there could directly affect session acquisition and enumeration behavior tested here.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `../../suite/e2e/tests/recovery/dry-run.test.ts` — This test explicitly stops and restarts the bridge mid-recovery to simulate device disconnect/reconnect. Changes to the bridge HTTP layer could affect reconnection behavior after bridge restart.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/transport-bridge/tests/http.test.ts`

_Updated: 2026-05-27T09:45:52.260Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mvarmuza/transport-bridge-restore-protocolmessages-flag&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mvarmuza/transport-bridge-restore-protocolmessages-flag&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-27T09:52:15.788Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-27T09:49:05.249Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mvarmuza/transport-bridge-restore-protocolmessages-flag/web/](https://dev.suite.sldev.cz/suite-web/mvarmuza/transport-bridge-restore-protocolmessages-flag/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->