### PR TITLE
Add Solana unstaking flow to suite-native

### DIFF
--- a/suite-native/blockchain/src/blockchainThunks.ts
+++ b/suite-native/blockchain/src/blockchainThunks.ts
@@ -86,7 +86,7 @@ export const onBlockchainConnectThunk = createThunk(
 export const onBlockchainNotificationThunk = createThunk(
     `${BLOCKCHAIN_MODULE_PREFIX}/onNotificationThunk`,
     (payload: BlockchainNotification, { dispatch, getState }) => {
-        const { descriptor } = payload.notification;
+        const { descriptor, tx } = payload.notification;
         const symbol = payload.coin.shortcut.toLowerCase();
         if (!isNetworkSymbol(symbol)) {
             return;
@@ -99,7 +99,10 @@ export const onBlockchainNotificationThunk = createThunk(
         );
 
         if (!account) return;
-        if (!shouldRefetchAccount({ accountKey: account.key })) return;
+
+        // Skip throttle for pending txs so broadcast shows immediately. Throttle still applies to confirmed.
+        const isPendingNotification = !tx?.blockHeight;
+        if (!isPendingNotification && !shouldRefetchAccount({ accountKey: account.key })) return;
 
         // Sometimes we randomly get notifications for all transactions in account at once, which would trigger lot of fetches.
         // We are throttling per account, we don't want to fetch account too often to save resources.

--- a/suite-native/module-earn/src/components/EarnTransactionDataReviewStepList.tsx
+++ b/suite-native/module-earn/src/components/EarnTransactionDataReviewStepList.tsx
@@ -2,8 +2,9 @@ import { useState } from 'react';
 import { View } from 'react-native';
 import { useSelector } from 'react-redux';
 
-import { type NetworkSymbol, getNetworkDecimals } from '@suite-common/wallet-config';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type AccountKey } from '@suite-common/wallet-types';
+import { asAmountUnit, unitsToSubunits } from '@suite-common/wallet-utils';
 import { Button, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
@@ -61,10 +62,10 @@ export const EarnTransactionDataReviewStepList = ({
         }
     };
 
-    const networkDecimals = getNetworkDecimals(accountSymbol) ?? 18;
-    const amountInWei = new BigNumber(amount)
-        .times(new BigNumber(10).pow(networkDecimals))
-        .toFixed(0);
+    const amountInBaseUnits = unitsToSubunits({
+        value: asAmountUnit(new BigNumber(amount)),
+        symbol: accountSymbol,
+    }).toString();
 
     return (
         <View>
@@ -77,7 +78,7 @@ export const EarnTransactionDataReviewStepList = ({
 
                 <EarnSummaryOutputItem
                     accountKey={accountKey}
-                    amount={amountInWei}
+                    amount={amountInBaseUnits}
                     fee={summaryOutput?.fee ?? '0'}
                     outputState={summaryOutput?.state}
                     onLayout={event => handleReadListItemHeight(event, 1)}

--- a/suite-native/module-earn/src/components/StakeClaimableCard.tsx
+++ b/suite-native/module-earn/src/components/StakeClaimableCard.tsx
@@ -5,7 +5,7 @@ import { useNavigation } from '@react-navigation/native';
 import { BASE_CRYPTO_MAX_DISPLAYED_DECIMALS } from '@suite-common/formatters';
 import { selectAccountNetworkSymbol, useAccountsSelector } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
-import { isPositiveBalance } from '@suite-common/wallet-utils';
+import { isPositiveBalance, isSupportedEthStakingNetworkSymbol } from '@suite-common/wallet-utils';
 import { Box, Card, InlineAlertBox, PressableOpacity, Text } from '@suite-native/atoms';
 import { CryptoAmountFormatter, CryptoToFiatAmountFormatter } from '@suite-native/formatters';
 import { Translation } from '@suite-native/intl';
@@ -59,7 +59,11 @@ export const StakeClaimableCard = ({ accountKey }: StakeClaimableCardProps) => {
         navigation.navigate(RootStackRoutes.ClaimReview, { accountKey, symbol });
     }, [accountKey, navigation, symbol, isClaimingDisabled]);
 
-    if (!symbol || !isPositiveBalance(claimableAmount)) {
+    if (
+        !symbol ||
+        !isPositiveBalance(claimableAmount) ||
+        !isSupportedEthStakingNetworkSymbol(symbol)
+    ) {
         return null;
     }
 

--- a/suite-native/module-earn/src/components/StakingManagementPendingSection.tsx
+++ b/suite-native/module-earn/src/components/StakingManagementPendingSection.tsx
@@ -1,5 +1,6 @@
+import { selectAccountNetworkSymbol } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
-import { isPositiveBalance } from '@suite-common/wallet-utils';
+import { isPositiveBalance, isSupportedEthStakingNetworkSymbol } from '@suite-common/wallet-utils';
 import { Text, VStack, useBottomSheetModal } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
@@ -43,6 +44,9 @@ export const StakingManagementPendingSection = ({
     const canClaim = useSelector((state: NativeStakingRootState) =>
         selectCanClaimByAccountKey(state, accountKey),
     );
+    const symbol = useSelector((state: NativeStakingRootState) =>
+        selectAccountNetworkSymbol(state, accountKey),
+    );
 
     const {
         bottomSheetRef: unstakingModalRef,
@@ -55,7 +59,11 @@ export const StakingManagementPendingSection = ({
         closeModal: closePendingStakeModal,
     } = useBottomSheetModal();
 
-    const isClaim = isPositiveBalance(claimableAmount) && canClaim;
+    const isClaim =
+        isPositiveBalance(claimableAmount) &&
+        canClaim &&
+        !!symbol &&
+        isSupportedEthStakingNetworkSymbol(symbol);
     const hasPendingUnstaking =
         isPositiveBalance(unstakingBalance) && !new BigNumber(unstakingBalance).eq(claimableAmount);
     const hasPendingDeposit = isPositiveBalance(totalStakePending);

--- a/suite-native/module-earn/src/components/UnstakeTransactionDataReviewStepList.tsx
+++ b/suite-native/module-earn/src/components/UnstakeTransactionDataReviewStepList.tsx
@@ -5,10 +5,10 @@ import { useSelector } from 'react-redux';
 import { type RouteProp, useRoute } from '@react-navigation/native';
 
 import { type AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
+import { asAmountUnit, unitsToSubunits } from '@suite-common/wallet-utils';
 import { Button, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { type RootStackParamList, type RootStackRoutes } from '@suite-native/navigation';
-import { ethToWei } from '@suite-native/staking';
 import {
     LIST_VERTICAL_SPACING,
     SlidingFooterOverlay,
@@ -17,6 +17,7 @@ import {
     selectReviewSummaryOutput,
     useActiveStepOffset,
 } from '@suite-native/transaction-management';
+import { BigNumber } from '@trezor/utils';
 
 import { EarnSummaryOutputItem } from './EarnSummaryOutputItem';
 import { UnstakeOutputItem } from './UnstakeOutputItem';
@@ -59,6 +60,10 @@ export const UnstakeTransactionDataReviewStepList = ({
         onTransactionSubmitted,
     });
 
+    if (!accountSymbol) {
+        return null;
+    }
+
     const areAllStepsDone = stepIndex === NUMBER_OF_STEPS - 1 || isTransactionReviewInProgress;
 
     const handleNextStep = () => {
@@ -69,27 +74,27 @@ export const UnstakeTransactionDataReviewStepList = ({
         }
     };
 
-    const amountInWei = ethToWei(amount);
+    const amountInBaseUnits = unitsToSubunits({
+        value: asAmountUnit(new BigNumber(amount)),
+        symbol: accountSymbol,
+    }).toString();
 
     return (
         <View>
             <VStack spacing={LIST_VERTICAL_SPACING}>
-                {!!accountSymbol && (
-                    <>
-                        <UnstakeOutputItem
-                            symbol={accountSymbol}
-                            outputState={stepIndex > 0 ? 'success' : 'active'}
-                            onLayout={event => handleReadListItemHeight(event, 0)}
-                        />
-                        <EarnSummaryOutputItem
-                            accountKey={accountKey}
-                            amount={amountInWei}
-                            fee={summaryOutput?.fee ?? selectedPrecomposed?.fee ?? '0'}
-                            outputState={summaryOutput?.state}
-                            onLayout={event => handleReadListItemHeight(event, 1)}
-                        />
-                    </>
-                )}
+                <UnstakeOutputItem
+                    symbol={accountSymbol}
+                    outputState={stepIndex > 0 ? 'success' : 'active'}
+                    onLayout={event => handleReadListItemHeight(event, 0)}
+                />
+
+                <EarnSummaryOutputItem
+                    accountKey={accountKey}
+                    amount={amountInBaseUnits}
+                    fee={summaryOutput?.fee ?? selectedPrecomposed?.fee ?? '0'}
+                    outputState={summaryOutput?.state}
+                    onLayout={event => handleReadListItemHeight(event, 1)}
+                />
             </VStack>
             {!areAllStepsDone && (
                 <SlidingFooterOverlay activeStepOffset={activeStepBottomOffset}>

--- a/suite-native/module-earn/src/hooks/useComposeEarnFees.ts
+++ b/suite-native/module-earn/src/hooks/useComposeEarnFees.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
+import { useIsFocused } from '@react-navigation/native';
 import { isFulfilled } from '@reduxjs/toolkit';
 
 import { createThunk } from '@suite-common/redux-utils';
@@ -83,6 +84,7 @@ export const useComposeEarnFees = ({
 }: UseComposeEarnFeesParams) => {
     const dispatch = useDispatch();
     const debounce = useDebounce();
+    const isFocused = useIsFocused();
     const {
         draft: formDraft,
         formDraftKey,
@@ -110,6 +112,9 @@ export const useComposeEarnFees = ({
         selectedFee,
         isLoading: areFeesLoading || isComposingFeeLevels,
     });
+
+    const effectiveFeeLevel = selectedFeeLevel ?? feeLevels.normal;
+    const isPrecomposeError = !isComposingFeeLevels && effectiveFeeLevel?.type === 'error';
 
     const composeFeeLevels = useCallback(async () => {
         if (!formState || !account || !feeInfo) {
@@ -173,14 +178,16 @@ export const useComposeEarnFees = ({
     }, [dispatch, formState, account, feeInfo, saveDraft, accountKey, formDraftPrefix]);
 
     useEffect(() => {
+        if (!isFocused) return;
         setIsComposingFeeLevels(!!formState && !!account && !!feeInfo);
         debounce(composeFeeLevels);
-    }, [account, debounce, composeFeeLevels, feeInfo, formState]);
+    }, [isFocused, account, debounce, composeFeeLevels, feeInfo, formState]);
 
     return {
         formDraft,
         formDraftKey,
         isFeeUnavailable: formState !== undefined && !isComposingFeeLevels && isFeeUnavailable,
+        isPrecomposeError,
         updateFeeLevelThunk: updateEarnSelectedFeeLevelThunk,
     };
 };

--- a/suite-native/module-earn/src/hooks/useEarnForm.ts
+++ b/suite-native/module-earn/src/hooks/useEarnForm.ts
@@ -54,11 +54,12 @@ export const useEarnForm = (accountKey: AccountKey) => {
         );
     }, [account, isValid, amountValue]);
 
-    const { formDraft, formDraftKey, isFeeUnavailable, updateFeeLevelThunk } = useComposeEarnFees({
-        accountKey,
-        formState: stakeFormState,
-        formDraftPrefix: 'stake',
-    });
+    const { formDraft, formDraftKey, isFeeUnavailable, isPrecomposeError, updateFeeLevelThunk } =
+        useComposeEarnFees({
+            accountKey,
+            formState: stakeFormState,
+            formDraftPrefix: 'stake',
+        });
 
     if (!account) return null;
 
@@ -69,6 +70,7 @@ export const useEarnForm = (accountKey: AccountKey) => {
         formDraft,
         formDraftKey,
         isFeeUnavailable,
+        isPrecomposeError,
         updateFeeLevelThunk,
     };
 };

--- a/suite-native/module-earn/src/hooks/useStakingPromoNavigation.ts
+++ b/suite-native/module-earn/src/hooks/useStakingPromoNavigation.ts
@@ -8,6 +8,7 @@ import { selectIsDeviceInViewOnlyMode } from '@suite-common/device';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { selectVisibleDeviceAccounts } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
+import { isSupportedSolStakingNetworkSymbol } from '@suite-common/wallet-utils';
 import { useAccountAlerts } from '@suite-native/accounts';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { useBottomSheetModal } from '@suite-native/atoms';
@@ -132,6 +133,13 @@ export const useStakingPromoNavigation = () => {
 
     const handleStakingPromoPress = useCallback(
         (item: StakingEarnItem) => {
+            // Temperary solution for SOL, while waiting for the Solana StakingManagement dashboard to be merged.
+            if (isSupportedSolStakingNetworkSymbol(item.symbol)) {
+                openInfoModal();
+
+                return;
+            }
+
             if (!isStakeFlowSupportedSymbol(item.symbol)) {
                 openInfoModal();
 

--- a/suite-native/module-earn/src/hooks/useUnstakeForm.ts
+++ b/suite-native/module-earn/src/hooks/useUnstakeForm.ts
@@ -54,6 +54,11 @@ export const useUnstakeForm = (accountKey: AccountKey) => {
     const unstakeFormState = useMemo(() => {
         if (!account || !isValid || !amountValue) return undefined;
 
+        if (account.networkType === 'solana') {
+            // Solana compose uses output amount (not calldata); pass the real amount, not '0'.
+            return buildEarnComposeFormState(account.descriptor, amountValue, '');
+        }
+
         const amountWei = ethToWei(amountValue);
         if (!isPositiveBalance(amountWei)) return undefined;
 
@@ -64,11 +69,12 @@ export const useUnstakeForm = (accountKey: AccountKey) => {
         );
     }, [account, isValid, amountValue]);
 
-    const { formDraft, formDraftKey, isFeeUnavailable, updateFeeLevelThunk } = useComposeEarnFees({
-        accountKey,
-        formState: unstakeFormState,
-        formDraftPrefix: 'unstake',
-    });
+    const { formDraft, formDraftKey, isFeeUnavailable, isPrecomposeError, updateFeeLevelThunk } =
+        useComposeEarnFees({
+            accountKey,
+            formState: unstakeFormState,
+            formDraftPrefix: 'unstake',
+        });
 
     const approximatedInstantEthAmount = useApproximateInstantUnstakeAmount(
         accountKey,
@@ -95,6 +101,7 @@ export const useUnstakeForm = (accountKey: AccountKey) => {
         formDraft,
         formDraftKey,
         isFeeUnavailable,
+        isPrecomposeError,
         updateFeeLevelThunk,
         approximatedInstantEthAmount,
     };

--- a/suite-native/module-earn/src/screens/ClaimReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/ClaimReviewScreen.tsx
@@ -13,6 +13,7 @@ import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet
 import {
     asAmountSubunit,
     getStakingLimitsByNetworkSymbol,
+    isSupportedEthStakingNetworkSymbol,
     subunitsToUnits,
 } from '@suite-common/wallet-utils';
 import { AccountDetailsCard } from '@suite-native/accounts';
@@ -74,11 +75,12 @@ export const ClaimReviewScreen = () => {
         [symbol],
     );
 
-    const { formDraft, formDraftKey, isFeeUnavailable, updateFeeLevelThunk } = useComposeEarnFees({
-        accountKey,
-        formState: claimFormState,
-        formDraftPrefix: 'claim',
-    });
+    const { formDraft, formDraftKey, isFeeUnavailable, isPrecomposeError, updateFeeLevelThunk } =
+        useComposeEarnFees({
+            accountKey,
+            formState: claimFormState,
+            formDraftPrefix: 'claim',
+        });
 
     const { analytics } = useServices(selectNativeAnalyticsDep);
     const registerNavigateBackAnalytics = useNavigateBackAnalytics({
@@ -122,7 +124,12 @@ export const ClaimReviewScreen = () => {
                 <Box paddingHorizontal="sp16" paddingBottom="sp16">
                     <Button
                         onPress={handleReviewAndSign}
-                        isDisabled={isInsufficientFeeBalance || isFeeUnavailable}
+                        isDisabled={
+                            isInsufficientFeeBalance ||
+                            isFeeUnavailable ||
+                            isPrecomposeError ||
+                            !isSupportedEthStakingNetworkSymbol(symbol)
+                        }
                     >
                         <Translation id="earn.claimReviewScreen.reviewAndSignButton" />
                     </Button>

--- a/suite-native/module-earn/src/screens/ClaimTransactionDataReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/ClaimTransactionDataReviewScreen.tsx
@@ -11,7 +11,6 @@ import {
     selectTransactionByAccountKeyAndTxid,
 } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
-import { isSupportedEthStakingNetworkSymbol } from '@suite-common/wallet-utils';
 import { Button, Card, LottieAnimation, Text, VStack } from '@suite-native/atoms';
 import {
     ConfirmOnTrezorWrapper,
@@ -35,6 +34,7 @@ import {
 } from '@suite-native/transaction-management';
 
 import { ClaimTransactionDataReviewStepList } from '../components/ClaimTransactionDataReviewStepList';
+import { getEarnPostSignParentRoute } from '../utils';
 
 const navigateToClaimedTransactionAction = ({
     accountKey,
@@ -52,12 +52,7 @@ const navigateToClaimedTransactionAction = ({
                 name: RootStackRoutes.AppTabs,
                 params: { screen: AppTabsRoutes.EarnStack },
             },
-            {
-                name: isSupportedEthStakingNetworkSymbol(symbol)
-                    ? RootStackRoutes.StakingManagement
-                    : RootStackRoutes.StakingDetail,
-                params: { accountKey },
-            },
+            getEarnPostSignParentRoute(symbol, accountKey),
             {
                 name: RootStackRoutes.TransactionDetailStack,
                 params: {

--- a/suite-native/module-earn/src/screens/EarnFormScreen.tsx
+++ b/suite-native/module-earn/src/screens/EarnFormScreen.tsx
@@ -59,6 +59,7 @@ export const EarnFormScreen = () => {
         formDraft,
         formDraftKey,
         isFeeUnavailable,
+        isPrecomposeError,
         updateFeeLevelThunk,
     } = earnForm;
     const {
@@ -91,7 +92,7 @@ export const EarnFormScreen = () => {
                     accountKey={accountKey}
                     symbol={account.symbol}
                     amountValue={amountValue}
-                    isDisabled={!isValid || isFeeUnavailable}
+                    isDisabled={!isValid || isFeeUnavailable || isPrecomposeError}
                     isDirty={isDirty}
                     onPress={() => handleSubmit()}
                 />

--- a/suite-native/module-earn/src/screens/UnstakeFlowScreen.tsx
+++ b/suite-native/module-earn/src/screens/UnstakeFlowScreen.tsx
@@ -65,6 +65,7 @@ export const UnstakeFlowScreen = () => {
         formDraft,
         formDraftKey,
         isFeeUnavailable,
+        isPrecomposeError,
         updateFeeLevelThunk,
         approximatedInstantEthAmount,
     } = unstakeForm;
@@ -98,7 +99,7 @@ export const UnstakeFlowScreen = () => {
                     <ScreenFooterGradient />
                     <Box paddingHorizontal="sp16" paddingBottom="sp16">
                         <Button
-                            isDisabled={!isValid || isFeeUnavailable}
+                            isDisabled={!isValid || isFeeUnavailable || isPrecomposeError}
                             onPress={handleReviewAndSign}
                         >
                             <Translation id="earn.earnFormScreen.reviewAndSign" />

--- a/suite-native/module-earn/src/screens/UnstakeTransactionDataReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/UnstakeTransactionDataReviewScreen.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 
-import { CommonActions, useFocusEffect } from '@react-navigation/native';
+import { CommonActions } from '@react-navigation/native';
 
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import {
@@ -11,7 +11,6 @@ import {
     selectTransactionByAccountKeyAndTxid,
 } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
-import { isSupportedEthStakingNetworkSymbol } from '@suite-common/wallet-utils';
 import { Button, Card, LottieAnimation, Text, VStack } from '@suite-native/atoms';
 import {
     ConfirmOnTrezorWrapper,
@@ -29,14 +28,13 @@ import {
 } from '@suite-native/navigation';
 import {
     type TransactionReviewOutputsState,
-    selectIsReceiveAddressOutputConfirmed,
     selectIsTransactionAlreadySigned,
     selectIsTransactionReviewInProgress,
     sendArrowsLottie,
 } from '@suite-native/transaction-management';
 
 import { UnstakeTransactionDataReviewStepList } from '../components/UnstakeTransactionDataReviewStepList';
-import { useStakingDetailNavigation } from '../hooks/useStakingDetailNavigation';
+import { getEarnPostSignParentRoute } from '../utils';
 
 const navigateToUnstakedTransactionAction = ({
     accountKey,
@@ -54,12 +52,7 @@ const navigateToUnstakedTransactionAction = ({
                 name: RootStackRoutes.AppTabs,
                 params: { screen: AppTabsRoutes.EarnStack },
             },
-            {
-                name: isSupportedEthStakingNetworkSymbol(symbol)
-                    ? RootStackRoutes.StakingManagement
-                    : RootStackRoutes.StakingDetail,
-                params: { accountKey },
-            },
+            getEarnPostSignParentRoute(symbol, accountKey),
             {
                 name: RootStackRoutes.TransactionDetailStack,
                 params: {
@@ -81,13 +74,8 @@ export const UnstakeTransactionDataReviewScreen = ({
     const { confirmOnTrezorRef, revealConfirmOnTrezorSheet, closeSheet } =
         useConfirmOnTrezorController();
     const { accountKey } = route.params;
-    const { navigateToStakingDetail } = useStakingDetailNavigation();
     const navigateToInitialScreen = useNavigateToInitialScreen();
     const [txid, setTxid] = useState<string>('');
-
-    const isAddressConfirmed = useSelector((state: TransactionReviewOutputsState) =>
-        selectIsReceiveAddressOutputConfirmed(state, 'unstake', accountKey),
-    );
 
     const isTransactionReviewInProgress = useSelector((state: TransactionReviewOutputsState) =>
         selectIsTransactionReviewInProgress(state, 'unstake', accountKey),
@@ -104,14 +92,6 @@ export const UnstakeTransactionDataReviewScreen = ({
     );
 
     const showSignSuccessMessage = isTransactionAlreadySigned && !!account;
-
-    useFocusEffect(
-        useCallback(() => {
-            if (isAddressConfirmed && account) {
-                navigateToStakingDetail({ accountKey, symbol: account.symbol });
-            }
-        }, [account, accountKey, isAddressConfirmed, navigateToStakingDetail]),
-    );
 
     useEffect(() => {
         if (isTransactionReviewInProgress) {

--- a/suite-native/module-earn/src/utils.ts
+++ b/suite-native/module-earn/src/utils.ts
@@ -1,14 +1,29 @@
 import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { type FormState } from '@suite-common/wallet-types';
+import { type AccountKey, type FormState } from '@suite-common/wallet-types';
 import {
     isSupportedEthStakingNetworkSymbol,
     isSupportedSolStakingNetworkSymbol,
 } from '@suite-common/wallet-utils';
+import { RootStackRoutes } from '@suite-native/navigation';
 
 import { USER_CANCELLED_ERROR_CODES } from './constants';
 
 export const isStakeFlowSupportedSymbol = (symbol: NetworkSymbol): boolean =>
     isSupportedEthStakingNetworkSymbol(symbol) || isSupportedSolStakingNetworkSymbol(symbol);
+
+export const getEarnPostSignParentRoute = (symbol: NetworkSymbol, accountKey: AccountKey) => {
+    if (isStakeFlowSupportedSymbol(symbol)) {
+        return {
+            name: RootStackRoutes.StakingManagement,
+            params: { accountKey },
+        } as const;
+    }
+
+    return {
+        name: RootStackRoutes.StakingDetail,
+        params: { accountKey },
+    } as const;
+};
 
 export const buildEarnComposeFormState = (
     contractAddress: string,

--- a/suite-native/staking/src/__tests__/solanaStakingSelectors.test.ts
+++ b/suite-native/staking/src/__tests__/solanaStakingSelectors.test.ts
@@ -69,6 +69,31 @@ const solAccountWithActivatingStaking: Account = {
     },
 } as unknown as Account;
 
+const solAccountWithActiveAndDeactivatingStaking: Account = {
+    symbol: 'sol',
+    accountLabel: 'SOL Account #5',
+    deviceState: staticStateString,
+    addresses: undefined,
+    key: 'sol5',
+    visible: true,
+    networkType: 'solana',
+    misc: {
+        solStakingAccounts: [
+            {
+                status: 'active',
+                stake: BigInt('1000000000'),
+                rentExemptReserve: BigInt('10'),
+            },
+            {
+                status: 'deactivating',
+                stake: BigInt('2000000000'),
+                rentExemptReserve: BigInt('20'),
+            },
+        ],
+        solEpoch: 5,
+    },
+} as unknown as Account;
+
 const solAccountWithDeactivatedStaking: Account = {
     symbol: 'sol',
     accountLabel: 'SOL Account #4',
@@ -398,6 +423,21 @@ describe('selectors', () => {
                     'non-existent-key' as AccountKey, // Todo: create properly via `createAccountKey()`
                 ),
             ).toEqual('0');
+        });
+
+        it('should exclude deactivating stake from the staked balance', () => {
+            const testState = getTestState({
+                accounts: [solAccountWithActiveAndDeactivatingStaking],
+            });
+
+            expect(
+                selectSolanaStakedBalanceByAccountKey(
+                    {
+                        ...testState,
+                    },
+                    'sol5' as AccountKey, // Todo: create properly via `createAccountKey()`
+                ),
+            ).toEqual('1');
         });
     });
 

--- a/suite-native/staking/src/__tests__/stakeFormSolanaNativeThunks.test.ts
+++ b/suite-native/staking/src/__tests__/stakeFormSolanaNativeThunks.test.ts
@@ -54,6 +54,16 @@ jest.mock('@trezor/coins-solana/runtime', () => ({
                     feeIncludingRentLamports: '2287880',
                 },
             }),
+            prepareUnstakeSolTx: jest.fn().mockResolvedValue({
+                success: true,
+                txShim: solanaTxShim,
+                solanaTxMeta: {
+                    deviceAmountLamports: '1000000000',
+                    feeLamports: '5000',
+                    rentLamports: '2282880',
+                    feeIncludingRentLamports: '2287880',
+                },
+            }),
             address: (value: string) => value,
         }),
 }));
@@ -200,7 +210,7 @@ describe('composeSolanaStakingTransactionFeeLevelsNativeThunk', () => {
         expect(levels.normal.solanaTxMeta.feeIncludingRentLamports).toBe('2287880');
     });
 
-    it('rejects unstake (out of scope on mobile)', async () => {
+    it('composes an unstake the same way as stake', async () => {
         const store = buildStore();
 
         const result = await dispatchCompose(store, {
@@ -209,11 +219,26 @@ describe('composeSolanaStakingTransactionFeeLevelsNativeThunk', () => {
             amount: '1',
         });
 
+        expect(result.ok).toBe(true);
+        const levels = (result as { payload: Record<string, any> }).payload;
+        expect(levels.normal.type).toBe('final');
+        expect(levels.normal.solanaTxMeta.feeIncludingRentLamports).toBe('2287880');
+    });
+
+    it('rejects claim (out of scope on mobile)', async () => {
+        const store = buildStore();
+
+        const result = await dispatchCompose(store, {
+            accountKey: SOL_ACCOUNT_KEY,
+            stakeType: 'claim',
+            amount: '1',
+        });
+
         expect(result).toEqual({
             ok: false,
             error: {
                 error: 'not-implemented',
-                message: 'Solana unstake is not supported on mobile.',
+                message: 'Solana claim is not supported on mobile.',
             },
         });
     });

--- a/suite-native/staking/src/__tests__/stakeNativeThunks.test.ts
+++ b/suite-native/staking/src/__tests__/stakeNativeThunks.test.ts
@@ -61,6 +61,16 @@ jest.mock('@trezor/coins-solana/runtime', () => ({
                     feeIncludingRentLamports: '2287880',
                 },
             }),
+            prepareUnstakeSolTx: jest.fn().mockResolvedValue({
+                success: true,
+                txShim: solanaTxShim,
+                solanaTxMeta: {
+                    deviceAmountLamports: '1000000000',
+                    feeLamports: '5000',
+                    rentLamports: '2282880',
+                    feeIncludingRentLamports: '2287880',
+                },
+            }),
             address: (value: string) => value,
         }),
 }));
@@ -255,8 +265,7 @@ describe('signStakeTransactionNativeThunk', () => {
         expect(ethereumSignTransactionMock).not.toHaveBeenCalled();
     });
 
-    it('rejects solana unstake/claim (out of scope on mobile)', async () => {
-        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    it('routes solana unstake to the solana staking thunk', async () => {
         const store = buildStore({
             accounts: [solAccount],
             blockchain: { sol: { url: 'http://localhost:8899' } },
@@ -268,11 +277,51 @@ describe('signStakeTransactionNativeThunk', () => {
             precomposedTransaction: buildSolanaPrecomposedTransaction(),
         });
 
+        expect(result).toEqual({ ok: true, txid: '0xpushedtxid' });
+        expect(solanaSignTransactionMock).toHaveBeenCalledTimes(1);
+        expect(ethereumSignTransactionMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects solana claim (out of scope on mobile)', async () => {
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const store = buildStore({
+            accounts: [solAccount],
+            blockchain: { sol: { url: 'http://localhost:8899' } },
+        });
+
+        const result = await dispatchDispatcher(store, {
+            accountKey: SOL_ACCOUNT_KEY,
+            stakeType: 'claim',
+            precomposedTransaction: buildSolanaPrecomposedTransaction(),
+        });
+
+        expect(result.ok).toBe(false);
+        expect(solanaSignTransactionMock).not.toHaveBeenCalled();
+        expect(ethereumSignTransactionMock).not.toHaveBeenCalled();
+        errorSpy.mockRestore();
+    });
+
+    it('rejects for unsupported networkType (cardano)', async () => {
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const cardanoAccount = {
+            ...solAccount,
+            symbol: 'ada',
+            networkType: 'cardano',
+            key: 'ada1' as AccountKey,
+        } as unknown as Account;
+        const store = buildStore({ accounts: [cardanoAccount] });
+
+        const result = await dispatchDispatcher(store, {
+            accountKey: 'ada1' as AccountKey,
+            stakeType: 'stake',
+            precomposedTransaction: buildPrecomposedTransaction(),
+        });
+
         expect(result).toEqual({
             ok: false,
             error: {
                 error: 'sign-transaction-failed',
-                message: 'Solana unstake is not supported on mobile.',
+                message: 'Staking is not supported for network type: cardano',
             },
         });
         expect(solanaSignTransactionMock).not.toHaveBeenCalled();

--- a/suite-native/staking/src/ethereumStakingSelectors.ts
+++ b/suite-native/staking/src/ethereumStakingSelectors.ts
@@ -128,15 +128,7 @@ export const selectUnstakingPeriodInDaysBySymbol = (
     return getUnstakingPeriodInDays(symbol ? getNetworkType(symbol) : undefined, validatorsQueue);
 };
 
-export const selectEntryPeriodInDaysBySymbol = (
-    state: NativeStakingRootState,
-    symbol?: NetworkSymbol,
-) => {
-    // Solana has no validator queue; entry period is one epoch, same as unstaking
-    if (symbol && getNetworkType(symbol) === 'solana') {
-        return getUnstakingPeriodInDays('solana');
-    }
-
+export const selectEthereumEntryPeriodInDays = (state: NativeStakingRootState) => {
     const validatorsQueue = selectEthValidatorsQueue(state);
 
     if (

--- a/suite-native/staking/src/index.ts
+++ b/suite-native/staking/src/index.ts
@@ -11,6 +11,7 @@ export {
     signSolanaStakingTransactionNativeThunk,
 } from './stakeFormSolanaNativeThunks';
 export type * from './types';
+export type * from './stakeFormSolanaNativeTypes';
 export * from './hooks/useSelector';
 
 export {

--- a/suite-native/staking/src/selectors.ts
+++ b/suite-native/staking/src/selectors.ts
@@ -13,6 +13,7 @@ import {
     getUnstakingPeriodInDays,
     isStakingSymbol,
 } from '@suite-common/wallet-utils';
+import { SOLANA_EPOCH_DAYS } from '@trezor/coins-solana/constants';
 import { exhaustive } from '@trezor/type-utils';
 
 import {
@@ -22,11 +23,11 @@ import {
     selectVisibleDeviceCardanoAccountsWithStakingByNetworkSymbol,
 } from './cardanoStakingSelectors';
 import {
-    selectEntryPeriodInDaysBySymbol,
     selectEntryPeriodRemainingInDaysByAccountKey,
     selectEthereumAccountHasStaking,
     selectEthereumCanClaimByAccountKey,
     selectEthereumClaimableAmountByAccountKey,
+    selectEthereumEntryPeriodInDays,
     selectEthereumIsStakeConfirmingByAccountKey,
     selectEthereumIsStakePendingByAccountKey,
     selectEthereumRewardsBalanceByAccountKey,
@@ -344,8 +345,26 @@ export const selectUnstakingPeriodInDaysByAccountKey = (
     return getUnstakingPeriodInDays(account.networkType, validatorsQueueData);
 };
 
-export {
-    selectEntryPeriodInDaysBySymbol,
-    selectEntryPeriodRemainingInDaysByAccountKey,
-    selectUnstakingPeriodInDaysBySymbol,
+export const selectEntryPeriodInDaysBySymbol = (
+    state: NativeStakingRootState,
+    symbol: NetworkSymbol | undefined,
+) => {
+    if (!symbol || !isStakingSymbol(symbol)) {
+        return undefined;
+    }
+
+    switch (symbol) {
+        case 'eth':
+        case 'thod':
+            return selectEthereumEntryPeriodInDays(state);
+        case 'dsol':
+        case 'sol':
+            return SOLANA_EPOCH_DAYS;
+        case 'ada':
+            return undefined;
+        default:
+            return exhaustive(symbol);
+    }
 };
+
+export { selectEntryPeriodRemainingInDaysByAccountKey, selectUnstakingPeriodInDaysBySymbol };

--- a/suite-native/staking/src/solanaStakingSelectors.ts
+++ b/suite-native/staking/src/solanaStakingSelectors.ts
@@ -71,13 +71,11 @@ export const selectSolanaStakedBalanceByAccountKey = (
     accountKey: AccountKey,
 ) => {
     const stakingInfo = selectSolStakingAccountsInfoByAccountKey(state, accountKey);
-    if (!stakingInfo) {
+    if (!stakingInfo?.solStakedBalance) {
         return '0';
     }
 
-    return new BigNumber(stakingInfo.solStakedBalance ?? '0')
-        .plus(stakingInfo.solPendingUnstakeBalance ?? '0')
-        .toString();
+    return stakingInfo.solStakedBalance;
 };
 
 export const selectExpectedRewardsForEpoch = (

--- a/suite-native/staking/src/stakeFormSolanaNativeThunks.ts
+++ b/suite-native/staking/src/stakeFormSolanaNativeThunks.ts
@@ -67,9 +67,8 @@ const buildSolanaStakeFormState = (
     stakeType,
 });
 
-// Resolves the Solana staking account (mainnet + devnet) and the backend URL needed to
-// build the transaction. Solana unstake/claim are intentionally out of scope for the
-// mobile flow.
+// Resolves the Solana staking account (mainnet + devnet) and the backend URL needed to  build the transaction.
+// Solana stake and unstake are supported on mobile
 const resolveSolanaStakingContext = (
     state: Parameters<typeof selectAccountByKey>[0] &
         Parameters<typeof selectNetworkBlockchainInfo>[0],
@@ -96,7 +95,7 @@ const resolveSolanaStakingContext = (
         };
     }
 
-    if (stakeType !== 'stake') {
+    if (stakeType === 'claim') {
         return {
             success: false,
             error: 'not-implemented',


### PR DESCRIPTION
## Description

Introduces a Solana unstaking flow in the suite-native app, bringing it to parity with the existing suite/desktop unstake experience. To avoid duplicating logic, the Solana stake-form compose helpers used by suite/desktop are extracted into suite-common so they can be shared between web and native, and the desktop unstake/stake flow is updated to delegate to those shared helpers.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/28029

## Screenshots:
<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 16 Plus - 2026-05-28 at 09 11 16" src="https://github.com/user-attachments/assets/1f9e9c37-19d8-4f32-8ed4-e0bc0bfad0ee" />
<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 16 Plus - 2026-05-28 at 09 12 11" src="https://github.com/user-attachments/assets/2b8d93f2-d4ee-4dec-b06b-daf62de3a2ca" />
