### PR TITLE
refactor(suite): unify account label selectors

### DIFF
--- a/packages/suite/src/components/suite/AccountLabel.tsx
+++ b/packages/suite/src/components/suite/AccountLabel.tsx
@@ -1,7 +1,5 @@
-import { selectIsLegacyLabelingVisible, selectLabelingDataForAccount } from '@suite/metadata';
-import { selectIsSuiteSyncEnabled, selectSuiteSyncAccountLabel } from '@suite-common/suite-sync';
+import { selectAccountLabel } from '@suite/account';
 import { type Account } from '@suite-common/wallet-types';
-import { parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
 import { type BadgeSize, type FlexProps, Row, Text, type TextProps } from '@trezor/components';
 import { type TypographyStyle } from '@trezor/theme';
 
@@ -33,21 +31,17 @@ export const AccountLabel = ({
     rowProps,
 }: AccountLabelProps) => {
     const { getDefaultAccountLabel } = useDefaultAccountLabel();
-    const { walletDescriptor } = parseDeviceStaticSessionId(account.deviceState);
-    const isSuiteSyncEnabled = useSelector(selectIsSuiteSyncEnabled);
-    const isLegacyLabelingVisible = useSelector(selectIsLegacyLabelingVisible);
-
-    const suiteSyncAccountLabel = useSelector(state =>
-        selectSuiteSyncAccountLabel(state, walletDescriptor, account.descriptor, account.symbol),
+    const accountLabel = useSelector(state =>
+        selectAccountLabel(state, {
+            accountDescriptor: account.descriptor,
+            accountKey: account.key,
+            deviceStaticId: account.deviceState,
+            networkSymbol: account.symbol,
+        }),
     );
 
-    const accountMetadata = useSelector(state => selectLabelingDataForAccount(state, account.key));
-
     const { symbol, accountType, index, path, networkType } = account;
-    const accountLabel =
-        (isSuiteSyncEnabled ? suiteSyncAccountLabel : null) ||
-        (isLegacyLabelingVisible ? accountMetadata.accountLabel : null) ||
-        getDefaultAccountLabel({ accountType, symbol, index });
+    const label = accountLabel || getDefaultAccountLabel({ accountType, symbol, index });
 
     return (
         <Row gap={12} overflow="hidden" maxWidth="100%" {...rowProps}>
@@ -58,7 +52,7 @@ export const AccountLabel = ({
                 typographyStyle={typographyStyle}
                 ellipsisLineCount={1}
             >
-                {accountLabel}
+                {label}
             </Text>
             {showAccountTypeBadge && (
                 <AccountTypeBadge

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountDetails.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountDetails.tsx
@@ -3,13 +3,11 @@ import { useEffect, useMemo, useRef } from 'react';
 import { motion, useAnimation } from 'framer-motion';
 import styled from 'styled-components';
 
+import { selectAccountLabel } from '@suite/account';
 import { useTranslation } from '@suite/intl';
 import { Labeling } from '@suite/labeling';
-import { selectIsLegacyLabelingVisible, selectLabelingDataForAccount } from '@suite/metadata';
-import { selectIsSuiteSyncEnabled, selectSuiteSyncAccountLabel } from '@suite-common/suite-sync';
 import { useDisplayBaseCurrency } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
-import { parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
 import { Column, H2, Row, Text, motionEasing } from '@trezor/components';
 import { CoinLogo } from '@trezor/product-components';
 
@@ -33,26 +31,18 @@ type AccountDetailsProps = {
 export const AccountDetails = ({ selectedAccount, isBalanceShown }: AccountDetailsProps) => {
     const hasMountedRef = useRef(false);
     const controls = useAnimation();
-
-    const isSuiteSyncEnabled = useSelector(selectIsSuiteSyncEnabled);
-    const isLegacyLabelingVisible = useSelector(selectIsLegacyLabelingVisible);
-
-    const selectedAccountLegacyLabels = useSelector(state =>
-        selectLabelingDataForAccount(state, selectedAccount.key),
-    );
     const { getDefaultAccountLabel } = useDefaultAccountLabel();
 
     const isContentBelowBreakpoint = useIsContentBelowBreakpoint();
     const { translationString } = useTranslation();
-    const { walletDescriptor } = parseDeviceStaticSessionId(selectedAccount.deviceState);
 
-    const suiteSyncAccountLabel = useSelector(state =>
-        selectSuiteSyncAccountLabel(
-            state,
-            walletDescriptor,
-            selectedAccount.descriptor,
-            selectedAccount.symbol,
-        ),
+    const accountLabel = useSelector(state =>
+        selectAccountLabel(state, {
+            accountDescriptor: selectedAccount.descriptor,
+            accountKey: selectedAccount.key,
+            deviceStaticId: selectedAccount.deviceState,
+            networkSymbol: selectedAccount.symbol,
+        }),
     );
 
     const { symbol, key, path, index, accountType, formattedBalance, deviceState, networkType } =
@@ -61,10 +51,7 @@ export const AccountDetails = ({ selectedAccount, isBalanceShown }: AccountDetai
 
     const defaultLabel = getDefaultAccountLabel({ accountType, symbol, index });
 
-    const label =
-        (isSuiteSyncEnabled ? suiteSyncAccountLabel : null) ||
-        (isLegacyLabelingVisible ? selectedAccountLegacyLabels.accountLabel : null) ||
-        defaultLabel;
+    const label = accountLabel || defaultLabel;
 
     const getTypographyStyle = () => {
         if (isBalanceShown) {
@@ -135,7 +122,7 @@ export const AccountDetails = ({ selectedAccount, isBalanceShown }: AccountDetai
                 <CoinLogo size={36} symbol={symbol} type="token" />
                 <Column
                     overflow="hidden"
-                    // To accomodate the labeling component
+                    // To accommodate the labeling component
                     padding={8}
                 >
                     <H2 typographyStyle={getTypographyStyle()}>{accountNameElement}</H2>

--- a/suite/account/package.json
+++ b/suite/account/package.json
@@ -12,9 +12,16 @@
     },
     "dependencies": {
         "@suite-common/connect-popup": "workspace:*",
+        "@suite-common/message-system": "workspace:*",
+        "@suite-common/redux-utils": "workspace:*",
+        "@suite-common/suite-sync": "workspace:*",
         "@suite-common/trading": "workspace:*",
+        "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
+        "@suite-common/wallet-utils": "workspace:*",
+        "@suite/metadata": "workspace:*",
+        "@trezor/connect": "workspace:*",
         "redux": "^5.0.1"
     }
 }

--- a/suite/account/src/index.ts
+++ b/suite/account/src/index.ts
@@ -11,3 +11,4 @@ export {
     type SelectedAccountRootStateWithTrading,
     type SelectedAccountState,
 } from './selectedAccountReducer';
+export { selectAccountLabel, type SelectAccountLabelState } from './selectAccountLabel';

--- a/suite/account/src/selectAccountLabel.ts
+++ b/suite/account/src/selectAccountLabel.ts
@@ -1,0 +1,67 @@
+import {
+    type MetadataRootState,
+    selectIsLegacyLabelingVisible,
+    selectLabelingDataForAccount,
+} from '@suite/metadata';
+import { type MessageSystemRootState } from '@suite-common/message-system';
+import { createWeakMapSelector } from '@suite-common/redux-utils';
+import {
+    type SuiteSyncDataRootState,
+    type WithSuiteSyncAndDeviceState,
+    selectIsSuiteSyncEnabled,
+    selectSuiteSyncAccountLabel,
+} from '@suite-common/suite-sync';
+import type { NetworkSymbol } from '@suite-common/wallet-config';
+import { type AccountsRootState } from '@suite-common/wallet-core';
+import type { AccountDescriptor, AccountKey } from '@suite-common/wallet-types';
+import { parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
+import { type StaticSessionId } from '@trezor/connect';
+
+type SelectAccountLabelParams = {
+    accountDescriptor: AccountDescriptor;
+    accountKey: AccountKey;
+    deviceStaticId: StaticSessionId;
+    networkSymbol: NetworkSymbol;
+};
+
+export type SelectAccountLabelState = MetadataRootState &
+    AccountsRootState &
+    WithSuiteSyncAndDeviceState &
+    MessageSystemRootState &
+    SuiteSyncDataRootState;
+
+const createMemoizedSelector = createWeakMapSelector.withTypes<SelectAccountLabelState>();
+
+export const selectAccountLabel = createMemoizedSelector(
+    [
+        selectIsLegacyLabelingVisible,
+        (state: SelectAccountLabelState, { accountKey }: SelectAccountLabelParams) =>
+            selectLabelingDataForAccount(state, accountKey),
+        selectIsSuiteSyncEnabled,
+        (
+            state: SelectAccountLabelState,
+            { deviceStaticId, accountDescriptor, networkSymbol }: SelectAccountLabelParams,
+        ) => {
+            const { walletDescriptor } = parseDeviceStaticSessionId(deviceStaticId);
+
+            return selectSuiteSyncAccountLabel(
+                state,
+                walletDescriptor,
+                accountDescriptor,
+                networkSymbol,
+            );
+        },
+    ],
+    (
+        isLegacyLabelingVisible,
+        { accountLabel },
+        isSuiteSyncEnabled,
+        suiteSyncAccountLabel,
+    ): string | null => {
+        if (isSuiteSyncEnabled) {
+            return suiteSyncAccountLabel ?? null;
+        }
+
+        return isLegacyLabelingVisible ? (accountLabel ?? null) : null;
+    },
+);

--- a/suite/account/tsconfig.json
+++ b/suite/account/tsconfig.json
@@ -5,12 +5,29 @@
         {
             "path": "../../suite-common/connect-popup"
         },
+        {
+            "path": "../../suite-common/message-system"
+        },
+        {
+            "path": "../../suite-common/redux-utils"
+        },
+        {
+            "path": "../../suite-common/suite-sync"
+        },
         { "path": "../../suite-common/trading" },
+        {
+            "path": "../../suite-common/wallet-config"
+        },
         {
             "path": "../../suite-common/wallet-core"
         },
         {
             "path": "../../suite-common/wallet-types"
-        }
+        },
+        {
+            "path": "../../suite-common/wallet-utils"
+        },
+        { "path": "../metadata" },
+        { "path": "../../packages/connect" }
     ]
 }

--- a/suite/metadata/src/selectIsLegacyLabelingVisible.ts
+++ b/suite/metadata/src/selectIsLegacyLabelingVisible.ts
@@ -3,7 +3,7 @@ import { type WithSuiteSyncState, selectIsSuiteSyncEnabled } from '@suite-common
 
 import { type MetadataRootState, selectIsMetadataEnabled } from './metadataReducer';
 
-type LegacyLabelingVisibleRootState = MetadataRootState &
+export type LegacyLabelingVisibleRootState = MetadataRootState &
     WithSuiteSyncState &
     MessageSystemRootState;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14235,9 +14235,16 @@ __metadata:
   resolution: "@suite/account@workspace:suite/account"
   dependencies:
     "@suite-common/connect-popup": "workspace:*"
+    "@suite-common/message-system": "workspace:*"
+    "@suite-common/redux-utils": "workspace:*"
+    "@suite-common/suite-sync": "workspace:*"
     "@suite-common/trading": "workspace:*"
+    "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
+    "@suite-common/wallet-utils": "workspace:*"
+    "@suite/metadata": "workspace:*"
+    "@trezor/connect": "workspace:*"
     redux: "npm:^5.0.1"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Account Labeling Labeling code cleanup.

## Testing
- account labeling works (both suite sync & legacy)

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/labels-desktop-cleanup2-account/web/](https://dev.suite.sldev.cz/suite-web/labels-desktop-cleanup2-account/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-28T11:44:44.072Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-28T11:43:09.551Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=labels-desktop-cleanup2-account&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->