### PR TITLE
feat(suite): Unify displayed Bitcoin Cash addresses in the desktop UI

### DIFF
--- a/suite-common/formatters/src/index.ts
+++ b/suite-common/formatters/src/index.ts
@@ -5,5 +5,6 @@ export type * from './types';
 export * from './makeFormatter';
 export * from './utils/sign';
 export * from './utils/convert';
+export * from './utils/clearAddressPrefix';
 export { BASE_CRYPTO_MAX_DISPLAYED_DECIMALS } from './formatters/prepareCryptoAmountFormatter';
 export { AddressFormatter, type AddressFormat } from './formatters/AddressFormatter';

--- a/suite-common/formatters/src/utils/clearAddressPrefix.ts
+++ b/suite-common/formatters/src/utils/clearAddressPrefix.ts
@@ -1,0 +1,2 @@
+// Removes mandatory BCH prefix for cashaddr format for display in the chunked view.
+export const clearAddressPrefix = (value: string) => value.replace(/^bitcoincash:/i, '');

--- a/suite-common/formatters/src/utils/tests/clearAddressPrefix.test.ts
+++ b/suite-common/formatters/src/utils/tests/clearAddressPrefix.test.ts
@@ -1,0 +1,13 @@
+import { clearAddressPrefix } from '../clearAddressPrefix';
+
+describe('clearAddressPrefix', () => {
+    test.each([
+        ['bitcoincash:qz8gjexl9x7gag53xl08mt7qskvjg8x2wueejjmttc', 'bitcoincash:'],
+        ['BITCOINCASH:QZ8GJEXL9X7GAG53XL08MT7QSKVJG8X2WUEEJJMTTC', 'BITCOINCASH:'],
+        ['12QeMLzSrB8XH8FvEzPMVoRxVAzTr5XM2y', ''],
+    ])('address=%s trims=%s', (address, trimmed) => {
+        const clearAddress = clearAddressPrefix(address);
+        const trimmedPart = address.replace(clearAddress, '');
+        expect(trimmedPart).toEqual(trimmed);
+    });
+});

--- a/suite-native/receive/src/components/DeviceScreenContent.tsx
+++ b/suite-native/receive/src/components/DeviceScreenContent.tsx
@@ -10,6 +10,7 @@ import {
 } from '@shopify/react-native-skia';
 
 import { selectDeviceModel } from '@suite-common/device';
+import { clearAddressPrefix } from '@suite-common/formatters';
 import { DeviceModelInternal } from '@trezor/device-utils';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
@@ -112,10 +113,10 @@ export const DeviceScreenContent = ({
 
     if (!deviceModel) return null;
 
-    const bchPrefixRemovedAddress = address.replace('bitcoincash:', '');
+    const clearedAddress = clearAddressPrefix(address);
 
     const addressLines = parseAddressToDeviceLines({
-        address: bchPrefixRemovedAddress,
+        address: clearedAddress,
         deviceModel,
         isPaginationEnabled,
         activePage,

--- a/suite/address/src/Address.tsx
+++ b/suite/address/src/Address.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import styled, { type RuleSet, css } from 'styled-components';
 
 import { selectSelectedDevice } from '@suite-common/device';
-import { AddressFormatter } from '@suite-common/formatters';
+import { AddressFormatter, clearAddressPrefix } from '@suite-common/formatters';
 import { DEFAULT_FLAGSHIP_MODEL } from '@suite-common/suite-constants';
 import { selectAddressDisplayType } from '@suite-common/wallet-core';
 import { IconButton, Row, Text, type TextProps, Tooltip } from '@trezor/components';
@@ -92,7 +92,7 @@ export const Address = ({
         format: isTruncated ? 'long' : 'full',
         isChunked: isAddressChunked,
     });
-    const formattedValueFull = AddressFormatter.format(value, {
+    const formattedValueFull = AddressFormatter.format(clearAddressPrefix(value), {
         format: 'full',
         isChunked: isAddressChunked,
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR catches up with suite-native code to display Bitcoin Cash addresses without `bitcoincash:` prefix. Adding simple `replace("bitcoincash:", "")` to displaying value did not sound like the right move and I added a utility to formatter module to clear Bitcoin Cash and probably other suffixes in the future. 

## Notes for QA

I updated generic component for displaying Addresses, so if there are multiple places where user can see an address preview it would make sense to check them too i.e. "receive", "send" etc. 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27510

## Screenshots:

Chunking enabled:
<img width="1398" height="498" alt="Screenshot 2026-05-29 at 14 57 04" src="https://github.com/user-attachments/assets/cede532c-df11-45c5-af27-cc794536ed5c" />
<img width="1447" height="522" alt="Screenshot 2026-05-29 at 14 54 03" src="https://github.com/user-attachments/assets/9a823e99-9330-4a6f-9cb4-18f68af53cb4" />

Chunking disabled:
<img width="1361" height="378" alt="Screenshot 2026-05-29 at 15 14 05" src="https://github.com/user-attachments/assets/14def5b7-e1fc-42bd-bfb9-f06ceec7962b" />


