### PR TITLE
feat(suite): track onboarding step views for drop-off analytics

### DIFF
--- a/packages/suite/src/config/onboarding/steps.ts
+++ b/packages/suite/src/config/onboarding/steps.ts
@@ -112,3 +112,11 @@ export const stepCategories: StepCategory[] = [
         ],
     },
 ];
+
+// 1-based encounter order on the happy path, derived from stepCategories above.
+// Sent as `stepIndex` in the onboarding/step-viewed analytics event so consumers
+// can sort steps without depending on names.
+const onboardingStepOrder = stepCategories.flatMap(category => category.steps.map(step => step.id));
+
+export const getOnboardingStepIndex = (id: Step['id']): number =>
+    onboardingStepOrder.indexOf(id) + 1;

--- a/packages/suite/src/views/onboarding/index.tsx
+++ b/packages/suite/src/views/onboarding/index.tsx
@@ -1,11 +1,14 @@
 import { useEffect, useMemo } from 'react';
 
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { goto } from '@suite/router';
+import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
 import { selectThpStep } from '@suite-common/thp';
 import { exhaustive } from '@trezor/type-utils';
 
 import { OnboardingLayout } from 'src/components/onboarding/OnboardingLayout';
+import { getOnboardingStepIndex } from 'src/config/onboarding/steps';
 import * as STEP from 'src/constants/onboarding/steps';
 import { useDispatch, useOnboarding, useSelector } from 'src/hooks/suite';
 import { UnexpectedState } from 'src/views/onboarding/UnexpectedState';
@@ -21,6 +24,7 @@ import { SecurityStep } from 'src/views/onboarding/steps/SecurityStep';
 
 export const Onboarding = () => {
     const dispatch = useDispatch();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     const { activeStepId, goToNextStep } = useOnboarding();
     const device = useSelector(selectSelectedDevice);
@@ -34,6 +38,19 @@ export const Onboarding = () => {
             dispatch(goto({ routeName: 'suite-index' }));
         }
     }, [device, thpStep, activeStepId, dispatch]);
+
+    // Fires once per step entry. activeStepId is the dep, so it does not fire on
+    // re-render and re-fires on re-entry (e.g. user navigates back and forward).
+    useEffect(() => {
+        analytics.report({
+            type: events.onboardingStepViewedEvent.name,
+            payload: {
+                stepName: activeStepId,
+                stepIndex: getOnboardingStepIndex(activeStepId),
+                platform: 'desktop',
+            },
+        });
+    }, [activeStepId, analytics]);
 
     const StepComponent = useMemo(() => {
         switch (activeStepId) {

--- a/suite/analytics/src/constants.ts
+++ b/suite/analytics/src/constants.ts
@@ -53,6 +53,7 @@ export enum EventType {
     MenuGuide = 'menu/guide',
     MenuNotificationsToggle = 'menu/notifications/toggle',
     MenuToggleDiscreet = 'menu/toggle-discreet',
+    OnboardingStepViewed = 'onboarding/step-viewed',
     PromoDashboardBanner = 'promo/dashboard-banner',
     PromoDesktop = 'promo/desktop',
     PromoMobile = 'promo/mobile',

--- a/suite/analytics/src/events/index.ts
+++ b/suite/analytics/src/events/index.ts
@@ -37,6 +37,7 @@ export { guideTooltipLinkNavigationEvent } from './guideTooltipLinkNavigationEve
 export { menuGuideEvent } from './menuGuideEvent';
 export { menuNotificationsToggleEvent } from './menuNotificationsToggleEvent';
 export { menuToggleDiscreetEvent } from './menuToggleDiscreetEvent';
+export { onboardingStepViewedEvent } from './onboardingStepViewedEvent';
 export { promoDashboardBannerEvent } from './promoDashboardBannerEvent';
 export { promoDesktopEvent } from './promoDesktopEvent';
 export { promoMobileEvent } from './promoMobileEvent';

--- a/suite/analytics/src/events/onboardingStepViewedEvent.ts
+++ b/suite/analytics/src/events/onboardingStepViewedEvent.ts
@@ -1,0 +1,57 @@
+import type { AttributeDef, EventDef } from '@suite-common/analytics';
+
+import { EventType } from '../constants';
+
+// Mirror of AnyStepId in packages/suite/src/types/onboarding — kept inline so
+// this package stays free of the desktop-app dependency edge. Keep in sync.
+type OnboardingStepName =
+    | 'firmware'
+    | 'authenticate-device'
+    | 'tutorial'
+    | 'create-or-recover'
+    | 'backup-type'
+    | 'recovery'
+    | 'security'
+    | 'set-pin'
+    | 'final';
+
+type Attributes = {
+    stepName: AttributeDef<OnboardingStepName>;
+    stepIndex: AttributeDef<number>;
+    platform: AttributeDef<'desktop'>;
+};
+
+export const onboardingStepViewedEvent: EventDef<Attributes, EventType.OnboardingStepViewed> = {
+    name: EventType.OnboardingStepViewed,
+    descriptionTrigger:
+        'Fired once when an onboarding step screen is entered. Re-fires on re-entry (e.g. user navigates back and forward), not on re-render. Desktop only.',
+    description: `Drives the onboarding funnel — every screen the user lands on during initial device setup produces exactly one event. There are 9 possible steps; not all fire in every session because some are model-gated and some are path-gated (create-new-wallet vs. recover-existing-seed). A given session typically fires 6–8 events.`,
+    changelog: [{ version: '26.6.1', notes: 'added' }],
+
+    attributes: {
+        stepName: {
+            changelog: [{ version: '26.6.1', notes: 'added' }],
+            description: `Identifier of the onboarding screen entered. One of:
+
+- \`firmware\` — Firmware installation / update. Shown whenever the connected device needs firmware work; otherwise the user is sent past it.
+- \`authenticate-device\` — Device authenticity (attestation) check. Only fires on T2B1, T3B1, T3T1, and T3W1 (models with Optiga). Older models (T1B1, T2T1) skip it.
+- \`tutorial\` — On-device tutorial walkthrough. Only fires on T2B1, T3B1, T3T1 (firmware ≥ 2.8.0), and T3W1.
+- \`create-or-recover\` — User picks between *create new wallet* and *recover existing seed*. This choice branches the rest of the funnel.
+- \`backup-type\` — Pick the backup format (BIP-39 vs. SLIP-39 variants). **Only fired when the user selects *create new wallet*** on \`create-or-recover\`.
+- \`recovery\` — Seed-recovery flow. **Only fired when the user selects *recover existing seed*** on \`create-or-recover\`.
+- \`security\` — Wallet creation + backup on device (\`resetDevice\` with \`skip_backup: false\`). Fires on both paths.
+- \`set-pin\` — PIN setup. Fires on both paths.
+- \`final\` — Onboarding success screen. Fires on both paths.`,
+        },
+        stepIndex: {
+            changelog: [{ version: '26.6.1', notes: 'added' }],
+            description:
+                '1-based ordinal of the step on the happy path (e.g. `firmware` = 1, `final` = 9). Lets consumers sort steps without depending on the string name. Derived from `stepCategories` in `packages/suite/src/config/onboarding/steps.ts` — keep that file as the source of truth.',
+        },
+        platform: {
+            changelog: [{ version: '26.6.1', notes: 'added' }],
+            description:
+                'Always `desktop`. Onboarding runs only on the desktop app; mobile/native have a separate flow and do not emit this event.',
+        },
+    },
+};


### PR DESCRIPTION
Add onboarding/step-viewed event fired once per step entry from the onboarding parent component. The useEffect depends on activeStepId, so the event fires on entry, never on re-render, and re-fires on re-entry. stepIndex is derived from the existing stepCategories config so the canonical step order stays a single source of truth.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/28139

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies onboarding step configuration, the onboarding view component, and the analytics events module (adding a new onboardingStepViewedEvent). The highest risk is breaking the onboarding flow navigation or step ordering, which would affect all tests that go through onboarding. However, since steps.ts and onboarding/index.tsx map to 121+ tests, only tests that specifically exercise the onboarding flow itself (not just pass through it) are prioritized. The analytics event changes (new event type, constants, events/index re-export) primarily risk breaking existing analytics event assertions. The recommended strategy is to run onboarding-specific tests across device models and analytics event tests as high priority, with additional onboarding edge cases and settings analytics tests at medium priority.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/config/onboarding/steps.ts`
- `packages/suite/src/views/onboarding/index.tsx`
- `suite/analytics/src/constants.ts`
- `suite/analytics/src/events/index.ts`
- `suite/analytics/src/events/onboardingStepViewedEvent.ts`

</details>

**Recommended tests (20)**

<details><summary>🔴 <b>High priority (8)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — This test directly validates analytics events including suiteReadyEvent, deviceConnectEvent, transportTypeEvent, and settingsAnalyticsEvent — all defined in suite/analytics/src/events/index.ts and suite/analytics/src/constants.ts which were changed. The new onboardingStepViewedEvent may also affect the analytics event infrastructure exercised here.
- `suite/e2e/tests/analytics/toggle.test.ts` — This test exercises analytics enable/disable during onboarding and verifies specific analytics events (settingsAnalyticsEvent, suiteReadyEvent) are fired or suppressed. Changes to analytics constants, events/index.ts, and the onboarding view directly affect this test's code paths.
- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — This test directly exercises the onboarding flow and analytics consent dialog. Changes to the onboarding view (index.tsx) and onboarding steps configuration (steps.ts) directly affect the onboarding flow navigation and analytics consent rendering.
- `suite/e2e/tests/onboarding/firmware-check.test.ts` — This test validates firmware readiness detection during onboarding across multiple device models. Changes to onboarding steps.ts and the onboarding view directly affect step ordering and flow logic that this test exercises.
- `suite/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts` — This test walks through the full onboarding wallet creation flow (analytics consent → firmware → wallet creation → backup → PIN) which directly exercises the onboarding view and step configuration changes.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-success.test.ts` — Full recovery onboarding flow (analytics → firmware → recovery → PIN → final) directly exercises the onboarding view and step configuration. A broken step sequence would cause this test to fail.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts` — Tests the complete T3T1 onboarding flow including analytics, firmware, authenticity check, tutorial skip, Shamir backup, and PIN setup — all governed by the onboarding steps configuration and view that were changed.
- `suite/e2e/tests/suite/initial-run.test.ts` — This test verifies that the onboarding/initial-run flow persists correctly across page reloads and that step progression (analytics → complete onboarding) works. Changes to steps.ts and the onboarding view directly affect this persistence and navigation logic.

</details>

<details><summary>🟡 <b>Medium priority (9)</b></summary>

- `suite/e2e/tests/analytics/staking-events.test.ts` — Tests StakingNavigate analytics events which are defined in the analytics events module. Changes to events/index.ts and constants.ts could affect event type definitions or exports used by this test.
- `suite/e2e/tests/analytics/wallet-connect-events.test.ts` — Tests WalletConnect analytics events (WalletConnectInit, WalletConnectPaired, etc.) which depend on EventType constants from the analytics module. Changes to constants.ts and events/index.ts could affect these event definitions.
- `suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts` — Tests the T1B1 onboarding wallet creation flow which exercises the onboarding steps and view. While a different device model, the step configuration changes could affect this flow.
- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-success.test.ts` — Tests T1B1 recovery onboarding flow through analytics, firmware, and recovery steps — all governed by the changed step configuration and onboarding view.
- `suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts` — Tests entropy check failure handling during the onboarding wallet creation flow, which navigates through the onboarding steps affected by the changed files.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts` — Tests that recovery mode persists across page reloads during onboarding, directly exercising the onboarding view's state management and step configuration.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts` — Tests offline onboarding wallet creation which exercises the onboarding flow and step progression in a degraded network state. Changes to steps.ts could break step ordering.
- `suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts` — Tests the T3W1 onboarding flow including THP pairing, firmware, tutorial, Shamir backup, and PIN — all using the onboarding view and step configuration that were changed.
- `suite/e2e/tests/settings/general.test.ts` — Tests multiple analytics events fired from settings (settingsGeneralChangeFiatEvent, settingsGeneralChangeThemeEvent, settingsAnalyticsEvent) which are defined in the analytics events module that was changed.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/analytics/promo-banner-events.test.ts` — Tests PromoDashboardBanner analytics events. While it uses EventType constants from the changed analytics module, the specific event type is unlikely to be affected by adding a new onboardingStepViewedEvent.
- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-advanced.test.ts` — Tests T1B1 advanced recovery which exercises the onboarding flow steps. Less likely to be affected than create-wallet or standard recovery flows, but step configuration changes could still impact navigation.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-fail.test.ts` — Tests device disconnection during T2T1 recovery onboarding. The error recovery path through onboarding steps could be affected by step configuration changes.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/analytics/src/events/onboardingStepViewedEvent.ts`

_Updated: 2026-05-28T08:34:25.799Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=28139-onboarding-end-tracking&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=28139-onboarding-end-tracking&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-28T08:39:35.059Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-28T08:37:25.392Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/28139-onboarding-end-tracking/web/](https://dev.suite.sldev.cz/suite-web/28139-onboarding-end-tracking/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->