### PR TITLE
fix(trading): prevent crash when all wallets are ejected

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingLayout/TradingLayout.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingLayout/TradingLayout.tsx
@@ -1,18 +1,32 @@
 import { type PropsWithChildren } from 'react';
 
 import { selectRouteName } from '@suite/router';
+import { selectSelectedDevice } from '@suite-common/device';
+import { selectVisibleDeviceAccounts } from '@suite-common/wallet-core';
 import { Column } from '@trezor/components';
 
+import { DiscoveryEmpty } from 'src/components/wallet/WalletLayout/AccountException/DiscoveryEmpty';
 import { useSelector } from 'src/hooks/suite';
+import { ConnectDeviceGenericPromo } from 'src/views/wallet/receive/components/ConnectDevicePromo';
 import { TradingLayoutNavigation } from 'src/views/wallet/trading/common/TradingLayout/TradingLayoutNavigation';
 
 export const TradingLayout = ({ children }: PropsWithChildren) => {
     const routeName = useSelector(selectRouteName);
+    const selectedDevice = useSelector(selectSelectedDevice);
+    const hasVisibleAccounts = useSelector(state => selectVisibleDeviceAccounts(state).length > 0);
+    const isSelectedDeviceConnected = !!selectedDevice?.connected;
+    const noVisibleAccountsContent = !isSelectedDeviceConnected ? (
+        <ConnectDeviceGenericPromo />
+    ) : (
+        <Column alignItems="center" height="100%">
+            <DiscoveryEmpty />
+        </Column>
+    );
 
     return (
         <Column data-testid="@trading" gap={24}>
             <TradingLayoutNavigation route={routeName} />
-            {children}
+            {hasVisibleAccounts ? children : noVisibleAccountsContent}
         </Column>
     );
 };

--- a/packages/suite/src/views/wallet/trading/common/TradingLayout/__tests__/TradingLayout.test.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingLayout/__tests__/TradingLayout.test.tsx
@@ -1,0 +1,165 @@
+import '@suite-common/test-utils/src/globalOverrides';
+
+import { screen } from '@testing-library/react';
+
+import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
+import { type Account, type AccountKey } from '@suite-common/wallet-types';
+
+import { type AppState } from 'src/reducers/store';
+import { initialAppState } from 'src/support/tests/__fixtures__/defaultAppState';
+import { configureStore } from 'src/support/tests/configureStore';
+import { extraDependenciesDesktopMock } from 'src/support/tests/extraDependenciesDesktop.mock';
+import { renderWithProviders } from 'src/support/tests/hooksHelper';
+
+import { TradingLayout } from '../TradingLayout';
+
+jest.mock('@suite-common/tx-simulation', () => ({}));
+
+jest.mock('@suite/intl', () => ({
+    ...jest.requireActual('@suite/intl'),
+    Translation: ({ id }: { id: string }) => <span data-testid={id}>{id}</span>,
+}));
+
+jest.mock('../TradingLayoutNavigation', () => ({
+    TradingLayoutNavigation: ({ route }: { route?: string }) => (
+        <div data-testid="trading-layout-navigation">{route}</div>
+    ),
+}));
+
+jest.mock('src/components/wallet/WalletLayout/AccountException/DiscoveryEmpty', () => ({
+    DiscoveryEmpty: () => <div data-testid="discovery-empty" />,
+}));
+
+jest.mock('src/views/wallet/receive/components/ConnectDevicePromo', () => ({
+    ConnectDeviceGenericPromo: () => <div data-testid="connect-device-promo" />,
+}));
+
+const DEVICE_SSID = 'btc-address@device_id:0' as const;
+const CONNECTED_SELECTED_DEVICE = mockSuiteDevice({
+    connected: true,
+    available: true,
+    state: { staticSessionId: DEVICE_SSID },
+});
+const DISCONNECTED_SELECTED_DEVICE = mockSuiteDevice({
+    connected: false,
+    available: false,
+    state: { staticSessionId: DEVICE_SSID },
+});
+
+const visibleBtcAccount = {
+    deviceState: DEVICE_SSID,
+    key: 'btc-account-key' as AccountKey,
+    accountType: 'normal',
+    visible: true,
+    empty: false,
+    symbol: 'btc',
+    networkType: 'bitcoin',
+} as unknown as Account;
+
+type BuildStateParams = {
+    accounts: Account[];
+    selectedDevice?: AppState['device']['selectedDevice'];
+};
+
+const buildState = ({
+    accounts,
+    selectedDevice = CONNECTED_SELECTED_DEVICE,
+}: BuildStateParams): AppState => ({
+    ...initialAppState,
+    device: {
+        ...initialAppState.device,
+        selectedDevice,
+    },
+    wallet: {
+        ...initialAppState.wallet,
+        accounts,
+    },
+    router: {
+        ...initialAppState.router,
+        app: 'wallet',
+        route: {
+            name: 'wallet-trading-buy',
+            pattern: '/accounts/coinmarket/buy',
+            app: 'wallet',
+        },
+    } as AppState['router'],
+});
+
+const mockStore = configureStore<AppState, any>();
+
+describe('TradingLayout', () => {
+    it('renders children when the selected device has visible accounts', () => {
+        const store = mockStore(buildState({ accounts: [visibleBtcAccount] }));
+
+        renderWithProviders(
+            store,
+            extraDependenciesDesktopMock.services,
+            <TradingLayout>
+                <div data-testid="trading-content" />
+            </TradingLayout>,
+        );
+
+        expect(screen.getByTestId('trading-layout-navigation')).toHaveTextContent(
+            'wallet-trading-buy',
+        );
+        expect(screen.getByTestId('trading-content')).toBeInTheDocument();
+        expect(screen.queryByTestId('discovery-empty')).not.toBeInTheDocument();
+    });
+
+    it('renders DiscoveryEmpty exception when the selected device has no visible accounts', () => {
+        const store = mockStore(buildState({ accounts: [] }));
+
+        renderWithProviders(
+            store,
+            extraDependenciesDesktopMock.services,
+            <TradingLayout>
+                <div data-testid="trading-content" />
+            </TradingLayout>,
+        );
+
+        expect(screen.queryByTestId('trading-content')).not.toBeInTheDocument();
+        expect(screen.getByTestId('trading-layout-navigation')).toBeInTheDocument();
+        expect(screen.getByTestId('discovery-empty')).toBeInTheDocument();
+        expect(screen.queryByTestId('connect-device-promo')).not.toBeInTheDocument();
+    });
+
+    it('renders DiscoveryEmpty when accounts exist but none match the selected device', () => {
+        const otherDeviceAccount = {
+            ...visibleBtcAccount,
+            deviceState: 'different-device@device_id:1',
+        } as Account;
+        const store = mockStore(buildState({ accounts: [otherDeviceAccount] }));
+
+        renderWithProviders(
+            store,
+            extraDependenciesDesktopMock.services,
+            <TradingLayout>
+                <div data-testid="trading-content" />
+            </TradingLayout>,
+        );
+
+        expect(screen.queryByTestId('trading-content')).not.toBeInTheDocument();
+        expect(screen.getByTestId('trading-layout-navigation')).toBeInTheDocument();
+        expect(screen.getByTestId('discovery-empty')).toBeInTheDocument();
+        expect(screen.queryByTestId('connect-device-promo')).not.toBeInTheDocument();
+    });
+
+    it('renders connect device promo when the selected device is disconnected', () => {
+        const store = mockStore(
+            buildState({ accounts: [], selectedDevice: DISCONNECTED_SELECTED_DEVICE }),
+        );
+
+        renderWithProviders(
+            store,
+            extraDependenciesDesktopMock.services,
+            <TradingLayout>
+                <div data-testid="trading-content" />
+            </TradingLayout>,
+        );
+
+        expect(screen.queryByTestId('trading-content')).not.toBeInTheDocument();
+        expect(screen.getByTestId('trading-layout-navigation')).toBeInTheDocument();
+        expect(screen.getByTestId('connect-device-promo')).toBeInTheDocument();
+        expect(screen.queryByTestId('discovery-empty')).not.toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
## Description

- Stop rendering trading form content when the wallet switcher has no visible accounts.
- Show the existing discovery empty state in trading instead of crashing with a fatal error.
- Keep the trading navigation visible while the empty state is shown.
- Add a TradingLayout regression test for both populated and empty-account states.

## Notes for QA

- Open Trading, eject all wallets from the wallet switcher, and verify the tab shows the empty discovery state instead of a fatal error.
- Re-enable or reconnect a wallet, open Trading again, and verify the regular trading content renders.

## Related Issue

Resolve #27431

## Screenshots:

N/A

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change modifies TradingLayout.tsx, a shared layout component that wraps all trading views (Buy, Sell, Swap). The second changed file is a unit test for TradingLayout itself, which has no E2E coverage. Since TradingLayout is a broad component used by 17 tests, the strategy focuses on one high-priority navigation test that validates all three trading form types render correctly, plus representative medium-priority tests covering complete Buy, Sell, and Swap flows to ensure the layout doesn't break any trading path. The risk is moderate — layout changes can affect rendering and visibility of child components across all trading views.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/views/wallet/trading/common/TradingLayout/TradingLayout.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingLayout/__tests__/TradingLayout.test.tsx`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — TradingLayout is the shared layout component wrapping all trading views (Buy, Sell, Swap). This navigation test exercises opening Buy, Sell, and Swap forms from multiple entry points and verifying form rendering — directly validating that the TradingLayout renders correctly and doesn't break form visibility across all trading types.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — This test exercises the full Buy flow including form rendering, quote display, offer confirmation, and transaction detail — all rendered within the TradingLayout. It validates that the layout correctly hosts the buy form and its various states (quotes, confirmation, detail).
- `suite/e2e/tests/trading/sell-solana.test.ts` — This test covers a complete Sell flow with quotes, confirmation, device prompt, transaction status, and offer comparison — all rendered within TradingLayout. It validates the layout works correctly for the sell trading path.
- `suite/e2e/tests/trading/swap-coins.test.ts` — This test exercises the full swap flow including form, quotes, device confirmation, toast notifications, and transaction status progression — all hosted within TradingLayout. It validates layout integrity for the swap trading path.
- `suite/e2e/tests/trading/buy-negative.test.ts` — Tests error states in the buy form (max/min limit errors, empty quotes, disabled buttons) which render inside TradingLayout. A layout change could affect error message visibility or button state rendering.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/trading/sell-inputs.test.ts` — Tests sell form input validation (decimals, insufficient funds, percentage buttons) rendered within TradingLayout. Less likely to be affected by a layout-level change but could surface layout-related rendering issues in form inputs.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/views/wallet/trading/common/TradingLayout/__tests__/TradingLayout.test.tsx`

_Updated: 2026-06-01T07:08:57.221Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/27431-trading-wallet-eject-crash&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/27431-trading-wallet-eject-crash&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-02T10:21:35.714Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-01T07:12:23.155Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/27431-trading-wallet-eject-crash/web/](https://dev.suite.sldev.cz/suite-web/fix/27431-trading-wallet-eject-crash/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->