### PR TITLE
fix(suite): Fix guide z-index

### DIFF
--- a/packages/suite/src/components/guide/GuideRouter.tsx
+++ b/packages/suite/src/components/guide/GuideRouter.tsx
@@ -117,6 +117,7 @@ export const GuideRouter = () => {
                 }}
                 onWidthResizeMove={handleResizeMove}
                 onWidthResizeEnd={handleResizeEnd}
+                zIndex={zIndices.guide}
             >
                 <Box
                     height="100vh"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to GuideRouter.tsx, the routing component within the Suite Guide panel. This is a narrowly scoped component that controls which view is rendered inside the guide (content nodes, search results, feedback forms, etc.). While static analysis maps it to 121 tests (because the guide panel is part of the global layout), only tests that directly interact with the guide panel are meaningfully affected. The recommended strategy is to run the two guide-specific tests at high priority and the bug report form test at medium priority, as these are the only tests that exercise guide panel navigation and content rendering.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/guide/GuideRouter.tsx`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/general/suite-guide.test.ts` — This test directly exercises the Suite Guide panel — opening it, navigating content, searching articles, and submitting bug reports. GuideRouter.tsx is the routing component that controls which guide content/view is displayed within the panel, so any change to it directly affects guide navigation behavior tested here.
- `suite/e2e/tests/suite/guide.test.ts` — This test covers opening/closing the guide panel, navigating guide content nodes, viewing details, submitting feedback forms, searching guide topics, and opening the guide during onboarding. GuideRouter.tsx directly controls the routing between these guide views, making this test critical for validating the change.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/suite/bug-report-form.test.ts` — This test opens the Guide panel and navigates to the Support and Feedback section to submit a bug report. GuideRouter.tsx routes between guide views including the feedback/bug report form, so a routing change could break the navigation path to the bug report form.

</details>

_Updated: 2026-05-28T11:27:58.402Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-guide-z-index&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-guide-z-index&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-28T13:38:59.809Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-28T13:36:23.645Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-guide-z-index/web/](https://dev.suite.sldev.cz/suite-web/fix-guide-z-index/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->