### PR TITLE
fix(suite): parse coin URI amounts strictly

### DIFF
--- a/packages/suite/src/utils/suite/__fixtures__/protocol.ts
+++ b/packages/suite/src/utils/suite/__fixtures__/protocol.ts
@@ -95,6 +95,33 @@ export const getProtocolInfo: getProtocolInfoFixture[] = [
         },
     },
     {
+        description: 'should ignore Bitcoin URI amount with trailing text',
+        uri: 'bitcoin:3QmuBaZrJNCxc5Xs7aGzZUK8RirUT8jRKf?amount=1btc',
+        result: {
+            scheme: 'bitcoin',
+            address: '3QmuBaZrJNCxc5Xs7aGzZUK8RirUT8jRKf',
+            amount: undefined,
+        },
+    },
+    {
+        description: 'should ignore Bitcoin URI amount with exponent notation',
+        uri: 'bitcoin:3QmuBaZrJNCxc5Xs7aGzZUK8RirUT8jRKf?amount=1e2',
+        result: {
+            scheme: 'bitcoin',
+            address: '3QmuBaZrJNCxc5Xs7aGzZUK8RirUT8jRKf',
+            amount: undefined,
+        },
+    },
+    {
+        description: 'should ignore Bitcoin URI amount with commas',
+        uri: 'bitcoin:3QmuBaZrJNCxc5Xs7aGzZUK8RirUT8jRKf?amount=50,000.00',
+        result: {
+            scheme: 'bitcoin',
+            address: '3QmuBaZrJNCxc5Xs7aGzZUK8RirUT8jRKf',
+            amount: undefined,
+        },
+    },
+    {
         description: 'invalid uri',
         uri: 'gibberish',
         result: null,

--- a/packages/suite/src/utils/suite/protocol.ts
+++ b/packages/suite/src/utils/suite/protocol.ts
@@ -12,6 +12,17 @@ export type CoinProtocolInfo = {
 };
 
 const removeLeadingTrailingSlashes = (text: string) => text.replace(/^\/{0,2}|\/$/g, '');
+const AMOUNT_REGEXP = /^\d+(?:\.\d+)?$/;
+
+const parseAmount = (amount: string | undefined): number | undefined => {
+    if (!amount || !AMOUNT_REGEXP.test(amount)) {
+        return undefined;
+    }
+
+    const parsedAmount = Number(amount);
+
+    return Number.isFinite(parsedAmount) && parsedAmount > 0 ? parsedAmount : undefined;
+};
 
 export const getProtocolInfo = (
     uri: string,
@@ -41,8 +52,7 @@ export const getProtocolInfo = (
             };
         }
 
-        const floatAmount = Number.parseFloat(params.amount ?? '');
-        const amount = !Number.isNaN(floatAmount) && floatAmount > 0 ? floatAmount : undefined;
+        const amount = parseAmount(params.amount);
 
         const address =
             removeLeadingTrailingSlashes(pathname) || removeLeadingTrailingSlashes(host);


### PR DESCRIPTION
## Description

Coin URI amount parsing in Suite used `Number.parseFloat`, which accepts partial numeric strings and exponent notation. A scanned or handled Bitcoin URI such as `bitcoin:...?amount=1btc`, `amount=1e2`, or `amount=50,000.00` could therefore prefill a different amount than the full URI value implies.

This changes coin URI amount parsing to accept only a complete positive decimal string before converting it to a number. Malformed amounts are ignored, matching the existing behavior for invalid or zero amounts.

BIP21 reference: https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki

## Notes for QA

Please focus on Bitcoin payment URI handling through QR scan and protocol/deep-link entry points. Valid decimal values such as `amount=0.1` should still prefill the send form. Malformed values such as `amount=1btc`, `amount=1e2`, and `amount=50,000.00` should leave the amount unset.

## Related Issue

N/A

## Screenshots:

N/A

## Testing

- Before the fix, the added regression fixtures failed because `1btc`, `1e2`, and `50,000.00` were parsed as `1`, `100`, and `50`.
- `yarn workspace @trezor/suite test:unit --coverage=0 src/utils/suite/__tests__/protocol.test.ts`
- `yarn exec eslint --cache --cache-strategy content --flag v10_config_lookup_from_file --max-warnings 0 packages/suite/src/utils/suite/protocol.ts packages/suite/src/utils/suite/__fixtures__/protocol.ts`
- `yarn prettier --check packages/suite/src/utils/suite/protocol.ts packages/suite/src/utils/suite/__fixtures__/protocol.ts`
- `git diff --check`
- `yarn build:libs`
- `yarn workspace @trezor/suite type-check` was attempted after `yarn build:libs`, but this local shallow checkout still fails outside the touched files on missing `submodules/trezor-common` fixture JSON files and workspace `TS6305` declaration build-state errors for unrelated `suite-common` packages.
