### PR TITLE
refactor(suite): type getState DI boundary across composition roots and legacy thunks

### DIFF
--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -5,6 +5,7 @@ import { type DesktopAnalyticsDep, createAnalytics } from '@suite/analytics';
 import type { FlagsState } from '@suite/flags';
 import { lockDevice } from '@suite/locks';
 import {
+    type MetadataRootState,
     metadataActions,
     metadataLabelingActions,
     selectLabelingDataForAccount,
@@ -41,6 +42,7 @@ import {
 } from '@suite-common/redux-utils';
 import { createMigrateSuiteSyncLabelsForRbfTransactionCompositionRoot } from '@suite-common/suite-rbf-labels-migrations';
 import {
+    type SuiteSyncCompositionRootState,
     selectAllLabelsForAccount,
     selectIsSuiteSyncEnabled,
     selectSuiteSyncWalletLabel,
@@ -88,7 +90,7 @@ const connectInitSettings: ConnectInitSettings = {
 };
 
 export type StoreAPIDep = {
-    getState: () => any;
+    getState: () => SuiteSyncCompositionRootState & MetadataRootState;
     dispatch: (_: any) => any;
 };
 

--- a/suite-common/connect-popup/src/methodHooks/types.ts
+++ b/suite-common/connect-popup/src/methodHooks/types.ts
@@ -1,5 +1,7 @@
 import { type Dispatch } from '@reduxjs/toolkit/react';
 
+import { type DeviceRootState } from '@suite-common/device';
+import { type AccountsRootState } from '@suite-common/wallet-core';
 import { type PrecomposedTransactionFinal } from '@suite-common/wallet-types';
 import {
     type CallMethodKeys,
@@ -9,13 +11,14 @@ import {
 import { type SerializedError } from '@trezor/connect-common/src/constants/errors';
 import { type Err, type Ok } from '@trezor/type-utils';
 
+import { type ConnectPopupStateRootState } from '../connectPopupReducer';
 import { type ConnectCallSource } from '../connectPopupTypes';
 
 export type PreCallHookParams<M extends CallMethodKeys> = {
     method: M;
     payload: Omit<CallMethodParams<M>, 'method'>;
     dispatch: Dispatch;
-    getState: () => any;
+    getState: () => AccountsRootState & DeviceRootState & ConnectPopupStateRootState;
     txSigningPrecomposed?: PrecomposedTransactionFinal;
     source: ConnectCallSource;
 };

--- a/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
+++ b/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
@@ -77,12 +77,14 @@ export type SubscribeSuiteSyncInternalErrorHandlerDep = {
     subscribeError: SubscribeSuiteSyncInternalErrorHandler;
 };
 
+export type SuiteSyncCompositionRootState = WithSuiteSyncAndDeviceState &
+    WithSuiteSyncQuotaManagerState &
+    MessageSystemRootState &
+    AccountsRootState &
+    SuiteSyncDataRootState;
+
 type CreateSuiteSyncCompositionRootDeps = {
-    getState: () => WithSuiteSyncAndDeviceState &
-        WithSuiteSyncQuotaManagerState &
-        MessageSystemRootState &
-        AccountsRootState &
-        SuiteSyncDataRootState;
+    getState: () => SuiteSyncCompositionRootState;
     dispatch: Dispatch;
     subscribeError: SubscribeSuiteSyncInternalErrorHandler;
     trezorConnect: Pick<typeof TrezorConnect, 'evoluGetNode' | 'evoluSignRegistrationRequest'>;

--- a/suite-common/suite-sync/src/index.ts
+++ b/suite-common/suite-sync/src/index.ts
@@ -12,7 +12,11 @@ export {
 export type { WithSuiteSyncAndDeviceState, WithSuiteSyncState } from './suiteSyncSelectors';
 export type { SuiteSyncInteraction } from './suiteSyncTypes';
 export { createSuiteSyncCompositionRoot } from './createSuiteSyncCompositionRoot';
-export type { SuiteSyncAnalytics, SuiteSyncAnalyticsDep } from './createSuiteSyncCompositionRoot';
+export type {
+    SuiteSyncAnalytics,
+    SuiteSyncAnalyticsDep,
+    SuiteSyncCompositionRootState,
+} from './createSuiteSyncCompositionRoot';
 export {
     suiteSyncSlice,
     suiteSyncReducer,

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -55,6 +55,7 @@ import { DISCOVERY_MODULE_PREFIX, discoveryActions } from './discoveryActions';
 import { isDiscoveryInProgress, selectDiscoveryByDevicePath } from './discoverySelectors';
 import { selectDeviceThunk } from './selectDeviceThunk';
 import { type CreateAccountActionProps, accountsActions } from '../accounts/accountsActions';
+import { type AccountsRootState } from '../accounts/accountsReducer';
 import { selectAccountsByDeviceState } from '../accounts/accountsSelectors';
 import { reportWalletBalanceThunk } from '../accounts/accountsThunks';
 import { selectAccountsToBeForgotten, selectDiscoveryAccountsParam } from '../selectors';
@@ -262,7 +263,10 @@ const trackCompleteDiscoveryResult = (
     {
         getState,
         analytics,
-    }: { getState: () => any; analytics: ExtraDependencies['services']['analytics'] },
+    }: {
+        getState: () => AccountsRootState;
+        analytics: ExtraDependencies['services']['analytics'];
+    },
 ) => {
     const discoveredAccounts = selectAccountsByDeviceState(getState(), deviceStaticSessionId);
 
@@ -319,7 +323,7 @@ const completeDiscovery = (
         fetchAndSaveMetadata,
         getState,
     }: {
-        getState: () => any;
+        getState: () => AccountsRootState;
         dispatch: ThunkDispatch<any, ExtraDependencies, AnyAction>;
         fetchAndSaveMetadata: SuiteCompatibleThunk<StaticSessionId>;
         analytics: ExtraDependencies['services']['analytics'];

--- a/suite-common/wallet-core/src/settings/walletSettingsThunks.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsThunks.ts
@@ -6,7 +6,11 @@ import { PROTO } from '@trezor/connect';
 
 import { changeNetworks, setBitcoinAmountUnits } from './walletSettingsActions';
 import { WALLET_SETTINGS } from './walletSettingsConstants';
-import { selectBitcoinAmountUnit, selectEnabledNetworks } from './walletSettingsReducer';
+import {
+    type WalletSettingsRootState,
+    selectBitcoinAmountUnit,
+    selectEnabledNetworks,
+} from './walletSettingsReducer';
 import { accountsActions } from '../accounts/accountsActions';
 import { selectAccountsToBeForgotten } from '../selectors';
 
@@ -40,13 +44,14 @@ export const changeCoinVisibility = createThunk<
     });
 });
 
-export const toggleBitcoinAmountUnits = () => (dispatch: Dispatch, getState: () => any) => {
-    const currentUnits = selectBitcoinAmountUnit(getState());
+export const toggleBitcoinAmountUnits =
+    () => (dispatch: Dispatch, getState: () => WalletSettingsRootState) => {
+        const currentUnits = selectBitcoinAmountUnit(getState());
 
-    const nextUnits =
-        currentUnits === PROTO.AmountUnit.BITCOIN
-            ? PROTO.AmountUnit.SATOSHI
-            : PROTO.AmountUnit.BITCOIN;
+        const nextUnits =
+            currentUnits === PROTO.AmountUnit.BITCOIN
+                ? PROTO.AmountUnit.SATOSHI
+                : PROTO.AmountUnit.BITCOIN;
 
-    dispatch(setBitcoinAmountUnits(nextUnits));
-};
+        dispatch(setBitcoinAmountUnits(nextUnits));
+    };

--- a/suite-native/state/src/extraDependencies.ts
+++ b/suite-native/state/src/extraDependencies.ts
@@ -14,6 +14,7 @@ import {
     notImplementedThunk,
 } from '@suite-common/redux-utils';
 import { createMigrateSuiteSyncLabelsForRbfTransactionCompositionRoot } from '@suite-common/suite-rbf-labels-migrations';
+import { type SuiteSyncCompositionRootState } from '@suite-common/suite-sync';
 import { analytics } from '@suite-native/analytics';
 import { forgetBluetoothDeviceThunk } from '@suite-native/bluetooth';
 import { selectTokenDefinitionsEnabledNetworks } from '@suite-native/discovery';
@@ -49,7 +50,7 @@ const bip329: Bip329 = {
 };
 
 type NativeAppDeps = {
-    getState: () => any;
+    getState: () => SuiteSyncCompositionRootState;
     dispatch: any;
 } & EnsureEncryptionKeyDep &
     MMKVStorageDep;

--- a/suite-native/suite-sync/src/createSuiteSyncNativeCompositionRoot.ts
+++ b/suite-native/suite-sync/src/createSuiteSyncNativeCompositionRoot.ts
@@ -8,6 +8,7 @@ import { type PlatformEncryptionDep } from '@suite-common/platform-encryption';
 import {
     type SuiteSyncAnalyticsDep,
     type SuiteSyncAsyncErrorHandlerDep,
+    type SuiteSyncCompositionRootState,
     createSuiteSyncCompositionRoot,
 } from '@suite-common/suite-sync';
 import {
@@ -21,7 +22,7 @@ import { type SuiteSync } from '@suite-common/suite-sync-types';
 import { type TrezorConnect } from '@trezor/connect';
 
 type SuiteSyncNativeCompositionRootDeps = {
-    getState: () => any;
+    getState: () => SuiteSyncCompositionRootState;
     dispatch: Dispatch;
     trezorConnect: TrezorConnect;
 } & SuiteSyncAnalyticsDep &

--- a/suite/suite-sync/src/createSuiteSyncDesktopCompositionRoot.ts
+++ b/suite/suite-sync/src/createSuiteSyncDesktopCompositionRoot.ts
@@ -7,6 +7,7 @@ import { type EnsureDelegatedIdentityKeyDep } from '@suite-common/delegated-iden
 import { type PlatformEncryptionDep } from '@suite-common/platform-encryption';
 import {
     type SuiteSyncAsyncErrorHandlerDep,
+    type SuiteSyncCompositionRootState,
     createSuiteSyncCompositionRoot,
 } from '@suite-common/suite-sync';
 import {
@@ -23,7 +24,7 @@ import { createOnSharedWorkerUnsupported } from './createOnSharedWorkerUnsupport
 import { createTurnOnDesktopSuiteSync } from './turnOnDesktopSuiteSync';
 
 type SuiteSyncDesktopCompositionRootDeps = {
-    getState: () => any;
+    getState: () => SuiteSyncCompositionRootState;
     dispatch: Dispatch;
     trezorConnect: TrezorConnect;
 } & PlatformEncryptionDep &


### PR DESCRIPTION
Standalone cherry-pick from the types-hardening staging branch (#27649), in the same series as #27852 and #27868.

## What

Replaces `getState: () => any` annotations with the precise root-state shape required by the selectors each function actually calls. This types the redux `getState` DI boundary across legacy thunks and the app composition roots, where `any` was previously masking all selector-input type checking.

## Commits

- **wallet-core** — `trackCompleteDiscoveryResult` / `completeDiscovery` → `() => AccountsRootState`; `toggleBitcoinAmountUnits` → `() => WalletSettingsRootState`
- **connect-popup** — `PreCallHookParams.getState` → `() => AccountsRootState & DeviceRootState & ConnectPopupStateRootState` (matches all three sign-transaction hook selectors)
- **suite-sync** — extracts a shared `SuiteSyncCompositionRootState` alias and applies it to the desktop and native SuiteSync composition roots
- **suite-native/state** — `NativeAppDeps.getState` → `() => SuiteSyncCompositionRootState`
- **@trezor/suite** — `StoreAPIDep.getState` → `() => SuiteSyncCompositionRootState & MetadataRootState`

## Why

Type-only change, no runtime impact. Each annotation is derived from the concrete selector calls in scope, so the new types are tight rather than widened. No dependency changes.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/type-getstate-deps&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/type-getstate-deps&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/type-getstate-deps&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-28T06:34:37.188Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-27T12:59:49.000Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/type-getstate-deps/web/](https://dev.suite.sldev.cz/suite-web/mroz22/type-getstate-deps/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->