### PR TITLE
fix(suite): make token approval modal copy generic for swap and yield

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModalTypeSelector.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModalTypeSelector.tsx
@@ -6,7 +6,16 @@ import { selectIsDebugModeActive } from '@suite/settings';
 import { getDisplaySymbol } from '@suite-common/wallet-config';
 import { type AmountSubunit, subunitsToUnits } from '@suite-common/wallet-utils';
 import { type TokenInfo } from '@trezor/blockchain-link-types';
-import { Box, CollapsibleBox, Column, Paragraph, RadioCard, Row, Text } from '@trezor/components';
+import {
+    Banner,
+    Box,
+    CollapsibleBox,
+    Column,
+    Paragraph,
+    RadioCard,
+    Row,
+    Text,
+} from '@trezor/components';
 import { borders } from '@trezor/theme';
 
 import { DebugOnlyBadge } from 'src/components/suite/DebugOnlyBadge';
@@ -71,11 +80,19 @@ export const ApproveModalTypeSelector = ({
                         intent="neutral"
                         priority="secondary"
                     >
-                        <Translation
-                            id="TR_EXCHANGE_APPROVAL_VALUE_INFINITE_INFO"
-                            values={translationValues}
-                        />
+                        <Translation id="TR_APPROVAL_VALUE_INFINITE_INFO" />
                     </Paragraph>
+                    <Banner
+                        intent="warning"
+                        icon
+                        margin={{ top: 8 }}
+                        description={
+                            <Translation
+                                id="TR_APPROVAL_VALUE_INFINITE_WARNING"
+                                values={translationValues}
+                            />
+                        }
+                    />
                 </RadioCard>
                 <RadioCard
                     isActive={approvalType === 'MINIMAL'}
@@ -97,10 +114,7 @@ export const ApproveModalTypeSelector = ({
                         intent="neutral"
                         priority="secondary"
                     >
-                        <Translation
-                            id="TR_EXCHANGE_APPROVAL_VALUE_MINIMAL_INFO"
-                            values={translationValues}
-                        />
+                        <Translation id="TR_APPROVAL_VALUE_MINIMAL_INFO" />
                     </Paragraph>
                 </RadioCard>
                 {isDebug ? (

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApproveModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApproveModal.tsx
@@ -15,6 +15,7 @@ import {
 } from '@suite-common/trading';
 import { getDisplaySymbol } from '@suite-common/wallet-config';
 import {
+    Banner,
     Box,
     CollapsibleBox,
     Column,
@@ -25,7 +26,7 @@ import {
     Text,
 } from '@trezor/components';
 import { CoinLogo } from '@trezor/product-components';
-import { borders, spacings } from '@trezor/theme';
+import { borders } from '@trezor/theme';
 
 import { DebugOnlyBadge } from 'src/components/suite/DebugOnlyBadge';
 import { AccountLabeling } from 'src/components/suite/labeling';
@@ -250,7 +251,7 @@ export const ApproveModal = ({
                 </>
             }
             description={
-                <Row margin={{ top: spacings.xs }} gap={spacings.xxs}>
+                <Row margin={{ top: 8 }} gap={4}>
                     <CoinLogo size={20} symbol={account.symbol} />
                     <AccountLabeling
                         account={account}
@@ -262,17 +263,17 @@ export const ApproveModal = ({
             // Disable shadow bottom to make `Fees` component fully visible
             shadowBottom={false}
         >
-            <Column gap={spacings.sm}>
+            <Column gap={12}>
                 <Box
-                    padding={spacings.sm}
+                    padding={12}
                     borderWidth={borders.widths.large}
                     borderRadius={borders.radii.sm}
                 >
-                    <Column gap={spacings.sm}>
+                    <Column gap={12}>
                         <Text>
                             <Translation id="TR_EXCHANGE_APPROVAL_PROVIDER" />
                         </Text>
-                        <Row gap={spacings.xs}>
+                        <Row gap={8}>
                             {provider?.logo && (
                                 <Icon src={invityAPI.getProviderLogoUrl(provider.logo)} alt="" />
                             )}
@@ -292,10 +293,10 @@ export const ApproveModal = ({
 
                 <Box
                     borderWidth={borders.widths.large}
-                    padding={spacings.sm}
+                    padding={12}
                     borderRadius={borders.radii.sm}
                 >
-                    <Column gap={spacings.sm}>
+                    <Column gap={12}>
                         <Text>
                             <Translation id="TR_EXCHANGE_APPROVAL_SET_LIMIT" />
                         </Text>
@@ -308,23 +309,31 @@ export const ApproveModal = ({
                                 <TradingCoinLogo
                                     cryptoId={selectedQuote.send}
                                     size={20}
-                                    margin={{ right: spacings.xxs }}
+                                    margin={{ right: 4 }}
                                 />
                                 <Text>
                                     <Translation id="TR_EXCHANGE_APPROVAL_VALUE_INFINITE" />
                                 </Text>
                             </Row>
                             <Paragraph
-                                margin={{ top: spacings.xxs }}
+                                margin={{ top: 4 }}
                                 typographyStyle="body-sm"
                                 intent="neutral"
                                 priority="secondary"
                             >
-                                <Translation
-                                    id="TR_EXCHANGE_APPROVAL_VALUE_INFINITE_INFO"
-                                    values={translationValues}
-                                />
+                                <Translation id="TR_APPROVAL_VALUE_INFINITE_INFO" />
                             </Paragraph>
+                            <Banner
+                                intent="warning"
+                                icon
+                                margin={{ top: 8 }}
+                                description={
+                                    <Translation
+                                        id="TR_APPROVAL_VALUE_INFINITE_WARNING"
+                                        values={translationValues}
+                                    />
+                                }
+                            />
                         </RadioCard>
                         <RadioCard
                             isActive={approvalType === 'MINIMAL'}
@@ -335,7 +344,7 @@ export const ApproveModal = ({
                                 <TradingCoinLogo
                                     cryptoId={selectedQuote.send}
                                     size={20}
-                                    margin={{ right: spacings.xxs }}
+                                    margin={{ right: 4 }}
                                 />
                                 <Text>
                                     <Translation
@@ -345,15 +354,12 @@ export const ApproveModal = ({
                                 </Text>
                             </Row>
                             <Paragraph
-                                margin={{ top: spacings.xxs }}
+                                margin={{ top: 4 }}
                                 typographyStyle="body-sm"
                                 intent="neutral"
                                 priority="secondary"
                             >
-                                <Translation
-                                    id="TR_EXCHANGE_APPROVAL_VALUE_MINIMAL_INFO"
-                                    values={translationValues}
-                                />
+                                <Translation id="TR_APPROVAL_VALUE_MINIMAL_INFO" />
                             </Paragraph>
                         </RadioCard>
                         {isDebug && dexTx.data ? (
@@ -371,7 +377,7 @@ export const ApproveModal = ({
                 </Box>
 
                 <Box
-                    padding={spacings.sm}
+                    padding={12}
                     borderWidth={borders.widths.large}
                     borderRadius={borders.radii.sm}
                 >

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -510,19 +510,23 @@ export const messages = defineMessages({
         defaultMessage: '{value} {send}',
         id: 'TR_EXCHANGE_APPROVAL_VALUE_MINIMAL',
     },
-    TR_EXCHANGE_APPROVAL_VALUE_MINIMAL_INFO: {
+    TR_APPROVAL_VALUE_MINIMAL_INFO: {
         defaultMessage:
-            "Approve only the amount needed for this swap. This helps reduce risk, but you'll need to approve again (and pay a fee) for future swaps.",
-        id: 'TR_EXCHANGE_APPROVAL_VALUE_MINIMAL_INFO',
+            'Approve this amount for the provider. Valid until fully used or revoked. Then a new approval and network fee will be required.',
+        id: 'TR_APPROVAL_VALUE_MINIMAL_INFO',
     },
     TR_EXCHANGE_APPROVAL_VALUE_INFINITE: {
         defaultMessage: 'Unlimited',
         id: 'TR_EXCHANGE_APPROVAL_VALUE_INFINITE',
     },
-    TR_EXCHANGE_APPROVAL_VALUE_INFINITE_INFO: {
+    TR_APPROVAL_VALUE_INFINITE_INFO: {
         defaultMessage:
-            'Approve unlimited {send} to skip future approval requests and reduce fees. Only use this option if you trust {provider}, as it will have access to all your {send}.',
-        id: 'TR_EXCHANGE_APPROVAL_VALUE_INFINITE_INFO',
+            'Approve once and avoid future network fees. This provider can spend any amount until you revoke the approval.',
+        id: 'TR_APPROVAL_VALUE_INFINITE_INFO',
+    },
+    TR_APPROVAL_VALUE_INFINITE_WARNING: {
+        defaultMessage: 'If the provider is compromised, all your {send} may be taken.',
+        id: 'TR_APPROVAL_VALUE_INFINITE_WARNING',
     },
     TR_EXCHANGE_APPROVAL_DATA: {
         defaultMessage: 'Approval transaction data',


### PR DESCRIPTION
## Description

The approval-amount modal is shared between the trading (swap) and yield/earn flows, but its copy referenced "swap", so the yield approval showed an incorrect description.
- Rename `TR_EXCHANGE_APPROVAL_VALUE_{MINIMAL,INFINITE}_INFO` to `TR_APPROVAL_VALUE_*` and reword them context-neutrally (key rename triggers re-translation in Crowdin)
- Add a separate "compromised provider" warning banner under the **Unlimited** option

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/28063

## Screenshots:

<img width="743" height="912" alt="image" src="https://github.com/user-attachments/assets/74f20e76-2b74-4878-b878-4e594d87f61e" />


<img width="757" height="880" alt="image" src="https://github.com/user-attachments/assets/bbc3cf56-df95-47b1-9f99-f8159c82134a" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect two token approval modal components (ApproveModalTypeSelector and ApproveModal) and the global intl messages file. The approval modals are specifically used in the token allowance/swap approval flow, not in the general trading buy/sell flows. The messages.ts file is a global dependency used by virtually all tests, so changes there are only concerning if specific translation keys used by the approval modals were modified. The recommended strategy focuses on swap tests involving tokens where approval modals are most likely triggered, while omitting buy/sell/navigation tests that don't exercise the allowance approval flow despite the broad static mapping.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModalTypeSelector.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApproveModal.tsx`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (4)**

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — This swap test exercises the full swap trading flow including confirmation modals. The ApproveModalTypeSelector and ApproveModal are part of the token approval flow that may be triggered during token swaps (e.g., SOL to USDC). Changes to these modal components could affect the swap confirmation UX.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Token-to-token swaps (USDT to USDC) are the most likely scenario to trigger token allowance/approval modals. Changes to ApproveModalTypeSelector and ApproveModal directly affect the approval flow that precedes token swaps.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Swapping a token (USDT on Solana) to a coin (BTC) may involve token approval flows. The ApproveModalTypeSelector change could affect how users select approval types before initiating token-based swaps.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Ethereum-based swaps with custom fee settings may encounter the approval modal when swapping ERC-20 tokens. The changed ApproveModal and messages.ts could affect text or flow within the Ethereum swap fee confirmation path.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApproveModal.tsx`

_Updated: 2026-05-27T15:47:30.411Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/approval-amount-copy&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/approval-amount-copy&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-27T15:53:29.754Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-27T15:50:59.728Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/approval-amount-copy/web/](https://dev.suite.sldev.cz/suite-web/fix/approval-amount-copy/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->