### PR TITLE
feat(suite): log DAC errorDetails to Sentry

### DIFF
--- a/packages/suite/src/middlewares/suite/sentryMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/sentryMiddleware.ts
@@ -128,10 +128,11 @@ const sentryMiddleware =
                 const { result } = action.payload;
                 if (!result) return;
 
-                const reportToSentry = (error: string) => {
+                const reportToSentry = (error: string, errorDetails?: string) => {
                     withSentryScope(scope => {
                         scope.setLevel('error');
                         scope.setTag('deviceAuthenticityError', error);
+                        scope.setExtra('errorDetails', errorDetails);
                         captureSentryMessage(
                             `Device authenticity invalid! ${JSON.stringify(result, null, 2)}`,
                             scope,
@@ -145,13 +146,16 @@ const sentryMiddleware =
                 }
                 // report errors from either one of the secure elements (or both)
                 if ('optigaResult' in result && result.optigaResult.error) {
-                    reportToSentry(result.optigaResult.error);
+                    const { error, errorDetails } = result.optigaResult;
+                    reportToSentry(error, errorDetails);
                 }
                 if ('tropicResult' in result && result.tropicResult?.error) {
-                    reportToSentry(result.tropicResult.error);
+                    const { error, errorDetails } = result.tropicResult;
+                    reportToSentry(error, errorDetails);
                 }
                 if ('mcuResult' in result && result.mcuResult?.error) {
-                    reportToSentry(result.mcuResult.error);
+                    const { error, errorDetails } = result.mcuResult;
+                    reportToSentry(error, errorDetails);
                 }
                 break;
             }


### PR DESCRIPTION
## Description

Followup to #28114 to log the new optional `errorDetails` field to Sentry.

Only for Suite Desktop/Web we have to explicitely add it.
Suite Native sends the entire payload to Sentry: https://github.com/trezor/trezor-suite/blob/c1e2c77735389b4d03e02ad4d9cf0a2242f0cdb3/suite-native/device/src/hooks/useDeviceAuthenticityCheck.ts#L73
Yes, it is very inconsistent, but we want to preserve data continuity..

## Notes for QA

Not testable (artifically modified authenticity proof response needed to simulate those errors).

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is `packages/suite/src/middlewares/suite/sentryMiddleware.ts`, which is a Sentry error-reporting middleware. It maps to 121 tests, meaning it is a globally imported infrastructure dependency loaded by virtually every E2E test. Sentry middleware operates passively (intercepting Redux actions to report errors) and does not affect any user-visible behavior, UI rendering, analytics event payloads, or application logic that the E2E tests assert on. None of the 120 analyzed tests have behaviors, assertions, or source hints that reference Sentry or error-reporting middleware. Therefore, no E2E tests are specifically at risk from this change, and running zero targeted tests is the appropriate strategy. If desired, a single smoke test (e.g., onboarding or initial-run) could be run as a sanity check, but there is no concrete evidence any test's assertions would be affected.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/middlewares/suite/sentryMiddleware.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/middlewares/suite/sentryMiddleware.ts`

_Updated: 2026-05-27T20:05:49.861Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/device-authenticity-errors-followup&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/device-authenticity-errors-followup&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-27T20:38:02.056Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-27T20:09:17.615Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/device-authenticity-errors-followup/web/](https://dev.suite.sldev.cz/suite-web/fix/device-authenticity-errors-followup/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->