### PR TITLE
Chore: follow-up cleanup for libESM rename

### DIFF
--- a/.depcheckrc.json
+++ b/.depcheckrc.json
@@ -1,5 +1,5 @@
 {
-    "ignore-patterns": ["libDev", "lib", "libESM", "build"],
+    "ignore-patterns": ["libDev", "lib", "build"],
     "ignores": [
         "babel*",
         "@babel/*",

--- a/nx.json
+++ b/nx.json
@@ -21,7 +21,7 @@
                 "{workspaceRoot}/tsconfig.base.json",
                 "{workspaceRoot}/tsconfig.lib.json"
             ],
-            "outputs": ["{projectRoot}/lib", "{projectRoot}/libESM", "{projectRoot}/build"],
+            "outputs": ["{projectRoot}/lib", "{projectRoot}/build"],
             "cache": true
         },
         "type-check": {

--- a/packages/protobuf/.depcheckrc.json
+++ b/packages/protobuf/.depcheckrc.json
@@ -1,4 +1,4 @@
 {
-    "ignore-patterns": ["lib", "libDev", "libESM"],
+    "ignore-patterns": ["lib", "libDev"],
     "ignores": ["@bufbuild/buf", "@bufbuild/protoc-gen-es", "tsx"]
 }

--- a/scripts/publish/babel-plugin-sanitize-internal-imports.js
+++ b/scripts/publish/babel-plugin-sanitize-internal-imports.js
@@ -2,7 +2,9 @@ const sanitizeInternalImports = (src, moduleType) => {
     const searchValue = new RegExp('@trezor/([^/]+)/src', 'g');
 
     if (moduleType === 'cjs' && searchValue.test(src)) {
-        throw `Cannot sanitize internal require, Connect does not support CJS anymore, got: ${src}`;
+        throw new Error(
+            `Cannot sanitize internal require, Connect does not support CJS anymore, got: ${src}`,
+        );
     }
 
     const replaceValue = `@trezor/$1/lib`;

--- a/skills/publish-config/SKILL.md
+++ b/skills/publish-config/SKILL.md
@@ -16,9 +16,9 @@ Applies to any package with `publishConfig`.
 3. **`publishConfig.main`** and **`publishConfig.types`** — both required.
 4. **`publishConfig.exports["."].default`** and **`publishConfig.exports["."].types`** — must export the same files as in Rule 3.
 5. **Wildcard exports** — (`./lib/*`) must be a passthrough string (`"./lib/*"`) — an object would double the `.mjs` extension.
-6. **Explicit (non-wildcard) exports** — not shape-checked (intentional overrides), but must still have a counterpart. Typically used to route a directory import to its `index.js`, e.g. `"./lib/protocol-thp": { "types": "./lib/protocol-thp/index.d.ts", "default": "./lib/protocol-thp/index.js" }` — without this, the wildcard would resolve to `protocol-thp.js` instead of `protocol-thp/index.js`.
+6. **Explicit (non-wildcard) exports** — not shape-checked (intentional overrides). Typically used to route a directory import to its `index.mjs`, e.g. `"./lib/protocol-thp": { "types": "./lib/protocol-thp/index.d.mts", "default": "./lib/protocol-thp/index.mjs" }` — without this, the wildcard would resolve to `protocol-thp.mjs` instead of `protocol-thp/index.mjs`.
 7. **Key order** — `"types"` must come before `"default"` in every condition object (recursive). TypeScript evaluates conditions in declaration order.
-8. **ESM-only packages** — must declare top-level `"type": "module"`. Do not duplicate it under `publishConfig.type` — `publishConfig` would only shadow the top level with the same value at publish time, so we keep a single source of truth.
+8. **`type`** — must declare top-level `"type": "module"`. Do not duplicate it under `publishConfig.type` — `publishConfig` would only shadow the top level with the same value at publish time, so we keep a single source of truth.
 
 ## Example
 
@@ -26,7 +26,7 @@ Applies to any package with `publishConfig`.
 {
     "name": "@trezor/example",
     "main": "./src/index.ts", // Rule 1
-    "type": "module", // Rule 9 — ESM-only packages only
+    "type": "module", // Rule 8
     "files": ["lib/", "CHANGELOG.md"], // Rule 2
     "publishConfig": {
         "main": "./lib/index.mjs", // Rule 3
@@ -34,14 +34,8 @@ Applies to any package with `publishConfig`.
         "exports": {
             ".": {
                 // Rule 4: exact shape required
-                "import": {
-                    "types": "./lib/index.d.mts", // Rule 7: "types" before "default"
-                    "default": "./lib/index.mjs",
-                },
-                "require": {
-                    "types": "./lib/index.d.ts",
-                    "default": "./lib/index.js",
-                },
+                "types": "./lib/index.d.mts", // Rule 7: "types" before "default"
+                "default": "./lib/index.mjs",
             },
             // Rule 5: ESM wildcard — passthrough string
             "./lib/*": "./lib/*",


### PR DESCRIPTION
## Description

Follow-up to #28173, targeting its branch `chore/cleanup-libESM`. Fixes inconsistencies and leftovers found while reviewing that PR.

- **`docs(publish-config)`**: the `SKILL.md` example still documented the old dual CJS/ESM `import`/`require` export shape (`./lib/index.d.ts` / `./lib/index.js`), which would now **fail** the `requirePublishConfig` validator the doc describes — it expects the flat `{ types, default }` ESM shape. Updated the example, fixed the stale `// Rule 9` comment (max rule is now 8), dropped the removed "counterpart" requirement from Rule 6, and switched its example extensions to `.d.mts` / `.mjs`.
- **`chore(scripts)`**: `babel-plugin-sanitize-internal-imports.js` threw a string literal (no stack trace, flagged by `no-throw-literal`) — now throws an `Error`.
- **`chore`**: removed stale `libESM` references from `nx.json` (`build:lib` outputs) and the depcheck `ignore-patterns` (root + `packages/protobuf`). Left `libESM` only in the dev-facing ignore files (`.gitignore`, `.easignore`, `.nxignore`, `.prettierignore`), as the base PR intended.

## Notes for QA

Docs/config only + one error-message change. No runtime behavior change. Verified that `libESM` no longer appears anywhere outside the intentionally-kept ignore files.