### PR TITLE
fix(suite): Fix images on desktop build

### DIFF
--- a/packages/suite-data/package.json
+++ b/packages/suite-data/package.json
@@ -23,7 +23,6 @@
         "@suite-common/suite-types": "workspace:*",
         "@suite-common/suite-utils": "workspace:*",
         "@suite/intl": "workspace:*",
-        "@trezor/env-utils": "workspace:*",
         "semver": "^7.7.1"
     },
     "devDependencies": {

--- a/packages/suite-data/src/guide/transformer.ts
+++ b/packages/suite-data/src/guide/transformer.ts
@@ -3,7 +3,6 @@ import * as fs from 'fs-extra';
 import { join } from 'path';
 
 import { type GuideNode } from '@suite-common/suite-types';
-import { resolveStaticPath } from '@trezor/env-utils';
 
 /** Removes the front-matter from beginning of a string. */
 const clean = (markdown: string): string => markdown.replace(/^---\n.*?\n---\n/s, '');
@@ -20,12 +19,18 @@ export const transformImagesMarkdown = (markdown: string) =>
     );
 
 /**
- * Transforms GitBook images path to Suite images path.
+ * Transforms GitBook images path to a stable Suite-internal path.
  *
- * ![](../../.gitbook/assets/example.png) to ![](static/guide/assets/example.png)
+ * ![](../../.gitbook/assets/example.png) to ![](/guide/assets/example.png)
+ *
+ * The ASSET_PREFIX/static prefix is intentionally applied at runtime
+ * (see GuideImage) — the build-time and runtime ASSET_PREFIX can differ
+ * (e.g. CI desktop builds run suite-data without ASSET_PREFIX, but the
+ * renderer bundle is built with ASSET_PREFIX=.), and baking it here
+ * would produce paths that don't resolve under file:// in the packaged app.
  */
 const transformImagesPath = (markdown: string) =>
-    markdown.replace(/(?<=\]\()(.*?)(?=\/assets)/g, resolveStaticPath('/guide'));
+    markdown.replace(/(?<=\]\()(.*?)(?=\/assets)/g, '/guide');
 
 /**
  * Given index of GitBook content transforms the content

--- a/packages/suite-data/tsconfig.json
+++ b/packages/suite-data/tsconfig.json
@@ -13,7 +13,6 @@
             "path": "../../suite-common/suite-utils"
         },
         { "path": "../../suite/intl" },
-        { "path": "../env-utils" },
         { "path": "../eslint" }
     ]
 }

--- a/packages/suite/src/components/guide/GuideImage.tsx
+++ b/packages/suite/src/components/guide/GuideImage.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 
 import { Translation } from '@suite/intl';
 import { Button, Modal } from '@trezor/components';
+import { resolveStaticPath } from '@trezor/env-utils';
 import { borders, zIndices } from '@trezor/theme';
 
 const ThumbnailImage = styled.img`
@@ -44,15 +45,20 @@ export const GuideImage = ({ src, alt }: GuideImageProps) => {
 
     if (!src) return null;
 
+    // The transformer emits internal asset paths as `/guide/assets/...`.
+    // Resolve them at runtime so each build target (web / desktop file://)
+    // gets the correct ASSET_PREFIX baked into its renderer bundle.
+    const resolvedSrc = src.startsWith('/guide/') ? resolveStaticPath(src) : src;
+
     const close = () => setIsOpen(false);
 
     return (
         <>
-            <ThumbnailImage src={src} alt={alt} onClick={() => setIsOpen(true)} />
+            <ThumbnailImage src={resolvedSrc} alt={alt} onClick={() => setIsOpen(true)} />
             {isOpen &&
                 createPortal(
                     <Modal.Backdrop onClick={close} zIndex={zIndices.guide}>
-                        <FullSizeImage src={src} alt={alt} onClick={close} />
+                        <FullSizeImage src={resolvedSrc} alt={alt} onClick={close} />
                         <CloseButtonWrapper>
                             <Button
                                 iconLeft="x"

--- a/packages/suite/src/components/guide/GuideRouter.tsx
+++ b/packages/suite/src/components/guide/GuideRouter.tsx
@@ -120,7 +120,7 @@ export const GuideRouter = () => {
                 zIndex={zIndices.guide}
             >
                 <Box
-                    height="100vh"
+                    height="100dvh"
                     maxWidth="100vw"
                     overflow="hidden auto"
                     borderWidth={{ left: borders.widths.small }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -16134,7 +16134,6 @@ __metadata:
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/suite-utils": "workspace:*"
     "@suite/intl": "workspace:*"
-    "@trezor/env-utils": "workspace:*"
     "@trezor/eslint": "workspace:*"
     "@types/fs-extra": "npm:^11.0.4"
     autoprefixer: "npm:^10.4.24"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- fixes guide images in desktop build
- fixes non scrollable header on mobile view

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are focused entirely on the Suite Guide feature: guide content parsing/transformation (parser.ts, transformer.ts), guide type definitions (guide.ts), and guide UI components (GuideNode.tsx, GuideRouter.tsx, GuideImage.tsx). Although GuideNode.tsx and GuideRouter.tsx statically map to 121 tests each, this is because they are part of the broader app shell that renders on every page. Only tests that specifically interact with the Guide panel are meaningfully affected. The two dedicated guide tests (general/suite-guide and suite/guide) provide strong direct coverage, while the bug-report-form test provides secondary coverage of the guide panel infrastructure.

<details><summary><b>Changed files (6)</b></summary>

- `packages/suite-data/src/guide/parser.ts`
- `packages/suite-data/src/guide/transformer.ts`
- `packages/suite/src/components/guide/GuideImage.tsx`
- `packages/suite/src/components/guide/GuideNode.tsx`
- `packages/suite/src/components/guide/GuideRouter.tsx`
- `suite-common/suite-types/src/guide.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/general/suite-guide.test.ts` — This test directly exercises the Guide panel functionality — opening the panel, searching for articles, viewing article content, and submitting bug reports. The changed files (GuideNode.tsx, GuideRouter.tsx, GuideImage.tsx, guide parser/transformer, guide types) are the core implementation of the Guide feature. Any regression in rendering guide nodes, routing between guide pages, parsing guide content, or displaying guide images would be caught here.
- `suite/e2e/tests/suite/guide.test.ts` — This test thoroughly exercises the Guide panel: opening/closing, navigating guide content nodes, viewing node details, searching for topics, viewing search results, and submitting feedback forms. It directly validates the rendering and navigation logic in GuideNode.tsx and GuideRouter.tsx, and the content parsed by the guide parser/transformer.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/suite/bug-report-form.test.ts` — This test opens the Guide panel and navigates to Support and Feedback to submit a bug report. While it doesn't deeply test guide content rendering, it relies on the Guide panel opening correctly (GuideRouter.tsx) and navigating within the guide structure, which could break if the router or node components have regressions.

</details>

⚠️ **Changes with no test coverage (4)**
- `packages/suite-data/src/guide/parser.ts`
- `packages/suite-data/src/guide/transformer.ts`
- `packages/suite/src/components/guide/GuideImage.tsx`
- `suite-common/suite-types/src/guide.ts`

_Updated: 2026-06-01T07:42:58.934Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-guide-bugs&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-guide-bugs&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-guide-bugs&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-01T07:48:08.994Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-01T07:45:42.812Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-guide-bugs/web/](https://dev.suite.sldev.cz/suite-web/fix-guide-bugs/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->