### PR TITLE
refactor(e2e): Refactored check links test to more separate tests

### DIFF
--- a/suite/e2e/tests/general/check-links.test.ts
+++ b/suite/e2e/tests/general/check-links.test.ts
@@ -6,12 +6,18 @@ import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
 import { expect, test } from '../../support/fixtures';
 import { createTestAnnotation } from '../../support/reporters/annotations';
 
+const IGNORED_PATTERNS = [
+    'github.com/trezor/trezor-suite/releases/tag',
+    'apps.apple.com/app/id1631884497',
+];
+
 async function getAllLinksFromAllPages(
     page: Page,
     testInfo: TestInfo,
     paths: Array<string>,
-): Promise<Set<string>> {
-    const allValidHrefs = new Set<string>();
+    filter: (url: string) => boolean,
+): Promise<string[]> {
+    const matchingLinks: string[] = [];
 
     for (const path of paths) {
         await test.step(`Get the links from ${path}`, async () => {
@@ -46,8 +52,11 @@ async function getAllLinksFromAllPages(
 
             for (const link of allHrefs) {
                 if (link) {
-                    // Normalize the links.
-                    allValidHrefs.add(new URL(link, page.url()).href);
+                    const url = new URL(link, page.url()).href;
+
+                    if (!IGNORED_PATTERNS.some(pattern => url.includes(pattern)) && filter(url)) {
+                        matchingLinks.push(url);
+                    }
                 } else {
                     testInfo.annotations.push({
                         type: 'Not Link',
@@ -58,7 +67,7 @@ async function getAllLinksFromAllPages(
         });
     }
 
-    return allValidHrefs;
+    return Array.from(new Set(matchingLinks));
 }
 
 async function fetchWithRetry(page: Page, url: string, maxRetries = 3) {
@@ -78,98 +87,128 @@ async function fetchWithRetry(page: Page, url: string, maxRetries = 3) {
     return response;
 }
 
+async function checkLinks(page: Page, urls: string[]) {
+    const chunkSize = 20;
+
+    // Implement batching to prevent network flooding and false failures or timeouts.
+    for (let i = 0; i < urls.length; i += chunkSize) {
+        const chunk = urls.slice(i, i + chunkSize);
+
+        await Promise.all(
+            chunk.map(async url => {
+                await test.step(`Checking link: ${url}`, async () => {
+                    const response = await fetchWithRetry(page, url);
+
+                    expect
+                        .soft(
+                            response.ok(),
+                            `${url} failed: HTTP Status ${response.status()} ${response.statusText()}`,
+                        )
+                        .toBeTruthy();
+                });
+            }),
+        );
+    }
+}
+
+const SECTIONS = {
+    general: [
+        '/',
+        '/notifications',
+        '/version',
+        '/bridge',
+        '/bridge-requested',
+        '/bridge-deprecated',
+        '/connect-popup',
+        '/udev',
+        '/switch-device',
+        '/password-manager',
+        '/coinmarket-redirect',
+    ],
+    onboarding: [
+        '/start',
+        '/onboarding',
+        '/recovery',
+        '/backup',
+        '/firmware',
+        '/firmware-type',
+        '/firmware-custom',
+        '/create-multi-share-backup',
+    ],
+    settings: [
+        '/settings',
+        '/settings/debug',
+        '/settings/device',
+        '/settings/coins',
+        '/settings/connected-apps',
+    ],
+    wallet: [
+        '/accounts',
+        '/accounts/send',
+        '/accounts/receive',
+        '/accounts/staking',
+        '/accounts/sign-verify',
+        '/accounts/details',
+        '/accounts/anonymize',
+        '/accounts/tokens',
+        '/accounts/tokens/hidden',
+        '/accounts/tokens/inactive',
+        '/accounts/tokens/defi',
+        '/accounts/nfts',
+        '/accounts/nfts/hidden',
+    ],
+    trading: [
+        '/accounts/coinmarket/buy',
+        '/accounts/coinmarket/exchange',
+        '/accounts/coinmarket/sell',
+        '/accounts/coinmarket/concierge',
+        '/accounts/coinmarket/transactions',
+    ],
+    earn: ['/earn', '/earn/yield/deposit', '/earn/yield/withdraw', '/earn/yield/claim'],
+} as const satisfies Record<string, string[]>;
+
+const allPaths = routes
+    .map(route => route.pattern)
+    .filter(pattern => pattern.split('/').filter(Boolean).length < 4);
+
+const coveredPaths = new Set<string>(Object.values(SECTIONS).flat());
+
+test('All routes are covered by SECTIONS', { tag: ['@webOnly', '@noDevice'] }, () => {
+    const uncovered = allPaths.filter(path => !coveredPaths.has(path));
+
+    expect(uncovered, `Routes not assigned to any section: ${uncovered.join(', ')}`).toHaveLength(
+        0,
+    );
+});
+
 test.describe('Check Links', { tag: ['@webOnly', '@nightlyOnly', '@T3T1'] }, () => {
     test.use({
         ignoreJSExceptions: ['Aborted by signal', 'Failed to fetch'],
     });
-    test.beforeEach(async ({ onboardingPage, settingsPage }) => {
-        await onboardingPage.completeOnboarding();
-        await settingsPage.changeNetworks({ enableNetworks: ['btc'] });
-    });
 
-    test(
-        'No 404s allowed',
-        {
-            annotation: createTestAnnotation({
-                testCase: 'Verify that each link is OK',
-                category: TestCategory.NotCategorized,
-                priority: TestPriority.Low,
-                stream: TestStream.Foundation,
-            }),
-        },
-        async ({ page }, testInfo) => {
-            let allUrls = new Set<string>();
+    for (const [section, paths] of Object.entries(SECTIONS) as [
+        keyof typeof SECTIONS,
+        string[],
+    ][]) {
+        test(
+            `${section} links return 200`,
+            {
+                annotation: createTestAnnotation({
+                    testCase: `Verify that all links in the ${section} section are OK`,
+                    category: TestCategory.NotCategorized,
+                    priority: TestPriority.Low,
+                    stream: TestStream.Foundation,
+                }),
+            },
+            async ({ page, onboardingPage, settingsPage }, testInfo) => {
+                test.slow();
 
-            const urlsToCheck: string[] = [];
-            // Test is slow due to opening the pages for all known routes.
-            // The standard timeout must be extended to ensure test completion.
-            test.slow();
+                await onboardingPage.completeOnboarding();
+                await settingsPage.changeNetworks({ enableNetworks: ['btc'] });
+                const links = await getAllLinksFromAllPages(page, testInfo, paths, () => true);
 
-            await test.step('Get all links from all routes', async () => {
-                // Create an array of all routes except those containing 4 segments
-                // to keep the list a bit shorter, and reduce execution time.
-                const allPaths = routes
-                    .map(route => route.pattern)
-                    .filter(pattern => {
-                        const segments = pattern.split('/').filter(segment => !!segment);
-
-                        return segments.length < 4;
-                    });
-
-                // After onboarding, the URL is cleared to the base domain by the application's routing logic.
-                // We need to navigate back to the correct base URL for the test environment.
-                allUrls = await getAllLinksFromAllPages(page, testInfo, allPaths);
-            });
-
-            await test.step('Filter known broken links', () => {
-                // Define patterns for known broken links here.
-                const ignoredPatterns: string[] = [
-                    'github.com/trezor/trezor-suite/releases/tag',
-                    'apps.apple.com/app/id1631884497',
-                ];
-                const knownBrokenLinks: string[] = [];
-
-                for (const url of allUrls) {
-                    const ignoredUrl = ignoredPatterns.some(pattern => url.includes(pattern));
-
-                    if (ignoredUrl) {
-                        knownBrokenLinks.push(url);
-                    } else {
-                        urlsToCheck.push(url);
-                    }
-                }
-
-                if (knownBrokenLinks.length > 0) {
-                    testInfo.annotations.push({
-                        type: 'Warning: Known Broken Links',
-                        description: `\nThe following links returned non-200 status codes but are known issues:\n${knownBrokenLinks.join('\n')}`,
-                    });
-                }
-            });
-
-            await test.step(`Check ${urlsToCheck.length} valid links`, async () => {
-                const chunkSize = 20;
-
-                // Implement batching to prevent network flooding and false failures or timeouts.
-                for (let i = 0; i < urlsToCheck.length; i += chunkSize) {
-                    const chunk = urlsToCheck.slice(i, i + chunkSize);
-
-                    await Promise.all(
-                        chunk.map(async url => {
-                            await test.step(`Checking link: ${url}`, async () => {
-                                const response = await fetchWithRetry(page, url);
-
-                                expect
-                                    .soft(
-                                        response.ok(),
-                                        `${url} failed: HTTP Status ${response.status()} ${response.statusText()}`,
-                                    )
-                                    .toBeTruthy();
-                            });
-                        }),
-                    );
-                }
-            });
-        },
-    );
+                await checkLinks(page, links);
+            },
+        );
+    }
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is the check-links E2E test itself. This is a self-contained change with no impact on other tests or application source code. The risk is limited to this single test breaking or behaving differently. Running just this one test provides full confidence.

<details><summary><b>Changed files (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts`

</details>

**Recommended tests (1)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — The changed file IS this test. Any modification to check-links.test.ts directly affects this test's behavior, assertions, and execution. It must be run to validate the changes.

</details>

_Updated: 2026-06-01T09:01:24.265Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-refactor-check-links&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-refactor-check-links&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-01T17:53:58.963Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-01T09:05:19.650Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-e2e-refactor-check-links/web/](https://dev.suite.sldev.cz/suite-web/fix-e2e-refactor-check-links/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->