### PR TITLE
feat(trading): align desktop clear-signed swap review with device

### DIFF
--- a/packages/product-components/src/components/AssetLogo/assetLogoUtils.ts
+++ b/packages/product-components/src/components/AssetLogo/assetLogoUtils.ts
@@ -43,7 +43,7 @@ export const getCoingeckoIdAndContractAddressIncludesNativeTokens = (
         .concat(contractAddress ?? [])
         .map(addr => addr ?? ZERO_ADDRESS);
 
-    const hasNative = addresses.includes(ZERO_ADDRESS);
+    const hasNative = addresses.length === 0 || addresses.includes(ZERO_ADDRESS);
 
     const shouldUseTradeId = hasNative && !!mainNetworkSymbol && isNetworkSymbol(mainNetworkSymbol);
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBody.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBody.tsx
@@ -6,6 +6,7 @@ import { preserveModalOnTxTimeout } from '@suite/modal';
 import { selectRouterUrl } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
+import { selectTradingExchangeSelectedQuote } from '@suite-common/trading';
 import { selectStablecoinYieldTxReview } from '@suite-common/wallet-core';
 import { type FormState } from '@suite-common/wallet-types';
 import {
@@ -45,6 +46,7 @@ export const TransactionReviewModalBody = ({
     const account = useSelector(selectAccountIncludingChosenInTrading);
     const device = useSelector(selectSelectedDevice);
     const yieldTxReview = useSelector(selectStablecoinYieldTxReview);
+    const swapSlippage = useSelector(selectTradingExchangeSelectedQuote)?.swapSlippage;
 
     const isYield = Boolean(yieldTxReview.precomposedTx);
     const vaultName = isYield ? yieldTxReview.vaultName : undefined;
@@ -110,6 +112,7 @@ export const TransactionReviewModalBody = ({
         precomposedForm,
         precomposedTx,
         vaultName,
+        swapSlippage,
     });
 
     const handleTryAgain = useCallback(

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalContent.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 
 import { type DeviceRootState, selectSelectedDevice } from '@suite-common/device';
+import { selectTradingExchangeSelectedQuote } from '@suite-common/trading';
 import {
     type SerializedTx,
     selectSendFormReviewButtonRequestsCount,
@@ -58,6 +59,7 @@ export const TransactionReviewModalContent = ({
 }: TransactionReviewModalContentProps) => {
     const { symbol, networkType } = account;
     const device = useSelector(selectSelectedDevice);
+    const swapSlippage = useSelector(selectTradingExchangeSelectedQuote)?.swapSlippage;
 
     const createdTxTimestamp = useMemo(
         () => precomposedTx.createdTimestamp ?? 0,
@@ -88,6 +90,7 @@ export const TransactionReviewModalContent = ({
                 precomposedForm,
                 precomposedTx,
                 vaultName,
+                swapSlippage,
             }),
         [
             account,
@@ -97,6 +100,7 @@ export const TransactionReviewModalContent = ({
             precomposedForm,
             precomposedTx,
             vaultName,
+            swapSlippage,
         ],
     );
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
@@ -175,6 +175,7 @@ const getOutputTitle = (
     stakeType: StakeType | undefined,
     evmTxType?: EvmTransactionPurpose,
     device?: TrezorDevice,
+    receiveAddress?: string,
 ): ReactNode | undefined => {
     const translation = getTranslationValues(networkType, stakeType, evmTxType, device);
     const contractTitle = getContractTitle(networkType, isApprovalFlowSupported(device), evmTxType);
@@ -241,8 +242,10 @@ const getOutputTitle = (
             );
         case 'recipient_name':
             return <Translation id="TR_TRADING_PROVIDER" />;
+        case 'swap_intent':
+            return <Translation id="TR_TRADING_INTENT" />;
         case 'traded_assets':
-            return <Translation id="TR_MY_ASSETS" />;
+            return <Translation id={receiveAddress ? 'TR_CONTRACT' : 'TR_MY_ASSETS'} />;
         case 'fee-limit':
             return <Translation id="TR_SUMMARY" />;
         case 'rewards':
@@ -438,6 +441,14 @@ const getOutputLines = ({
                     value,
                 },
             ];
+        case 'swap_intent':
+            return [
+                {
+                    id: 'swap_intent',
+                    type: 'data',
+                    value: translationString('TR_TRADING_INTENT_SWAP', {}),
+                },
+            ];
         case 'amount': {
             if (isYieldAction(evmTxType)) {
                 return [
@@ -571,6 +582,7 @@ export const TransactionReviewOutput = (props: TransactionReviewOutputProps) => 
         nativeToken,
     } = props;
     const rewards = type === 'rewards' ? props.rewards : undefined;
+    const receiveAddress = type === 'traded_assets' ? props.receiveAddress : undefined;
     const { networkType, symbol } = account;
     const accounts = useSelector(selectAccounts);
     const device = useSelector(selectSelectedDevice);
@@ -590,6 +602,7 @@ export const TransactionReviewOutput = (props: TransactionReviewOutputProps) => 
         stakeType,
         evmTxType,
         device,
+        receiveAddress,
     );
 
     const outputLines = getOutputLines({
@@ -656,6 +669,7 @@ export const TransactionReviewOutput = (props: TransactionReviewOutputProps) => 
                 state={state}
                 send={send}
                 receive={receive}
+                receiveAddress={receiveAddress}
             />
         );
     }

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputAssets.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputAssets.tsx
@@ -2,6 +2,9 @@ import { type ReactNode } from 'react';
 
 import { type CryptoId } from 'invity-api';
 
+import { Address } from '@suite/address';
+import { Translation } from '@suite/intl';
+import { selectLanguage } from '@suite/settings';
 import { selectTradingCoinSymbolByCryptoId, toTokenCryptoId } from '@suite-common/trading';
 import { getCoingeckoId, getNetwork } from '@suite-common/wallet-config';
 import {
@@ -9,6 +12,7 @@ import {
     type FormStateTradingFiatCurrency,
     type TokenAddress,
 } from '@suite-common/wallet-types';
+import { localizeNumber } from '@suite-common/wallet-utils';
 import { Card, Column, Divider, H4, InfoItem, Row, Text } from '@trezor/components';
 import { mapPaddingTypeToPadding } from '@trezor/components/src/components/Card/utils';
 import { AssetLogo, CoinLogo, isCoinSymbol } from '@trezor/product-components';
@@ -23,6 +27,7 @@ export type TransactionReviewOutputAssetsProps = {
     state: 'active' | 'confirmed' | 'unconfirmed';
     send: FormStateTradingCryptoCurrency;
     receive: FormStateTradingCryptoCurrency | FormStateTradingFiatCurrency;
+    receiveAddress?: string;
 };
 
 type TransactionReviewOutputAssetsCryptoCurrencyProps = {
@@ -39,13 +44,19 @@ const TransactionReviewOutputAssetsCryptoCurrency = ({
     type,
 }: TransactionReviewOutputAssetsCryptoCurrencyProps) => {
     const { symbol, contractAddress, amount } = cryptoCurrency;
+    const locale = useSelector(selectLanguage);
     const network = getNetwork(symbol);
     const isTokenAmount = !!cryptoCurrency.contractAddress;
+    const formattedAmount = localizeNumber(amount, locale);
 
     const cryptoId = contractAddress
         ? toTokenCryptoId(symbol, contractAddress)
         : (getCoingeckoId(symbol) as CryptoId);
-    const displaySymbol = useSelector(state => selectTradingCoinSymbolByCryptoId(state, cryptoId));
+    const displaySymbol = useSelector(state =>
+        contractAddress
+            ? selectTradingCoinSymbolByCryptoId(state, cryptoId)
+            : network.displaySymbol,
+    );
 
     const getCoinLogo = () =>
         isCoinSymbol(symbol) ? (
@@ -55,7 +66,7 @@ const TransactionReviewOutputAssetsCryptoCurrency = ({
     return (
         <InfoItem
             label={
-                <Row alignItems="center" gap={spacings.sm}>
+                <Row alignItems="center" gap={12} margin={{ left: 32 }}>
                     {network.coingeckoId ? (
                         <AssetLogo
                             size={20}
@@ -71,7 +82,7 @@ const TransactionReviewOutputAssetsCryptoCurrency = ({
                         data-testid={`@modal/assets/${type}/crypto`}
                     >
                         {type === 'receive' ? ' + ' : ' - '}
-                        {amount} {displaySymbol}
+                        {formattedAmount} {displaySymbol}
                     </Text>
                 </Row>
             }
@@ -124,31 +135,60 @@ export const TransactionReviewOutputAssets = ({
     title,
     send,
     receive,
+    receiveAddress,
     state,
 }: TransactionReviewOutputAssetsProps) => (
-    <Card
-        paddingType="none"
-        fillType={state === 'confirmed' ? 'flat' : 'default'}
-        header={
-            <Row gap={spacings.sm} padding={mapPaddingTypeToPadding({ paddingType: 'small' })}>
-                <TransactionReviewOutputStatus state={state} />
-                <H4
-                    margin={{ left: spacings.xxs }}
-                    typographyStyle={state !== 'unconfirmed' ? 'body-sm-strong' : 'body-sm'}
-                >
-                    {title}
-                </H4>
-            </Row>
-        }
-    >
-        <Column>
-            <Column padding={mapPaddingTypeToPadding({ paddingType: 'small' })}>
-                <TransactionReviewOutputAssetsCryptoCurrency cryptoCurrency={send} type="send" />
+    <>
+        <Card
+            paddingType="none"
+            fillType={state === 'confirmed' ? 'flat' : 'default'}
+            header={
+                <Row gap={spacings.sm} padding={mapPaddingTypeToPadding({ paddingType: 'small' })}>
+                    <TransactionReviewOutputStatus state={state} />
+                    <H4
+                        margin={{ left: spacings.xxs }}
+                        typographyStyle={state !== 'unconfirmed' ? 'body-sm-strong' : 'body-sm'}
+                    >
+                        {title}
+                    </H4>
+                </Row>
+            }
+        >
+            <Column>
+                <Column padding={mapPaddingTypeToPadding({ paddingType: 'small' })}>
+                    <TransactionReviewOutputAssetsCryptoCurrency
+                        cryptoCurrency={send}
+                        type="send"
+                    />
+                </Column>
+                <Divider margin={{}} />
+                <Column padding={mapPaddingTypeToPadding({ paddingType: 'small' })}>
+                    <TransactionReviewOutputAssetsTo receive={receive} />
+                </Column>
+                {receiveAddress && (
+                    <>
+                        <Divider margin={{}} />
+                        <Column padding={mapPaddingTypeToPadding({ paddingType: 'small' })}>
+                            <InfoItem
+                                label={
+                                    <Text intent="neutral" padding={{ left: 32 }}>
+                                        <Translation id="TR_RECIPIENT" />
+                                    </Text>
+                                }
+                                direction="row"
+                                verticalAlignment="start"
+                            >
+                                <Address
+                                    typographyStyle="body-sm"
+                                    value={receiveAddress}
+                                    isChunked={false}
+                                    isDeviceRendered
+                                />
+                            </InfoItem>
+                        </Column>
+                    </>
+                )}
             </Column>
-            <Divider margin={{}} />
-            <Column padding={mapPaddingTypeToPadding({ paddingType: 'small' })}>
-                <TransactionReviewOutputAssetsTo receive={receive} />
-            </Column>
-        </Column>
-    </Card>
+        </Card>
+    </>
 );

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewTotalOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewTotalOutput.tsx
@@ -12,6 +12,7 @@ import {
     getEvmTransactionTextSignature,
     getIsUpdatedEthereumSendFlow,
     getIsUpdatedSendFlow,
+    isClearSignedEvmTradingSwapTransaction,
     isEvmApprovalTx,
     isEvmYieldTxByTextSignature,
     isTestnet,
@@ -36,6 +37,7 @@ interface GetLinesParams {
     isRbfAction?: boolean;
     stakeType?: StakeType;
     nativeToken?: TokenInfo;
+    isClearSignedTradingSwap: boolean;
 }
 
 const getLines = ({
@@ -46,6 +48,7 @@ const getLines = ({
     isRbfAction,
     stakeType,
     nativeToken,
+    isClearSignedTradingSwap,
 }: GetLinesParams): OutputElementLine[] => {
     const isUpdatedSendFlow = getIsUpdatedSendFlow(device);
     const isUpdatedEthereumSendFlow = getIsUpdatedEthereumSendFlow(device, networkType, stakeType);
@@ -72,7 +75,7 @@ const getLines = ({
         .minus(precomposedTx.fee)
         .toString();
 
-    if (precomposedForm.trading?.isSlip24Active) {
+    if (precomposedForm.trading?.isSlip24Active || isClearSignedTradingSwap) {
         return [
             {
                 id: 'fee',
@@ -181,6 +184,13 @@ export const TransactionReviewTotalOutput = ({
             ? precomposedTx.nativeToken
             : undefined;
     const isFiatVisible = !isTestnet(account.symbol) && account.accountType !== 'placeholder';
+    const isClearSignedTradingSwap = isClearSignedEvmTradingSwapTransaction({
+        account,
+        device,
+        precomposedTx,
+        transactionData: precomposedForm.transactionData,
+        trading: precomposedForm.trading,
+    });
     const lines = getLines({
         device,
         networkType,
@@ -189,17 +199,19 @@ export const TransactionReviewTotalOutput = ({
         isRbfAction: isRbf,
         stakeType,
         nativeToken,
+        isClearSignedTradingSwap,
     });
+
+    const titleId = (() => {
+        if (isClearSignedTradingSwap) return 'TR_NETWORK_FEE';
+        if (precomposedForm.trading?.isSlip24Active) return 'TR_SUMMARY';
+
+        return 'TR_TOTAL_INCLUDING_FEE';
+    })();
 
     return (
         <TransactionReviewOutputElement
-            title={
-                precomposedForm.trading?.isSlip24Active ? (
-                    <Translation id="TR_SUMMARY" />
-                ) : (
-                    <Translation id="TR_TOTAL_INCLUDING_FEE" />
-                )
-            }
+            title={<Translation id={titleId} />}
             account={account}
             lines={lines}
             state={state}

--- a/suite-common/trading/src/__tests__/utils.test.ts
+++ b/suite-common/trading/src/__tests__/utils.test.ts
@@ -711,6 +711,30 @@ describe('getTradingFormState', () => {
                 },
             });
         });
+
+        it('should propagate trade.receiveAddress', () => {
+            const trade = {
+                exchange: 'test-exchange',
+                receive: 'ethereum' as CryptoId,
+                receiveStringAmount: '1',
+                send: 'bitcoin' as CryptoId,
+                sendStringAmount: '0.025',
+                receiveAddress: '0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3',
+            } as ExchangeTrade;
+
+            const result = getTradingFormState({
+                activeSection,
+                trade,
+                providers: { 'test-exchange': mockProvider },
+                isSlip24Active: false,
+                sendAccountKey,
+                receiveAccountKey,
+            });
+
+            expect(result).toMatchObject({
+                receiveAddress: '0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3',
+            });
+        });
     });
 
     describe('edge cases', () => {

--- a/suite-common/trading/src/thunks/exchange/confirmApprovalThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/confirmApprovalThunk.ts
@@ -57,13 +57,19 @@ export const confirmApprovalThunk = createThunk(
 
         dispatch(tradingExchangeActions.saveTransactionId(undefined));
 
-        const response = await invityAPI.doExchangeTrade({
+        const rawResponse = await invityAPI.doExchangeTrade({
             trade,
             receiveAddress,
             refundAddress,
             extraField,
             returnUrl: undefined,
         });
+
+        // invity drops DEX-specific fields on the response — preserve those the review flow needs
+        const response = rawResponse && {
+            ...rawResponse,
+            swapSlippage: rawResponse.swapSlippage ?? trade.swapSlippage,
+        };
 
         if (!response) {
             dispatch(

--- a/suite-common/trading/src/thunks/exchange/confirmExchangeTradeThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/confirmExchangeTradeThunk.ts
@@ -67,7 +67,7 @@ export const confirmExchangeTradeThunk = createThunk(
             }
         }
 
-        const response = await invityAPI.doExchangeTrade(
+        const rawResponse = await invityAPI.doExchangeTrade(
             {
                 trade,
                 receiveAddress,
@@ -82,6 +82,12 @@ export const confirmExchangeTradeThunk = createThunk(
         if (signal.aborted) {
             return undefined;
         }
+
+        // invity drops DEX-specific fields on the response — preserve those the review flow needs
+        const response = rawResponse && {
+            ...rawResponse,
+            swapSlippage: rawResponse.swapSlippage ?? trade.swapSlippage,
+        };
 
         if (!response) {
             dispatch(

--- a/suite-common/trading/src/utils.ts
+++ b/suite-common/trading/src/utils.ts
@@ -388,6 +388,7 @@ export const getTradingFormState = ({
                 activeSection,
                 recipientName: provider.companyName,
                 isSlip24Active: isSlip24Active && !!receiveAccountKey,
+                receiveAddress: trade.receiveAddress,
                 send: {
                     cryptoId: trade.send,
                     accountKey: sendAccountKey,

--- a/suite-common/wallet-types/src/sendForm.ts
+++ b/suite-common/wallet-types/src/sendForm.ts
@@ -48,6 +48,7 @@ type FormStateTradingSell = {
 export type FormStateTradingExchange = {
     activeSection: 'exchange';
     receive: FormStateTradingCryptoCurrency;
+    receiveAddress?: string;
 } & FormStateTradingCommon;
 
 export type FormStateTrading =

--- a/suite-common/wallet-types/src/transactionReviewOutput.ts
+++ b/suite-common/wallet-types/src/transactionReviewOutput.ts
@@ -23,6 +23,7 @@ export type ReviewOutput =
               | 'regular_legacy'
               | 'approve_data'
               | 'recipient_name'
+              | 'swap_intent'
               | 'fee-limit';
           label?: string;
           value: string;
@@ -30,6 +31,7 @@ export type ReviewOutput =
           token?: TokenInfo;
           send?: undefined;
           receive?: undefined;
+          receiveAddress?: undefined;
       }
     | {
           type: 'fee-replace';
@@ -39,6 +41,7 @@ export type ReviewOutput =
           token?: undefined;
           send?: undefined;
           receive?: undefined;
+          receiveAddress?: undefined;
       }
     | {
           type: 'reduce-output';
@@ -48,6 +51,7 @@ export type ReviewOutput =
           token?: undefined;
           send?: undefined;
           receive?: undefined;
+          receiveAddress?: undefined;
       }
     | {
           type: 'traded_assets';
@@ -57,6 +61,7 @@ export type ReviewOutput =
           token?: undefined;
           send: FormStateTradingCryptoCurrency;
           receive: FormStateTradingCryptoCurrency | FormStateTradingFiatCurrency;
+          receiveAddress?: string;
       }
     | {
           type: 'rewards';
@@ -67,6 +72,7 @@ export type ReviewOutput =
           token?: undefined;
           send?: undefined;
           receive?: undefined;
+          receiveAddress?: undefined;
       };
 
 export type ReviewOutputType = ReviewOutput['type'];

--- a/suite-common/wallet-utils/src/__tests__/reviewTransactionUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/reviewTransactionUtils.test.ts
@@ -1,0 +1,219 @@
+import { type TrezorDevice } from '@suite-common/suite-types';
+import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
+import {
+    type Account,
+    type FormState,
+    type FormStateTrading,
+    type GeneralPrecomposedTransactionFinal,
+} from '@suite-common/wallet-types';
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+import type { TokenInfo } from '@trezor/connect';
+
+import {
+    constructTransactionReviewOutputs,
+    isClearSignedEvmTradingSwapTransaction,
+} from '../reviewTransactionUtils';
+
+const buildPrecomposedTx = (to: string | undefined): GeneralPrecomposedTransactionFinal =>
+    ({
+        outputs: to ? [{ address: to, amount: '0' }] : [],
+    }) as unknown as GeneralPrecomposedTransactionFinal;
+
+// LI.FI Diamond swapTokensMultipleV3ERC20ToERC20 — from the user's screenshot
+const LIFI_DIAMOND = '0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE';
+const LIFI_SWAP_DATA = `0x5fd9ae2e${'00'.repeat(32 * 4)}`;
+
+// ERC-20 transfer (global selector a9059cbb) — works on any contract
+const ERC20_TRANSFER_DATA = `0xa9059cbb${'00'.repeat(32 * 2)}`;
+
+// ERC-20 approve (global selector 095ea7b3)
+const ERC20_APPROVE_DATA = `0x095ea7b3${'00'.repeat(32 * 2)}`;
+
+const buildTrading = (overrides: Partial<FormStateTrading> = {}): FormStateTrading => ({
+    activeSection: 'exchange',
+    isSlip24Active: false,
+    recipientName: 'LiFi',
+    send: {
+        cryptoId: undefined,
+        accountKey: 'eth-account' as Account['key'],
+        symbol: 'eth',
+        amount: '1',
+    },
+    receive: {
+        cryptoId: undefined,
+        accountKey: 'eth-account' as Account['key'],
+        symbol: 'eth',
+        amount: '0.97',
+    },
+    receiveAddress: '0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3',
+    ...overrides,
+});
+
+const buildFormState = (overrides: Partial<FormState> = {}): FormState => ({
+    outputs: [],
+    feePerUnit: '1',
+    feeLimit: '21000',
+    options: [],
+    isCoinControlEnabled: false,
+    hasCoinControlBeenOpened: false,
+    selectedUtxos: [],
+    transactionData: undefined,
+    trading: undefined,
+    ...overrides,
+});
+
+const buildEthereumAccount = (overrides: Partial<Account> = {}): Account =>
+    mockWalletAccount({
+        symbol: 'eth',
+        accountType: 'normal',
+        ...overrides,
+    });
+
+const buildUpdatedDevice = () =>
+    mockSuiteDevice(undefined, {
+        major_version: 2,
+        minor_version: 6,
+        patch_version: 3,
+    });
+
+const buildPrecomposedTransaction = ({
+    to,
+    token,
+}: {
+    to: string;
+    token?: TokenInfo;
+}): GeneralPrecomposedTransactionFinal =>
+    ({
+        outputs: [{ address: to, amount: '1000000' }],
+        fee: '21000',
+        totalSpent: token ? '1000000' : '1021000',
+        feePerByte: '1',
+        token,
+        useNativeRbf: false,
+        isTokenKnown: true,
+    }) as unknown as GeneralPrecomposedTransactionFinal;
+
+const usdcToken: TokenInfo = {
+    balance: '1000000',
+    contract: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+    decimals: 6,
+    name: 'USD Coin',
+    standard: 'ERC20',
+    symbol: 'USDC',
+};
+
+describe('isClearSignedEvmTradingSwapTransaction', () => {
+    const account = buildEthereumAccount();
+    const device = buildUpdatedDevice();
+
+    it('returns true for clear-signed exchange swap transaction', () => {
+        const result = isClearSignedEvmTradingSwapTransaction({
+            account,
+            device,
+            precomposedTx: buildPrecomposedTx(LIFI_DIAMOND),
+            transactionData: LIFI_SWAP_DATA,
+            trading: buildTrading(),
+        });
+
+        expect(result).toBe(true);
+    });
+
+    it('returns false for clear-signed approve in exchange flow', () => {
+        const result = isClearSignedEvmTradingSwapTransaction({
+            account,
+            device,
+            precomposedTx: buildPrecomposedTx('0x0000000000000000000000000000000000001234'),
+            transactionData: ERC20_APPROVE_DATA,
+            trading: buildTrading(),
+        });
+
+        expect(result).toBe(false);
+    });
+
+    it('returns false outside trading exchange flow', () => {
+        const result = isClearSignedEvmTradingSwapTransaction({
+            account,
+            device,
+            precomposedTx: buildPrecomposedTx('0x0000000000000000000000000000000000001234'),
+            transactionData: ERC20_TRANSFER_DATA,
+            trading: undefined,
+        });
+
+        expect(result).toBe(false);
+    });
+
+    it('returns false when device does not support clear signing (e.g. Model One)', () => {
+        const deviceWithoutClearSigning: TrezorDevice = {
+            ...device,
+            unavailableCapabilities: { evmClearSigning: 'no-support' },
+        } as TrezorDevice;
+
+        const result = isClearSignedEvmTradingSwapTransaction({
+            account,
+            device: deviceWithoutClearSigning,
+            precomposedTx: buildPrecomposedTx(LIFI_DIAMOND),
+            transactionData: LIFI_SWAP_DATA,
+            trading: buildTrading(),
+        });
+
+        expect(result).toBe(false);
+    });
+});
+
+describe('constructTransactionReviewOutputs', () => {
+    const account = buildEthereumAccount();
+    const device = buildUpdatedDevice();
+
+    it('renders swap-specific outputs only for clear-signed exchange swap', () => {
+        const outputs = constructTransactionReviewOutputs({
+            account,
+            device,
+            decreaseOutputId: undefined,
+            precomposedForm: buildFormState({
+                transactionData: LIFI_SWAP_DATA,
+                trading: buildTrading(),
+            }),
+            precomposedTx: buildPrecomposedTransaction({ to: LIFI_DIAMOND, token: usdcToken }),
+        });
+
+        expect(outputs).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ type: 'recipient_name' }),
+                expect.objectContaining({ type: 'swap_intent', value: 'swap' }),
+                expect.objectContaining({
+                    type: 'traded_assets',
+                    receiveAddress: '0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3',
+                }),
+            ]),
+        );
+    });
+
+    it('does not render swap-specific outputs for approve transaction in exchange flow', () => {
+        const outputs = constructTransactionReviewOutputs({
+            account,
+            device,
+            decreaseOutputId: undefined,
+            precomposedForm: buildFormState({
+                transactionData: ERC20_APPROVE_DATA,
+                trading: buildTrading(),
+            }),
+            precomposedTx: buildPrecomposedTransaction({
+                to: '0x0000000000000000000000000000000000001234',
+                token: usdcToken,
+            }),
+        });
+
+        expect(outputs).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ type: 'contract' }),
+                expect.objectContaining({ type: 'approve_data' }),
+            ]),
+        );
+        expect(outputs).not.toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ type: 'swap_intent' }),
+                expect.objectContaining({ type: 'traded_assets' }),
+            ]),
+        );
+    });
+});

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.ts
@@ -1,6 +1,6 @@
 import { fromWei, toWei } from 'web3-utils';
 
-import { Calldata } from '@suite-common/calldata';
+import { Calldata, isEvmClearSigningTx } from '@suite-common/calldata';
 import { EVM_SPENDER_LABELS, KNOWN_VAULTS } from '@suite-common/suite-constants';
 import { type TrezorDevice } from '@suite-common/suite-types';
 import { EARN_YIELD_CLAIM_PROVIDER, networks } from '@suite-common/wallet-config';
@@ -16,7 +16,7 @@ import {
 } from '@suite-common/wallet-types';
 import type { CardanoOutput } from '@trezor/connect';
 import { getFirmwareVersion } from '@trezor/device-utils';
-import { versionUtils } from '@trezor/utils';
+import { BigNumber, versionUtils } from '@trezor/utils';
 
 import { datetimeToLocktime } from './bitcoinUtils';
 import { getShortFingerprint, isCardanoTx } from './cardanoUtils';
@@ -114,6 +114,47 @@ type ConstructOutputsParams = {
     precomposedForm: FormState | StakeFormState;
     vaultName?: string;
     availableRewards?: YieldClaimReward[];
+    swapSlippage?: string;
+    isClearSignedTradingSwap: boolean;
+};
+
+type IsClearSignedEvmTradingSwapTransactionParams = {
+    account: Account;
+    device: TrezorDevice;
+    precomposedTx: GeneralPrecomposedTransactionFinal;
+    transactionData?: string;
+    trading?: FormState['trading'];
+};
+
+const getClearSignedSwapRecipientName = (
+    precomposedTx: GeneralPrecomposedTransactionFinal,
+    fallback: string,
+): string => {
+    const routerAddress = precomposedTx.outputs.find(
+        o => 'address' in o && typeof o.address === 'string',
+    )?.address as string | undefined;
+
+    return (routerAddress && EVM_SPENDER_LABELS[routerAddress.toLowerCase()]) ?? fallback;
+};
+
+export const isClearSignedEvmTradingSwapTransaction = ({
+    account,
+    device,
+    precomposedTx,
+    transactionData,
+    trading,
+}: IsClearSignedEvmTradingSwapTransactionParams): boolean => {
+    if (!isExchangeTradingForm(trading)) return false;
+    if (!isEvmClearSigningSupportedByDevice(device)) return false;
+    if (isEvmApprovalTx(transactionData)) return false;
+    if (account.networkType !== 'ethereum' || !transactionData) return false;
+    const network = networks[account.symbol];
+    if (!('chainId' in network)) return false;
+    const to = precomposedTx.outputs.find(
+        o => 'address' in o && typeof o.address === 'string',
+    )?.address;
+
+    return isEvmClearSigningTx(network.chainId, to, transactionData);
 };
 
 const constructOldFlow = ({
@@ -121,6 +162,7 @@ const constructOldFlow = ({
     decreaseOutputId,
     account,
     precomposedForm,
+    isClearSignedTradingSwap,
 }: ConstructOutputsParams): ReviewOutput[] => {
     const outputs: ReviewOutput[] = [];
 
@@ -247,7 +289,11 @@ const constructOldFlow = ({
 
     if (networkType === 'tron' && precomposedForm.destinationTag) {
         outputs.push({ type: 'note', value: precomposedForm.destinationTag });
-    } else if (precomposedForm.transactionData && (!precomposedTx.token || isYieldOperation)) {
+    } else if (
+        precomposedForm.transactionData &&
+        (!precomposedTx.token || isYieldOperation) &&
+        !isClearSignedTradingSwap
+    ) {
         outputs.push({ type: 'data', value: precomposedForm.transactionData });
     }
 
@@ -281,6 +327,8 @@ const constructNewFlow = ({
     precomposedForm,
     vaultName,
     availableRewards,
+    swapSlippage,
+    isClearSignedTradingSwap,
     isApprovalFlowSupported,
     isEvmClearSigningSupported,
     isUpdatedEthereumSendFlow,
@@ -373,10 +421,11 @@ const constructNewFlow = ({
     if (isTron && precomposedForm.destinationTag) {
         outputs.push({ type: 'note', value: precomposedForm.destinationTag });
     } else if (
-        (precomposedForm.transactionData && !precomposedTx.token && !isEvmApproval) ||
-        (precomposedForm.transactionData && isEvmApproval && !isApprovalFlowSupported) ||
-        (precomposedForm.transactionData && isYieldOp && !isUpdatedEthereumSendFlow) ||
-        (precomposedForm.transactionData && isClaimOp && !isEvmClaimClearSign)
+        ((precomposedForm.transactionData && !precomposedTx.token && !isEvmApproval) ||
+            (precomposedForm.transactionData && isEvmApproval && !isApprovalFlowSupported) ||
+            (precomposedForm.transactionData && isYieldOp && !isUpdatedEthereumSendFlow) ||
+            (precomposedForm.transactionData && isClaimOp && !isEvmClaimClearSign)) &&
+        !isClearSignedTradingSwap
     ) {
         outputs.push({ type: 'data', value: precomposedForm.transactionData });
     }
@@ -439,14 +488,39 @@ const constructNewFlow = ({
                 }
             }
         });
-    } else if (precomposedForm.trading?.isSlip24Active && isExchangeTradingForm(trading)) {
-        outputs.push({ type: 'recipient_name', value: trading.recipientName });
+    } else if (
+        (precomposedForm.trading?.isSlip24Active || isClearSignedTradingSwap) &&
+        isExchangeTradingForm(trading)
+    ) {
+        const recipientName = isClearSignedTradingSwap
+            ? getClearSignedSwapRecipientName(precomposedTx, trading.recipientName)
+            : trading.recipientName;
+
+        if (recipientName) {
+            outputs.push({ type: 'recipient_name', value: recipientName });
+        }
+        if (isClearSignedTradingSwap) {
+            outputs.push({ type: 'swap_intent', value: 'swap' });
+        }
+        // TODO: extract the receive amount directly from the actual transaction data
+        // instead of deriving it from the quote and slippage.
+        const receive =
+            isClearSignedTradingSwap && swapSlippage
+                ? {
+                      ...trading.receive,
+                      amount: new BigNumber(trading.receive.amount)
+                          .multipliedBy(new BigNumber(100).minus(swapSlippage))
+                          .dividedBy(100)
+                          .toString(),
+                  }
+                : trading.receive;
         outputs.push({
             type: 'traded_assets',
-            value: '', // placeholder
-            value2: '', // placeholder
+            value: '',
+            value2: '',
             send: trading.send,
-            receive: trading.receive,
+            receive,
+            receiveAddress: isClearSignedTradingSwap ? trading.receiveAddress : undefined,
         });
     } else {
         precomposedTx.outputs.forEach(o => {
@@ -563,7 +637,12 @@ const constructNewFlow = ({
     return outputs;
 };
 
-type ConstructTransactionReviewOutputsProps = ConstructOutputsParams & { device: TrezorDevice };
+type ConstructTransactionReviewOutputsProps = Omit<
+    ConstructOutputsParams,
+    'isClearSignedTradingSwap'
+> & {
+    device: TrezorDevice;
+};
 
 export const constructTransactionReviewOutputs = ({
     device,
@@ -578,16 +657,24 @@ export const constructTransactionReviewOutputs = ({
         device,
         params.account.networkType,
     ); // > 2.9.0 && isStellar
+    const isClearSignedTradingSwap = isClearSignedEvmTradingSwapTransaction({
+        account: params.account,
+        device,
+        precomposedTx: params.precomposedTx,
+        transactionData: params.precomposedForm.transactionData,
+        trading: params.precomposedForm.trading,
+    });
     if (!isUpdatedSendFlow) {
-        return constructOldFlow(params);
+        return constructOldFlow({ ...params, isClearSignedTradingSwap });
     }
 
     return constructNewFlow({
+        ...params,
+        isClearSignedTradingSwap,
         isUpdatedEthereumSendFlow,
         isApprovalFlowSupported: isApprovalSupported(device),
         isEvmClearSigningSupported: isEvmClearSigningSupportedByDevice(device),
         isUpdatedStellarSendFlow,
-        ...params,
     });
 };
 
@@ -599,6 +686,7 @@ export const constructTransactionReviewOutputsOptional = ({
     precomposedForm,
     precomposedTx,
     vaultName,
+    swapSlippage,
 }: Partial<ConstructTransactionReviewOutputsProps>): ReviewOutput[] => {
     if (
         account === undefined ||
@@ -617,5 +705,6 @@ export const constructTransactionReviewOutputsOptional = ({
         precomposedForm,
         precomposedTx,
         vaultName,
+        swapSlippage,
     });
 };

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -1266,6 +1266,26 @@ export const messages = defineMessages({
         defaultMessage: 'Provider',
         id: 'TR_TRADING_PROVIDER',
     },
+    TR_TRADING_INTENT: {
+        defaultMessage: 'Intent',
+        id: 'TR_TRADING_INTENT',
+    },
+    TR_TRADING_INTENT_SWAP: {
+        defaultMessage: 'Swap',
+        id: 'TR_TRADING_INTENT_SWAP',
+    },
+    TR_RECIPIENT: {
+        defaultMessage: 'Recipient',
+        id: 'TR_RECIPIENT',
+    },
+    TR_CONTRACT: {
+        defaultMessage: 'Contract',
+        id: 'TR_CONTRACT',
+    },
+    TR_NETWORK_FEE: {
+        defaultMessage: 'Network fee',
+        id: 'TR_NETWORK_FEE',
+    },
     TR_TRADING_PROVIDERS: {
         defaultMessage: 'Providers',
         id: 'TR_TRADING_PROVIDERS',


### PR DESCRIPTION
## Description
Clear-sign modal implementation

## Notes for QA
- Minimum amount does not match device yet, we need to investigate why the data are different

## Related Issue

Resolve #27430

## Screenshots:
<img width="618" height="734" alt="image" src="https://github.com/user-attachments/assets/86faa7d1-18fc-454e-b51e-d5364986752d" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes modify reviewTransactionUtils.ts, a utility in suite-common/wallet-utils that formats transaction review data displayed during device confirmation prompts (addresses, amounts, fees, gas parameters). While this file is transitively imported by 121 tests, only tests that actually exercise transaction review/confirmation flows on the device prompt are meaningfully affected. The highest risk is in send, swap, and staking flows that assert specific formatted values on device prompts. The unit test file (reviewTransactionUtils.test.ts) has no E2E coverage mapping but provides direct unit-level coverage of the changed logic.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/wallet-utils/src/__tests__/reviewTransactionUtils.test.ts`
- `suite-common/wallet-utils/src/reviewTransactionUtils.ts`

</details>

**Recommended tests (18)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — This test exercises Bitcoin transaction review with custom fees, displaying total amount, fee, and fee rate on the device prompt — directly using reviewTransactionUtils for formatting transaction details shown during the confirmation flow.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — This test verifies Ethereum transaction review with custom gas parameters (gas limit, max fee per gas, max priority fee per gas) displayed on the device prompt during swap confirmation — directly consuming reviewTransactionUtils for formatting transaction review data.
- `suite/e2e/tests/wallet/send-eth.test.ts` — This test explicitly verifies ETH send transaction review details on the device prompt including gas limit, fee rates in Gwei, crypto amounts, and max fee calculations — all of which are formatted/computed by reviewTransactionUtils.
- `suite/e2e/tests/wallet/send-base.test.ts` — This test verifies a full Base (L2 ETH) send transaction review flow with custom fee parameters, device prompt assertions on gas limit/fee rates/amounts, and transaction confirmation — directly exercising reviewTransactionUtils formatting logic.
- `suite/e2e/tests/wallet/send-sol.test.ts` — This test verifies Solana send-max transaction review including recipient address formatting, crypto amount display, fee display, and total amount on the device prompt — all of which depend on reviewTransactionUtils.
- `suite/e2e/tests/wallet/send-doge.test.ts` — This test verifies DOGE send transaction review on the device prompt with amount, total, fee, and address formatting, plus error handling for amounts exceeding MAX_SAFE_INTEGER — directly exercising transaction review utilities.

</details>

<details><summary>🟡 <b>Medium priority (12)</b></summary>

- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — This test verifies device prompt details during a BTC sell transaction including formatted address, crypto amount with symbol, and fee — which likely use reviewTransactionUtils for transaction review formatting.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — This test verifies Ethereum sell transaction device prompt with destination address and crypto amount formatting, using custom gas fees — transaction review data likely flows through reviewTransactionUtils.
- `suite/e2e/tests/trading/sell-solana.test.ts` — This test verifies Solana sell transaction review with device prompt showing address, total crypto amount, and fee — transaction review formatting is likely handled by reviewTransactionUtils.
- `suite/e2e/tests/trading/swap-coins.test.ts` — This test verifies swap transaction confirmation on the device with address, amount, and fee display, and reads composedTransactionInfo from Redux state — which reviewTransactionUtils helps produce.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — This test verifies device prompt details during a SOL-to-USDC swap including address, amount, and fee — transaction review formatting likely depends on reviewTransactionUtils.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — This test verifies device prompt for USDT-to-BTC swap with address, crypto amount with symbol, and fee assertions — transaction review data likely flows through reviewTransactionUtils.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test verifies ETH staking transaction device prompt showing stake amount and fee — the transaction review display likely uses reviewTransactionUtils for formatting.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — This test verifies ETH unstake and claim transaction device prompts with amount and fee display — transaction review formatting likely depends on reviewTransactionUtils.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test exercises Bitcoin regtest send form with multiple outputs, locktime, and OP_RETURN — the device confirmation step uses transaction review formatting from reviewTransactionUtils.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — This test exercises LTC send with MimbleWimble peg-out outputs and device confirmation — transaction review data formatting likely uses reviewTransactionUtils.
- `suite/e2e/tests/staking/ada/stake.test.ts` — This test verifies Cardano staking device confirmation screens showing stake key registration, delegation, fees, and amounts — transaction review formatting may use reviewTransactionUtils.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — This test verifies SOL staking device prompt with stake amount, fees, and rent display — transaction review data likely flows through reviewTransactionUtils.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/wallet-utils/src/__tests__/reviewTransactionUtils.test.ts`

_Updated: 2026-05-29T09:06:55.549Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/trading-clear-signed-evm-preview-27430&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/trading-clear-signed-evm-preview-27430&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/trading-clear-signed-evm-preview-27430&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-02T13:28:13.891Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-02T12:10:39.560Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/trading-clear-signed-evm-preview-27430/web/](https://dev.suite.sldev.cz/suite-web/feat/trading-clear-signed-evm-preview-27430/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->
