### PR TITLE
fix(suite): Fix guide modal z-index

### DIFF
--- a/packages/suite/src/components/guide/GuideImage.tsx
+++ b/packages/suite/src/components/guide/GuideImage.tsx
@@ -51,7 +51,7 @@ export const GuideImage = ({ src, alt }: GuideImageProps) => {
             <ThumbnailImage src={src} alt={alt} onClick={() => setIsOpen(true)} />
             {isOpen &&
                 createPortal(
-                    <Modal.Backdrop onClick={close}>
+                    <Modal.Backdrop onClick={close} zIndex={zIndices.guide}>
                         <FullSizeImage src={src} alt={alt} onClick={close} />
                         <CloseButtonWrapper>
                             <Button


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to GuideImage.tsx, a component within the guide/help panel subsystem. The risk is narrow — it could affect rendering of images in guide articles and content nodes. Two tests directly exercise the Guide panel UI: suite/guide.test.ts (high priority, comprehensive guide interaction) and general/suite-guide.test.ts (medium priority, article search and viewing). No static coverage mapping was available, so these recommendations are inferred from LLM analysis of test behaviors and source hints.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/guide/GuideImage.tsx`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/suite/guide.test.ts` — This test directly exercises the Guide panel UI, including navigating guide content nodes and viewing their details. GuideImage.tsx is a component used to render images within guide content, so changes to it could affect how guide articles and content nodes are displayed. The test verifies guide node navigation, article viewing, and search results — all of which may render guide images.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/general/suite-guide.test.ts` — This test opens the Suite Guide panel, searches for support articles by name, and views article content. Guide articles likely contain images rendered by GuideImage.tsx. A rendering issue in GuideImage could break article display or layout, which this test would catch via the article header assertion.

</details>

_Updated: 2026-05-29T16:26:39.654Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-guide-modal-zindex&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-guide-modal-zindex&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-29T16:32:51.928Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-29T16:30:00.766Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-guide-modal-zindex/web/](https://dev.suite.sldev.cz/suite-web/fix-guide-modal-zindex/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->