### PR TITLE
chore(ci): pin exact SFW binary

### DIFF
--- a/.github/actions/minimal-yarn-install/action.yml
+++ b/.github/actions/minimal-yarn-install/action.yml
@@ -34,6 +34,7 @@ runs:
       with:
         mode: firewall-free
         job-summary: errors
+        firewall-version: 1.11.0
 
     - name: Install dependencies using Yarn
       shell: bash

--- a/.github/actions/release-connect-npm/action.yml
+++ b/.github/actions/release-connect-npm/action.yml
@@ -61,6 +61,7 @@ runs:
       with:
         mode: firewall-free
         job-summary: errors
+        firewall-version: 1.11.0
 
     - name: Install dependencies
       shell: bash

--- a/.github/actions/release-connect/action.yml
+++ b/.github/actions/release-connect/action.yml
@@ -68,6 +68,7 @@ runs:
       with:
         mode: firewall-free
         job-summary: errors
+        firewall-version: 1.11.0
 
     - name: Install dependencies
       shell: bash

--- a/.github/workflows/bot-crowdin-sync.yml
+++ b/.github/workflows/bot-crowdin-sync.yml
@@ -42,6 +42,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install dependencies
         run: sfw yarn install
 

--- a/.github/workflows/build-analytics-docs.yml
+++ b/.github/workflows/build-analytics-docs.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml

--- a/.github/workflows/build-desktop-apps.yml
+++ b/.github/workflows/build-desktop-apps.yml
@@ -46,6 +46,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install deps and build libs
         run: |
           sfw yarn install --immutable
@@ -98,6 +99,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install deps and build libs
         run: |
           sfw yarn install --immutable
@@ -158,6 +160,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install deps and build libs
         run: |
           sfw yarn install --immutable

--- a/.github/workflows/build-llm-test-analysis-nightly.yml
+++ b/.github/workflows/build-llm-test-analysis-nightly.yml
@@ -54,6 +54,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install dependencies
         shell: bash
         run: sfw yarn workspaces focus @trezor/e2e-utils

--- a/.github/workflows/build-node-bridge.yml
+++ b/.github/workflows/build-node-bridge.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install deps and build libs
         run: |
           sfw yarn install --immutable

--- a/.github/workflows/build-storybook-native.yml
+++ b/.github/workflows/build-storybook-native.yml
@@ -49,6 +49,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install Yarn dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml

--- a/.github/workflows/build-suite-desktop-e2e.yml
+++ b/.github/workflows/build-suite-desktop-e2e.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install dependencies, build libs
         shell: bash
         run: |

--- a/.github/workflows/build-suite-native-adhoc.yml
+++ b/.github/workflows/build-suite-native-adhoc.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install libs
         run: |
           sfw yarn workspaces focus @suite-native/app

--- a/.github/workflows/build-suite-native-preview.yml
+++ b/.github/workflows/build-suite-native-preview.yml
@@ -53,6 +53,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install libs
         run: |
           sfw yarn workspaces focus @suite-native/app

--- a/.github/workflows/build-suite-web-e2e.yml
+++ b/.github/workflows/build-suite-web-e2e.yml
@@ -52,6 +52,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install dependencies
         shell: bash
         run: |

--- a/.github/workflows/build-suite-web.yml
+++ b/.github/workflows/build-suite-web.yml
@@ -62,6 +62,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml

--- a/.github/workflows/check-code-validation.yml
+++ b/.github/workflows/check-code-validation.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
@@ -175,6 +176,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Yarn Dedupe check
         run: sfw yarn dedupe --check
       - name: Check dependency domain lists

--- a/.github/workflows/check-test-health-nightly.yml
+++ b/.github/workflows/check-test-health-nightly.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install dependencies
         shell: bash
         run: sfw yarn workspaces focus @trezor/e2e-utils

--- a/.github/workflows/check-test-health.yml
+++ b/.github/workflows/check-test-health.yml
@@ -52,6 +52,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install dependencies
         shell: bash
         run: sfw yarn workspaces focus @trezor/e2e-utils

--- a/.github/workflows/chore-purge-android-e2e-build.yml
+++ b/.github/workflows/chore-purge-android-e2e-build.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install Yarn dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml

--- a/.github/workflows/release-connect-bump-versions.yml
+++ b/.github/workflows/release-connect-bump-versions.yml
@@ -48,6 +48,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install dependencies
         run: sfw yarn install
 

--- a/.github/workflows/release-connect-npm.yml
+++ b/.github/workflows/release-connect-npm.yml
@@ -61,6 +61,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install dependencies
         run: sfw yarn install
 
@@ -91,8 +92,7 @@ jobs:
 
   deploy-npm-connect-dependencies:
     name: Deploy NPM ${{ needs.identify-release-packages.outputs.deploymentType }} ${{ matrix.package }}
-    needs:
-      [extract-version, sanity-check-version-match, identify-release-packages]
+    needs: [extract-version, sanity-check-version-match, identify-release-packages]
     environment: production-connect
     runs-on: ubuntu-latest
     strategy:
@@ -133,8 +133,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package:
-          ["connect", "connect-web", "connect-webextension", "connect-mobile"]
+        package: ["connect", "connect-web", "connect-webextension", "connect-mobile"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/release-suite-coin-icons.yml
+++ b/.github/workflows/release-suite-coin-icons.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Download crypto icons
         run: |
           sfw yarn install

--- a/.github/workflows/release-suite-definitions.yml
+++ b/.github/workflows/release-suite-definitions.yml
@@ -42,6 +42,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Build and sign ${{ github.event.inputs.environment }} token-definitions
         if: ${{ github.event.inputs.environment == 'develop-definitions' && github.ref == 'refs/heads/develop' }}
         run: |

--- a/.github/workflows/release-suite-desktop-web-staging.yml
+++ b/.github/workflows/release-suite-desktop-web-staging.yml
@@ -67,6 +67,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install deps and build libs
         run: |
           sfw yarn install --immutable
@@ -194,6 +195,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
@@ -252,6 +254,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install deps and build libs
         run: |
           sfw yarn install --immutable

--- a/.github/workflows/release-suite-message-system-config.yml
+++ b/.github/workflows/release-suite-message-system-config.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Build and sign ${{ env.RELEASE_ENV }} message-system config file
         env:
           IS_CODESIGN_BUILD: ${{ env.RELEASE_ENV == 'production' && 'true' || 'false' }}

--- a/.github/workflows/release-suite-native-develop.yml
+++ b/.github/workflows/release-suite-native-develop.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install libs
         run: |
           sfw yarn workspaces focus @suite-native/app

--- a/.github/workflows/release-suite-native-production.yml
+++ b/.github/workflows/release-suite-native-production.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install libs
         run: |
           sfw yarn workspaces focus @suite-native/app
@@ -79,6 +80,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install libs
         run: |
           sfw yarn workspaces focus @suite-native/app
@@ -119,6 +121,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install libs
         run: |
           sfw yarn workspaces focus @suite-native/app

--- a/.github/workflows/template-connect-test-params.yml
+++ b/.github/workflows/template-connect-test-params.yml
@@ -68,6 +68,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - run: sfw yarn workspaces focus @trezor/connect
       - if: ${{ inputs.testEnv == 'web' }}
         run: |

--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -77,6 +77,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install Yarn dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml

--- a/.github/workflows/template-suite-native-prepare-test-app-android.yml
+++ b/.github/workflows/template-suite-native-prepare-test-app-android.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install Yarn dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml

--- a/.github/workflows/template-suite-run-e2e.yml
+++ b/.github/workflows/template-suite-run-e2e.yml
@@ -149,6 +149,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install PW Dependencies
         shell: bash
         run: |

--- a/.github/workflows/test-blockchain-link.yml
+++ b/.github/workflows/test-blockchain-link.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install dependencies
         run: sfw yarn --immutable
 

--- a/.github/workflows/test-connect-misc.yml
+++ b/.github/workflows/test-connect-misc.yml
@@ -76,6 +76,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install dependencies
         run: sfw yarn install
 
@@ -111,5 +112,6 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - run: sfw yarn install --immutable
       - run: yarn workspace @trezor/protobuf update:protobuf

--- a/.github/workflows/test-e2e-controller-pr.yml
+++ b/.github/workflows/test-e2e-controller-pr.yml
@@ -101,6 +101,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install dependencies
         run: sfw yarn workspaces focus @trezor/e2e-utils
 

--- a/.github/workflows/test-misc.yml
+++ b/.github/workflows/test-misc.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - run: sfw yarn install --immutable
       - run: yarn workspace @suite/intl translations:list-unused
 
@@ -64,6 +65,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - run: sfw yarn install --immutable
       - run: ./scripts/circular-dependencies/check-circular-dependencies.sh
 
@@ -86,6 +88,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - run: sfw yarn install --immutable
       - run: yarn message-system-sign-config
       - name: Unit Tests - Suite, Connect, Common
@@ -126,6 +129,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - run: sfw yarn install --immutable
       - run: yarn generate-package @trezor/meow-package
       - run: rm -rf packages/meow-package
@@ -146,5 +150,6 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - run: sfw yarn install --immutable
       - run: yarn tsx ./packages/components/scripts/test-img-paths-exist.ts

--- a/.github/workflows/test-request-manager.yml
+++ b/.github/workflows/test-request-manager.yml
@@ -35,5 +35,6 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - run: sfw yarn install --immutable
       - run: yarn workspace @trezor/request-manager test:all

--- a/.github/workflows/test-suite-manual-release.yml
+++ b/.github/workflows/test-suite-manual-release.yml
@@ -51,6 +51,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install PW Dependencies
         shell: bash
         run: |

--- a/.github/workflows/test-suite-native-e2e-ios.yml
+++ b/.github/workflows/test-suite-native-e2e-ios.yml
@@ -55,6 +55,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install Yarn dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
@@ -130,6 +131,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install Yarn dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml

--- a/.github/workflows/test-suite-native-e2e-manual-reporter.yml
+++ b/.github/workflows/test-suite-native-e2e-manual-reporter.yml
@@ -48,6 +48,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install Yarn dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml

--- a/.github/workflows/test-suite-web-e2e-nightly.yml
+++ b/.github/workflows/test-suite-web-e2e-nightly.yml
@@ -113,6 +113,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install dependencies
         run: sfw yarn workspaces focus @trezor/e2e-utils
 

--- a/.github/workflows/test-transport.yml
+++ b/.github/workflows/test-transport.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install dependencies
         run: |
           sfw yarn workspaces focus @trezor/transport-test
@@ -87,6 +88,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install dependencies
         shell: bash
         run: |

--- a/.github/workflows/test-trezor-user-env-link-e2e.yml
+++ b/.github/workflows/test-trezor-user-env-link-e2e.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - name: Install dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml

--- a/.github/workflows/test-urls.yml
+++ b/.github/workflows/test-urls.yml
@@ -28,5 +28,6 @@ jobs:
         with:
           mode: firewall-free
           job-summary: errors
+          firewall-version: 1.11.0
       - run: sfw yarn install --immutable
       - run: yarn workspace @trezor/urls test:e2e


### PR DESCRIPTION
## Description

Pin exact SFW release so that we do not repeat the same error as was solved in https://github.com/trezor/trezor-suite/pull/28130

v1.11.0 is latest https://github.com/SocketDev/sfw-free/releases 

The SocketDev/action downloads the binary via github rest API `getReleaseByTag`, [see here](https://github.com/SocketDev/action/blob/ba6de6cc0565af1f42295590380973573297e31f/src/tools/firewall.js#L46-L50)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=ci/pin-sfw-binary&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=ci/pin-sfw-binary&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=ci/pin-sfw-binary&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-28T06:04:44.586Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-28T06:02:22.059Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/ci/pin-sfw-binary/web/](https://dev.suite.sldev.cz/suite-web/ci/pin-sfw-binary/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->