### PR TITLE
chore(suite-desktop): sign all binaries on windows

### DIFF
--- a/packages/suite-desktop/electron-builder-config.js
+++ b/packages/suite-desktop/electron-builder-config.js
@@ -132,6 +132,7 @@ module.exports = {
         icon: 'build/static/images/desktop/512x512.png',
         artifactName: 'Trezor-Suite-${version}-win-${arch}.${ext}',
         target: ['nsis'],
+        signExts: ['.exe', '.dll'],
         signtoolOptions: {
             publisherName: ['SatoshiLabs, s.r.o.', 'Trezor Company s.r.o.'],
             // TODO #14482: when Electron-main is migrated to ESM, and we declare whole suite-desktop package as ESM, rename .mjs files to .js


### PR DESCRIPTION
## Description

Low hanging fruit to to include all `.exe` and `.dll` files to signing, not just the exe [which are default](https://github.com/electron-userland/electron-builder/blob/2ca6042c08a1d5d9ef28f368497debf4898497c0/packages/app-builder-lib/src/winPackager.ts#L239)

Not that it matters from security standpoint – during installation, windows checks only the `Trezor Suite.exe` signature.
But some users reported that AppLocker is more stringent than default Windows environment, and updates fail for them unless they add exception for Trezor Suite. Currently some external `dlls` provided via Electron (via Chromium) are not signed by the original source, so we shall sign them.

## Notes for QA

Smoke test that windows Suite works [with ad-hoc build](https://github.com/trezor/trezor-suite/actions/runs/26584732038)
:warning: But since this is related to signing, it must also be tested with real codesign build, i.e. next RC!
- Use Windows 11 ideally with:
  - non-elevated user
  - Windows SmartScreen on max security setting
  - Smart App Control is on
  - User Account Control on max security setting
- Test that Suite installs and runs:
  - status quo maintained, only the existing reputation-based warnings pop up, no warnings about unsigned app
- Tor and Bluetooth works (they're separate `.exe` subprocesses, so test that the signing doesn't break it)

:information_source: I have built :window:  Trezor Suite with self-signed certificate, which is not valid (untrusted root), but I verified with `DigiCertUtil.exe` on Windows 11 that the signature is applied on all files in question.
This tests that the real signature will also be applied during codesign production build.

:information_source: disregard LLM recommendations, that's a miss. Playwright tests do not use electron-builder at all, they run electron directly without building :slightly_smiling_face: 

## Related Issue

Resolve https://github.com/trezor/trezor-suite-private/issues/2

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is limited to the Electron builder configuration file (electron-builder-config.js), which controls how the Suite desktop app is packaged and built. This is a build/packaging concern rather than runtime application logic, so the risk of functional regression is low. However, the two Electron-specific bridge tests are worth running at medium priority since they directly exercise the packaged Electron app's launch behavior, bundled processes, and lifecycle — all of which could be affected by builder config changes. No other tests are recommended since they exercise web or runtime application features unrelated to Electron packaging.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite-desktop/electron-builder-config.js`

</details>

**Recommended tests (2)**

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — This test launches the Electron app and validates its lifecycle behavior (window title, bridge spawning, renderer reload). Changes to electron-builder-config.js could affect how the Electron app is packaged and launched, potentially impacting app initialization, window properties, or bundled process behavior.
- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — This test launches the Electron app in daemon mode and validates bridge process spawning. Electron builder configuration changes could affect how the app binary is built, how the node-bridge is bundled, or how daemon mode flags are handled during packaging.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite-desktop/electron-builder-config.js`

_Updated: 2026-05-28T15:32:09.412Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->