### PR TITLE
feat(suite): enable address chunking for Cardano tx. sending

### DIFF
--- a/suite-common/wallet-core/src/send/sendFormCardanoThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormCardanoThunks.ts
@@ -1,6 +1,7 @@
 import { createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import {
+    AddressDisplayOptions,
     type PrecomposedLevelsCardano,
     type PrecomposedTransactionCardano,
 } from '@suite-common/wallet-types';
@@ -23,6 +24,7 @@ import {
     type SignTransactionError,
     type SignTransactionThunkArguments,
 } from './sendFormTypes';
+import { selectAddressDisplayType } from '../settings/walletSettingsReducer';
 
 export const composeCardanoTransactionFeeLevelsThunk = createThunk<
     PrecomposedLevelsCardano,
@@ -149,7 +151,7 @@ export const signCardanoSendFormTransactionThunk = createThunk<
     `${SEND_MODULE_PREFIX}/signCardanoSendFormTransactionThunk`,
     async (
         { precomposedTransaction, selectedAccount, device, paymentRequests },
-        { rejectWithValue },
+        { getState, rejectWithValue },
     ) => {
         const { symbol, accountType } = selectedAccount;
 
@@ -160,6 +162,7 @@ export const signCardanoSendFormTransactionThunk = createThunk<
             });
 
         const payment_req = paymentRequests?.[0];
+        const addressDisplayType = selectAddressDisplayType(getState());
 
         // todo: add chunkify once we allow it for Cardano
         const response = await TrezorConnect.cardanoSignTransaction({
@@ -181,6 +184,7 @@ export const signCardanoSendFormTransactionThunk = createThunk<
             ttl: precomposedTransaction.ttl?.toString(),
             derivationType: getDerivationType(accountType),
             payment_req,
+            chunkify: addressDisplayType == AddressDisplayOptions.CHUNKED,
         });
 
         if (!response.success) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR enables visual address chunking for ADA transactions

## Notes for QA

Only affects transaction sending for Cardano. During development I faced hopefully local-only issue when fiat denomination couldn't be loaded and transaction sending was failing. 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27658

## Screenshots:

<img width="707" height="841" alt="Screenshot 2026-05-28 at 18 03 57" src="https://github.com/user-attachments/assets/d207fa12-8ce3-4fda-8a3c-d87dc66c6463" />
<img width="448" height="640" alt="Screenshot 2026-05-28 at 18 03 54" src="https://github.com/user-attachments/assets/d710da46-2fc2-4365-b2fb-577546ee55f7" />
