### PR TITLE
fix(device-authenticity): wrap `verifyAuthenticityProof` errors

### DIFF
--- a/packages/device-authenticity/src/__fixtures__/verifyAuthenticityProof.ts
+++ b/packages/device-authenticity/src/__fixtures__/verifyAuthenticityProof.ts
@@ -34,8 +34,11 @@ const replaceInHex = (hexData: string, searchValue: string, replaceValue: string
         Buffer.from(replaceValue).toString('hex'),
     );
 
-// Note: most test cases are applied three times similarly for Optiga, Tropic and MCU.
-export const verifyAuthenticityProofFixtures: Fixture[] = [
+/*
+ Fixtures common for matchRootPubKeyToCertificate and verifyAuthenticityProof.
+ Most test cases are applied three times similarly for Optiga, Tropic and MCU.
+*/
+export const matchRootPubKeyToCertificateFixtures: Fixture[] = [
     // The most common happy path that mimicks a production device & an ordinary user.
     {
         description: 'succeeds for optiga (with prod keys)',
@@ -311,5 +314,117 @@ export const verifyAuthenticityProofFixtures: Fixture[] = [
             caPubKey: CA_PUB_KEY_TROPIC,
             rootPubKey: T3W1_ROOT_PUB_KEY_TROPIC,
         },
+    },
+    {
+        description: 'fails with INVALID_DEVICE_CERTIFICATE on mismatched signature algorithms',
+        params: {
+            ...defaultOptigaProps,
+            certificates: [DEVICE_CERT_OPTIGA, CA_CERT_TROPIC],
+        },
+        result: {
+            valid: false,
+            error: 'INVALID_DEVICE_CERTIFICATE',
+            errorDetails: 'Mismatched signature algorithms in device and CA certificates',
+        },
+    },
+    {
+        description: 'fails with INVALID_DEVICE_CERTIFICATE when CA cert extensions are invalid',
+        params: {
+            ...defaultOptigaProps,
+            certificates: [CA_CERT_OPTIGA, DEVICE_CERT_OPTIGA],
+        },
+        result: {
+            valid: false,
+            error: 'INVALID_DEVICE_CERTIFICATE',
+            errorDetails: 'CA keyCertSign not set',
+        },
+    },
+    {
+        description:
+            'fails with INVALID_DEVICE_CERTIFICATE when Ed25519 CA cert extensions are invalid',
+        params: {
+            ...defaultTropicProps,
+            certificates: [CA_CERT_TROPIC, DEVICE_CERT_TROPIC],
+        },
+        result: {
+            valid: false,
+            error: 'INVALID_DEVICE_CERTIFICATE',
+            errorDetails: 'CA keyCertSign not set',
+        },
+    },
+    {
+        description: 'fails with INVALID_DEVICE_CERTIFICATE when device cert is not signed by CA',
+        params: {
+            ...defaultOptigaProps,
+            certificates: [`${DEVICE_CERT_OPTIGA.slice(0, -2)}ff`, CA_CERT_OPTIGA],
+        },
+        result: {
+            valid: false,
+            caPubKey: CA_PUB_KEY_OPTIGA,
+            rootPubKey: T2B1_ROOT_PUB_KEY_OPTIGA,
+            error: 'INVALID_DEVICE_CERTIFICATE',
+        },
+    },
+];
+
+// Fixtures that are not applicable for matchRootPubKeyToCertificate
+export const verifyAuthenticityProofFixtures: Fixture[] = [
+    ...matchRootPubKeyToCertificateFixtures,
+    // Error detail scenarios — invalid inputs caught and wrapped in result objects.
+    {
+        description: 'fails with INVALID_DEVICE_MODEL for unknown device model',
+        params: {
+            ...defaultOptigaProps,
+            deviceModel: 'UNKNOWN',
+        },
+        result: { valid: false, error: 'INVALID_DEVICE_MODEL' },
+    },
+    {
+        description: 'fails with INVALID_DEVICE_CERTIFICATE on malformed certificate hex',
+        params: {
+            ...defaultOptigaProps,
+            certificates: ['not-valid-hex'],
+        },
+        result: {
+            valid: false,
+            error: 'INVALID_DEVICE_CERTIFICATE',
+            errorDetails: "This can't be an X.509 certificate. Wrong data type.",
+        },
+    },
+    {
+        description: 'fails with INVALID_DEVICE_CERTIFICATE on truncated certificate',
+        params: {
+            ...defaultOptigaProps,
+            certificates: [DEVICE_CERT_OPTIGA.slice(0, 20), CA_CERT_OPTIGA],
+        },
+        result: {
+            valid: false,
+            error: 'INVALID_DEVICE_CERTIFICATE',
+            errorDetails: 'Certificate contains more than the three specified children.',
+        },
+    },
+    {
+        description: 'fails with RESPONSE_MALFORMED on empty certificates',
+        params: {
+            ...defaultOptigaProps,
+            certificates: [],
+        },
+        result: { valid: false, error: 'RESPONSE_MALFORMED' },
+    },
+    {
+        description: 'fails with RESPONSE_MALFORMED when P-256 path receives wrong cert count',
+        params: {
+            ...defaultOptigaProps,
+            certificates: [DEVICE_CERT_OPTIGA],
+        },
+        result: { valid: false, error: 'RESPONSE_MALFORMED' },
+    },
+    {
+        description: 'fails with RESPONSE_MALFORMED when MLDSA44 path receives wrong cert count',
+        params: {
+            ...defaultMCUProps,
+            certificates: [DEVICE_CERT_MCU, DEVICE_CERT_MCU],
+        },
+        result: { valid: false, error: 'RESPONSE_MALFORMED' },
     },
 ];

--- a/packages/device-authenticity/src/__tests__/verifyAuthenticityProof.test.ts
+++ b/packages/device-authenticity/src/__tests__/verifyAuthenticityProof.test.ts
@@ -8,7 +8,10 @@ import {
     T3W1_ROOT_PUB_KEY_TROPIC,
     defaultOptigaProps,
 } from '../../mocks/mockDeviceAuthenticityData';
-import { verifyAuthenticityProofFixtures } from '../__fixtures__/verifyAuthenticityProof';
+import {
+    matchRootPubKeyToCertificateFixtures,
+    verifyAuthenticityProofFixtures,
+} from '../__fixtures__/verifyAuthenticityProof';
 import { getRootPubKeys } from '../utils';
 import {
     matchRootPubKeyToCertificate,
@@ -50,6 +53,18 @@ describe(verifyAuthenticityProof.name, () => {
 
         expect(verify.valid).toBe(true);
     });
+
+    it('fails with INVALID_DEVICE_CERTIFICATE when CA cert validity is in the future', async () => {
+        jest.useFakeTimers({ now: new Date('2022-01-01') });
+        const result = await verifyAuthenticityProof(defaultOptigaProps);
+        jest.useRealTimers();
+
+        expect(result).toEqual({
+            valid: false,
+            error: 'INVALID_DEVICE_CERTIFICATE',
+            errorDetails: expect.stringContaining("can't be in the future"),
+        });
+    });
 });
 
 describe(matchRootPubKeyToCertificate.name, () => {
@@ -73,7 +88,7 @@ describe(matchRootPubKeyToCertificate.name, () => {
         ).resolves.toBe(undefined);
     });
 
-    verifyAuthenticityProofFixtures.forEach(({ description, params, result }) => {
+    matchRootPubKeyToCertificateFixtures.forEach(({ description, params, result }) => {
         it(description, async () => {
             const { config, deviceModel, allowDebugKeys, certificates } = params;
             const allRootPubKeys = getRootPubKeys({ config, deviceModel, allowDebugKeys });

--- a/packages/device-authenticity/src/types.ts
+++ b/packages/device-authenticity/src/types.ts
@@ -30,6 +30,7 @@ export type VerifyAuthenticityProofResult =
           caPubKey?: string;
           rootPubKey: string;
           error?: never;
+          errorDetails?: never;
           serialNumber?: string;
       }
     | {
@@ -46,6 +47,7 @@ export type VerifyAuthenticityProofResult =
               | 'RESPONSE_PAYLOAD_MISSING'
               | 'RESPONSE_MALFORMED'
               | 'SERIAL_NUMBER_MISMATCH';
+          errorDetails?: string;
       };
 
 export type ResultsToValidate = {

--- a/packages/device-authenticity/src/verifyAuthenticityProof.ts
+++ b/packages/device-authenticity/src/verifyAuthenticityProof.ts
@@ -255,13 +255,26 @@ export const verifyAuthenticityProof = async ({
     blacklistConfig,
 }: VerifyAuthenticityProofParams): Promise<VerifyAuthenticityProofResult> => {
     // Parse config with given device model, type of secure element and debug mode.
-    const allRootPubKeys = getRootPubKeys({ config, deviceModel, allowDebugKeys });
+    let allRootPubKeys: string[];
+    try {
+        allRootPubKeys = getRootPubKeys({ config, deviceModel, allowDebugKeys });
+    } catch {
+        return { valid: false, error: 'INVALID_DEVICE_MODEL' };
+    }
     const caPubKeyBlacklist = getCaPubKeyBlacklist({ blacklistConfig, allowDebugKeys });
+    let parsedCertificates: ParsedCertificate[];
+    try {
+        // Parse all x509 certificates received from AuthenticityProof
+        parsedCertificates = certificates.map(c =>
+            parseCertificate(new Uint8Array(Buffer.from(c, 'hex'))),
+        );
+    } catch (e) {
+        return { valid: false, error: 'INVALID_DEVICE_CERTIFICATE', errorDetails: e.message };
+    }
 
-    // Parse all x509 certificates received from AuthenticityProof
-    const parsedCertificates = certificates.map(c =>
-        parseCertificate(new Uint8Array(Buffer.from(c, 'hex'))),
-    );
+    if (parsedCertificates.length < 1) {
+        return { valid: false, error: 'RESPONSE_MALFORMED' };
+    }
     // For both signing schemes, the 1st certificate is the one expected to be signed by rootPubKey (checked by matchRootPubKeyToCertificate)
     const firstCertAlgName = parsedCertificates[0].signatureAlgorithm.algorithmName;
 
@@ -271,13 +284,17 @@ export const verifyAuthenticityProof = async ({
         }
         const [deviceCert] = parsedCertificates;
 
-        return await verifyOnlyDeviceCertificate({
-            deviceCert,
-            signature,
-            signedData,
-            deviceModel,
-            allRootPubKeys,
-        });
+        try {
+            return await verifyOnlyDeviceCertificate({
+                deviceCert,
+                signature,
+                signedData,
+                deviceModel,
+                allRootPubKeys,
+            });
+        } catch (e) {
+            return { valid: false, error: 'INVALID_DEVICE_CERTIFICATE', errorDetails: e.message };
+        }
     }
     if (firstCertAlgName === 'Ed25519' || firstCertAlgName === 'P-256') {
         if (parsedCertificates.length !== 2) {
@@ -285,15 +302,19 @@ export const verifyAuthenticityProof = async ({
         }
         const [deviceCert, caCert] = parsedCertificates;
 
-        return await verifyDeviceAndCACertificates({
-            deviceCert,
-            caCert,
-            signature,
-            signedData,
-            deviceModel,
-            allRootPubKeys,
-            caPubKeyBlacklist,
-        });
+        try {
+            return await verifyDeviceAndCACertificates({
+                deviceCert,
+                caCert,
+                signature,
+                signedData,
+                deviceModel,
+                allRootPubKeys,
+                caPubKeyBlacklist,
+            });
+        } catch (e) {
+            return { valid: false, error: 'INVALID_DEVICE_CERTIFICATE', errorDetails: e.message };
+        }
     }
 
     return { valid: false, error: 'RESPONSE_MALFORMED' }; // unknown signature


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

while i was working on the [authenticity proof streaming](https://github.com/trezor/trezor-suite/pull/27998) i've noticed that the workflow doesnt work as expected.

`verifyAuthenticityProof` either returns { valid: false } or throw Errors, so in case of invalid received cert instead of return:

```
optigaResult: {
    valid: true,
    ...
  },
  tropicResult: {
    valid: false,
    error: 'Bad TBS Certificate. There are fewer than the seven required children.'
  },
  mcuResult: {
    valid: false,
    error: 'Certificate contains more than the three specified children.'
  }
}
```
TrezorConnect method returns:

```
{ success: false, error: 'Bad TBS Certificate. There are fewer than the seven required children.'  }
```

and we dont know what exactly happened


This could be tested using emulator where received certs are curently malformed

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are confined to the device-authenticity package, modifying the verifyAuthenticityProof function, its types, and its unit test. While this file is statically imported by 121+ E2E tests (indicating it's a broadly shared dependency), the actual runtime impact is narrow: it primarily affects the device authenticity check step during onboarding. Only tests that explicitly exercise the authenticity check flow during onboarding are meaningfully at risk. The unit test file covers the core logic directly, and only a few E2E tests exercise the authenticity check in their user flows.

<details><summary><b>Changed files (3)</b></summary>

- `packages/device-authenticity/src/__tests__/verifyAuthenticityProof.test.ts`
- `packages/device-authenticity/src/types.ts`
- `packages/device-authenticity/src/verifyAuthenticityProof.ts`

</details>

**Recommended tests (4)**

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts` — The T3T1 onboarding flow includes a device authenticity check step (onboardingPage passes through authenticity check). Changes to verifyAuthenticityProof could cause the authenticity check to fail or behave differently during onboarding, blocking wallet creation.
- `suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts` — The T3W1 onboarding flow explicitly includes firmware hash check error dismissal and authenticity-related steps. Changes to the authenticity proof verification could affect whether the onboarding flow completes successfully on this device model.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts` — This test includes the authenticity check step during offline onboarding. Changes to verifyAuthenticityProof could affect how the authenticity check behaves when offline, though the test may dismiss firmware hash check errors gracefully.
- `suite/e2e/tests/onboarding/firmware-check.test.ts` — This test validates firmware readiness detection during onboarding and disables unnecessary firmware checks. Changes to the authenticity verification types or logic could interact with the firmware check flow since authenticity and firmware checks are adjacent onboarding steps.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/device-authenticity/src/__tests__/verifyAuthenticityProof.test.ts`

_Updated: 2026-05-27T14:07:44.508Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/device-authenticity-errors&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/device-authenticity-errors&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-27T16:09:34.988Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-27T15:17:40.178Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/device-authenticity-errors/web/](https://dev.suite.sldev.cz/suite-web/fix/device-authenticity-errors/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->