### PR TITLE
feat(trading): split buy & sell into separate header buttons

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderActions.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderActions.tsx
@@ -27,11 +27,7 @@ export const HeaderActions = () => {
 
     return (
         <Row gap={12} alignItems="center">
-            <HeaderDropdown
-                isDisabled={isAccountLoading}
-                isTradingDisabled={!isTradingAvailable}
-                showSignAndVerify
-            />
+            <HeaderDropdown isDisabled={isAccountLoading} showSignAndVerify />
 
             {isTradingAvailable && <TradeActions selectedAccount={selectedAccount} />}
 

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderDropdown.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderDropdown.tsx
@@ -1,17 +1,12 @@
 import { type JSX } from 'react';
 
 import { selectSelectedAccount } from '@suite/account';
-import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
-import { useServices } from '@suite-common/dependency-injection';
-import { getTradingPrefilledFromAccountData, tradingActions } from '@suite-common/trading';
 import { hasNetworkFeatures } from '@suite-common/wallet-utils';
 import { Dropdown, type DropdownMenuItemProps, type IconName } from '@trezor/components';
-import { breakpoints } from '@trezor/theme';
 
 import { AppNavigationTooltip } from 'src/components/suite/AppNavigation/AppNavigationTooltip';
-import { useDispatch, useSelector } from 'src/hooks/suite';
-import { useConditionalRender } from 'src/support/suite/ConditionalRender';
+import { useSelector } from 'src/hooks/suite';
 
 import { useGoToWithAnalytics } from './useGoToWithAnalytics';
 
@@ -26,23 +21,11 @@ type ActionItem = {
 
 type HeaderDropdownProps = {
     isDisabled?: boolean;
-    isTradingDisabled?: boolean;
     showSignAndVerify?: boolean;
 };
-export const HeaderDropdown = ({
-    isDisabled,
-    isTradingDisabled,
-    showSignAndVerify,
-}: HeaderDropdownProps) => {
-    const { analytics } = useServices(selectDesktopAnalyticsDep);
-    const dispatch = useDispatch();
+export const HeaderDropdown = ({ isDisabled, showSignAndVerify }: HeaderDropdownProps) => {
     const goToWithAnalytics = useGoToWithAnalytics();
     const account = useSelector(selectSelectedAccount);
-
-    const isBuyVisible = useConditionalRender({
-        container: 'content',
-        minWidth: breakpoints.laptop,
-    });
 
     const additionalActions: ActionItem[] = [
         ...(showSignAndVerify
@@ -61,33 +44,6 @@ export const HeaderDropdown = ({
                   },
               ]
             : []),
-        {
-            id: 'wallet-trading-buy',
-            callback: () => {
-                if (account) {
-                    dispatch(
-                        tradingActions.setTradingFromPrefilledAccount(
-                            getTradingPrefilledFromAccountData(account),
-                        ),
-                    );
-                }
-
-                goToWithAnalytics({ routeName: 'wallet-trading-buy' });
-
-                analytics.report({
-                    type: events.tradeNavigateEvent.name,
-                    payload: {
-                        action: 'navigate',
-                        type: 'buy/sell',
-                        from: account ? 'account/header' : 'dashboard/header',
-                        networkSymbol: account?.symbol,
-                    },
-                });
-            },
-            title: <Translation id="TR_TRADING_BUY_AND_SELL" />,
-            icon: 'currencyCircleDollar',
-            isHidden: isBuyVisible || isTradingDisabled,
-        },
     ];
 
     const visibleAdditionalActions = additionalActions?.filter(action => !action.isHidden);

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/TradeActions.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/TradeActions.tsx
@@ -4,13 +4,11 @@ import { goto, selectIsAccountTabPage, selectRouteName } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { getTradingPrefilledFromAccountData, tradingActions } from '@suite-common/trading';
 import { type SelectedAccountStatus } from '@suite-common/wallet-types';
-import { Row } from '@trezor/components';
-import { breakpoints } from '@trezor/theme';
+import { ButtonGroup, Row } from '@trezor/components';
 
 import { AppNavigationTooltip } from 'src/components/suite/AppNavigation/AppNavigationTooltip';
 import { HeaderActionButton } from 'src/components/suite/layouts/SuiteLayout/PageHeader/HeaderActionButton';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { ConditionalRender } from 'src/support/suite/ConditionalRender';
 
 interface TradeActionsProps {
     selectedAccount?: SelectedAccountStatus;
@@ -41,7 +39,9 @@ export const TradeActions = ({ selectedAccount }: TradeActionsProps) => {
         dispatch(goto(payload));
     };
 
-    const onBuyAndSellClick = () => {
+    const navigateToTrading = (type: 'buy' | 'sell') => {
+        const routeName = `wallet-trading-${type}` as const;
+
         if (account) {
             dispatch(
                 tradingActions.setTradingFromPrefilledAccount(
@@ -50,13 +50,13 @@ export const TradeActions = ({ selectedAccount }: TradeActionsProps) => {
             );
         }
 
-        goToWithAnalytics({ routeName: 'wallet-trading-buy' });
+        goToWithAnalytics({ routeName, preserveParams: false });
 
         analytics.report({
             type: events.tradeNavigateEvent.name,
             payload: {
                 action: 'navigate',
-                type: 'buy/sell',
+                type,
                 from: account ? 'account/header' : 'dashboard/header',
                 networkSymbol: account?.symbol,
             },
@@ -68,18 +68,22 @@ export const TradeActions = ({ selectedAccount }: TradeActionsProps) => {
     return (
         <Row gap={12}>
             <AppNavigationTooltip>
-                <ConditionalRender container="content" minWidth={breakpoints.laptop}>
+                <ButtonGroup intent="neutral" priority="secondary" isDisabled={isAccountLoading}>
                     <HeaderActionButton
-                        icon="currencyCircleDollar"
-                        onClick={onBuyAndSellClick}
+                        icon="plus"
+                        onClick={() => navigateToTrading('buy')}
                         data-testid="@wallet/menu/wallet-trading-buy"
-                        intent="neutral"
-                        priority="secondary"
-                        isDisabled={isAccountLoading}
                     >
-                        <Translation id="TR_TRADING_BUY_AND_SELL" />
+                        <Translation id="TR_NAV_BUY" />
                     </HeaderActionButton>
-                </ConditionalRender>
+                    <HeaderActionButton
+                        icon="minus"
+                        onClick={() => navigateToTrading('sell')}
+                        data-testid="@wallet/menu/wallet-trading-sell"
+                    >
+                        <Translation id="TR_NAV_SELL" />
+                    </HeaderActionButton>
+                </ButtonGroup>
             </AppNavigationTooltip>
         </Row>
     );

--- a/suite/e2e/support/pageObjects/walletPage.ts
+++ b/suite/e2e/support/pageObjects/walletPage.ts
@@ -22,6 +22,7 @@ export class WalletPage {
     readonly stakeAddress: Locator;
     readonly walletExtraDropDown: Locator;
     readonly openTradingGlobalButton: Locator;
+    readonly openSellGlobalButton: Locator;
     readonly openSwapSidebarButton: Locator;
     readonly tradingDropdownBuyButton: Locator;
     readonly balanceOfAccount = (params: WalletParams) =>
@@ -85,6 +86,7 @@ export class WalletPage {
         this.stakeAddress = this.page.getByTestId('@cardano/staking/address');
         this.walletExtraDropDown = this.page.getByTestId('@wallet/menu/extra-dropdown');
         this.openTradingGlobalButton = this.page.getByTestId('@wallet/menu/wallet-trading-buy');
+        this.openSellGlobalButton = this.page.getByTestId('@wallet/menu/wallet-trading-sell');
         this.openSwapSidebarButton = this.page.getByTestId('@suite/menu/wallet-trading-exchange');
         this.tradingDropdownBuyButton = this.page
             .getByRole('list')

--- a/suite/e2e/tests/trading/navigation.test.ts
+++ b/suite/e2e/tests/trading/navigation.test.ts
@@ -35,10 +35,6 @@ test.describe('Trading - Navigation', { tag: ['@T3W1', '@T3T1'] }, () => {
 
             await test.step('Buy from global header', async () => {
                 await dashboardPage.navigateTo();
-                const isBuyButtonUnderDropDown = await walletPage.walletExtraDropDown.isVisible();
-                if (isBuyButtonUnderDropDown) {
-                    await walletPage.walletExtraDropDown.click();
-                }
                 await walletPage.openTradingGlobalButton.click();
                 await tradingPage.verifyBuyFormOpened(/Bitcoin|Ethereum|Litecoin/);
             });
@@ -56,6 +52,12 @@ test.describe('Trading - Navigation', { tag: ['@T3W1', '@T3T1'] }, () => {
 
             // SELL
             // We don't test cases where navigation goes first thru buy form
+            await test.step('Sell from global header', async () => {
+                await dashboardPage.navigateTo();
+                await walletPage.openSellGlobalButton.click();
+                await tradingPage.verifySellFormOpened(/Bitcoin|Ethereum|Litecoin/);
+            });
+
             await test.step('Sell from account trade section', async () => {
                 await walletPage.openAccount({ symbol: 'btc' });
                 await walletPage.sellButton.click();


### PR DESCRIPTION
## Description

Splits the combined **Buy & sell** page-header action into two separate buttons inside a `ButtonGroup`:

- **Buy** — `plus` icon, routes to `wallet-trading-buy`
- **Sell** — `minus` icon, routes to `wallet-trading-sell`

Both buttons always render in the page header — the previous laptop-breakpoint collapse into the extra "..." dropdown is removed (`HeaderActionButton` still falls back to icon-only `IconButton` below the mobile breakpoint).

Analytics `tradeNavigateEvent.type` switches from `'buy/sell'` to the more specific `'buy'` / `'sell'` (both already in the union).

> Based on #28140 — merge that first.

## Notes for QA

- Verify Buy and Sell render side-by-side in the page header on Dashboard and on any account detail page.
- Clicking **Buy** opens the buy form; clicking **Sell** opens the sell form, both pre-filled with the selected account when applicable.
- Narrow the window down to mobile width — buttons should collapse to icon-only, no "..." dropdown for buy/sell.

## Related Issue

Resolve #28141

## Screenshots:
<img width="1125" height="495" alt="image" src="https://github.com/user-attachments/assets/32465090-3d86-4f2f-b56a-767828d53b30" />
<img width="684" height="378" alt="image" src="https://github.com/user-attachments/assets/10ef6aab-e831-4d54-8eed-1a6d7525c8b7" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/28141/split-buy-sell-header&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/28141/split-buy-sell-header&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-09T08:22:39.393Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add account types ada | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-09T08:20:43.704Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/28141/split-buy-sell-header/web/](https://dev.suite.sldev.cz/suite-web/feat/28141/split-buy-sell-header/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies three PageHeader components (HeaderActions, HeaderDropdown, TradeActions) that power the global trading/send/receive buttons in the Suite layout header, along with the walletPage page object used extensively across trading and wallet E2E tests, and the navigation.test.ts test itself. The primary risk is breaking trading flow entry points (buy/sell/swap navigation from header, dashboard, and account pages) and the discreet mode toggle. The recommended strategy focuses on the directly-changed navigation test, global send/receive flows, and a representative sample of buy/sell/swap flows that exercise the changed header components and page object methods.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderActions.tsx`
- `packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderDropdown.tsx`
- `packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/TradeActions.tsx`
- `suite/e2e/support/pageObjects/walletPage.ts`
- `suite/e2e/tests/trading/navigation.test.ts`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — This test file is itself changed in the PR and directly tests navigation to Buy/Sell/Swap trading forms from various entry points including the global header button (openTradingGlobalButton), dashboard asset cards, and account trade sections. The TradeActions.tsx and HeaderActions.tsx components power these global trading entry points, making this test the primary validation target.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test exercises global receive and send flows from the wallet menu header (@wallet/menu/wallet-global-receive, @wallet/menu/wallet-global-send), which are rendered by HeaderActions.tsx and TradeActions.tsx. Changes to these header action components could break the global send/receive entry points tested here.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — This test navigates to the trading/buy flow via walletPage.openTrading, which is defined in the changed walletPage.ts page object. It also relies on the global trading entry points rendered by TradeActions.tsx.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — Uses walletPage.openTradingGlobalButton to open the buy flow, directly exercising the global trading button rendered by TradeActions.tsx/HeaderActions.tsx and the walletPage page object.
- `suite/e2e/tests/trading/buy-negative.test.ts` — Uses walletPage.openTradingGlobalButton to navigate to the buy form, which exercises the TradeActions.tsx header component and the changed walletPage page object.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — Opens trading via walletPage.openTrading and navigates to the sell tab, relying on the changed walletPage page object and the header trading actions.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Uses walletPage.openSwapTrading to enter the swap flow, which relies on the changed walletPage page object. The swap sidebar button may also be rendered via header actions.
- `suite/e2e/tests/dashboard/assets.test.ts` — Tests buying an asset (BTC) from the dashboard assets section, which navigates to the trading page. The buy button on asset cards may interact with TradeActions.tsx header components, and the test uses walletPage-related flows.
- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — Tests the hide-balance button which is part of the header actions UI (HeaderActions.tsx). Changes to HeaderActions.tsx could affect the discreet mode toggle placement or functionality.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/trading/sell-inputs.test.ts` — Uses walletPage.openTrading and walletPage.sellButton to navigate to sell form, relying on the changed walletPage page object for entry point interactions.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Uses walletPage.openSwapTrading from the changed walletPage page object to enter the swap flow.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — Uses walletPage.swapButton to open the swap form, relying on the changed walletPage page object for navigation.

</details>

_Updated: 2026-06-09T08:17:35.953Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->