### PR TITLE
feat(trading): optimize trading form rerenders

### DIFF
--- a/packages/suite/src/hooks/suite/useFiatFromCryptoValue.ts
+++ b/packages/suite/src/hooks/suite/useFiatFromCryptoValue.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { selectBaseCurrency, selectFiatRatesByFiatRateKey } from '@suite-common/wallet-core';
 import { type RateTypeWithoutHistoric, type TokenAddress } from '@suite-common/wallet-types';
@@ -33,7 +35,10 @@ export const useFiatFromCryptoValue = ({
     );
 
     const rate = useHistoricRate ? historicRate : currentRate?.rate;
-    const fiatAmount = rate ? toFiatCurrency({ amount, rate }) : null;
+    const fiatAmount = useMemo(
+        () => (rate ? toFiatCurrency({ amount, rate }) : null),
+        [amount, rate],
+    );
 
     return { baseCurrencyCode, fiatAmount, rate, currentRate };
 };

--- a/packages/suite/src/utils/wallet/trading/tradingTypingUtils.ts
+++ b/packages/suite/src/utils/wallet/trading/tradingTypingUtils.ts
@@ -37,6 +37,11 @@ export const isTradingExchangeContext = (
     context: TradingFormMapProps[keyof TradingFormMapProps],
 ): context is TradingFormMapProps[TradingExchangeType] => context.type === 'exchange';
 
+export const isTradingExchangeOrSellContext = (
+    context: TradingFormMapProps[keyof TradingFormMapProps],
+): context is TradingFormMapProps[TradingExchangeType] | TradingFormMapProps[TradingSellType] =>
+    isTradingExchangeContext(context) || isTradingSellContext(context);
+
 export const getCryptoQuoteAmountProps = (
     quoteInput: TradingTradeType | undefined,
     context: TradingFormContextValues<TradingType>,

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
@@ -1,8 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
 
-import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
-import { useServices } from '@suite-common/dependency-injection';
 import {
     TRADING_FORM_OUTPUT_AMOUNT,
     TRADING_FORM_OUTPUT_FIAT,
@@ -18,7 +16,7 @@ import {
 } from '@suite-common/trading';
 import { type TokenAddress } from '@suite-common/wallet-types';
 import { convertAmountSubunitsToUnits } from '@suite-common/wallet-utils';
-import { Column, FractionButton, Row } from '@trezor/components';
+import { Column, Row } from '@trezor/components';
 import { useCurrentRef } from '@trezor/react-utils';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -41,12 +39,11 @@ import {
     type TradingFormInputSellAssetProps,
 } from './TradingFormInput/TradingFormInputSellAsset/TradingFormInputSellAsset';
 import { TradingFormSection } from './TradingFormSection';
+import { TradingFractionButtons } from './TradingFractionButtons';
 import { TradingNetworkReserveBanner } from './TradingNetworkReserveBanner';
-import { generateFractionButtons } from './tradingFormInputsUtils';
 
 export const TradingExchangeFormInputs = () => {
     const context = useTradingFormContext<TradingExchangeType>();
-    const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     const { isLoading } = useSelector(selectTradingLoadingAndTimestamp);
 
@@ -147,30 +144,7 @@ export const TradingExchangeFormInputs = () => {
                         />
                         {amountInCrypto && (
                             <Row justifyContent="space-between" alignItems="flex-start">
-                                <Row gap={8} data-testid="@trading/form/fraction-buttons">
-                                    {generateFractionButtons(helpers).map(button => {
-                                        const { percentValue, ...buttonProps } = button;
-
-                                        return (
-                                            <FractionButton
-                                                key={buttonProps.id}
-                                                {...buttonProps}
-                                                onClick={() => {
-                                                    analytics.report({
-                                                        type: events.appFormPercentButtonsEvent
-                                                            .name,
-                                                        payload: {
-                                                            type: 'swap',
-                                                            value: percentValue,
-                                                        },
-                                                    });
-                                                    button.onClick();
-                                                    context.resetSelectedOffer();
-                                                }}
-                                            />
-                                        );
-                                    })}
-                                </Row>
+                                <TradingFractionButtons />
                                 <TradingBalance
                                     balance={outputAmount}
                                     displaySymbol={sendCryptoSelect?.displaySymbol}

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCountry/TradingFormInputCountrySubdivision.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCountry/TradingFormInputCountrySubdivision.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { useWatch } from 'react-hook-form';
 
 import { Translation, useTranslation } from '@suite/intl';
 import {
@@ -26,9 +27,9 @@ export const TradingFormInputCountrySubdivision = ({
 }: TradingFormInputCountrySubdivisionProps) => {
     const { translationString } = useTranslation();
     const [isModalOpen, setIsModalOpen] = useState(false);
-    const { watch, defaultSubdivision } = useTradingFormContext<TradingTradeBuySellType>();
+    const { defaultSubdivision } = useTradingFormContext<TradingTradeBuySellType>();
 
-    const subdivisionValue = watch()[TRADING_FORM_COUNTRY_SUBDIVISION_SELECT];
+    const subdivisionValue = useWatch({ name: TRADING_FORM_COUNTRY_SUBDIVISION_SELECT });
 
     const subdivisionLabel = useMemo(() => {
         const resolvedLabel = subdivisionValue?.label ?? defaultSubdivision?.label;

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputCryptoAmount.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputCryptoAmount.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { type FieldErrors, type UseFormReturn, useWatch } from 'react-hook-form';
 
 import { useTranslation } from '@suite/intl';
@@ -15,7 +15,6 @@ import {
 import { formInputsMaxLength } from '@suite-common/validators';
 import { getDisplaySymbol } from '@suite-common/wallet-config';
 import { selectAccountByKey, selectIsNetworkReserveEnabled } from '@suite-common/wallet-core';
-import { getNetworkReserve } from '@suite-common/wallet-utils';
 import { NumberInput } from '@trezor/product-components';
 import { useDidUpdate } from '@trezor/react-utils';
 
@@ -29,19 +28,13 @@ import {
     type TradingSellExchangeFormProps,
 } from 'src/types/trading/tradingForm';
 import {
-    validateCryptoLimits,
-    validateDecimals,
-    validateInteger,
-    validateMin,
-    validateNetworkReserve,
-    validateReserveOrBalance,
-} from 'src/utils/suite/validation';
-import {
     isTradingBuyContext,
     isTradingExchangeContext,
-    isTradingSellContext,
+    isTradingExchangeOrSellContext,
 } from 'src/utils/wallet/trading/tradingTypingUtils';
 import { getFeeInUnits, tradingGetAccountLabel } from 'src/utils/wallet/trading/tradingUtils';
+
+import { getCryptoInputRules } from './tradingFormInputFiatCryptoRules';
 
 export const TradingFormInputCryptoAmount = ({
     cryptoInputName,
@@ -52,20 +45,21 @@ export const TradingFormInputCryptoAmount = ({
 }: TradingFormInputFiatCryptoProps) => {
     const { translationString } = useTranslation();
     const { CryptoAmountFormatter } = useFormatters();
+    const { cryptoIdToSymbolAndContractAddress } = useTradingUtils();
+    const { getAssetDecimals } = useTradingAssetDecimals();
     const locale = useSelector(selectLanguage);
     const isNetworkReserveEnabled = useSelector(selectIsNetworkReserveEnabled);
 
     const context = useTradingFormContext();
     const { amountLimits, account, network } = context;
-
-    const { cryptoIdToSymbolAndContractAddress } = useTradingUtils();
     const {
         control,
         formState: { errors },
         getValues,
+        setValue,
         trigger,
         clearErrors,
-    } = useTradingFormContext() as UseFormReturn<TradingAllFormProps>;
+    } = context as UseFormReturn<TradingAllFormProps>;
 
     const sendCryptoSelect = useWatch({
         control,
@@ -75,79 +69,87 @@ export const TradingFormInputCryptoAmount = ({
         selectAccountByKey(state, sendCryptoSelect?.accountKey),
     );
     const validationAccount = selectedSendAccount ?? account;
-    const feeInUnits =
-        isTradingSellContext(context) || isTradingExchangeContext(context)
-            ? getFeeInUnits({
-                  symbol: validationAccount.symbol,
-                  composedLevels: context.composedLevels,
-                  selectedFee: context.composedTransactionInfo?.selectedFee,
-              })
-            : undefined;
     const { shouldSendInSats } = useBitcoinAmountUnit(validationAccount.symbol);
 
-    const cryptoSelect = getValues(cryptoSelectName);
-    const cryptoInputError =
-        cryptoInputName === TRADING_FORM_OUTPUT_AMOUNT
-            ? (errors as FieldErrors<TradingSellExchangeFormProps>)?.outputs?.[0]?.amount
-            : (errors as FieldErrors<TradingBuyFormProps>).cryptoInput;
+    const isBuyContext = isTradingBuyContext(context);
+    const isExchangeOrSellContext = isTradingExchangeOrSellContext(context);
+    const setFractionButton = isExchangeOrSellContext
+        ? context.form.helpers.setFractionButton
+        : undefined;
+    const handleResetSelectedOffer = isTradingExchangeContext(context)
+        ? context.resetSelectedOffer
+        : undefined;
+    const setShowReserveBanner = isExchangeOrSellContext ? context.setShowReserveBanner : undefined;
 
+    const cryptoSelect = getValues(cryptoSelectName);
+    const outputToken = getValues('outputs')?.[0]?.token;
     const { coinSymbol, contractAddress } = cryptoIdToSymbolAndContractAddress(cryptoSelect?.id);
     const displaySymbol = tradingGetAccountLabel(
         getDisplaySymbol(coinSymbol ?? '', contractAddress),
         shouldSendInSats,
     );
-    const { getAssetDecimals } = useTradingAssetDecimals();
-    const decimals = isTradingBuyContext(context)
+    const decimals = isBuyContext
         ? getNetworkDecimalsWithFallback(network.symbol)
         : getAssetDecimals({
               accountKey: getValues(TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT)?.accountKey,
               cryptoId: cryptoSelect?.id,
           });
-
+    const feeInUnits = isExchangeOrSellContext
+        ? getFeeInUnits({
+              symbol: validationAccount.symbol,
+              composedLevels: context.composedLevels,
+              selectedFee: context.composedTransactionInfo?.selectedFee,
+          })
+        : undefined;
+    const cryptoInputError =
+        cryptoInputName === TRADING_FORM_OUTPUT_AMOUNT
+            ? (errors as FieldErrors<TradingSellExchangeFormProps>)?.outputs?.[0]?.amount
+            : (errors as FieldErrors<TradingBuyFormProps>).cryptoInput;
     const isNetworkReserveError =
-        (isTradingExchangeContext(context) || isTradingSellContext(context)) &&
-        cryptoInputError?.type === 'networkReserve';
-    const setShowReserveBanner =
-        isTradingExchangeContext(context) || isTradingSellContext(context)
-            ? context.setShowReserveBanner
-            : undefined;
+        isExchangeOrSellContext && cryptoInputError?.type === 'networkReserve';
+
+    const cryptoInputRules = useMemo(
+        () =>
+            getCryptoInputRules({
+                isBuyContext,
+                translationString,
+                shouldSendInSats,
+                decimals,
+                amountLimits,
+                formatter: CryptoAmountFormatter,
+                validationAccount,
+                outputToken,
+                isNetworkReserveEnabled,
+                contractAddress,
+                feeInUnits,
+            }),
+        [
+            isBuyContext,
+            translationString,
+            shouldSendInSats,
+            decimals,
+            amountLimits,
+            CryptoAmountFormatter,
+            validationAccount,
+            outputToken,
+            isNetworkReserveEnabled,
+            contractAddress,
+            feeInUnits,
+        ],
+    );
+
+    const handleChange = useCallback(() => {
+        if (setFractionButton) {
+            setValue(TRADING_FORM_OUTPUT_MAX, undefined, { shouldDirty: true });
+            setFractionButton(undefined);
+        }
+        handleResetSelectedOffer?.();
+        clearErrors(fiatInputName);
+    }, [setValue, setFractionButton, handleResetSelectedOffer, clearErrors, fiatInputName]);
 
     useEffect(() => {
         setShowReserveBanner?.(isNetworkReserveError);
     }, [isNetworkReserveError, setShowReserveBanner]);
-
-    const cryptoInputRules = {
-        validate: {
-            min: validateMin(translationString),
-            integer: validateInteger(translationString, { except: !shouldSendInSats }),
-            decimals: validateDecimals(translationString, { decimals }),
-            limits: validateCryptoLimits(translationString, {
-                amountLimits,
-                areSatsUsed: !!shouldSendInSats,
-                formatter: CryptoAmountFormatter,
-            }),
-            ...(!isTradingBuyContext(context)
-                ? {
-                      reserveOrBalance: validateReserveOrBalance(translationString, {
-                          account: validationAccount,
-                          areSatsUsed: !!shouldSendInSats,
-                          contractAddress: getValues('outputs')?.[0]?.token,
-                      }),
-                      networkReserve: isNetworkReserveEnabled
-                          ? validateNetworkReserve(translationString, {
-                                reserve: getNetworkReserve({
-                                    symbol: validationAccount.symbol,
-                                    contractAddress,
-                                    isEnabled: isNetworkReserveEnabled,
-                                }),
-                                balance: validationAccount.formattedBalance,
-                                fee: feeInUnits?.toString(),
-                            })
-                          : () => undefined,
-                  }
-                : {}),
-        },
-    };
 
     useDidUpdate(() => {
         if (amountLimits) {
@@ -165,19 +167,7 @@ export const TradingFormInputCryptoAmount = ({
             locale={locale}
             labelLeft={labelLeft}
             labelRight={labelRight}
-            onChange={() => {
-                if (isTradingSellContext(context)) {
-                    context.setValue(TRADING_FORM_OUTPUT_MAX, undefined, { shouldDirty: true });
-                    context.form.helpers.setFractionButton(undefined);
-                }
-                if (isTradingExchangeContext(context)) {
-                    context.setValue(TRADING_FORM_OUTPUT_MAX, undefined, { shouldDirty: true });
-                    context.form.helpers.setFractionButton(undefined);
-                    context.resetSelectedOffer();
-                }
-
-                clearErrors(fiatInputName);
-            }}
+            onChange={handleChange}
             hasError={!!cryptoInputError}
             control={control}
             rules={cryptoInputRules}

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputFiat.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputFiat.tsx
@@ -1,10 +1,5 @@
-import { useEffect } from 'react';
-import {
-    type FieldErrors,
-    type UseControllerProps,
-    useFormContext,
-    useWatch,
-} from 'react-hook-form';
+import { useCallback, useEffect, useMemo } from 'react';
+import { type FieldErrors, useFormContext, useWatch } from 'react-hook-form';
 
 import { useTranslation } from '@suite/intl';
 import { selectLanguage } from '@suite/settings';
@@ -21,18 +16,13 @@ import { formInputsMaxLength } from '@suite-common/validators';
 import { selectCurrentFiatRates, selectIsNetworkReserveEnabled } from '@suite-common/wallet-core';
 import { type TokenAddress } from '@suite-common/wallet-types';
 import {
-    buildCurrencyShortOption,
     convertAmountSubunitsToUnits,
     findToken,
-    getDecimalsForBaseCurrency,
-    getFiatRateKey,
     getNetworkReserve,
-    toFiatCurrency,
 } from '@suite-common/wallet-utils';
 import { type BaseCurrencyCode, isFiatBaseCurrencyCode } from '@trezor/blockchain-link-types';
 import { NumberInput } from '@trezor/product-components';
 import { useDidUpdate } from '@trezor/react-utils';
-import { BigNumber } from '@trezor/utils';
 
 import { useSelector } from 'src/hooks/suite';
 import { useFiatFromCryptoValue } from 'src/hooks/suite/useFiatFromCryptoValue';
@@ -43,13 +33,15 @@ import {
     type TradingFormInputFiatCryptoProps,
     type TradingSellExchangeFormProps,
 } from 'src/types/trading/tradingForm';
-import { validateDecimals, validateMin, validateNetworkReserve } from 'src/utils/suite/validation';
 import {
     isTradingExchangeContext,
+    isTradingExchangeOrSellContext,
     isTradingSellContext,
 } from 'src/utils/wallet/trading/tradingTypingUtils';
 import { getFeeInUnits } from 'src/utils/wallet/trading/tradingUtils';
 import { TradingFormInputCurrency } from 'src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCurrency';
+
+import { getFiatInputRules } from './tradingFormInputFiatCryptoRules';
 
 export const TradingFormInputFiat = ({
     cryptoInputName,
@@ -60,6 +52,7 @@ export const TradingFormInputFiat = ({
     const { translationString } = useTranslation();
     const locale = useSelector(selectLanguage);
     const isNetworkReserveEnabled = useSelector(selectIsNetworkReserveEnabled);
+    const rates = useSelector(selectCurrentFiatRates);
 
     const context = useTradingFormContext();
     const { account, amountLimits } = context;
@@ -74,11 +67,38 @@ export const TradingFormInputFiat = ({
         control,
         name: TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT,
     });
-    const tokenAddress = sendCryptoSelect?.contractAddress as TokenAddress | undefined;
+    const outputCurrencySelect = useWatch({ control, name: TRADING_FORM_OUTPUT_CURRENCY });
+    const fiatCurrencySelect = useWatch({ control, name: TRADING_FORM_FIAT_CURRENCY_SELECT });
+    const cryptoAmount = useWatch({ control, name: cryptoInputName });
+    const { areSatsDisplayed } = useBitcoinAmountUnit(account.symbol);
 
+    const isExchangeContext = isTradingExchangeContext(context);
+    const isSellContext = isTradingSellContext(context);
+    const isExchangeOrSellContext = isTradingExchangeOrSellContext(context);
+    const setShowReserveBanner = isExchangeOrSellContext ? context.setShowReserveBanner : undefined;
+    const setFractionButton = isExchangeOrSellContext
+        ? context.form.helpers.setFractionButton
+        : undefined;
+    const handleResetSelectedOffer = isExchangeContext ? context.resetSelectedOffer : undefined;
+
+    const tokenAddress = (sendCryptoSelect?.contractAddress ?? undefined) as
+        | TokenAddress
+        | undefined;
     const balance = tokenAddress
         ? findToken(account.tokens, tokenAddress)?.balance
         : account.formattedBalance;
+    const networkReserve = getNetworkReserve({
+        symbol: account.symbol,
+        contractAddress: tokenAddress,
+        isEnabled: isNetworkReserveEnabled,
+    });
+    const feeInUnits = isExchangeOrSellContext
+        ? getFeeInUnits({
+              symbol: account.symbol,
+              composedLevels: context.composedLevels,
+              selectedFee: context.composedTransactionInfo?.selectedFee,
+          })
+        : undefined;
 
     const { fiatAmount } = useFiatFromCryptoValue({
         amount: balance || '',
@@ -86,29 +106,12 @@ export const TradingFormInputFiat = ({
         tokenAddress,
         rateType: 'current',
     });
-
-    const networkReserve = getNetworkReserve({
-        symbol: account.symbol,
-        contractAddress: tokenAddress,
-        isEnabled: isNetworkReserveEnabled,
-    });
-
     const { fiatAmount: networkReserveFiatAmount } = useFiatFromCryptoValue({
         amount: networkReserve || '',
         symbol: account.symbol,
         tokenAddress,
         rateType: 'current',
     });
-
-    const feeInUnits =
-        isTradingSellContext(context) || isTradingExchangeContext(context)
-            ? getFeeInUnits({
-                  symbol: account.symbol,
-                  composedLevels: context.composedLevels,
-                  selectedFee: context.composedTransactionInfo?.selectedFee,
-              })
-            : undefined;
-
     const { fiatAmount: feeFiatAmount } = useFiatFromCryptoValue({
         amount: feeInUnits?.toString() || '',
         symbol: account.symbol,
@@ -116,11 +119,6 @@ export const TradingFormInputFiat = ({
         rateType: 'current',
     });
 
-    const rates = useSelector(selectCurrentFiatRates);
-    const outputCurrencySelect = useWatch({ control, name: TRADING_FORM_OUTPUT_CURRENCY });
-    const fiatCurrencySelect = useWatch({ control, name: TRADING_FORM_FIAT_CURRENCY_SELECT });
-    const cryptoAmount = useWatch({ control, name: cryptoInputName });
-    const { areSatsDisplayed } = useBitcoinAmountUnit(account.symbol);
     const normalizedCryptoAmount =
         account.symbol === 'btc' && areSatsDisplayed && cryptoAmount
             ? convertAmountSubunitsToUnits(
@@ -135,17 +133,6 @@ export const TradingFormInputFiat = ({
     } else if (isFiatBaseCurrencyCode(fiatCurrencySelect?.value)) {
         selectedCurrencyCode = fiatCurrencySelect.value;
     }
-    const fiatInputDecimals = getDecimalsForBaseCurrency({
-        code: selectedCurrencyCode,
-        isInSats: false,
-    });
-    const selectedCurrencyLabel =
-        buildCurrencyShortOption({
-            currency: selectedCurrencyCode,
-            areSatsDisplayed: false,
-        }).label ||
-        context.amountLimits?.currency ||
-        'USD';
 
     const fiatInputError =
         fiatInputName === TRADING_FORM_OUTPUT_FIAT
@@ -155,134 +142,52 @@ export const TradingFormInputFiat = ({
         cryptoInputName === TRADING_FORM_OUTPUT_AMOUNT
             ? (errors as FieldErrors<TradingSellExchangeFormProps>)?.outputs?.[0]?.amount
             : undefined;
-
     const isNetworkReserveError =
-        (isTradingExchangeContext(context) || isTradingSellContext(context)) &&
-        fiatInputError?.type === 'networkReserve';
-    const setShowReserveBanner =
-        isTradingExchangeContext(context) || isTradingSellContext(context)
-            ? context.setShowReserveBanner
-            : undefined;
+        isExchangeOrSellContext && fiatInputError?.type === 'networkReserve';
+
+    const fiatInputRules = useMemo(
+        () =>
+            getFiatInputRules({
+                isExchangeContext,
+                isSellContext,
+                translationString,
+                fiatAmount,
+                isNetworkReserveEnabled,
+                networkReserveFiatAmount,
+                feeFiatAmount,
+                normalizedCryptoAmount,
+                amountLimits,
+                accountSymbol: account.symbol,
+                selectedCurrencyCode,
+                tokenAddress,
+                rates,
+            }),
+        [
+            isExchangeContext,
+            isSellContext,
+            amountLimits,
+            translationString,
+            isNetworkReserveEnabled,
+            networkReserveFiatAmount,
+            fiatAmount,
+            feeFiatAmount,
+            normalizedCryptoAmount,
+            account.symbol,
+            selectedCurrencyCode,
+            tokenAddress,
+            rates,
+        ],
+    );
+
+    const handleChange = useCallback(() => {
+        setFractionButton?.(undefined);
+        handleResetSelectedOffer?.();
+        clearErrors(cryptoInputName);
+    }, [setFractionButton, handleResetSelectedOffer, clearErrors, cryptoInputName]);
 
     useEffect(() => {
         setShowReserveBanner?.(isNetworkReserveError);
     }, [isNetworkReserveError, setShowReserveBanner]);
-
-    const fiatInputRules: UseControllerProps['rules'] = {
-        ...(isTradingExchangeContext(context)
-            ? {
-                  validate: {
-                      min: validateMin(translationString),
-                      decimals: validateDecimals(translationString, {
-                          decimals: fiatInputDecimals,
-                      }),
-                      balance: (value: string) => {
-                          const valueBigNumber = new BigNumber(value);
-                          if (
-                              fiatAmount &&
-                              valueBigNumber.isGreaterThan(new BigNumber(fiatAmount))
-                          ) {
-                              return translationString('AMOUNT_IS_NOT_ENOUGH');
-                          }
-                      },
-                      networkReserve: isNetworkReserveEnabled
-                          ? validateNetworkReserve(translationString, {
-                                reserve: networkReserveFiatAmount?.toString(),
-                                balance: fiatAmount?.toString(),
-                                fee: feeFiatAmount?.toString(),
-                            })
-                          : () => undefined,
-                      minFiat: () => {
-                          if (
-                              normalizedCryptoAmount &&
-                              context.amountLimits?.minCrypto &&
-                              new BigNumber(normalizedCryptoAmount).isLessThan(
-                                  new BigNumber(context.amountLimits.minCrypto),
-                              )
-                          ) {
-                              const fiatRateKey = getFiatRateKey(
-                                  account.symbol,
-                                  selectedCurrencyCode || 'usd',
-                                  tokenAddress,
-                              );
-                              const rate = rates?.[fiatRateKey]?.rate;
-                              const minFiat = toFiatCurrency({
-                                  amount: context.amountLimits.minCrypto,
-                                  rate,
-                              })?.toString();
-
-                              if (minFiat) {
-                                  return translationString('TR_BUY_VALIDATION_ERROR_MINIMUM_FIAT', {
-                                      minimum: new BigNumber(minFiat).toFixed(
-                                          fiatInputDecimals,
-                                          BigNumber.ROUND_HALF_UP,
-                                      ),
-                                      currency: selectedCurrencyLabel,
-                                  });
-                              } else {
-                                  return translationString('TR_BUY_VALIDATION_ERROR_MINIMUM_FIAT', {
-                                      minimum: context.amountLimits.minCrypto,
-                                      currency: selectedCurrencyLabel,
-                                  });
-                              }
-                          }
-                      },
-                  },
-              }
-            : {
-                  validate: {
-                      min: validateMin(translationString),
-                      decimals: validateDecimals(translationString, {
-                          decimals: fiatInputDecimals,
-                      }),
-                      ...(isTradingSellContext(context)
-                          ? {
-                                networkReserve: isNetworkReserveEnabled
-                                    ? validateNetworkReserve(translationString, {
-                                          reserve: networkReserveFiatAmount?.toString(),
-                                          balance: fiatAmount?.toString(),
-                                          fee: feeFiatAmount?.toString(),
-                                      })
-                                    : () => undefined,
-                            }
-                          : {}),
-                      minFiat: (value: string) => {
-                          if (
-                              value &&
-                              context.amountLimits?.minFiat &&
-                              new BigNumber(value).isLessThan(
-                                  new BigNumber(context.amountLimits.minFiat),
-                              )
-                          ) {
-                              return translationString('TR_BUY_VALIDATION_ERROR_MINIMUM_FIAT', {
-                                  minimum: new BigNumber(context.amountLimits.minFiat).toFixed(
-                                      fiatInputDecimals,
-                                      BigNumber.ROUND_HALF_UP,
-                                  ),
-                                  currency: selectedCurrencyLabel,
-                              });
-                          }
-                      },
-                      maxFiat: (value: string) => {
-                          if (
-                              value &&
-                              context.amountLimits?.maxFiat &&
-                              new BigNumber(value).isGreaterThan(
-                                  new BigNumber(context.amountLimits.maxFiat),
-                              )
-                          ) {
-                              return translationString('TR_BUY_VALIDATION_ERROR_MAXIMUM_FIAT', {
-                                  maximum: new BigNumber(context.amountLimits.maxFiat).toFixed(
-                                      fiatInputDecimals,
-                                      BigNumber.ROUND_HALF_UP,
-                                  ),
-                                  currency: selectedCurrencyLabel,
-                              });
-                          }
-                      },
-                  },
-              }),
-    };
 
     useDidUpdate(() => {
         if (amountLimits) {
@@ -296,17 +201,7 @@ export const TradingFormInputFiat = ({
             locale={locale}
             labelLeft={labelLeft}
             labelRight={labelRight}
-            onChange={() => {
-                if (isTradingSellContext(context)) {
-                    context.form.helpers.setFractionButton(undefined);
-                }
-                if (isTradingExchangeContext(context)) {
-                    context.form.helpers.setFractionButton(undefined);
-                    context.resetSelectedOffer();
-                }
-
-                clearErrors(cryptoInputName);
-            }}
+            onChange={handleChange}
             hasError={!!(fiatInputError ?? cryptoInputError)}
             control={control}
             rules={fiatInputRules}

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/__tests__/tradingFormInputFiatCryptoRules.test.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/__tests__/tradingFormInputFiatCryptoRules.test.ts
@@ -1,0 +1,252 @@
+import { type TranslationFunction } from '@suite/intl';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { type RatesByKey, asCryptoBaseCurrencyCode } from '@suite-common/wallet-types';
+import { type BaseCurrencyCode } from '@trezor/blockchain-link-types';
+import { BigNumber } from '@trezor/utils';
+
+import { getFiatInputRules } from '../tradingFormInputFiatCryptoRules';
+
+const t = ((key: string, values?: Record<string, unknown>) =>
+    values ? `${key}:${JSON.stringify(values)}` : key) as TranslationFunction;
+
+const btcUsdKey = asCryptoBaseCurrencyCode('btc-usd');
+
+type Props = Parameters<typeof getFiatInputRules>[0];
+type Validator = (value: string) => string | undefined;
+type ValidateMap = Record<
+    'min' | 'decimals' | 'balance' | 'networkReserve' | 'minFiat' | 'maxFiat',
+    Validator
+>;
+
+const baseProps: Props = {
+    isExchangeContext: false,
+    isSellContext: false,
+    translationString: t,
+    fiatAmount: new BigNumber('100'),
+    isNetworkReserveEnabled: false,
+    networkReserveFiatAmount: null,
+    feeFiatAmount: null,
+    normalizedCryptoAmount: undefined,
+    amountLimits: undefined,
+    accountSymbol: 'btc' as NetworkSymbol,
+    selectedCurrencyCode: 'usd' as BaseCurrencyCode,
+    tokenAddress: undefined,
+    rates: undefined,
+};
+
+const getValidators = (props: Props) =>
+    (getFiatInputRules(props) as { validate: ValidateMap }).validate;
+
+describe('getFiatInputRules — exchange context', () => {
+    const exchangeProps = { ...baseProps, isExchangeContext: true };
+
+    it('includes balance, networkReserve, minFiat but not maxFiat', () => {
+        const validate = getValidators(exchangeProps);
+        expect(validate).toHaveProperty('min');
+        expect(validate).toHaveProperty('decimals');
+        expect(validate).toHaveProperty('balance');
+        expect(validate).toHaveProperty('networkReserve');
+        expect(validate).toHaveProperty('minFiat');
+        expect(validate).not.toHaveProperty('maxFiat');
+    });
+
+    describe('balance', () => {
+        it('returns undefined when value is within fiatAmount', () => {
+            const { balance } = getValidators(exchangeProps);
+            expect(balance('50')).toBeUndefined();
+            expect(balance('100')).toBeUndefined();
+        });
+
+        it('returns error when value exceeds fiatAmount', () => {
+            const { balance } = getValidators(exchangeProps);
+            expect(balance('100.01')).toBe('AMOUNT_IS_NOT_ENOUGH');
+            expect(balance('200')).toBe('AMOUNT_IS_NOT_ENOUGH');
+        });
+
+        it('returns undefined when fiatAmount is null', () => {
+            const { balance } = getValidators({ ...exchangeProps, fiatAmount: null });
+            expect(balance('999')).toBeUndefined();
+        });
+
+        it('returns undefined when fiatAmount is undefined', () => {
+            const { balance } = getValidators({ ...exchangeProps, fiatAmount: undefined });
+            expect(balance('999')).toBeUndefined();
+        });
+    });
+
+    describe('networkReserve', () => {
+        it('returns undefined (noop) when isNetworkReserveEnabled is false', () => {
+            const { networkReserve } = getValidators({
+                ...exchangeProps,
+                isNetworkReserveEnabled: false,
+            });
+            expect(networkReserve('50')).toBeUndefined();
+        });
+
+        it('returns undefined when value stays within balance minus reserve and fee', () => {
+            const { networkReserve } = getValidators({
+                ...exchangeProps,
+                isNetworkReserveEnabled: true,
+                fiatAmount: new BigNumber('100'),
+                networkReserveFiatAmount: new BigNumber('10'),
+                feeFiatAmount: new BigNumber('5'),
+            });
+
+            expect(networkReserve('85')).toBeUndefined();
+        });
+
+        it('returns error when value exceeds balance minus reserve and fee', () => {
+            const { networkReserve } = getValidators({
+                ...exchangeProps,
+                isNetworkReserveEnabled: true,
+                fiatAmount: new BigNumber('100'),
+                networkReserveFiatAmount: new BigNumber('10'),
+                feeFiatAmount: new BigNumber('5'),
+            });
+
+            expect(networkReserve('85.01')).toBe('AMOUNT_EXCEEDS_NETWORK_RESERVE');
+        });
+    });
+
+    describe('minFiat', () => {
+        it('returns undefined when normalizedCryptoAmount is undefined', () => {
+            const { minFiat } = getValidators({
+                ...exchangeProps,
+                normalizedCryptoAmount: undefined,
+                amountLimits: { currency: 'BTC', minCrypto: '0.01' },
+            });
+            expect(minFiat('')).toBeUndefined();
+        });
+
+        it('returns undefined when amountLimits.minCrypto is undefined', () => {
+            const { minFiat } = getValidators({
+                ...exchangeProps,
+                normalizedCryptoAmount: '0.001',
+                amountLimits: { currency: 'BTC' },
+            });
+            expect(minFiat('')).toBeUndefined();
+        });
+
+        it('returns undefined when normalizedCryptoAmount >= minCrypto', () => {
+            const { minFiat } = getValidators({
+                ...exchangeProps,
+                normalizedCryptoAmount: '0.01',
+                amountLimits: { currency: 'BTC', minCrypto: '0.01' },
+            });
+            expect(minFiat('')).toBeUndefined();
+        });
+
+        it('returns error with converted fiat minimum when rate is available', () => {
+            const rates = {
+                [btcUsdKey]: { rate: 50000 },
+            } as unknown as RatesByKey;
+
+            const { minFiat } = getValidators({
+                ...exchangeProps,
+                normalizedCryptoAmount: '0.0001',
+                amountLimits: { currency: 'BTC', minCrypto: '0.01' },
+                rates,
+                selectedCurrencyCode: 'usd' as BaseCurrencyCode,
+            });
+
+            // 0.01 BTC * 50000 = 500 USD → "500.00"
+            expect(minFiat('')).toBe(
+                'TR_BUY_VALIDATION_ERROR_MINIMUM_FIAT:{"minimum":"500.00","currency":"USD"}',
+            );
+        });
+
+        it('falls back to minCrypto when rate is not available', () => {
+            const { minFiat } = getValidators({
+                ...exchangeProps,
+                normalizedCryptoAmount: '0.0001',
+                amountLimits: { currency: 'BTC', minCrypto: '0.01' },
+                rates: undefined,
+            });
+
+            expect(minFiat('')).toBe(
+                'TR_BUY_VALIDATION_ERROR_MINIMUM_FIAT:{"minimum":"0.01","currency":"USD"}',
+            );
+        });
+    });
+});
+
+describe('getFiatInputRules — non-exchange context', () => {
+    it('includes minFiat and maxFiat but not balance', () => {
+        const validate = getValidators(baseProps);
+        expect(validate).toHaveProperty('min');
+        expect(validate).toHaveProperty('decimals');
+        expect(validate).toHaveProperty('minFiat');
+        expect(validate).toHaveProperty('maxFiat');
+        expect(validate).not.toHaveProperty('balance');
+    });
+
+    it('excludes networkReserve in buy context (isSellContext: false)', () => {
+        const validate = getValidators({ ...baseProps, isSellContext: false });
+        expect(validate).not.toHaveProperty('networkReserve');
+    });
+
+    it('includes networkReserve in sell context (isSellContext: true)', () => {
+        const validate = getValidators({ ...baseProps, isSellContext: true });
+        expect(validate).toHaveProperty('networkReserve');
+    });
+
+    describe('minFiat', () => {
+        const propsWithLimits = {
+            ...baseProps,
+            amountLimits: { currency: 'USD', minFiat: '10', maxFiat: '1000' },
+        };
+
+        it('returns undefined when value is empty', () => {
+            const { minFiat } = getValidators(propsWithLimits);
+            expect(minFiat('')).toBeUndefined();
+        });
+
+        it('returns undefined when amountLimits.minFiat is not set', () => {
+            const { minFiat } = getValidators({ ...baseProps, amountLimits: { currency: 'USD' } });
+            expect(minFiat('1')).toBeUndefined();
+        });
+
+        it('returns undefined when value >= minFiat', () => {
+            const { minFiat } = getValidators(propsWithLimits);
+            expect(minFiat('10')).toBeUndefined();
+            expect(minFiat('50')).toBeUndefined();
+        });
+
+        it('returns error when value < minFiat', () => {
+            const { minFiat } = getValidators(propsWithLimits);
+            expect(minFiat('9.99')).toBe(
+                'TR_BUY_VALIDATION_ERROR_MINIMUM_FIAT:{"minimum":"10.00","currency":"USD"}',
+            );
+        });
+    });
+
+    describe('maxFiat', () => {
+        const propsWithLimits = {
+            ...baseProps,
+            amountLimits: { currency: 'USD', minFiat: '10', maxFiat: '1000' },
+        };
+
+        it('returns undefined when value is empty', () => {
+            const { maxFiat } = getValidators(propsWithLimits);
+            expect(maxFiat('')).toBeUndefined();
+        });
+
+        it('returns undefined when amountLimits.maxFiat is not set', () => {
+            const { maxFiat } = getValidators({ ...baseProps, amountLimits: { currency: 'USD' } });
+            expect(maxFiat('99999')).toBeUndefined();
+        });
+
+        it('returns undefined when value <= maxFiat', () => {
+            const { maxFiat } = getValidators(propsWithLimits);
+            expect(maxFiat('1000')).toBeUndefined();
+            expect(maxFiat('500')).toBeUndefined();
+        });
+
+        it('returns error when value > maxFiat', () => {
+            const { maxFiat } = getValidators(propsWithLimits);
+            expect(maxFiat('1000.01')).toBe(
+                'TR_BUY_VALIDATION_ERROR_MAXIMUM_FIAT:{"maximum":"1000.00","currency":"USD"}',
+            );
+        });
+    });
+});

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/tradingFormInputFiatCryptoRules.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/tradingFormInputFiatCryptoRules.ts
@@ -1,0 +1,214 @@
+import { type UseControllerProps } from 'react-hook-form';
+
+import { type TranslationFunction } from '@suite/intl';
+import { type Formatter } from '@suite-common/formatters';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { type Account, type RatesByKey, type TokenAddress } from '@suite-common/wallet-types';
+import {
+    buildCurrencyShortOption,
+    getDecimalsForBaseCurrency,
+    getFiatRateKey,
+    getNetworkReserve,
+    toFiatCurrency,
+} from '@suite-common/wallet-utils';
+import { type BaseCurrencyCode } from '@trezor/blockchain-link-types';
+import { BigNumber } from '@trezor/utils';
+
+import {
+    type AmountLimitProps,
+    validateCryptoLimits,
+    validateDecimals,
+    validateInteger,
+    validateMin,
+    validateNetworkReserve,
+    validateReserveOrBalance,
+} from 'src/utils/suite/validation';
+
+type FiatInputRulesProps = {
+    isExchangeContext: boolean;
+    isSellContext: boolean;
+    translationString: TranslationFunction;
+    fiatAmount: BigNumber | null | undefined;
+    isNetworkReserveEnabled: boolean;
+    networkReserveFiatAmount: BigNumber | null | undefined;
+    feeFiatAmount: BigNumber | null | undefined;
+    normalizedCryptoAmount: string | undefined;
+    amountLimits: AmountLimitProps | undefined;
+    accountSymbol: NetworkSymbol;
+    selectedCurrencyCode: BaseCurrencyCode | '';
+    tokenAddress: TokenAddress | undefined;
+    rates: RatesByKey | undefined;
+};
+
+export const getFiatInputRules = ({
+    isExchangeContext,
+    isSellContext,
+    translationString,
+    fiatAmount,
+    isNetworkReserveEnabled,
+    networkReserveFiatAmount,
+    feeFiatAmount,
+    normalizedCryptoAmount,
+    amountLimits,
+    accountSymbol,
+    selectedCurrencyCode,
+    tokenAddress,
+    rates,
+}: FiatInputRulesProps): UseControllerProps['rules'] => {
+    const fiatInputDecimals = getDecimalsForBaseCurrency({
+        code: selectedCurrencyCode,
+        isInSats: false,
+    });
+    const selectedCurrencyLabel =
+        buildCurrencyShortOption({ currency: selectedCurrencyCode, areSatsDisplayed: false })
+            .label ||
+        amountLimits?.currency ||
+        'USD';
+
+    const networkReserve = isNetworkReserveEnabled
+        ? validateNetworkReserve(translationString, {
+              reserve: networkReserveFiatAmount?.toString(),
+              balance: fiatAmount?.toString(),
+              fee: feeFiatAmount?.toString(),
+          })
+        : () => undefined;
+
+    if (isExchangeContext) {
+        return {
+            validate: {
+                min: validateMin(translationString),
+                decimals: validateDecimals(translationString, { decimals: fiatInputDecimals }),
+                balance: (value: string) => {
+                    if (fiatAmount && new BigNumber(value).isGreaterThan(fiatAmount)) {
+                        return translationString('AMOUNT_IS_NOT_ENOUGH');
+                    }
+                },
+                networkReserve,
+                minFiat: () => {
+                    if (
+                        !normalizedCryptoAmount ||
+                        !amountLimits?.minCrypto ||
+                        !new BigNumber(normalizedCryptoAmount).isLessThan(amountLimits.minCrypto)
+                    ) {
+                        return;
+                    }
+                    const fiatRateKey = getFiatRateKey(
+                        accountSymbol,
+                        selectedCurrencyCode || 'usd',
+                        tokenAddress,
+                    );
+                    const rate = rates?.[fiatRateKey]?.rate;
+                    const minFiat = toFiatCurrency({
+                        amount: amountLimits.minCrypto,
+                        rate,
+                    })?.toString();
+                    const minimum = minFiat
+                        ? new BigNumber(minFiat).toFixed(fiatInputDecimals, BigNumber.ROUND_HALF_UP)
+                        : amountLimits.minCrypto;
+
+                    return translationString('TR_BUY_VALIDATION_ERROR_MINIMUM_FIAT', {
+                        minimum,
+                        currency: selectedCurrencyLabel,
+                    });
+                },
+            },
+        };
+    }
+
+    return {
+        validate: {
+            min: validateMin(translationString),
+            decimals: validateDecimals(translationString, { decimals: fiatInputDecimals }),
+            ...(isSellContext ? { networkReserve } : {}),
+            minFiat: (value: string) => {
+                if (
+                    value &&
+                    amountLimits?.minFiat &&
+                    new BigNumber(value).isLessThan(amountLimits.minFiat)
+                ) {
+                    return translationString('TR_BUY_VALIDATION_ERROR_MINIMUM_FIAT', {
+                        minimum: new BigNumber(amountLimits.minFiat).toFixed(
+                            fiatInputDecimals,
+                            BigNumber.ROUND_HALF_UP,
+                        ),
+                        currency: selectedCurrencyLabel,
+                    });
+                }
+            },
+            maxFiat: (value: string) => {
+                if (
+                    value &&
+                    amountLimits?.maxFiat &&
+                    new BigNumber(value).isGreaterThan(amountLimits.maxFiat)
+                ) {
+                    return translationString('TR_BUY_VALIDATION_ERROR_MAXIMUM_FIAT', {
+                        maximum: new BigNumber(amountLimits.maxFiat).toFixed(
+                            fiatInputDecimals,
+                            BigNumber.ROUND_HALF_UP,
+                        ),
+                        currency: selectedCurrencyLabel,
+                    });
+                }
+            },
+        },
+    };
+};
+
+type CryptoInputRulesProps = {
+    isBuyContext: boolean;
+    translationString: TranslationFunction;
+    shouldSendInSats: boolean | undefined;
+    decimals: number;
+    amountLimits: AmountLimitProps | undefined;
+    formatter: Formatter<string, string>;
+    validationAccount: Account;
+    outputToken: string | null | undefined;
+    isNetworkReserveEnabled: boolean;
+    contractAddress: string | undefined;
+    feeInUnits: string | undefined;
+};
+
+export const getCryptoInputRules = ({
+    isBuyContext,
+    translationString,
+    shouldSendInSats,
+    decimals,
+    amountLimits,
+    formatter,
+    validationAccount,
+    outputToken,
+    isNetworkReserveEnabled,
+    contractAddress,
+    feeInUnits,
+}: CryptoInputRulesProps): UseControllerProps['rules'] => ({
+    validate: {
+        min: validateMin(translationString),
+        integer: validateInteger(translationString, { except: !shouldSendInSats }),
+        decimals: validateDecimals(translationString, { decimals }),
+        limits: validateCryptoLimits(translationString, {
+            amountLimits,
+            areSatsUsed: !!shouldSendInSats,
+            formatter,
+        }),
+        ...(!isBuyContext
+            ? {
+                  reserveOrBalance: validateReserveOrBalance(translationString, {
+                      account: validationAccount,
+                      areSatsUsed: !!shouldSendInSats,
+                      contractAddress: outputToken ?? undefined,
+                  }),
+                  networkReserve: isNetworkReserveEnabled
+                      ? validateNetworkReserve(translationString, {
+                            reserve: getNetworkReserve({
+                                symbol: validationAccount.symbol,
+                                contractAddress,
+                                isEnabled: isNetworkReserveEnabled,
+                            }),
+                            balance: validationAccount.formattedBalance,
+                            fee: feeInUnits,
+                        })
+                      : () => undefined,
+              }
+            : {}),
+    },
+});

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputPaymentMethod/TradingFormInputPaymentMethod.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputPaymentMethod/TradingFormInputPaymentMethod.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import type { ReactNode } from 'react';
+import { useWatch } from 'react-hook-form';
 
 import { Translation, useTranslation } from '@suite/intl';
 import { PaymentMethodIcon } from '@suite/trading';
@@ -63,10 +64,9 @@ export const TradingFormInputPaymentMethod = ({
         form: {
             state: { isFormLoading },
         },
-        watch,
     } = useTradingFormContext<TradingTradeBuySellType>();
 
-    const paymentMethod = watch()[TRADING_FORM_PAYMENT_METHOD_SELECT];
+    const paymentMethod = useWatch({ name: TRADING_FORM_PAYMENT_METHOD_SELECT });
     const hasPaymentMethods = paymentMethods.length > 0;
 
     const selectedOption = hasPaymentMethods

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFractionButtons.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFractionButtons.tsx
@@ -1,0 +1,49 @@
+import { useMemo } from 'react';
+
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
+import { useServices } from '@suite-common/dependency-injection';
+import { FractionButton, Row } from '@trezor/components';
+
+import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
+import {
+    isTradingExchangeContext,
+    isTradingSellContext,
+} from 'src/utils/wallet/trading/tradingTypingUtils';
+
+import { generateFractionButtons } from './tradingFormInputsUtils';
+
+export const TradingFractionButtons = () => {
+    const context = useTradingFormContext<'sell' | 'exchange'>();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
+
+    const analyticsType = isTradingSellContext(context) ? 'sell' : 'swap';
+    const fractionButtons = useMemo(
+        () => generateFractionButtons(context.form.helpers),
+        [context.form.helpers],
+    );
+
+    return (
+        <Row gap={8} data-testid="@trading/form/fraction-buttons">
+            {fractionButtons.map(button => {
+                const { percentValue, onClick, ...buttonProps } = button;
+
+                return (
+                    <FractionButton
+                        key={buttonProps.id}
+                        {...buttonProps}
+                        onClick={() => {
+                            analytics.report({
+                                type: events.appFormPercentButtonsEvent.name,
+                                payload: { type: analyticsType, value: percentValue },
+                            });
+                            onClick();
+                            if (isTradingExchangeContext(context)) {
+                                context.resetSelectedOffer();
+                            }
+                        }}
+                    />
+                );
+            })}
+        </Row>
+    );
+};

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingSellFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingSellFormInputs.tsx
@@ -1,8 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
 
-import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
-import { useServices } from '@suite-common/dependency-injection';
 import {
     TRADING_FORM_OUTPUT_AMOUNT,
     TRADING_FORM_OUTPUT_FIAT,
@@ -14,7 +12,7 @@ import {
 } from '@suite-common/trading';
 import { type TokenAddress } from '@suite-common/wallet-types';
 import { convertAmountSubunitsToUnits } from '@suite-common/wallet-utils';
-import { Column, FractionButton, Row } from '@trezor/components';
+import { Column, Row } from '@trezor/components';
 import { useCurrentRef } from '@trezor/react-utils';
 
 import { useSelector } from 'src/hooks/suite';
@@ -27,6 +25,7 @@ import { TradingFormInputPaymentMethod } from 'src/views/wallet/trading/common/T
 
 import { TradingFormCard } from './TradingFormCard';
 import { TradingFormFees } from './TradingFormFees';
+import { TradingFractionButtons } from './TradingFractionButtons';
 import { TradingSelectedOfferProvider } from '../TradingSelectedOffer/TradingSelectedOfferProvider';
 import { AssetPickerInputBalance } from './TradingFormInput/TradingFormInputAssetPicker';
 import { TradingFormInputCountrySubdivision } from './TradingFormInput/TradingFormInputCountry/TradingFormInputCountrySubdivision';
@@ -36,11 +35,9 @@ import {
 } from './TradingFormInput/TradingFormInputSellAsset/TradingFormInputSellAsset';
 import { TradingFormSection } from './TradingFormSection';
 import { TradingNetworkReserveBanner } from './TradingNetworkReserveBanner';
-import { generateFractionButtons } from './tradingFormInputsUtils';
 
 export const TradingSellFormInputs = () => {
     const context = useTradingFormContext<TradingSellType>();
-    const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     const {
         feeInfo,
@@ -112,29 +109,7 @@ export const TradingSellFormInputs = () => {
                         />
                         {amountInCrypto && (
                             <Row justifyContent="space-between" alignItems="flex-start">
-                                <Row gap={8} data-testid="@trading/form/fraction-buttons">
-                                    {generateFractionButtons(helpers).map(button => {
-                                        const { percentValue, ...buttonProps } = button;
-
-                                        return (
-                                            <FractionButton
-                                                key={buttonProps.id}
-                                                {...buttonProps}
-                                                onClick={() => {
-                                                    analytics.report({
-                                                        type: events.appFormPercentButtonsEvent
-                                                            .name,
-                                                        payload: {
-                                                            type: 'sell',
-                                                            value: percentValue,
-                                                        },
-                                                    });
-                                                    button.onClick();
-                                                }}
-                                            />
-                                        );
-                                    })}
-                                </Row>
+                                <TradingFractionButtons />
                                 <TradingBalance
                                     balance={outputAmount}
                                     displaySymbol={sendCryptoSelect?.id}

--- a/packages/suite/src/views/wallet/trading/common/TradingOffers/TradingOffersModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingOffers/TradingOffersModal.tsx
@@ -1,3 +1,5 @@
+import { useCallback } from 'react';
+
 import { Translation } from '@suite/intl';
 import { type TradingTradeType } from '@suite-common/trading';
 import { Box, Modal } from '@trezor/components';
@@ -22,10 +24,13 @@ export const TradingOffersModal = ({ onClose, onSelect }: TradingOffersModalProp
         ? [...new Map(context.quotes.map(quote => [quote.exchange, quote])).values()]
         : [];
 
-    const handleSelect = (quote: TradingTradeType) => {
-        onSelect(quote);
-        onClose();
-    };
+    const handleSelect = useCallback(
+        (quote: TradingTradeType) => {
+            onSelect(quote);
+            onClose();
+        },
+        [onSelect, onClose],
+    );
 
     return (
         <Modal

--- a/packages/suite/src/views/wallet/trading/common/TradingOffers/TradingOffersModalItem.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingOffers/TradingOffersModalItem.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { memo, useCallback } from 'react';
 
 import { type ExchangeTrade } from 'invity-api';
 import styled from 'styled-components';
@@ -29,7 +29,7 @@ const ProviderWrapper = styled.div`
     justify-content: center;
 `;
 
-export const TradingOffersModalItem = ({ quote, onSelect }: TradingOffersModalItemProps) => {
+const TradingOffersModalItemInner = ({ quote, onSelect }: TradingOffersModalItemProps) => {
     const context = useTradingFormContext();
     const providers = getProvidersInfoProps(context);
     const {
@@ -85,3 +85,5 @@ export const TradingOffersModalItem = ({ quote, onSelect }: TradingOffersModalIt
         </CardList.Item>
     );
 };
+
+export const TradingOffersModalItem = memo(TradingOffersModalItemInner);

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOfferProvider.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOfferProvider.tsx
@@ -1,6 +1,4 @@
-import { type ReactNode, useState } from 'react';
-
-import { type BuyTrade, type ExchangeTrade, type SellFiatTrade } from 'invity-api';
+import { type ReactNode, useCallback, useState } from 'react';
 
 import { Translation } from '@suite/intl';
 import { type TradingTradeType, useProviderMetadataChangeEffect } from '@suite-common/trading';
@@ -12,7 +10,6 @@ import {
     getSelectedQuote,
     isTradingBuyContext,
     isTradingExchangeContext,
-    isTradingSellContext,
 } from 'src/utils/wallet/trading/tradingTypingUtils';
 
 import { TradingOffersModal } from '../TradingOffers/TradingOffersModal';
@@ -40,15 +37,13 @@ export const TradingSelectedOfferProvider = () => {
     const providers = getProvidersInfoProps(context);
     const quote = getSelectedQuote(context);
 
-    const onQuoteSelect = (selected: TradingTradeType) => {
-        if (isTradingBuyContext(context)) {
-            context.onQuoteSelected(selected as BuyTrade);
-        } else if (isTradingSellContext(context)) {
-            context.onQuoteSelected(selected as SellFiatTrade);
-        } else if (isTradingExchangeContext(context)) {
-            context.onQuoteSelected(selected as ExchangeTrade);
-        }
-    };
+    const onQuoteSelected = context.onQuoteSelected as (selected: TradingTradeType) => void;
+    const onQuoteSelect = useCallback(
+        (selected: TradingTradeType) => onQuoteSelected(selected),
+        [onQuoteSelected],
+    );
+
+    const handleModalClose = useCallback(() => setIsModalOpen(false), []);
 
     useProviderMetadataChangeEffect(
         type,
@@ -101,10 +96,7 @@ export const TradingSelectedOfferProvider = () => {
                 </Row>
             </GhostContainer>
             {isModalOpen && (
-                <TradingOffersModal
-                    onClose={() => setIsModalOpen(false)}
-                    onSelect={onQuoteSelect}
-                />
+                <TradingOffersModal onClose={handleModalClose} onSelect={onQuoteSelect} />
             )}
         </>
     );


### PR DESCRIPTION
## Description

- Memoize trading fiat and crypto input rules and move the validation logic into a shared helper covered by unit tests.
- Reuse a shared fraction-buttons component in sell and exchange forms to avoid recreating button arrays and handlers on each render.
- Replace broad form subscriptions in payment method and country subdivision inputs with field-level `useWatch` subscriptions.
- Memoize the offers modal item and stabilize selected-offer modal callbacks to reduce unnecessary rerenders in the offer selection flow.

## Notes for QA

- In Trading Sell, enter amounts and use the fraction buttons, then verify the amount updates correctly and payment method and country subdivision selectors still react normally.
- In Trading Exchange, change fiat and crypto amounts and select an offer, then verify validations still appear correctly and the selected offer updates as before.

## Related Issue

Resolve #26288

## Screenshots:

N/A

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/trading-26288-optimize-form-rerenders&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/trading-26288-optimize-form-rerenders&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-03T20:58:17.663Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-03T20:55:59.912Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/trading-26288-optimize-form-rerenders/web/](https://dev.suite.sldev.cz/suite-web/feat/trading-26288-optimize-form-rerenders/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->