### PR TITLE
chore(deps): replace cbor with cborg in connect and address-validator

### DIFF
--- a/jest.config.base.swc.js
+++ b/jest.config.base.swc.js
@@ -33,5 +33,9 @@ module.exports = {
         '^bcrypto/lib/(.*)$': 'bcrypto/lib/$1-browser',
         '^uint8array-tools$': require.resolve('uint8array-tools'),
         '^usb$': '<rootDir>../../packages/transport/mocks/usb.js',
+        // cborg is pure ESM and its `exports` map only declares an `import` condition, so Jest's
+        // CJS resolver cannot resolve the bare specifier (used transitively via @trezor/address-validator).
+        // Map it straight to its entry file; @swc/jest then transpiles the ESM source.
+        '^cborg$': path.resolve(__dirname, 'node_modules/cborg/cborg.js'),
     },
 };

--- a/packages/address-validator/jest.config.cjs
+++ b/packages/address-validator/jest.config.cjs
@@ -1,7 +1,15 @@
+const path = require('path');
+
 const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
     testEnvironment: '../../JestCustomEnv.js',
-    transformIgnorePatterns: ['/node_modules/(?!(@scure/base|@noble/hashes)/)'],
+    // `cborg` is pure-ESM (its `exports` field only declares `import`). Map the bare specifier
+    // to its entry file directly and whitelist it for swc transpilation below.
+    moduleNameMapper: {
+        ...baseConfig.moduleNameMapper,
+        '^cborg$': path.resolve(__dirname, '../../node_modules/cborg/cborg.js'),
+    },
+    transformIgnorePatterns: ['/node_modules/(?!(@scure/base|@noble/hashes|cborg)/)'],
 };

--- a/packages/address-validator/package.json
+++ b/packages/address-validator/package.json
@@ -30,7 +30,7 @@
     "dependencies": {
         "@noble/hashes": "^2.0.1",
         "@scure/base": "^2.0.0",
-        "cbor": "^10.0.12",
+        "cborg": "^5.1.1",
         "crc": "^3.8.0"
     },
     "devDependencies": {

--- a/packages/address-validator/src/ada_validator.ts
+++ b/packages/address-validator/src/ada_validator.ts
@@ -1,5 +1,5 @@
 import { bech32 } from '@scure/base';
-import * as cbor from 'cbor';
+import { type TagDecoder, decode as cborDecode } from 'cborg';
 import CRC from 'crc';
 
 import * as base58 from './crypto/base58';
@@ -8,11 +8,17 @@ import type { Currency, NetworkEnvironment } from './currency-types';
 
 const DEFAULT_NETWORK: NetworkEnvironment = 'prod';
 
+// Byron addresses wrap their hash in CBOR tag 24 (encoded-CBOR data item). We need the raw
+// inner bytes for CRC32 verification (not the decoded inner CBOR), so this handler captures
+// them under `.value` to mirror the legacy `cbor.Tagged` shape.
+const TAGS: TagDecoder[] = [];
+TAGS[24] = decode => ({ value: decode() }) as unknown as ReturnType<TagDecoder>;
+
 function getDecoded(address: string): any {
     try {
         const decoded = base58.decode(address);
 
-        return cbor.decode(new Uint8Array(decoded).buffer as ArrayBuffer);
+        return cborDecode(new Uint8Array(decoded), { tags: TAGS });
     } catch {
         return null;
     }

--- a/packages/connect/e2e/vitest.setup.ts
+++ b/packages/connect/e2e/vitest.setup.ts
@@ -1,16 +1,5 @@
 import { vi } from 'vitest';
 
-// Ensure process.nextTick is available in browser.
-// vite-plugin-node-polyfills provides it but uses a conditional guard
-// (globalThis.process = globalThis.process || polyfill) which is a no-op
-// when Vitest already sets a partial process object. The cbor package
-// (used by cardanoSignMessage) depends on Node.js streams that call process.nextTick.
-if (typeof process !== 'undefined' && typeof process.nextTick !== 'function') {
-    process.nextTick = (fn: (...a: unknown[]) => void, ...args: unknown[]) => {
-        queueMicrotask(() => fn(...args));
-    };
-}
-
 // Load TX cache data: Node reads JSON files at runtime via fs,
 // browser uses a pre-built virtual module (see txCachePlugin in vitest.config.ts).
 const CACHE: Record<string, unknown> =

--- a/packages/connect/jest.config.cjs
+++ b/packages/connect/jest.config.cjs
@@ -1,3 +1,5 @@
+const path = require('path');
+
 const { testPathIgnorePatterns, ...baseConfig } = require('../../jest.config.base.swc');
 
 module.exports = {
@@ -6,4 +8,13 @@ module.exports = {
     collectCoverage: true,
     setupFiles: ['<rootDir>/setupJest.ts'],
     testPathIgnorePatterns: [...testPathIgnorePatterns, 'e2e'],
+    // `cborg` is pure-ESM (its `exports` field only declares `import`). Map the bare specifier
+    // to the entry file directly and let swc transpile it (whitelisted below).
+    moduleNameMapper: {
+        ...baseConfig.moduleNameMapper,
+        '^cborg$': path.resolve(__dirname, '../../node_modules/cborg/cborg.js'),
+    },
+    transformIgnorePatterns: [
+        'node_modules/?!(uuid|react-intl|@formatjs/*|intl-messageformat|cborg)/',
+    ],
 };

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -105,7 +105,7 @@
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
         "@trezor/utxo-lib": "workspace:*",
-        "cbor": "^10.0.12",
+        "cborg": "^5.1.1",
         "cross-fetch": "^4.1.0",
         "jws": "^4.0.1",
         "viem": "^2.48.1"

--- a/packages/connect/src/api/cardano/cardanoUtils.ts
+++ b/packages/connect/src/api/cardano/cardanoUtils.ts
@@ -1,6 +1,6 @@
 import type { types } from '@fivebinaries/coin-selection';
 import { coinSelection } from '@fivebinaries/coin-selection';
-import * as cbor from 'cbor';
+import { encode as cborEncode } from 'cborg';
 
 import type { AccountUtxo, CardanoCertificate } from '@trezor/connect-common';
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
@@ -130,19 +130,18 @@ export const hexStringByteLength = (s: string) => s.length / 2;
 // See https://cips.cardano.org/cips/cip8. The byte layout is consumed by CIP-30 verifiers,
 // so the encoding must stay deterministic.
 export const createCose = (payload: string, signature: string, address: string, pubKey: string) => {
-    const coseSignature = cbor.encode([
-        Buffer.from(
-            cbor.encode(
-                new Map()
-                    .set(1, -8) // alg: EdDSA
-                    .set('address', Buffer.from(address, 'hex')),
-            ),
-        ),
+    const protectedHeaders = cborEncode(
+        new Map()
+            .set(1, -8) // alg: EdDSA
+            .set('address', Buffer.from(address, 'hex')),
+    );
+    const coseSignature = cborEncode([
+        protectedHeaders,
         new Map().set('hashed', false),
         Buffer.from(payload, 'hex'),
         Buffer.from(signature, 'hex'),
     ]);
-    const coseKey = cbor.encode(
+    const coseKey = cborEncode(
         new Map()
             .set(1, 1) // kty: OKP
             .set(3, -8) // alg: EdDSA

--- a/packages/suite-build/configs/base.webpack.config.ts
+++ b/packages/suite-build/configs/base.webpack.config.ts
@@ -49,7 +49,7 @@ const config: webpack.Configuration = {
         fallback: {
             // Polyfills crypto API for NodeJS libraries in the browser. 'crypto' does not run without 'stream'
             crypto: require.resolve('crypto-browserify'), // required by multiple dependencies
-            stream: require.resolve('stream-browserify'), // required by utxo-lib and keccak
+            stream: require.resolve('stream-browserify'), // required by jws (@trezor/connect firmware-signature verification) and the crypto-browserify chain (cipher-base, hash-base)
             vm: require.resolve('vm-browserify'), // ignore "vm" imports in "asn1.js@4.10.1" > crypto-browserify"
             util: require.resolve('util'), // required by "xrpl.js"
             assert: require.resolve('assert'), // required by multiple dependencies

--- a/yarn.lock
+++ b/yarn.lock
@@ -15320,7 +15320,7 @@ __metadata:
     "@noble/hashes": "npm:^2.0.1"
     "@scure/base": "npm:^2.0.0"
     "@trezor/eslint": "workspace:*"
-    cbor: "npm:^10.0.12"
+    cborg: "npm:^5.1.1"
     crc: "npm:^3.8.0"
   peerDependencies:
     tslib: ^2.6.2
@@ -15794,7 +15794,7 @@ __metadata:
     "@types/node": "npm:22.13.10"
     "@types/w3c-web-usb": "npm:^1.0.14"
     "@vitest/browser-playwright": "npm:^4.1.6"
-    cbor: "npm:^10.0.12"
+    cborg: "npm:^5.1.1"
     cross-fetch: "npm:^4.1.0"
     crypto-browserify: "npm:3.12.1"
     jest: "npm:29.7.0"
@@ -21475,12 +21475,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cbor@npm:^10.0.12":
-  version: 10.0.12
-  resolution: "cbor@npm:10.0.12"
-  dependencies:
-    nofilter: "npm:^3.0.2"
-  checksum: 10/296b6564c60e856aa13500ddeaf95aa979b05a80b543e85f6a2992d335e049ce2fd750a724a5d99095a9fee1c2bfcb934437683f2c19d8db4e129ea57813fb22
+"cborg@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "cborg@npm:5.1.1"
+  bin:
+    cborg: lib/bin.js
+  checksum: 10/e8be4314ab7cc9bba8be86089e195735d7df8ef32d07f64f7084cc9a9627628aea873648da0392cd84064eb6148f72927607b8ca062bafe660577ac62cdabda2
   languageName: node
   linkType: hard
 
@@ -36733,13 +36733,6 @@ __metadata:
   version: 1.15.0
   resolution: "node-stream-zip@npm:1.15.0"
   checksum: 10/3fb56144d23456e1b42fe9d24656999e4ef6aeccce3cae43fc97ba6c341ee448aeceb4dc8fb57ee78eab1a6da49dd46c9650fdb2f16b137630a335df9560c647
-  languageName: node
-  linkType: hard
-
-"nofilter@npm:^3.0.2":
-  version: 3.1.0
-  resolution: "nofilter@npm:3.1.0"
-  checksum: 10/f63d87231dfda4b783db17d75b15aac948f78e65f4f1043096ef441147f6667ff74cd4b3f57ada5dbe240be282d3e9838558ac863a66cb04ef25fff7b2b4be4e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## ⛔ Blocked — do not merge (deferred)

`cborg` is **pure ESM** and its `exports` map declares only an `import` condition (no `require`/`default`). That breaks every **CJS** test runtime that loads the swapped code:

- **Jest** — `@suite-common/*` unit tests that import `@trezor/address-validator` fail with `Cannot find module 'cborg'`. Fixable with a `moduleNameMapper` in the shared base Jest config (map `cborg` → its entry file).
- **Playwright e2e** (`suite/e2e`, which transitively loads `address-validator`) — `No exports main defined in cborg/package.json`, so **every shard fails to load**. **Not** fixable the same way: Playwright runs in CJS and has no `moduleNameMapper`.

### Options evaluated

1. **Patch `cborg`** (add a `require` condition via `yarn patch`) — 1 line, fixes all runtimes on Node 24 via `require(esm)`. **Rejected** — don't want to maintain a dependency patch.
2. **Migrate `suite/e2e` to native ESM** so `cborg`'s `import` condition resolves — investigated in depth, **not viable** as a contained change (see below).

### Why ESM migration of e2e is not viable (key finding)

Native ESM (Playwright's mode under `"type": "module"`) requires **explicit file extensions on every import**. The monorepo is written entirely **bundler-style (extensionless)** — webpack/jest/metro/swc resolve extensions, native Node ESM does not (and `--experimental-specifier-resolution=node` was removed in Node 17+). Concretely:

- **2,758** extensionless relative imports in `suite-common/*/src` alone; **thousands** more across `packages/*` and `suite/*`.
- 100+ extensionless deep workspace imports (`@scope/pkg/src/…`).
- Workspace packages expose TS source via extensionless `main: "src/index"` and re-export via `export *`, which native ESM cannot statically resolve from a CJS module.

So running e2e under native ESM requires either a **repo-wide codemod** adding extensions to thousands of imports (plus `allowImportingTsExtensions`, bare-specifier + directory-index handling) **or a custom Playwright ESM resolver hook** that re-implements bundler resolution. Converting packages to `type: module` (prototyped on the `mroz22/suite-e2e-esm` branch) is necessary but nowhere near sufficient.

### Decision

`cbor` → `cborg` is **deferred**. The swap itself is byte-exact and ready (below); landing it needs one of: the `cborg` patch, a Playwright resolver hook, or a broader native-ESM initiative — none in scope here. The `type: module` package conversions are a separate, optional incremental-ESM track.

---

## What

Replaces `cbor@10.0.12` (CJS, depends on Node `stream` via its `nofilter` transitive) with `cborg@5.1.1` (pure ESM, zero dependencies, isomorphic) across both call sites in the monorepo.

Two atomic commits:

1. **`chore(connect): replace cbor with cborg`** — `cardanoUtils.createCose` (CIP-0008 COSE_Sign1 / COSE_Key encoding for `cardanoSignMessage`). Drops the `process.nextTick` polyfill in `e2e/vitest.setup.ts` whose only reason for existing was `cbor`'s Node-stream usage.
2. **`chore(address-validator): replace cbor with cborg`** — `ada_validator.getDecoded` (Byron `Ae2td…` / `DdzFF…` address decoding). Supplies a tag-24 handler that exposes inner bytes as `.value`, matching the legacy `cbor.Tagged` shape consumed by `CRC.crc32(tagged.value)`.

After this PR, `cbor` and its `nofilter` dep are **gone from the monorepo entirely**.

## Why `cborg` over `cbor` — concern by concern

Each claim links to its proof. Exact pinned versions: `cbor@10.0.12`, `cborg@5.1.1`.

**1. Supply chain / dependency tree.** `cborg` has **zero runtime dependencies**; `cbor` pulls in `nofilter`. The swap drops one direct **and** one transitive dependency from the monorepo.
- Proof: [`cborg@5.1.1/package.json`](https://unpkg.com/cborg@5.1.1/package.json) — no `dependencies` field — vs [`cbor@10.0.12/package.json`](https://unpkg.com/cbor@10.0.12/package.json) — `"dependencies": { "nofilter": "^3.0.2" }`. This PR's `yarn.lock` diff removes both `cbor` and `nofilter` (and `nofilter`'s entry).

**2. Module format (ESM vs CommonJS).** `cborg` is **pure ESM** (`"type": "module"`, `exports` exposes only an `import` condition), which matches the monorepo's ESM build and tree-shaking. `cbor` ships CommonJS (no `"type"`, CJS `main`, no `exports` map), so it had to be consumed via a `import * as cbor` namespace.
- Proof: [`cborg` package.json](https://unpkg.com/cborg@5.1.1/package.json) (`"type": "module"`, `"exports"`) vs [`cbor` package.json](https://unpkg.com/cbor@10.0.12/package.json). The import sites in this PR change from `import * as cbor from 'cbor'` to named `import { encode } / { decode } from 'cborg'`.

**3. Node-core coupling / browser fit.** `cbor`'s `nofilter` **is a Node stream** (Duplex/Transform), which is exactly why the browser path needed Node-stream behaviour incl. `process.nextTick`. `cborg` is **isomorphic and `Uint8Array`-native** and pulls in no Node core. This PR deletes the `process.nextTick` shim in `packages/connect/e2e/vitest.setup.ts` whose comment named `cbor` as its sole reason.
- Proof: [`nofilter`](https://github.com/hildjj/nofilter) — *"Read and write a growable buffer as a **stream**"* (keywords: stream, duplex, transform); [cborg README](https://github.com/rvagg/cborg) — *"suitable for the browser (is `Uint8Array` native) and Node.js"*; the deleted shim is visible in this PR's `vitest.setup.ts` diff.
- ⚠️ **Honest scope:** this removes `cbor`'s *contribution* to Node-core coupling — it does **not** let us drop the suite-web `stream-browserify` webpack fallback. A CI build with that fallback removed proved it is still required by `jws` (`@trezor/connect` firmware-signature verification) and the `crypto-browserify` chain (`cipher-base`, `hash-base`), all unrelated to `cbor`. This PR only **corrects** that fallback's stale `// required by utxo-lib and keccak` comment.

**4. Encoding strictness / determinism (correctness).** `createCose` emits a CIP-0008 `COSE_Sign1` / `COSE_Key` consumed **byte-for-byte** by CIP-30 verifiers, so deterministic output is a correctness requirement, not a nicety. `cborg` is **built around strictness and deterministic, content-addressable encoding** ("converge on same-bytes for same-data"); `cbor` is flexible by default.
- Proof: [cborg README](https://github.com/rvagg/cborg) — *"focuses on strictness and deterministic data representations"* — and [Deterministic encoding recommendations](https://github.com/rvagg/cborg#deterministic-encoding-recommendations).
- We **prove the swap is byte-identical** for our vectors: golden COSE unit tests in #28107 (merged) + EMURGO / CIP-30 round-trip provenance in #28105.

**5. Node version support.** `cbor@10` requires `node >= 20`; `cborg` declares no `engines` constraint.
- Proof: [`cbor` package.json](https://unpkg.com/cbor@10.0.12/package.json) — `"engines": { "node": ">=20" }` — vs [`cborg` package.json](https://unpkg.com/cborg@5.1.1/package.json) — no `engines`.

_Not claimed: that `cborg` is more popular (it isn't — `cbor` has ~5× the npm downloads) or measurably faster here (no benchmark was run). The case for the swap is the five concerns above._

## How we know it's safe (byte-exact)

The safety net for this swap landed first in #28107 (now **merged** into `develop`), which provides:

- Bit-exact unit tests for `createCose` against golden COSE hex (5/5, all green here).
- Provenance proof in the reference-only #28105: the golden hex was generated and verified byte-for-byte against EMURGO's official CIP-0008 reference implementation **and** round-tripped through `@cardano-foundation/cardano-verify-datasignature` (an independent CIP-30 verifier).

Address-validator decode is covered by its existing tests: all 45 cases pass (including Cardano Byron mainnet/testnet).

#28107 is now merged, so this PR is rebased directly on `develop` (no longer stacked).

## Local verification

```
yarn workspace @trezor/connect test:unit cardano        → 15 passed
yarn workspace @trezor/address-validator test:unit      → 45 passed
yarn workspace @trezor/address-validator type-check     → clean
yarn workspace @trezor/connect type-check               → no new errors in changed files
```

## Jest config note

`cborg`'s `exports` field only declares `import` (no `require`), so Jest's CJS resolver can't find it through the bare specifier. Both `packages/connect/jest.config.cjs` and `packages/address-validator/jest.config.cjs` now map `cborg` to its entry file directly and whitelist it for swc transpilation. Build/runtime is unaffected — both packages are `"type": "module"` and resolve `cborg` natively.

## Related

- #28107 (merged) — tests + safety net for this swap.
- Provenance: #28105 (reference-only EMURGO + CIP-30 verifier proof; do not merge).
- Relates to #27403.
- #28230 — bumps `crc` v3 → v4 and imports calculators directly; both PRs touch `ada_validator.ts` (the `crc32(tagged.value)` callsite), so whichever lands second rebases.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/cardano-replace-cbor-with-cborg&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/cardano-replace-cbor-with-cborg&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/cardano-replace-cbor-with-cborg&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-04T11:41:12.502Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-04T11:39:14.956Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/cardano-replace-cbor-with-cborg/web/](https://dev.suite.sldev.cz/suite-web/mroz22/cardano-replace-cbor-with-cborg/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

