### PR TITLE
refactor(transport-bridge): inline bindHandlers wrapper into start()

### DIFF
--- a/packages/transport-bridge/src/http.ts
+++ b/packages/transport-bridge/src/http.ts
@@ -245,364 +245,353 @@ export class TrezordNode {
             address: ADDRESS.hostname,
         });
 
-        // TODO: inline bindHandlers into start(). The wrapper made sense when two
-        // servers (21328 + 21325) shared the same handler set; with a single HTTP
-        // server it adds an indirection with no readers. Kept as a wrapper here
-        // only to minimise the review diff for the 21325 compatibility-port drop.
-        const bindHandlers = () => {
-            app.use([
-                (req, res, next, context) => {
-                    // directly navigating to status page of bridge in browser. when request is not issued by js, there is no origin header
-                    if (
-                        !req.headers.origin &&
-                        req.headers.host &&
-                        [
-                            `${ADDRESS.hostname}:${app.getServerAddress().port}`,
-                            `localhost:${app.getServerAddress().port}`,
-                        ].includes(req.headers.host)
-                    ) {
-                        next(req, res);
-                    } else {
-                        const isOriginAllowed = checkOrigin({
-                            request: req,
-                            allowedOrigin: [
-                                'sldev.cz',
-                                'trezor.io',
-                                'localhost',
-                                // When using Tor it will send string "null" as default, and it will not allow calling to localhost.
-                                // To allow it to be sent, you can go to about:config and set the attributes below:
-                                // "network.http.referer.hideOnionSource - false"
-                                // "network.proxy.allow_hijacking_localhost - false"
-                                'trezoriovpjcahpzkrewelclulmszwbqpzmzgub37gbcjlvluxtruqad.onion',
-                            ],
-                            pathname: req.url,
-                            logger: context.logger,
-                        });
-
-                        if (isOriginAllowed) {
-                            next(req, res);
-                        } else {
-                            // error handling identic to legacy trezord-go
-                            switch (req.url) {
-                                case '/enumerate':
-                                case '/listen':
-                                    res.statusCode = 403;
-                                    break;
-                                default:
-                                    res.statusCode = 404;
-                            }
-                            res.end();
-                        }
-                    }
-                },
-            ]);
-
-            // origin was checked in previous app.use. if it didn't not satisfy the check, it did not move on to this handler
-            app.use([
-                (req, res, next) => {
-                    if (req.headers.origin) {
-                        res.setHeader('Access-Control-Allow-Origin', req.headers.origin);
-                    }
-
-                    next(req, res);
-                },
-            ]);
-
-            app.post('/enumerate', [
-                (_req, res) => {
-                    res.setHeader('Content-Type', 'text/plain');
-                    const signal = this.createAbortSignal(res);
-                    this.core.enumerate({ signal }).then(result => {
-                        if (!result.success) {
-                            res.statusCode = 400;
-
-                            return this.handleResponse(
-                                res,
-                                str({ error: result.error.code, message: result.error.message }),
-                            );
-                        }
-                        res.statusCode = 200;
-                        this.handleResponse(res, str(result.payload.descriptors));
-                    });
-                },
-            ]);
-
-            app.post('/listen', [
-                parseBodyJSON,
-                validateDescriptorsJSON,
-                (req, res) => {
-                    res.setHeader('Content-Type', 'text/plain');
-                    this.listenSubscriptions.push({
-                        descriptors: req.body,
-                        req,
-                        res,
-                    });
-                    this.checkAffectedSubscriptions();
-                },
-            ]);
-
-            app.post('/acquire/:path/:previous', [
-                parseBodyJSON,
-                validateAcquireParams,
-                (req, res) => {
-                    res.setHeader('Content-Type', 'text/plain');
-                    const signal = this.createAbortSignal(res);
-                    this.core
-                        .acquire({
-                            path: req.params.path,
-                            previous: req.params.previous,
-                            // @ts-expect-error
-                            sessionOwner: req?.body?.sessionOwner,
-                            signal,
-                        })
-                        .then(result => {
-                            if (!result.success) {
-                                res.statusCode = 400;
-
-                                return this.handleResponse(
-                                    res,
-                                    str({
-                                        error: result.error.code,
-                                        message: result.error.message,
-                                    }),
-                                );
-                            }
-                            res.statusCode = 200;
-                            this.handleResponse(res, str({ session: result.payload.session }));
-                        });
-                },
-            ]);
-
-            app.post('/release/:session', [
-                validateSessionParams,
-                parseBodyText,
-                (req, res) => {
-                    this.core
-                        .release({
-                            session: req.params.session,
-                        })
-                        .then(result => {
-                            if (!result.success) {
-                                res.statusCode = 400;
-
-                                return this.handleResponse(
-                                    res,
-                                    str({
-                                        error: result.error.code,
-                                        message: result.error.message,
-                                    }),
-                                );
-                            }
-                            res.statusCode = 200;
-
-                            this.handleResponse(res, str({ session: req.params.session }));
-                        });
-                },
-            ]);
-
-            app.post('/abort/:session', [
-                validateSessionParams,
-                parseBodyText,
-                (req, res) => {
-                    let statusCode = 400;
-                    this.abortableSignals.forEach(s => {
-                        if (s.session === req.params.session) {
-                            statusCode = 200;
-                            s.abort();
-                        }
-                    });
-                    this.removeAbortableSignal(req.params.session);
-
-                    res.statusCode = statusCode;
-
-                    return this.handleResponse(
-                        res,
-                        str(
-                            statusCode === 200
-                                ? { success: true }
-                                : { error: ERRORS.SESSION_NOT_FOUND },
-                        ),
-                    );
-                },
-            ]);
-
-            app.post('/call/:session', [
-                validateSessionParams,
-                parseBodyText,
-                validateProtocolMessageBody(true),
-                (req, res) => {
-                    const { session } = req.params;
-                    const signal = this.createAbortSignal(res, session);
-                    this.core
-                        .call({
-                            ...req.body,
-                            session,
-                            signal,
-                        })
-                        .then(result => {
-                            this.removeAbortableSignal(session);
-                            if (!result.success) {
-                                res.statusCode = 400;
-
-                                return this.handleResponse(
-                                    res,
-                                    str({
-                                        error: result.error.code,
-                                        message: result.error.message,
-                                    }),
-                                );
-                            }
-                            res.statusCode = 200;
-
-                            this.handleResponse(res, str(result.payload));
-                        });
-                },
-            ]);
-
-            app.post('/read/:session', [
-                validateSessionParams,
-                parseBodyText,
-                validateProtocolMessageBody(false),
-                (req, res) => {
-                    const { session } = req.params;
-                    const signal = this.createAbortSignal(res, session);
-                    this.core
-                        .receive({
-                            ...req.body,
-                            session,
-                            signal,
-                        })
-                        .then(result => {
-                            this.removeAbortableSignal(session);
-                            if (!result.success) {
-                                res.statusCode = 400;
-
-                                return this.handleResponse(
-                                    res,
-                                    str({
-                                        error: result.error.code,
-                                        message: result.error.message,
-                                    }),
-                                );
-                            }
-                            res.statusCode = 200;
-
-                            this.handleResponse(res, str(result.payload));
-                        });
-                },
-            ]);
-
-            app.post('/post/:session', [
-                validateSessionParams,
-                parseBodyText,
-                validateProtocolMessageBody(true),
-                (req, res) => {
-                    const { session } = req.params;
-                    const signal = this.createAbortSignal(res, session);
-                    this.core
-                        .send({
-                            ...req.body,
-                            session,
-                            signal,
-                        })
-                        .then(result => {
-                            this.removeAbortableSignal(session);
-                            if (!result.success) {
-                                res.statusCode = 400;
-
-                                return this.handleResponse(
-                                    res,
-                                    str({
-                                        error: result.error.code,
-                                        message: result.error.message,
-                                    }),
-                                );
-                            }
-                            res.statusCode = 200;
-
-                            this.handleResponse(res, str(result.payload));
-                        });
-                },
-            ]);
-
-            app.get('/', [
-                (_req, res) => {
-                    res.writeHead(301, {
-                        Location: `${ADDRESS.origin}:${app.getServerAddress().port}/status`,
-                    });
-                    res.end();
-                },
-            ]);
-
-            app.get('/status', [
-                async (_req, res) => {
-                    res.statusCode = 200;
-                    res.appendHeader('Content-Type', 'text/html');
-
-                    try {
-                        const ui = await fs.readFile(
-                            // todo: using npx tsx ./packages/transport-bridge/src/bin.ts
-                            // will serve only the unbuilt template from src/ui folder instead from dist/ui folder
-                            path.join(__dirname, this.assetPrefix, 'ui/index.html'),
-                            'utf-8',
-                        );
-
-                        this.handleResponse(res, ui);
-                    } catch (error) {
-                        this.logger.error('Failed to fetch status page', error);
-                        // you need to run yarn workspace @trezor/transport-bridge build:ui to make it available (or build:lib will do)
-                        this.handleResponse(res, 'Failed to fetch status page');
-                    }
-                },
-            ]);
-
-            app.get('/status-data', [
-                async (_req, res) => {
-                    const signal = this.createAbortSignal(res);
-                    await this.core.enumerate({ signal });
-                    const props = {
-                        intro: `To download full logs go to ${ADDRESS.origin}:${app.getServerAddress().port}/logs`,
-                        version: this.version,
-                        bundledVersion: this.bundledVersion,
-                        devices: this.descriptors,
-                        logs: this.logger.getLog(),
-                    };
-                    res.appendHeader('Content-Type', 'application/json');
-                    this.handleResponse(res, str(props));
-                },
-            ]);
-
-            app.get('/logs', [
-                (_req, res) => {
-                    res.appendHeader('Content-Type', 'text/plain');
-                    res.appendHeader(
-                        'Content-Disposition',
-                        'attachment; filename=trezor-bridge.txt',
-                    );
-                    res.statusCode = 200;
-
-                    this.handleResponse(
-                        res,
-                        app.logger
-                            .getLog()
-                            .map(l => l.message.join('. '))
-                            .join('.\n'),
-                    );
-                },
-            ]);
-
-            app.post('/', [this.handleInfo.bind(this)]);
-
-            app.post('/configure', [this.handleInfo.bind(this)]);
-        };
-
         const appRes = await app.start();
 
         if (!appRes.success) {
             throw new Error(appRes.error);
         }
 
-        bindHandlers();
+        app.use([
+            (req, res, next, context) => {
+                // directly navigating to status page of bridge in browser. when request is not issued by js, there is no origin header
+                if (
+                    !req.headers.origin &&
+                    req.headers.host &&
+                    [
+                        `${ADDRESS.hostname}:${app.getServerAddress().port}`,
+                        `localhost:${app.getServerAddress().port}`,
+                    ].includes(req.headers.host)
+                ) {
+                    next(req, res);
+                } else {
+                    const isOriginAllowed = checkOrigin({
+                        request: req,
+                        allowedOrigin: [
+                            'sldev.cz',
+                            'trezor.io',
+                            'localhost',
+                            // When using Tor it will send string "null" as default, and it will not allow calling to localhost.
+                            // To allow it to be sent, you can go to about:config and set the attributes below:
+                            // "network.http.referer.hideOnionSource - false"
+                            // "network.proxy.allow_hijacking_localhost - false"
+                            'trezoriovpjcahpzkrewelclulmszwbqpzmzgub37gbcjlvluxtruqad.onion',
+                        ],
+                        pathname: req.url,
+                        logger: context.logger,
+                    });
+
+                    if (isOriginAllowed) {
+                        next(req, res);
+                    } else {
+                        // error handling identic to legacy trezord-go
+                        switch (req.url) {
+                            case '/enumerate':
+                            case '/listen':
+                                res.statusCode = 403;
+                                break;
+                            default:
+                                res.statusCode = 404;
+                        }
+                        res.end();
+                    }
+                }
+            },
+        ]);
+
+        // origin was checked in previous app.use. if it didn't not satisfy the check, it did not move on to this handler
+        app.use([
+            (req, res, next) => {
+                if (req.headers.origin) {
+                    res.setHeader('Access-Control-Allow-Origin', req.headers.origin);
+                }
+
+                next(req, res);
+            },
+        ]);
+
+        app.post('/enumerate', [
+            (_req, res) => {
+                res.setHeader('Content-Type', 'text/plain');
+                const signal = this.createAbortSignal(res);
+                this.core.enumerate({ signal }).then(result => {
+                    if (!result.success) {
+                        res.statusCode = 400;
+
+                        return this.handleResponse(
+                            res,
+                            str({ error: result.error.code, message: result.error.message }),
+                        );
+                    }
+                    res.statusCode = 200;
+                    this.handleResponse(res, str(result.payload.descriptors));
+                });
+            },
+        ]);
+
+        app.post('/listen', [
+            parseBodyJSON,
+            validateDescriptorsJSON,
+            (req, res) => {
+                res.setHeader('Content-Type', 'text/plain');
+                this.listenSubscriptions.push({
+                    descriptors: req.body,
+                    req,
+                    res,
+                });
+                this.checkAffectedSubscriptions();
+            },
+        ]);
+
+        app.post('/acquire/:path/:previous', [
+            parseBodyJSON,
+            validateAcquireParams,
+            (req, res) => {
+                res.setHeader('Content-Type', 'text/plain');
+                const signal = this.createAbortSignal(res);
+                this.core
+                    .acquire({
+                        path: req.params.path,
+                        previous: req.params.previous,
+                        // @ts-expect-error
+                        sessionOwner: req?.body?.sessionOwner,
+                        signal,
+                    })
+                    .then(result => {
+                        if (!result.success) {
+                            res.statusCode = 400;
+
+                            return this.handleResponse(
+                                res,
+                                str({
+                                    error: result.error.code,
+                                    message: result.error.message,
+                                }),
+                            );
+                        }
+                        res.statusCode = 200;
+                        this.handleResponse(res, str({ session: result.payload.session }));
+                    });
+            },
+        ]);
+
+        app.post('/release/:session', [
+            validateSessionParams,
+            parseBodyText,
+            (req, res) => {
+                this.core
+                    .release({
+                        session: req.params.session,
+                    })
+                    .then(result => {
+                        if (!result.success) {
+                            res.statusCode = 400;
+
+                            return this.handleResponse(
+                                res,
+                                str({
+                                    error: result.error.code,
+                                    message: result.error.message,
+                                }),
+                            );
+                        }
+                        res.statusCode = 200;
+
+                        this.handleResponse(res, str({ session: req.params.session }));
+                    });
+            },
+        ]);
+
+        app.post('/abort/:session', [
+            validateSessionParams,
+            parseBodyText,
+            (req, res) => {
+                let statusCode = 400;
+                this.abortableSignals.forEach(s => {
+                    if (s.session === req.params.session) {
+                        statusCode = 200;
+                        s.abort();
+                    }
+                });
+                this.removeAbortableSignal(req.params.session);
+
+                res.statusCode = statusCode;
+
+                return this.handleResponse(
+                    res,
+                    str(
+                        statusCode === 200
+                            ? { success: true }
+                            : { error: ERRORS.SESSION_NOT_FOUND },
+                    ),
+                );
+            },
+        ]);
+
+        app.post('/call/:session', [
+            validateSessionParams,
+            parseBodyText,
+            validateProtocolMessageBody(true),
+            (req, res) => {
+                const { session } = req.params;
+                const signal = this.createAbortSignal(res, session);
+                this.core
+                    .call({
+                        ...req.body,
+                        session,
+                        signal,
+                    })
+                    .then(result => {
+                        this.removeAbortableSignal(session);
+                        if (!result.success) {
+                            res.statusCode = 400;
+
+                            return this.handleResponse(
+                                res,
+                                str({
+                                    error: result.error.code,
+                                    message: result.error.message,
+                                }),
+                            );
+                        }
+                        res.statusCode = 200;
+
+                        this.handleResponse(res, str(result.payload));
+                    });
+            },
+        ]);
+
+        app.post('/read/:session', [
+            validateSessionParams,
+            parseBodyText,
+            validateProtocolMessageBody(false),
+            (req, res) => {
+                const { session } = req.params;
+                const signal = this.createAbortSignal(res, session);
+                this.core
+                    .receive({
+                        ...req.body,
+                        session,
+                        signal,
+                    })
+                    .then(result => {
+                        this.removeAbortableSignal(session);
+                        if (!result.success) {
+                            res.statusCode = 400;
+
+                            return this.handleResponse(
+                                res,
+                                str({
+                                    error: result.error.code,
+                                    message: result.error.message,
+                                }),
+                            );
+                        }
+                        res.statusCode = 200;
+
+                        this.handleResponse(res, str(result.payload));
+                    });
+            },
+        ]);
+
+        app.post('/post/:session', [
+            validateSessionParams,
+            parseBodyText,
+            validateProtocolMessageBody(true),
+            (req, res) => {
+                const { session } = req.params;
+                const signal = this.createAbortSignal(res, session);
+                this.core
+                    .send({
+                        ...req.body,
+                        session,
+                        signal,
+                    })
+                    .then(result => {
+                        this.removeAbortableSignal(session);
+                        if (!result.success) {
+                            res.statusCode = 400;
+
+                            return this.handleResponse(
+                                res,
+                                str({
+                                    error: result.error.code,
+                                    message: result.error.message,
+                                }),
+                            );
+                        }
+                        res.statusCode = 200;
+
+                        this.handleResponse(res, str(result.payload));
+                    });
+            },
+        ]);
+
+        app.get('/', [
+            (_req, res) => {
+                res.writeHead(301, {
+                    Location: `${ADDRESS.origin}:${app.getServerAddress().port}/status`,
+                });
+                res.end();
+            },
+        ]);
+
+        app.get('/status', [
+            async (_req, res) => {
+                res.statusCode = 200;
+                res.appendHeader('Content-Type', 'text/html');
+
+                try {
+                    const ui = await fs.readFile(
+                        // todo: using npx tsx ./packages/transport-bridge/src/bin.ts
+                        // will serve only the unbuilt template from src/ui folder instead from dist/ui folder
+                        path.join(__dirname, this.assetPrefix, 'ui/index.html'),
+                        'utf-8',
+                    );
+
+                    this.handleResponse(res, ui);
+                } catch (error) {
+                    this.logger.error('Failed to fetch status page', error);
+                    // you need to run yarn workspace @trezor/transport-bridge build:ui to make it available (or build:lib will do)
+                    this.handleResponse(res, 'Failed to fetch status page');
+                }
+            },
+        ]);
+
+        app.get('/status-data', [
+            async (_req, res) => {
+                const signal = this.createAbortSignal(res);
+                await this.core.enumerate({ signal });
+                const props = {
+                    intro: `To download full logs go to ${ADDRESS.origin}:${app.getServerAddress().port}/logs`,
+                    version: this.version,
+                    bundledVersion: this.bundledVersion,
+                    devices: this.descriptors,
+                    logs: this.logger.getLog(),
+                };
+                res.appendHeader('Content-Type', 'application/json');
+                this.handleResponse(res, str(props));
+            },
+        ]);
+
+        app.get('/logs', [
+            (_req, res) => {
+                res.appendHeader('Content-Type', 'text/plain');
+                res.appendHeader('Content-Disposition', 'attachment; filename=trezor-bridge.txt');
+                res.statusCode = 200;
+
+                this.handleResponse(
+                    res,
+                    app.logger
+                        .getLog()
+                        .map(l => l.message.join('. '))
+                        .join('.\n'),
+                );
+            },
+        ]);
+
+        app.post('/', [this.handleInfo.bind(this)]);
+
+        app.post('/configure', [this.handleInfo.bind(this)]);
         this.server.push(app);
         this.port = appRes.payload.port;
     }


### PR DESCRIPTION
## Summary

The `bindHandlers` arrow function in the bridge HTTP server's `start()` was a leftover from the dual-server setup (ports 21328 + 21325), where the same handler set had to be bound to two servers. With the legacy 21325 compatibility port dropped in 1774c788cb2 there is a single server, so the wrapper is pure indirection with no readers — as the `TODO` comment introduced alongside the port drop already noted.

This PR inlines the handler registration directly into `start()`.

**Execution order is preserved:** `app.start()` and its success check run first (exactly as before, when `bindHandlers()` was invoked *after* `app.start()`), then the handlers are registered.

The diff is large but mechanical — the handler body dedents one level, plus one prettier reflow of a line that now fits on a single line. `git diff -w` shows the only real changes are: the removed `TODO` + wrapper, and moving the `app.start()` block above the handler registration.

No behavior change.

Part of the cleanup series tracked in #23794. This is **PR 1C** of five small cleanup PRs (1A–1E).

- PR 1A: #28095
- PR 1B: #28102
- PR 1C: #28104
- PR 1D: #28136
- PR 1E: #28137

## Test plan

- [x] `yarn workspace @trezor/transport-bridge type-check`
- [x] `yarn workspace @trezor/transport-bridge lint:js`
- [x] `yarn workspace @trezor/transport-bridge test:unit` (18/18 — includes HTTP server start/stop + endpoint tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mvarmuza/transport-bridge-inline-bindhandlers&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mvarmuza/transport-bridge-inline-bindhandlers&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mvarmuza/transport-bridge-inline-bindhandlers&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-27T12:14:48.751Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-27T12:10:20.150Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mvarmuza/transport-bridge-inline-bindhandlers/web/](https://dev.suite.sldev.cz/suite-web/mvarmuza/transport-bridge-inline-bindhandlers/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->


