### PR TITLE
Lower the BTC min fee

### DIFF
--- a/packages/suite/src/hooks/wallet/useRbfForm.ts
+++ b/packages/suite/src/hooks/wallet/useRbfForm.ts
@@ -34,7 +34,8 @@ import { useCompose } from './form/useCompose';
 import { useFees } from './form/useFees';
 import { useBitcoinAmountUnit } from './useBitcoinAmountUnit';
 
-const MIN_FEE_RATE_PER_VB = 1; // minimum fee rate in sat/vB, introduced because nodes lowered min relay tx fee, but not incremental fee
+// Conservative minimum fee rate floor in sat/vB. Bitcoin Core has officially lowered both the min relay tx fee and the incremental relay fee, but actual minimums depend on individual node configurations.
+const MIN_FEE_RATE_PER_VB = 0.2;
 
 export type UseRbfProps = {
     account: Account;

--- a/suite-common/wallet-core/src/fees/feesUtils.ts
+++ b/suite-common/wallet-core/src/fees/feesUtils.ts
@@ -11,7 +11,7 @@ const NETWORK_FEE_OVERRIDES: Record<
 > = {
     bitcoin: {
         minFeePerUnit: {
-            normal: '1',
+            normal: '0.2',
             high: '2',
         },
     },

--- a/suite-common/wallet-core/src/send/composeCancelTransaction/calculateNewFee.ts
+++ b/suite-common/wallet-core/src/send/composeCancelTransaction/calculateNewFee.ts
@@ -3,13 +3,11 @@ import { calculateChainedTransactionsFeeForRbf } from '@suite-common/wallet-util
 import { BigNumber } from '@trezor/utils';
 
 /**
- * The current default value for the minRelayTxFee in Bitcoin Core is 1000 satoshi/kB (= 1 sat/B).
- * A node operator may specify a different value via the startup parameter.
- *
- * @see https://github.com/bitcoin/bitcoin/blob/97153a702600430bdaf6af4f6f4eb8593e32819f/src/validation.h#L63
- * @see https://bitcoin.stackexchange.com/questions/48235/what-is-the-minrelaytxfee
+ * Default minimum relay fee in sat/vB used for BIP-125 RBF replacement transactions.
+ * Bitcoin Core has officially lowered both the min relay tx fee and the incremental relay fee defaults,
+ * but actual minimums depend on each node's configuration, so we keep a conservative floor.
  */
-const BIP_125_DEFAULT_RELAY_FEE = 1;
+const DEFAULT_RELAY_FEE_PER_VB = 0.2;
 
 type CancelTransactionProps = {
     newTransactionSize: number;
@@ -22,7 +20,7 @@ export const calculateNewFee = ({
     newTransactionSize,
     chainedTxs,
     originalFee,
-    relayFee = BIP_125_DEFAULT_RELAY_FEE,
+    relayFee = DEFAULT_RELAY_FEE_PER_VB,
 }: CancelTransactionProps) => {
     /**
      * Rules:

--- a/suite-common/wallet-core/tests/send/composeCancelTransaction/calculateNewFee.test.ts
+++ b/suite-common/wallet-core/tests/send/composeCancelTransaction/calculateNewFee.test.ts
@@ -11,8 +11,8 @@ describe(calculateNewFee.name, () => {
 
         expect(result.chainedTransactionFees).toBe(1410); // This is just sum of fees in `chainedTxsFixture`
 
-        // (originalFee + newTransactionSize * RELAY_FEE) / newTransactionSize = (1410 + 110 * 1) / 110 = 13.81818181818181818182
-        expect(result.newFeeRate.toString()).toBe('13.81818181818181818182');
+        // (originalFee + newTransactionSize * RELAY_FEE) / newTransactionSize = (1410 + 110 * 0.2) / 110 = 13.01818181818181818182
+        expect(result.newFeeRate.toString()).toBe('13.01818181818181818182');
     });
 
     it('accounts RELAY_FEE for the new transaction size (110B) which is less then original TX (141B) ', () => {

--- a/suite-common/wallet-core/tests/send/composeCancelTransaction/composeCancelTransactionThunk.test.ts
+++ b/suite-common/wallet-core/tests/send/composeCancelTransaction/composeCancelTransactionThunk.test.ts
@@ -168,7 +168,7 @@ describe(composeCancelTransactionThunk.name, () => {
         const { feeLevels: secondFeeLevels } = second;
         // @ts-expect-error: indexing with noUncheckedIndexedAccess
         const secondFeeLevel: (typeof secondFeeLevels)[number] = secondFeeLevels[0];
-        expect(secondFeeLevel.feePerUnit).toBe('13.81818181818181818182'); // = (1410 + 110 * 1) / 110
+        expect(secondFeeLevel.feePerUnit).toBe('13.01818181818181818182'); // = (1410 + 110 * 0.2) / 110
         expect(second.baseFee).toBe(1410); // This is the sum of fees for chained transactions
         expect(second.outputs).toStrictEqual([
             {


### PR DESCRIPTION
Lowered the min fees required, also lowered the RBF fees.

## Notes for QA

**Happy paths**
- Send BTC with Normal fee — verify fee rate can go as low as 0.2 sat/vB
- RBF a BTC tx — verify replacement accepts fee rates down to 0.2 sat/vB
- Cancel a BTC tx (BIP-125) — verify cancel composes successfully at low fee rates
- Send BTC with Low fee — verify minimum still 0.1 sat/vB (unchanged)
- Send BTC with High fee — verify minimum still 2 sat/vB (unchanged)

**Edge cases**
- Backend returns fee estimate below 0.2 sat/vB for Normal — verify 0.2 floor applies
- RBF when original tx fee rate was < 1 sat/vB — verify bump fee calculates correctly
- Cancel tx with chained transactions at low fee — verify BIP-125 rules still satisfied


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/28090


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes focus on RBF (Replace-By-Fee) form logic (useRbfForm.ts), fee utility functions (feesUtils.ts), and cancel transaction fee calculation (calculateNewFee.ts). The unit test file for calculateNewFee has no E2E coverage mapping. All three source files map to 121 tests each, indicating they are broadly imported utilities — most of these tests don't exercise fee or RBF logic directly. The recommended strategy targets tests that explicitly exercise send forms with fee parameters, pending transaction speed-up flows (RBF), and staking transactions with speed-up options, as these are the most likely to regress from fee calculation changes.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite/src/hooks/wallet/useRbfForm.ts`
- `suite-common/wallet-core/src/fees/feesUtils.ts`
- `suite-common/wallet-core/src/send/composeCancelTransaction/calculateNewFee.ts`
- `suite-common/wallet-core/tests/send/composeCancelTransaction/calculateNewFee.test.ts`

</details>

**Recommended tests (15)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/wallet/pending-transactions.test.ts` — This test exercises Bitcoin send transactions with multiple outputs on regtest, including pending transaction display and speed-up options. The useRbfForm hook is directly used for RBF (Replace-By-Fee) / speed-up functionality, and calculateNewFee is core to computing replacement transaction fees. Changes to fee calculation logic could break the pending transaction speed-up flow tested here.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test covers the Bitcoin send form on regtest including filling amounts, addresses, custom fees (locktime), and completing device confirmation. The feesUtils and useRbfForm changes directly affect the send form's fee handling and transaction composition logic.

</details>

<details><summary>🟡 <b>Medium priority (10)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test verifies ETH staking with pending transactions and a speed-up button. The speed-up flow uses RBF logic (useRbfForm) and fee calculation utilities (feesUtils). Changes to fee computation could affect whether the speed-up option works correctly.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — This test includes pending staking transactions with speed-up buttons and fee display, which exercises fee calculation and potentially RBF-related logic. Changes to feesUtils could affect fee display and speed-up functionality.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — This test covers ETH unstaking with pending transactions and a speed-up option, directly exercising fee calculation and RBF functionality. Changes to fee utilities could affect the speed-up button behavior and fee display.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — This test explicitly verifies custom Bitcoin fee settings during a swap, including fee rate display on the device and in the UI. The feesUtils changes could directly affect how Bitcoin fee rates are calculated and displayed in this flow.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — This test verifies custom Ethereum fee parameters (gas limit, max fee per gas, priority fee) during a swap flow. The feesUtils changes could affect how these fee values are calculated and passed through the swap confirmation.
- `suite/e2e/tests/wallet/send-eth.test.ts` — This test verifies custom Ethereum gas fee parameters in the send form, including gas limit, max fee per gas, and priority fee. The feesUtils changes could affect fee calculations displayed in the send flow and on the device prompt.
- `suite/e2e/tests/wallet/send-base.test.ts` — This test covers sending on the Base (EVM) network with custom Ethereum fees and verifies fee details on the device. The feesUtils changes could affect the Ethereum fee calculation logic used in this flow.
- `suite/e2e/tests/wallet/send-doge.test.ts` — This test verifies DOGE transaction sending including fee display on the device prompt. Fee calculation changes in feesUtils could affect how the fee amount is computed and displayed for UTXO-based coins like DOGE.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — This test verifies Bitcoin fee calculation during a sell flow (expectBitcoinFeeCalculated) and displays fee on the device prompt. Changes to feesUtils could affect the Bitcoin fee computation used in the sell confirmation.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — This test explicitly sets a custom fee rate for BTC sell transactions and uses a Max button that subtracts fees from the balance. Changes to feesUtils could affect the fee calculation that determines the max sellable amount.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/wallet/send-sol.test.ts` — This test covers Solana send-max which requires fee calculation to determine the maximum sendable amount. While Solana fees are simpler than BTC/ETH, feesUtils changes could still affect the fee retrieval logic used here.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — This test sends LTC with a MimbleWimble peg-out output, exercising UTXO-based send form logic. Fee calculation changes could affect the transaction composition for LTC sends.
- `suite/e2e/tests/staking/staking-form.test.ts` — This test validates ETH staking form inputs including a Max button that accounts for a withdrawal buffer. Fee calculation changes could indirectly affect how the max stakeable amount is computed.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/wallet-core/tests/send/composeCancelTransaction/calculateNewFee.test.ts`

_Updated: 2026-05-28T12:58:43.757Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/lower-btc-normal-fee-rate&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/lower-btc-normal-fee-rate&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/lower-btc-normal-fee-rate&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-02T21:26:19.812Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-02T21:38:14.614Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/lower-btc-normal-fee-rate/web/](https://dev.suite.sldev.cz/suite-web/fix/lower-btc-normal-fee-rate/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->