### PR TITLE
[readability nitpick]: refactor: invert throw and return branches into guard clauses

### DIFF
--- a/packages/blockchain-link/src/workers/evm-rpc/handlers/subscribe.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/handlers/subscribe.ts
@@ -63,16 +63,14 @@ export const subscribe = async (
 ): Promise<Responses.Subscribe> => {
     const { payload } = request;
 
-    let response: { subscribed: boolean };
-
-    if (payload.type === 'block') {
-        response = await subscribeBlock(request);
-    } else {
+    if (payload.type !== 'block') {
         throw new CustomError(
             'invalid_param',
             `Subscription type '${payload.type}' not supported by EVM RPC worker`,
         );
     }
+
+    const response = await subscribeBlock(request);
 
     return {
         type: RESPONSES.SUBSCRIBE,
@@ -83,16 +81,14 @@ export const subscribe = async (
 export const unsubscribe = (request: Request<MessageTypes.Unsubscribe>): Responses.Unsubscribe => {
     const { payload } = request;
 
-    let response: { subscribed: boolean };
-
-    if (payload.type === 'block') {
-        response = unsubscribeBlock(request);
-    } else {
+    if (payload.type !== 'block') {
         throw new CustomError(
             'invalid_param',
             `Unsubscription type '${payload.type}' not supported by EVM RPC worker`,
         );
     }
+
+    const response = unsubscribeBlock(request);
 
     return {
         type: RESPONSES.UNSUBSCRIBE,

--- a/packages/suite/src/components/guide/HeaderBreadcrumb.tsx
+++ b/packages/suite/src/components/guide/HeaderBreadcrumb.tsx
@@ -69,13 +69,11 @@ export const HeaderBreadcrumb = () => {
     return (
         <Row gap={4} maxWidth="calc(100% - 36px - 8px)" flexWrap="wrap">
             <TextButton
-                onClick={() => {
-                    if (grandParentNode) {
-                        navigateToCategory(grandParentNode);
-                    } else {
-                        navigateToGuideDashboard();
-                    }
-                }}
+                onClick={() =>
+                    grandParentNode
+                        ? navigateToCategory(grandParentNode)
+                        : navigateToGuideDashboard()
+                }
                 size="small"
                 isUnderlined
                 intent="neutral"

--- a/suite-common/wallet-core/src/token/stellarTokenThunks.ts
+++ b/suite-common/wallet-core/src/token/stellarTokenThunks.ts
@@ -116,30 +116,28 @@ const manageTrustline = async (
         },
     });
 
-    if (response.success) {
-        const signature = Buffer.from(response.payload.signature, 'hex').toString('base64');
-        transaction.addSignature(account.descriptor, signature);
-        const serializedTx = transaction.toEnvelope().toXDR('hex');
-
-        // Submit transaction to the network
-        const pushResponse = await TrezorConnect.pushTransaction({
-            tx: serializedTx,
-            coin: account.symbol,
-            identity: tryGetAccountIdentity(account),
-        });
-
-        if (pushResponse.success) {
-            return;
-        } else {
-            return rejectWithValue({
-                error: 'sign-transaction-failed',
-                message: pushResponse.error.message,
-            });
-        }
-    } else {
+    if (!response.success) {
         return rejectWithValue({
             error: 'sign-transaction-failed',
             message: response.error.message,
+        });
+    }
+
+    const signature = Buffer.from(response.payload.signature, 'hex').toString('base64');
+    transaction.addSignature(account.descriptor, signature);
+    const serializedTx = transaction.toEnvelope().toXDR('hex');
+
+    // Submit transaction to the network
+    const pushResponse = await TrezorConnect.pushTransaction({
+        tx: serializedTx,
+        coin: account.symbol,
+        identity: tryGetAccountIdentity(account),
+    });
+
+    if (!pushResponse.success) {
+        return rejectWithValue({
+            error: 'sign-transaction-failed',
+            message: pushResponse.error.message,
         });
     }
 };

--- a/suite/e2e/support/mocks/ada-endpoints.ts
+++ b/suite/e2e/support/mocks/ada-endpoints.ts
@@ -66,13 +66,9 @@ export const fixtures = [
     {
         method: 'GET_ACCOUNT_INFO',
         default: true,
-        response: ({ params }: any) => {
-            if (isFirstAccount(params.descriptor)) {
-                return { data: ADA_MOCKED_ACCOUNT };
-            } else {
-                return { data: ADA_MOCKED_EMPTY_ACCOUNT };
-            }
-        },
+        response: ({ params }: any) => ({
+            data: isFirstAccount(params.descriptor) ? ADA_MOCKED_ACCOUNT : ADA_MOCKED_EMPTY_ACCOUNT,
+        }),
     },
     {
         method: 'GET_ACCOUNT_UTXO',

--- a/suite/metadata/src/metadataPasswordsActions.ts
+++ b/suite/metadata/src/metadataPasswordsActions.ts
@@ -218,26 +218,26 @@ export const addPasswordMetadata =
             cloneObject(provider.data[fileName]) ||
             METADATA_PASSWORDS.DEFAULT_PASSWORD_MANAGER_STATE;
 
-        if ('config' in metadata) {
-            metadata.entries[nextId] = payload;
-
-            dispatch(
-                metadataDataThunks.setMetadata({
-                    provider,
-                    fileName,
-                    data: metadata,
-                }),
-            );
-
-            metadataDataThunks.encryptAndSaveMetadata({
-                providerInstance,
-                fileName,
-                data: metadata,
-                aesKey,
-            });
-        } else {
+        if (!('config' in metadata)) {
             return Promise.resolve({ success: false, error: 'trying to edit wrong object' });
         }
+
+        metadata.entries[nextId] = payload;
+
+        dispatch(
+            metadataDataThunks.setMetadata({
+                provider,
+                fileName,
+                data: metadata,
+            }),
+        );
+
+        metadataDataThunks.encryptAndSaveMetadata({
+            providerInstance,
+            fileName,
+            data: metadata,
+            aesKey,
+        });
     };
 
 export const removePasswordMetadata =
@@ -259,24 +259,24 @@ export const removePasswordMetadata =
 
         const metadata = cloneObject(provider.data[fileName]);
 
-        if (metadata && 'config' in metadata) {
-            delete metadata.entries[index];
-
-            dispatch(
-                metadataDataThunks.setMetadata({
-                    provider,
-                    fileName,
-                    data: metadata,
-                }),
-            );
-
-            metadataDataThunks.encryptAndSaveMetadata({
-                providerInstance,
-                fileName,
-                data: metadata,
-                aesKey,
-            });
-        } else {
+        if (!metadata || !('config' in metadata)) {
             return Promise.resolve({ success: false, error: 'trying to edit wrong object' });
         }
+
+        delete metadata.entries[index];
+
+        dispatch(
+            metadataDataThunks.setMetadata({
+                provider,
+                fileName,
+                data: metadata,
+            }),
+        );
+
+        metadataDataThunks.encryptAndSaveMetadata({
+            providerInstance,
+            fileName,
+            data: metadata,
+            aesKey,
+        });
     };


### PR DESCRIPTION
## Description

Inverts `if (condition) { ... } else { throw }` blocks into guard clauses (`if (!condition) throw; ...`) and collapses a couple of trivial `if/else` branches into expressions.

This removes the need for pre-declared mutable `let response;` variables that were only assigned inside the happy-path branch, makes the error path a leading guard, and de-nests the main logic. No behavioural change — the same conditions throw the same errors and return the same values.

Affected:
- `blockchain-link` EVM RPC `subscribe`/`unsubscribe` handlers — guard on unsupported subscription type
- `suite` guide `HeaderBreadcrumb` — ternary for navigation target
- `wallet-core` `stellarTokenThunks` — guard clauses in trustline management
- `suite` e2e ADA endpoint mocks
- `suite` metadata passwords actions

Extracted as a standalone change from the larger cleanup PR #27472.

## Related Issue

N/A

## Screenshots

N/A

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This changeset touches 5 files across different domains: an EVM RPC subscription handler, a Guide UI breadcrumb component, Stellar token thunks, ADA test mocks, and metadata password actions. The highest risk is in the ADA mock endpoints file which directly affects ADA staking E2E tests. The Guide HeaderBreadcrumb change has moderate risk since it's a UI component within the guide panel. The stellarTokenThunks change is narrowly scoped to Stellar token handling. The EVM RPC subscribe handler and metadata passwords action have no direct E2E test coverage.

<details><summary><b>Changed files (5)</b></summary>

- `packages/blockchain-link/src/workers/evm-rpc/handlers/subscribe.ts`
- `packages/suite/src/components/guide/HeaderBreadcrumb.tsx`
- `suite-common/wallet-core/src/token/stellarTokenThunks.ts`
- `suite/e2e/support/mocks/ada-endpoints.ts`
- `suite/metadata/src/metadataPasswordsActions.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `../../suite/e2e/tests/staking/ada/stake.test.ts` — The changed file suite/e2e/support/mocks/ada-endpoints.ts is a test support mock used directly by the ADA staking tests. The stake test imports ADA_MOCKED_ACCOUNT and uses blockbookMock with ada endpoints, so any change to the mock data could break this test.
- `../../suite/e2e/tests/staking/ada/unstake.test.ts` — The ADA unstake test also depends on the ada-endpoints mock for setting up staked account state via blockbookMock/updateAccountState. Changes to this mock file directly affect the test's preconditions and assertions.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `../../suite/e2e/tests/general/suite-guide.test.ts` — The HeaderBreadcrumb.tsx component is part of the Guide panel UI. This test directly exercises opening the Guide panel, navigating guide content, and viewing article headers — functionality where the breadcrumb component renders. A rendering bug in the breadcrumb could affect guide navigation.
- `../../suite/e2e/tests/suite/guide.test.ts` — This test exercises guide panel interactions including opening/closing the panel, navigating guide nodes and verifying labels, submitting feedback, and searching articles. The HeaderBreadcrumb component is part of the guide navigation UI that renders during these flows.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `../../suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — The stellarTokenThunks.ts change could affect token resolution for disabled networks. This test specifically swaps a token to an asset on a disabled network (XLM/Stellar), which is the exact network the Stellar token thunks handle. If the thunk change affects how disabled-network tokens are resolved, this test would catch it.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/blockchain-link/src/workers/evm-rpc/handlers/subscribe.ts`
- `suite/metadata/src/metadataPasswordsActions.ts`

_Updated: 2026-05-27T11:46:42.328Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/invert-throw-return-branches&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/invert-throw-return-branches&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/invert-throw-return-branches&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-27T11:53:46.216Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-27T11:51:18.115Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/invert-throw-return-branches/web/](https://dev.suite.sldev.cz/suite-web/mroz22/invert-throw-return-branches/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->