### PR TITLE
feat(trading): remove swap from page header

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderDropdown.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderDropdown.tsx
@@ -43,10 +43,6 @@ export const HeaderDropdown = ({
         container: 'content',
         minWidth: breakpoints.laptop,
     });
-    const isSwapVisible = useConditionalRender({
-        container: 'content',
-        minWidth: breakpoints.tablet,
-    });
 
     const additionalActions: ActionItem[] = [
         ...(showSignAndVerify
@@ -91,33 +87,6 @@ export const HeaderDropdown = ({
             title: <Translation id="TR_TRADING_BUY_AND_SELL" />,
             icon: 'currencyCircleDollar',
             isHidden: isBuyVisible || isTradingDisabled,
-        },
-        {
-            id: 'wallet-swap',
-            callback: () => {
-                if (account) {
-                    dispatch(
-                        tradingActions.setTradingFromPrefilledAccount(
-                            getTradingPrefilledFromAccountData(account),
-                        ),
-                    );
-                }
-
-                goToWithAnalytics({ routeName: 'wallet-trading-exchange', preserveParams: false });
-
-                analytics.report({
-                    type: events.tradeNavigateEvent.name,
-                    payload: {
-                        action: 'navigate',
-                        type: 'exchange',
-                        from: account ? 'account/header' : 'dashboard/header',
-                        networkSymbol: account?.symbol,
-                    },
-                });
-            },
-            title: <Translation id="TR_TRADING_SWAP" />,
-            icon: 'repeat',
-            isHidden: isSwapVisible || isTradingDisabled,
         },
     ];
 

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/TradeActions.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/TradeActions.tsx
@@ -2,11 +2,9 @@ import { type DesktopAnalyticsDep, events } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { goto, selectIsAccountTabPage, selectRouteName } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
-import { selectSelectedDevice } from '@suite-common/device';
 import { getTradingPrefilledFromAccountData, tradingActions } from '@suite-common/trading';
 import { type SelectedAccountStatus } from '@suite-common/wallet-types';
 import { Row } from '@trezor/components';
-import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
 import { breakpoints } from '@trezor/theme';
 
 import { AppNavigationTooltip } from 'src/components/suite/AppNavigation/AppNavigationTooltip';
@@ -22,7 +20,6 @@ export const TradeActions = ({ selectedAccount }: TradeActionsProps) => {
     const { analytics } = useServices<DesktopAnalyticsDep>();
     const dispatch = useDispatch();
     const account = selectedAccount?.account;
-    const device = useSelector(selectSelectedDevice);
     const isAccountTabPage = useSelector(selectIsAccountTabPage);
     const currentRouteName = useSelector(selectRouteName);
 
@@ -66,28 +63,6 @@ export const TradeActions = ({ selectedAccount }: TradeActionsProps) => {
         });
     };
 
-    const onSwapClick = () => {
-        if (account) {
-            dispatch(
-                tradingActions.setTradingFromPrefilledAccount(
-                    getTradingPrefilledFromAccountData(account),
-                ),
-            );
-        }
-
-        goToWithAnalytics({ routeName: 'wallet-trading-exchange', preserveParams: false });
-
-        analytics.report({
-            type: events.tradeNavigateEvent.name,
-            payload: {
-                action: 'navigate',
-                type: 'exchange',
-                from: account ? 'account/header' : 'dashboard/header',
-                networkSymbol: account?.symbol,
-            },
-        });
-    };
-
     const isAccountLoading = selectedAccount ? selectedAccount.status === 'loading' : false;
 
     return (
@@ -105,20 +80,6 @@ export const TradeActions = ({ selectedAccount }: TradeActionsProps) => {
                         <Translation id="TR_TRADING_BUY_AND_SELL" />
                     </HeaderActionButton>
                 </ConditionalRender>
-                {!hasBitcoinOnlyFirmware(device) && (
-                    <ConditionalRender container="content" minWidth={breakpoints.tablet}>
-                        <HeaderActionButton
-                            icon="repeat"
-                            onClick={onSwapClick}
-                            data-testid="@wallet/menu/wallet-trading-exchange"
-                            intent="neutral"
-                            priority="secondary"
-                            isDisabled={isAccountLoading}
-                        >
-                            <Translation id="TR_TRADING_SWAP" />
-                        </HeaderActionButton>
-                    </ConditionalRender>
-                )}
             </AppNavigationTooltip>
         </Row>
     );

--- a/suite/e2e/support/pageObjects/walletPage.ts
+++ b/suite/e2e/support/pageObjects/walletPage.ts
@@ -22,7 +22,7 @@ export class WalletPage {
     readonly stakeAddress: Locator;
     readonly walletExtraDropDown: Locator;
     readonly openTradingGlobalButton: Locator;
-    readonly openSwapGlobalButton: Locator;
+    readonly openSwapSidebarButton: Locator;
     readonly tradingDropdownBuyButton: Locator;
     readonly balanceOfAccount = (params: WalletParams) =>
         this.accountButton(params).getByTestId(`@wallet/coin-balance/value-${params.symbol}`);
@@ -84,7 +84,7 @@ export class WalletPage {
         this.stakeAddress = this.page.getByTestId('@cardano/staking/address');
         this.walletExtraDropDown = this.page.getByTestId('@wallet/menu/extra-dropdown');
         this.openTradingGlobalButton = this.page.getByTestId('@wallet/menu/wallet-trading-buy');
-        this.openSwapGlobalButton = this.page.getByTestId('@wallet/menu/wallet-trading-exchange');
+        this.openSwapSidebarButton = this.page.getByTestId('@suite/menu/wallet-trading-exchange');
         this.tradingDropdownBuyButton = this.page
             .getByRole('list')
             .getByTestId('@wallet/menu/wallet-trading-buy');
@@ -240,7 +240,7 @@ export class WalletPage {
     @step()
     async openSwapTrading(params: WalletParams = {}) {
         await this.openAccount(params);
-        await this.openSwapGlobalButton.click();
+        await this.openSwapSidebarButton.click();
     }
 
     @step()

--- a/suite/e2e/tests/trading/navigation.test.ts
+++ b/suite/e2e/tests/trading/navigation.test.ts
@@ -72,9 +72,9 @@ test.describe('Trading - Navigation', { tag: ['@T3W1', '@T3T1'] }, () => {
             });
 
             // SWAP
-            await test.step('Swap from Global header', async () => {
+            await test.step('Swap from sidebar', async () => {
                 await dashboardPage.navigateTo();
-                await walletPage.openSwapGlobalButton.click();
+                await walletPage.openSwapSidebarButton.click();
                 await tradingPage.verifySwapFormOpened(/Bitcoin|Ethereum|Litecoin/);
             });
 


### PR DESCRIPTION
## Description

- Remove the Swap action button from the page header.
- Remove the Swap entry from the page header overflow dropdown.
- Keep the page header trading actions limited to Buy and Sell.
- Limit this PR to the page header only; sidebar Swap navigation is handled separately.

## Notes for QA

- Open the dashboard or an account page on desktop width and verify the page header no longer shows Swap.
- Open the page header overflow menu on a narrower layout and verify Swap is absent while Buy and Sell remain available.

## Related Issue

Resolve #28057

## Screenshots:

<img width="1508" height="96" alt="image" src="https://github.com/user-attachments/assets/12eab6d9-f6e4-4914-b439-c15bd0d2f0c7" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect two PageHeader components: HeaderDropdown.tsx (likely the main header dropdown menu with options like discreet mode toggle, device switcher access) and TradeActions.tsx (the global buy/sell/swap action buttons in the header). Both files map to all 121 tests because they're part of the SuiteLayout rendered on every page, but only tests that directly interact with header dropdown functionality or global trading entry points are meaningfully at risk. The recommended strategy focuses on tests that exercise global trading navigation buttons and header dropdown features like discreet mode, keeping the test set small and targeted.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderDropdown.tsx`
- `packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/TradeActions.tsx`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — TradeActions.tsx directly provides the global trading buttons (buy, sell, swap) in the page header. This test exercises navigation to buy/sell/swap forms from the global header (openTradingGlobalButton, openSwapGlobalButton), which are rendered by TradeActions.tsx. Any breakage in TradeActions would directly cause these navigation paths to fail.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test directly exercises global receive and send buttons (@wallet/menu/wallet-global-receive, @wallet/menu/wallet-global-send) which are likely rendered in the PageHeader area alongside TradeActions. HeaderDropdown.tsx likely contains or sits adjacent to these global action buttons. Changes to the header dropdown or trade actions layout could break these global entry points.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — HeaderDropdown.tsx likely contains the discreet mode toggle (hideBalanceButton) in the page header dropdown menu. This test directly validates toggling discreet mode via the dashboard header and checking the analytics event menuToggleDiscreetEvent, which would be affected if the dropdown rendering changes.
- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — TradeActions.tsx renders the trading action buttons in the header. While buy-bitcoin navigates primarily through the wallet page's openTrading flow, changes to TradeActions could affect the trading entry point rendering or state that these flows depend on.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — This test uses openTradingGlobalButton from the wallet page, which maps to the global trading button rendered by TradeActions.tsx in the page header. A change to TradeActions could break this entry point.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — The assets test interacts with the dashboard layout where HeaderDropdown and TradeActions are rendered. While it primarily tests the assets section, the buy button interaction on assets navigates to trading, which could be affected if TradeActions rendering is broken.
- `suite/e2e/tests/settings/general.test.ts` — HeaderDropdown.tsx is part of the SuiteLayout header visible on the settings page. The test navigates between dashboard and settings pages where the header is rendered. While the test focuses on settings controls, a broken header dropdown could interfere with navigation.

</details>

_Updated: 2026-05-28T07:51:18.593Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/remove-swap-page-header&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/remove-swap-page-header&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-28T08:54:51.354Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-28T08:52:27.018Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/remove-swap-page-header/web/](https://dev.suite.sldev.cz/suite-web/feat/remove-swap-page-header/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->