### PR TITLE
test(agent): fix agent moved to GHA

### DIFF
--- a/.github/workflows/test-suite-nightly-fix-agent.yml
+++ b/.github/workflows/test-suite-nightly-fix-agent.yml
@@ -3,14 +3,185 @@ name: "[Test] Nightly Suite Fix Agent"
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.run_id }}
   cancel-in-progress: false
 
+env:
+  # Hardcoded report for controlled testing. Will be replaced with the output of the analyze job.
+  REPORT_PATH: packages/e2e-utils/src/fixBot/2026-05-20.json
 jobs:
-  hello-world:
+  prepare-matrix:
     runs-on: ubuntu-latest
     if: github.repository == 'trezor/trezor-suite'
-    timeout-minutes: 5
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - run: echo "Hello, fix bot!"
+      - name: Checkout report
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          sparse-checkout: ${{ env.REPORT_PATH }}
+          sparse-checkout-cone-mode: false
+
+      - name: Build matrix from report
+        id: set-matrix
+        run: |
+          MATRIX=$(jq -c '[.fix_tasks[].id]' "$REPORT_PATH")
+          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+
+  build-desktop:
+    if: github.repository == 'trezor/trezor-suite'
+    uses: ./.github/workflows/build-suite-desktop-e2e.yml
+
+  build-web:
+    runs-on: ubuntu-24.04
+    if: github.repository == 'trezor/trezor-suite'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: true
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: yarn
+
+      - name: Cache node_modules
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: node_modules
+          key: node_modules-${{ hashFiles('yarn.lock') }}
+          restore-keys: node_modules-
+
+      - name: Install dependencies
+        run: yarn workspaces focus @trezor/suite-web @trezor/suite-data @trezor/suite-build
+
+      - name: Build message system config
+        run: yarn message-system-sign-config 1>/dev/null
+
+      - name: Build suite-data lib
+        run: yarn workspace @trezor/suite-data build:lib
+
+      - name: Build suite-web
+        run: yarn workspace @trezor/suite-web build
+
+      - name: Compress web build
+        run: tar -czf web-build.tar.gz -C packages/suite-web build
+
+      - name: Upload web build artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: web-app-build-e2e
+          path: web-build.tar.gz
+          retention-days: 7
+
+  fix:
+    needs: [prepare-matrix, build-desktop, build-web]
+    runs-on: ubuntu-24.04
+    if: github.repository == 'trezor/trezor-suite'
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        task-id: ${{ fromJSON(needs.prepare-matrix.outputs.matrix) }}
+    env:
+      COMPOSE_FILE: ./docker/docker-compose.suite-ci-e2e.yml
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: true
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: yarn
+
+      - name: Cache node_modules
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: node_modules
+          key: node_modules-${{ hashFiles('yarn.lock') }}
+          restore-keys: node_modules-
+
+      - name: Install dependencies
+        run: yarn workspaces focus @trezor/suite-e2e @trezor/e2e-utils @trezor/suite-web
+
+      - name: Install Playwright browsers
+        run: yarn workspace @trezor/suite-e2e exec playwright install chromium --with-deps
+
+      - name: Build message system config
+        run: yarn message-system-sign-config 1>/dev/null
+
+      - name: Download desktop artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: desktop-app-build-e2e
+          path: artifact-download
+
+      - name: Extract desktop artifact
+        run: tar -xzf artifact-download/app-build.tar.gz -C packages/suite-desktop
+
+      - name: Download web artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: web-app-build-e2e
+          path: artifact-download
+
+      - name: Extract web artifact
+        run: tar -xzf artifact-download/web-build.tar.gz -C packages/suite-web
+
+      - name: Start web preview server
+        run: nohup yarn workspace @trezor/suite-web preview > /tmp/web-preview.log 2>&1 &
+
+      - name: Pull Docker images
+        run: docker compose pull --quiet
+
+      - name: Start Docker services
+        run: docker compose up -d
+
+        # This needs to be discussed with Tali
+      - name: Configure git identity
+        run: |
+          git config --global user.email "nightly-fix-bot@trezor.io"
+          git config --global user.name "Nightly Fix Bot"
+
+      - name: Checkout fix branch
+        run: |
+          BRANCH=$(jq -r --arg id "${{ matrix.task-id }}" '.fix_tasks[] | select(.id == $id) | .branch' "$REPORT_PATH")
+          git checkout -b "$BRANCH"
+          echo "BRANCH=$BRANCH" >> $GITHUB_ENV
+
+      - name: Wait for web preview server
+        timeout-minutes: 2
+        run: curl -sf --retry 30 --retry-delay 2 --retry-connrefused --max-time 5 http://localhost:8000 -o /dev/null
+
+      - name: Run fix agent
+        id: run-fix-agent
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.E2E_CLAUDE_API_KEY }}
+          PASSPHRASE: ${{ secrets.E2E_TEST_PASSPHRASE }}
+          TASK_ID: ${{ matrix.task-id }}
+          TEST_TIMEOUT_OVERRIDE: 180000
+          REPORT_PATH: ${{ github.workspace }}/${{ env.REPORT_PATH }}
+        run: yarn workspace @trezor/e2e-utils fix-bot:fix
+
+      - name: Publish PR
+        if: ${{ !cancelled() && steps.run-fix-agent.outcome != 'skipped' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: yarn workspace @trezor/e2e-utils fix-bot:publish
+
+      - name: Docker Compose Down
+        if: always()
+        run: docker compose down

--- a/packages/e2e-utils/package.json
+++ b/packages/e2e-utils/package.json
@@ -16,7 +16,8 @@
         "select-tests-llm": "tsx ./src/llmTestSelector/index.ts",
         "generate-usage-dashboard": "tsx ./src/llmUsageDashboard/index.ts",
         "fix-bot:analyze": "tsx src/fixBot/analyze.ts",
-        "fix-bot:fix": "tsx src/fixBot/fix.ts"
+        "fix-bot:fix": "tsx src/fixBot/fix.ts",
+        "fix-bot:publish": "tsx src/fixBot/publish.ts"
     },
     "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",

--- a/packages/e2e-utils/src/fixBot/2026-05-20.json
+++ b/packages/e2e-utils/src/fixBot/2026-05-20.json
@@ -1,0 +1,71 @@
+{
+    "run_date": "2026-05-20",
+    "web_run_id": "007199e04ba138b1",
+    "desktop_run_id": "276fc2726b584397",
+    "fix_tasks": [
+        {
+            "id": "fix-001",
+            "branch": "fix/nightly-2026-05-20-multi-session-stolen-step",
+            "root_cause": "The test has a commented-out code block (lines 55-64) that was supposed to steal the Bridge session again before asserting 'Use here' in step 3, so the device stays 'Connected' forever.",
+            "fix_scope": "TEST_CODE",
+            "confidence": "HIGH",
+            "fix_description": "In suite/e2e/tests/suite/multiple-sessions.test.ts, the commented-out block at lines 55-64 needs to be either uncommented and fixed, or the test logic for step 3 ('After reloading inactive suite session does not take Bridge session back') needs to be restructured to properly set up the precondition: steal the Bridge session again and reload the page before asserting that the device status shows 'Use here'. Without this setup, step 3 inherits the 'Connected' state from step 2 and nothing triggers a session change.",
+            "diagnosis": "### Session overtaken by another\n\n**File:** suite/e2e/tests/suite/multiple-sessions.test.ts\n**Platform:** both\n**Error:** `expect(locator).toHaveText()` failed — expected \"Use here\" (`TR_USE_HERE`) but received \"Connected\". Locator: `[data-testid-alt='@deviceStatus']`. Timeout: 30000ms. Line 67.\n**Visual evidence:** The trace shows the complete test timeline:\n- The test successfully steals the Bridge session (step 1) — device status changes to \"Use here\"\n- The test clicks \"Use here\" to take the session back (step 2) — device status returns to \"Connected\"\n- Step 3 expects \"Use here\" again, but the device remains \"Connected\" for the entire 30-second timeout\n- Zero Redux actions were dispatched during the final 30-second wait, confirming nothing triggered a session change\n- The Switch Device modal at the time of step 2 showed \"Connected\" with Standard wallet visible\n- Final screenshot shows the dashboard with \"Connected\" device status\n**Root cause:** The test has a commented-out code block at lines 55-64 that was supposed to call `stealBridgeSession()` again before step 3. This block would have: (1) stolen the session again, (2) verified \"Use here\" appeared, and (3) reloaded the page. Without this block, step 3 inherits the \"Connected\" state from step 2 and nothing ever causes the device session to be stolen again. The step 3 name (\"After reloading inactive suite session does not take Bridge session back\") confirms it was designed to run after the now-commented-out reload step.",
+            "validations": [
+                {
+                    "platform": "web",
+                    "group": "T3W1",
+                    "spec": "suite/e2e/tests/suite/multiple-sessions.test.ts"
+                },
+                {
+                    "platform": "web",
+                    "group": "T3T1",
+                    "spec": "suite/e2e/tests/suite/multiple-sessions.test.ts"
+                },
+                {
+                    "platform": "desktop",
+                    "group": "T3W1",
+                    "spec": "suite/e2e/tests/suite/multiple-sessions.test.ts"
+                },
+                {
+                    "platform": "desktop",
+                    "group": "T3T1",
+                    "spec": "suite/e2e/tests/suite/multiple-sessions.test.ts"
+                }
+            ]
+        },
+        {
+            "id": "fix-002",
+            "branch": "fix/nightly-2026-05-20-recovery-dry-run-reload",
+            "root_cause": "After page reload in the partial recovery test, the device is not fully reconnected when the 'Check' button is clicked, so the dry-run recovery modal never appears.",
+            "fix_scope": "TEST_CODE",
+            "confidence": "MEDIUM",
+            "fix_description": "In suite/e2e/tests/recovery/t2t1-dry-run.test.ts, the 'Recovery after partial recovery' test needs to ensure the device is fully reconnected and ready before clicking the 'Check' button after page reload. The trace shows the Settings > Device page with the 'Check' button visible but the modal never appears after clicking it. Add an explicit wait for device 'Connected' status or add a retry mechanism for the recovery modal initialization after page reload.",
+            "diagnosis": "### Recovery after partial recovery\n\n**File:** suite/e2e/tests/recovery/t2t1-dry-run.test.ts\n**Platform:** web\n**Error:** `expect(locator).toHaveText()` failed — `getByTestId('@modal/header')` expected \"Check wallet backup\" but element not found. Timeout: 30000ms. At recoveryModal.ts:42 via `verifyDryCheckPrompt()`.\n**Visual evidence:** The trace shows:\n- The test successfully completes onboarding and navigates to the dashboard\n- It then navigates to Settings > Device tab\n- The \"Wallet backup\" section with a green \"Check\" button is visible\n- From this point through the entire 30-second timeout, the UI remains on Settings > Device with NO modal overlay visible\n- The final screenshot confirms: Settings > Device tab, \"Check\" button visible, no modal\n- No network anomalies — all requests returned 200\n**Root cause:** After the page reload (this test scenario involves recovering after a partial/interrupted recovery), the \"Check\" button click to initiate the dry-run recovery check did not trigger the expected modal. The device communication likely failed silently — the T2T1 emulator may not have fully reconnected after the page reload, so the backup check request was never sent to the device. This is a known flaky test (quarantined) caused by a race condition between page reload and device reconnection.",
+            "validations": [
+                {
+                    "platform": "web",
+                    "group": "T2T1",
+                    "spec": "suite/e2e/tests/recovery/t2t1-dry-run.test.ts"
+                }
+            ]
+        }
+    ],
+    "skipped": [
+        {
+            "root_cause": "Coinmarket pages throw unhandled promise rejections when in-flight API requests to exchange.trezor.io are aborted by rapid page navigation.",
+            "reason": "PRODUCT_BUG — The application's coinmarket pages (exchange, sell) do not catch AbortError/TypeError when fetch requests are aborted by navigation. These bubble up as unhandled rejections caught by the exceptionLogger fixture. Fix requires product code changes to gracefully handle aborted fetches.",
+            "affected_tests": ["suite/e2e/tests/general/check-links.test.ts"]
+        },
+        {
+            "root_cause": "Apple App Store URL returns HTTP 429 Too Many Requests when hit repeatedly from CI environments.",
+            "reason": "INFRA — External rate limiting from Apple. The test's fetchWithRetry logic (3 retries with 2s/4s/6s backoff) is insufficient to outlast Apple's rate limiter in CI. This is an inherent limitation of testing external URLs from automated environments.",
+            "affected_tests": ["suite/e2e/tests/general/check-links.test.ts"]
+        },
+        {
+            "root_cause": "T1B1 emulator returns Failure_UnexpectedMessage (messages.c:257:Unknown message) during wallet initialization, breaking the onboarding flow.",
+            "reason": "INFRA — The T1B1 emulator firmware does not properly handle a protobuf message sent during wallet creation. The identical error on both web and desktop platforms confirms this is a firmware/emulator compatibility issue, not a Suite UI bug. Requires firmware team investigation.",
+            "affected_tests": ["suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts"]
+        }
+    ]
+}

--- a/packages/e2e-utils/src/fixBot/FIX_AGENT.md
+++ b/packages/e2e-utils/src/fixBot/FIX_AGENT.md
@@ -5,7 +5,7 @@ Your fix task is embedded at the bottom of this prompt. Read it before doing any
 
 ## Context
 
-- **Working directory:** the repo root (a git worktree already on the fix branch — do not switch branches)
+- **Working directory:** the repo root (already checked out on the fix branch — do not switch branches)
 - **Test location:** `suite/e2e/tests/`
 - **Web playwright config:** `suite/e2e/playwright-config/playwright-web.config.ts`
 - **Desktop playwright config:** `suite/e2e/playwright-config/playwright-desktop.config.ts`
@@ -29,6 +29,17 @@ Allowed changes depend on the fix task's `fix_scope`:
 - `LOCATOR_ADD` — files inside `suite/e2e/` AND `data-testid` attributes in product source files. No other product code changes.
 
 ## Environment
+
+**Web build:** `packages/suite-web/build` is pre-built and served as a static bundle via vite
+preview on `http://localhost:8000`. There is no hot reload — for `LOCATOR_ADD` fixes that modify
+a product component, kill the server, rebuild, and restart before running web tests:
+
+```bash
+pkill -f "vite preview" || true
+yarn workspace @trezor/suite-web build
+nohup yarn workspace @trezor/suite-web preview > /tmp/web-preview.log 2>&1 &
+curl -sf --retry 30 --retry-delay 2 --retry-connrefused --max-time 5 http://localhost:8000 -o /dev/null
+```
 
 **Desktop build:** `packages/suite-desktop/dist` and `packages/suite-desktop/build` are present.
 For `LOCATOR_ADD` fixes that modify a product component, remove them and rebuild before running
@@ -65,10 +76,10 @@ touch /tmp/preflight-marker
   <spec-without-suite-e2e-prefix>)
 ```
 
-Exit code 0 = already passing — record as passed in the final status.
+Exit code 0 = already passing in pre-flight.
 Non-zero = failing — read the trace before deciding anything further (see below).
 
-**If all validations already pass:** write the status block (Step 4) and stop.
+**If all validations already pass in pre-flight:** write the status block (Step 4) with `result: "not_duplicated"` and stop — do not enter the fix loop.
 
 ### Reading traces after pre-flight and any test run
 
@@ -154,7 +165,7 @@ Write two files to the repo root (current directory) using the Write tool.
 ```json
 {
   "task_id": "<id from fix task>",
-  "result": "<pass | partial | fail>",
+  "result": "<pass | partial | fail | not_duplicated>",
   "iterations": <number of fix iterations performed, 0 if none needed>,
   "passed": ["<platform>/<group>/<spec>"],
   "failed": ["<platform>/<group>/<spec>"],
@@ -163,9 +174,10 @@ Write two files to the repo root (current directory) using the Write tool.
 ```
 
 `pr_title` must be the full PR title including the `Nightly fix <YY-MM-DD> - ` prefix. Base it on the fix you just made.
-`pass` — all validations pass.
+`pass` — all validations pass after fixes.
 `partial` — at least one passes, at least one fails.
-`fail` — zero validations pass.
+`fail` — zero validations pass after fixes.
+`not_duplicated` — all validations already passed in pre-flight; failure could not be reproduced.
 
 List every validation exactly once in either `passed` or `failed`.
 Use `<platform>/<group>/<spec>` format with the `spec` value as-is (repo-root-relative path).

--- a/packages/e2e-utils/src/fixBot/analyze.ts
+++ b/packages/e2e-utils/src/fixBot/analyze.ts
@@ -1,4 +1,3 @@
-import { config as loadEnv } from 'dotenv';
 import { execFileSync, spawnSync } from 'node:child_process';
 import { closeSync, existsSync, mkdirSync, openSync, readFileSync, unlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -12,12 +11,8 @@ function main(): void {
         encoding: 'utf-8',
     }).trim();
 
-    loadEnv({ path: join(root, 'packages/e2e-utils/.env') });
-
     if (!process.env.CURRENTS_API_KEY) {
-        error('CURRENTS_API_KEY is not set.');
-        error('Add it to packages/e2e-utils/.env:');
-        error('  CURRENTS_API_KEY=your_key_here');
+        error('CURRENTS_API_KEY is not set. It must be provided via the workflow environment.');
         process.exit(1);
     }
 

--- a/packages/e2e-utils/src/fixBot/docs.md
+++ b/packages/e2e-utils/src/fixBot/docs.md
@@ -33,7 +33,7 @@ After completing its work, the fix agent writes two files to the **worktree root
     ```json
     {
         "task_id": "fix-001",
-        "result": "pass | partial | fail",
+        "result": "pass | partial | fail | not_duplicated",
         "iterations": 2,
         "passed": ["web/T3W1/suite/e2e/tests/wallet/send.ts"],
         "failed": [],
@@ -122,7 +122,7 @@ One Claude Code invocation per fix task. Receives a single fix task entry from `
 ### Loop
 
 ```
-Setup environment (dev server / build electron app / emulator)
+Setup environment (web preview server (pre-built static) / build electron app / emulator)
 Pre-flight run: playwright test <spec> for each validation
   → confirms failure is real
   → produces fresh local trace + screenshots
@@ -152,11 +152,12 @@ Every iteration commits locally. First iteration is a regular commit, subsequent
 - First commit: generic message, e.g. `test(e2e): fix send-button locator` — save its SHA
 - Subsequent iterations: `git commit --fixup <SHA of the iteration-1 commit>` (no custom message, auto-generated)
 
-| Result    | Action                                           |
-| --------- | ------------------------------------------------ |
-| All pass  | Push branch, create PR ✅                        |
-| Some pass | Push branch, create PR ⚠️                        |
-| Zero pass | Written summary in job log — no branch pushed ❌ |
+| Result         | Action                                           |
+| -------------- | ------------------------------------------------ |
+| All pass       | Push branch, create PR ✅                        |
+| Some pass      | Push branch, create PR ⚠️                        |
+| Zero pass      | Written summary in job log — no branch pushed ❌ |
+| Not duplicated | Written summary in job log — no branch pushed 🔵 |
 
 ### Git strategy
 

--- a/packages/e2e-utils/src/fixBot/fix.ts
+++ b/packages/e2e-utils/src/fixBot/fix.ts
@@ -1,93 +1,48 @@
 import { execFileSync, spawnSync } from 'node:child_process';
-import {
-    closeSync,
-    cpSync,
-    existsSync,
-    mkdirSync,
-    openSync,
-    readFileSync,
-    readdirSync,
-    symlinkSync,
-    unlinkSync,
-} from 'node:fs';
+import { closeSync, openSync, readFileSync, unlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 
 import { error, log } from '../logger';
-import { publishPR } from './publish';
 import { logAgentResult, reportTokenUsage } from './reportTokenUsage';
-import { type FixTask, ReportSchema } from './schemas';
+import { ReportSchema } from './schemas';
 
-const AUTOMATABLE = new Set<FixTask['fix_scope']>(['TEST_CODE', 'LOCATOR_ADD']);
+function main(): void {
+    const reportPath = process.env.REPORT_PATH;
+    const taskId = process.env.TASK_ID;
 
-function isAutomatable(task: FixTask): boolean {
-    return AUTOMATABLE.has(task.fix_scope) && task.validations.length > 0;
-}
-
-function latestReport(reportDir: string): string {
-    const files = readdirSync(reportDir)
-        .filter(f => /^\d{4}-\d{2}-\d{2}\.json$/.test(f))
-        .sort();
-    if (!files.length) throw new Error(`No report files in ${reportDir}`);
-
-    const fileIndex = files.length - 1;
-    // @ts-expect-error: noUncheckedIndexedAccess
-    const fileName: string = files[fileIndex];
-
-    return join(reportDir, fileName);
-}
-
-function setupWorktree(root: string, task: FixTask, worktreePath: string): void {
-    if (existsSync(worktreePath)) {
-        execFileSync('git', ['worktree', 'remove', worktreePath, '--force']);
-    }
-    try {
-        execFileSync('git', ['branch', '-D', '--', task.branch]);
-    } catch {
-        // branch doesn't exist yet on first run
+    if (!reportPath) {
+        error('REPORT_PATH env var is required');
+        process.exit(1);
     }
 
-    execFileSync('git', ['worktree', 'add', worktreePath, '-b', task.branch, 'origin/develop']);
-    symlinkSync(join(root, 'node_modules'), join(worktreePath, 'node_modules'));
-
-    execFileSync('git', [
-        '-C',
-        worktreePath,
-        'submodule',
-        'update',
-        '--init',
-        'submodules/trezor-common',
-    ]);
-    // use default git hooks instead of personal custom ones
-    execFileSync('git', [
-        '-C',
-        worktreePath,
-        'config',
-        'core.hooksPath',
-        join(worktreePath, '.husky'),
-    ]);
-
-    const envFile = join(root, 'suite/e2e/.env');
-    if (existsSync(envFile)) {
-        cpSync(envFile, join(worktreePath, 'suite/e2e/.env'));
+    if (!taskId) {
+        error('TASK_ID env var is required');
+        process.exit(1);
     }
 
-    for (const dir of ['packages/suite-desktop/dist', 'packages/suite-desktop/build'] as const) {
-        const src = join(root, dir);
-        if (existsSync(src)) {
-            mkdirSync(join(worktreePath, dirname(dir)), { recursive: true });
-            symlinkSync(src, join(worktreePath, dir));
-        }
-    }
-}
+    const root = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+        encoding: 'utf-8',
+    }).trim();
+    const fixAgentDir = join(root, 'packages/e2e-utils/src/fixBot');
+    const reportDir = join(fixAgentDir, 'reports');
 
-function runAgent(
-    root: string,
-    fixAgentDir: string,
-    reportDir: string,
-    task: FixTask,
-    worktreePath: string,
-): void {
+    const report = ReportSchema.parse(JSON.parse(readFileSync(reportPath, 'utf-8')));
+    const task = report.fix_tasks.find(t => t.id === taskId);
+
+    if (!task) {
+        error(`Task '${taskId}' not found in ${reportPath}`);
+        process.exit(1);
+    }
+
+    const webCount = task.validations.filter(v => v.platform === 'web').length;
+    const desktopCount = task.validations.filter(v => v.platform === 'desktop').length;
+
+    log(`━━━ Task ${task.id} ━━━`);
+    log(`Scope:   ${task.fix_scope}`);
+    log(`Branch:  ${task.branch}`);
+    log(`Web:     ${webCount}  Desktop: ${desktopCount}`);
+
     const prompt = `${readFileSync(join(fixAgentDir, 'FIX_AGENT.md'), 'utf-8')}\n\n---\n\n## Fix Task\n\n\`\`\`json\n${JSON.stringify(task, null, 2)}\n\`\`\`\n`;
 
     // Write stdout to a temp file to avoid spawnSync's in-memory buffer limit (ENOBUFS).
@@ -108,7 +63,7 @@ function runAgent(
             '--settings',
             join(fixAgentDir, 'settings.json'),
         ],
-        { input: prompt, cwd: worktreePath, env, stdio: ['pipe', stdoutFd, 'inherit'] },
+        { input: prompt, cwd: root, env, stdio: ['pipe', stdoutFd, 'inherit'] },
     );
 
     closeSync(stdoutFd);
@@ -123,49 +78,8 @@ function runAgent(
     if (result.status !== 0 || result.signal) {
         log(`Agent exited with status=${result.status ?? '?'} signal=${result.signal ?? 'none'}`);
     }
-}
 
-function runTask(root: string, fixAgentDir: string, reportDir: string, task: FixTask): void {
-    const sanitizedWorktreeName = task.branch.replaceAll('/', '-').replace(/[^a-zA-Z0-9_-]/g, '_');
-    const worktreePath = join(tmpdir(), sanitizedWorktreeName);
-
-    const webCount = task.validations.filter(v => v.platform === 'web').length;
-    const desktopCount = task.validations.filter(v => v.platform === 'desktop').length;
-
-    log(`━━━ Task ${task.id} ━━━`);
-    log(`Scope:   ${task.fix_scope}`);
-    log(`Branch:  ${task.branch}`);
-    log(`Web:     ${webCount}  Desktop: ${desktopCount}`);
-
-    setupWorktree(root, task, worktreePath);
-    log('Worktree ready.\n');
-
-    runAgent(root, fixAgentDir, reportDir, task, worktreePath);
-    log(`Agent done. Processing results.`);
-
-    publishPR({ worktreePath, branch: task.branch });
-}
-
-function main(): void {
-    const root = execFileSync('git', ['rev-parse', '--show-toplevel'], {
-        encoding: 'utf-8',
-    }).trim();
-    const fixAgentDir = join(root, 'packages/e2e-utils/src/fixBot');
-    const reportDir = join(fixAgentDir, 'reports');
-
-    const reportPath = process.argv[2] ?? latestReport(reportDir);
-    const report = ReportSchema.parse(JSON.parse(readFileSync(reportPath, 'utf-8')));
-
-    const tasks = report.fix_tasks.filter(isAutomatable);
-    log(`${tasks.length} automatable task(s) in ${reportPath}\n`);
-
-    for (const task of tasks) {
-        try {
-            runTask(root, fixAgentDir, reportDir, task);
-        } catch (err) {
-            error(`Task ${task.id} failed: ${err}`);
-        }
-    }
+    log('Agent done.');
 }
 
 main();

--- a/packages/e2e-utils/src/fixBot/publish.ts
+++ b/packages/e2e-utils/src/fixBot/publish.ts
@@ -5,32 +5,28 @@ import { join } from 'node:path';
 import { log } from '../logger';
 import { type FixResult, FixResultSchema } from './schemas';
 
-export interface PublishOptions {
-    worktreePath: string;
-    branch: string;
-    base?: string;
-    remote?: string;
-}
+const BASE_BRANCH = 'develop';
+const GIT_REMOTE = 'origin';
 
 const ICONS: Record<FixResult['result'], string> = {
     pass: '✅',
     partial: '⚠️',
     fail: '❌',
+    not_duplicated: '🔵',
 };
 
-export function publishPR({
-    worktreePath,
-    branch,
-    base = 'develop',
-    remote = 'origin',
-}: PublishOptions): void {
-    const resultFile = join(worktreePath, 'fix-result.json');
+function publishPR(): void {
+    const branch = process.env.BRANCH;
 
-    if (!existsSync(worktreePath)) {
-        log(`Result: ❌  worktree not found: ${worktreePath}`);
-
-        return;
+    if (!branch) {
+        log('BRANCH env var is required');
+        process.exit(1);
     }
+
+    const root = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+        encoding: 'utf-8',
+    }).trim();
+    const resultFile = join(root, 'fix-result.json');
 
     if (!existsSync(resultFile)) {
         log(`Result: ❌  fix-result.json missing — agent did not complete`);
@@ -53,26 +49,25 @@ export function publishPR({
         return;
     }
 
-    log(`  → Pushing ${branch} to ${remote}...`);
-    execFileSync('git', ['-C', worktreePath, 'push', '--', remote, branch], { stdio: 'inherit' });
+    if (result === 'not_duplicated') {
+        log('  → No branch pushed (failure not reproduced in pre-flight).');
 
-    const prDescriptionFile = join(worktreePath, 'pr-description.md');
-    const prArgs = ['pr', 'create', '--title', pr_title, '--head', branch, '--base', base];
+        return;
+    }
+
+    log(`  → Pushing ${branch} to ${GIT_REMOTE}...`);
+    // TODO: add --force-with-lease to handle retries when branch was already pushed in a previous run
+    execFileSync('git', ['push', '--', GIT_REMOTE, branch], { stdio: 'inherit' });
+
+    const prDescriptionFile = join(root, 'pr-description.md');
+    const prArgs = ['pr', 'create', '--title', pr_title, '--head', branch, '--base', BASE_BRANCH];
 
     if (existsSync(prDescriptionFile)) prArgs.push('--body-file', prDescriptionFile);
 
+    // TODO: if 'gh pr create' errors because a PR for this branch already exists, catch it
+    // and print the existing PR URL instead (e.g. via `gh pr list --head <branch> --json url`)
     const prUrl = execFileSync('gh', prArgs, { encoding: 'utf-8' }).trim();
     log(`PR: ${prUrl}`);
 }
 
-// Entry point when called directly by GHA matrix jobs:
-// tsx publish.ts <worktreePath> <branch> [base]
-const isMain = /publish\.[jt]s$/.test(process.argv[1] ?? '');
-if (isMain) {
-    const [worktreePath, branch, base] = process.argv.slice(2);
-    if (!worktreePath || !branch) {
-        process.stderr.write('Usage: tsx publish.ts <worktreePath> <branch> [base]\n');
-        process.exit(1);
-    }
-    publishPR({ worktreePath, branch, base });
-}
+publishPR();

--- a/packages/e2e-utils/src/fixBot/schemas.ts
+++ b/packages/e2e-utils/src/fixBot/schemas.ts
@@ -17,13 +17,23 @@ export const FixTaskSchema = z.object({
     validations: z.array(TestToValidateSchema),
 });
 
+export const SkippedTaskSchema = z.object({
+    root_cause: z.string(),
+    reason: z.string(),
+    affected_tests: z.array(z.string()),
+});
+
 export const ReportSchema = z.object({
+    run_date: z.string(),
+    web_run_id: z.string().nullable(),
+    desktop_run_id: z.string().nullable(),
     fix_tasks: z.array(FixTaskSchema),
+    skipped: z.array(SkippedTaskSchema),
 });
 
 export const FixResultSchema = z.object({
     task_id: z.string(),
-    result: z.enum(['pass', 'partial', 'fail']),
+    result: z.enum(['pass', 'partial', 'fail', 'not_duplicated']),
     passed: z.array(z.string()),
     failed: z.array(z.string()),
     iterations: z.number().int().nonnegative(),
@@ -48,6 +58,7 @@ export const ClaudeResultSchema = z.object({
 });
 
 export type FixTask = z.infer<typeof FixTaskSchema>;
+export type SkippedTask = z.infer<typeof SkippedTaskSchema>;
 export type Report = z.infer<typeof ReportSchema>;
 export type FixResult = z.infer<typeof FixResultSchema>;
 export type ClaudeResult = z.infer<typeof ClaudeResultSchema>;


### PR DESCRIPTION
ATM with hardcoede results to process and not analyzer, here is a run and PR it created:

[RUN](https://github.com/trezor/trezor-suite/actions/runs/26553427056)

[PR1 - no changes](https://github.com/trezor/trezor-suite/pull/28129) - i have improved logic to not push the PR if issue was not duplicated

[PR2 - attempt to fix, it passes but kind of changed the test](https://github.com/trezor/trezor-suite/pull/28128)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=nightly-agent-fixer-6&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=nightly-agent-fixer-6&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-29T09:01:38.757Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-29T08:59:15.454Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/nightly-agent-fixer-6/web/](https://dev.suite.sldev.cz/suite-web/nightly-agent-fixer-6/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->