### PR TITLE
refactor(suite): reuse destinationTag for tron memo

### DIFF
--- a/packages/suite/src/views/wallet/send/Options/TronOptions/TronNote.tsx
+++ b/packages/suite/src/views/wallet/send/Options/TronOptions/TronNote.tsx
@@ -7,8 +7,7 @@ import { Card, Column, H4, Icon, IconButton, Row, Text, Textarea } from '@trezor
 
 import { useSendFormContext } from 'src/hooks/wallet';
 
-const inputAsciiName = 'tronDataAscii';
-const inputHexName = 'transactionData';
+const inputName = 'destinationTag';
 
 type TronNoteProps = {
     close: () => void;
@@ -19,7 +18,6 @@ export const TronNote = ({ close }: TronNoteProps) => {
         account: { symbol },
         register,
         watch,
-        setValue,
         composeTransaction,
         resetDefaultValue,
     } = useSendFormContext();
@@ -28,26 +26,21 @@ export const TronNote = ({ close }: TronNoteProps) => {
 
     const networkDisplaySymbol = getNetworkDisplaySymbol(symbol);
 
-    const asciiValue = watch(inputAsciiName);
-    const hexValue = watch(inputHexName);
-
-    const isHexTooLong = !hexValue ? false : hexValue.length > formInputsMaxLength.tronNote;
-    const error = isHexTooLong ? translationString('TR_TRON_NOTE_TOO_LONG') : undefined;
-
-    useEffect(() => {
-        setValue(inputHexName, Buffer.from(asciiValue || '', 'utf8').toString('hex'));
-    }, [asciiValue, setValue]);
+    const value = watch(inputName);
+    const byteSize = Buffer.from(value || '', 'utf8').length;
+    const isTooLong = byteSize > formInputsMaxLength.tronNote;
+    const error = isTooLong ? translationString('TR_TRON_NOTE_TOO_LONG') : undefined;
 
     useEffect(() => {
-        composeTransaction(inputHexName);
-    }, [hexValue, composeTransaction]);
+        composeTransaction(inputName);
+    }, [value, composeTransaction]);
 
     const handleClose = () => {
-        resetDefaultValue(inputAsciiName);
+        resetDefaultValue(inputName);
         close();
     };
 
-    const { ref: inputRef, ...inputField } = register(inputAsciiName);
+    const { ref: inputRef, ...inputField } = register(inputName);
 
     return (
         <Card>
@@ -80,13 +73,13 @@ export const TronNote = ({ close }: TronNoteProps) => {
                 </Row>
 
                 <Textarea
-                    hasError={isHexTooLong}
+                    hasError={isTooLong}
                     bottomText={error}
-                    defaultValue={asciiValue}
+                    defaultValue={value}
                     innerRef={inputRef}
                     rows={3}
                     characterCount={{
-                        current: hexValue?.length,
+                        current: byteSize,
                         max: formInputsMaxLength.tronNote,
                     }}
                     {...inputField}

--- a/packages/suite/src/views/wallet/send/Options/TronOptions/TronOptions.tsx
+++ b/packages/suite/src/views/wallet/send/Options/TronOptions/TronOptions.tsx
@@ -10,14 +10,14 @@ export const TronOptions = () => {
     const { getDefaultValue, toggleOption, composeTransaction } = useSendFormContext();
 
     const options = getDefaultValue('options', []);
-    const isNoteEnabled = options.includes('transactionData');
+    const isNoteEnabled = options.includes('destinationTag');
 
     const toggle = (option: FormOptions) => {
         toggleOption(option);
         composeTransaction();
     };
 
-    const toggleNote = () => toggle('transactionData');
+    const toggleNote = () => toggle('destinationTag');
 
     return (
         <Column gap={16}>

--- a/suite-common/wallet-core/src/send/sendFormTronThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormTronThunks.ts
@@ -277,8 +277,8 @@ export const composeTronTransactionFeeLevelsThunk = createThunk<
                   },
               };
 
-        const tronData = formState.transactionData
-            ? formState.transactionData.replace(/^0x/, '')
+        const tronData = formState.destinationTag
+            ? Buffer.from(formState.destinationTag, 'utf8').toString('hex')
             : undefined;
 
         const bandwidthEstimate = await TrezorConnect.tronComposeTransaction({
@@ -464,8 +464,8 @@ export const signTronSendFormTransactionThunk = createThunk<
                   },
               };
 
-        const tronData = formState.transactionData
-            ? formState.transactionData.replace(/^0x/, '')
+        const tronData = formState.destinationTag
+            ? Buffer.from(formState.destinationTag, 'utf8').toString('hex')
             : undefined;
 
         const composed = await TrezorConnect.tronComposeTransaction({

--- a/suite-common/wallet-types/src/sendForm.ts
+++ b/suite-common/wallet-types/src/sendForm.ts
@@ -81,9 +81,8 @@ export interface FormState {
     ethereumNonce?: string; // TODO: ethereum RBF
     ethereumDataAscii?: string;
     ethereumAdjustGasLimit?: string; // if used, final gas limit = estimated limit * ethereumAdjustGasLimit
-    tronDataAscii?: string;
     transactionData?: string; // used for solana serialized txn from trading api, ethereum or tron txn hex data
-    destinationTag?: string; // For Ripple, Stellar, and Solana
+    destinationTag?: string; // For Ripple, Stellar, Solana, and Tron
     rbfParams?: RbfTransactionParams;
     isCoinControlEnabled: boolean;
     hasCoinControlBeenOpened: boolean;

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.ts
@@ -237,15 +237,13 @@ const constructOldFlow = ({
             });
     }
 
-    if (precomposedForm.tronDataAscii) {
-        outputs.push({ type: 'note', value: precomposedForm.tronDataAscii });
-    } else {
-        if (
-            precomposedForm.transactionData &&
-            (!precomposedTx.token || precomposedForm.yieldMetadata)
-        ) {
-            outputs.push({ type: 'data', value: precomposedForm.transactionData });
-        }
+    if (networkType === 'tron' && precomposedForm.destinationTag) {
+        outputs.push({ type: 'note', value: precomposedForm.destinationTag });
+    } else if (
+        precomposedForm.transactionData &&
+        (!precomposedTx.token || precomposedForm.yieldMetadata)
+    ) {
+        outputs.push({ type: 'data', value: precomposedForm.transactionData });
     }
 
     // For bump fee we have to analyze tx data,
@@ -356,18 +354,16 @@ const constructNewFlow = ({
         });
     }
 
-    if (precomposedForm.tronDataAscii) {
-        outputs.push({ type: 'note', value: precomposedForm.tronDataAscii });
-    } else {
-        if (
-            (precomposedForm.transactionData && !precomposedTx.token && !isEvmApproval) ||
-            (precomposedForm.transactionData && isEvmApproval && !isApprovalFlowSupported) ||
-            (precomposedForm.transactionData &&
-                precomposedForm.yieldMetadata &&
-                !isUpdatedEthereumSendFlow)
-        ) {
-            outputs.push({ type: 'data', value: precomposedForm.transactionData });
-        }
+    if (isTron && precomposedForm.destinationTag) {
+        outputs.push({ type: 'note', value: precomposedForm.destinationTag });
+    } else if (
+        (precomposedForm.transactionData && !precomposedTx.token && !isEvmApproval) ||
+        (precomposedForm.transactionData && isEvmApproval && !isApprovalFlowSupported) ||
+        (precomposedForm.transactionData &&
+            precomposedForm.yieldMetadata &&
+            !isUpdatedEthereumSendFlow)
+    ) {
+        outputs.push({ type: 'data', value: precomposedForm.transactionData });
     }
 
     const isRbf = isRbfBumpFeeTransaction(precomposedTx);

--- a/suite-native/module-send/src/components/TronNoteInput.tsx
+++ b/suite-native/module-send/src/components/TronNoteInput.tsx
@@ -19,9 +19,6 @@ import { Translation, useTranslate } from '@suite-native/intl';
 
 import { type SendOutputsFormValues } from '../sendOutputsFormSchema';
 
-const inputAsciiName = 'tronDataAscii';
-const inputHexName = 'transactionData';
-
 type TronNoteInputProps = {
     symbol: NetworkSymbol;
 };
@@ -34,41 +31,33 @@ export const TronNoteInput = ({ symbol }: TronNoteInputProps) => {
 
     const networkDisplaySymbol = getNetworkDisplaySymbol(symbol);
 
-    const asciiValue = watch(inputAsciiName) ?? '';
-    const hexValue = Buffer.from(localNote || '', 'utf8').toString('hex');
-
-    const hexByteSize = hexValue.length;
+    const value = watch('destinationTag') ?? '';
+    const hexByteSize = Buffer.from(localNote || '', 'utf8').length;
     const isHexTooLong = hexByteSize > formInputsMaxLength.tronNote;
 
     useEffect(() => {
-        setLocalNote(asciiValue);
-    }, [asciiValue]);
-
-    useEffect(() => {
-        setValue(inputHexName, Buffer.from(asciiValue || '', 'utf8').toString('hex'));
-    }, [asciiValue, setValue]);
+        setLocalNote(value);
+    }, [value]);
 
     const onOpenPress = () => {
-        setLocalNote(asciiValue);
+        setLocalNote(value);
         openModal();
     };
 
     const onSavePress = () => {
-        setValue(inputAsciiName, localNote);
-        setValue(inputHexName, hexValue);
+        setValue('destinationTag', localNote);
         closeModal();
     };
 
     const onRemovePress = () => {
-        setValue(inputAsciiName, '');
-        setValue(inputHexName, '');
+        setValue('destinationTag', '');
         setLocalNote('');
         closeModal();
     };
 
     return (
         <>
-            {asciiValue ? (
+            {value ? (
                 <Card>
                     <VStack spacing="sp12" alignItems="center">
                         <HStack alignItems="center">
@@ -78,7 +67,7 @@ export const TronNoteInput = ({ symbol }: TronNoteInputProps) => {
                                 </Text>
 
                                 <Text variant="body-sm" color="contentSecondary" numberOfLines={1}>
-                                    {asciiValue}
+                                    {value}
                                 </Text>
                             </VStack>
 
@@ -151,7 +140,7 @@ export const TronNoteInput = ({ symbol }: TronNoteInputProps) => {
                         <Translation id="moduleSend.tron.note.saveButton" />
                     </Button>
 
-                    {asciiValue && (
+                    {value && (
                         <Button intent="neutral" priority="secondary" onPress={onRemovePress}>
                             <Translation id="moduleSend.tron.note.removeButton" />
                         </Button>

--- a/suite-native/module-send/src/sendOutputsFormSchema.ts
+++ b/suite-native/module-send/src/sendOutputsFormSchema.ts
@@ -274,7 +274,6 @@ export type OutputsFormValues = yup.InferType<typeof outputSchema>;
 export const sendOutputsFormValidationSchema = yup.object({
     outputs: yup.array(outputSchema).required(),
     transactionData: yup.string(),
-    tronDataAscii: yup.string(),
     isDestinationTagEnabled: yup.boolean(),
     destinationTag: yup
         .string()

--- a/suite-native/module-send/src/utils.ts
+++ b/suite-native/module-send/src/utils.ts
@@ -10,7 +10,7 @@ export const getOutputFieldName = <TField extends SendOutputFieldName>(
 ): `outputs.${number}.${TField}` => `outputs.${index}.${field}`;
 
 export const constructFormDraft = ({
-    formValues: { outputs, transactionData, tronDataAscii, ...restFormValues },
+    formValues: { outputs, transactionData, ...restFormValues },
     tokenContract,
     feeLevel = { label: 'normal', feePerUnit: '' },
     selectedUtxos = [],
@@ -37,7 +37,6 @@ export const constructFormDraft = ({
     feePerUnit: feeLevel.feePerUnit,
     feeLimit: feeLevel.feeLimit ?? '',
     transactionData: transactionData || undefined,
-    tronDataAscii: tronDataAscii || undefined,
     ...restFormValues,
 });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Drop the chain-specific `tronDataAscii` form field and reuse the existing `destinationTag` field for Tron memos. The UTF-8 → hex conversion happens inline in the compose/sign thunks instead of via a form-level useEffect.

This unifies Tron's memo storage with XRP/Stellar/Solana, which already use `destinationTag` for the same field.

This is a prerequisite for supporting custom calldata in Tron send. Previously the memo was overloaded onto `transactionData`, which represents calldata on EVM chains — wrong semantic field.

## Notes for QA

Tron memo should work the same way as before.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/tron-note-field-refactor&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/tron-note-field-refactor&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/tron-note-field-refactor&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-29T13:05:15.570Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-29T13:02:38.948Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/tron-note-field-refactor/web/](https://dev.suite.sldev.cz/suite-web/feat/tron-note-field-refactor/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->