### PR TITLE
feat(suite): clear sign claim transactions

### DIFF
--- a/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
@@ -29,26 +29,32 @@ import {
     AddressDisplayOptions,
     type FormState,
     type PrecomposedTransactionFinal,
+    type YieldClaimReward,
 } from '@suite-common/wallet-types';
 import { getAccountIdentity, getMevProtectedTxData, sanitizeHex } from '@suite-common/wallet-utils';
 import TrezorConnect, { type StaticSessionId } from '@trezor/connect';
 import { BigNumber } from '@trezor/utils';
 
+type ClaimMerklReward = YieldAccountsRewards[number]['rewards'][number];
+
 type BuildClaimReviewStateParams = {
     data: EvmHexString;
     contractAddress: EvmHexString;
     fee: EvmFeeHex;
+    rewards: ClaimMerklReward[];
 };
 
 type BuildClaimReviewStateResult = {
     formState: FormState;
     precomposedTransaction: PrecomposedTransactionFinal;
+    availableRewards: YieldClaimReward[];
 };
 
 const buildClaimReviewState = ({
     data,
     contractAddress,
     fee,
+    rewards,
 }: BuildClaimReviewStateParams): BuildClaimReviewStateResult => {
     const feePriceWei = new BigNumber(
         hexToNumberString(fee.type === 'eip1559' ? fee.maxFeePerGas : fee.gasPrice),
@@ -96,13 +102,17 @@ const buildClaimReviewState = ({
         selectedUtxos: [],
     };
 
+    const availableRewards = rewards.map(reward => ({
+        tokenAddress: reward.token.address,
+        tokenSymbol: reward.token.symbol,
+    }));
+
     const precomposedTransaction: PrecomposedTransactionFinal = {
         type: 'final',
         bytes: 0,
         inputs: [],
         outputs: [{ address: contractAddress, amount: '0' }],
         outputsPermutation: [0],
-
         totalSpent: feeWei,
         fee: feeWei,
         feePerByte: feePerUnitGwei,
@@ -111,7 +121,7 @@ const buildClaimReviewState = ({
         maxPriorityFeePerGas: eip1559Fields.maxPriorityFeePerGasGwei,
     };
 
-    return { formState, precomposedTransaction };
+    return { formState, precomposedTransaction, availableRewards };
 };
 
 interface GetEstimatedClaimFeeParams {
@@ -171,7 +181,7 @@ async function getEstimatedFee({
 type ClaimMerklRewardsParams = {
     account: Account;
     flowKey: string;
-    rewards: YieldAccountsRewards[number]['rewards'];
+    rewards: ClaimMerklReward[];
 };
 
 export const claimMerklRewardsThunk = createThunk(
@@ -283,16 +293,18 @@ export const claimMerklRewardsThunk = createThunk(
                 throw new Error('Fee information is missing for the transaction.');
             }
 
-            const { formState, precomposedTransaction } = buildClaimReviewState({
+            const { formState, precomposedTransaction, availableRewards } = buildClaimReviewState({
                 data: unsignedClaimTx.data,
                 contractAddress: unsignedClaimTx.to,
                 fee: parsedSelectedFee,
+                rewards,
             });
 
             dispatch(
                 stablecoinYieldActions.storePrecomposedTransaction({
                     precomposedTx: precomposedTransaction,
                     precomposedForm: formState,
+                    availableRewards,
                     accountKey: account.key,
                 }),
             );

--- a/packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts
@@ -12,7 +12,6 @@ import {
     type Account,
     AddressDisplayOptions,
     type EvmSelectedFee,
-    type YieldFormMetadata,
 } from '@suite-common/wallet-types';
 import { getAccountIdentity, getMevProtectedTxData } from '@suite-common/wallet-utils';
 import TrezorConnect from '@trezor/connect';
@@ -24,7 +23,6 @@ export type SendYieldTransactionParams = {
     amount: string;
     token: YieldFlowDisplayToken;
     unsignedTransaction: string;
-    flowType: YieldFormMetadata['type'];
     vaultName: string;
     dispatch: Dispatch;
     getState: () => AppState;
@@ -36,7 +34,6 @@ export const sendYieldTransaction = async ({
     amount,
     token,
     unsignedTransaction,
-    flowType,
     vaultName,
     dispatch,
     getState,
@@ -59,8 +56,6 @@ export const sendYieldTransaction = async ({
         amount,
         token,
         symbol: account.symbol,
-        flowType,
-        vaultName,
     });
 
     const { transactionForSigning, formState, precomposedTransaction } = transactionReview;
@@ -69,6 +64,7 @@ export const sendYieldTransaction = async ({
         stablecoinYieldActions.storePrecomposedTransaction({
             precomposedTx: precomposedTransaction,
             precomposedForm: formState,
+            vaultName,
             accountKey: account.key,
         }),
     );

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts
@@ -133,7 +133,6 @@ export const submitYieldDepositThunk = createThunk(
                 amount,
                 token: flowData.token,
                 unsignedTransaction: actionTransaction.unsignedTransaction,
-                flowType,
                 vaultName,
                 dispatch,
                 getState,

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts
@@ -76,14 +76,12 @@ export const submitYieldWithdrawThunk = createThunk(
             const vaultName = flowData.vault.outputToken?.name ?? flowData.vault.metadata.name;
             const isSharesInput = withdrawInputUnit === 'shares';
             const reviewToken = isSharesInput ? flowData.receiptToken : flowData.token;
-            const reviewFlowType = isSharesInput ? 'redeem' : 'withdraw';
 
             const result = await sendYieldTransaction({
                 account,
                 amount,
                 token: reviewToken,
                 unsignedTransaction,
-                flowType: reviewFlowType,
                 vaultName,
                 dispatch,
                 getState,

--- a/packages/suite/src/components/earn/yield/claim/YieldClaim.tsx
+++ b/packages/suite/src/components/earn/yield/claim/YieldClaim.tsx
@@ -1,10 +1,13 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
-import { Translation } from '@suite/intl';
+import { FirmwareUpgradeNeededModal } from '@suite/firmware-upgrade';
+import { Translation, useTranslation } from '@suite/intl';
 import { openModal } from '@suite/modal';
+import { goto } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
+import { isStablecoinYieldSupported } from '@suite-common/device';
 import { type YieldAccountRewards } from '@suite-common/earn-stablecoin-api';
 import { Context } from '@suite-common/message-system';
 import {
@@ -15,6 +18,7 @@ import {
 import { type Account } from '@suite-common/wallet-types';
 import { Banner, Button, Card, Column, Text } from '@trezor/components';
 
+import { selectIsConnectionModalOpen } from 'src/actions/device/deviceSelectors';
 import { setConnectionModal, setConnectionMode } from 'src/actions/device/deviceSlice';
 import { claimMerklRewardsThunk } from 'src/actions/wallet/stablecoin-yield';
 import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
@@ -36,9 +40,13 @@ export const YieldClaim = ({ account }: YieldClaimProps) => {
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const dispatch = useDispatch();
     const { device } = useDevice();
+    const { translationString } = useTranslation();
     const flowKey = account.key;
     const { isDisabled, content, variant } = useMessageSystemYield('claim');
+    const [isFirmwareModalOpen, setIsFirmwareModalOpen] = useState(false);
+    const [isAwaitingConnectionForFwUpdate, setIsAwaitingConnectionForFwUpdate] = useState(false);
 
+    const isConnectionModalOpen = useSelector(selectIsConnectionModalOpen);
     const yieldTxReview = useSelector(selectStablecoinYieldTxReview);
     const claimSession = useSelector(state =>
         selectStablecoinYieldSession(state, 'claim', flowKey),
@@ -48,6 +56,7 @@ export const YieldClaim = ({ account }: YieldClaimProps) => {
         (!!yieldTxReview.precomposedTx && yieldTxReview.accountKey === account.key);
     const isClaiming = isClaimSubmitting || !!claimSession.action.pendingTransaction;
     const isDeviceConnected = !!device?.connected && device.available;
+    const isClaimFirmwareOutdated = !isStablecoinYieldSupported(device, 'claim');
 
     const { merklRewardsQuery, missingRateTickersQuery } = useMerklRewards(account);
     const accountRewards: YieldAccountRewards | undefined =
@@ -62,6 +71,16 @@ export const YieldClaim = ({ account }: YieldClaimProps) => {
         };
     }, [dispatch, flowKey]);
 
+    useEffect(() => {
+        if (isAwaitingConnectionForFwUpdate && !isConnectionModalOpen) {
+            setIsAwaitingConnectionForFwUpdate(false);
+            if (device?.connected) {
+                setIsFirmwareModalOpen(false);
+                dispatch(goto({ routeName: 'firmware-index', params: { cancelable: true } }));
+            }
+        }
+    }, [isAwaitingConnectionForFwUpdate, isConnectionModalOpen, device?.connected, dispatch]);
+
     useYieldPendingTransactionTracking({
         account,
         flowType: 'claim',
@@ -71,6 +90,12 @@ export const YieldClaim = ({ account }: YieldClaimProps) => {
 
     const handleClaim = async () => {
         if (!accountRewards) return;
+
+        if (isClaimFirmwareOutdated) {
+            setIsFirmwareModalOpen(true);
+
+            return;
+        }
 
         if (!isDeviceConnected) {
             if (device?.descriptor?.apiType === 'bluetooth') {
@@ -98,6 +123,26 @@ export const YieldClaim = ({ account }: YieldClaimProps) => {
         } catch {
             // cancelled or rejected — isClaiming resets via Redux (discardTransaction in finally)
         }
+    };
+
+    const handleFirmwareModalClose = () => {
+        setIsFirmwareModalOpen(false);
+        setIsAwaitingConnectionForFwUpdate(false);
+    };
+
+    const handleFirmwareUpdate = () => {
+        if (!device?.connected) {
+            if (device?.descriptor?.apiType === 'bluetooth') {
+                dispatch(setConnectionMode('bluetooth'));
+            }
+            setIsAwaitingConnectionForFwUpdate(true);
+            dispatch(setConnectionModal(true));
+
+            return;
+        }
+
+        setIsFirmwareModalOpen(false);
+        dispatch(goto({ routeName: 'firmware-index', params: { cancelable: true } }));
     };
 
     const handleTxClick = useCallback(
@@ -137,6 +182,13 @@ export const YieldClaim = ({ account }: YieldClaimProps) => {
 
     return (
         <Column width="100%" alignItems="center">
+            {isFirmwareModalOpen && (
+                <FirmwareUpgradeNeededModal
+                    onClose={handleFirmwareModalClose}
+                    onUpdate={handleFirmwareUpdate}
+                    featureName={translationString('TR_EARN_STABLECOIN_YIELD_TITLE')}
+                />
+            )}
             <Column gap={24} width="100%" maxWidth={500}>
                 <ContextMessage context={Context.getEarnYield('claim')} />
 

--- a/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
@@ -41,6 +41,7 @@ export const YieldPageHeader = ({
     const { isBelowMobile } = useLayoutSize();
     const vaultName = vault?.outputToken?.name;
     const networkSymbol = account?.symbol;
+    const isHowItWorksVisible = !isInvalid;
 
     const onBackClick = () => {
         analytics.report({
@@ -148,29 +149,31 @@ export const YieldPageHeader = ({
                     </Row>
                 )}
 
-                <Box margin={{ left: 'auto' }}>
-                    {isBelowMobile ? (
-                        <IconButton
-                            icon="info"
-                            intent="neutral"
-                            priority="secondary"
-                            size="large"
-                            aria-label={translationString('TR_EARN_HOW_IT_WORKS')}
-                            onClick={onHowItWorksClick}
-                            isDisabled={!account || !routeParams}
-                            tooltip={{ content: <Translation id="TR_EARN_HOW_IT_WORKS" /> }}
-                        />
-                    ) : (
-                        <Button
-                            intent="neutral"
-                            priority="secondary"
-                            onClick={onHowItWorksClick}
-                            isDisabled={!account || !routeParams}
-                        >
-                            <Translation id="TR_EARN_HOW_IT_WORKS" />
-                        </Button>
-                    )}
-                </Box>
+                {isHowItWorksVisible && (
+                    <Box margin={{ left: 'auto' }}>
+                        {isBelowMobile ? (
+                            <IconButton
+                                icon="info"
+                                intent="neutral"
+                                priority="secondary"
+                                size="large"
+                                aria-label={translationString('TR_EARN_HOW_IT_WORKS')}
+                                onClick={onHowItWorksClick}
+                                isDisabled={!account || !routeParams}
+                                tooltip={{ content: <Translation id="TR_EARN_HOW_IT_WORKS" /> }}
+                            />
+                        ) : (
+                            <Button
+                                intent="neutral"
+                                priority="secondary"
+                                onClick={onHowItWorksClick}
+                                isDisabled={!account || !routeParams}
+                            >
+                                <Translation id="TR_EARN_HOW_IT_WORKS" />
+                            </Button>
+                        )}
+                    </Box>
+                )}
             </Row>
         </PageHeader>
     );

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBody.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBody.tsx
@@ -6,6 +6,7 @@ import { preserveModalOnTxTimeout } from '@suite/modal';
 import { selectRouterUrl } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
+import { selectStablecoinYieldTxReview } from '@suite-common/wallet-core';
 import { type FormState } from '@suite-common/wallet-types';
 import {
     constructTransactionReviewOutputsOptional,
@@ -43,6 +44,11 @@ export const TransactionReviewModalBody = ({
     const dispatch = useDispatch();
     const account = useSelector(selectAccountIncludingChosenInTrading);
     const device = useSelector(selectSelectedDevice);
+    const yieldTxReview = useSelector(selectStablecoinYieldTxReview);
+
+    const isYield = Boolean(yieldTxReview.precomposedTx);
+    const vaultName = isYield ? yieldTxReview.vaultName : undefined;
+    const availableRewards = isYield ? yieldTxReview.availableRewards : undefined;
     const [isSending, setIsSending] = useState(false);
     const { precomposedTx, serializedTx } = txInfoState;
     const [hasTxReviewExpired, setHasTxReviewExpired] = useState(false);
@@ -100,8 +106,10 @@ export const TransactionReviewModalBody = ({
         account,
         decreaseOutputId,
         device,
+        availableRewards,
         precomposedForm,
         precomposedTx,
+        vaultName,
     });
 
     const handleTryAgain = useCallback(
@@ -142,6 +150,8 @@ export const TransactionReviewModalBody = ({
             tryAgainSignTx={tryAgainSignTx}
             cancelSignTx={cancelSignTx}
             precomposedForm={precomposedForm}
+            vaultName={vaultName}
+            availableRewards={availableRewards}
             precomposedTx={precomposedTx}
             isSending={isSending}
             setIsSending={setIsSending}

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx
@@ -18,6 +18,7 @@ import {
     type GeneralPrecomposedTransactionFinal,
     type ReviewOutput,
     type StakeType,
+    type YieldClaimReward,
 } from '@suite-common/wallet-types';
 import {
     getStakeType,
@@ -80,6 +81,8 @@ export type TransactionReviewModalBodyInnerProps = {
     tryAgainSignTx: () => void;
     cancelSignTx: () => void;
     precomposedForm: FormState;
+    vaultName?: string;
+    availableRewards?: YieldClaimReward[];
     precomposedTx: GeneralPrecomposedTransactionFinal;
     isSending: boolean;
     setIsSending: (value: boolean) => void;
@@ -98,6 +101,8 @@ export const TransactionReviewModalBodyInner = ({
     isRbfConfirmedError,
     cancelSignTx,
     precomposedForm,
+    vaultName,
+    availableRewards,
     isSending,
     setIsSending,
     hasTxReviewExpired,
@@ -294,6 +299,8 @@ export const TransactionReviewModalBodyInner = ({
                     account={account}
                     precomposedTx={precomposedTx}
                     precomposedForm={precomposedForm}
+                    vaultName={vaultName}
+                    availableRewards={availableRewards}
                     serializedTx={serializedTx}
                     isSending={isSending}
                     reviewStep={reviewStep}

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalContent.tsx
@@ -9,6 +9,7 @@ import {
     type Account,
     type FormState,
     type GeneralPrecomposedTransactionFinal,
+    type YieldClaimReward,
 } from '@suite-common/wallet-types';
 import {
     constructTransactionReviewOutputsOptional,
@@ -18,7 +19,6 @@ import {
     isRbfTransaction,
 } from '@suite-common/wallet-utils';
 import { Column } from '@trezor/components';
-import { spacings } from '@trezor/theme';
 
 import { useSelector } from 'src/hooks/suite';
 
@@ -31,6 +31,8 @@ type TransactionReviewModalContentProps = {
     account: Account;
     precomposedTx: GeneralPrecomposedTransactionFinal;
     precomposedForm: FormState;
+    vaultName?: string;
+    availableRewards?: YieldClaimReward[];
     isSending: boolean;
     onTryAgain: (cancel: boolean) => void;
     reviewStep: number;
@@ -47,6 +49,8 @@ export const TransactionReviewModalContent = ({
     serializedTx,
     reviewStep,
     precomposedForm,
+    vaultName,
+    availableRewards,
     onTryAgain,
     isSending,
     hasTxReviewExpired,
@@ -78,12 +82,22 @@ export const TransactionReviewModalContent = ({
         () =>
             constructTransactionReviewOutputsOptional({
                 account,
+                availableRewards,
                 decreaseOutputId,
                 device,
                 precomposedForm,
                 precomposedTx,
+                vaultName,
             }),
-        [account, decreaseOutputId, device, precomposedForm, precomposedTx],
+        [
+            account,
+            availableRewards,
+            decreaseOutputId,
+            device,
+            precomposedForm,
+            precomposedTx,
+            vaultName,
+        ],
     );
 
     const stakeType = getStakeType(precomposedForm, outputs);
@@ -111,7 +125,7 @@ export const TransactionReviewModalContent = ({
     }
 
     return (
-        <Column gap={spacings.md}>
+        <Column gap={16}>
             <TransactionReviewOutputList
                 account={account}
                 precomposedTx={precomposedTx}

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
@@ -16,6 +16,7 @@ import {
     type EvmTransactionPurpose,
     type ReviewOutput,
     type StakeType,
+    type YieldClaimReward,
 } from '@suite-common/wallet-types';
 import {
     type EvmApprovalPurpose,
@@ -142,6 +143,13 @@ const getTranslationValues = (
         return yieldStrings[evmTxType];
     }
 
+    if (evmTxType === 'claim') {
+        return {
+            value: 'TR_EARN_YIELD_REVIEW_CLAIM_TITLE',
+            label: 'TR_EARN_YIELD_REVIEW_CLAIM_TITLE',
+        };
+    }
+
     return null;
 };
 
@@ -237,6 +245,8 @@ const getOutputTitle = (
             return <Translation id="TR_MY_ASSETS" />;
         case 'fee-limit':
             return <Translation id="TR_SUMMARY" />;
+        case 'rewards':
+            return <Translation id="TR_REWARD_TOKENS" />;
         default:
             return exhaustive(type);
     }
@@ -253,6 +263,7 @@ interface GetOutputLinesParams {
     device?: TrezorDevice;
     token?: ReviewOutput['token'];
     nativeToken?: TokenInfo;
+    rewards?: YieldClaimReward[];
     translationString: TranslationFunction;
     locale: Locale;
 }
@@ -268,6 +279,7 @@ const getOutputLines = ({
     device,
     token,
     nativeToken,
+    rewards,
     translationString,
     locale,
 }: GetOutputLinesParams): OutputElementLine[] => {
@@ -360,6 +372,16 @@ const getOutputLines = ({
                         },
                     ];
                 }
+            }
+
+            if (evmTxType === 'claim' && type === 'data') {
+                return [
+                    {
+                        id: 'data',
+                        type: 'default',
+                        value,
+                    },
+                ];
             }
 
             const translation = translationValues?.value;
@@ -510,6 +532,12 @@ const getOutputLines = ({
                     value: `${localizeNumber(value, locale)} SUN`,
                 },
             ];
+        case 'rewards':
+            return (rewards ?? []).map(reward => ({
+                id: `reward-${reward.tokenAddress}`,
+                value: reward.tokenSymbol || reward.tokenAddress,
+                type: 'default' as const,
+            }));
         default:
             return exhaustive(type);
     }
@@ -525,22 +553,24 @@ export type TransactionReviewOutputProps = {
     nativeToken?: TokenInfo;
 } & ReviewOutput;
 
-export const TransactionReviewOutput = ({
-    type,
-    state,
-    label,
-    value,
-    value2,
-    send,
-    receive,
-    token,
-    account,
-    stakeType,
-    isRbf,
-    isTrading,
-    evmTxType,
-    nativeToken,
-}: TransactionReviewOutputProps) => {
+export const TransactionReviewOutput = (props: TransactionReviewOutputProps) => {
+    const {
+        type,
+        state,
+        label,
+        value,
+        value2,
+        send,
+        receive,
+        token,
+        account,
+        stakeType,
+        isRbf,
+        isTrading,
+        evmTxType,
+        nativeToken,
+    } = props;
+    const rewards = type === 'rewards' ? props.rewards : undefined;
     const { networkType, symbol } = account;
     const accounts = useSelector(selectAccounts);
     const device = useSelector(selectSelectedDevice);
@@ -555,7 +585,7 @@ export const TransactionReviewOutput = ({
     const outputTitle = getOutputTitle(
         type,
         networkType,
-        value,
+        value ?? '',
         isRbf,
         stakeType,
         evmTxType,
@@ -565,13 +595,14 @@ export const TransactionReviewOutput = ({
     const outputLines = getOutputLines({
         type,
         account,
-        value,
+        value: value ?? '',
         value2,
         label,
         stakeType,
         evmTxType,
         device,
         token,
+        rewards,
         translationString,
         nativeToken,
         locale,

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 
 import { Translation } from '@suite/intl';
 import type { DeviceRootState } from '@suite-common/device';
-import { selectSelectedDevice } from '@suite-common/device';
 import { selectSendFormReviewLastButtonCode } from '@suite-common/wallet-core';
 import type {
     FormState,
@@ -16,8 +15,8 @@ import type {
 import {
     findAccountsByAddress,
     getEvmTransactionTextSignature,
-    getIsUpdatedEthereumSendFlow,
     isEvmApprovalTx,
+    isEvmYieldTxByTextSignature,
 } from '@suite-common/wallet-utils';
 import { Column, H4 } from '@trezor/components';
 import { spacings, spacingsPx } from '@trezor/theme';
@@ -81,11 +80,7 @@ export const TransactionReviewOutputList = ({
     const outputRefs = useRef<(HTMLDivElement | null)[]>([]);
     const totalOutputRef = useRef<HTMLDivElement | null>(null);
     const accounts = useSelector(state => state.wallet.accounts);
-    const device = useSelector(selectSelectedDevice);
     const { networkType, symbol } = account;
-    const isUpdatedEthereumSendFlow = device
-        ? getIsUpdatedEthereumSendFlow(device, networkType)
-        : false;
     const isMultirecipient = outputs.filter(({ type }) => type === 'address').length > 1;
     const isFirstOutputAddress = outputs[0]?.type === 'address';
 
@@ -107,6 +102,10 @@ export const TransactionReviewOutputList = ({
     const isStaking = stakeType;
 
     const isApprovalTx = isEvmApprovalTx(precomposedForm.transactionData);
+
+    const evmTxType = getEvmTransactionTextSignature(precomposedForm.transactionData);
+
+    const isYieldOperation = isEvmYieldTxByTextSignature(evmTxType) || evmTxType === 'claim';
 
     const isInternalTransfer =
         isFirstOutputAddress &&
@@ -138,6 +137,7 @@ export const TransactionReviewOutputList = ({
         !isApprovalTx &&
         !isTrading &&
         !isInternalTransfer &&
+        !isYieldOperation &&
         !signedTx
     ) {
         return (
@@ -182,13 +182,7 @@ export const TransactionReviewOutputList = ({
                                 isRbf={isRbfAction}
                                 isTrading={!!isTrading}
                                 stakeType={stakeType}
-                                evmTxType={
-                                    isUpdatedEthereumSendFlow && precomposedForm.yieldMetadata
-                                        ? precomposedForm.yieldMetadata.type
-                                        : getEvmTransactionTextSignature(
-                                              precomposedForm.transactionData,
-                                          )
-                                }
+                                evmTxType={evmTxType}
                                 nativeToken={nativeToken}
                             />
                         </Column>

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewTotalOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewTotalOutput.tsx
@@ -9,9 +9,11 @@ import {
     type StakeType,
 } from '@suite-common/wallet-types';
 import {
+    getEvmTransactionTextSignature,
     getIsUpdatedEthereumSendFlow,
     getIsUpdatedSendFlow,
     isEvmApprovalTx,
+    isEvmYieldTxByTextSignature,
     isTestnet,
 } from '@suite-common/wallet-utils';
 import type { TokenInfo } from '@trezor/blockchain-link-types';
@@ -50,6 +52,8 @@ const getLines = ({
     const isEthereum = networkType === 'ethereum';
     const isSolana = networkType === 'solana';
     const showAmountWithoutFee = isEthereum || isSolana;
+    const evmTxType = getEvmTransactionTextSignature(precomposedForm.transactionData);
+    const isYieldOrClaimOperation = isEvmYieldTxByTextSignature(evmTxType) || evmTxType === 'claim';
 
     const feeLabelId = ((network: NetworkType) => {
         switch (network) {
@@ -101,7 +105,7 @@ const getLines = ({
         const isFeeOnly =
             isUnknownStakingValue ||
             (isEvmApprovalTx(precomposedForm.transactionData) && isApprovalFlowSupported(device)) ||
-            !!precomposedForm.yieldMetadata;
+            isYieldOrClaimOperation;
 
         return isFeeOnly ? [feeLine] : [amountLine, feeLine];
     }
@@ -133,7 +137,7 @@ const getLines = ({
         type: 'amount',
     };
 
-    if (precomposedForm.yieldMetadata) {
+    if (isYieldOrClaimOperation) {
         return [
             totalLine,
             {

--- a/packages/suite/src/types/earn/earnLayout.ts
+++ b/packages/suite/src/types/earn/earnLayout.ts
@@ -8,6 +8,7 @@ export type EarnLayoutInvalidReason =
     | 'missing-vault'
     | 'network-mismatch'
     | 'token-mismatch'
+    | 'firmware-not-supported'
     | 'yield-opportunities-error';
 
 export type EarnLayoutState =

--- a/packages/suite/src/utils/suite/transactionReview.ts
+++ b/packages/suite/src/utils/suite/transactionReview.ts
@@ -101,10 +101,9 @@ export const getTransactionReviewModalActionTranslation = ({
     }
 
     if (routeName === 'earn-yield-withdraw') {
-        const yieldType =
-            'yieldMetadata' in precomposedForm ? precomposedForm.yieldMetadata?.type : undefined;
-
-        return { id: yieldType === 'redeem' ? 'TR_EARN_YIELD_REDEEM' : 'TR_EARN_YIELD_WITHDRAW' };
+        return {
+            id: txSignature === 'redeem' ? 'TR_EARN_YIELD_REDEEM' : 'TR_EARN_YIELD_WITHDRAW',
+        };
     }
 
     if (routeName === 'earn-yield-claim') {

--- a/packages/suite/src/views/earn/EarnLayoutFallback.tsx
+++ b/packages/suite/src/views/earn/EarnLayoutFallback.tsx
@@ -35,6 +35,8 @@ export const EarnLayoutFallback = ({ layoutState }: EarnLayoutFallbackProps) => 
             );
         case 'token-mismatch':
             return <EarnException title={<Translation id="TR_EARN_YIELD_TOKEN_NOT_EXIST" />} />;
+        case 'firmware-not-supported':
+            return null;
         case 'yield-opportunities-error':
             return <EarnException title={<Translation id="TR_EARN_YIELD_OPPORTUNITIES_ERROR" />} />;
     }

--- a/packages/suite/src/views/earn/yield/useEarnLayout.tsx
+++ b/packages/suite/src/views/earn/yield/useEarnLayout.tsx
@@ -2,7 +2,9 @@ import { useEffect } from 'react';
 
 import { type TranslationKey } from '@suite/intl';
 import { type EarnParams, goto } from '@suite/router';
+import { isStablecoinYieldSupported, selectSelectedDevice } from '@suite-common/device';
 import { type YieldDto, useAllYieldOpportunities } from '@suite-common/earn-stablecoin-api';
+import { type TrezorDevice } from '@suite-common/suite-types';
 import { type EarnAnalyticsStep } from '@suite-common/suite-types/src/staking';
 import { getNetworkByYieldXyzId } from '@suite-common/wallet-config';
 import { type YieldActionFlowType } from '@suite-common/wallet-core';
@@ -11,7 +13,7 @@ import { getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils';
 
 import { YieldPageHeader } from 'src/components/earn';
 import { useEarnRouteAccount } from 'src/components/earn/utils/useEarnRouteAccount';
-import { useDispatch, useLayout } from 'src/hooks/suite';
+import { useDispatch, useLayout, useSelector } from 'src/hooks/suite';
 import { type EarnLayoutState } from 'src/types/earn/earnLayout';
 
 type EarnYieldAnalyticsStep = Extract<EarnAnalyticsStep, 'yield-supply' | 'yield-withdraw'>;
@@ -23,8 +25,10 @@ type UseEarnLayoutParams = {
 
 type GetEarnLayoutResultParams = {
     account?: Account;
+    device?: TrezorDevice;
     routeParams?: EarnParams;
     vault?: YieldDto;
+    type: YieldActionFlowType;
     isYieldOpportunitiesLoading: boolean;
     isYieldOpportunitiesSuccess: boolean;
     isYieldOpportunitiesError: boolean;
@@ -79,8 +83,10 @@ const isVaultTokenMismatch = ({
 
 const getEarnLayoutResult = ({
     account,
+    device,
     routeParams,
     vault,
+    type,
     isYieldOpportunitiesLoading,
     isYieldOpportunitiesSuccess,
     isYieldOpportunitiesError,
@@ -117,6 +123,10 @@ const getEarnLayoutResult = ({
         return { status: 'invalid', reason: 'token-mismatch' };
     }
 
+    if (device && !isStablecoinYieldSupported(device, type)) {
+        return { status: 'invalid', reason: 'firmware-not-supported' };
+    }
+
     return { status: 'valid', account, routeParams, vault };
 };
 
@@ -124,6 +134,7 @@ export const useEarnLayout = ({ type, fallbackTitleId }: UseEarnLayoutParams): E
     const analyticsStep = getAnalyticsStep(type);
     const dispatch = useDispatch();
     const { account, routeParams } = useEarnRouteAccount();
+    const selectedDevice = useSelector(selectSelectedDevice);
     const {
         yieldOpportunities,
         isLoading: isYieldOpportunitiesLoading,
@@ -144,12 +155,23 @@ export const useEarnLayout = ({ type, fallbackTitleId }: UseEarnLayoutParams): E
 
     const layoutState = getEarnLayoutResult({
         account,
+        device: selectedDevice,
         routeParams,
         vault,
+        type,
         isYieldOpportunitiesLoading,
         isYieldOpportunitiesSuccess,
         isYieldOpportunitiesError,
     });
+
+    const isFirmwareNotSupported =
+        layoutState.status === 'invalid' && layoutState.reason === 'firmware-not-supported';
+
+    useEffect(() => {
+        if (isFirmwareNotSupported) {
+            dispatch(goto({ routeName: 'suite-earn' }));
+        }
+    }, [dispatch, isFirmwareNotSupported]);
 
     useLayout(
         'Earn',

--- a/suite-common/calldata/src/calldata.ts
+++ b/suite-common/calldata/src/calldata.ts
@@ -40,7 +40,10 @@ export const Calldata = {
             },
         },
         distributor: {
-            claim: { encode: buildClaim },
+            claim: {
+                encode: buildClaim,
+                decode: createEvmDecoder(EVM_ABI.distributor.claim),
+            },
         },
         everstake: {
             stake: { encode: buildStake },

--- a/suite-common/device/src/deviceUtils.ts
+++ b/suite-common/device/src/deviceUtils.ts
@@ -3,6 +3,7 @@ import type {
     DeviceErrorType,
     TrezorDevice,
     TrezorDeviceWithState,
+    YieldFlowType,
 } from '@suite-common/suite-types';
 import { type Device } from '@trezor/connect';
 import { DeviceModelInternal, getFirmwareVersionArray } from '@trezor/device-utils';
@@ -40,14 +41,25 @@ export const isApprovalFlowSupported = (device: TrezorDevice | undefined) =>
 export const isEvmClearSigningSupported = (device: TrezorDevice | undefined) =>
     !device?.unavailableCapabilities?.['evmClearSigning'];
 
-export const isStablecoinYieldSupported = (device: TrezorDevice | undefined) => {
+export const isStablecoinYieldSupported = (
+    device: TrezorDevice | undefined,
+    flowType?: YieldFlowType,
+): boolean => {
     if (device?.features?.internal_model === DeviceModelInternal.T1B1) {
         return true;
     }
 
     const firmware = getFirmwareVersionArray(device);
 
-    return firmware !== null && versionUtils.isNewerOrEqual(firmware, [2, 12, 0]);
+    if (firmware === null) {
+        return false;
+    }
+
+    if (flowType === 'claim') {
+        return versionUtils.isNewerOrEqual(firmware, [2, 12, 1]);
+    }
+
+    return versionUtils.isNewerOrEqual(firmware, [2, 12, 0]);
 };
 
 export const isTrezorDeviceWithState = (

--- a/suite-common/earn-stablecoin/src/signing/stablecoinYieldSigningUtils.ts
+++ b/suite-common/earn-stablecoin/src/signing/stablecoinYieldSigningUtils.ts
@@ -5,7 +5,6 @@ import {
     type EvmSelectedFee,
     type FormState,
     type PrecomposedTransactionFinal,
-    type YieldFormMetadata,
 } from '@suite-common/wallet-types';
 import {
     asAmountUnit,
@@ -32,9 +31,7 @@ type BuildStablecoinYieldReviewTokenParams = {
 
 type BuildStablecoinYieldReviewStateParams = BuildStablecoinYieldReviewTokenParams & {
     amount: string;
-    flowType: YieldFormMetadata['type'];
     tx: StablecoinYieldParsedTransactionForSigning;
-    vaultName: string;
 };
 
 type BuildStablecoinYieldReviewStateResult = {
@@ -127,8 +124,6 @@ export const buildStablecoinYieldReviewState = ({
     amount,
     token,
     symbol,
-    flowType,
-    vaultName,
 }: BuildStablecoinYieldReviewStateParams): BuildStablecoinYieldReviewStateResult => {
     const gasPriceHex = tx.maxFeePerGas ?? tx.gasPrice ?? ('0x0' as `0x${string}`);
     const gasLimit = evmHexToBigNumber(tx.gasLimit);
@@ -172,7 +167,6 @@ export const buildStablecoinYieldReviewState = ({
         isCoinControlEnabled: false,
         hasCoinControlBeenOpened: false,
         selectedUtxos: [],
-        yieldMetadata: { type: flowType, vaultName },
     };
 
     const precomposedTransaction: PrecomposedTransactionFinal = {

--- a/suite-common/wallet-config/src/earnRewardsProvider.ts
+++ b/suite-common/wallet-config/src/earnRewardsProvider.ts
@@ -1,6 +1,8 @@
 import { type NetworkSymbol } from './types';
 import { getNetworkFeatures } from './utils';
 
+export const EARN_YIELD_CLAIM_PROVIDER = 'Merkl.xyz';
+
 const MERKL_XYZ_CONTRACT: Partial<Record<NetworkSymbol, `0x${string}`>> = {
     eth: '0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae',
     arb: '0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae',

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
@@ -6,6 +6,7 @@ import {
     type AccountKey,
     type FormState,
     type PrecomposedTransactionFinal,
+    type YieldClaimReward,
 } from '@suite-common/wallet-types';
 import { isSafeObjectKey } from '@trezor/utils';
 
@@ -37,6 +38,8 @@ export const STABLECOIN_YIELD_PREFIX = '@suite-common/wallet-core/stablecoin-yie
 export type StablecoinYieldTxReviewState = {
     precomposedTx?: PrecomposedTransactionFinal;
     precomposedForm?: FormState;
+    vaultName?: string;
+    availableRewards?: YieldClaimReward[];
     serializedTx?: StablecoinYieldSerializedTx;
     accountKey?: AccountKey;
 };
@@ -115,6 +118,8 @@ export const initialStablecoinYieldSessionState: StablecoinYieldSessionState = {
 export const initialStablecoinYieldTxReviewState: StablecoinYieldTxReviewState = {
     precomposedTx: undefined,
     precomposedForm: undefined,
+    vaultName: undefined,
+    availableRewards: undefined,
     serializedTx: undefined,
     accountKey: undefined,
 };
@@ -452,11 +457,15 @@ export const stablecoinYieldSlice = createSlice({
             action: PayloadAction<{
                 precomposedTx: PrecomposedTransactionFinal;
                 precomposedForm: FormState;
+                vaultName?: string;
+                availableRewards?: YieldClaimReward[];
                 accountKey: AccountKey;
             }>,
         ) {
             state.txReview.precomposedTx = action.payload.precomposedTx;
             state.txReview.precomposedForm = action.payload.precomposedForm;
+            state.txReview.vaultName = action.payload.vaultName;
+            state.txReview.availableRewards = action.payload.availableRewards;
             state.txReview.accountKey = action.payload.accountKey;
             state.txReview.serializedTx = undefined;
         },
@@ -469,6 +478,8 @@ export const stablecoinYieldSlice = createSlice({
         discardTransaction(state) {
             state.txReview.precomposedTx = undefined;
             state.txReview.precomposedForm = undefined;
+            state.txReview.vaultName = undefined;
+            state.txReview.availableRewards = undefined;
             state.txReview.serializedTx = undefined;
             state.txReview.accountKey = undefined;
         },

--- a/suite-common/wallet-types/src/index.ts
+++ b/suite-common/wallet-types/src/index.ts
@@ -12,6 +12,7 @@ export * from './transaction';
 export type * from './transactionReviewOutput';
 export * from './ethereumStaking';
 export type * from './stakeForm';
+export type * from './stablecoinYield';
 export type * from './send';
 export type * from './globalSendReceive';
 export * from './baseCurrency';

--- a/suite-common/wallet-types/src/sendForm.ts
+++ b/suite-common/wallet-types/src/sendForm.ts
@@ -89,10 +89,4 @@ export interface FormState {
     selectedUtxos: AccountUtxo[];
     utxoSorting?: UtxoSorting;
     trading?: FormStateTrading;
-    yieldMetadata?: YieldFormMetadata;
 }
-
-export type YieldFormMetadata = {
-    type: 'deposit' | 'withdraw' | 'redeem';
-    vaultName: string;
-};

--- a/suite-common/wallet-types/src/stablecoinYield.ts
+++ b/suite-common/wallet-types/src/stablecoinYield.ts
@@ -1,0 +1,4 @@
+export type YieldClaimReward = {
+    tokenAddress: string;
+    tokenSymbol: string;
+};

--- a/suite-common/wallet-types/src/transaction.ts
+++ b/suite-common/wallet-types/src/transaction.ts
@@ -255,6 +255,7 @@ export type EvmTransactionPurpose =
     | 'deposit'
     | 'withdraw'
     | 'redeem'
+    | 'claim'
     | '';
 
 export interface RbfTransactionParamsEthereum {

--- a/suite-common/wallet-types/src/transactionReviewOutput.ts
+++ b/suite-common/wallet-types/src/transactionReviewOutput.ts
@@ -1,6 +1,7 @@
 import type { TokenInfo } from '@trezor/connect';
 
 import { type FormStateTradingCryptoCurrency, type FormStateTradingFiatCurrency } from './sendForm';
+import type { YieldClaimReward } from './stablecoinYield';
 
 export type ReviewOutput =
     | {
@@ -56,6 +57,16 @@ export type ReviewOutput =
           token?: undefined;
           send: FormStateTradingCryptoCurrency;
           receive: FormStateTradingCryptoCurrency | FormStateTradingFiatCurrency;
+      }
+    | {
+          type: 'rewards';
+          rewards: YieldClaimReward[];
+          value?: undefined;
+          value2?: undefined;
+          label?: undefined;
+          token?: undefined;
+          send?: undefined;
+          receive?: undefined;
       };
 
 export type ReviewOutputType = ReviewOutput['type'];

--- a/suite-common/wallet-utils/src/__tests__/ethUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/ethUtils.test.ts
@@ -1,4 +1,4 @@
-import { Calldata } from '@suite-common/calldata';
+import { Calldata, asEvmAddress } from '@suite-common/calldata';
 import { UINT256_MAX } from '@suite-common/suite-constants';
 import { BigNumber } from '@trezor/utils';
 
@@ -11,6 +11,8 @@ import {
     sanitizeHex,
     strip,
 } from '../ethUtils';
+
+const VALID_CLAIM_ADDRESS = asEvmAddress('0x1111111111111111111111111111111111111111');
 
 describe('eth utils', () => {
     it('padLeftEven', () => {
@@ -143,6 +145,24 @@ describe('eth utils', () => {
                 '000000000000000000000000742D35CC6634C0532925A3B8D40E592E43A73654' +
                 '00000000000000000000000000000000000000000000000000000000000003E8';
             expect(getEvmTransactionTextSignature(upperNoPrefix)).toBe('transfer');
+        });
+
+        it('returns "claim" for valid distributor claim call', () => {
+            const claimData = Calldata.evm.distributor.claim.encode(
+                {
+                    users: [VALID_CLAIM_ADDRESS],
+                    tokens: [VALID_CLAIM_ADDRESS],
+                    amounts: [new BigNumber(1)],
+                    proofs: [[]],
+                },
+                { sender: VALID_CLAIM_ADDRESS },
+            ).data;
+
+            expect(getEvmTransactionTextSignature(claimData ?? undefined)).toBe('claim');
+        });
+
+        it('returns "unknown" for selector-only claim (too short)', () => {
+            expect(getEvmTransactionTextSignature('0x71ee95c0')).toBe('unknown');
         });
     });
 

--- a/suite-common/wallet-utils/src/deviceUtils.ts
+++ b/suite-common/wallet-utils/src/deviceUtils.ts
@@ -38,3 +38,7 @@ export const parseDeviceStaticSessionId = (deviceStaticSessionId: string) => {
 // local copy of import { isApprovalFlowSupported } from '@suite-common/device'; > reviewTransactionUtils
 export const isApprovalFlowSupported = (device: TrezorDevice | undefined) =>
     !device?.unavailableCapabilities?.['evmApproval'];
+
+// local copy of import { isEvmClearSigningSupported } from '@suite-common/device'; > reviewTransactionUtils
+export const isEvmClearSigningSupported = (device: TrezorDevice | undefined) =>
+    !device?.unavailableCapabilities?.['evmClearSigning'];

--- a/suite-common/wallet-utils/src/ethUtils.ts
+++ b/suite-common/wallet-utils/src/ethUtils.ts
@@ -52,6 +52,8 @@ export const getEvmTransactionTextSignature = (data?: string): EvmTransactionPur
     if (Calldata.evm.erc4626.withdraw.decode(data)) return 'withdraw';
     if (Calldata.evm.erc4626.redeem.decode(data)) return 'redeem';
 
+    if (Calldata.evm.distributor.claim.decode(data)) return 'claim';
+
     return 'unknown';
 };
 

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.ts
@@ -3,7 +3,7 @@ import { fromWei, toWei } from 'web3-utils';
 import { Calldata } from '@suite-common/calldata';
 import { EVM_SPENDER_LABELS, KNOWN_VAULTS } from '@suite-common/suite-constants';
 import { type TrezorDevice } from '@suite-common/suite-types';
-import { networks } from '@suite-common/wallet-config';
+import { EARN_YIELD_CLAIM_PROVIDER, networks } from '@suite-common/wallet-config';
 import {
     type Account,
     type FormState,
@@ -12,6 +12,7 @@ import {
     type ReviewOutputState,
     type StakeFormState,
     type StakeType,
+    type YieldClaimReward,
 } from '@suite-common/wallet-types';
 import type { CardanoOutput } from '@trezor/connect';
 import { getFirmwareVersion } from '@trezor/device-utils';
@@ -19,7 +20,10 @@ import { versionUtils } from '@trezor/utils';
 
 import { datetimeToLocktime } from './bitcoinUtils';
 import { getShortFingerprint, isCardanoTx } from './cardanoUtils';
-import { isApprovalFlowSupported as isApprovalSupported } from './deviceUtils';
+import {
+    isApprovalFlowSupported as isApprovalSupported,
+    isEvmClearSigningSupported as isEvmClearSigningSupportedByDevice,
+} from './deviceUtils';
 import {
     getEvmTransactionTextSignature,
     isEvmApprovalTx,
@@ -108,6 +112,8 @@ type ConstructOutputsParams = {
     decreaseOutputId: number | undefined;
     account: Account;
     precomposedForm: FormState | StakeFormState;
+    vaultName?: string;
+    availableRewards?: YieldClaimReward[];
 };
 
 const constructOldFlow = ({
@@ -121,6 +127,8 @@ const constructOldFlow = ({
     const isCardano = isCardanoTx(account, precomposedTx);
     const isStellar = account.networkType === 'stellar';
     const { networkType } = account;
+    const evmTxType = getEvmTransactionTextSignature(precomposedForm.transactionData);
+    const isYieldOperation = isEvmYieldTxByTextSignature(evmTxType);
 
     const hasDestinationTag = 'destinationTag' in precomposedForm;
 
@@ -239,10 +247,7 @@ const constructOldFlow = ({
 
     if (networkType === 'tron' && precomposedForm.destinationTag) {
         outputs.push({ type: 'note', value: precomposedForm.destinationTag });
-    } else if (
-        precomposedForm.transactionData &&
-        (!precomposedTx.token || precomposedForm.yieldMetadata)
-    ) {
+    } else if (precomposedForm.transactionData && (!precomposedTx.token || isYieldOperation)) {
         outputs.push({ type: 'data', value: precomposedForm.transactionData });
     }
 
@@ -262,11 +267,7 @@ const constructOldFlow = ({
                 value: precomposedForm.destinationTag,
             });
         }
-    } else if (
-        (!isBumpFeeRbf || !precomposedTx.useNativeRbf) &&
-        !stakeType &&
-        !precomposedForm.yieldMetadata
-    ) {
+    } else if ((!isBumpFeeRbf || !precomposedTx.useNativeRbf) && !stakeType && !isYieldOperation) {
         outputs.push({ type: 'fee', value: precomposedTx.fee });
     }
 
@@ -278,13 +279,17 @@ const constructNewFlow = ({
     decreaseOutputId,
     account,
     precomposedForm,
+    vaultName,
+    availableRewards,
     isApprovalFlowSupported,
+    isEvmClearSigningSupported,
     isUpdatedEthereumSendFlow,
     isUpdatedStellarSendFlow,
 }: ConstructOutputsParams & {
     isUpdatedEthereumSendFlow: boolean;
     isUpdatedStellarSendFlow: boolean;
     isApprovalFlowSupported: boolean;
+    isEvmClearSigningSupported: boolean;
 }): ReviewOutput[] => {
     const outputs: ReviewOutput[] = [];
 
@@ -302,19 +307,30 @@ const constructNewFlow = ({
     const trading = precomposedForm?.trading;
 
     const evmTxType = getEvmTransactionTextSignature(precomposedForm.transactionData);
-    const isYieldOp = !!precomposedForm.yieldMetadata || isEvmYieldTxByTextSignature(evmTxType);
+    const isClaimOp = evmTxType === 'claim';
+    const isYieldOp = isEvmYieldTxByTextSignature(evmTxType);
+    const isEvmClaimClearSign = isUpdatedEthereumSendFlow && isEvmClearSigningSupported;
+
+    if (isClaimOp && isEvmClaimClearSign) {
+        outputs.push(
+            { type: 'data', value: EARN_YIELD_CLAIM_PROVIDER },
+            { type: 'rewards', rewards: availableRewards ?? [] },
+        );
+
+        return outputs;
+    }
 
     if (isYieldOp && isUpdatedEthereumSendFlow) {
         const fallbackAddress = precomposedTx.outputs.find(
             o => 'address' in o && typeof o.address === 'string',
         )?.address;
-        const vaultName =
-            precomposedForm.yieldMetadata?.vaultName ??
+        const resolvedVaultName =
+            vaultName ??
             (typeof fallbackAddress === 'string'
                 ? (KNOWN_VAULTS[fallbackAddress.toLowerCase()] ?? fallbackAddress)
                 : '');
 
-        outputs.push({ type: 'data', value: '' }, { type: 'address', value: vaultName });
+        outputs.push({ type: 'data', value: '' }, { type: 'address', value: resolvedVaultName });
 
         precomposedTx.outputs.forEach(o => {
             if ('address' in o && typeof o.address === 'string') {
@@ -359,9 +375,8 @@ const constructNewFlow = ({
     } else if (
         (precomposedForm.transactionData && !precomposedTx.token && !isEvmApproval) ||
         (precomposedForm.transactionData && isEvmApproval && !isApprovalFlowSupported) ||
-        (precomposedForm.transactionData &&
-            precomposedForm.yieldMetadata &&
-            !isUpdatedEthereumSendFlow)
+        (precomposedForm.transactionData && isYieldOp && !isUpdatedEthereumSendFlow) ||
+        (precomposedForm.transactionData && isClaimOp && !isEvmClaimClearSign)
     ) {
         outputs.push({ type: 'data', value: precomposedForm.transactionData });
     }
@@ -570,6 +585,7 @@ export const constructTransactionReviewOutputs = ({
     return constructNewFlow({
         isUpdatedEthereumSendFlow,
         isApprovalFlowSupported: isApprovalSupported(device),
+        isEvmClearSigningSupported: isEvmClearSigningSupportedByDevice(device),
         isUpdatedStellarSendFlow,
         ...params,
     });
@@ -577,10 +593,12 @@ export const constructTransactionReviewOutputs = ({
 
 export const constructTransactionReviewOutputsOptional = ({
     account,
+    availableRewards,
     decreaseOutputId,
     device,
     precomposedForm,
     precomposedTx,
+    vaultName,
 }: Partial<ConstructTransactionReviewOutputsProps>): ReviewOutput[] => {
     if (
         account === undefined ||
@@ -593,9 +611,11 @@ export const constructTransactionReviewOutputsOptional = ({
 
     return constructTransactionReviewOutputs({
         account,
+        availableRewards,
         decreaseOutputId,
         device,
         precomposedForm,
         precomposedTx,
+        vaultName,
     });
 };

--- a/suite-native/module-earn/src/yieldTransactionThunks.ts
+++ b/suite-native/module-earn/src/yieldTransactionThunks.ts
@@ -63,16 +63,12 @@ export const signYieldActionReviewThunk = createThunk<
         let transactionReview: ReturnType<typeof buildStablecoinYieldTransactionReview>;
 
         try {
-            const vaultName = flowData.vault.outputToken?.name ?? flowData.vault.metadata.name;
-
             transactionReview = buildStablecoinYieldTransactionReview({
                 amount: review.amount,
-                flowType,
                 selectedFee: null,
                 symbol: flowData.account.symbol,
                 token: flowData.token,
                 unsignedTransaction: review.unsignedTransaction,
-                vaultName,
             });
         } catch (error) {
             const message =

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItem.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItem.tsx
@@ -117,6 +117,10 @@ export const ReviewOutputItem = ({
     tokenContract,
     flowType,
 }: ReviewOutputItemProps) => {
+    if (reviewOutput.type === 'rewards') {
+        return null;
+    }
+
     const { state, type, value, value2, token } = reviewOutput;
 
     const tradedSend = reviewOutput.type === 'traded_assets' ? reviewOutput.send : undefined;

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputItem.test.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputItem.test.tsx
@@ -95,6 +95,18 @@ describe('ReviewOutputItem', () => {
         );
     });
 
+    it('should not render output card for type "rewards"', () => {
+        const { queryByTestId } = renderReviewOutputItem({
+            reviewOutput: {
+                type: 'rewards',
+                rewards: [],
+                state: 'active',
+            } as StatefulReviewOutput,
+        });
+
+        expect(queryByTestId('review-output-card/title')).toBeNull();
+    });
+
     it('should render value for type "destination-tag" and value set', () => {
         const { getByTestId } = renderReviewOutputItem({
             reviewOutput: {

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -9339,6 +9339,10 @@ export const messages = defineMessages({
         id: 'TR_TOTAL_INCLUDING_FEE',
         defaultMessage: 'Total including fee',
     },
+    TR_REWARD_TOKENS: {
+        id: 'TR_REWARD_TOKENS',
+        defaultMessage: 'Reward tokens',
+    },
     TR_INCLUDING_FEE: {
         id: 'TR_INCLUDING_FEE',
         defaultMessage: 'Including fee',
@@ -9790,6 +9794,10 @@ export const messages = defineMessages({
     TR_EARN_YIELD_REVIEW_REDEEM_AMOUNT: {
         id: 'TR_EARN_YIELD_REVIEW_REDEEM_AMOUNT',
         defaultMessage: 'Redeem amount',
+    },
+    TR_EARN_YIELD_REVIEW_CLAIM_TITLE: {
+        id: 'TR_EARN_YIELD_REVIEW_CLAIM_TITLE',
+        defaultMessage: 'Claim rewards from',
     },
     TR_EARN_DASHBOARD_ACTIVE: {
         id: 'TR_EARN_DASHBOARD_ACTIVE',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Claim flow now follows the clear-signing path prepared in firmware: the signing request sends enough initial calldata for the device to classify and display the claim details. Suite also renders the sign tx modal as a structured claim operation with **provider**, **reward tokens**, and **fee summary** instead of raw contract `calldata`.

As part of the cleanup, `YieldFormMetadata` was removed from `FormState`. Yield operation type is now derived from unsigned transaction calldata, while claim-specific review data lives in the stablecoin-yield review state.

## Notes for QA

Need to use the latest firmware https://github.com/trezor/trezor-suite-firmware-release/tree/main/firmware/unsigned

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27749

## Screenshots:

<img width="709" height="799" alt="image" src="https://github.com/user-attachments/assets/d4022770-57d6-4c85-97eb-accaabc8a815" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/suite-claim-clear-sign&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/suite-claim-clear-sign&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/suite-claim-clear-sign&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-28T17:12:25.382Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-28T17:10:36.778Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/suite-claim-clear-sign/web/](https://dev.suite.sldev.cz/suite-web/feat/suite-claim-clear-sign/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->