### PR TITLE
suite: unify desktop address label selectors

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
@@ -1,20 +1,15 @@
 import { type ReactNode, useEffect, useState } from 'react';
 
-import { Address } from '@suite/address';
+import { Address, selectAddressLabel } from '@suite/address';
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { Translation, useTranslation } from '@suite/intl';
 import { Labeling } from '@suite/labeling';
-import {
-    selectIsLegacyLabelingVisible,
-    selectIsMetadataEnabled,
-    selectLabelingDataForSelectedAccount,
-} from '@suite/metadata';
+import { selectIsMetadataEnabled } from '@suite/metadata';
 import { MODAL_CONTEXT_USER } from '@suite/modal';
 import { selectDesktopSuiteSyncInteraction } from '@suite/suite-sync';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDeviceLabelOrName } from '@suite-common/device';
-import { selectIsSuiteSyncEnabled, selectSuiteSyncAddressLabels } from '@suite-common/suite-sync';
 import { getDeviceInternalModel } from '@suite-common/suite-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { getDisplaySymbol } from '@suite-common/wallet-config';
@@ -75,24 +70,24 @@ export const ConfirmValueModal = ({
     const { device } = useDevice();
     const modalContext = useSelector(state => state.modal.context);
     const deviceLabel = useSelector(selectSelectedDeviceLabelOrName);
-    const { addressLabels } = useSelector(selectLabelingDataForSelectedAccount);
     const isMetadataEnabled = useSelector(selectIsMetadataEnabled);
     const dispatch = useDispatch();
     const { openNodeById } = useGuideOpenNode();
     const { translationString } = useTranslation();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
 
-    const isSuiteSyncEnabled = useSelector(selectIsSuiteSyncEnabled);
-    const isLegacyLabelingVisible = useSelector(selectIsLegacyLabelingVisible);
-
-    const suiteSyncAddressLabels = useSelector(state =>
-        account && isSuiteSyncEnabled
-            ? selectSuiteSyncAddressLabels(state, account.deviceState)
-            : undefined,
-    );
     const suiteSyncInteraction = useSelector(state =>
         account
             ? selectDesktopSuiteSyncInteraction(state, account.deviceState, isMetadataEnabled)
+            : null,
+    );
+
+    const addressLabel = useSelector(state =>
+        account && isAddress
+            ? selectAddressLabel(state, {
+                  address: value,
+                  deviceStaticId: account.deviceState,
+              })
             : null,
     );
 
@@ -127,10 +122,6 @@ export const ConfirmValueModal = ({
             dispatch(validateOnDevice());
         }
     }, [canConfirmOnDevice, dispatch, isConfirmed, modalContext, validateOnDevice]);
-
-    const addressLabel =
-        suiteSyncAddressLabels?.find(it => it.address === value)?.label ??
-        (isLegacyLabelingVisible ? addressLabels[value] : undefined);
 
     return (
         <Modal.Backdrop onClick={onCancel}>
@@ -226,7 +217,7 @@ export const ConfirmValueModal = ({
                                             defaultValue: value,
                                             networkSymbol: account.symbol,
                                             accountDescriptor: account.descriptor,
-                                            value: addressLabel,
+                                            value: addressLabel ?? undefined,
                                         }}
                                         maxWidth={290}
                                     >

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TargetAddressLabel.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TargetAddressLabel.tsx
@@ -1,11 +1,7 @@
-import { Address } from '@suite/address';
+import { Address, selectAddressLabelsForAccount } from '@suite/address';
 import { Translation } from '@suite/intl';
-import { selectIsLegacyLabelingVisible } from '@suite/metadata';
-import { type AccountLabels } from '@suite-common/metadata-types';
-import { returnStableArrayIfEmpty } from '@suite-common/redux-utils';
-import { selectIsSuiteSyncEnabled, selectSuiteSyncAddressLabels } from '@suite-common/suite-sync';
-import { type SuiteSyncAddress } from '@suite-common/suite-sync-storage';
 import type { NetworkSymbol } from '@suite-common/wallet-config';
+import type { AccountKey } from '@suite-common/wallet-types';
 import type { StaticSessionId } from '@trezor/connect';
 import { type ArrayElement } from '@trezor/type-utils';
 
@@ -17,7 +13,7 @@ type TargetAddressLabelProps = {
     symbol: NetworkSymbol;
     target: ArrayElement<WalletAccountTransaction['targets']>;
     type: WalletAccountTransaction['type'];
-    accountMetadata?: AccountLabels;
+    accountKey: AccountKey;
     deviceStaticSessionId: StaticSessionId;
 };
 
@@ -25,17 +21,16 @@ export const TargetAddressLabel = ({
     symbol,
     target,
     type,
-    accountMetadata,
+    accountKey,
     deviceStaticSessionId,
 }: TargetAddressLabelProps) => {
     const isLocalTarget = (type === 'sent' || type === 'self') && target.isAccountTarget;
-    const isSuiteSyncEnabled = useSelector(selectIsSuiteSyncEnabled);
-    const isLegacyLabelingVisible = useSelector(selectIsLegacyLabelingVisible);
-
-    const suiteSyncAddressLabels = useSelector(state =>
-        isSuiteSyncEnabled
-            ? selectSuiteSyncAddressLabels(state, deviceStaticSessionId)
-            : returnStableArrayIfEmpty<SuiteSyncAddress>(),
+    const addressLabels = useSelector(state =>
+        selectAddressLabelsForAccount(state, {
+            addresses: target.addresses ?? [],
+            accountKey,
+            deviceStaticId: deviceStaticSessionId,
+        }),
     );
 
     if (isLocalTarget) {
@@ -45,10 +40,6 @@ export const TargetAddressLabel = ({
     return (
         <span data-testid="@wallet/transaction/target-address">
             {target.addresses?.map((a, i) => {
-                const addressLabel =
-                    suiteSyncAddressLabels.find(it => it.address === a)?.label ??
-                    (isLegacyLabelingVisible ? accountMetadata?.addressLabels[a] : undefined);
-
                 if (a.startsWith('OP_RETURN ')) {
                     return <span key={i}>{a}</span>;
                 }
@@ -59,7 +50,7 @@ export const TargetAddressLabel = ({
                     // Using index as a key is safe as the array doesn't change (no filter/reordering, pushing new items)
                     <AddressLabeling key={i} address={a} symbol={symbol} />
                 ) : (
-                    <span key={i}>{addressLabel ?? <Address value={a} isTruncated />}</span>
+                    <span key={i}>{addressLabels[a] ?? <Address value={a} isTruncated />}</span>
                 );
             })}
         </span>

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
@@ -175,7 +175,7 @@ export const TransactionTarget = ({
                 return (
                     <TargetAddressLabel
                         symbol={transaction.symbol}
-                        accountMetadata={accountMetadata}
+                        accountKey={accountKey}
                         target={payload}
                         type={transaction.type}
                         deviceStaticSessionId={transaction.deviceState}
@@ -194,7 +194,7 @@ export const TransactionTarget = ({
             default:
                 return exhaustive(type);
         }
-    }, [type, transaction, payload, accountMetadata]);
+    }, [accountKey, type, transaction, payload]);
 
     const outputLabel =
         suiteSyncOutputLabels.find(it => it.txId === transaction.txid && it.txTargetId === targetId)

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelectionList/UtxoSelection/UtxoSelection.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelectionList/UtxoSelection/UtxoSelection.tsx
@@ -1,6 +1,6 @@
 import { type MouseEventHandler, type ReactNode } from 'react';
 
-import { Address } from '@suite/address';
+import { Address, selectAddressLabel } from '@suite/address';
 import { Translation, useTranslation } from '@suite/intl';
 import { Labeling } from '@suite/labeling';
 import {
@@ -9,12 +9,8 @@ import {
 } from '@suite/metadata';
 import { openModal } from '@suite/modal';
 import { returnStableArrayIfEmpty } from '@suite-common/redux-utils';
-import {
-    selectIsSuiteSyncEnabled,
-    selectSuiteSyncAddressLabels,
-    selectSuiteSyncOutputLabels,
-} from '@suite-common/suite-sync';
-import { type SuiteSyncAddress, type SuiteSyncOutput } from '@suite-common/suite-sync-storage';
+import { selectIsSuiteSyncEnabled, selectSuiteSyncOutputLabels } from '@suite-common/suite-sync';
+import { type SuiteSyncOutput } from '@suite-common/suite-sync-storage';
 import { useDisplayBaseCurrency } from '@suite-common/wallet-core';
 import { formatNetworkAmount, isSameUtxo } from '@suite-common/wallet-utils';
 import {
@@ -90,14 +86,8 @@ export const UtxoSelection = ({ transaction, utxo }: UtxoSelectionProps) => {
     const isLegacyLabelingVisible = useSelector(selectIsLegacyLabelingVisible);
 
     // selecting metadata from store rather than send form context which does not update on metadata change
-    const { addressLabels, outputLabels } = useSelector(selectLabelingDataForSelectedAccount);
+    const { outputLabels } = useSelector(selectLabelingDataForSelectedAccount);
     const { shallDisplayBaseCurrency } = useDisplayBaseCurrency(account.symbol);
-    const suiteSyncAddressLabels = useSelector(state =>
-        isSuiteSyncEnabled
-            ? selectSuiteSyncAddressLabels(state, account.deviceState)
-            : returnStableArrayIfEmpty<SuiteSyncAddress>(),
-    );
-
     const suiteSyncOutputLabels = useSelector(state =>
         isSuiteSyncEnabled
             ? selectSuiteSyncOutputLabels(state, account.deviceState)
@@ -106,6 +96,12 @@ export const UtxoSelection = ({ transaction, utxo }: UtxoSelectionProps) => {
     const { translationString } = useTranslation();
 
     const dispatch = useDispatch();
+    const addressLabel = useSelector(state =>
+        selectAddressLabel(state, {
+            address: utxo.address,
+            deviceStaticId: account.deviceState,
+        }),
+    );
 
     const coinjoinUnavailableMessage = useCoinjoinUnavailableUtxos({ account, utxo });
     const isPendingTransaction = utxo.confirmations === 0;
@@ -137,10 +133,6 @@ export const UtxoSelection = ({ transaction, utxo }: UtxoSelectionProps) => {
         }
     };
 
-    const addressLabel =
-        suiteSyncAddressLabels.find(it => it.address === utxo.address)?.label ??
-        (isLegacyLabelingVisible ? addressLabels[utxo.address] : undefined);
-
     const outputLabel =
         suiteSyncOutputLabels.find(it => it.txId === utxo.txid && it.txTargetId === `${utxo.vout}`)
             ?.label ??
@@ -168,7 +160,7 @@ export const UtxoSelection = ({ transaction, utxo }: UtxoSelectionProps) => {
                                     defaultValue: utxo.address,
                                     accountDescriptor: account.descriptor,
                                     networkSymbol: account.symbol,
-                                    value: addressLabel,
+                                    value: addressLabel ?? undefined,
                                 }}
                                 displayValue={<Address value={utxo.address} isTruncated />}
                                 placeholder={translationString('TR_LABELING_ADDRESS_LABEL')}

--- a/suite/address/src/index.ts
+++ b/suite/address/src/index.ts
@@ -1,4 +1,5 @@
 export * from './Address';
 export * from './copyAddressActions';
 export * from './selectAddressLabel';
+export * from './selectAddressLabelsForAccount';
 export * from './selectLabeledUnusedAddresses';

--- a/suite/address/src/selectAddressLabel.ts
+++ b/suite/address/src/selectAddressLabel.ts
@@ -42,15 +42,11 @@ export const selectAddressLabel = createMemoizedSelector(
         isSuiteSyncEnabled,
         suiteSyncAddressLabels,
         address,
-    ) => {
-        const suiteSyncAddressLabel = suiteSyncAddressLabels.find(
-            item => item.address === address,
-        )?.label;
-
+    ): string | null => {
         if (isSuiteSyncEnabled) {
-            return suiteSyncAddressLabel ?? undefined;
+            return suiteSyncAddressLabels.find(item => item.address === address)?.label ?? null;
         }
 
-        return isLegacyLabelingVisible ? addressLabels[address] : undefined;
+        return isLegacyLabelingVisible ? (addressLabels[address] ?? null) : null;
     },
 );

--- a/suite/address/src/selectAddressLabelsForAccount.ts
+++ b/suite/address/src/selectAddressLabelsForAccount.ts
@@ -1,0 +1,90 @@
+import {
+    type LegacyLabelingVisibleRootState,
+    selectIsLegacyLabelingVisible,
+    selectLabelingDataForAccount,
+} from '@suite/metadata';
+import { type MessageSystemRootState } from '@suite-common/message-system';
+import { createWeakMapSelector } from '@suite-common/redux-utils';
+import {
+    type SuiteSyncDataRootState,
+    type WithSuiteSyncAndDeviceState,
+    selectIsSuiteSyncEnabled,
+    selectSuiteSyncAddressLabels,
+} from '@suite-common/suite-sync';
+import { type AccountsRootState } from '@suite-common/wallet-core';
+import { type AccountKey } from '@suite-common/wallet-types';
+import { type StaticSessionId } from '@trezor/connect';
+
+type SelectAddressLabelsForAccountParams = {
+    addresses: string[];
+    accountKey: AccountKey;
+    deviceStaticId: StaticSessionId;
+};
+
+export type SelectAddressLabelsForAccountState = LegacyLabelingVisibleRootState &
+    AccountsRootState &
+    WithSuiteSyncAndDeviceState &
+    MessageSystemRootState &
+    SuiteSyncDataRootState;
+
+const createMemoizedSelector =
+    createWeakMapSelector.withTypes<SelectAddressLabelsForAccountState>();
+
+type LabelsMap = Record<string, string | null>;
+
+export const selectAddressLabelsForAccount = createMemoizedSelector(
+    [
+        selectIsLegacyLabelingVisible,
+        (
+            state: SelectAddressLabelsForAccountState,
+            { accountKey }: SelectAddressLabelsForAccountParams,
+        ) => selectLabelingDataForAccount(state, accountKey),
+        selectIsSuiteSyncEnabled,
+        (
+            state: SelectAddressLabelsForAccountState,
+            { deviceStaticId }: SelectAddressLabelsForAccountParams,
+        ) => selectSuiteSyncAddressLabels(state, deviceStaticId),
+        (
+            _state: SelectAddressLabelsForAccountState,
+            { addresses }: SelectAddressLabelsForAccountParams,
+        ) => addresses,
+    ],
+    (
+        isLegacyLabelingVisible,
+        { addressLabels },
+        isSuiteSyncEnabled,
+        suiteSyncAddressLabels,
+        addresses,
+    ): LabelsMap => {
+        if (isSuiteSyncEnabled) {
+            const suiteSyncAddressLabelsMap = suiteSyncAddressLabels.reduce<LabelsMap>(
+                (acc, item) => {
+                    acc[item.address] = item.label ?? null;
+
+                    return acc;
+                },
+                {},
+            );
+
+            return addresses.reduce<LabelsMap>((acc, address) => {
+                acc[address] = suiteSyncAddressLabelsMap[address] ?? null;
+
+                return acc;
+            }, {});
+        }
+
+        if (isLegacyLabelingVisible) {
+            return addresses.reduce<LabelsMap>((acc, address) => {
+                acc[address] = addressLabels[address] ?? null;
+
+                return acc;
+            }, {});
+        }
+
+        return addresses.reduce<LabelsMap>((acc, address) => {
+            acc[address] = null;
+
+            return acc;
+        }, {});
+    },
+);

--- a/suite/receive/src/FreshAddress.tsx
+++ b/suite/receive/src/FreshAddress.tsx
@@ -204,7 +204,7 @@ export const FreshAddress = ({
                                     defaultValue: currentFreshAddress?.address,
                                     networkSymbol: account.symbol,
                                     accountDescriptor: account.descriptor,
-                                    value: currentFreshAddressLabel,
+                                    value: currentFreshAddressLabel ?? undefined,
                                 }}
                                 deviceStaticSessionId={account.deviceState}
                                 displayValue={


### PR DESCRIPTION
Address Labeling Labeling code cleanup.

## Testing
- address labeling works (both suite sync & legacy) for:
    -  Trasaction target (output)
    - UTXO selection
    - confirmation address dialog

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=labels-desktop-cleanup&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=labels-desktop-cleanup&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=labels-desktop-cleanup&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-29T09:06:01.360Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-29T09:03:27.656Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/labels-desktop-cleanup/web/](https://dev.suite.sldev.cz/suite-web/labels-desktop-cleanup/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->