### PR TITLE
chore(transport): drop stale trezord-go URL comments

### DIFF
--- a/packages/transport/src/transports/bridge.ts
+++ b/packages/transport/src/transports/bridge.ts
@@ -103,7 +103,6 @@ export class BridgeTransport extends AbstractTransport {
         );
     }
 
-    // https://github.com/trezor/trezord-go/blob/f559ee5079679aeb5f897c65318d3310f78223ca/core/core.go#L373
     public listen() {
         if (this.listening) {
             return error({ code: ERRORS.ALREADY_LISTENING });
@@ -130,12 +129,10 @@ export class BridgeTransport extends AbstractTransport {
         }
     }
 
-    // https://github.com/trezor/trezord-go/blob/f559ee5079679aeb5f897c65318d3310f78223ca/core/core.go#L235
     public enumerate({ signal }: AbstractTransportMethodParams<'enumerate'> = {}) {
         return this.scheduleAction(signal => this.post('/enumerate', { signal }), { signal });
     }
 
-    // https://github.com/trezor/trezord-go/blob/f559ee5079679aeb5f897c65318d3310f78223ca/core/core.go#L420
     public acquire({ input, signal }: AbstractTransportMethodParams<'acquire'>) {
         return this.scheduleAction(
             async signal => {
@@ -154,7 +151,6 @@ export class BridgeTransport extends AbstractTransport {
         );
     }
 
-    // https://github.com/trezor/trezord-go/blob/f559ee5079679aeb5f897c65318d3310f78223ca/core/core.go#L354
     public release({ path: _, session, signal }: AbstractTransportMethodParams<'release'>) {
         return this.scheduleAction(
             async signal => {
@@ -209,7 +205,6 @@ export class BridgeTransport extends AbstractTransport {
         return abortController.signal;
     };
 
-    // https://github.com/trezor/trezord-go/blob/f559ee5079679aeb5f897c65318d3310f78223ca/core/core.go#L534
     public call({
         session,
         name,


### PR DESCRIPTION
## Summary

Five comments in `BridgeTransport` were permalinks into trezord-go source (`core/core.go#LXXX`), placed before the `listen` / `enumerate` / `acquire` / `release` / `call` methods. Each pointed at where that endpoint was implemented in the legacy trezord-go daemon.

With legacy trezord-go (port 21325) support dropped in 1774c788cb2, the only bridge we talk to is the bundled `@trezor/transport-bridge` node server. These source pointers are no longer accurate or useful, so this PR removes them.

No behavior change — comment-only deletion (5 lines).

Part of the cleanup series tracked in #23794. This is **PR 1B** of five small cleanup PRs (1A–1E).

- PR 1A: #28095
- PR 1B: #28102
- PR 1C: #28104
- PR 1D: #28136
- PR 1E: #28137

## Test plan

Comment-only removal — no functional, type, or dependency impact. TypeScript ignores comments, no ESLint rule governs them, and unit tests / depcheck are unaffected. CI validates the package build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to packages/transport/src/transports/bridge.ts, which is a core transport layer file used by virtually all E2E tests (121 tests mapped). Because it is such a broad dependency, most tests are only transitively affected and should not all be run. Without detailed LLM analysis of specific test behaviors, we recommend a small representative set of tests that exercise different device communication patterns (discovery, multi-step flows, settings read/write) to validate the bridge transport changes. If the bridge transport change is minor (e.g., a bugfix or refactor), this minimal set should provide sufficient confidence; if it is a major architectural change, broader testing may be warranted.

<details><summary><b>Changed files (1)</b></summary>

- `packages/transport/src/transports/bridge.ts`

</details>

**Recommended tests (3)**

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/general/wallet-discovery.test.ts` — Wallet discovery directly exercises device communication via the bridge transport layer. Changes to bridge.ts could affect how the app discovers and connects to hardware wallets, making this a plausible regression path.
- `suite/e2e/tests/backup/t2t1-success.test.ts` — Backup flows require active device communication through the bridge transport. A successful backup test validates that the bridge transport can sustain a multi-step device interaction without breaking.
- `suite/e2e/tests/settings/device/t2t1-device-settings.test.ts` — Device settings tests exercise direct device communication via the bridge transport for reading and writing device configuration, making them sensitive to bridge transport changes.

</details>

_Updated: 2026-05-27T11:56:18.644Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mvarmuza/transport-drop-trezord-url-comments/web/](https://dev.suite.sldev.cz/suite-web/mvarmuza/transport-drop-trezord-url-comments/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mvarmuza/transport-drop-trezord-url-comments&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mvarmuza/transport-drop-trezord-url-comments&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-27T12:03:34.284Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-27T12:01:05.444Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->


