### PR TITLE
refactor(suite): use network type instead of symbol

### DIFF
--- a/packages/suite/src/views/wallet/send/Outputs/Address.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Address.tsx
@@ -112,15 +112,8 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
 
     const [isExternalAddressCheckWarningDismissed, setIsExternalAddressCheckWarningDismissed] =
         useState(false);
-    const isExternalAddressCheckEnabled = [
-        'eth',
-        'tsep',
-        'thod',
-        'sol',
-        'dsol',
-        'trx',
-        'ttrx',
-    ].includes(symbol);
+
+    const isExternalAddressCheckEnabled = ['ethereum', 'solana', 'tron'].includes(networkType);
 
     useEffect(() => {
         setIsExternalAddressCheckWarningDismissed(false);

--- a/suite-native/module-send/src/hooks/useAddressValidationAlerts/useAddressValidationAlerts.ts
+++ b/suite-native/module-send/src/hooks/useAddressValidationAlerts/useAddressValidationAlerts.ts
@@ -61,7 +61,8 @@ export const useAddressValidationAlerts = ({ inputIndex }: UseAddressValidationA
 
         const shouldCheckContractAddress =
             (wasTokenAlertDisplayed || !shouldShowTokenAlert) &&
-            ['eth', 'tsep', 'thod', 'trx', 'ttrx'].includes(symbol) &&
+            // Solana uses different address validation logic than Ethereum and Tron
+            (networkType === 'ethereum' || networkType === 'tron') &&
             !wasContractAlertDisplayed;
 
         if (shouldShowTokenAlert) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Uses general network type parameter instead of specific network symbol to determine if validation is needed

## Notes for QA

Should work exactly the same way for both: desktop and mobile. Can be tested on the send flow with any known contract address. 

WETH contract: `0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2`

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26392

