### PR TITLE
feat(suite-native-27048): preselect receive address in trading form

### DIFF
--- a/suite-common/trading/src/index.ts
+++ b/suite-common/trading/src/index.ts
@@ -37,6 +37,7 @@ export type * from './types/tradingDetail';
 export type * from './types';
 export * from './utils';
 export * from './utils/buy/buyUtils';
+export * from './utils/receiveAccountUtils';
 export * from './utils/tradeOperationUtils';
 export * from './utils/exchange/exchangeUtils';
 export * from './utils/exchange/signDataUtils';

--- a/suite-common/trading/src/utils/__tests__/receiveAccountUtils.test.ts
+++ b/suite-common/trading/src/utils/__tests__/receiveAccountUtils.test.ts
@@ -1,0 +1,66 @@
+import { asAccountDescriptor } from '@suite-common/wallet-types';
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+
+import { getReceiveAccountPreselection } from '../receiveAccountUtils';
+
+const btcUnusedAddress = 'bc1qfcjv620stvtzjeelg26ncgww8ks49zy8lracjz';
+
+const btcAccount = mockWalletAccount({
+    symbol: 'btc',
+    descriptor: asAccountDescriptor('btc-descriptor'),
+    addresses: {
+        change: [],
+        used: [],
+        unused: [
+            {
+                address: btcUnusedAddress,
+                path: "m/84'/0'/0'/0/0",
+                transfers: 0,
+                balance: '0',
+                sent: '0',
+                received: '0',
+            },
+        ],
+    },
+});
+
+const ethAccount = mockWalletAccount({
+    symbol: 'eth',
+    descriptor: asAccountDescriptor('0x0000000000000000000000000000000000000001'),
+});
+
+describe('getReceiveAccountPreselection', () => {
+    it('returns null when there are no accounts', () => {
+        expect(getReceiveAccountPreselection({ symbol: 'btc', accounts: [] })).toBeNull();
+    });
+
+    it('returns the send account key when send account has the receive symbol', () => {
+        const sendAccount = mockWalletAccount({
+            symbol: 'eth',
+            descriptor: asAccountDescriptor('eth-send-descriptor'),
+        });
+
+        expect(
+            getReceiveAccountPreselection({
+                symbol: 'eth',
+                accounts: [ethAccount],
+                sendAccount,
+            }),
+        ).toEqual({
+            accountKey: sendAccount.key,
+        });
+    });
+
+    it('returns the first unused address for non-account-based networks', () => {
+        expect(getReceiveAccountPreselection({ symbol: 'btc', accounts: [btcAccount] })).toEqual({
+            accountKey: btcAccount.key,
+            address: btcUnusedAddress,
+        });
+    });
+
+    it('returns the first account key for account-based networks', () => {
+        expect(getReceiveAccountPreselection({ symbol: 'eth', accounts: [ethAccount] })).toEqual({
+            accountKey: ethAccount.key,
+        });
+    });
+});

--- a/suite-common/trading/src/utils/__tests__/receiveAccountUtils.test.ts
+++ b/suite-common/trading/src/utils/__tests__/receiveAccountUtils.test.ts
@@ -31,7 +31,9 @@ const ethAccount = mockWalletAccount({
 
 describe('getReceiveAccountPreselection', () => {
     it('returns null when there are no accounts', () => {
-        expect(getReceiveAccountPreselection({ symbol: 'btc', accounts: [] })).toBeNull();
+        expect(
+            getReceiveAccountPreselection({ receiveAssetNetworkSymbol: 'btc', accounts: [] }),
+        ).toBeNull();
     });
 
     it('returns the send account key when send account has the receive symbol', () => {
@@ -42,7 +44,7 @@ describe('getReceiveAccountPreselection', () => {
 
         expect(
             getReceiveAccountPreselection({
-                symbol: 'eth',
+                receiveAssetNetworkSymbol: 'eth',
                 accounts: [ethAccount],
                 sendAccount,
             }),
@@ -52,14 +54,24 @@ describe('getReceiveAccountPreselection', () => {
     });
 
     it('returns the first unused address for non-account-based networks', () => {
-        expect(getReceiveAccountPreselection({ symbol: 'btc', accounts: [btcAccount] })).toEqual({
+        expect(
+            getReceiveAccountPreselection({
+                receiveAssetNetworkSymbol: 'btc',
+                accounts: [btcAccount],
+            }),
+        ).toEqual({
             accountKey: btcAccount.key,
             address: btcUnusedAddress,
         });
     });
 
     it('returns the first account key for account-based networks', () => {
-        expect(getReceiveAccountPreselection({ symbol: 'eth', accounts: [ethAccount] })).toEqual({
+        expect(
+            getReceiveAccountPreselection({
+                receiveAssetNetworkSymbol: 'eth',
+                accounts: [ethAccount],
+            }),
+        ).toEqual({
             accountKey: ethAccount.key,
         });
     });

--- a/suite-common/trading/src/utils/__tests__/receiveAccountUtils.test.ts
+++ b/suite-common/trading/src/utils/__tests__/receiveAccountUtils.test.ts
@@ -50,6 +50,7 @@ describe('getReceiveAccountPreselection', () => {
             }),
         ).toEqual({
             accountKey: sendAccount.key,
+            address: sendAccount.descriptor,
         });
     });
 
@@ -62,17 +63,6 @@ describe('getReceiveAccountPreselection', () => {
         ).toEqual({
             accountKey: btcAccount.key,
             address: btcUnusedAddress,
-        });
-    });
-
-    it('returns the first account key for account-based networks', () => {
-        expect(
-            getReceiveAccountPreselection({
-                receiveAssetNetworkSymbol: 'eth',
-                accounts: [ethAccount],
-            }),
-        ).toEqual({
-            accountKey: ethAccount.key,
         });
     });
 });

--- a/suite-common/trading/src/utils/receiveAccountUtils.ts
+++ b/suite-common/trading/src/utils/receiveAccountUtils.ts
@@ -1,0 +1,45 @@
+import { type NetworkSymbol, isAccountBasedNetwork } from '@suite-common/wallet-config';
+import { type Account, type AccountKey } from '@suite-common/wallet-types';
+
+import { getUnusedAddressFromAccount } from '../utils';
+
+type GetReceiveAccountPreselectionParams = {
+    symbol: NetworkSymbol;
+    accounts: Account[];
+    sendAccount?: Account;
+};
+
+export type ReceiveAccountPreselection = {
+    accountKey: AccountKey;
+    address?: string;
+};
+
+export const getReceiveAccountPreselection = ({
+    symbol,
+    accounts,
+    sendAccount,
+}: GetReceiveAccountPreselectionParams): ReceiveAccountPreselection | null => {
+    if (accounts.length === 0) {
+        return null;
+    }
+
+    if (!isAccountBasedNetwork(symbol)) {
+        const account = accounts[0];
+        const { address } = getUnusedAddressFromAccount(account);
+
+        return {
+            accountKey: account.key,
+            address,
+        };
+    }
+
+    if (sendAccount?.symbol === symbol) {
+        return {
+            accountKey: sendAccount.key,
+        };
+    }
+
+    return {
+        accountKey: accounts[0].key,
+    };
+};

--- a/suite-common/trading/src/utils/receiveAccountUtils.ts
+++ b/suite-common/trading/src/utils/receiveAccountUtils.ts
@@ -19,7 +19,9 @@ export const getReceiveAccountPreselection = ({
     accounts,
     sendAccount,
 }: GetReceiveAccountPreselectionParams): ReceiveAccountPreselection | null => {
-    if (accounts.length === 0) {
+    const account = accounts?.[0];
+
+    if (!account) {
         return null;
     }
 
@@ -32,7 +34,6 @@ export const getReceiveAccountPreselection = ({
         };
     }
 
-    const account = accounts[0];
     const { address } = getUnusedAddressFromAccount(account);
 
     return {

--- a/suite-common/trading/src/utils/receiveAccountUtils.ts
+++ b/suite-common/trading/src/utils/receiveAccountUtils.ts
@@ -1,4 +1,4 @@
-import { type NetworkSymbol, isAccountBasedNetwork } from '@suite-common/wallet-config';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type Account, type AccountKey } from '@suite-common/wallet-types';
 
 import { getUnusedAddressFromAccount } from '../utils';
@@ -23,26 +23,20 @@ export const getReceiveAccountPreselection = ({
         return null;
     }
 
-    const isAccountBased = isAccountBasedNetwork(receiveAssetNetworkSymbol);
-
     if (sendAccount?.symbol === receiveAssetNetworkSymbol) {
+        const { address } = getUnusedAddressFromAccount(sendAccount);
+
         return {
             accountKey: sendAccount.key,
-            address: isAccountBased ? undefined : getUnusedAddressFromAccount(sendAccount).address,
-        };
-    }
-
-    if (!isAccountBased) {
-        const account = accounts[0];
-        const { address } = getUnusedAddressFromAccount(account);
-
-        return {
-            accountKey: account.key,
             address,
         };
     }
 
+    const account = accounts[0];
+    const { address } = getUnusedAddressFromAccount(account);
+
     return {
-        accountKey: accounts[0].key,
+        accountKey: account.key,
+        address,
     };
 };

--- a/suite-common/trading/src/utils/receiveAccountUtils.ts
+++ b/suite-common/trading/src/utils/receiveAccountUtils.ts
@@ -4,7 +4,7 @@ import { type Account, type AccountKey } from '@suite-common/wallet-types';
 import { getUnusedAddressFromAccount } from '../utils';
 
 type GetReceiveAccountPreselectionParams = {
-    symbol: NetworkSymbol;
+    receiveAssetNetworkSymbol: NetworkSymbol;
     accounts: Account[];
     sendAccount?: Account;
 };
@@ -15,7 +15,7 @@ export type ReceiveAccountPreselection = {
 };
 
 export const getReceiveAccountPreselection = ({
-    symbol,
+    receiveAssetNetworkSymbol,
     accounts,
     sendAccount,
 }: GetReceiveAccountPreselectionParams): ReceiveAccountPreselection | null => {
@@ -23,19 +23,22 @@ export const getReceiveAccountPreselection = ({
         return null;
     }
 
-    if (!isAccountBasedNetwork(symbol)) {
+    const isAccountBased = isAccountBasedNetwork(receiveAssetNetworkSymbol);
+
+    if (sendAccount?.symbol === receiveAssetNetworkSymbol) {
+        return {
+            accountKey: sendAccount.key,
+            address: isAccountBased ? undefined : getUnusedAddressFromAccount(sendAccount).address,
+        };
+    }
+
+    if (!isAccountBased) {
         const account = accounts[0];
         const { address } = getUnusedAddressFromAccount(account);
 
         return {
             accountKey: account.key,
             address,
-        };
-    }
-
-    if (sendAccount?.symbol === symbol) {
-        return {
-            accountKey: sendAccount.key,
         };
     }
 

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyAlert.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyAlert.test.tsx
@@ -1,3 +1,4 @@
+import { deviceInitialState } from '@suite-common/device';
 import { Form } from '@suite-native/forms';
 import { renderWithBasicProvider } from '@suite-native/test-utils';
 import { act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
@@ -9,7 +10,10 @@ import { BuyAlert } from '../BuyAlert';
 
 describe('BuyAlert', () => {
     let form: BuyFormType;
-    const preloadedState = { wallet: getWalletState({ tradeType: 'buy' }) };
+    const preloadedState = {
+        device: deviceInitialState,
+        wallet: getWalletState({ tradeType: 'buy' }),
+    };
 
     const renderFormHook = () =>
         renderHookWithStoreProvider(() => useBuyForm(), {

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyFiatCurrencyPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyFiatCurrencyPicker.test.tsx
@@ -1,3 +1,4 @@
+import { deviceInitialState } from '@suite-common/device';
 import { type useListDataFilter } from '@suite-common/trading';
 import { Form } from '@suite-native/forms';
 import {
@@ -26,7 +27,10 @@ describe('BuyFiatCurrencyPicker', () => {
     });
 
     const renderFiatCurrencyPicker = () => {
-        const preloadedState = { wallet: { trading: getInitializedTradingState() } };
+        const preloadedState = {
+            device: deviceInitialState,
+            wallet: { trading: getInitializedTradingState() },
+        };
         const { result } = renderHookWithStoreProvider(() => useBuyForm(), {
             preloadedState,
         });

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyPaymentMethodPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyPaymentMethodPicker.test.tsx
@@ -1,5 +1,6 @@
 import { type EnhancedStore, combineReducers } from '@reduxjs/toolkit';
 
+import { deviceInitialState } from '@suite-common/device';
 import { extraDependenciesCommonMock } from '@suite-common/test-utils';
 import { tradingBuyActions } from '@suite-common/trading';
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
@@ -42,11 +43,13 @@ const services = {
 describe('BuyPaymentMethodPicker', () => {
     let form: BuyFormType;
     const defaultPreloadedState = {
+        device: deviceInitialState,
         locale: localeInitialState,
         wallet: getWalletState({ tradeType: 'buy' }),
     };
 
     const reducer = {
+        device: createStaticReducer(deviceInitialState),
         locale: createStaticReducer(localeInitialState),
         wallet: combineReducers({
             settings: createStaticReducer(initialWalletSettingsState),
@@ -142,6 +145,7 @@ describe('BuyPaymentMethodPicker', () => {
             const store = createLightStore({
                 reducer,
                 preloadedState: {
+                    device: deviceInitialState,
                     wallet: {
                         trading: getWalletState({ tradeType: 'buy' }).trading,
                     },

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyReceiveAccountCryptoBalance.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyReceiveAccountCryptoBalance.test.tsx
@@ -1,3 +1,4 @@
+import { deviceInitialState } from '@suite-common/device';
 import { Form } from '@suite-native/forms';
 import {
     act,
@@ -15,7 +16,10 @@ import {
 
 describe('BuyReceiveAccountCryptoBalance', () => {
     let buyForm: BuyFormType;
-    const preloadedState = { wallet: getWalletState({ tradeType: 'buy' }) };
+    const preloadedState = {
+        device: deviceInitialState,
+        wallet: getWalletState({ tradeType: 'buy' }),
+    };
 
     const renderBuyForm = () => {
         const { result } = renderHookWithStoreProvider(() => useBuyForm(), {

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeAlert.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeAlert.test.tsx
@@ -1,3 +1,4 @@
+import { deviceInitialState } from '@suite-common/device';
 import { FeatureFlag, featureFlagsInitialState } from '@suite-native/feature-flags';
 import { Form } from '@suite-native/forms';
 import { renderWithBasicProvider } from '@suite-native/test-utils';
@@ -11,6 +12,7 @@ import { ExchangeAlert } from '../ExchangeAlert';
 describe('ExchangeAlert', () => {
     let form: ExchangeFormType;
     const preloadedState = {
+        device: deviceInitialState,
         featureFlags: {
             ...featureFlagsInitialState,
             [FeatureFlag.IsTradingResidenceCheckEnabled]: false,

--- a/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveAccountCryptoBalance.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveAccountCryptoBalance.test.tsx
@@ -1,3 +1,4 @@
+import { deviceInitialState } from '@suite-common/device';
 import { FeatureFlag, featureFlagsInitialState } from '@suite-native/feature-flags';
 import { Form } from '@suite-native/forms';
 import {
@@ -17,6 +18,7 @@ import {
 describe('ExchangeReceiveAccountCryptoBalance', () => {
     let exchangeForm: ExchangeFormType;
     const preloadedState = {
+        device: deviceInitialState,
         featureFlags: {
             ...featureFlagsInitialState,
             [FeatureFlag.IsTradingResidenceCheckEnabled]: false,

--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyForm.test.tsx
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyForm.test.tsx
@@ -4,24 +4,28 @@ import { type EnhancedStore } from '@reduxjs/toolkit';
 import type { BuyTrade, CryptoId } from 'invity-api';
 
 import { selectTradingProviderMetadata, tradingBuyActions } from '@suite-common/trading';
-import { type AccountKey, asAccountDescriptor } from '@suite-common/wallet-types';
 import { Form, useField } from '@suite-native/forms';
 import {
     type TestStore,
     act,
     renderHook,
     renderHookWithStoreProvider,
+    waitFor,
 } from '@suite-native/test-utils-store';
 import {
+    btc1NormalAccount,
+    btc2legacyAccount,
     btcAsset,
     buyMercuryo,
     buyQuotes,
     cexdirectCreditCardBuyQuote,
-    getBtcAccount,
+    eth1NormalAccount,
+    eth2legacyAccount,
     getInitializedTradingState,
     mercuryoApplePayBuyQuote,
     mercuryoCreditCardBuyQuote,
     usdcAsset,
+    usdtAsset,
 } from '@suite-native/trading-fixtures';
 import { buyActions, selectTradingResidenceCountry } from '@suite-native/trading-state';
 import { type BuyFormType, type TradeableAsset } from '@suite-native/trading-types';
@@ -39,9 +43,11 @@ jest.mock('@trezor/react-utils', () => {
     };
 });
 
-const btc1AccountKey = 'btc-account-1' as AccountKey; // Todo: create properly via `createAccountKey()`
-const btc2AccountKey = 'btc-account-2' as AccountKey; // Todo: create properly via `createAccountKey()`
-const btc3AccountKey = 'btc-account-3' as AccountKey; // Todo: create properly via `createAccountKey()`
+const btc1AccountKey = btc1NormalAccount.key;
+const btc2AccountKey = btc2legacyAccount.key;
+const eth1AccountKey = eth1NormalAccount.key;
+const eth2AccountKey = eth2legacyAccount.key;
+const accountDeviceState = btc1NormalAccount.deviceState;
 
 describe('useBuyForm', () => {
     const renderUseTradingBuyForm = (store: TestStore) =>
@@ -53,6 +59,13 @@ describe('useBuyForm', () => {
 
         return createTradingLightStore({
             overrides: {
+                device: {
+                    selectedDevice: {
+                        state: {
+                            staticSessionId: accountDeviceState,
+                        },
+                    },
+                },
                 wallet: {
                     trading: tradingState,
                     settings: {
@@ -61,12 +74,10 @@ describe('useBuyForm', () => {
                             : PROTO.AmountUnit.BITCOIN,
                     },
                     accounts: [
-                        getBtcAccount(btc1AccountKey),
-                        getBtcAccount(btc2AccountKey),
-                        {
-                            ...getBtcAccount(btc3AccountKey),
-                            descriptor: asAccountDescriptor(''),
-                        },
+                        btc1NormalAccount,
+                        btc2legacyAccount,
+                        eth1NormalAccount,
+                        eth2legacyAccount,
                     ],
                 },
             },
@@ -107,6 +118,23 @@ describe('useBuyForm', () => {
         });
     });
 
+    it('should preselect receiveAccount when asset is selected', async () => {
+        const store = getInitializedStore();
+        const { result } = renderUseTradingBuyForm(store);
+
+        act(() => {
+            result.current.setValue('asset', btcAsset);
+        });
+
+        await waitFor(() => {
+            expect(result.current.getValues('receiveAccount')).toEqual(
+                expect.objectContaining({
+                    account: expect.objectContaining({ key: btc1AccountKey }),
+                }),
+            );
+        });
+    });
+
     it('should dispatch tradingBuy/assetChanged on asset change', () => {
         const store = getInitializedStore();
         const dispatchSpy = jest.spyOn(store, 'dispatch');
@@ -116,8 +144,62 @@ describe('useBuyForm', () => {
         act(() => {
             result.current.setValue('asset', usdcAsset);
         });
-        expect(dispatchSpy).toHaveBeenCalledTimes(1);
         expect(dispatchSpy).toHaveBeenCalledWith(buyActions.assetChanged());
+    });
+
+    it('should dispatch tradingBuy/assetTokenChanged when asset changes within the same network', () => {
+        const store = getInitializedStore();
+        const dispatchSpy = jest.spyOn(store, 'dispatch');
+        const { result } = renderUseTradingBuyForm(store);
+
+        act(() => {
+            result.current.setValue('asset', usdcAsset);
+        });
+
+        dispatchSpy.mockClear();
+
+        act(() => {
+            result.current.setValue('asset', usdtAsset);
+        });
+
+        expect(dispatchSpy).toHaveBeenCalledWith(buyActions.assetTokenChanged());
+        expect(dispatchSpy).not.toHaveBeenCalledWith(buyActions.assetChanged());
+    });
+
+    it('should keep selected receiveAccount when asset changes within the same network', async () => {
+        const store = getInitializedStore();
+        const { result } = renderUseTradingBuyForm(store);
+
+        act(() => {
+            result.current.setValue('asset', usdcAsset);
+        });
+
+        await waitFor(() => {
+            expect(result.current.getValues('receiveAccount')).toEqual({
+                account: expect.objectContaining({ key: eth1AccountKey }),
+            });
+        });
+
+        act(() => {
+            store.dispatch(tradingBuyActions.setTradingAccountKey(eth2AccountKey));
+            store.dispatch(tradingBuyActions.setReceiveAccountKey(eth2AccountKey));
+        });
+
+        await waitFor(() => {
+            expect(result.current.getValues('receiveAccount')).toEqual({
+                account: expect.objectContaining({ key: eth2AccountKey }),
+            });
+        });
+
+        act(() => {
+            result.current.setValue('asset', usdtAsset);
+        });
+
+        await waitFor(() => {
+            expect(result.current.getValues('receiveAccount')).toEqual({
+                account: expect.objectContaining({ key: eth2AccountKey }),
+            });
+        });
     });
 
     it('should not clear selected account when asset is set to undefined', () => {

--- a/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
@@ -5,12 +5,16 @@ import { useDispatch, useSelector } from 'react-redux';
 import type { BuyCryptoPaymentMethod, BuyTrade, CryptoId, FiatCurrencyCode } from 'invity-api';
 
 import { useServices } from '@suite-common/dependency-injection';
-import { type TradingAmountLimitProps, selectTradingBuyQuotesRequest } from '@suite-common/trading';
+import {
+    type TradingAmountLimitProps,
+    cryptoIdToSymbol,
+    selectTradingBuyQuotesRequest,
+} from '@suite-common/trading';
 import { getNetwork } from '@suite-common/wallet-config';
 import { type WalletSettingsRootState, selectIsAmountInSats } from '@suite-common/wallet-core';
 import { convertAmountUnitsToSubunits } from '@suite-common/wallet-utils';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
-import { useForm } from '@suite-native/forms';
+import { useForm, useWatch } from '@suite-native/forms';
 import { useTranslate } from '@suite-native/intl';
 import { getSymbolFromTradeableAsset } from '@suite-native/trading-atoms';
 import { MAX_CRYPTO_DECIMALS, MAX_FIAT_DECIMALS } from '@suite-native/trading-consts';
@@ -29,6 +33,7 @@ import { useContextForTradingForm } from '../general/form/useContextForTradingFo
 import { useCountryChangeEffect } from '../general/form/useCountryChangeEffect';
 import { useProviderMetadataChangeEffect } from '../general/form/useProviderMetadataChangeEffect';
 import { useReceiveAccountChangeEffect } from '../general/form/useReceiveAccountChangeEffect';
+import { useReceiveAccountPreselectionEffect } from '../general/form/useReceiveAccountPreselectionEffect';
 
 const useAmountAndCurrencyFieldsChangeEffect = ({ setValue, getValues, watch }: BuyFormType) => {
     const dispatch = useDispatch();
@@ -75,6 +80,9 @@ const useAmountAndCurrencyFieldsChangeEffect = ({ setValue, getValues, watch }: 
 
                     case 'asset': {
                         if (asset?.cryptoId !== prevCryptoId.current) {
+                            const prevSymbol = cryptoIdToSymbol(prevCryptoId.current);
+                            const symbol = cryptoIdToSymbol(asset?.cryptoId);
+
                             analytics.report({
                                 type: events.tradingParameterChangedEvent.name,
                                 payload: {
@@ -84,7 +92,11 @@ const useAmountAndCurrencyFieldsChangeEffect = ({ setValue, getValues, watch }: 
                             });
                             prevCryptoId.current = asset?.cryptoId as CryptoId | undefined;
                             setValue('cryptoValue', undefined, { shouldValidate: true });
-                            dispatch(buyActions.assetChanged());
+                            dispatch(
+                                prevSymbol === symbol
+                                    ? buyActions.assetTokenChanged()
+                                    : buyActions.assetChanged(),
+                            );
                         }
                         break;
                     }
@@ -224,10 +236,16 @@ export const useBuyForm = (): BuyFormType => {
         validation: buyFormValidationSchema,
         context,
     });
-    const { setValue, watch } = form;
+    const { control, setValue, watch } = form;
+    const asset = useWatch({ control, name: 'asset' });
 
     useAmountAndCurrencyFieldsChangeEffect(form);
     useReceiveAccountChangeEffect(setValue, selectBuySelectedReceiveAccount);
+    useReceiveAccountPreselectionEffect({
+        receiveAsset: asset,
+        selectReceiveAccount: selectBuySelectedReceiveAccount,
+        tradingType: 'buy',
+    });
     useBuyQuotesChangeEffect(form);
     useBuyQuoteChangeEffect(form);
     useValidations(form, limits);

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeForm.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeForm.test.ts
@@ -5,19 +5,27 @@ import {
     selectTradingProviderMetadata,
     tradingExchangeActions,
 } from '@suite-common/trading';
-import { type AccountKey } from '@suite-common/wallet-types';
 import { events } from '@suite-native/analytics';
-import { type TestStore, act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
 import {
+    type TestStore,
+    act,
+    renderHookWithStoreProvider,
+    waitFor,
+} from '@suite-native/test-utils-store';
+import {
+    accounts,
+    btc1NormalAccount,
     btcAsset,
     cexdirectFloatingQuote,
+    eth1NormalAccount,
+    eth2legacyAccount,
     exchangeCexdirect,
     exchangeQuotes,
-    getBtcAccount,
     invityDexQuote,
     mercuryoFixedBestQuote,
     mercuryoFixedWorstQuote,
     usdcAsset,
+    usdtAsset,
 } from '@suite-native/trading-fixtures';
 import { exchangeActions } from '@suite-native/trading-state';
 import { type ExchangeFormType } from '@suite-native/trading-types';
@@ -48,7 +56,10 @@ const createPrefetchDexQuoteApprovalThunkMock = (
     return () => result;
 };
 
-const btc1AccountKey = 'btc-account-1' as AccountKey; // Todo: create properly via `createAccountKey()`
+const btc1AccountKey = btc1NormalAccount.key;
+const eth1AccountKey = eth1NormalAccount.key;
+const eth2AccountKey = eth2legacyAccount.key;
+const accountDeviceState = btc1NormalAccount.deviceState;
 
 describe('useExchangeForm', () => {
     let store: TestStore;
@@ -60,7 +71,15 @@ describe('useExchangeForm', () => {
         createTradingLightStore({
             tradeType: 'exchange',
             overrides: {
+                device: {
+                    selectedDevice: {
+                        state: {
+                            staticSessionId: accountDeviceState,
+                        },
+                    },
+                },
                 wallet: {
+                    accounts,
                     settings: {
                         bitcoinAmountUnit,
                     },
@@ -286,16 +305,8 @@ describe('useExchangeForm', () => {
             renderUseExchangeForm();
 
             await act(async () => {
-                store.dispatch(
-                    tradingExchangeActions.setTradingAccountKey(
-                        'eth-account-1' as AccountKey, // Todo: create properly via `createAccountKey()`
-                    ),
-                );
-                store.dispatch(
-                    tradingExchangeActions.setReceiveAccountKey(
-                        'eth-account-1' as AccountKey, // Todo: create properly via `createAccountKey()`
-                    ),
-                );
+                store.dispatch(tradingExchangeActions.setTradingAccountKey(eth1AccountKey));
+                store.dispatch(tradingExchangeActions.setReceiveAccountKey(eth1AccountKey));
                 store.dispatch(tradingExchangeActions.saveQuotes([dexQuoteWithDexTx]));
                 await Promise.resolve();
             });
@@ -312,16 +323,8 @@ describe('useExchangeForm', () => {
             renderUseExchangeForm();
 
             await act(async () => {
-                store.dispatch(
-                    tradingExchangeActions.setTradingAccountKey(
-                        'eth-account-1' as AccountKey, // Todo: create properly via `createAccountKey()`
-                    ),
-                );
-                store.dispatch(
-                    tradingExchangeActions.setReceiveAccountKey(
-                        'eth-account-1' as AccountKey, // Todo: create properly via `createAccountKey()`
-                    ),
-                );
+                store.dispatch(tradingExchangeActions.setTradingAccountKey(eth1AccountKey));
+                store.dispatch(tradingExchangeActions.setReceiveAccountKey(eth1AccountKey));
                 store.dispatch(tradingExchangeActions.saveQuotes([dexQuoteWithDexTx]));
                 await Promise.resolve();
                 store.dispatch(
@@ -348,7 +351,7 @@ describe('useExchangeForm', () => {
                 store.dispatch(tradingExchangeActions.setTradingAccountKey(btc1AccountKey));
             });
 
-            expect(result.current.getValues('sendAccount')).toEqual(getBtcAccount(btc1AccountKey));
+            expect(result.current.getValues('sendAccount')).toEqual(btc1NormalAccount);
         });
     });
 
@@ -422,9 +425,93 @@ describe('useExchangeForm', () => {
 
             expect(result.current.getValues('receiveAccount')).toEqual(
                 expect.objectContaining({
-                    account: getBtcAccount(btc1AccountKey),
+                    account: btc1NormalAccount,
                 }),
             );
+        });
+
+        it('should preselect receiveAccount when receiveAsset is selected', async () => {
+            const { result } = renderUseExchangeForm();
+
+            act(() => {
+                result.current.setValue('receiveAsset', btcAsset);
+            });
+
+            await waitFor(() => {
+                expect(result.current.getValues('receiveAccount')).toEqual(
+                    expect.objectContaining({
+                        account: btc1NormalAccount,
+                    }),
+                );
+            });
+        });
+
+        it('should preselect receiveAccount for the new receiveAsset after receiveAsset changes', async () => {
+            const { result } = renderUseExchangeForm();
+
+            act(() => {
+                result.current.setValue('receiveAsset', btcAsset);
+            });
+
+            await waitFor(() => {
+                expect(result.current.getValues('receiveAccount')).toEqual(
+                    expect.objectContaining({
+                        account: btc1NormalAccount,
+                    }),
+                );
+            });
+
+            act(() => {
+                result.current.setValue('receiveAsset', usdcAsset);
+            });
+
+            await waitFor(() => {
+                expect(result.current.getValues('receiveAccount')).toEqual(
+                    expect.objectContaining({
+                        account: eth1NormalAccount,
+                    }),
+                );
+            });
+        });
+
+        it('should keep selected receiveAccount when receiveAsset changes within the same network', async () => {
+            const { result } = renderUseExchangeForm();
+
+            act(() => {
+                result.current.setValue('receiveAsset', usdcAsset);
+            });
+
+            await waitFor(() => {
+                expect(result.current.getValues('receiveAccount')).toEqual(
+                    expect.objectContaining({
+                        account: eth1NormalAccount,
+                    }),
+                );
+            });
+
+            act(() => {
+                store.dispatch(tradingExchangeActions.setReceiveAccountKey(eth2AccountKey));
+            });
+
+            await waitFor(() => {
+                expect(result.current.getValues('receiveAccount')).toEqual(
+                    expect.objectContaining({
+                        account: eth2legacyAccount,
+                    }),
+                );
+            });
+
+            act(() => {
+                result.current.setValue('receiveAsset', usdtAsset);
+            });
+
+            await waitFor(() => {
+                expect(result.current.getValues('receiveAccount')).toEqual(
+                    expect.objectContaining({
+                        account: eth2legacyAccount,
+                    }),
+                );
+            });
         });
     });
 
@@ -454,6 +541,24 @@ describe('useExchangeForm', () => {
             });
 
             expect(dispatchSpy).toHaveBeenCalledWith(exchangeActions.receiveAssetChanged());
+        });
+
+        it('should dispatch receiveTokenChanged action when receiveAsset changes within the same network', () => {
+            const dispatchSpy = jest.spyOn(store, 'dispatch');
+            const { result } = renderUseExchangeForm();
+
+            act(() => {
+                result.current.setValue('receiveAsset', usdcAsset);
+            });
+
+            dispatchSpy.mockClear();
+
+            act(() => {
+                result.current.setValue('receiveAsset', usdtAsset);
+            });
+
+            expect(dispatchSpy).toHaveBeenCalledWith(exchangeActions.receiveTokenChanged());
+            expect(dispatchSpy).not.toHaveBeenCalledWith(exchangeActions.receiveAssetChanged());
         });
     });
 
@@ -539,11 +644,7 @@ describe('useExchangeForm', () => {
             const { result } = renderUseExchangeForm();
 
             act(() => {
-                store.dispatch(
-                    tradingExchangeActions.setTradingAccountKey(
-                        'eth-account-1' as AccountKey, // Todo: create properly via `createAccountKey()`
-                    ),
-                );
+                store.dispatch(tradingExchangeActions.setTradingAccountKey(eth1AccountKey));
                 result.current.setValue('sendAsset', usdcAsset);
                 result.current.setValue('sendCryptoAmount', amount);
             });

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeForm.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeForm.ts
@@ -6,6 +6,7 @@ import type { CryptoId, ExchangeTrade } from 'invity-api';
 import { useServices } from '@suite-common/dependency-injection';
 import {
     type TradingExchangeAmountLimitProps,
+    cryptoIdToSymbol,
     exchangeThunks,
     requiresTokenApproval,
     selectTradingExchangeProviders,
@@ -15,7 +16,7 @@ import { getNetwork } from '@suite-common/wallet-config';
 import { type WalletSettingsRootState, selectIsAmountInSats } from '@suite-common/wallet-core';
 import { convertAmountUnitsToSubunits } from '@suite-common/wallet-utils';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
-import { useForm } from '@suite-native/forms';
+import { useForm, useWatch } from '@suite-native/forms';
 import { useTranslate } from '@suite-native/intl';
 import { getSymbolFromTradeableAsset } from '@suite-native/trading-atoms';
 import {
@@ -32,6 +33,7 @@ import { exchangeFormValidationSchema } from '../../utils/exchange/exchangeFormV
 import { useContextForTradingForm } from '../general/form/useContextForTradingForm';
 import { useProviderMetadataChangeEffect } from '../general/form/useProviderMetadataChangeEffect';
 import { useReceiveAccountChangeEffect } from '../general/form/useReceiveAccountChangeEffect';
+import { useReceiveAccountPreselectionEffect } from '../general/form/useReceiveAccountPreselectionEffect';
 import { useSendAccountAssetBalance } from '../general/form/useSendAccountAssetBalance';
 import { useSendAccountChangeEffect } from '../general/form/useSendAccountChangeEffect';
 
@@ -141,6 +143,9 @@ const useAmountAndCurrencyFieldsChangeEffect = ({ setValue, watch }: ExchangeFor
 
                 case 'receiveAsset':
                     if (receiveAsset?.cryptoId !== prevReceiveCryptoId.current) {
+                        const prevReceiveSymbol = cryptoIdToSymbol(prevReceiveCryptoId.current);
+                        const receiveSymbol = cryptoIdToSymbol(receiveAsset?.cryptoId);
+
                         analytics.report({
                             type: events.tradingParameterChangedEvent.name,
                             payload: {
@@ -152,7 +157,11 @@ const useAmountAndCurrencyFieldsChangeEffect = ({ setValue, watch }: ExchangeFor
                         prevReceiveCryptoId.current = receiveAsset?.cryptoId as
                             | CryptoId
                             | undefined;
-                        dispatch(exchangeActions.receiveAssetChanged());
+                        dispatch(
+                            prevReceiveSymbol === receiveSymbol
+                                ? exchangeActions.receiveTokenChanged()
+                                : exchangeActions.receiveAssetChanged(),
+                        );
                     }
                     break;
 
@@ -256,12 +265,19 @@ export const useExchangeForm = () => {
         validation: exchangeFormValidationSchema,
         context,
     });
-    const { setValue, watch } = form;
+    const { control, setValue, watch } = form;
+    const receiveAsset = useWatch({ control, name: 'receiveAsset' });
 
     useExchangeQuotesChangeEffect(form);
     useExchangeQuoteChangeEffect(form);
     useSendAccountChangeEffect(setValue, selectExchangeSelectedSendAccount);
     useReceiveAccountChangeEffect(setValue, selectExchangeSelectedReceiveAccount);
+    useReceiveAccountPreselectionEffect({
+        receiveAsset,
+        selectSendAccount: selectExchangeSelectedSendAccount,
+        selectReceiveAccount: selectExchangeSelectedReceiveAccount,
+        tradingType: 'exchange',
+    });
     useAmountAndCurrencyFieldsChangeEffect(form);
     useDexQuoteApprovalInfoChangeEffect(form);
     useSendAccountAssetBalance(form, setBalance, setSendSymbol, setContractAddress, setAccountKey);

--- a/suite-native/module-trading/src/hooks/general/__tests__/useFocusedValueWatch.test.tsx
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useFocusedValueWatch.test.tsx
@@ -1,5 +1,6 @@
 import { combineReducers } from '@reduxjs/toolkit';
 
+import { deviceInitialState } from '@suite-common/device';
 import { extraDependenciesCommonMock } from '@suite-common/test-utils';
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
 import { Form } from '@suite-native/forms';
@@ -25,6 +26,7 @@ describe('useFocusedValueWatch', () => {
     let store: TestStore;
 
     const reducer = {
+        device: createStaticReducer(deviceInitialState),
         locale: localeReducer,
         wallet: combineReducers({
             settings: createStaticReducer(initialWalletSettingsState),
@@ -34,6 +36,7 @@ describe('useFocusedValueWatch', () => {
     } as const;
 
     const preloadedState = {
+        device: deviceInitialState,
         wallet: {
             trading: getWalletState({ tradeType: 'buy' }).trading,
         },

--- a/suite-native/module-trading/src/hooks/general/form/__tests__/useReceiveAccountPreselectionEffect.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/__tests__/useReceiveAccountPreselectionEffect.test.ts
@@ -1,0 +1,112 @@
+import { tradingBuyActions, tradingExchangeActions } from '@suite-common/trading';
+import { type AccountKey } from '@suite-common/wallet-types';
+import { renderHookWithStoreProvider } from '@suite-native/test-utils-store';
+import {
+    MOCK_ACCOUNT_DEVICE_SESSION_ID,
+    adaAsset,
+    btc1NormalAccount,
+    btcAsset,
+} from '@suite-native/trading-fixtures';
+import {
+    selectBuySelectedReceiveAccount,
+    selectExchangeSelectedReceiveAccount,
+} from '@suite-native/trading-state';
+import { type TradeableAsset } from '@suite-native/trading-types';
+
+import { createTradingLightStore } from '../../../../__tests__/tradingTestUtils';
+import { useReceiveAccountPreselectionEffect } from '../useReceiveAccountPreselectionEffect';
+
+const btc1AccountKey = btc1NormalAccount.key;
+
+describe('useReceiveAccountPreselectionEffect', () => {
+    const renderUseReceiveAccountPreselectionEffect = ({
+        store,
+        tradingType = 'buy',
+        receiveAsset = btcAsset,
+    }: {
+        store: ReturnType<typeof createTradingLightStore>;
+        tradingType?: 'buy' | 'exchange';
+        receiveAsset?: TradeableAsset;
+    }) =>
+        renderHookWithStoreProvider(
+            () =>
+                useReceiveAccountPreselectionEffect({
+                    tradingType,
+                    receiveAsset,
+                    selectReceiveAccount:
+                        tradingType === 'buy'
+                            ? selectBuySelectedReceiveAccount
+                            : selectExchangeSelectedReceiveAccount,
+                }),
+            { store },
+        );
+
+    const createStore = ({
+        selectedReceiveAccountKey,
+        tradeType = 'buy',
+    }: {
+        selectedReceiveAccountKey?: AccountKey;
+        tradeType?: 'buy' | 'exchange';
+    } = {}) =>
+        createTradingLightStore({
+            tradeType,
+            overrides: {
+                device: {
+                    selectedDevice: {
+                        state: {
+                            staticSessionId: MOCK_ACCOUNT_DEVICE_SESSION_ID,
+                        },
+                    },
+                },
+                wallet: {
+                    accounts: [btc1NormalAccount],
+                    trading: {
+                        [tradeType]: {
+                            ...(tradeType === 'buy'
+                                ? { tradingAccountKey: selectedReceiveAccountKey }
+                                : { receiveAccountKey: selectedReceiveAccountKey }),
+                        },
+                    },
+                },
+            },
+        });
+
+    it('should dispatch buy actions when account is preselected', () => {
+        const store = createStore();
+
+        renderUseReceiveAccountPreselectionEffect({ store });
+
+        expect(store.getActions()).toEqual([
+            tradingBuyActions.setTradingAccountKey(btc1AccountKey),
+            tradingBuyActions.setReceiveAccountKey(btc1AccountKey),
+            tradingBuyActions.setReceiveAddress('UNUSED1'),
+        ]);
+    });
+
+    it('should dispatch exchange actions when account is preselected', () => {
+        const store = createStore({ tradeType: 'exchange' });
+
+        renderUseReceiveAccountPreselectionEffect({ store, tradingType: 'exchange' });
+
+        expect(store.getActions()).toEqual([
+            tradingExchangeActions.setReceiveAccountKey(btc1AccountKey),
+            tradingExchangeActions.setReceiveAddress('UNUSED1'),
+        ]);
+    });
+
+    it('should not dispatch actions when no preselected account can be found', () => {
+        const store = createStore();
+
+        renderUseReceiveAccountPreselectionEffect({ store, receiveAsset: adaAsset });
+
+        expect(store.getActions()).toEqual([]);
+    });
+
+    it('should not dispatch actions when selectedReceiveAccount already has account set', () => {
+        const store = createStore({ selectedReceiveAccountKey: btc1AccountKey });
+
+        renderUseReceiveAccountPreselectionEffect({ store });
+
+        expect(store.getActions()).toEqual([]);
+    });
+});

--- a/suite-native/module-trading/src/hooks/general/form/useReceiveAccountPreselectionEffect.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useReceiveAccountPreselectionEffect.ts
@@ -1,0 +1,89 @@
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import {
+    type TradingType,
+    getReceiveAccountPreselection,
+    tradingBuyActions,
+    tradingExchangeActions,
+} from '@suite-common/trading';
+import { type AccountsRootState } from '@suite-common/wallet-core';
+import { type Account } from '@suite-common/wallet-types';
+import { getSymbolFromTradeableAsset } from '@suite-native/trading-atoms';
+import {
+    type CombinedSelectorsRootState,
+    selectVisibleDeviceAccountsByNetworkSymbolSorted,
+} from '@suite-native/trading-state';
+import {
+    type ReceiveAccount,
+    type TradeableAsset,
+    type TradingRootState,
+} from '@suite-native/trading-types';
+
+type ReceiveAccountSelector = (
+    state: TradingRootState & AccountsRootState,
+) => ReceiveAccount | undefined;
+
+type SendAccountSelector = (state: TradingRootState & AccountsRootState) => Account | undefined;
+
+type UseReceiveAccountPreselectionEffectProps = {
+    receiveAsset?: TradeableAsset;
+    tradingType: Exclude<TradingType, 'sell'>;
+    selectReceiveAccount: ReceiveAccountSelector;
+    selectSendAccount?: SendAccountSelector;
+};
+
+export const useReceiveAccountPreselectionEffect = ({
+    tradingType,
+    receiveAsset,
+    selectReceiveAccount,
+    selectSendAccount,
+}: UseReceiveAccountPreselectionEffectProps) => {
+    const dispatch = useDispatch();
+
+    const receiveSymbol = getSymbolFromTradeableAsset(receiveAsset);
+
+    const accounts = useSelector((state: CombinedSelectorsRootState) =>
+        selectVisibleDeviceAccountsByNetworkSymbolSorted(state, receiveSymbol ?? null),
+    );
+    const selectedReceiveAccount = useSelector(selectReceiveAccount);
+    const selectedSendAccount = useSelector((state: TradingRootState & AccountsRootState) =>
+        selectSendAccount?.(state),
+    );
+
+    useEffect(() => {
+        if (!receiveSymbol || accounts.length === 0 || !!selectedReceiveAccount) {
+            return;
+        }
+
+        const preselectedAccount = getReceiveAccountPreselection({
+            symbol: receiveSymbol,
+            accounts,
+            sendAccount: selectedSendAccount,
+        });
+
+        if (!preselectedAccount) {
+            return;
+        }
+
+        const { accountKey, address } = preselectedAccount;
+
+        if (tradingType === 'buy') {
+            dispatch(tradingBuyActions.setTradingAccountKey(accountKey));
+            dispatch(tradingBuyActions.setReceiveAccountKey(accountKey));
+            dispatch(tradingBuyActions.setReceiveAddress(address));
+
+            return;
+        }
+
+        dispatch(tradingExchangeActions.setReceiveAccountKey(accountKey));
+        dispatch(tradingExchangeActions.setReceiveAddress(address));
+    }, [
+        accounts,
+        dispatch,
+        receiveSymbol,
+        selectedReceiveAccount,
+        tradingType,
+        selectedSendAccount,
+    ]);
+};

--- a/suite-native/module-trading/src/hooks/general/form/useReceiveAccountPreselectionEffect.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useReceiveAccountPreselectionEffect.ts
@@ -41,10 +41,10 @@ export const useReceiveAccountPreselectionEffect = ({
 }: UseReceiveAccountPreselectionEffectProps) => {
     const dispatch = useDispatch();
 
-    const receiveSymbol = getSymbolFromTradeableAsset(receiveAsset);
+    const receiveAssetNetworkSymbol = getSymbolFromTradeableAsset(receiveAsset);
 
     const accounts = useSelector((state: CombinedSelectorsRootState) =>
-        selectVisibleDeviceAccountsByNetworkSymbolSorted(state, receiveSymbol ?? null),
+        selectVisibleDeviceAccountsByNetworkSymbolSorted(state, receiveAssetNetworkSymbol ?? null),
     );
     const selectedReceiveAccount = useSelector(selectReceiveAccount);
     const selectedSendAccount = useSelector((state: TradingRootState & AccountsRootState) =>
@@ -52,12 +52,12 @@ export const useReceiveAccountPreselectionEffect = ({
     );
 
     useEffect(() => {
-        if (!receiveSymbol || accounts.length === 0 || !!selectedReceiveAccount) {
+        if (!receiveAssetNetworkSymbol || accounts.length === 0 || !!selectedReceiveAccount) {
             return;
         }
 
         const preselectedAccount = getReceiveAccountPreselection({
-            symbol: receiveSymbol,
+            receiveAssetNetworkSymbol,
             accounts,
             sendAccount: selectedSendAccount,
         });
@@ -81,7 +81,7 @@ export const useReceiveAccountPreselectionEffect = ({
     }, [
         accounts,
         dispatch,
-        receiveSymbol,
+        receiveAssetNetworkSymbol,
         selectedReceiveAccount,
         tradingType,
         selectedSendAccount,

--- a/suite-native/module-trading/src/utils/buy/__tests__/quotesUtils.test.ts
+++ b/suite-native/module-trading/src/utils/buy/__tests__/quotesUtils.test.ts
@@ -1,5 +1,6 @@
 import type { BuyTrade, CryptoId } from 'invity-api';
 
+import { deviceInitialState } from '@suite-common/device';
 import { type TradingAssetOption } from '@suite-common/trading';
 import { act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
 import {
@@ -19,7 +20,10 @@ describe('quotesUtils', () => {
 
     const renderUseTradingBuyForm = () =>
         renderHookWithStoreProvider(() => useBuyForm(), {
-            preloadedState: { wallet: { trading: getInitializedTradingState() } },
+            preloadedState: {
+                device: deviceInitialState,
+                wallet: { trading: getInitializedTradingState() },
+            },
         });
 
     beforeEach(() => {

--- a/suite-native/trading-atoms/src/utils/general/__tests__/receiveAccountUtils.test.ts
+++ b/suite-native/trading-atoms/src/utils/general/__tests__/receiveAccountUtils.test.ts
@@ -87,9 +87,10 @@ describe('receiveAccountUtils', () => {
         });
 
         it('should throw when address is specified for account without addresses', () => {
-            expect(() =>
-                getReceiveAccountFromAccountAndAddressString(getEthAccount(), 'ANYADDRESS'),
-            ).toThrow('Account has no addresses');
+            const ethAccount = getEthAccount();
+            expect(getReceiveAccountFromAccountAndAddressString(ethAccount, 'ANYADDRESS')).toEqual({
+                account: ethAccount,
+            });
         });
     });
 });

--- a/suite-native/trading-atoms/src/utils/general/receiveAccountUtils.ts
+++ b/suite-native/trading-atoms/src/utils/general/receiveAccountUtils.ts
@@ -1,11 +1,12 @@
 import { invariant } from '@suite-common/suite-utils';
+import { isAccountBasedNetwork } from '@suite-common/wallet-config';
 import type { ReceiveAccount } from '@suite-native/trading-types';
 
 export const getReceiveAccountFromAccountAndAddressString = (
     account: ReceiveAccount['account'],
     receiveAddress?: string,
 ): ReceiveAccount => {
-    if (!receiveAddress) {
+    if (!receiveAddress || isAccountBasedNetwork(account.symbol)) {
         return { account };
     }
 

--- a/suite-native/trading-fixtures/src/__fixtures__/accounts.ts
+++ b/suite-native/trading-fixtures/src/__fixtures__/accounts.ts
@@ -10,6 +10,9 @@ export const btc1NormalAccount = mockWalletAccount({
     deviceState: MOCK_ACCOUNT_DEVICE_SESSION_ID,
     accountType: 'normal',
     descriptor: asAccountDescriptor('btc1-normal'),
+    balance: '1000000',
+    availableBalance: '1000000',
+    formattedBalance: '0.01',
     addresses: {
         used: [
             {
@@ -83,6 +86,16 @@ export const eth1NormalAccount = mockWalletAccount({
 
     accountType: 'normal',
     descriptor: asAccountDescriptor('eth1-normal'),
+    tokens: [
+        {
+            standard: 'ERC20',
+            name: 'USDC',
+            contract: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+            symbol: 'usdc',
+            decimals: 6,
+            balance: '1',
+        },
+    ],
     visible: true,
 });
 

--- a/suite-native/trading-state/src/reducers/__tests__/buySlice.test.ts
+++ b/suite-native/trading-state/src/reducers/__tests__/buySlice.test.ts
@@ -3,7 +3,12 @@ import type { CryptoId } from 'invity-api';
 import { type TradingBuyState } from '@suite-common/trading';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { tradingInitialState } from '@suite-native/trading-consts';
-import { buyQuotes, mercuryoApplePayBuyQuote } from '@suite-native/trading-fixtures';
+import {
+    btc1NormalAccount,
+    buyQuotes,
+    eth1NormalAccount,
+    mercuryoApplePayBuyQuote,
+} from '@suite-native/trading-fixtures';
 
 import { buyActions, buyReducer } from '../buySlice';
 
@@ -106,6 +111,41 @@ describe('buySlice', () => {
             const state = buyReducer(prevState, buyActions.assetChanged());
 
             expect(state.quotesRequest).toBeUndefined();
+        });
+    });
+
+    describe('assetTokenChanged', () => {
+        it('should clear amount limits and quotes request data without clearing receive account info', () => {
+            const tradingAccountKey = btc1NormalAccount.key;
+            const receiveAccountKey = eth1NormalAccount.key;
+            const receiveAddress = 'bc1qxyz';
+            const prevState: TradingBuyState = {
+                ...tradingInitialState.buy,
+                amountLimits: {
+                    currency: 'CZK',
+                    minFiat: '100',
+                    maxCrypto: '0.01',
+                    maxFiat: '1000',
+                    minCrypto: '0.0001',
+                },
+                quotesRequest: {
+                    wantCrypto: true,
+                    receiveCurrency: 'btc' as CryptoId,
+                    fiatCurrency: 'czk',
+                    country: 'CZ',
+                },
+                tradingAccountKey,
+                receiveAccountKey,
+                receiveAddress,
+            };
+
+            const state = buyReducer(prevState, buyActions.assetTokenChanged());
+
+            expect(state.amountLimits).toBeUndefined();
+            expect(state.quotesRequest).toBeUndefined();
+            expect(state.tradingAccountKey).toBe(tradingAccountKey);
+            expect(state.receiveAccountKey).toBe(receiveAccountKey);
+            expect(state.receiveAddress).toBe(receiveAddress);
         });
     });
 

--- a/suite-native/trading-state/src/reducers/__tests__/exchangeSlice.test.ts
+++ b/suite-native/trading-state/src/reducers/__tests__/exchangeSlice.test.ts
@@ -3,7 +3,11 @@ import type { CryptoId } from 'invity-api';
 import { type TradingExchangeState } from '@suite-common/trading';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { tradingInitialState } from '@suite-native/trading-consts';
-import { exchangeQuotes, mercuryoFixedWorstQuote } from '@suite-native/trading-fixtures';
+import {
+    eth1NormalAccount,
+    exchangeQuotes,
+    mercuryoFixedWorstQuote,
+} from '@suite-native/trading-fixtures';
 
 import { exchangeActions, exchangeReducer } from '../exchangeSlice';
 
@@ -114,6 +118,34 @@ describe('exchangeSlice', () => {
             expect(state.quotesRequest).toBeUndefined();
             expect(state.receiveAccountKey).toBeUndefined();
             expect(state.receiveAddress).toBeUndefined();
+        });
+    });
+
+    describe('receiveTokenChanged', () => {
+        it('should clear amount limits and quotes request data without clearing receive account info', () => {
+            const receiveAccountKey = eth1NormalAccount.key;
+            const receiveAddress = 'bc1qxyz';
+            const prevState: TradingExchangeState = {
+                ...tradingInitialState.exchange,
+                amountLimits: {
+                    currency: 'BTC',
+                    minCrypto: '0.001',
+                    maxCrypto: '10',
+                },
+                quotesRequest: {
+                    send: 'bitcoin' as CryptoId,
+                    receive: 'ethereum' as CryptoId,
+                },
+                receiveAccountKey,
+                receiveAddress,
+            };
+
+            const state = exchangeReducer(prevState, exchangeActions.receiveTokenChanged());
+
+            expect(state.amountLimits).toBeUndefined();
+            expect(state.quotesRequest).toBeUndefined();
+            expect(state.receiveAccountKey).toBe(receiveAccountKey);
+            expect(state.receiveAddress).toBe(receiveAddress);
         });
     });
 });

--- a/suite-native/trading-state/src/reducers/buySlice.ts
+++ b/suite-native/trading-state/src/reducers/buySlice.ts
@@ -29,6 +29,10 @@ const buySlice = createSlice({
             state.amountLimits = undefined;
             state.quotesRequest = undefined;
         },
+        assetTokenChanged: state => {
+            state.amountLimits = undefined;
+            state.quotesRequest = undefined;
+        },
         fiatCurrencyChanged: state => {
             state.amountLimits = undefined;
             state.quotesRequest = undefined;

--- a/suite-native/trading-state/src/reducers/exchangeSlice.ts
+++ b/suite-native/trading-state/src/reducers/exchangeSlice.ts
@@ -32,6 +32,10 @@ const exchangeSlice = createSlice({
             state.receiveAccountKey = undefined;
             state.receiveAddress = undefined;
         },
+        receiveTokenChanged: state => {
+            state.amountLimits = undefined;
+            state.quotesRequest = undefined;
+        },
     },
 });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* Add `getReceiveAccountPreselection` to pick a default receive account when a trade asset is selected.
* Add `useReceiveAccountPreselectionEffect` hook that reacts to receive-asset changes and dispatches the preselected account/address into the buy or exchange form state.
* Wire the hook into the `useBuyForm` and `useExchangeForm`


<!--- Describe your changes in detail -->

## Notes for QA
* Check that the rules for pre-selection works as expected in Buy/Exchange forms

## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/27048

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/27048-preselect-receive-address-in-trading-form&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/27048-preselect-receive-address-in-trading-form&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/27048-preselect-receive-address-in-trading-form&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-29T07:40:16.933Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-29T07:37:13.902Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/27048-preselect-receive-address-in-trading-form/web/](https://dev.suite.sldev.cz/suite-web/feat/27048-preselect-receive-address-in-trading-form/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->