### PR TITLE
fix(suite-native): adjust divider on the connection settings card

### DIFF
--- a/suite-native/module-settings/src/components/ConnectionSettings.tsx
+++ b/suite-native/module-settings/src/components/ConnectionSettings.tsx
@@ -6,7 +6,7 @@ import { selectIsPortfolioTrackerDevice } from '@suite-common/device';
 import {
     Box,
     Card,
-    CardDivider,
+    Divider,
     HStack,
     PressableOpacity,
     RoundedIcon,
@@ -52,8 +52,7 @@ export const ConnectionSettings = () => {
                     borderColor={null}
                     noShadow
                 />
-
-                <CardDivider />
+                <Divider />
                 <Box paddingHorizontal="sp16" paddingVertical="sp12">
                     <WalletConnectPairBottomSheet ref={bottomSheetRef} onClose={closeModal} />
                     <PressableOpacity onPress={openModal} testID="@settings/wallet-connect-add">


### PR DESCRIPTION
`CardDividier` doesn't seem to work well for `<Card noPadding>`.

## Screenshots:

| Before | After |
| --- | --- |
| <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/a144d4fd-9be9-46b1-a3f2-e56bff355553" /> | <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/1c75ab2e-6ea1-4283-aedc-a5dc23bfbf10" /> |

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/connection-settings-card&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->