### PR TITLE
28143 swap old receive address sent in swap request after switching to assetnetwork

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingExchangeHandleChange.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingExchangeHandleChange.ts
@@ -9,6 +9,7 @@ import {
     useTradingRefetchScheduler,
 } from '@suite-common/trading';
 import { type Network } from '@suite-common/wallet-config';
+import { type AccountKey } from '@suite-common/wallet-types';
 import { noop } from '@trezor/utils';
 
 import { useDispatch } from 'src/hooks/suite';
@@ -17,6 +18,7 @@ type TradingExchangeUseHandleChangeProps = {
     formValues: TradingExchangeFormProps;
     network: Network;
     shouldSendInSats: boolean | undefined;
+    receiveAccountKey?: AccountKey;
 
     composeRequestCallback: () => void;
     setIsScheduledQuotesRefresh?: (value: boolean) => void;
@@ -34,6 +36,7 @@ export const useTradingExchangeHandleChange = ({
     formValues,
     network,
     shouldSendInSats,
+    receiveAccountKey,
     composeRequestCallback,
     setIsScheduledQuotesRefresh = noop,
 }: TradingExchangeUseHandleChangeProps) => {
@@ -48,7 +51,7 @@ export const useTradingExchangeHandleChange = ({
 
         const promise = dispatch(
             exchangeThunks.handleRequestThunk({
-                formValues,
+                formValues: { ...formValues, receiveAccountKey },
                 network,
                 shouldSendInSats,
                 composeRequestCallback,
@@ -75,6 +78,7 @@ export const useTradingExchangeHandleChange = ({
     }, [
         dispatch,
         formValues,
+        receiveAccountKey,
         network,
         shouldSendInSats,
         composeRequestCallback,

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingExchangeHandleChange.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingExchangeHandleChange.ts
@@ -18,6 +18,10 @@ type TradingExchangeUseHandleChangeProps = {
     formValues: TradingExchangeFormProps;
     network: Network;
     shouldSendInSats: boolean | undefined;
+    // receiveAddress and receiveAccountKey are read from useTradingReceiveAddress
+    // directly rather than mirrored onto the outer form. Makes the receive identity
+    // a single source of truth and closes the stale-address race exposed by #28143.
+    receiveAddress?: string;
     receiveAccountKey?: AccountKey;
 
     composeRequestCallback: () => void;
@@ -36,6 +40,7 @@ export const useTradingExchangeHandleChange = ({
     formValues,
     network,
     shouldSendInSats,
+    receiveAddress,
     receiveAccountKey,
     composeRequestCallback,
     setIsScheduledQuotesRefresh = noop,
@@ -51,7 +56,11 @@ export const useTradingExchangeHandleChange = ({
 
         const promise = dispatch(
             exchangeThunks.handleRequestThunk({
-                formValues: { ...formValues, receiveAccountKey },
+                formValues: {
+                    ...formValues,
+                    receiveAddress,
+                    receiveAccountKey,
+                },
                 network,
                 shouldSendInSats,
                 composeRequestCallback,
@@ -78,6 +87,7 @@ export const useTradingExchangeHandleChange = ({
     }, [
         dispatch,
         formValues,
+        receiveAddress,
         receiveAccountKey,
         network,
         shouldSendInSats,

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
@@ -66,6 +66,7 @@ export const useTradingFormActions = <T extends TradingSellExchangeFormProps>({
     composedLevels,
     composedTransactionInfo,
     setShowReserveBanner,
+    receiveAddress,
 }: TradingUseFormActionsProps<T>): TradingUseFormActionsReturnProps => {
     const dispatch = useDispatch();
     const { symbol } = account;
@@ -358,9 +359,14 @@ export const useTradingFormActions = <T extends TradingSellExchangeFormProps>({
         }
     }, [previousValues, values, handleChange, handleSubmit, isNotFormPage, pageType, type]);
 
-    // call change handler on every change of receive address
-    // effect only for exchange form
+    // Trigger a quotes refetch when the receive identity changes. `receiveAddress`
+    // is no longer mirrored onto the outer form (single source of truth lives in
+    // useTradingReceiveAddress) so we track it separately here.
+    const previousReceiveAddress = useRef<string | undefined>(receiveAddress);
     useEffect(() => {
+        const receiveAddressChanged = isChanged(receiveAddress, previousReceiveAddress.current);
+        previousReceiveAddress.current = receiveAddress;
+
         if (type !== 'exchange' || pageType === 'confirm' || pageType === 'retry') return;
 
         const formValues = values as TradingExchangeFormProps | null;
@@ -369,11 +375,6 @@ export const useTradingFormActions = <T extends TradingSellExchangeFormProps>({
         const receiveCryptoChanged = isChanged(
             formValues?.receiveCryptoSelect,
             prevFormValues?.receiveCryptoSelect,
-        );
-
-        const receiveAddressChanged = isChanged(
-            formValues?.receiveAddress,
-            prevFormValues?.receiveAddress,
         );
 
         if (receiveCryptoChanged || receiveAddressChanged) {
@@ -385,7 +386,16 @@ export const useTradingFormActions = <T extends TradingSellExchangeFormProps>({
 
             previousValues.current = values;
         }
-    }, [values, previousValues, handleChange, handleSubmit, dispatch, pageType, type]);
+    }, [
+        values,
+        receiveAddress,
+        previousValues,
+        handleChange,
+        handleSubmit,
+        dispatch,
+        pageType,
+        type,
+    ]);
 
     return {
         isBalanceZero,

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -237,6 +237,7 @@ export const useTradingExchangeForm = ({
         formValues: values,
         network,
         shouldSendInSats,
+        receiveAddress: tradingReceiveAddress.receiveAddress,
         receiveAccountKey: tradingReceiveAddress.selectedAccount?.key,
         composeRequestCallback: () => {
             composeRequest(TRADING_FORM_OUTPUT_AMOUNT);
@@ -260,6 +261,7 @@ export const useTradingExchangeForm = ({
         composedLevels,
         composedTransactionInfo,
         setShowReserveBanner,
+        receiveAddress: tradingReceiveAddress.receiveAddress,
     });
 
     const selectQuote = async (quote: ExchangeTrade) => {
@@ -620,14 +622,6 @@ export const useTradingExchangeForm = ({
 
         fetchFeesAndComposeRef.current();
     }, [transactionData, outputAddress, ethereumAdjustGasLimit, pageType, fetchFeesAndComposeRef]);
-
-    useEffect(() => {
-        setValueRef.current('receiveAddress', receiveAddress);
-    }, [receiveAddress, setValueRef]);
-
-    useEffect(() => {
-        setValueRef.current('extraField', extraField);
-    }, [extraField, setValueRef]);
 
     useEffect(() => {
         dispatch(tradingThunks.loadInitialDataThunk({ activeSection: type }));

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -237,6 +237,7 @@ export const useTradingExchangeForm = ({
         formValues: values,
         network,
         shouldSendInSats,
+        receiveAccountKey: tradingReceiveAddress.selectedAccount?.key,
         composeRequestCallback: () => {
             composeRequest(TRADING_FORM_OUTPUT_AMOUNT);
         },

--- a/packages/suite/src/types/trading/tradingForm.ts
+++ b/packages/suite/src/types/trading/tradingForm.ts
@@ -340,6 +340,10 @@ export interface TradingUseFormActionsProps<T extends TradingSellExchangeFormPro
     composedLevels: PrecomposedLevels | PrecomposedLevelsCardano | undefined;
     composedTransactionInfo: TradingComposedTransactionInfo;
     setShowReserveBanner: (showReserveBanner: boolean) => void;
+    // Exchange-only: receiveAddress is sourced from useTradingReceiveAddress rather
+    // than mirrored onto the outer form. Passed in so the receive-address change
+    // detection can trigger a quotes refetch.
+    receiveAddress?: string;
 }
 
 export interface TradingUseFormActionsReturnProps {

--- a/suite-common/trading/src/constants.ts
+++ b/suite-common/trading/src/constants.ts
@@ -45,8 +45,6 @@ export const TRADING_FORM_PROVIDER_SELECT = 'provider';
 export const TRADING_FORM_AMOUNT_IN_CRYPTO = 'amountInCrypto';
 
 export const TRADING_EXCHANGE_FROM_ADDRESS = 'fromAddress';
-export const TRADING_EXCHANGE_RECEIVE_ADDRESS = 'receiveAddress';
-export const TRADING_EXCHANGE_EXTRA_FIELD = 'extraField';
 
 export const TRADING_BUY_RECEIVE_ADDRESS = 'receiveAddress';
 

--- a/suite-common/trading/src/thunks/exchange/__tests__/handleExchangeRequestThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/handleExchangeRequestThunk.test.ts
@@ -3,10 +3,13 @@ import { type CryptoId, type ExchangeTrade } from 'invity-api';
 
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
 import { getNetwork } from '@suite-common/wallet-config';
-import { type AccountKey } from '@suite-common/wallet-types';
+import { prepareAccountsReducer } from '@suite-common/wallet-core';
+import { type Account, type AccountKey } from '@suite-common/wallet-types';
+import { cloneObject, mergeDeepObject } from '@trezor/utils';
 
 import { exchangeThunks } from '../';
 import { MIN_MAX_QUOTES_OK } from '../../../__fixtures__/exchangeUtils';
+import { accountEth } from '../../../__fixtures__/utils';
 import { invityAPI } from '../../../invityAPI';
 import { initialState } from '../../../reducers/tradingCommonReducer';
 import { prepareTradingReducer } from '../../../reducers/tradingReducer';
@@ -18,6 +21,8 @@ import {
 } from '../../../types';
 
 const tradingReducer = prepareTradingReducer(extraDependenciesCommonMock);
+const accountsReducer = prepareAccountsReducer(extraDependenciesCommonMock);
+const cloneExchangeQuotes = () => cloneObject(MIN_MAX_QUOTES_OK) as ExchangeTrade[];
 
 describe('handleExchangeRequestThunk', () => {
     afterEach(() => {
@@ -35,6 +40,7 @@ describe('handleExchangeRequestThunk', () => {
             reducer: combineReducers({
                 wallet: combineReducers({
                     trading: tradingReducer,
+                    accounts: accountsReducer,
                 }),
             }),
             preloadedState: {
@@ -57,6 +63,7 @@ describe('handleExchangeRequestThunk', () => {
                             },
                         },
                     },
+                    accounts: [accountEth as unknown as Account],
                 },
             },
         });
@@ -195,36 +202,106 @@ describe('handleExchangeRequestThunk', () => {
 
     describe('should not save quotes when', () => {
         const { input, store } = getMocks();
+        const overrideInput = (overrides: { formValues?: Record<string, unknown> }) =>
+            mergeDeepObject.withOptions(
+                { mergeArrays: false },
+                input,
+                overrides,
+            ) as HandleExchangeRequestThunkProps;
         const outputs = input.formValues.outputs.map(output => ({
             ...output,
             amount: undefined as unknown as string,
         }));
-        const inputAmountIncorrect = {
-            ...input,
+        const inputAmountIncorrect = overrideInput({ formValues: { outputs } });
+        const inputReceiveCryptoSelectIncorrect = overrideInput({
+            formValues: { receiveCryptoSelect: null },
+        });
+        const inputSendCryptoSelectIncorrect = overrideInput({
+            formValues: { sendCryptoSelect: undefined },
+        });
+        const inputCrossFormatLeak = overrideInput({
             formValues: {
-                ...input.formValues,
-                outputs,
+                receiveCryptoSelect: input.formValues.sendCryptoSelect, // bitcoin
+                receiveAddress: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
             },
-        };
-        const inputReceiveCryptoSelectIncorrect = {
-            ...input,
+        });
+
+        const ethAddress = '0x742d35Cc6634C0532925a3b844Bc454e4438f44e';
+        const ethAccountKey = (accountEth as unknown as Account).key;
+        const inputSameFormatLeakEthToBsc = overrideInput({
             formValues: {
-                ...input.formValues,
-                receiveCryptoSelect: null,
+                receiveCryptoSelect: {
+                    id: 'binancecoin' as CryptoId,
+                    isNativeToken: true,
+                    name: 'BNB Smart Chain',
+                    coingeckoId: 'binance-smart-chain',
+                    contractAddress: null,
+                    symbol: 'bsc',
+                    displaySymbol: 'BNB',
+                    networkName: 'BNB Smart Chain',
+                    networkSymbol: 'bsc',
+                } satisfies TradingAssetOption,
+                receiveAddress: ethAddress,
+                receiveAccountKey: ethAccountKey,
             },
-        };
-        const inputSendCryptoSelectIncorrect = {
-            ...input,
+        });
+
+        const inputSameFormatLeakEthToEtc = overrideInput({
             formValues: {
-                ...input.formValues,
-                sendCryptoSelect: undefined,
+                receiveCryptoSelect: {
+                    id: 'ethereum-classic' as CryptoId,
+                    isNativeToken: true,
+                    name: 'Ethereum Classic',
+                    coingeckoId: 'ethereum-classic',
+                    contractAddress: null,
+                    symbol: 'etc',
+                    displaySymbol: 'ETC',
+                    networkName: 'Ethereum Classic',
+                    networkSymbol: 'etc',
+                } satisfies TradingAssetOption,
+                receiveAddress: ethAddress,
+                receiveAccountKey: ethAccountKey,
             },
-        };
+        });
+
+        const inputAccountKeyMissing = overrideInput({
+            formValues: {
+                receiveAddress: ethAddress,
+                receiveAccountKey: 'nonexistent-key' as AccountKey,
+            },
+        });
+        const inputMatchingAccountKeyInvalidAddress = overrideInput({
+            formValues: {
+                receiveAddress: 'not-valid-eth-address',
+                receiveAccountKey: ethAccountKey,
+            },
+        });
+        const inputUnknownReceiveSymbol = overrideInput({
+            formValues: {
+                receiveCryptoSelect: {
+                    ...input.formValues.receiveCryptoSelect!,
+                    id: 'unknown-coin' as CryptoId,
+                },
+                receiveAddress: ethAddress,
+            },
+        });
 
         it.each([
             ['output amount is incorrect', inputAmountIncorrect],
             ['receiveCryptoSelect is not selected', inputReceiveCryptoSelectIncorrect],
             ['sendCryptoSelect is not selected', inputSendCryptoSelectIncorrect],
+            ['cross-format stale leak ETH to BTC (#28143)', inputCrossFormatLeak],
+            ['same-format stale leak ETH to BSC (#28143)', inputSameFormatLeakEthToBsc],
+            ['same-format stale leak ETH to ETC (#28143)', inputSameFormatLeakEthToEtc],
+            [
+                'receiveAccountKey provided but account no longer in state (#28143)',
+                inputAccountKeyMissing,
+            ],
+            [
+                'receiveAccountKey matches but receiveAddress is invalid for symbol (#28143)',
+                inputMatchingAccountKeyInvalidAddress,
+            ],
+            ['receiveAddress provided for unknown receive symbol', inputUnknownReceiveSymbol],
         ])(`%s`, async (_description, formValues) => {
             const promise = store.dispatch(exchangeThunks.handleRequestThunk(formValues));
 
@@ -255,6 +332,51 @@ describe('handleExchangeRequestThunk', () => {
         expect(state.exchange.quotes.length).toEqual(0);
         expect(state.exchange.quotesRequest).toBeUndefined();
         expect(state.isLoading).toBe(false);
+    });
+
+    it('should accept a receiveAddress whose receiveAccountKey resolves to a matching-symbol account (#28143)', async () => {
+        const { input, store } = getMocks();
+        const mockQuotes = cloneExchangeQuotes();
+
+        invityAPI.getExchangeQuotes = () => Promise.resolve(mockQuotes);
+
+        const ethAccountKey = (accountEth as unknown as Account).key;
+        const quotesResponse = await store
+            .dispatch(
+                exchangeThunks.handleRequestThunk({
+                    ...input,
+                    formValues: {
+                        ...input.formValues,
+                        receiveAddress: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+                        receiveAccountKey: ethAccountKey,
+                    },
+                }),
+            )
+            .unwrap();
+
+        expect(quotesResponse?.length).toEqual(11);
+        expect(store.getState().wallet.trading.exchange.quotes.length).toEqual(11);
+    });
+
+    it('should accept an ETH-format receiveAddress with no account key against an ETH receive symbol (#28143)', async () => {
+        const { input, store } = getMocks();
+        const mockQuotes = cloneExchangeQuotes();
+
+        invityAPI.getExchangeQuotes = () => Promise.resolve(mockQuotes);
+
+        const quotesResponse = await store
+            .dispatch(
+                exchangeThunks.handleRequestThunk({
+                    ...input,
+                    formValues: {
+                        ...input.formValues,
+                        receiveAddress: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+                    },
+                }),
+            )
+            .unwrap();
+
+        expect(quotesResponse?.length).toEqual(11);
     });
 
     it('should not save quotes when empty array is returned from the response', async () => {

--- a/suite-common/trading/src/thunks/exchange/handleExchangeRequestThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/handleExchangeRequestThunk.ts
@@ -2,7 +2,10 @@ import { type ExchangeTrade, type ExchangeTradeQuoteRequest } from 'invity-api';
 
 import { createThunk } from '@suite-common/redux-utils';
 import { type Network } from '@suite-common/wallet-config';
+import { selectAccountByKey } from '@suite-common/wallet-core';
+import { type AccountKey } from '@suite-common/wallet-types';
 import { convertAmountSubunitsToUnits } from '@suite-common/wallet-utils';
+import { validate as validateAddress } from '@trezor/address-validator';
 
 import { TRADING_EXCHANGE_THUNK_PREFIX } from '../../constants';
 import { invityAPI } from '../../invityAPI';
@@ -14,7 +17,7 @@ import {
     type MinimalExchangeFormProps,
     type TradingExchangeType,
 } from '../../types';
-import { addIdsToQuotes, getNetworkDecimalsWithFallback } from '../../utils';
+import { addIdsToQuotes, cryptoIdToSymbol, getNetworkDecimalsWithFallback } from '../../utils';
 import { exchangeUtils } from '../../utils/exchange/exchangeUtils';
 
 type GetQuotesRequest = {
@@ -69,6 +72,53 @@ export const getQuoteRequestData = ({
     return request;
 };
 
+const isReceiveAddressValid = (
+    receiveAddress: string,
+    receiveSymbol: NonNullable<ReturnType<typeof cryptoIdToSymbol>>,
+): boolean => {
+    try {
+        return validateAddress(receiveAddress, receiveSymbol);
+    } catch {
+        return false;
+    }
+};
+
+// Prevent stale receive addresses after TO-network changes (#28143).
+// Account keys prove selected-account chain membership for same-format networks,
+// but the submitted address must still be valid for the receive network.
+const isReceiveAddressCoherent = ({
+    receiveAddress,
+    receiveCryptoSelectId,
+    receiveAccountKey,
+    state,
+}: {
+    receiveAddress: string | undefined;
+    receiveCryptoSelectId: ExchangeTradeQuoteRequest['receive'];
+    receiveAccountKey: AccountKey | undefined;
+    state: Parameters<typeof selectAccountByKey>[0];
+}): boolean => {
+    if (!receiveAddress) {
+        return true;
+    }
+
+    const receiveSymbol = cryptoIdToSymbol(receiveCryptoSelectId);
+    if (!receiveSymbol) {
+        return false;
+    }
+
+    if (!isReceiveAddressValid(receiveAddress, receiveSymbol)) {
+        return false;
+    }
+
+    if (receiveAccountKey) {
+        const receiveAccount = selectAccountByKey(state, receiveAccountKey);
+
+        return receiveAccount?.symbol === receiveSymbol;
+    }
+
+    return true;
+};
+
 export const handleExchangeRequestThunk = createThunk<
     ExchangeTrade[],
     HandleExchangeRequestThunkProps,
@@ -93,6 +143,19 @@ export const handleExchangeRequestThunk = createThunk<
         });
 
         if (!requestData) {
+            dispatch(tradingActions.stopRefetchQuotes());
+
+            return rejectWithValue('Invalid request data');
+        }
+
+        if (
+            !isReceiveAddressCoherent({
+                receiveAddress: requestData.receiveAddress,
+                receiveCryptoSelectId: requestData.receive,
+                receiveAccountKey: formValues.receiveAccountKey,
+                state: getState(),
+            })
+        ) {
             dispatch(tradingActions.stopRefetchQuotes());
 
             return rejectWithValue('Invalid request data');

--- a/suite-common/trading/src/types.ts
+++ b/suite-common/trading/src/types.ts
@@ -262,6 +262,7 @@ export type MinimalExchangeFormProps = {
     setMaxOutputId?: number;
     receiveAddress?: string;
     fromAddress?: string;
+    receiveAccountKey?: AccountKey;
 };
 
 export type TradingExchangeStepType = 'RECEIVING_ADDRESS' | 'SEND_TRANSACTION' | 'SIGN_DATA';

--- a/suite-common/trading/src/types.ts
+++ b/suite-common/trading/src/types.ts
@@ -250,8 +250,6 @@ export interface TradingExchangeFormProps extends FormState {
     [constants.TRADING_EXCHANGE_COMPARATOR_KYC_FILTER]: TradingExchangeKycFilter;
     [constants.TRADING_EXCHANGE_COMPARATOR_RATE_FILTER]: TradingExchangeRateFilter;
     [constants.TRADING_EXCHANGE_FROM_ADDRESS]?: string | undefined;
-    [constants.TRADING_EXCHANGE_RECEIVE_ADDRESS]?: string | undefined;
-    [constants.TRADING_EXCHANGE_EXTRA_FIELD]?: string | undefined;
     [constants.TRADING_FORM_PROVIDER_SELECT]?: string;
 }
 

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeQuotes.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeQuotes.test.ts
@@ -423,6 +423,7 @@ describe('useExchangeQuotes', () => {
                     receiveCryptoSelect: { id: 'bitcoin' as CryptoId },
                     fromAddress: ethAccount.descriptor,
                     receiveAddress: 'btc-receive-address',
+                    receiveAccountKey: btcAccount.key,
                 } satisfies MinimalExchangeFormProps,
                 network: expect.objectContaining({ tradeCryptoId: 'ethereum' }),
                 composeRequestCallback: expect.anything(),

--- a/suite-native/module-trading/src/utils/exchange/__tests__/quotesUtils.test.ts
+++ b/suite-native/module-trading/src/utils/exchange/__tests__/quotesUtils.test.ts
@@ -155,6 +155,7 @@ describe('quotesUtils', () => {
                 receiveCryptoSelect: { id: 'bitcoin' as CryptoId },
                 outputs: [{ amount: '1' }],
                 receiveAddress: 'btc-receive-addr',
+                receiveAccountKey: btc1NormalAccount.key,
             } satisfies MinimalExchangeFormProps);
         });
 
@@ -174,6 +175,7 @@ describe('quotesUtils', () => {
                 sendCryptoSelect: { id: 'ethereum' as CryptoId },
                 receiveCryptoSelect: { id: 'bitcoin' as CryptoId },
                 outputs: [{ amount: '1' }],
+                receiveAccountKey: btc1NormalAccount.key,
             } satisfies MinimalExchangeFormProps);
         });
 
@@ -194,6 +196,7 @@ describe('quotesUtils', () => {
                 receiveCryptoSelect: { id: 'ethereum' as CryptoId },
                 outputs: [{ amount: '1' }],
                 receiveAddress: eth1NormalAccount.descriptor,
+                receiveAccountKey: eth1NormalAccount.key,
             } satisfies MinimalExchangeFormProps);
         });
 

--- a/suite-native/module-trading/src/utils/exchange/quotesUtils.ts
+++ b/suite-native/module-trading/src/utils/exchange/quotesUtils.ts
@@ -33,6 +33,7 @@ export const tradingExchangeFormToTradingExchangeFormProps = (
         outputs: [{ amount: sendCryptoAmount }],
         fromAddress: getFromAddress(sendAccount),
         receiveAddress: getReceiveAccountAddressText(receiveAccount),
+        receiveAccountKey: receiveAccount?.account.key,
     };
 };
 


### PR DESCRIPTION
## Summary

Switching the TO asset on the swap form could carry the previous asset's `receiveAddress` into the next quote request.  Root cause was a one-render race between the receive-address form mirror and the receive-crypto select.

## Changes

- **a5c7e2557a**  — rejects quote requests where `receiveAddress` does not match the selected receive symbol. Chain membership via `receiveAccountKey` catches same-format EVM leaks; address-format fallback catches cross-format leaks.
- **ba6649c6e2** — removes the form-state mirror that caused the race in the first place. Receive identity lives in `useTradingReceiveAddress` only. Web-only.

## QA 

- **Desktop**: Apart of the obvious, also test happy path end-to-end (quote → confirm → sign) to confirm the refactor didn't break the normal flow.
- **Mobile**: reproduce the original issue scenario (rapid TO asset switch across ETH, SOL, XRP, Stellar) on suite-native; verify request payloads carry a matching `receiveAddress`.

## Related Issue

Resolve #28143

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=28143-swap-old-receive-address-sent-in-swap-request-after-switching-to-assetnetwork&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=28143-swap-old-receive-address-sent-in-swap-request-after-switching-to-assetnetwork&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=28143-swap-old-receive-address-sent-in-swap-request-after-switching-to-assetnetwork&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-29T22:11:40.718Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-28T22:19:50.397Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/28143-swap-old-receive-address-sent-in-swap-request-after-switching-to-assetnetwork/web/](https://dev.suite.sldev.cz/suite-web/28143-swap-old-receive-address-sent-in-swap-request-after-switching-to-assetnetwork/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->