### PR TITLE
fix: widen prettier tsconfig override to match all tsconfig variants

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -31,7 +31,7 @@
             }
         },
         {
-            "files": ["tsconfig.json"],
+            "files": ["tsconfig*.json"],
             "options": {
                 "trailingComma": "none",
                 "printWidth": 50

--- a/coins/coins-solana/tsconfig.libESM.json
+++ b/coins/coins-solana/tsconfig.libESM.json
@@ -2,5 +2,8 @@
     "extends": "../../tsconfig.libESM.json",
     "compilerOptions": { "outDir": "./libESM" },
     "include": ["./src"],
-    "references": [{ "path": "../../packages/type-utils" }, { "path": "../../packages/utils" }]
+    "references": [
+        { "path": "../../packages/type-utils" },
+        { "path": "../../packages/utils" }
+    ]
 }

--- a/packages/blockchain-link-types/tsconfig.libESM.json
+++ b/packages/blockchain-link-types/tsconfig.libESM.json
@@ -2,5 +2,9 @@
     "extends": "../../tsconfig.libESM.json",
     "include": ["./src"],
     "compilerOptions": { "outDir": "./libESM" },
-    "references": [{ "path": "../utils" }, { "path": "../utxo-lib" }, { "path": "../type-utils" }]
+    "references": [
+        { "path": "../utils" },
+        { "path": "../utxo-lib" },
+        { "path": "../type-utils" }
+    ]
 }

--- a/packages/connect-mobile/tsconfig.libESM.json
+++ b/packages/connect-mobile/tsconfig.libESM.json
@@ -2,5 +2,8 @@
     "extends": "../../tsconfig.libESM.json",
     "include": ["./src"],
     "compilerOptions": { "outDir": "./libESM" },
-    "references": [{ "path": "../connect-common" }, { "path": "../utils" }]
+    "references": [
+        { "path": "../connect-common" },
+        { "path": "../utils" }
+    ]
 }

--- a/packages/connect-plugin-stellar/tsconfig.libESM.json
+++ b/packages/connect-plugin-stellar/tsconfig.libESM.json
@@ -2,5 +2,8 @@
     "extends": "../../tsconfig.libESM.json",
     "include": ["./src"],
     "compilerOptions": { "outDir": "./libESM" },
-    "references": [{ "path": "../utils" }, { "path": "../eslint" }]
+    "references": [
+        { "path": "../utils" },
+        { "path": "../eslint" }
+    ]
 }

--- a/packages/device-authenticity/tsconfig.libESM.json
+++ b/packages/device-authenticity/tsconfig.libESM.json
@@ -2,5 +2,9 @@
     "extends": "../../tsconfig.libESM.json",
     "include": ["./src"],
     "compilerOptions": { "outDir": "./libESM" },
-    "references": [{ "path": "../crypto-utils" }, { "path": "../protobuf" }, { "path": "../utils" }]
+    "references": [
+        { "path": "../crypto-utils" },
+        { "path": "../protobuf" },
+        { "path": "../utils" }
+    ]
 }

--- a/packages/device-utils/tsconfig.libESM.json
+++ b/packages/device-utils/tsconfig.libESM.json
@@ -2,5 +2,8 @@
     "extends": "../../tsconfig.libESM.json",
     "include": ["./src"],
     "compilerOptions": { "outDir": "./libESM" },
-    "references": [{ "path": "../protobuf" }, { "path": "../utils" }]
+    "references": [
+        { "path": "../protobuf" },
+        { "path": "../utils" }
+    ]
 }

--- a/packages/schema-utils/tsconfig.libESM.json
+++ b/packages/schema-utils/tsconfig.libESM.json
@@ -2,5 +2,8 @@
     "extends": "../../tsconfig.libESM.json",
     "include": ["./src"],
     "compilerOptions": { "outDir": "./libESM" },
-    "references": [{ "path": "../type-utils" }, { "path": "../eslint" }]
+    "references": [
+        { "path": "../type-utils" },
+        { "path": "../eslint" }
+    ]
 }

--- a/packages/transport-web/tsconfig.libESM.json
+++ b/packages/transport-web/tsconfig.libESM.json
@@ -6,5 +6,8 @@
         "lib": ["DOM", "ES2023"],
         "types": []
     },
-    "references": [{ "path": "../transport-common" }, { "path": "../eslint" }]
+    "references": [
+        { "path": "../transport-common" },
+        { "path": "../eslint" }
+    ]
 }

--- a/packages/utils/tsconfig.libESM.json
+++ b/packages/utils/tsconfig.libESM.json
@@ -2,5 +2,8 @@
     "extends": "../../tsconfig.libESM.json",
     "include": ["./src"],
     "compilerOptions": { "outDir": "./libESM" },
-    "references": [{ "path": "../eslint" }, { "path": "../type-utils" }]
+    "references": [
+        { "path": "../eslint" },
+        { "path": "../type-utils" }
+    ]
 }

--- a/packages/utxo-lib/tsconfig.libESM.json
+++ b/packages/utxo-lib/tsconfig.libESM.json
@@ -2,5 +2,8 @@
     "extends": "../../tsconfig.libESM.json",
     "include": ["./src"],
     "compilerOptions": { "outDir": "./libESM" },
-    "references": [{ "path": "../utils" }, { "path": "../eslint" }]
+    "references": [
+        { "path": "../utils" },
+        { "path": "../eslint" }
+    ]
 }

--- a/scripts/utils/getPrettierConfig.ts
+++ b/scripts/utils/getPrettierConfig.ts
@@ -1,5 +1,9 @@
 import prettier from 'prettier';
 
+// resolveConfig resolves overrides based on the file path passed to it.
+// Here we pass the config file path (not a tsconfig path), so tsconfig-specific
+// overrides from .prettierrc (like printWidth: 50) won't apply automatically.
+// We hardcode them here to stay in sync with the .prettierrc tsconfig override.
 export const getPrettierConfig = async () => {
     const prettierConfigPath = await prettier.resolveConfigFile();
     const prettierConfig = {


### PR DESCRIPTION
The `.prettierrc` override for tsconfig files used an exact `tsconfig.json` pattern, so variants like tsconfig.libESM.json didn't get the `printWidth: 50` setting. This caused`yarn update-project-references` and the pre-commit prettier hook to fight over formatting, the script wrote wrapped references, the hook collapsed them back.

The`printWidth: 50` is also hardcoded in `getPrettierConfig` because resolveConfig is called with the config file path rather than the target tsconfig path, so `.prettierrc` overrides don't apply automatically, comment was added to explain this.

**Notes for QA**

  **Happy paths**
  - Run yarn update-project-references — verify no unstaged diffs remain after pre-commit hook
  - Run yarn verify-project-references — verify it passes cleanly

  **Edge cases**
  - none identified

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/prettier-tsconfig-override&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/prettier-tsconfig-override&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-28T11:32:08.188Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-28T11:29:27.560Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/prettier-tsconfig-override/web/](https://dev.suite.sldev.cz/suite-web/fix/prettier-tsconfig-override/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->