### PR TITLE
feat(suite): enable btc dust phishing protection

### DIFF
--- a/suite-common/token-definitions/src/phishing/phishing.ts
+++ b/suite-common/token-definitions/src/phishing/phishing.ts
@@ -14,6 +14,7 @@ import { PhishingTransactionValidator } from './validator';
 type NetworkPhishingValidators = Map<NetworkType, PhishingTransactionValidator>;
 
 const PHISHING_VALIDATORS: NetworkPhishingValidators = new Map([
+    ['bitcoin', new PhishingTransactionValidator().addDetector(detectors.dustValue)],
     [
         'ethereum',
         new PhishingTransactionValidator()

--- a/suite-common/token-definitions/src/phishing/phishing.ts
+++ b/suite-common/token-definitions/src/phishing/phishing.ts
@@ -14,7 +14,12 @@ import { PhishingTransactionValidator } from './validator';
 type NetworkPhishingValidators = Map<NetworkType, PhishingTransactionValidator>;
 
 const PHISHING_VALIDATORS: NetworkPhishingValidators = new Map([
-    ['bitcoin', new PhishingTransactionValidator().addDetector(detectors.dustValue)],
+    [
+        'bitcoin',
+        new PhishingTransactionValidator()
+            .addDetector(detectors.dustValue)
+            .addDetector(detectors.zeroValue),
+    ],
     [
         'ethereum',
         new PhishingTransactionValidator()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Seems like in the original phishing detectors PR https://github.com/trezor/trezor-suite/pull/25263 option was not enabled for bitcoin. This PR enables it for BTC too

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

Tested on a desktop only with well-known seed-phrase and enabled threshold to be $5

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27977

## Screenshots:
<img width="885" height="329" alt="Screenshot 2026-05-28 at 16 24 38" src="https://github.com/user-attachments/assets/e5a112e4-24cf-4422-9c7b-23e68e980f90" />
<img width="1431" height="559" alt="Screenshot 2026-05-28 at 16 24 23" src="https://github.com/user-attachments/assets/6dc4ed75-ee62-4700-b58b-8ca26c270926" />
<img width="856" height="577" alt="Screenshot 2026-05-28 at 16 24 31" src="https://github.com/user-attachments/assets/492916fd-4a79-4ac5-a0ea-c399db748e1c" />
