### PR TITLE
Feat(suite-native-28043): animations polishing in trade

### DIFF
--- a/suite-native/module-trading/src/components/exchange/ExchangeConfirmation.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeConfirmation.tsx
@@ -1,4 +1,4 @@
-import { FadeIn, FadeOut } from 'react-native-reanimated';
+import { FadeIn, FadeOut, LinearTransition } from 'react-native-reanimated';
 
 import { type ApprovalStatus, getApprovalStatus } from '@suite-common/trading';
 import { AnimatedBox, Button, VStack } from '@suite-native/atoms';
@@ -44,11 +44,11 @@ export const ExchangeConfirmation = () => {
                 activateButtonElement
             ) : (
                 <VStack spacing="sp16">
-                    <AnimatedBox entering={FadeIn} exiting={FadeOut}>
+                    <AnimatedBox entering={FadeIn} exiting={FadeOut} layout={LinearTransition}>
                         <Button
                             onPress={selectQuote}
                             testID={CONFIRMATION_TEST_ID}
-                            isDisabled={isLoading || !canProceed}
+                            isDisabled={!canProceed}
                             isLoading={isLoading}
                         >
                             {!isLoading && (
@@ -57,7 +57,7 @@ export const ExchangeConfirmation = () => {
                         </Button>
                     </AnimatedBox>
                     {canRevoke && (
-                        <AnimatedBox entering={FadeIn} exiting={FadeOut}>
+                        <AnimatedBox entering={FadeIn} exiting={FadeOut} layout={LinearTransition}>
                             <Button
                                 onPress={selectQuoteForRevoke}
                                 testID={REVOKE_TEST_ID}

--- a/suite-native/module-trading/src/components/exchange/ExchangeConfirmation.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeConfirmation.tsx
@@ -2,6 +2,7 @@ import { FadeIn, FadeOut } from 'react-native-reanimated';
 
 import { type ApprovalStatus, getApprovalStatus } from '@suite-common/trading';
 import { AnimatedBox, Button, VStack } from '@suite-native/atoms';
+import { useWatch } from '@suite-native/forms';
 import { Translation } from '@suite-native/intl';
 
 import { useExchangeFormContext } from '../../hooks/exchange/useExchangeFormContext';
@@ -13,12 +14,13 @@ export const REVOKE_TEST_ID = '@trading/exchange/revoke-button';
 
 export const ExchangeConfirmation = () => {
     const form = useExchangeFormContext();
-    const receiveAsset = form.watch('receiveAsset');
+    const receiveAsset = useWatch({ name: 'receiveAsset', control: form.control });
+    const quote = useWatch({ name: 'quote', control: form.control });
+
+    const { canProceed, selectQuote, selectQuoteForRevoke, isLoading } =
+        useExchangeSelectQuote(form);
+
     const receiveCryptoId = receiveAsset?.cryptoId;
-
-    const { canProceed, selectQuote, selectQuoteForRevoke } = useExchangeSelectQuote(form);
-
-    const quote = form.watch('quote');
     const approvalStatus = getApprovalStatus(quote);
     const canRevoke =
         (['approved', 'needs_increase', 'needs_revoke'] as ApprovalStatus[]).includes(
@@ -32,19 +34,26 @@ export const ExchangeConfirmation = () => {
             buttonTestId: CONFIRMATION_TEST_ID,
         });
 
+    if (!isLoading && !canProceed && !canRevoke && !isReceivingInactiveStellarToken) {
+        return null;
+    }
+
     return (
-        <VStack spacing="sp16">
+        <>
             {isReceivingInactiveStellarToken ? (
                 activateButtonElement
             ) : (
-                <>
-                    {canProceed && (
-                        <AnimatedBox entering={FadeIn} exiting={FadeOut}>
-                            <Button onPress={selectQuote} testID={CONFIRMATION_TEST_ID}>
-                                <Translation id="moduleTrading.tradingScreen.buttons.continue" />
-                            </Button>
-                        </AnimatedBox>
-                    )}
+                <VStack spacing="sp16">
+                    <AnimatedBox entering={FadeIn} exiting={FadeOut}>
+                        <Button
+                            onPress={selectQuote}
+                            testID={CONFIRMATION_TEST_ID}
+                            disabled={isLoading || !canProceed}
+                            isLoading={isLoading}
+                        >
+                            <Translation id="moduleTrading.tradingScreen.buttons.continue" />
+                        </Button>
+                    </AnimatedBox>
                     {canRevoke && (
                         <AnimatedBox entering={FadeIn} exiting={FadeOut}>
                             <Button
@@ -57,8 +66,8 @@ export const ExchangeConfirmation = () => {
                             </Button>
                         </AnimatedBox>
                     )}
-                </>
+                </VStack>
             )}
-        </VStack>
+        </>
     );
 };

--- a/suite-native/module-trading/src/components/exchange/ExchangeConfirmation.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeConfirmation.tsx
@@ -48,10 +48,12 @@ export const ExchangeConfirmation = () => {
                         <Button
                             onPress={selectQuote}
                             testID={CONFIRMATION_TEST_ID}
-                            disabled={isLoading || !canProceed}
+                            isDisabled={isLoading || !canProceed}
                             isLoading={isLoading}
                         >
-                            <Translation id="moduleTrading.tradingScreen.buttons.continue" />
+                            {!isLoading && (
+                                <Translation id="moduleTrading.tradingScreen.buttons.continue" />
+                            )}
                         </Button>
                     </AnimatedBox>
                     {canRevoke && (

--- a/suite-native/module-trading/src/components/exchange/ExchangeForm.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeForm.tsx
@@ -1,22 +1,14 @@
 import { memo } from 'react';
-import { Platform } from 'react-native';
-import {
-    FadeInUp,
-    FadeOutUp,
-    LinearTransition,
-    StretchInY,
-    StretchOutY,
-} from 'react-native-reanimated';
+import { LinearTransition } from 'react-native-reanimated';
 
-import { AnimatedBox, Card, VStack } from '@suite-native/atoms';
+import { AnimatedBox, VStack } from '@suite-native/atoms';
 import { AmountEditingDoneButton } from '@suite-native/trading-atoms';
 
 import { ExchangeAlert } from './ExchangeAlert';
 import { ExchangeCard } from './ExchangeCard';
 import { ExchangeConfirmation } from './ExchangeConfirmation';
 import { ExchangeFormQuoteDebugView } from './ExchangeFormQuoteDebugView';
-import { ExchangeRateAndProviderPicker } from './ExchangeRateAndProviderPicker';
-import { ExchangeReceiveAccountPicker } from './receive/ExchangeReceiveAccountPicker';
+import { ExchangePickersCard } from './ExchangePickersCard';
 import { useExchangeFormContext } from '../../hooks/exchange/useExchangeFormContext';
 import { useExchangeQuotes } from '../../hooks/exchange/useExchangeQuotes';
 import { useFocusedValueWatch } from '../../hooks/general/useFocusedValueWatch';
@@ -28,9 +20,6 @@ type ExchangeFormMemoizedProps = {
 const EXCHANGE_FORM_TEST_ID = '@trading/exchange/form';
 const AMOUNT_EDITING_DONE_BUTTON_TEST_ID = '@trading/exchange/amount-editing-done-button';
 
-const cardEnteringAnimation = Platform.OS === 'android' ? StretchInY : FadeInUp;
-const cardExitingAnimation = Platform.OS === 'android' ? StretchOutY : FadeOutUp;
-
 const ExchangeFormMemoized = memo(({ isAmountInputActive }: ExchangeFormMemoizedProps) => (
     <AnimatedBox layout={LinearTransition}>
         <VStack spacing="sp16" testID={EXCHANGE_FORM_TEST_ID}>
@@ -41,16 +30,7 @@ const ExchangeFormMemoized = memo(({ isAmountInputActive }: ExchangeFormMemoized
                 <AmountEditingDoneButton testID={AMOUNT_EDITING_DONE_BUTTON_TEST_ID} />
             ) : (
                 <>
-                    <AnimatedBox
-                        layout={LinearTransition}
-                        entering={cardEnteringAnimation}
-                        exiting={cardExitingAnimation}
-                    >
-                        <Card noPadding>
-                            <ExchangeReceiveAccountPicker />
-                            <ExchangeRateAndProviderPicker />
-                        </Card>
-                    </AnimatedBox>
+                    <ExchangePickersCard />
                     <ExchangeConfirmation />
                 </>
             )}

--- a/suite-native/module-trading/src/components/exchange/ExchangePickersCard.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePickersCard.tsx
@@ -1,0 +1,50 @@
+import { Platform } from 'react-native';
+import {
+    FadeInUp,
+    FadeOutUp,
+    LinearTransition,
+    StretchInY,
+    StretchOutY,
+} from 'react-native-reanimated';
+import { useSelector } from 'react-redux';
+
+import { selectTradingExchangeIsLoading } from '@suite-common/trading';
+import { AnimatedBox, Card } from '@suite-native/atoms';
+import { useWatch } from '@suite-native/forms';
+import { getSymbolFromTradeableAsset } from '@suite-native/trading-atoms';
+
+import { ExchangeRateAndProviderPicker } from './ExchangeRateAndProviderPicker';
+import { ExchangeReceiveAccountPicker } from './receive/ExchangeReceiveAccountPicker';
+import { useExchangeFormContext } from '../../hooks/exchange/useExchangeFormContext';
+
+const cardEnteringAnimation = Platform.OS === 'android' ? StretchInY : FadeInUp;
+const cardExitingAnimation = Platform.OS === 'android' ? StretchOutY : FadeOutUp;
+
+export const ExchangePickersCard = () => {
+    const isLoading = useSelector(selectTradingExchangeIsLoading);
+    const { control } = useExchangeFormContext();
+
+    const receiveAsset = useWatch({ name: 'receiveAsset', control });
+    const quote = useWatch({ name: 'quote', control });
+
+    const selectedSymbol = getSymbolFromTradeableAsset(receiveAsset);
+    const isReceiveAccountPickerVisible = selectedSymbol !== undefined;
+    const isRateAndProviderPickerVisible = quote !== undefined || isLoading;
+
+    if (!isReceiveAccountPickerVisible && !isRateAndProviderPickerVisible) {
+        return null;
+    }
+
+    return (
+        <AnimatedBox
+            layout={LinearTransition}
+            entering={cardEnteringAnimation}
+            exiting={cardExitingAnimation}
+        >
+            <Card noPadding>
+                <ExchangeReceiveAccountPicker />
+                <ExchangeRateAndProviderPicker />
+            </Card>
+        </AnimatedBox>
+    );
+};

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewView.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewView.tsx
@@ -38,7 +38,7 @@ export const ExchangePreviewView = memo(
         const hasEIP712SignData = hasEip712SignData(quote);
 
         return (
-            <VStack spacing="sp20" paddingVertical="sp20">
+            <VStack spacing="sp16">
                 <LastErrorMessage tradingType="exchange" />
                 {!!isApproved && (
                     <InlineAlertBox
@@ -53,7 +53,7 @@ export const ExchangePreviewView = memo(
                         <InlineAlertBox variant="critical" title={txnErrorString} />
                     </Animated.View>
                 )}
-                <AnimatedVStack layout={LinearTransition}>
+                <AnimatedVStack layout={LinearTransition} spacing="sp16">
                     <ExchangeFromAccountTradePreviewCard quote={quote} />
                     <ExchangeToAccountTradePreviewCard quote={quote} />
                     <ExchangeFiatDeviationWarning quote={quote} />

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeConfirmation.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeConfirmation.test.tsx
@@ -1,22 +1,23 @@
 import type { CryptoId, ExchangeTrade } from 'invity-api';
 
 import { Button } from '@suite-native/atoms';
+import { Form } from '@suite-native/forms';
 import { getTranslation } from '@suite-native/intl';
-import { renderWithStoreProvider, screen } from '@suite-native/test-utils-store';
-import { getInitializedTradingStateWithQuotes } from '@suite-native/trading-fixtures';
+import { act, screen } from '@suite-native/test-utils-store';
+import { type ExchangeFormType } from '@suite-native/trading-types';
 
+import {
+    type PreloadedStatePartial,
+    type TradingTestPreloadedState,
+    createTradingFeatureFlags,
+    renderHookWithTradingProvider,
+    renderWithTradingProvider,
+} from '../../../__tests__/tradingTestUtils';
+import { useExchangeForm } from '../../../hooks/exchange/useExchangeForm';
 import { ExchangeConfirmation } from '../ExchangeConfirmation';
 
 jest.mock('../../../hooks/exchange/useExchangeSelectQuote', () => ({
     useExchangeSelectQuote: jest.fn(),
-}));
-
-let mockQuote: ExchangeTrade;
-
-jest.mock('../../../hooks/exchange/useExchangeFormContext', () => ({
-    useExchangeFormContext: () => ({
-        watch: () => mockQuote,
-    }),
 }));
 
 jest.mock('../../../hooks/general/useTradingStellarActivateToken', () => ({
@@ -24,24 +25,46 @@ jest.mock('../../../hooks/general/useTradingStellarActivateToken', () => ({
 }));
 
 describe('ExchangeConfirmation', () => {
+    let exchangeForm: ExchangeFormType;
+
     const mockUseExchangeSelectQuote =
         require('../../../hooks/exchange/useExchangeSelectQuote').useExchangeSelectQuote;
     const mockUseTradingStellarActivateToken =
         require('../../../hooks/general/useTradingStellarActivateToken').useTradingStellarActivateToken;
 
+    const baseOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {
+        featureFlags: createTradingFeatureFlags(),
+    };
+
+    const defaultQuote: ExchangeTrade = {
+        send: 'ethereum--0x6b175474e89094c44da98b954eedeac495271d0f' as CryptoId,
+        receive: 'ethereum' as CryptoId,
+        exchange: 'test-provider',
+        isDex: false,
+    };
+
+    const setQuote = (quote: ExchangeTrade | undefined) => {
+        act(() => {
+            exchangeForm.setValue('quote', quote);
+        });
+    };
+
     const mockSelectQuote = (canProceed = true) =>
         mockUseExchangeSelectQuote.mockReturnValue({
             canProceed,
             selectQuote: jest.fn(),
-            selecteQuoteForRevoke: jest.fn(),
+            selectQuoteForRevoke: jest.fn(),
+            isLoading: false,
             isConsentRequested: false,
             giveConsent: jest.fn(),
             cancelConsent: jest.fn(),
         });
 
     const renderConfirmation = () =>
-        renderWithStoreProvider(<ExchangeConfirmation />, {
-            preloadedState: { wallet: { trading: getInitializedTradingStateWithQuotes() } },
+        renderWithTradingProvider(<ExchangeConfirmation />, {
+            tradeType: 'exchange',
+            overrides: baseOverrides,
+            wrapper: ({ children }) => <Form form={exchangeForm}>{children}</Form>,
         });
 
     const queryContinueButton = () =>
@@ -51,12 +74,14 @@ describe('ExchangeConfirmation', () => {
         screen.queryByText(getTranslation('moduleTrading.tradingScreen.buttons.revoke'));
 
     beforeEach(() => {
-        mockQuote = {
-            send: 'ethereum--0x6b175474e89094c44da98b954eedeac495271d0f' as CryptoId,
-            receive: 'ethereum' as CryptoId,
-            exchange: 'test-provider',
-            isDex: false,
-        };
+        jest.clearAllMocks();
+
+        const { result } = renderHookWithTradingProvider(() => useExchangeForm(), {
+            tradeType: 'exchange',
+            overrides: baseOverrides,
+        });
+        exchangeForm = result.current;
+        setQuote(defaultQuote);
 
         mockUseTradingStellarActivateToken.mockReturnValue({
             isReceivingInactiveStellarToken: false,
@@ -73,7 +98,6 @@ describe('ExchangeConfirmation', () => {
     });
 
     it('should not render "Continue" button when canProceed is false', () => {
-        mockQuote.isDex = false;
         mockSelectQuote(false);
 
         renderConfirmation();
@@ -90,7 +114,10 @@ describe('ExchangeConfirmation', () => {
     });
 
     it('should not render "Revoke" button when approval is needed', () => {
-        mockQuote.isDex = true;
+        setQuote({
+            ...defaultQuote,
+            isDex: true,
+        });
         mockSelectQuote();
 
         renderConfirmation();
@@ -99,8 +126,11 @@ describe('ExchangeConfirmation', () => {
     });
 
     it('should render "Revoke" button when approval status is approved', () => {
-        mockQuote.isDex = true;
-        mockQuote.preapprovedStringAmount = '100';
+        setQuote({
+            ...defaultQuote,
+            isDex: true,
+            preapprovedStringAmount: '100',
+        });
         mockSelectQuote();
 
         renderConfirmation();
@@ -109,9 +139,12 @@ describe('ExchangeConfirmation', () => {
     });
 
     it('should render "Revoke" button when approval status is needs_increase', () => {
-        mockQuote.isDex = true;
-        mockQuote.preapprovedStringAmount = '100';
-        mockQuote.status = 'APPROVAL_REQ';
+        setQuote({
+            ...defaultQuote,
+            isDex: true,
+            preapprovedStringAmount: '100',
+            status: 'APPROVAL_REQ',
+        });
 
         mockSelectQuote();
 
@@ -121,8 +154,7 @@ describe('ExchangeConfirmation', () => {
     });
 
     it('should not render "Revoke" button when approval status is null', () => {
-        mockQuote.isDex = false;
-
+        setQuote(undefined);
         mockSelectQuote();
 
         renderConfirmation();
@@ -131,10 +163,13 @@ describe('ExchangeConfirmation', () => {
     });
 
     it('should render "Revoke" button when approval status is needs_revoke', () => {
-        mockQuote.isDex = true;
-        mockQuote.preapprovedStringAmount = '100';
-        mockQuote.status = 'APPROVAL_REQ';
-        mockQuote.send = 'ethereum--0xdac17f958d2ee523a2206206994597c13d831ec7' as CryptoId;
+        setQuote({
+            ...defaultQuote,
+            isDex: true,
+            preapprovedStringAmount: '100',
+            status: 'APPROVAL_REQ',
+            send: 'ethereum--0xdac17f958d2ee523a2206206994597c13d831ec7' as CryptoId,
+        });
 
         mockSelectQuote();
 
@@ -153,7 +188,9 @@ describe('ExchangeConfirmation', () => {
 
         const { queryByText } = renderConfirmation();
         expect(queryByText('Activate')).toBeTruthy();
-        expect(queryByText('Continue')).toBeNull();
+        expect(
+            queryByText(getTranslation('moduleTrading.tradingScreen.buttons.continue')),
+        ).toBeNull();
     });
 
     it('should not render activate button when not trading inactive Stellar token', () => {
@@ -166,14 +203,19 @@ describe('ExchangeConfirmation', () => {
 
         const { queryByText } = renderConfirmation();
         expect(queryByText('Activate')).toBeNull();
-        expect(queryByText('Continue')).toBeTruthy();
+        expect(
+            queryByText(getTranslation('moduleTrading.tradingScreen.buttons.continue')),
+        ).toBeTruthy();
     });
 
     it('should not render Revoke button, when canProceed is false', () => {
-        mockQuote.isDex = true;
-        mockQuote.preapprovedStringAmount = '100';
-        mockQuote.status = 'APPROVAL_REQ';
-        mockQuote.send = 'ethereum--0xdac17f958d2ee523a2206206994597c13d831ec7' as CryptoId;
+        setQuote({
+            ...defaultQuote,
+            isDex: true,
+            preapprovedStringAmount: '100',
+            status: 'APPROVAL_REQ',
+            send: 'ethereum--0xdac17f958d2ee523a2206206994597c13d831ec7' as CryptoId,
+        });
 
         mockSelectQuote(false);
 

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangePickersCard.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangePickersCard.test.tsx
@@ -1,0 +1,102 @@
+import { Form } from '@suite-native/forms';
+import { act } from '@suite-native/test-utils-store';
+import { btcAsset, mercuryoFixedWorstQuote } from '@suite-native/trading-fixtures';
+import { type ExchangeFormType } from '@suite-native/trading-types';
+
+import {
+    type PreloadedStatePartial,
+    type TradingTestPreloadedState,
+    createTradingFeatureFlags,
+    renderHookWithTradingProvider,
+    renderWithTradingProvider,
+} from '../../../__tests__/tradingTestUtils';
+import { useExchangeForm } from '../../../hooks/exchange/useExchangeForm';
+import { ExchangePickersCard } from '../ExchangePickersCard';
+
+const reportMock = jest.fn();
+const mockNavigate = jest.fn();
+const services = {
+    analytics: {
+        report: reportMock,
+    },
+};
+
+jest.mock('@react-navigation/native', () => ({
+    ...jest.requireActual('@react-navigation/native'),
+    useNavigation: () => ({
+        navigate: mockNavigate,
+    }),
+}));
+
+describe('ExchangePickersCard', () => {
+    let exchangeForm: ExchangeFormType;
+    let unmount: (() => void) | undefined;
+
+    const baseOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {
+        featureFlags: createTradingFeatureFlags(),
+    };
+
+    const renderExchangePickersCard = (
+        extraOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
+    ) => {
+        const result = renderWithTradingProvider(<ExchangePickersCard />, {
+            services,
+            tradeType: 'exchange',
+            overrides: { ...baseOverrides, ...extraOverrides },
+            wrapper: ({ children }) => <Form form={exchangeForm}>{children}</Form>,
+        });
+
+        ({ unmount } = result);
+
+        return result;
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        const { result } = renderHookWithTradingProvider(() => useExchangeForm(), {
+            services,
+            tradeType: 'exchange',
+            overrides: baseOverrides,
+        });
+        exchangeForm = result.current;
+    });
+
+    afterEach(() => {
+        unmount?.();
+    });
+
+    it('should render nothing when no picker can be displayed', () => {
+        const { toJSON } = renderExchangePickersCard();
+
+        expect(toJSON()).toBeNull();
+    });
+
+    it('should render receive account picker when receive asset is selected', () => {
+        act(() => {
+            exchangeForm.setValue('receiveAsset', btcAsset);
+        });
+
+        const { getByText } = renderExchangePickersCard();
+
+        expect(getByText('Receive account')).toBeOnTheScreen();
+    });
+
+    it('should render provider picker when quotes are loading', () => {
+        const { getByText } = renderExchangePickersCard({
+            wallet: { trading: { exchange: { isLoading: true } } },
+        });
+
+        expect(getByText('Provider')).toBeOnTheScreen();
+    });
+
+    it('should render provider picker when quote is selected', () => {
+        act(() => {
+            exchangeForm.setValue('quote', mercuryoFixedWorstQuote);
+        });
+
+        const { getByText } = renderExchangePickersCard();
+
+        expect(getByText('Provider')).toBeOnTheScreen();
+    });
+});

--- a/suite-native/module-trading/src/components/exchange/receive/ExchangeReceiveAccountPicker.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/ExchangeReceiveAccountPicker.tsx
@@ -1,6 +1,7 @@
 import { useSelector } from 'react-redux';
 
 import { selectTradingExchangeIsLoading } from '@suite-common/trading';
+import { useWatch } from '@suite-native/forms';
 import { getSymbolFromTradeableAsset } from '@suite-native/trading-atoms';
 import { selectExchangeSelectedReceiveAccount } from '@suite-native/trading-state';
 
@@ -10,12 +11,13 @@ import { ReceiveAccountPicker } from '../../general/ReceiveAccount/ReceiveAccoun
 const RECEIVE_ACCOUNT_PICKER_TEST_ID = '@trading/exchange/receive-account';
 
 export const ExchangeReceiveAccountPicker = () => {
-    const { watch } = useExchangeFormContext();
+    const { control } = useExchangeFormContext();
     const selectedReceiveAccount = useSelector(selectExchangeSelectedReceiveAccount);
     const isLoading = useSelector(selectTradingExchangeIsLoading);
 
-    const [asset, quote] = watch(['receiveAsset', 'quote']);
-    const selectedSymbol = getSymbolFromTradeableAsset(asset);
+    const receiveAsset = useWatch({ name: 'receiveAsset', control });
+    const quote = useWatch({ name: 'quote', control });
+    const selectedSymbol = getSymbolFromTradeableAsset(receiveAsset);
     const noBottomBorder = !isLoading && !quote;
 
     return (

--- a/suite-native/module-trading/src/components/fees/FeePickerCard.tsx
+++ b/suite-native/module-trading/src/components/fees/FeePickerCard.tsx
@@ -5,7 +5,7 @@ import type { ExchangeTrade, SellFiatTrade } from 'invity-api';
 import { type TradingExchangeType, type TradingSellType } from '@suite-common/trading';
 import { type FormDraftRootState, selectDeepCopyOfFormDraft } from '@suite-common/wallet-core';
 import { type AccountKey, type FeeLevelLabel } from '@suite-common/wallet-types';
-import { AnimatedContainerCard, Divider } from '@suite-native/atoms';
+import { Card, Divider } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { TradeInfoHeader } from '@suite-native/trading-atoms';
 import { getFormDraftKeyByTradeType } from '@suite-native/trading-state';
@@ -33,7 +33,7 @@ export const FeePickerCard = ({ trade, accountKey, tradingType }: FeePickerCardP
     );
 
     return (
-        <AnimatedContainerCard noPadding>
+        <Card noPadding>
             <TradeInfoHeader
                 title={<Translation id="moduleTrading.tradingExchangePreviewScreen.details" />}
             />
@@ -47,6 +47,6 @@ export const FeePickerCard = ({ trade, accountKey, tradingType }: FeePickerCardP
                 formDraft={formDraft}
                 formDraftKey={formDraftKey}
             />
-        </AnimatedContainerCard>
+        </Card>
     );
 };

--- a/suite-native/module-trading/src/components/general/Header/Header.tsx
+++ b/suite-native/module-trading/src/components/general/Header/Header.tsx
@@ -6,11 +6,7 @@ import { selectIsAmountInputActive } from '@suite-native/trading-state';
 
 import { HeaderTabs } from './HeaderTabs';
 
-export type HeaderProps = {
-    isFormMountedRecently?: boolean;
-};
-
-export const Header = ({ isFormMountedRecently }: HeaderProps) => {
+export const Header = () => {
     const shouldHideHeader = useSelector(selectIsAmountInputActive);
 
     if (shouldHideHeader) {
@@ -18,7 +14,7 @@ export const Header = ({ isFormMountedRecently }: HeaderProps) => {
     }
 
     return (
-        <AnimatedBox entering={isFormMountedRecently ? undefined : FadeInUp} exiting={FadeOutUp}>
+        <AnimatedBox entering={FadeInUp} exiting={FadeOutUp}>
             <HeaderTabs />
         </AnimatedBox>
     );

--- a/suite-native/module-trading/src/components/general/Header/HeaderTabs.tsx
+++ b/suite-native/module-trading/src/components/general/Header/HeaderTabs.tsx
@@ -1,13 +1,18 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { type NativeScrollEvent, type NativeSyntheticEvent } from 'react-native';
 import { FlatList } from 'react-native-gesture-handler';
+import { FadeIn, FadeOut } from 'react-native-reanimated';
+
+import { LinearGradient } from 'expo-linear-gradient';
 
 import { useServices } from '@suite-common/dependency-injection';
 import { type TradingTypeWithConcierge } from '@suite-common/trading';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
-import { HStack, IconButton, useBottomSheetModal } from '@suite-native/atoms';
+import { AnimatedBox, HStack, IconButton, useBottomSheetModal } from '@suite-native/atoms';
 import { type IconName } from '@suite-native/icons';
 import { useTranslate } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+import { hexToRgba } from '@trezor/utils';
 
 import { HeaderTab } from './HeaderTab';
 import { useTradingTabs } from '../../../hooks/general/useTradingTabs';
@@ -50,16 +55,39 @@ const useTabsData = () => {
 
 const tabsStyle = prepareNativeStyle(({ spacings }) => ({
     gap: spacings.sp12,
+    paddingHorizontal: spacings.sp16,
+}));
+
+const tabsEdgeGradientStyle = prepareNativeStyle(({ spacings }) => ({
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    bottom: 0,
+    width: spacings.sp40,
+    pointerEvents: 'none',
 }));
 
 export const HeaderTabs = () => {
     const listRef = useRef<FlatList>(null);
-    const { applyStyle } = useNativeStyles();
+    const { applyStyle, utils } = useNativeStyles();
     const { activeTab, setActiveTab } = useTradingTabs();
     const data = useTabsData();
     const { translate } = useTranslate();
     const { bottomSheetRef, openModal, closeModal } = useBottomSheetModal();
     const { analytics } = useServices(selectNativeAnalyticsDep);
+
+    const [isGradientEnabled, setIsGradientEnabled] = useState(true);
+
+    const tabsEdgeGradientColors = useMemo<[string, string, string, string]>(() => {
+        const backgroundColor = utils.colors.surfaceFillPage;
+
+        return [
+            hexToRgba(backgroundColor, 0.01),
+            hexToRgba(backgroundColor, 0.45),
+            hexToRgba(backgroundColor, 0.85),
+            backgroundColor,
+        ];
+    }, [utils.colors.surfaceFillPage]);
 
     const activeTabIndex = useMemo(
         () => data.findIndex(tab => tab.key === activeTab),
@@ -77,6 +105,19 @@ export const HeaderTabs = () => {
             viewPosition: 0.5,
         });
     }, [activeTabIndex]);
+
+    const handleScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+        const { contentOffset, layoutMeasurement, contentSize } = event.nativeEvent;
+
+        const { x } = contentOffset;
+        const { width: visibleWidth } = layoutMeasurement;
+        const { width: totalWidth } = contentSize;
+
+        const threshold = 8;
+        const isEnabled = x + visibleWidth < totalWidth - threshold;
+
+        setIsGradientEnabled(isEnabled);
+    };
 
     const onTabPress = (tab: TradingTypeWithConcierge) => {
         if (tab === activeTab) {
@@ -96,12 +137,13 @@ export const HeaderTabs = () => {
 
     return (
         <>
-            <HStack justifyContent="space-between">
+            <HStack spacing={0} paddingRight="sp16">
                 <FlatList
                     ref={listRef}
                     horizontal
                     showsHorizontalScrollIndicator={false}
                     accessible={true}
+                    onScroll={handleScroll}
                     contentContainerStyle={applyStyle(tabsStyle)}
                     renderItem={({ item }) => (
                         <HeaderTab
@@ -121,6 +163,17 @@ export const HeaderTabs = () => {
                         });
                     }}
                 />
+                {isGradientEnabled && (
+                    <AnimatedBox entering={FadeIn.duration(200)} exiting={FadeOut}>
+                        <LinearGradient
+                            start={{ x: 0, y: 0.5 }}
+                            end={{ x: 1, y: 0.5 }}
+                            colors={tabsEdgeGradientColors}
+                            locations={[0, 0.45, 0.8, 1]}
+                            style={applyStyle(tabsEdgeGradientStyle)}
+                        />
+                    </AnimatedBox>
+                )}
                 <IconButton
                     iconName="gear"
                     size="medium"

--- a/suite-native/module-trading/src/components/general/HistoryButton.tsx
+++ b/suite-native/module-trading/src/components/general/HistoryButton.tsx
@@ -1,5 +1,5 @@
-import { Pressable } from 'react-native';
-import { FadeInDown, FadeOutDown, LinearTransition } from 'react-native-reanimated';
+import { Platform, Pressable } from 'react-native';
+import { FadeInDown, LinearTransition } from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
@@ -41,6 +41,8 @@ const buttonStyle = prepareNativeStyle(utils => ({
     alignItems: 'center',
 }));
 
+const isAndroid = Platform.OS === 'android';
+
 export const HistoryButton = () => {
     const { applyStyle } = useNativeStyles();
     const navigation = useNavigation<NavigationProps>();
@@ -58,8 +60,8 @@ export const HistoryButton = () => {
 
     return (
         <AnimatedBox
-            entering={FadeInDown}
-            exiting={FadeOutDown}
+            key={isAndroid ? activeTradingType : undefined}
+            entering={isMountedRecently && isAndroid ? undefined : FadeInDown}
             layout={isMountedRecently ? undefined : LinearTransition}
         >
             <Pressable onPress={handleOnPress} testID={TRADE_HISTORY_BUTTON_TEST_ID}>

--- a/suite-native/module-trading/src/components/general/HistoryButton.tsx
+++ b/suite-native/module-trading/src/components/general/HistoryButton.tsx
@@ -1,4 +1,3 @@
-import { memo } from 'react';
 import { Pressable } from 'react-native';
 import { FadeInDown, FadeOutDown, LinearTransition } from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
@@ -15,9 +14,10 @@ import {
     type TradingStackParamList,
     type TradingStackRoutes,
 } from '@suite-native/navigation';
-import { selectIsAmountInputActive } from '@suite-native/trading-state';
+import { selectActiveTradingType, selectIsAmountInputActive } from '@suite-native/trading-state';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
+import { useMountedRecentlyFlag } from '../../hooks/general/useMountedRecentlyFlag';
 import { useWatchAllTrades } from '../../hooks/general/useWatchAllTrades';
 
 export type HistoryButtonProps = {
@@ -41,17 +41,26 @@ const buttonStyle = prepareNativeStyle(utils => ({
     alignItems: 'center',
 }));
 
-const HistoryButtonMemoized = memo(({ isFormMountedRecently }: HistoryButtonProps) => {
+export const HistoryButton = () => {
     const { applyStyle } = useNativeStyles();
     const navigation = useNavigation<NavigationProps>();
+    const activeTradingType = useSelector(selectActiveTradingType);
+    const isMountedRecently = useMountedRecentlyFlag(activeTradingType);
+
+    const { totalTrades } = useWatchAllTrades();
+    const shouldHideButton = useSelector(selectIsAmountInputActive);
 
     const handleOnPress = () => navigation.navigate(RootStackRoutes.TradingHistory);
 
+    if (totalTrades === 0 || shouldHideButton) {
+        return null;
+    }
+
     return (
         <AnimatedBox
-            entering={isFormMountedRecently ? undefined : FadeInDown}
+            entering={FadeInDown}
             exiting={FadeOutDown}
-            layout={LinearTransition}
+            layout={isMountedRecently ? undefined : LinearTransition}
         >
             <Pressable onPress={handleOnPress} testID={TRADE_HISTORY_BUTTON_TEST_ID}>
                 <HStack style={applyStyle(buttonStyle)}>
@@ -63,15 +72,4 @@ const HistoryButtonMemoized = memo(({ isFormMountedRecently }: HistoryButtonProp
             </Pressable>
         </AnimatedBox>
     );
-});
-
-export const HistoryButton = (props: HistoryButtonProps) => {
-    const { totalTrades } = useWatchAllTrades();
-    const shouldHideButton = useSelector(selectIsAmountInputActive);
-
-    if (totalTrades === 0 || shouldHideButton) {
-        return null;
-    }
-
-    return <HistoryButtonMemoized {...props} />;
 };

--- a/suite-native/module-trading/src/components/general/ProviderReceiveAddress.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderReceiveAddress.tsx
@@ -41,7 +41,7 @@ export const ProviderReceiveAddress = ({ trade }: { trade: ExchangeTrade | SellF
             ? ((trade as ExchangeTrade).sendAddress ?? (trade as ExchangeTrade)?.dexTx?.to)
             : (trade as SellFiatTrade).destinationAddress;
 
-    if (!networkType) {
+    if (!networkType || (tradeType === 'sell' && !receiveAddress)) {
         return null;
     }
 
@@ -73,7 +73,7 @@ export const ProviderReceiveAddress = ({ trade }: { trade: ExchangeTrade | SellF
                             />
                         </AnimatedBox>
                     ) : (
-                        <VStack spacing="sp12">
+                        <VStack spacing="sp12" testID="@trading/provider-receive-address-skeleton">
                             <SkeletonSmall widthPercentage={0.8} height={14} />
                             <SkeletonSmall widthPercentage={0.3} height={14} />
                         </VStack>

--- a/suite-native/module-trading/src/components/general/ProviderReceiveAddress.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderReceiveAddress.tsx
@@ -16,6 +16,9 @@ import { AddressFormatter } from '@suite-native/formatters';
 import { Translation, useTranslate } from '@suite-native/intl';
 import { SkeletonSmall, TradeInfoRow } from '@suite-native/trading-atoms';
 
+const SKELETON_RECEIVE_ADDRESS_HEIGHT = 14;
+const SKELETON_RECEIVE_ADDRESS_SPACING = 12;
+
 export const ProviderReceiveAddress = ({ trade }: { trade: ExchangeTrade | SellFiatTrade }) => {
     const { translate } = useTranslate();
     const tradeType = isExchangeTrade(trade) ? 'exchange' : 'sell';
@@ -64,7 +67,14 @@ export const ProviderReceiveAddress = ({ trade }: { trade: ExchangeTrade | SellF
                 <VStack spacing="sp4">
                     <Text variant="body-sm">{addressTitle}</Text>
                     {receiveAddress ? (
-                        <AnimatedBox entering={FadeIn}>
+                        <AnimatedBox
+                            entering={FadeIn}
+                            style={{
+                                height:
+                                    SKELETON_RECEIVE_ADDRESS_HEIGHT * 2 +
+                                    SKELETON_RECEIVE_ADDRESS_SPACING,
+                            }}
+                        >
                             <AddressFormatter
                                 value={receiveAddress}
                                 format="full"
@@ -74,8 +84,14 @@ export const ProviderReceiveAddress = ({ trade }: { trade: ExchangeTrade | SellF
                         </AnimatedBox>
                     ) : (
                         <VStack spacing="sp12" testID="@trading/provider-receive-address-skeleton">
-                            <SkeletonSmall widthPercentage={0.8} height={14} />
-                            <SkeletonSmall widthPercentage={0.3} height={14} />
+                            <SkeletonSmall
+                                widthPercentage={0.8}
+                                height={SKELETON_RECEIVE_ADDRESS_HEIGHT}
+                            />
+                            <SkeletonSmall
+                                widthPercentage={0.3}
+                                height={SKELETON_RECEIVE_ADDRESS_HEIGHT}
+                            />
                         </VStack>
                     )}
                 </VStack>

--- a/suite-native/module-trading/src/components/general/ProviderReceiveAddress.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderReceiveAddress.tsx
@@ -11,10 +11,10 @@ import {
     selectTradingSellAccountKey,
 } from '@suite-common/trading';
 import { type AccountsRootState, selectAccountNetworkType } from '@suite-common/wallet-core';
-import { Text, VStack } from '@suite-native/atoms';
+import { AnimatedBox, Text, VStack } from '@suite-native/atoms';
 import { AddressFormatter } from '@suite-native/formatters';
 import { Translation, useTranslate } from '@suite-native/intl';
-import { TradeInfoRow } from '@suite-native/trading-atoms';
+import { SkeletonSmall, TradeInfoRow } from '@suite-native/trading-atoms';
 
 export const ProviderReceiveAddress = ({ trade }: { trade: ExchangeTrade | SellFiatTrade }) => {
     const { translate } = useTranslate();
@@ -23,7 +23,7 @@ export const ProviderReceiveAddress = ({ trade }: { trade: ExchangeTrade | SellF
         selectTradingProviderByNameAndTradeType(state, trade.exchange, tradeType),
     );
     const sendAccountKey = useSelector((state: TradingRootState) =>
-        isExchangeTrade(trade)
+        tradeType === 'exchange'
             ? selectTradingExchangeAccountKey(state)
             : selectTradingSellAccountKey(state),
     );
@@ -38,10 +38,10 @@ export const ProviderReceiveAddress = ({ trade }: { trade: ExchangeTrade | SellF
 
     const receiveAddress =
         tradeType === 'exchange'
-            ? (trade as ExchangeTrade).sendAddress
+            ? ((trade as ExchangeTrade).sendAddress ?? (trade as ExchangeTrade)?.dexTx?.to)
             : (trade as SellFiatTrade).destinationAddress;
 
-    if (!receiveAddress || !networkType) {
+    if (!networkType) {
         return null;
     }
 
@@ -63,12 +63,21 @@ export const ProviderReceiveAddress = ({ trade }: { trade: ExchangeTrade | SellF
             <TradeInfoRow>
                 <VStack spacing="sp4">
                     <Text variant="body-sm">{addressTitle}</Text>
-                    <AddressFormatter
-                        value={receiveAddress}
-                        format="full"
-                        variant="body-sm"
-                        color="contentSecondary"
-                    />
+                    {receiveAddress ? (
+                        <AnimatedBox entering={FadeIn}>
+                            <AddressFormatter
+                                value={receiveAddress}
+                                format="full"
+                                variant="body-sm"
+                                color="contentSecondary"
+                            />
+                        </AnimatedBox>
+                    ) : (
+                        <VStack spacing="sp12">
+                            <SkeletonSmall widthPercentage={0.8} height={14} />
+                            <SkeletonSmall widthPercentage={0.3} height={14} />
+                        </VStack>
+                    )}
                 </VStack>
             </TradeInfoRow>
         </Animated.View>

--- a/suite-native/module-trading/src/components/general/__tests__/ProviderReceiveAddress.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/ProviderReceiveAddress.test.tsx
@@ -133,13 +133,12 @@ describe('ProviderReceiveAddress', () => {
         expect(getByText('1A1z P1eP 5QGe fi2D MPTf TL5S Lmv7 Divf Na')).toBeOnTheScreen();
     });
 
-    it('should not render anything when receive address is missing for exchange trade', () => {
+    it('should render skeleton when receive address is missing for exchange trade', () => {
         const tradeWithoutAddress = { ...mockExchangeTrade, sendAddress: undefined };
 
-        const { queryByText } = renderProviderReceiveAddress(tradeWithoutAddress, 'exchange');
+        const { getByTestId } = renderProviderReceiveAddress(tradeWithoutAddress, 'exchange');
 
-        // User should not see any address information when address is missing
-        expect(queryByText(receiveAddressLabel('Mercuryo'))).toBeNull();
+        expect(getByTestId('@trading/provider-receive-address-skeleton')).toBeOnTheScreen();
     });
 
     it('should not render anything when destination address is missing for sell fiat trade', () => {

--- a/suite-native/module-trading/src/components/general/__tests__/ProviderReceiveAddress.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/ProviderReceiveAddress.test.tsx
@@ -133,6 +133,24 @@ describe('ProviderReceiveAddress', () => {
         expect(getByText('1A1z P1eP 5QGe fi2D MPTf TL5S Lmv7 Divf Na')).toBeOnTheScreen();
     });
 
+    it('should display address from dexTx when sendAddress is not available', () => {
+        const dexTrade: ExchangeTrade = {
+            ...mockExchangeTrade,
+            isDex: true,
+            sendAddress: undefined,
+            dexTx: {
+                to: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa',
+                from: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa',
+                data: '0x',
+                value: '0',
+            },
+        };
+        const { getByText } = renderProviderReceiveAddress(dexTrade, 'exchange');
+
+        expect(getByText(contractAddressLabel('Mercuryo'))).toBeOnTheScreen();
+        expect(getByText('1A1z P1eP 5QGe fi2D MPTf TL5S Lmv7 Divf Na')).toBeOnTheScreen();
+    });
+
     it('should render skeleton when receive address is missing for exchange trade', () => {
         const tradeWithoutAddress = { ...mockExchangeTrade, sendAddress: undefined };
 

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeSelectQuote.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeSelectQuote.ts
@@ -13,6 +13,7 @@ import {
     selectTradingMaxSlippagePercentage,
     tradingExchangeActions,
 } from '@suite-common/trading';
+import { useWatch } from '@suite-native/forms';
 import {
     type RootStackParamList,
     RootStackRoutes,
@@ -40,7 +41,8 @@ type NavigationProps = StackToStackCompositeNavigationProps<
 
 export const useExchangeSelectQuote = (form: ExchangeFormType) => {
     const dispatch = useDispatch();
-    const [candidateQuote, receiveAsset] = form.watch(['quote', 'receiveAsset']);
+    const candidateQuote = useWatch({ name: 'quote', control: form.control });
+    const receiveAsset = useWatch({ name: 'receiveAsset', control: form.control });
 
     const isLoading = useSelector(selectTradingExchangeIsLoading);
     const isDexQuoteApprovalPrefetchLoadingForCandidateQuote = useSelector(

--- a/suite-native/module-trading/src/screens/TradingExchangePreviewScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingExchangePreviewScreen.tsx
@@ -12,6 +12,7 @@ import {
     selectTradingExchangeSelectedQuote,
 } from '@suite-common/trading';
 import { useAlert } from '@suite-native/alerts';
+import { VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
     type RootStackParamList,
@@ -187,12 +188,14 @@ const TradingExchangePreviewScreenContent = ({
                 />
             }
         >
-            <ExchangePreviewView
-                quote={quote}
-                txnErrorString={errorString}
-                isApproved={isApproved}
-            />
-            <Footer />
+            <VStack spacing="sp16">
+                <ExchangePreviewView
+                    quote={quote}
+                    txnErrorString={errorString}
+                    isApproved={isApproved}
+                />
+                <Footer />
+            </VStack>
         </Screen>
     );
 };

--- a/suite-native/module-trading/src/screens/TradingExchangePreviewScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingExchangePreviewScreen.tsx
@@ -188,7 +188,7 @@ const TradingExchangePreviewScreenContent = ({
                 />
             }
         >
-            <VStack spacing="sp16">
+            <VStack spacing="sp16" flex={1}>
                 <ExchangePreviewView
                     quote={quote}
                     txnErrorString={errorString}

--- a/suite-native/module-trading/src/screens/TradingReceiveAccountsPickerScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingReceiveAccountsPickerScreen.tsx
@@ -58,7 +58,7 @@ export const TradingReceiveAccountsPickerScreen = () => {
         );
 
     return (
-        <Screen header={<ScreenHeader title={title} closeActionType="close" />}>
+        <Screen header={<ScreenHeader title={title} closeActionType="back" />}>
             <AccountList
                 symbol={symbol}
                 pickerMode={pickerMode}

--- a/suite-native/module-trading/src/screens/TradingScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingScreen.tsx
@@ -11,7 +11,7 @@ import { RootStackRoutes, Screen } from '@suite-native/navigation';
 import { TradingEnvironmentWarning } from '@suite-native/trading-debug';
 import { Footer } from '@suite-native/trading-provider-utils';
 import {
-    selectActiveTradingType,
+    selectHasActiveTradingType,
     selectIsTradingEnabled,
     selectTradeToBeOpened,
 } from '@suite-native/trading-state';
@@ -22,15 +22,14 @@ import { LegalGatewayContextMessage } from '../components/general/LegalGatewayCo
 import { TradingTabContent } from '../components/general/TradingTabContent';
 import { TradingTypeAwareContextMessage } from '../components/general/TradingTypeAwareContextMessage';
 import { useActiveTradingTypeReaction } from '../hooks/general/useActiveTradingTypeReaction';
-import { useMountedRecentlyFlag } from '../hooks/general/useMountedRecentlyFlag';
 
 const TradingScreenContent = () => {
     const tradeToBeOpened = useSelector(selectTradeToBeOpened);
-    const activeTradingType = useSelector(selectActiveTradingType);
+    const hasActiveTradingType = useSelector(selectHasActiveTradingType);
     const navigation = useNavigation<NavigationProps>();
-    const isScreenMountedRecently = useMountedRecentlyFlag(activeTradingType);
     useActiveTradingTypeReaction();
     const { analytics } = useServices(selectNativeAnalyticsDep);
+
     useEffect(() => {
         if (tradeToBeOpened) {
             analytics.report({
@@ -41,17 +40,19 @@ const TradingScreenContent = () => {
         }
     }, [tradeToBeOpened, navigation, analytics]);
 
-    if (!activeTradingType) {
+    if (!hasActiveTradingType) {
         return null;
     }
 
     return (
-        <VStack spacing="sp16">
+        <VStack spacing="sp16" style={{ flex: 1 }}>
             <TradingEnvironmentWarning />
-            <Header isFormMountedRecently={isScreenMountedRecently} />
-            <TradingTabContent />
-            <HistoryButton isFormMountedRecently={isScreenMountedRecently} />
-            <Footer isFormMountedRecently={isScreenMountedRecently} />
+            <Header />
+            <VStack spacing="sp16" paddingHorizontal="sp16" style={{ flex: 1 }}>
+                <TradingTabContent />
+                <HistoryButton />
+                <Footer />
+            </VStack>
         </VStack>
     );
 };
@@ -65,6 +66,7 @@ export const TradingScreen = () => {
 
     return (
         <Screen
+            noHorizontalPadding
             header={
                 <>
                     <DeviceManagerScreenHeader />
@@ -73,7 +75,7 @@ export const TradingScreen = () => {
             }
         >
             <TradingScreenContent />
-            <LegalGatewayContextMessage marginVertical="sp16" />
+            <LegalGatewayContextMessage marginVertical="sp16" paddingHorizontal="sp16" />
         </Screen>
     );
 };

--- a/suite-native/module-trading/src/screens/TradingScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingScreen.tsx
@@ -45,10 +45,10 @@ const TradingScreenContent = () => {
     }
 
     return (
-        <VStack spacing="sp16" style={{ flex: 1 }}>
+        <VStack spacing="sp16" flex={1}>
             <TradingEnvironmentWarning />
             <Header />
-            <VStack spacing="sp16" paddingHorizontal="sp16" style={{ flex: 1 }}>
+            <VStack spacing="sp16" paddingHorizontal="sp16" flex={1}>
                 <TradingTabContent />
                 <HistoryButton />
                 <Footer />

--- a/suite-native/trading-atoms/src/components/Skeleton/SkeletonLarge.tsx
+++ b/suite-native/trading-atoms/src/components/Skeleton/SkeletonLarge.tsx
@@ -1,17 +1,19 @@
-import { Dimensions } from 'react-native';
+import { useWindowDimensions } from 'react-native';
 
 import { BoxSkeleton } from '@suite-native/atoms';
 
 export type SkeletonLargeProps = {
     widthPercentage: number;
+    height?: number;
 };
 
 const SKELETON_LARGE_HEIGHT = 60;
 
-export const SkeletonLarge = ({ widthPercentage }: SkeletonLargeProps) => (
-    <BoxSkeleton
-        width={Dimensions.get('window').width * widthPercentage}
-        height={SKELETON_LARGE_HEIGHT}
-        borderRadius="r16"
-    />
-);
+export const SkeletonLarge = ({
+    widthPercentage,
+    height = SKELETON_LARGE_HEIGHT,
+}: SkeletonLargeProps) => {
+    const { width } = useWindowDimensions();
+
+    return <BoxSkeleton width={width * widthPercentage} height={height} borderRadius="r16" />;
+};

--- a/suite-native/trading-atoms/src/components/Skeleton/SkeletonLargeRow.tsx
+++ b/suite-native/trading-atoms/src/components/Skeleton/SkeletonLargeRow.tsx
@@ -7,12 +7,14 @@ export type SkeletonRowProps = {
     rightWidthPercentage: number;
 };
 
+const CONTENT_HEIGHT = 46;
+
 export const SkeletonLargeRow = ({
     leftWidthPercentage,
     rightWidthPercentage,
 }: SkeletonRowProps) => (
     <HStack justifyContent="space-between" alignItems="center">
-        <SkeletonLarge widthPercentage={leftWidthPercentage} height={46} />
-        <SkeletonLarge widthPercentage={rightWidthPercentage} height={46} />
+        <SkeletonLarge widthPercentage={leftWidthPercentage} height={CONTENT_HEIGHT} />
+        <SkeletonLarge widthPercentage={rightWidthPercentage} height={CONTENT_HEIGHT} />
     </HStack>
 );

--- a/suite-native/trading-atoms/src/components/Skeleton/SkeletonLargeRow.tsx
+++ b/suite-native/trading-atoms/src/components/Skeleton/SkeletonLargeRow.tsx
@@ -12,7 +12,7 @@ export const SkeletonLargeRow = ({
     rightWidthPercentage,
 }: SkeletonRowProps) => (
     <HStack justifyContent="space-between" alignItems="center">
-        <SkeletonLarge widthPercentage={leftWidthPercentage} />
-        <SkeletonLarge widthPercentage={rightWidthPercentage} />
+        <SkeletonLarge widthPercentage={leftWidthPercentage} height={46} />
+        <SkeletonLarge widthPercentage={rightWidthPercentage} height={46} />
     </HStack>
 );

--- a/suite-native/trading-atoms/src/components/Skeleton/SkeletonSmall.tsx
+++ b/suite-native/trading-atoms/src/components/Skeleton/SkeletonSmall.tsx
@@ -1,16 +1,19 @@
-import { Dimensions } from 'react-native';
+import { useWindowDimensions } from 'react-native';
 
 import { BoxSkeleton } from '@suite-native/atoms';
 
 export type SkeletonSmallProps = {
     widthPercentage: number;
+    height?: number;
 };
 
 const SKELETON_SMALL_HEIGHT = 20;
 
-export const SkeletonSmall = ({ widthPercentage }: SkeletonSmallProps) => (
-    <BoxSkeleton
-        width={Dimensions.get('window').width * widthPercentage}
-        height={SKELETON_SMALL_HEIGHT}
-    />
-);
+export const SkeletonSmall = ({
+    widthPercentage,
+    height = SKELETON_SMALL_HEIGHT,
+}: SkeletonSmallProps) => {
+    const { width } = useWindowDimensions();
+
+    return <BoxSkeleton width={width * widthPercentage} height={height} />;
+};

--- a/suite-native/trading-debug/src/components/TradingEnvironmentWarning.tsx
+++ b/suite-native/trading-debug/src/components/TradingEnvironmentWarning.tsx
@@ -1,6 +1,6 @@
 import { useSelector } from 'react-redux';
 
-import { InlineAlertBox } from '@suite-native/atoms';
+import { InlineAlertBox, VStack } from '@suite-native/atoms';
 import { selectTradingEnvironment } from '@suite-native/trading-state';
 
 export const TradingEnvironmentWarning = () => {
@@ -11,6 +11,11 @@ export const TradingEnvironmentWarning = () => {
     }
 
     return (
-        <InlineAlertBox title={`Trading environment: ${tradingEnvironment}`} variant="warning" />
+        <VStack paddingHorizontal="sp16">
+            <InlineAlertBox
+                title={`Trading environment: ${tradingEnvironment}`}
+                variant="warning"
+            />
+        </VStack>
     );
 };

--- a/suite-native/trading-debug/src/components/TradingEnvironmentWarning.tsx
+++ b/suite-native/trading-debug/src/components/TradingEnvironmentWarning.tsx
@@ -1,6 +1,6 @@
 import { useSelector } from 'react-redux';
 
-import { InlineAlertBox, VStack } from '@suite-native/atoms';
+import { Box, InlineAlertBox } from '@suite-native/atoms';
 import { selectTradingEnvironment } from '@suite-native/trading-state';
 
 export const TradingEnvironmentWarning = () => {
@@ -11,11 +11,11 @@ export const TradingEnvironmentWarning = () => {
     }
 
     return (
-        <VStack paddingHorizontal="sp16">
+        <Box paddingHorizontal="sp16">
             <InlineAlertBox
                 title={`Trading environment: ${tradingEnvironment}`}
                 variant="warning"
             />
-        </VStack>
+        </Box>
     );
 };

--- a/suite-native/trading-provider-utils/src/components/Footer.tsx
+++ b/suite-native/trading-provider-utils/src/components/Footer.tsx
@@ -1,4 +1,4 @@
-import { FadeInDown, FadeOutDown, LinearTransition } from 'react-native-reanimated';
+import { FadeInDown } from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
 
 import type { ProviderMetadata } from 'invity-api';
@@ -11,10 +11,6 @@ import { selectIsAmountInputActive } from '@suite-native/trading-state';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 import { HowTradingWorksSheet } from './HowTradingWorksSheet';
-
-export type FooterProps = {
-    isFormMountedRecently?: boolean;
-};
 
 interface FooterProviderContentProps {
     provider: ProviderMetadata | undefined;
@@ -58,7 +54,7 @@ const linkStyle = prepareNativeStyle(({ spacings }) => ({
     paddingVertical: spacings.sp10,
 }));
 
-export const Footer = ({ isFormMountedRecently }: FooterProps) => {
+export const Footer = () => {
     const { applyStyle } = useNativeStyles();
     const { bottomSheetRef, openModal, closeModal } = useBottomSheetModal();
 
@@ -70,12 +66,8 @@ export const Footer = ({ isFormMountedRecently }: FooterProps) => {
     }
 
     return (
-        <>
-            <AnimatedBox
-                entering={isFormMountedRecently ? undefined : FadeInDown}
-                exiting={FadeOutDown}
-                layout={LinearTransition}
-            >
+        <VStack style={{ marginTop: 'auto' }}>
+            <AnimatedBox entering={FadeInDown}>
                 <VStack alignItems="center" paddingBottom="sp12">
                     <FooterProviderContent provider={providerInfo} />
                     <Link
@@ -92,6 +84,6 @@ export const Footer = ({ isFormMountedRecently }: FooterProps) => {
                 </VStack>
             </AnimatedBox>
             <HowTradingWorksSheet ref={bottomSheetRef} closeModal={closeModal} />
-        </>
+        </VStack>
     );
 };

--- a/suite-native/trading-provider-utils/src/components/Footer.tsx
+++ b/suite-native/trading-provider-utils/src/components/Footer.tsx
@@ -54,6 +54,10 @@ const linkStyle = prepareNativeStyle(({ spacings }) => ({
     paddingVertical: spacings.sp10,
 }));
 
+const stackStyle = prepareNativeStyle(() => ({
+    marginTop: 'auto',
+}));
+
 export const Footer = () => {
     const { applyStyle } = useNativeStyles();
     const { bottomSheetRef, openModal, closeModal } = useBottomSheetModal();
@@ -66,7 +70,7 @@ export const Footer = () => {
     }
 
     return (
-        <VStack style={{ marginTop: 'auto' }}>
+        <VStack style={applyStyle(stackStyle)}>
             <AnimatedBox entering={FadeInDown}>
                 <VStack alignItems="center" paddingBottom="sp12">
                     <FooterProviderContent provider={providerInfo} />

--- a/suite-native/trading-provider-utils/src/index.ts
+++ b/suite-native/trading-provider-utils/src/index.ts
@@ -1,3 +1,3 @@
-export { Footer, type FooterProps } from './components/Footer';
+export { Footer } from './components/Footer';
 export { HowTradingWorksSheet } from './components/HowTradingWorksSheet';
 export { KycPolicyWarning, hasKycPolicyWarning } from './components/KycPolicyWarning';

--- a/suite-native/trading-state/src/selectors/commonSelectors.ts
+++ b/suite-native/trading-state/src/selectors/commonSelectors.ts
@@ -169,6 +169,9 @@ export const selectIsAmountInputActive = (state: TradingRootState) =>
 export const selectActiveTradingType = (state: TradingRootState) =>
     state.wallet.trading.activeTradingType;
 
+export const selectHasActiveTradingType = (state: TradingRootState) =>
+    state.wallet.trading.activeTradingType !== null;
+
 export const selectAmountInBaseFiatCurrency = createFiatRatesMemoizedSelector(
     [
         selectCurrentFiatRates,

--- a/suite-native/transaction-management/src/components/fees/FeeSelector.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeeSelector.tsx
@@ -120,8 +120,6 @@ export const FeeSelector = ({
         return <InlineAlertBox variant="critical" title={feeUnavailableErrorTitle} />;
     }
 
-    if (!fee && !areFeesLoading) return null;
-
     return (
         <>
             {networkType === 'tron' ? (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* Pin footer to bottom and remove layout animation.
* Replace Dimensions with useWindowDimensions to fix review screen crash
* Adjust skeleton height to match content of ExchangeForm
* Reduce re-renders on tab switches via new selector
* Make header full-width with right-side gradient
* Remove memo from history button (no longer re-renders)
* AccountPickerScreen: add back icon
* PreviewScreen: consistent spacing + skeletons to prevent layout jumps
* Keep confirm button on screen while quotes are loading just hide button text in loading state (consulted with Jemel)
* Extract exchange pickers to remove gap when no content is shown
* Update tests to match the above

(There is something wrong with Button atom styling, by changing disable state the button should change its bgColor but it doesn't work, it correctly internally selects new bg color but the applyStyle is not applying it )


## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/28043
Resolve: #28312 

## Screenshots:

https://github.com/user-attachments/assets/11281b92-209e-45a2-a962-f28933c474d0


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/28043-animations-polishing-in-trade&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->