### PR TITLE
fix(suite): removes deprecated sfw --silent param from workflows

### DIFF
--- a/.github/actions/minimal-yarn-install/action.yml
+++ b/.github/actions/minimal-yarn-install/action.yml
@@ -37,4 +37,4 @@ runs:
 
     - name: Install dependencies using Yarn
       shell: bash
-      run: sfw --silent yarn --immutable
+      run: sfw yarn --immutable

--- a/.github/actions/release-connect-npm/action.yml
+++ b/.github/actions/release-connect-npm/action.yml
@@ -64,7 +64,7 @@ runs:
 
     - name: Install dependencies
       shell: bash
-      run: sfw --silent yarn install --immutable
+      run: sfw yarn install --immutable
 
     - name: Check version
       shell: bash

--- a/.github/actions/release-connect/action.yml
+++ b/.github/actions/release-connect/action.yml
@@ -72,7 +72,7 @@ runs:
     - name: Install dependencies
       shell: bash
       run: |
-        sfw --silent yarn install --immutable # focus install is not used here to make sure that all global patches are applied for the release.
+        sfw yarn install --immutable # focus install is not used here to make sure that all global patches are applied for the release.
 
     - name: Build connect-explorer-theme
       shell: bash

--- a/.github/workflows/bot-crowdin-sync.yml
+++ b/.github/workflows/bot-crowdin-sync.yml
@@ -43,7 +43,7 @@ jobs:
           mode: firewall-free
           job-summary: errors
       - name: Install dependencies
-        run: sfw --silent yarn install
+        run: sfw yarn install
 
       - name: Set source branch
         run: echo "SOURCE_BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV

--- a/.github/workflows/build-analytics-docs.yml
+++ b/.github/workflows/build-analytics-docs.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          sfw --silent yarn workspaces focus @trezor/analytics-docs
+          sfw yarn workspaces focus @trezor/analytics-docs
 
       - name: Build analytics-docs
         env:

--- a/.github/workflows/build-desktop-apps.yml
+++ b/.github/workflows/build-desktop-apps.yml
@@ -48,7 +48,7 @@ jobs:
           job-summary: errors
       - name: Install deps and build libs
         run: |
-          sfw --silent yarn install --immutable
+          sfw yarn install --immutable
           yarn message-system-sign-config
           yarn workspace @trezor/suite-data build:lib
           yarn workspace @trezor/transport-bridge build:lib
@@ -100,7 +100,7 @@ jobs:
           job-summary: errors
       - name: Install deps and build libs
         run: |
-          sfw --silent yarn install --immutable
+          sfw yarn install --immutable
           yarn message-system-sign-config
           yarn workspace @trezor/suite-data build:lib
           yarn workspace @trezor/transport-bridge build:lib
@@ -160,7 +160,7 @@ jobs:
           job-summary: errors
       - name: Install deps and build libs
         run: |
-          sfw --silent yarn install --immutable
+          sfw yarn install --immutable
           yarn message-system-sign-config
 
       - name: Build libs

--- a/.github/workflows/build-llm-test-analysis-nightly.yml
+++ b/.github/workflows/build-llm-test-analysis-nightly.yml
@@ -56,7 +56,7 @@ jobs:
           job-summary: errors
       - name: Install dependencies
         shell: bash
-        run: sfw --silent yarn workspaces focus @trezor/e2e-utils
+        run: sfw yarn workspaces focus @trezor/e2e-utils
 
       - name: Delete existing LLM analysis cache from S3 (no_cache)
         if: ${{ inputs.no_cache }}

--- a/.github/workflows/build-node-bridge.yml
+++ b/.github/workflows/build-node-bridge.yml
@@ -38,7 +38,7 @@ jobs:
           job-summary: errors
       - name: Install deps and build libs
         run: |
-          sfw --silent yarn install --immutable
+          sfw yarn install --immutable
 
       - name: Build bin.js file
         run: |

--- a/.github/workflows/build-storybook-native.yml
+++ b/.github/workflows/build-storybook-native.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install Yarn dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          sfw --silent yarn install
+          sfw yarn install
 
       - name: Build storybook
         working-directory: ./suite-native/storybook

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -39,8 +39,8 @@ jobs:
       - name: Install dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          sfw --silent yarn workspaces focus @trezor/components
-          sfw --silent yarn workspaces focus @trezor/product-components
+          sfw yarn workspaces focus @trezor/components
+          sfw yarn workspaces focus @trezor/product-components
 
       - name: Build storybook
         env:

--- a/.github/workflows/build-suite-desktop-e2e.yml
+++ b/.github/workflows/build-suite-desktop-e2e.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependencies, build libs
         shell: bash
         run: |
-          sfw --silent yarn workspaces focus @trezor/suite-desktop @trezor/suite-desktop-core @trezor/suite-build @trezor/suite @trezor/suite-data @trezor/transport-bridge @suite-common/message-system @trezor/suite-desktop-ui
+          sfw yarn workspaces focus @trezor/suite-desktop @trezor/suite-desktop-core @trezor/suite-build @trezor/suite @trezor/suite-data @trezor/transport-bridge @suite-common/message-system @trezor/suite-desktop-ui
           yarn message-system-sign-config
           yarn workspace @trezor/suite-data build:lib
           yarn workspace @trezor/transport-bridge build:lib

--- a/.github/workflows/build-suite-native-adhoc.yml
+++ b/.github/workflows/build-suite-native-adhoc.yml
@@ -45,7 +45,7 @@ jobs:
           job-summary: errors
       - name: Install libs
         run: |
-          sfw --silent yarn workspaces focus @suite-native/app
+          sfw yarn workspaces focus @suite-native/app
       - name: Trigger adhoc build Android
         working-directory: suite-native/app
         if: ${{ github.event.inputs.PLATFORM == 'android' || github.event.inputs.PLATFORM == 'all' }}

--- a/.github/workflows/build-suite-native-preview.yml
+++ b/.github/workflows/build-suite-native-preview.yml
@@ -55,7 +55,7 @@ jobs:
           job-summary: errors
       - name: Install libs
         run: |
-          sfw --silent yarn workspaces focus @suite-native/app
+          sfw yarn workspaces focus @suite-native/app
 
       - name: Check runtimeVersion builds
         run: |

--- a/.github/workflows/build-suite-web-e2e.yml
+++ b/.github/workflows/build-suite-web-e2e.yml
@@ -56,7 +56,7 @@ jobs:
         shell: bash
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          sfw --silent yarn workspaces focus @trezor/suite-web @trezor/suite-data @trezor/suite-build
+          sfw yarn workspaces focus @trezor/suite-web @trezor/suite-data @trezor/suite-build
 
       - name: Build Suite Web
         shell: bash

--- a/.github/workflows/build-suite-web.yml
+++ b/.github/workflows/build-suite-web.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Install dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          sfw --silent yarn workspaces focus @trezor/suite-web @trezor/suite-data @trezor/suite-build
+          sfw yarn workspaces focus @trezor/suite-web @trezor/suite-data @trezor/suite-build
 
       - name: Build suite-web
         env:

--- a/.github/workflows/check-code-validation.yml
+++ b/.github/workflows/check-code-validation.yml
@@ -42,7 +42,7 @@ jobs:
       # We can skip the build for all dependencies, even for those whitelisted, because this process is used only to validate the yarn.lock file and populate the cache.
       - name: Install deps
         run: |
-          sfw --silent yarn --immutable --mode=skip-build
+          sfw yarn --immutable --mode=skip-build
 
   type-check:
     name: Type Checking
@@ -176,7 +176,7 @@ jobs:
           mode: firewall-free
           job-summary: errors
       - name: Yarn Dedupe check
-        run: sfw --silent yarn dedupe --check
+        run: sfw yarn dedupe --check
       - name: Check dependency domain lists
         run: ./scripts/ci/list-missing-dependencies.sh
       - name: Verify Workspace Resolutions

--- a/.github/workflows/check-test-health-nightly.yml
+++ b/.github/workflows/check-test-health-nightly.yml
@@ -42,7 +42,7 @@ jobs:
           job-summary: errors
       - name: Install dependencies
         shell: bash
-        run: sfw --silent yarn workspaces focus @trezor/e2e-utils
+        run: sfw yarn workspaces focus @trezor/e2e-utils
 
       - name: Check test health and manage quarantine
         env:

--- a/.github/workflows/check-test-health.yml
+++ b/.github/workflows/check-test-health.yml
@@ -54,7 +54,7 @@ jobs:
           job-summary: errors
       - name: Install dependencies
         shell: bash
-        run: sfw --silent yarn workspaces focus @trezor/e2e-utils
+        run: sfw yarn workspaces focus @trezor/e2e-utils
 
       - name: Check test health and manage quarantine
         env:

--- a/.github/workflows/chore-purge-android-e2e-build.yml
+++ b/.github/workflows/chore-purge-android-e2e-build.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install Yarn dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          sfw --silent yarn install
+          sfw yarn install
 
       - name: Prebuild native expo project
         working-directory: ./suite-native/app

--- a/.github/workflows/release-connect-bump-versions.yml
+++ b/.github/workflows/release-connect-bump-versions.yml
@@ -49,7 +49,7 @@ jobs:
           mode: firewall-free
           job-summary: errors
       - name: Install dependencies
-        run: sfw --silent yarn install
+        run: sfw yarn install
 
       # The script connect-bump-versions.ts needs to build packages so dependencies are required.
       - name: Build dependencies

--- a/.github/workflows/release-connect-npm.yml
+++ b/.github/workflows/release-connect-npm.yml
@@ -62,7 +62,7 @@ jobs:
           mode: firewall-free
           job-summary: errors
       - name: Install dependencies
-        run: sfw --silent yarn install
+        run: sfw yarn install
 
       - name: Get packages that need release
         id: set-packages-need-release
@@ -91,7 +91,8 @@ jobs:
 
   deploy-npm-connect-dependencies:
     name: Deploy NPM ${{ needs.identify-release-packages.outputs.deploymentType }} ${{ matrix.package }}
-    needs: [extract-version, sanity-check-version-match, identify-release-packages]
+    needs:
+      [extract-version, sanity-check-version-match, identify-release-packages]
     environment: production-connect
     runs-on: ubuntu-latest
     strategy:
@@ -132,7 +133,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: ["connect", "connect-web", "connect-webextension", "connect-mobile"]
+        package:
+          ["connect", "connect-web", "connect-webextension", "connect-mobile"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/release-suite-coin-icons.yml
+++ b/.github/workflows/release-suite-coin-icons.yml
@@ -34,7 +34,7 @@ jobs:
           job-summary: errors
       - name: Download crypto icons
         run: |
-          sfw --silent yarn install
+          sfw yarn install
           cd suite-common/icons
           yarn download-crypto-icons
 

--- a/.github/workflows/release-suite-definitions.yml
+++ b/.github/workflows/release-suite-definitions.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Build and sign ${{ github.event.inputs.environment }} token-definitions
         if: ${{ github.event.inputs.environment == 'develop-definitions' && github.ref == 'refs/heads/develop' }}
         run: |
-          sfw --silent yarn install
+          sfw yarn install
           cd suite-common/token-definitions
 
           yarn nfts simple ethereum polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche
@@ -58,7 +58,7 @@ jobs:
           IS_CODESIGN_BUILD: "true"
           JWS_PRIVATE_KEY_ENV: ${{ secrets.JWS_PRIVATE_KEY_ENV }}
         run: |
-          sfw --silent yarn install
+          sfw yarn install
           cd suite-common/token-definitions
 
           yarn nfts simple ethereum polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche

--- a/.github/workflows/release-suite-desktop-web-staging.yml
+++ b/.github/workflows/release-suite-desktop-web-staging.yml
@@ -69,7 +69,7 @@ jobs:
           job-summary: errors
       - name: Install deps and build libs
         run: |
-          sfw --silent yarn install --immutable
+          sfw yarn install --immutable
           yarn message-system-sign-config
           yarn workspace @trezor/suite-data build:lib
           yarn workspace @trezor/transport-bridge build:lib
@@ -197,7 +197,7 @@ jobs:
       - name: Install dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          sfw --silent yarn install --immutable # focus install is not used here to make sure that all global patches are applied for the release.
+          sfw yarn install --immutable # focus install is not used here to make sure that all global patches are applied for the release.
 
       - name: Build suite-web
         env:
@@ -254,7 +254,7 @@ jobs:
           job-summary: errors
       - name: Install deps and build libs
         run: |
-          sfw --silent yarn install --immutable
+          sfw yarn install --immutable
           yarn message-system-sign-config
           yarn workspace @trezor/suite-data build:lib
           yarn workspace @trezor/transport-bridge build:lib

--- a/.github/workflows/release-suite-message-system-config.yml
+++ b/.github/workflows/release-suite-message-system-config.yml
@@ -41,7 +41,7 @@ jobs:
           IS_CODESIGN_BUILD: ${{ env.RELEASE_ENV == 'production' && 'true' || 'false' }}
           JWS_PRIVATE_KEY_ENV: ${{ secrets.JWS_PRIVATE_KEY_ENV }}
         run: |
-          sfw --silent yarn install
+          sfw yarn install
           yarn message-system-sign-config
 
       - name: Upload ${{ env.RELEASE_ENV }}  message-system config file

--- a/.github/workflows/release-suite-native-develop.yml
+++ b/.github/workflows/release-suite-native-develop.yml
@@ -40,7 +40,7 @@ jobs:
           job-summary: errors
       - name: Install libs
         run: |
-          sfw --silent yarn workspaces focus @suite-native/app
+          sfw yarn workspaces focus @suite-native/app
       - name: Build on EAS Android
         run: eas build
           --platform android

--- a/.github/workflows/release-suite-native-production.yml
+++ b/.github/workflows/release-suite-native-production.yml
@@ -47,7 +47,7 @@ jobs:
           job-summary: errors
       - name: Install libs
         run: |
-          sfw --silent yarn workspaces focus @suite-native/app
+          sfw yarn workspaces focus @suite-native/app
       - name: Build on EAS iOS
         run: eas build
           --platform ios
@@ -81,7 +81,7 @@ jobs:
           job-summary: errors
       - name: Install libs
         run: |
-          sfw --silent yarn workspaces focus @suite-native/app
+          sfw yarn workspaces focus @suite-native/app
       - name: Build on EAS Android
         run: eas build
           --platform android
@@ -121,7 +121,7 @@ jobs:
           job-summary: errors
       - name: Install libs
         run: |
-          sfw --silent yarn workspaces focus @suite-native/app
+          sfw yarn workspaces focus @suite-native/app
 
       - name: Get Suite version
         id: get_version

--- a/.github/workflows/template-connect-test-params.yml
+++ b/.github/workflows/template-connect-test-params.yml
@@ -68,11 +68,11 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
-      - run: sfw --silent yarn workspaces focus @trezor/connect
+      - run: sfw yarn workspaces focus @trezor/connect
       - if: ${{ inputs.testEnv == 'web' }}
         run: |
-          sfw --silent yarn workspaces focus @trezor/connect-web
-          sfw --silent yarn && yarn build:libs
+          sfw yarn workspaces focus @trezor/connect-web
+          sfw yarn && yarn build:libs
       - name: Install Playwright chromium
         if: ${{ inputs.testEnv == 'web' }}
         run: yarn workspace @trezor/connect-web exec playwright install --with-deps chromium

--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Install Yarn dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          sfw --silent yarn install
+          sfw yarn install
 
       # Detox runtime may indirectly import the built config, and that would crash if message-system is not built
       - name: Sign message system config

--- a/.github/workflows/template-suite-native-prepare-test-app-android.yml
+++ b/.github/workflows/template-suite-native-prepare-test-app-android.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install Yarn dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          sfw --silent yarn install
+          sfw yarn install
 
       - name: Setup Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5

--- a/.github/workflows/template-suite-run-e2e.yml
+++ b/.github/workflows/template-suite-run-e2e.yml
@@ -152,7 +152,7 @@ jobs:
       - name: Install PW Dependencies
         shell: bash
         run: |
-          sfw --silent yarn workspaces focus @trezor/suite-e2e ${{ inputs.workspace-dependencies }}
+          sfw yarn workspaces focus @trezor/suite-e2e ${{ inputs.workspace-dependencies }}
 
       - name: Install Playwright Browsers
         if: inputs.target == 'web' && steps.playwright-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/test-blockchain-link.yml
+++ b/.github/workflows/test-blockchain-link.yml
@@ -39,7 +39,7 @@ jobs:
           mode: firewall-free
           job-summary: errors
       - name: Install dependencies
-        run: sfw --silent yarn --immutable
+        run: sfw yarn --immutable
 
       - name: Build dependencies
         run: yarn build:libs

--- a/.github/workflows/test-connect-misc.yml
+++ b/.github/workflows/test-connect-misc.yml
@@ -77,7 +77,7 @@ jobs:
           mode: firewall-free
           job-summary: errors
       - name: Install dependencies
-        run: sfw --silent yarn install
+        run: sfw yarn install
 
       - name: Pack packages
         run: yarn tsx ./scripts/ci/pack-packages.ts
@@ -111,5 +111,5 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
-      - run: sfw --silent yarn install --immutable
+      - run: sfw yarn install --immutable
       - run: yarn workspace @trezor/protobuf update:protobuf

--- a/.github/workflows/test-e2e-controller-pr.yml
+++ b/.github/workflows/test-e2e-controller-pr.yml
@@ -102,7 +102,7 @@ jobs:
           mode: firewall-free
           job-summary: errors
       - name: Install dependencies
-        run: sfw --silent yarn workspaces focus @trezor/e2e-utils
+        run: sfw yarn workspaces focus @trezor/e2e-utils
 
       - name: Run LLM test selector
         env:

--- a/.github/workflows/test-misc.yml
+++ b/.github/workflows/test-misc.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
-      - run: sfw --silent yarn install --immutable
+      - run: sfw yarn install --immutable
       - run: yarn workspace @suite/intl translations:list-unused
 
   media-duplicates:
@@ -64,7 +64,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
-      - run: sfw --silent yarn install --immutable
+      - run: sfw yarn install --immutable
       - run: ./scripts/circular-dependencies/check-circular-dependencies.sh
 
   test-unit:
@@ -86,7 +86,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
-      - run: sfw --silent yarn install --immutable
+      - run: sfw yarn install --immutable
       - run: yarn message-system-sign-config
       - name: Unit Tests - Suite, Connect, Common
         run: yarn test:unit:all --exclude='@suite-native/*' -- --silent
@@ -126,7 +126,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
-      - run: sfw --silent yarn install --immutable
+      - run: sfw yarn install --immutable
       - run: yarn generate-package @trezor/meow-package
       - run: rm -rf packages/meow-package
 
@@ -146,5 +146,5 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
-      - run: sfw --silent yarn install --immutable
+      - run: sfw yarn install --immutable
       - run: yarn tsx ./packages/components/scripts/test-img-paths-exist.ts

--- a/.github/workflows/test-request-manager.yml
+++ b/.github/workflows/test-request-manager.yml
@@ -35,5 +35,5 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
-      - run: sfw --silent yarn install --immutable
+      - run: sfw yarn install --immutable
       - run: yarn workspace @trezor/request-manager test:all

--- a/.github/workflows/test-suite-manual-release.yml
+++ b/.github/workflows/test-suite-manual-release.yml
@@ -55,7 +55,7 @@ jobs:
         shell: bash
         run: |
           echo "Installing Playwright dependencies"
-          sfw --silent yarn workspaces focus @trezor/suite-e2e
+          sfw yarn workspaces focus @trezor/suite-e2e
           # Playwright runtime may indirectly import the built config, and that would crash if message-system is not built
           yarn message-system-sign-config
 

--- a/.github/workflows/test-suite-native-e2e-ios.yml
+++ b/.github/workflows/test-suite-native-e2e-ios.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install Yarn dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          sfw --silent yarn install
+          sfw yarn install
 
       - name: Use latest stable Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
@@ -133,7 +133,7 @@ jobs:
       - name: Install Yarn dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          sfw --silent yarn install
+          sfw yarn install
 
       # Detox runtime may indirectly import the built config, and that would crash if message-system is not built
       - name: Sign message system config

--- a/.github/workflows/test-suite-native-e2e-manual-reporter.yml
+++ b/.github/workflows/test-suite-native-e2e-manual-reporter.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install Yarn dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          sfw --silent yarn install
+          sfw yarn install
 
       - name: Extract Release Build
         id: extract_branch

--- a/.github/workflows/test-suite-web-e2e-nightly.yml
+++ b/.github/workflows/test-suite-web-e2e-nightly.yml
@@ -114,7 +114,7 @@ jobs:
           mode: firewall-free
           job-summary: errors
       - name: Install dependencies
-        run: sfw --silent yarn workspaces focus @trezor/e2e-utils
+        run: sfw yarn workspaces focus @trezor/e2e-utils
 
       - name: Download per-test coverage map artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/.github/workflows/test-transport.yml
+++ b/.github/workflows/test-transport.yml
@@ -47,7 +47,7 @@ jobs:
           job-summary: errors
       - name: Install dependencies
         run: |
-          sfw --silent yarn workspaces focus @trezor/transport-test
+          sfw yarn workspaces focus @trezor/transport-test
 
       - name: Setup containers
         run: |
@@ -90,7 +90,7 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: |
-          sfw --silent yarn workspaces focus @trezor/transport -A
+          sfw yarn workspaces focus @trezor/transport -A
 
       - name: Build transport tester
         run: |

--- a/.github/workflows/test-trezor-user-env-link-e2e.yml
+++ b/.github/workflows/test-trezor-user-env-link-e2e.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          sfw --silent yarn workspaces focus @trezor/trezor-user-env-link
+          sfw yarn workspaces focus @trezor/trezor-user-env-link
 
       - name: Run e2e tests
         run: |

--- a/.github/workflows/test-urls.yml
+++ b/.github/workflows/test-urls.yml
@@ -28,5 +28,5 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
-      - run: sfw --silent yarn install --immutable
+      - run: sfw yarn install --immutable
       - run: yarn workspace @trezor/urls test:e2e


### PR DESCRIPTION
Root cause: --silent was added for sfw v1.3.1, but that flag doesn't exist in v1.3.2

The chain of events:

May 21 — a539addfa6 (chore(ci): silence sfw summaries when successful)

Jiri added --silent to 43 workflow files while pinned to SocketDev/action v1.3.1. The flag worked at the time.

May 25 — 46a29737da (dependabot PR)

Dependabot created a branch dependabot/github_actions/github-actions-a7eda07807 that bumps SocketDev/action from v1.3.1 → v1.3.2. This new version dropped the --silent flag.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-desktop-builde-wf&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-desktop-builde-wf&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-28T04:56:12.020Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-28T04:53:29.473Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-desktop-builde-wf/web/](https://dev.suite.sldev.cz/suite-web/fix-desktop-builde-wf/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->