### PR TITLE
test(connect): update ethereumSignTransaction definitions fixture for new screen format

### DIFF
--- a/packages/connect/e2e/__fixtures__/ethereumSignTransactionDefinitions.ts
+++ b/packages/connect/e2e/__fixtures__/ethereumSignTransactionDefinitions.ts
@@ -23,7 +23,7 @@ export default {
                 },
             },
             result: {},
-            deviceScreen: 'Send0.01WETHMinimumtoReceive0USDTUniswapfee0.3%',
+            deviceScreen: /"body":"UniswapV3Router".*"body":"Swap".*0\.01WETH.*0USDT.*0\.3%/,
             deviceScreenSkip: ['1', '<2.12.1'],
         },
     ],


### PR DESCRIPTION
## Description

The firmware now emits structured JSON objects (`{title, body}`) for device screen tiles instead of flat text. The old `deviceScreen` string `'Send0.01WETHMinimumtoReceive0USDTUniswapfee0.3%'` no longer matches this format.

Updated the fixture to use a regex that matches the key fields in order: provider (`UniswapV3Router`), intent (`Swap`), and the swap amounts (`0.01 WETH`, `0 USDT`, `0.3%`).

Full [pass here](https://github.com/trezor/trezor-suite/actions/runs/26624456406/job/78457777520)

## Notes for QA

No manual testing needed — this is a test fixture update to keep the e2e test passing against current firmware screen output.

## Screenshots:

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-ethereum-sign-tx-definitions-test/web/](https://dev.suite.sldev.cz/suite-web/fix-ethereum-sign-tx-definitions-test/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-ethereum-sign-tx-definitions-test&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-ethereum-sign-tx-definitions-test&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-29T07:23:38.075Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->