### PR TITLE
feat(ci): Added option to LLM test analysis to rebuild the cache from…

### DIFF
--- a/.github/workflows/build-llm-test-analysis-nightly.yml
+++ b/.github/workflows/build-llm-test-analysis-nightly.yml
@@ -5,6 +5,11 @@ on:
   schedule:
     - cron: "0 5 * * 1-5"
   workflow_dispatch:
+    inputs:
+      no_cache:
+        description: "Delete the cached analysis file on S3 and re-analyze all test files from scratch"
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}
@@ -53,7 +58,13 @@ jobs:
         shell: bash
         run: sfw --silent yarn workspaces focus @trezor/e2e-utils
 
+      - name: Delete existing LLM analysis cache from S3 (no_cache)
+        if: ${{ inputs.no_cache }}
+        run: |
+          aws s3 rm s3://dev.suite.sldev.cz/coverage/e2e/llm-analysis.json || true
+
       - name: Download existing LLM analysis cache from S3
+        if: ${{ !inputs.no_cache }}
         run: |
           mkdir -p packages/e2e-utils/coverage-map
           aws s3 cp s3://dev.suite.sldev.cz/coverage/e2e/llm-analysis.json packages/e2e-utils/coverage-map/llm-analysis.json || true
@@ -62,7 +73,7 @@ jobs:
         env:
           CLAUDE_API_KEY: ${{ secrets.E2E_CLAUDE_API_KEY }}
         run: |
-          yarn workspace @trezor/e2e-utils analyze-tests ../../suite/e2e/tests --buildCache --exclude "manual/**"
+          yarn workspace @trezor/e2e-utils analyze-tests ../../suite/e2e/tests --buildCache --exclude "manual/**" ${{ inputs.no_cache && '--force' || '' }}
 
       - name: Upload LLM analysis cache to S3
         if: always()

--- a/packages/e2e-utils/src/llmTestAnalyzer/index.ts
+++ b/packages/e2e-utils/src/llmTestAnalyzer/index.ts
@@ -291,6 +291,7 @@ const reportUsageTotals = (apiKey: string | undefined) => {
 const main = async () => {
     const args = process.argv.slice(2);
     const buildCache = args.includes('--buildCache');
+    const force = args.includes('--force');
     const positionalArgs = args.filter(a => !a.startsWith('--'));
 
     const excludePatterns: string[] = [];
@@ -329,6 +330,7 @@ const main = async () => {
                 'Options:',
                 '  --buildCache        Build/update the analysis cache file instead of printing.',
                 '                      Skips files whose sha256 hash has not changed since last run.',
+                '  --force             Re-analyze all files even if their sha256 hash matches the cache.',
                 `  --cache-file <path> Path to the cache file. Default: ${DEFAULT_CACHE_FILE}`,
                 '  --exclude <pattern> Glob pattern for files to exclude. Can be repeated.',
                 '                      Example: --exclude "**/manual/**"',
@@ -390,7 +392,7 @@ const main = async () => {
                 const testSource = fs.readFileSync(testFile, 'utf8');
                 const currentHash = hashContent(testSource);
                 const cached = cache[relPath];
-                if (cached?.sha256 === currentHash) {
+                if (!force && cached?.sha256 === currentHash) {
                     log(`Cache up-to-date, skipping ${relPath}`);
                     continue;
                 }


### PR DESCRIPTION
… scratch

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is `packages/e2e-utils/src/llmTestAnalyzer/index.ts`, which is a utility used for LLM-based test analysis tooling itself — it is not part of any application runtime code or test infrastructure that E2E tests exercise. None of the 51 candidate tests reference this module in their source hints or behavioral descriptions, and there is no static coverage mapping linking any test to this file. This is a meta-tooling change with no risk of causing E2E test regressions, so no tests need to be run.

<details><summary><b>Changed files (1)</b></summary>

- `packages/e2e-utils/src/llmTestAnalyzer/index.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/e2e-utils/src/llmTestAnalyzer/index.ts`

_Updated: 2026-05-27T11:38:16.931Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat-ci-llm-analysis-cache-refresh&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat-ci-llm-analysis-cache-refresh&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-27T11:45:04.973Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-27T11:42:47.954Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat-ci-llm-analysis-cache-refresh/web/](https://dev.suite.sldev.cz/suite-web/feat-ci-llm-analysis-cache-refresh/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->