### PR TITLE
fix(suite-common): skip generic fee estimation for tron

### DIFF
--- a/suite-common/wallet-core/src/fees/feesUtils.ts
+++ b/suite-common/wallet-core/src/fees/feesUtils.ts
@@ -42,6 +42,11 @@ export const getNewFeeInfo = async ({
     device,
 }: GetNewFeeInfoProps): Promise<BlockchainEstimatedFeeLevel | undefined> => {
     const { symbol } = network;
+
+    if (network.networkType === 'tron') {
+        return;
+    }
+
     if (network.networkType === 'ethereum') {
         const result = await TrezorConnect.blockchainEstimateFee({
             coin: symbol,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`getNewFeeInfo` was sending a generic `estimateFee` request for every network on send form mount. Tron's blockbook rejects it. Tron has no block-target fee model, fees are computed per-tx

## Notes for QA

Just regression, send works as before

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27964

## Screenshots:

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/tron-skip-fee-estimation/web/](https://dev.suite.sldev.cz/suite-web/fix/tron-skip-fee-estimation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/tron-skip-fee-estimation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/tron-skip-fee-estimation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/tron-skip-fee-estimation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-28T13:56:30.728Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-28T13:54:29.379Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change to `feesUtils.ts` in the wallet-core fees module is a broad utility file mapped to 121 tests, but its impact is most directly felt in tests that exercise fee calculation, fee display, and send/swap/sell/stake transaction flows. The highest risk areas are tests that explicitly assert on fee values, max amounts (which require fee subtraction), and fee parameters on device confirmation screens. The recommended strategy focuses on send-form tests across different networks (ETH, SOL, BTC/regtest, DOGE, LTC), trading fee tests (swap-fees-bitcoin, swap-fees-ethereum), sell flow tests with fee assertions, and staking tests that verify fee display. Tests unrelated to fee computation (analytics, backup, browser, metadata, onboarding) are omitted despite static mapping since they only transitively import the changed file.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/wallet-core/src/fees/feesUtils.ts`

</details>

**Recommended tests (20)**

<details><summary>🔴 <b>High priority (7)</b></summary>

- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — This test directly exercises Bitcoin custom fee settings during a swap trade, displaying fee, total amount, and fee rate in confirmation modals and on device emulator. Changes to feesUtils.ts would directly affect fee calculation and display logic tested here.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — This test exercises custom Ethereum fee parameters (gas limit, max fee per gas, max priority fee per gas) through the swap flow, verifying fee calculations in the confirmation modal and hardware device display. Directly dependent on fee utility logic.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — This test explicitly asserts that 'Bitcoin fee is calculated' (expectBitcoinFeeCalculated) during the sell flow and verifies fee amounts on the device prompt. Fee calculation utilities are directly exercised.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — This test sets custom Ethereum fee parameters (gas limit, max fee per gas, max priority fee per gas) for a sell transaction and verifies the resulting fee on the device prompt. Directly exercises fee utility calculations.
- `suite/e2e/tests/wallet/send-eth.test.ts` — This test fills in custom Ethereum gas fee parameters, calculates maximum fee (gasLimit * maxFeePerGas), and verifies fee display on device prompt and emulator. The fee calculation logic from feesUtils is directly exercised.
- `suite/e2e/tests/wallet/send-sol.test.ts` — This test calculates send-max amounts by deducting fees and network reserve from balance, and verifies fee amounts on device prompts. Fee utility changes directly impact the max amount calculation and fee display.
- `suite/e2e/tests/staking/staking-form.test.ts` — This test exercises the staking form's Max button which calculates maximum stakeable amount minus a withdrawal buffer, and validates fee display. It uses percentage-based balance calculations that depend on fee utilities.

</details>

<details><summary>🟡 <b>Medium priority (12)</b></summary>

- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test fills send form fields including amounts with locktime, sends transactions, and verifies OP_RETURN outputs. Fee calculation is part of the send transaction flow exercised here.
- `suite/e2e/tests/wallet/send-doge.test.ts` — This test verifies fee display on the device prompt for a DOGE transaction (fee amount '0.01450643 DOGE') and total amount calculation. Fee utility changes could affect these displayed values.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — This test sends LTC with a MimbleWimble peg-out output using broadcast mode with max amount, which requires fee calculation to determine the sendable amount.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — This test exercises sell form percentage buttons and Max button for BTC, which calculates max sellable amount by subtracting custom fee from total balance. Fee calculation logic is directly involved.
- `suite/e2e/tests/trading/sell-solana.test.ts` — This test verifies fee information (max fee and max fee fiat) is displayed and resolved before proceeding with a Solana sell, and checks device prompt fee amount is greater than 0.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — This test sells an ERC-20 token and verifies fee amount on the device prompt is greater than 0. Ethereum fee calculation from feesUtils is part of this flow.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test verifies the fee display ('0.000290278609719 ETH') on the device prompt during ETH staking. Fee calculation utilities are used to compute and format this value.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — This test verifies fee amounts displayed during unstaking and claiming ETH transactions on the device prompt. Fee utility changes could affect these calculations.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — This test verifies SOL staking fee display using stakeFeeFormatted and total crypto amount (stake + rent) on the device prompt. Fee formatting utilities are directly involved.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — This test verifies transaction fee display for both unstaking and claiming SOL operations on the device prompt. Fee calculation is exercised in both flows.
- `suite/e2e/tests/staking/ada/stake.test.ts` — This test verifies Cardano staking fee display on the device confirmation screen and checks the max fee in the staking modal. Fee formatting utilities are exercised.
- `suite/e2e/tests/trading/swap-coins.test.ts` — This test reads Solana fee from the form via composedTransactionInfo Redux state and verifies it on the device emulator display. Fee utility changes could affect the fee computation.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — While primarily about backend configuration, this test triggers discovery which involves fee fetching. A broken feesUtils could cause discovery errors that would surface in this test's assertions about account loading.

</details>

_Updated: 2026-05-28T13:48:41.353Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->