### PR TITLE
fix(suite): correct yield withdraw completion values

### DIFF
--- a/packages/suite/src/components/earn/yield/common/YieldFlowCompleteWithdraw.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldFlowCompleteWithdraw.tsx
@@ -3,43 +3,62 @@ import { type YieldFlowCompleteValue } from '@suite-common/wallet-core';
 import { Column, Row, Text } from '@trezor/components';
 
 import { YieldFlowComplete } from './YieldFlowComplete';
+import { YieldFlowTransferRow } from './YieldFlowTransferRow';
 import { YieldTokenValue } from './YieldTokenValue';
 
 type YieldFlowCompleteWithdrawProps = {
-    value: YieldFlowCompleteValue;
+    input: YieldFlowCompleteValue;
+    output?: YieldFlowCompleteValue;
     vaultId: string;
 };
 
-export const YieldFlowCompleteWithdraw = ({ value, vaultId }: YieldFlowCompleteWithdrawProps) => (
-    <YieldFlowComplete
-        type="withdraw"
-        heading={<Translation id="TR_EARN_YIELD_WITHDRAW_COMPLETE" />}
-        description={
-            <Translation
-                id="TR_EARN_YIELD_WITHDRAW_COMPLETE_DESCRIPTION"
-                values={{ displaySymbol: value.token.symbol }}
-            />
-        }
-        vaultId={vaultId}
-        showFeedback
-    >
-        <Row
-            justifyContent="space-between"
-            alignItems="center"
-            padding={{ vertical: 16, horizontal: 20 }}
-        >
-            <Column gap={8}>
-                <Text typographyStyle="body-md">
-                    <Translation id="TR_EARN_YIELD_AMOUNT_TO_WITHDRAW" />
-                </Text>
-                <YieldTokenValue
-                    token={{
-                        ...value.token,
-                        contractAddress: value.token.contractAddress ?? null,
-                    }}
-                    amount={value.amount}
+export const YieldFlowCompleteWithdraw = ({
+    input,
+    output,
+    vaultId,
+}: YieldFlowCompleteWithdrawProps) => {
+    const receivedValue = output ?? input;
+
+    return (
+        <YieldFlowComplete
+            type="withdraw"
+            heading={<Translation id="TR_EARN_YIELD_WITHDRAW_COMPLETE" />}
+            description={
+                <Translation
+                    id="TR_EARN_YIELD_WITHDRAW_COMPLETE_DESCRIPTION"
+                    values={{ displaySymbol: receivedValue.token.symbol }}
                 />
-            </Column>
-        </Row>
-    </YieldFlowComplete>
-);
+            }
+            vaultId={vaultId}
+            showFeedback
+        >
+            {output ? (
+                <YieldFlowTransferRow
+                    inputLabelId="TR_EARN_YIELD_AMOUNT_TO_WITHDRAW"
+                    outputLabelId="TR_RECEIVED"
+                    input={input}
+                    output={output}
+                />
+            ) : (
+                <Row
+                    justifyContent="space-between"
+                    alignItems="center"
+                    padding={{ vertical: 16, horizontal: 20 }}
+                >
+                    <Column gap={8}>
+                        <Text typographyStyle="body-md">
+                            <Translation id="TR_RECEIVED" />
+                        </Text>
+                        <YieldTokenValue
+                            token={{
+                                ...receivedValue.token,
+                                contractAddress: receivedValue.token.contractAddress ?? null,
+                            }}
+                            amount={receivedValue.amount}
+                        />
+                    </Column>
+                </Row>
+            )}
+        </YieldFlowComplete>
+    );
+};

--- a/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
+++ b/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
@@ -22,7 +22,6 @@ export const YieldWithdrawForm = () => {
         token,
         receiptToken,
         maxAmount,
-        completedAmount,
         errorMessage,
         pendingTransaction,
         isAmountEmpty,
@@ -33,6 +32,8 @@ export const YieldWithdrawForm = () => {
         otherUnitTokenSymbol,
         canToggleWithdrawUnit,
         withdrawInputUnit,
+        completedInput,
+        completedOutput,
         setAmountInput,
         toggleWithdrawInputUnit,
         submitAction,
@@ -117,10 +118,8 @@ export const YieldWithdrawForm = () => {
             <Column gap={24} width="100%" maxWidth={500}>
                 {flow.currentStep === 'complete' ? (
                     <YieldFlowCompleteWithdraw
-                        value={{
-                            token: withdrawInputUnit === 'shares' ? receiptToken : token,
-                            amount: completedAmount,
-                        }}
+                        input={completedInput}
+                        output={completedOutput}
                         vaultId={vault.id}
                     />
                 ) : (

--- a/packages/suite/src/components/earn/yield/withdraw/useYieldWithdraw.ts
+++ b/packages/suite/src/components/earn/yield/withdraw/useYieldWithdraw.ts
@@ -1,4 +1,8 @@
 import { type EarnParams } from '@suite/router';
+import {
+    type YieldFlowCompleteValue,
+    getConvertedOutputTokenBalanceToInputTokenAmount,
+} from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 
 import { type YieldFlowContextValues, useYieldFlow } from '../hooks/useYieldFlow';
@@ -8,10 +12,15 @@ type UseYieldWithdrawProps = {
     routeParams: EarnParams;
 };
 
+export type YieldWithdrawContextValues = YieldFlowContextValues & {
+    completedInput: YieldFlowCompleteValue;
+    completedOutput?: YieldFlowCompleteValue;
+};
+
 export const useYieldWithdraw = ({
     account,
     routeParams,
-}: UseYieldWithdrawProps): YieldFlowContextValues | null => {
+}: UseYieldWithdrawProps): YieldWithdrawContextValues | null => {
     const flowResult = useYieldFlow({ account, routeParams, flowType: 'withdraw' });
     const { vault, token, receiptToken } = flowResult;
 
@@ -19,5 +28,34 @@ export const useYieldWithdraw = ({
         return null;
     }
 
-    return { ...flowResult, token, receiptToken, vault };
+    const { completedAmount, withdrawInputUnit } = flowResult;
+    const isSharesInput = withdrawInputUnit === 'shares';
+    const pricePerShareState = vault.state?.pricePerShareState;
+    const completedInput = {
+        token: isSharesInput ? receiptToken : token,
+        amount: completedAmount,
+    };
+    const completedOutput = isSharesInput
+        ? {
+              token,
+              amount: pricePerShareState
+                  ? getConvertedOutputTokenBalanceToInputTokenAmount({
+                        networkSymbol: token.networkSymbol,
+                        token,
+                        outputToken: receiptToken,
+                        outputTokenBalance: completedAmount,
+                        pricePerShareState,
+                    })
+                  : completedAmount,
+          }
+        : undefined;
+
+    return {
+        ...flowResult,
+        token,
+        receiptToken,
+        vault,
+        completedInput,
+        completedOutput,
+    };
 };

--- a/packages/suite/src/components/earn/yield/withdraw/useYieldWithdrawContext.ts
+++ b/packages/suite/src/components/earn/yield/withdraw/useYieldWithdrawContext.ts
@@ -2,9 +2,9 @@ import { createContext, useContext } from 'react';
 
 import { throwError } from '@trezor/utils';
 
-import { type YieldFlowContextValues } from '../hooks/useYieldFlow';
+import { type YieldWithdrawContextValues } from './useYieldWithdraw';
 
-export const YieldWithdrawContext = createContext<YieldFlowContextValues | null>(null);
+export const YieldWithdrawContext = createContext<YieldWithdrawContextValues | null>(null);
 YieldWithdrawContext.displayName = 'YieldWithdrawContext';
 
 export const useYieldWithdrawContext = () =>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes the yield withdraw completion screen so it shows the actual received underlying token instead of blindly reusing the user-selected input unit.

Withdraw completion now supports two display modes:

- redeeming shares shows a transfer row from receipt token to underlying token
- withdrawing directly in the underlying token shows a single received value

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/28069

## Screenshots:

<img width="1102" height="907" alt="Screenshot 2026-05-27 at 12 49 48" src="https://github.com/user-attachments/assets/98b613da-27e5-4820-a454-0406fc751403" />

<img width="1191" height="886" alt="Screenshot 2026-05-27 at 16 09 01" src="https://github.com/user-attachments/assets/2992ff3b-7f91-42a0-9868-b12b9a869b23" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are focused on the earn/yield withdraw flow: the withdraw form component, its hook (useYieldWithdraw), its context provider (useYieldWithdrawContext), and the complete-withdraw UI (YieldFlowCompleteWithdraw). These directly power the unstaking and claiming user flows across ETH, ADA, and SOL staking. The highest risk is in the three network-specific unstake tests which exercise the full withdraw form → device confirmation → completion flow. The static coverage maps these files to 121 tests, but that's because they're bundled into the main app — only the staking/unstaking tests actually exercise this code path in a meaningful way.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite/src/components/earn/yield/common/YieldFlowCompleteWithdraw.tsx`
- `packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx`
- `packages/suite/src/components/earn/yield/withdraw/useYieldWithdraw.ts`
- `packages/suite/src/components/earn/yield/withdraw/useYieldWithdrawContext.ts`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/staking/eth/unstake.test.ts` — This test directly exercises the ETH unstaking and claiming flow, which is the primary user-facing functionality affected by changes to YieldWithdrawForm, useYieldWithdraw, useYieldWithdrawContext, and YieldFlowCompleteWithdraw. The test verifies unstaking form display, transaction confirmation, balance updates after unstaking, and the claim card flow — all of which map to the withdraw/claim components being changed.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — This test covers the Cardano unstaking flow including the unstake modal with fee information, device confirmation, balance updates after unstaking, and deposit reclamation. The changed withdraw form and context components are likely shared across staking networks, making this a direct test of the yield withdraw functionality for ADA.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — This test exercises the Solana unstaking and claiming flow end-to-end, including the unstake form, device confirmation, epoch-based state transitions, and the claim card with balance updates. The YieldWithdrawForm and YieldFlowCompleteWithdraw components are directly exercised by both the unstake and claim user flows tested here.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — This test covers the Cardano reward claiming flow, which likely uses the YieldFlowCompleteWithdraw component for the claim confirmation and completion UI. It verifies claim modal display, device confirmation, balance updates, and toast notifications after claiming rewards.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — While primarily a staking test, this test verifies the staking dashboard amounts (including unstaking display) and the unstake button state, which exercises the staking UI that shares context with the withdraw components. Changes to useYieldWithdrawContext could affect how unstaking state is displayed on the dashboard.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test verifies the complete ETH staking lifecycle including the 'Unstake to Claim' button state after staking activation. Changes to the withdraw context or form could affect the disabled/enabled state of the unstake button that this test asserts on.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/staking/sol/stake-more.test.ts` — This test checks the unstake button state on the SOL staking dashboard. While the primary flow is stake-more, changes to the withdraw context could affect how the unstake button enabled/disabled state is determined.
- `suite/e2e/tests/staking/staking-form.test.ts` — This test validates the staking form's input validation and percentage buttons for ETH. While it focuses on staking (not withdraw), the staking form infrastructure may share validation patterns with the yield withdraw form, and changes to useYieldWithdraw could have indirect effects on shared form utilities.

</details>

_Updated: 2026-05-27T14:30:05.874Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/yield-withdraw-complete-values&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/yield-withdraw-complete-values&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-27T14:35:49.773Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-27T15:51:54.091Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/yield-withdraw-complete-values/web/](https://dev.suite.sldev.cz/suite-web/fix/yield-withdraw-complete-values/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->