### PR TITLE
fix(e2e): Default cardano backend

### DIFF
--- a/suite/e2e/support/pageObjects/settings/coinsTab.ts
+++ b/suite/e2e/support/pageObjects/settings/coinsTab.ts
@@ -5,8 +5,6 @@ import type { BackendType, NetworkSymbol } from '@suite-common/wallet-config';
 import { step } from '../../common';
 import { expect } from '../../testExtends/customMatchers';
 
-const CARDANO_BLOCKFROST_URL = 'wss://ada-b13-tws.trezor.io/';
-
 export class CoinsTab {
     readonly networkButton = (symbol: NetworkSymbol) =>
         this.page.getByTestId(`@settings/wallet/network/${symbol}`);
@@ -57,13 +55,5 @@ export class CoinsTab {
         await this.coinBackendSelectorOption(backend).click();
         await this.coinAddressInput.fill(backendUrl);
         await this.coinAdvanceSettingSaveButton.click();
-    }
-
-    // To compare stability between our Cardano BE servers and official ones
-    // We will use official for month to collect data. Remove afterwards.
-    @step()
-    async temporarilySetOfficialCardanoBackend() {
-        await this.openNetworkAdvanceSettings('ada');
-        await this.changeBackend('blockfrost', CARDANO_BLOCKFROST_URL);
     }
 }

--- a/suite/e2e/support/pageObjects/settings/settingsPage.ts
+++ b/suite/e2e/support/pageObjects/settings/settingsPage.ts
@@ -264,9 +264,6 @@ export class SettingsPage {
         await this.navigateTo('coins');
         for (const network of options.enableNetworks) {
             await this.coinsTab.enableNetwork(network);
-            if (network === 'ada') {
-                await this.coinsTab.temporarilySetOfficialCardanoBackend();
-            }
         }
 
         for (const network of options.disableNetworks ?? []) {

--- a/suite/e2e/tests/settings/coins.test.ts
+++ b/suite/e2e/tests/settings/coins.test.ts
@@ -77,7 +77,6 @@ test.describe('Coin Settings', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () => {
                 await assetsSection.activateAssetsModalSaveButton.click();
                 await page.discoveryShouldFinish();
                 await settingsPage.navigateTo('coins');
-                await settingsPage.coinsTab.temporarilySetOfficialCardanoBackend();
                 for (const network of defaultUncheckedTestnet) {
                     await settingsPage.coinsTab.enableNetwork(network);
                 }

--- a/suite/e2e/tests/wallet/discovery.test.ts
+++ b/suite/e2e/tests/wallet/discovery.test.ts
@@ -34,9 +34,6 @@ test.describe('Discovery', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () => {
             await settingsPage.navigateTo('coins');
             for (const coin of coinsToActivate) {
                 await settingsPage.coinsTab.enableNetwork(coin);
-                if (coin === 'ada') {
-                    await settingsPage.coinsTab.temporarilySetOfficialCardanoBackend();
-                }
             }
         });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is to settingsPage.ts, a core page object used across a very large number of E2E tests for settings navigation, network configuration, device settings, and application preferences. Since this is a shared page object with no static coverage mapping available, tests were inferred from the LLM analysis. The highest-risk tests are those in the settings/ directory that directly exercise settingsPage methods (device settings, coin configuration, general settings, safety checks). Medium-priority tests cover flows that depend on specific settingsPage methods like metadata provider management, recovery dry runs, analytics toggles, and connect permissions. The recommended strategy is to run all high-priority settings tests first, then medium-priority tests that use more specialized settingsPage features.

<details><summary><b>Changed files (1)</b></summary>

- `suite/e2e/support/pageObjects/settings/settingsPage.ts`

</details>

**Recommended tests (26)**

<details><summary>🔴 <b>High priority (12)</b></summary>

- `suite/e2e/tests/settings/general.test.ts` — Directly exercises settingsPage methods (navigateTo('application'), fiat currency change, theme change, language change, analytics toggle). Changes to settingsPage.ts could break any of these core settings interactions.
- `suite/e2e/tests/settings/coins.test.ts` — Heavily uses settingsPage.navigateTo('coins'), settingsPage.coinsTab (network buttons, enable/disable, backend configuration, activate coins). Core settings page object functionality under test.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — Uses settingsPage.coinsTab extensively including enableNetwork, openNetworkAdvanceSettings, changeBackend, and activateCoinsButton. Direct consumer of settingsPage backend configuration methods.
- `suite/e2e/tests/settings/passphrase.test.ts` — Navigates to Settings > Device page and interacts with the passphrase-switch toggle via settingsPage. Directly tests settingsPage device tab interactions.
- `suite/e2e/tests/settings/safety-checks.test.ts` — Uses settingsPage.safetyChecksButton, safetyChecksConfirmButton, safetyChecksRadioButton — all locators/methods defined in settingsPage.ts. Direct test of settings device tab functionality.
- `suite/e2e/tests/settings/t2t1-device-settings.test.ts` — Exercises settingsPage methods: changeDeviceName, changeDeviceBackground, display rotation, firmware update modal, wipe modal — all device settings page object methods.
- `suite/e2e/tests/settings/t1b1-device-settings.test.ts` — Uses settingsPage device tab for PIN switch toggle and changeDeviceBackground. Directly exercises settingsPage device settings methods.
- `suite/e2e/tests/settings/t3b1-device-settings.test.ts` — Uses settingsPage for changeDeviceName, changeDeviceBackground, firmware modal, and wipe flow. Directly tests settingsPage device tab page object.
- `suite/e2e/tests/settings/forget-device.test.ts` — Extensively uses settingsPage device tab methods: deviceForgetButton, deviceForgetConfirmButton, deviceForgetCancelButton, unplugDeviceModal, completeBluetoothForgetFlow, verifyForgetDeviceModal, and coinsTab.enableNetwork.
- `suite/e2e/tests/settings/autodetect.test.ts` — Tests auto-detection of theme and locale, which relies on the settings page's analytics section and heading locators that may be defined via settingsPage interactions.
- `suite/e2e/tests/settings/electrum.test.ts` — Uses settingsPage.navigateTo('coins') and settingsPage.coinsTab methods (changeBackend, openNetworkAdvanceSettings, toggleTestnetNetworks, enableNetwork). Directly exercises coins tab settings.
- `suite/e2e/tests/settings/application-log.test.ts` — Uses settingsPage.navigateTo('application') and the show-log button interaction defined on the settings page. Directly tests settings general/application section.

</details>

<details><summary>🟡 <b>Medium priority (14)</b></summary>

- `suite/e2e/tests/suite/safety-checks-warning.test.ts` — Uses settingsPage.changeSafetyChecksLevel with 'prompt' and 'strict' modes. The safety checks level changing method is defined in settingsPage.ts.
- `suite/e2e/tests/settings/firmware/custom-firmware.test.ts` — Uses settingsPage.deviceTab for custom firmware modal interactions. Changes to settingsPage device tab locators could affect this test.
- `suite/e2e/tests/recovery/dry-run.test.ts` — Uses settingsPage.navigateTo('device') and settingsPage checkSeedButton to initiate the dry run flow. Changes to device tab navigation or button locators would break this test.
- `suite/e2e/tests/recovery/t2t1-dry-run.test.ts` — Uses settingsPage.navigateTo('device') and settingsPage checkSeedButton. Same device tab entry point dependency as dry-run.test.ts.
- `suite/e2e/tests/recovery/t1b1-dry-run.test.ts` — Uses settingsPage device settings page and checkSeedButton to initiate T1B1 dry run recovery. Depends on settingsPage device tab methods.
- `suite/e2e/tests/general/eap-modal.test.ts` — Navigates to Settings > Application page and interacts with earlyAccessJoinButton and joinEarlyAccessProgram — settings page methods for the EAP feature.
- `suite/e2e/tests/analytics/toggle.test.ts` — Uses settingsPage to navigate to application settings and interact with the analytics toggle. The settings page analytics section locators are part of settingsPage.ts.
- `suite/e2e/tests/metadata/legacy/metadata-lifecycle.test.ts` — Uses settingsPage application settings for metadata/labeling toggle (metadataSelectInput dropdown). Changes to settings page metadata UI methods would affect this test.
- `suite/e2e/tests/metadata/legacy/switching-providers.test.ts` — Uses settingsPage application section for metadata disconnect/connect provider buttons. Settings page metadata provider interactions are defined in settingsPage.ts.
- `suite/e2e/tests/metadata/legacy/remembered-device.test.ts` — Uses settingsPage for metadata toggle, disconnect-provider-button, and connect-provider-button interactions in application settings. Depends on settingsPage metadata UI methods.
- `suite/e2e/tests/suite/db-locale-migration.test.ts` — Uses settingsPage language selection (Language enum, languageMap, language-select input) to change language. Changes to settingsPage language methods could break this test.
- `suite/e2e/tests/dashboard/assets.test.ts` — Uses settingsPage.changeNetworks to enable BTC. While changeNetworks is a commonly used method, this test relies on it as a setup step and any breaking change would cause failure.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Navigates to Settings > Connect page (@settings/connect-apps) to manage TrezorConnect app permissions. Uses settingsPage for connect tab navigation.
- `suite/e2e/tests/backup/t3t1-t2t1-create-additional-share.test.ts` — Uses settingsPage.navigateTo('device') and settingsPage.deviceTab methods (createMultiShareBackupButton, proceedMultiShareBackupModal, multiShareBackupGotItButton) for multi-share backup.

</details>

_Updated: 2026-06-01T09:00:17.952Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-nightly&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-nightly&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-01T09:14:08.895Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-01T09:11:40.238Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-e2e-nightly/web/](https://dev.suite.sldev.cz/suite-web/fix-e2e-nightly/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->