### PR TITLE
refactor(transport): drop legacy hex-without-envelope bridge format

### DIFF
--- a/packages/transport-bridge/tests/http.test.ts
+++ b/packages/transport-bridge/tests/http.test.ts
@@ -148,17 +148,13 @@ describe('http', () => {
             const { trezordNode, url } = await setupTrezordNode();
 
             let res;
-            // no protocol, legacy way
+            // raw body without a protocol envelope is rejected (legacy hex format dropped)
             res = await bridgeApiCall({
                 url: `${url}call/1`,
                 method: 'POST',
                 body: GET_FEATURES,
             });
-            if (!res.success) {
-                throw new Error(res.error.code + ' ' + res.error.message);
-            }
-            expect(res.payload).toBe(FEATURES);
-            // invalid legacy message (not a hex)
+            expect(res.success).toBe(false);
             res = await bridgeApiCall({
                 url: `${url}call/1`,
                 method: 'POST',
@@ -237,17 +233,13 @@ describe('http', () => {
             const { trezordNode, url } = await setupTrezordNode();
 
             let res;
-            // no protocol, legacy way
+            // raw body without a protocol envelope is rejected (legacy hex format dropped)
             res = await bridgeApiCall({
                 url: `${url}post/1`,
                 method: 'POST',
                 body: GET_FEATURES,
             });
-            if (!res.success) {
-                throw new Error(res.error.code + ' ' + res.error.message);
-            }
-            expect(res.payload).toBe('');
-            // invalid legacy message (not a hex)
+            expect(res.success).toBe(false);
             res = await bridgeApiCall({
                 url: `${url}post/1`,
                 method: 'POST',
@@ -344,15 +336,12 @@ describe('http', () => {
             const { trezordNode, url } = await setupTrezordNode();
 
             let res;
-            // no protocol, legacy way
+            // raw body without a protocol envelope is rejected (legacy hex format dropped)
             res = await bridgeApiCall({
                 url: `${url}read/1`,
                 method: 'POST',
             });
-            if (!res.success) {
-                throw new Error(res.error.code + ' ' + res.error.message);
-            }
-            expect(res.payload).toBe(FEATURES);
+            expect(res.success).toBe(false);
 
             // protocol bridge, json response without magic header
             res = await bridgeApiCall({
@@ -590,7 +579,7 @@ describe('http', () => {
             const callPromise = bridgeApiCall({
                 url: url + 'call/1',
                 method: 'POST',
-                body: '000000000000',
+                body: JSON.stringify({ protocol: 'v1', data: '3f2323' + '000000000000' }),
                 signal: abortController.signal,
             });
 

--- a/packages/transport/src/utils/bridgeProtocolMessage.ts
+++ b/packages/transport/src/utils/bridgeProtocolMessage.ts
@@ -2,28 +2,17 @@ import type { ThpChannelState, TransportProtocol } from '@trezor/protocol';
 
 export type BridgeProtocolMessage = {
     data: string;
-    protocol?: TransportProtocol['name'];
+    protocol: TransportProtocol['name'];
     thpState?: ThpChannelState;
 };
 
 // validate expected body:
-// - string with hex (legacy bridge /call and /read results)
-// - empty string (legacy bridge /write result, withMessage == false)
 // - json string (protocol message)
 // - parsed json string (parsed protocol message)
 export function validateProtocolMessage(body: unknown, withData = true): BridgeProtocolMessage {
     const isHex = (s: string) => /^[0-9A-Fa-f]+$/g.test(s); // TODO: trezor/utils accepts 0x prefix (eth)
     const isValidProtocol = (s: any): s is BridgeProtocolMessage['protocol'] =>
         s === 'v1' || s === 'v2' || s === 'bridge';
-
-    // Legacy bridge results
-    if (typeof body === 'string') {
-        if ((withData && isHex(body)) || (!withData && !body.length)) {
-            return {
-                data: body,
-            };
-        }
-    }
 
     let json: Record<string, any> | undefined | null;
     if (typeof body === 'object') {
@@ -58,7 +47,7 @@ export function validateProtocolMessage(body: unknown, withData = true): BridgeP
 
 export function createProtocolMessage(
     body: unknown,
-    protocol?: TransportProtocol | TransportProtocol['name'],
+    protocol: TransportProtocol | TransportProtocol['name'],
     thpState?: ThpChannelState,
 ) {
     let data;
@@ -70,11 +59,6 @@ export function createProtocolMessage(
     }
     if (typeof data !== 'string') {
         data = '';
-    }
-
-    // Legacy bridge message
-    if (!protocol) {
-        return data;
     }
 
     return JSON.stringify({

--- a/packages/transport/tests/bridgeProtocolMessage.test.ts
+++ b/packages/transport/tests/bridgeProtocolMessage.test.ts
@@ -10,9 +10,9 @@ type Fixture = {
 
 const fixtures: Fixture[] = [
     {
-        description: 'valid hex, with data=true',
+        description: 'raw hex without a protocol envelope is rejected (legacy format dropped)',
         params: ['09AF', true],
-        result: { data: '09AF' },
+        throws: 'Invalid BridgeProtocolMessage body',
     },
     {
         description: 'empty body with data=true',
@@ -22,7 +22,7 @@ const fixtures: Fixture[] = [
     {
         description: 'empty body with data=false',
         params: ['', false],
-        result: { data: '' },
+        throws: 'Invalid BridgeProtocolMessage body',
     },
     {
         description: 'parsable and valid protocol message as a string',


### PR DESCRIPTION
## Summary

The `BridgeTransport` ↔ `@trezor/transport-bridge` wire protocol used to support a legacy mode where the body was a bare hex string (no JSON envelope), inherited from the trezord-go HTTP API. Since the `protocolMessages` flag was dropped, the modern `BridgeTransport` unconditionally serialises requests as JSON `{protocol, data, thpState}` and the bundled node bridge always returns the same shape. The bare-hex path is unreachable from any production client.

This PR drops the two dead branches in `bridgeProtocolMessage.ts`:

- `validateProtocolMessage` no longer special-cases a string body that looks like hex (or an empty body when `withData=false`). String bodies now go straight to `JSON.parse`; non-JSON inputs throw `Invalid BridgeProtocolMessage body` as expected.
- `createProtocolMessage` no longer returns bare hex when called without a protocol; the `protocol` parameter is now required.
- `BridgeProtocolMessage['protocol']` is narrowed from optional to required to match: every `BridgeProtocolMessage` now carries a protocol, statically. The type ripples cleanly through `core.ts` without source edits.

**Tests updated to match:**

- `bridgeProtocolMessage.test.ts`: the two fixtures that previously returned `{data}` for raw hex / empty-body legacy now throw, matching the new behaviour.
- `transport-bridge/http.test.ts`: the "no protocol, legacy way" cases in `/call` `/post` `/read` now assert a 4xx rejection instead of a successful round-trip; the `/call aborted` test sends a v1 envelope (the abort is what's being tested, not the legacy body shape).

⚠️ This is a **server-side behaviour change**: the node bridge now rejects raw-hex request bodies. Safe because no real client produces them since 1774c788cb2 (legacy trezord-go port drop).

Part of the cleanup series tracked in #23794. This is **PR 1D** of five small cleanup PRs (1A–1E).

- PR 1A: #28095
- PR 1B: #28102
- PR 1C: #28104
- PR 1D: #28136
- PR 1E: #28137

## Test plan

- [x] `yarn workspace @trezor/transport type-check`
- [x] `yarn workspace @trezor/transport-bridge type-check`
- [x] `yarn workspace @trezor/transport lint:js`
- [x] `yarn workspace @trezor/transport-bridge lint:js`
- [x] `yarn workspace @trezor/transport test:unit bridgeProtocolMessage` (9/9)
- [x] `yarn workspace @trezor/transport-bridge test:unit` (18/18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies bridge protocol message utilities (encoding/decoding) in the transport layer and includes unit test changes for both the bridge HTTP layer and the protocol message module. The core production change is in bridgeProtocolMessage.ts, which is a foundational transport utility used broadly across Suite. Since the two test files changed are unit tests (not E2E tests), they have no direct E2E coverage. The E2E risk is concentrated in tests that explicitly exercise bridge transport behavior — session management, bridge spawning/lifecycle, and bridge reconnection scenarios. Most of the 114 statically-mapped tests only transitively depend on this utility and are unlikely to be affected unless the change introduces a fundamental protocol regression.

<details><summary><b>Changed files (3)</b></summary>

- `packages/transport-bridge/tests/http.test.ts`
- `packages/transport/src/utils/bridgeProtocolMessage.ts`
- `packages/transport/tests/bridgeProtocolMessage.test.ts`

</details>

**Recommended tests (7)**

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/suite/bridge.test.ts` — This test directly exercises the Bridge page and bridge transport connectivity. Changes to bridgeProtocolMessage.ts affect how messages are encoded/decoded over the bridge protocol, which is the core transport mechanism tested here.
- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — This test validates bridge spawning, bridge API responses, and device reconnection after bridge restart. Changes to bridge protocol message handling could affect the bridge API response parsing and device communication flow.
- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — This test validates bridge daemon lifecycle (start/stop) and multi-instance bridge connectivity. Bridge protocol message changes could affect how the bridge communicates with clients.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test directly uses BridgeTransport (bridge.init, bridge.enumerate, bridge.acquire) to steal and reclaim sessions. bridgeProtocolMessage.ts changes directly affect how these bridge API calls encode/decode their messages.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — This test explicitly asserts TransportType event reports 'BridgeTransport' with a valid version number, which depends on successful bridge protocol communication. A regression in message encoding could cause transport detection to fail.
- `suite/e2e/tests/recovery/dry-run.test.ts` — This test exercises bridge stop/restart scenarios (trezorUserEnv.stopBridge/startBridge) and verifies recovery after disconnection, making it sensitive to bridge protocol message handling changes.
- `suite/e2e/tests/recovery/t2t1-dry-run.test.ts` — Similar to dry-run.test.ts, this test stops and restarts the bridge mid-flow and verifies recovery. Bridge protocol message changes could affect reconnection behavior.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/transport-bridge/tests/http.test.ts`
- `packages/transport/tests/bridgeProtocolMessage.test.ts`

_Updated: 2026-05-28T06:54:07.886Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mvarmuza/transport-drop-legacy-hex-format&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mvarmuza/transport-drop-legacy-hex-format&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-28T13:55:10.305Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-28T13:51:47.634Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mvarmuza/transport-drop-legacy-hex-format/web/](https://dev.suite.sldev.cz/suite-web/mvarmuza/transport-drop-legacy-hex-format/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->


