### PR TITLE
test(e2e-suite): improve JS exception diagnostics and check-links…

### DIFF
--- a/suite/e2e/support/testExtends/suiteBaseFixture.ts
+++ b/suite/e2e/support/testExtends/suiteBaseFixture.ts
@@ -1,6 +1,7 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 
 import { ElectronApplication, Page, test as base } from '@playwright/test';
+import { inspect } from 'node:util';
 
 import { TestAnnotationType } from '@trezor/e2e-utils';
 import { SetupEmu, TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
@@ -167,36 +168,79 @@ const suiteBaseTest = currentsTest.extend<SuiteTestOptions & SuiteBaseFixture>({
             await use(page);
         }
     },
+
     exceptionLogger: [
         async ({ page, ignoreJSExceptions }, use, testInfo) => {
             const errors: Error[] = [];
             const ignored: Error[] = [];
-            page.on('pageerror', error => {
-                if (ignoreJSExceptions.some(exception => error.message.includes(exception))) {
+
+            // Listener handler
+            const handlePageError = (error: Error) => {
+                const message = error?.message || '';
+                const isIgnored = ignoreJSExceptions.some(exception =>
+                    message.toLowerCase().includes(exception.toLowerCase()),
+                );
+
+                if (isIgnored) {
                     ignored.push(error);
                 } else {
                     errors.push(error);
                 }
-            });
+            };
 
+            // Start listening
+            page.on('pageerror', handlePageError);
+
+            // Error format handler
+            const formatError = (error: unknown): string => {
+                if (error instanceof Error) {
+                    let output = error.stack || `${error.name}: ${error.message}`;
+
+                    if (error.cause) {
+                        output += `\nCaused by: ${formatError(error.cause)}`;
+                    }
+
+                    return output;
+                }
+
+                /*
+                 * Fallback for non-Error objects.
+                 * Use Node's `util.inspect` to safely handle circular references
+                 * without crashes during test teardown.
+                 */
+                if (typeof error === 'object' && error !== null) {
+                    return inspect(error, {
+                        showHidden: false,
+                        depth: 3, // How deep to look inside the object
+                        colors: false,
+                        getters: true, // Catch hidden error properties
+                    });
+                }
+
+                return String(error);
+            };
+
+            // Run the actual test
             await use();
 
+            // Handle annotations
             if (ignored.length > 0) {
                 testInfo.annotations.push({
                     type: 'Warning, Ignored JS exceptions',
-                    description: `\n${ignored.map(error => `${error.message}\n${error.stack}`).join('\n-----\n')}`,
+                    description: `\n${ignored.map(formatError).join('\n-----\n')}`,
                 });
             }
 
             if (errors.length > 0) {
                 throw new Error(
                     `There was a JS exception during test run.
-                    \n${errors.map(error => `${error.message}\n${error.stack}`).join('\n-----\n')}`,
+                    \n${errors.map(formatError).join('\n-----\n')}`,
                 );
             }
         },
         { auto: true },
     ],
+
     coverageMapCollector: [
         async ({ page }, use, testInfo) => {
             await use();

--- a/suite/e2e/tests/general/check-links.test.ts
+++ b/suite/e2e/tests/general/check-links.test.ts
@@ -79,6 +79,9 @@ async function fetchWithRetry(page: Page, url: string, maxRetries = 3) {
 }
 
 test.describe('Check Links', { tag: ['@webOnly', '@nightlyOnly', '@T3T1'] }, () => {
+    test.use({
+        ignoreJSExceptions: ['Aborted by signal', 'Failed to fetch'],
+    });
     test.beforeEach(async ({ onboardingPage, settingsPage }) => {
         await onboardingPage.completeOnboarding();
         await settingsPage.changeNetworks({ enableNetworks: ['btc'] });
@@ -120,7 +123,10 @@ test.describe('Check Links', { tag: ['@webOnly', '@nightlyOnly', '@T3T1'] }, () 
 
             await test.step('Filter known broken links', () => {
                 // Define patterns for known broken links here.
-                const ignoredPatterns: string[] = ['github.com/trezor/trezor-suite/releases/tag'];
+                const ignoredPatterns: string[] = [
+                    'github.com/trezor/trezor-suite/releases/tag',
+                    'apps.apple.com/app/id1631884497',
+                ];
                 const knownBrokenLinks: string[] = [];
 
                 for (const url of allUrls) {


### PR DESCRIPTION
…reliability

1. Enhance `exceptionLogger` in `suiteBaseFixture` to provide better visibility into JS exceptions.
2. Stabilize the check-links test by ignoring JSException and update ignored patterns.

## Description

### Problem

The check-links E2E test suite has been failing intermittently in CI with a cryptic error message: `Error: There was a JS exception during test run. [Object]`

This generic message provided no insight into the underlying issue, making it impossible to debug whether these were genuine application bugs or noise from the testing environment.

### Investigation

By improving the readability of the JS exception reporting in `suiteBaseFixture.ts` (upgrading the error serializer to handle structured objects and recursive error causes), we were able to inspect the actual exceptions. 

This revealed two primary root causes:
 1. Benign Navigation Errors: During bulk link extraction, the browser frequently triggers non-critical errors like "Failed to fetch" and "Aborted by signal" due to rapid navigation. These were being treated as test-breaking exceptions.
 2. External Rate Limiting: The test suite was triggering HTTP 429 (Too Many Requests) errors when attempting to validate third-party links (specifically the Apple App Store), which are outside of our control and caused the test to fail.

### Solution

 1. Enhanced Diagnostics: Updated the `exceptionLogger` in `suiteBaseFixture.ts` to properly serialize non-Error objects using J`SON.stringify` and added support for Error.cause. This ensures future errors provide full context rather than `[Object]`.
 2. Test Stabilization:
    - Configured `ignoreJSExceptions` in `check-links.test.ts` to filter out common, non-critical navigation errors ("Failed to fetch", "Aborted by signal").
    - Added problematic third-party domains (Apple App Store) to the `ignoredPatterns` list to prevent test flakiness caused by external rate limiting.



<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This changeset modifies two files: a test file (check-links.test.ts) and a base fixture file (suiteBaseFixture.ts). The check-links test must be run since it was directly changed. The suiteBaseFixture.ts is a foundational fixture likely used by many/all E2E tests, but without static mapping data and without knowing the nature of the change (which could range from a trivial fix to a breaking structural change), we cannot confidently identify which other tests are specifically affected beyond the directly modified test. If the suiteBaseFixture change is structural or breaking, a broader test run would be warranted, but based on available evidence only the directly changed test can be recommended with confidence.

<details><summary><b>Changed files (2)</b></summary>

- `suite/e2e/support/testExtends/suiteBaseFixture.ts`
- `suite/e2e/tests/general/check-links.test.ts`

</details>

**Recommended tests (1)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test file was directly modified in the changeset. It must be run to verify that the changes to the test itself are correct and the test passes.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/e2e/support/testExtends/suiteBaseFixture.ts`

_Updated: 2026-05-29T09:59:38.470Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/fix-check-links-js-exception&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/fix-check-links-js-exception&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-29T10:05:02.563Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-29T10:02:59.332Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/fix-check-links-js-exception/web/](https://dev.suite.sldev.cz/suite-web/test/fix-check-links-js-exception/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->