### PR TITLE
feat(suite-native): yield earn promo routing

### DIFF
--- a/suite-native/app/src/navigation/RootStackNavigator.tsx
+++ b/suite-native/app/src/navigation/RootStackNavigator.tsx
@@ -39,6 +39,7 @@ import {
     StakingManagementScreen,
     UnstakeFlowScreen,
     UnstakeTransactionDataReviewScreen,
+    YieldInsufficientBalanceScreen,
     YieldStackNavigator,
 } from '@suite-native/module-earn';
 import { FeatureFeedbackModalScreen } from '@suite-native/module-home';
@@ -152,6 +153,11 @@ export const RootStackNavigator = () => {
                 options={{ title: RootStackRoutes.YieldNavigator }}
                 name={RootStackRoutes.YieldNavigator}
                 component={YieldStackNavigator}
+            />
+            <RootStack.Screen
+                options={{ title: RootStackRoutes.YieldInsufficientBalance }}
+                name={RootStackRoutes.YieldInsufficientBalance}
+                component={YieldInsufficientBalanceScreen}
             />
             <RootStack.Screen
                 options={{ title: RootStackRoutes.EarnForm }}

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2428,6 +2428,11 @@ export const messages = {
             subtitle: 'The minimum amount to stake is {minAmount} {displaySymbol}.',
             getButton: 'Get more {displaySymbol}',
         },
+        yieldInsufficientBalance: {
+            title: "You don't have enough {tokenSymbol}",
+            subtitle: 'Get more {tokenSymbol} in this account to start earning yield.',
+            getButton: 'Get more {tokenSymbol}',
+        },
         earnConsentsScreen: {
             title: 'Before you continue',
             entryPeriodCard: {

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2370,7 +2370,7 @@ export const messages = {
         poweredBy: 'Powered by',
         portfolioTracker: {
             alert: {
-                title: 'Staking is disabled in the portfolio tracker',
+                title: 'Earn is disabled in the portfolio tracker',
                 description:
                     'Connect your device to enable full functionality or use our desktop app.',
                 copyLabel: 'Tap to copy',
@@ -2568,6 +2568,12 @@ export const messages = {
                 subtitle:
                     'Support the {networkName} network. Lock in your funds and earn staking rewards.',
                 cta: 'Enable {networkName}',
+                stablecoinYield: {
+                    title: 'Enable {networkName} to use Stablecoin Yield',
+                    subtitle:
+                        'Add the {networkName} network to deposit eligible stablecoins and earn yield.',
+                    cta: 'Enable {networkName}',
+                },
             },
             adaInfo: 'Your ADA stays fully accessible while earning rewards.',
         },

--- a/suite-native/module-earn/src/components/EarnInsufficientBalanceContent.tsx
+++ b/suite-native/module-earn/src/components/EarnInsufficientBalanceContent.tsx
@@ -1,0 +1,67 @@
+import { type ReactNode } from 'react';
+
+import { useNavigation } from '@react-navigation/native';
+
+import { Box, Button, Pictogram, Text, VStack } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+import {
+    AppTabsRoutes,
+    type RootStackParamList,
+    RootStackRoutes,
+    type StackNavigationProps,
+    TradingStackRoutes,
+} from '@suite-native/navigation';
+
+type EarnInsufficientBalanceContentProps = {
+    title: ReactNode;
+    subtitle: ReactNode;
+    primaryButtonContent: ReactNode;
+};
+
+type NavigationProp = StackNavigationProps<RootStackParamList, RootStackRoutes>;
+
+export const EarnInsufficientBalanceContent = ({
+    title,
+    subtitle,
+    primaryButtonContent,
+}: EarnInsufficientBalanceContentProps) => {
+    const navigation = useNavigation<NavigationProp>();
+
+    const handleGetCoin = () => {
+        navigation.navigate(RootStackRoutes.AppTabs, {
+            screen: AppTabsRoutes.TradeStack,
+            params: {
+                screen: TradingStackRoutes.Trading,
+                params: { tradingType: 'exchange' },
+            },
+        });
+    };
+
+    const handleCancel = () => {
+        navigation.goBack();
+    };
+
+    return (
+        <VStack flex={1} justifyContent="space-between">
+            <Box flex={1} justifyContent="center" alignItems="center">
+                <VStack spacing="sp24" alignItems="center">
+                    <Pictogram variant="success" icon="coinSlash" />
+                    <VStack spacing="sp12" alignItems="center">
+                        <Text variant="headline-md" textAlign="center">
+                            {title}
+                        </Text>
+                        <Text variant="body-md" color="contentSecondary" textAlign="center">
+                            {subtitle}
+                        </Text>
+                    </VStack>
+                </VStack>
+            </Box>
+            <VStack spacing="sp12">
+                <Button onPress={handleGetCoin}>{primaryButtonContent}</Button>
+                <Button intent="neutral" priority="secondary" onPress={handleCancel}>
+                    <Translation id="generic.buttons.cancel" />
+                </Button>
+            </VStack>
+        </VStack>
+    );
+};

--- a/suite-native/module-earn/src/components/EnableNetworkForEarnBottomSheet.tsx
+++ b/suite-native/module-earn/src/components/EnableNetworkForEarnBottomSheet.tsx
@@ -10,11 +10,13 @@ import { CryptoIcon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
+import { type EarnType } from './EarnItemInfoModal';
 import { StakingPromoRingIcon } from './StakingPromoRingIcon';
 
-type EnableNetworkForStakingBottomSheetProps = {
+type EnableNetworkForEarnBottomSheetProps = {
     ref: BottomSheetModalRef;
     symbol: NetworkSymbol | null;
+    type?: EarnType;
     onEnablePress: () => void;
     onDismiss?: () => void;
 };
@@ -24,15 +26,30 @@ const buttonContainerStyle = prepareNativeStyle(utils => ({
     marginTop: utils.spacings.sp24,
 }));
 
-export const EnableNetworkForStakingBottomSheet = ({
+const translationIdByEarnType = {
+    staking: {
+        title: 'earn.earnScreen.enableNetworkModal.title',
+        subtitle: 'earn.earnScreen.enableNetworkModal.subtitle',
+        cta: 'earn.earnScreen.enableNetworkModal.cta',
+    },
+    'stablecoin-yield': {
+        title: 'earn.earnScreen.enableNetworkModal.stablecoinYield.title',
+        subtitle: 'earn.earnScreen.enableNetworkModal.stablecoinYield.subtitle',
+        cta: 'earn.earnScreen.enableNetworkModal.stablecoinYield.cta',
+    },
+} as const;
+
+export const EnableNetworkForEarnBottomSheet = ({
     ref,
     symbol,
+    type = 'staking',
     onEnablePress,
     onDismiss,
-}: EnableNetworkForStakingBottomSheetProps) => {
+}: EnableNetworkForEarnBottomSheetProps) => {
     const { applyStyle } = useNativeStyles();
 
     const networkName = symbol ? getNetwork(symbol).name : '';
+    const translationIds = translationIdByEarnType[type];
 
     return (
         <BottomSheetModal ref={ref} onDismiss={onDismiss}>
@@ -43,26 +60,15 @@ export const EnableNetworkForStakingBottomSheet = ({
                     </StakingPromoRingIcon>
                     <TitleHeader
                         titleVariant="headline-sm"
-                        title={
-                            <Translation
-                                id="earn.earnScreen.enableNetworkModal.title"
-                                values={{ networkName }}
-                            />
-                        }
+                        title={<Translation id={translationIds.title} values={{ networkName }} />}
                         subtitle={
-                            <Translation
-                                id="earn.earnScreen.enableNetworkModal.subtitle"
-                                values={{ networkName }}
-                            />
+                            <Translation id={translationIds.subtitle} values={{ networkName }} />
                         }
                         textAlign="center"
                     />
                     <Box style={applyStyle(buttonContainerStyle)}>
                         <Button onPress={onEnablePress}>
-                            <Translation
-                                id="earn.earnScreen.enableNetworkModal.cta"
-                                values={{ networkName }}
-                            />
+                            <Translation id={translationIds.cta} values={{ networkName }} />
                         </Button>
                     </Box>
                 </Box>

--- a/suite-native/module-earn/src/hooks/__tests__/useEarnDepositsCardData.test.tsx
+++ b/suite-native/module-earn/src/hooks/__tests__/useEarnDepositsCardData.test.tsx
@@ -20,7 +20,8 @@ jest.mock('@suite-native/intl', () => ({
 const mockUseSelector = jest.mocked(useSelector);
 const mockUseTranslate = jest.mocked(useTranslate);
 
-const testContractAddress = 'test-contract-address' as TokenAddress;
+const testUnderlyingTokenContract = 'test-underlying-token-contract' as TokenAddress;
+const testReceiptTokenContract = 'test-receipt-token-contract' as TokenAddress;
 const testTokenSymbol = 'USDC' as TokenSymbol;
 
 const stakingActiveItem: StakingEarnItem = {
@@ -62,11 +63,14 @@ const invalidStakingActiveItem: StakingEarnItem = {
 const stablecoinYieldActiveItem: StablecoinYieldEarnItem = {
     id: 'steakhouse-usdc',
     type: 'stablecoin-yield',
+    yieldId: 'steakhouse-usdc',
     vaultName: 'Steakhouse USDC Vault',
     tokenSymbol: testTokenSymbol,
     networkSymbol: 'eth',
-    contractAddress: testContractAddress,
-    tokenContractAddress: testContractAddress,
+    underlyingTokenContract: testUnderlyingTokenContract,
+    receiptTokenContract: testReceiptTokenContract,
+    contractAddress: testReceiptTokenContract,
+    tokenContractAddress: testUnderlyingTokenContract,
     accountKey: 'usdc-account' as AccountKey,
     accountLabel: 'Ethereum #3',
     tokenBalance: '400',
@@ -76,11 +80,14 @@ const stablecoinYieldActiveItem: StablecoinYieldEarnItem = {
 const secondStablecoinYieldActiveItem: StablecoinYieldEarnItem = {
     id: 'moonwell-usdc',
     type: 'stablecoin-yield',
+    yieldId: 'moonwell-usdc',
     vaultName: 'Moonwell USDC Vault',
     tokenSymbol: testTokenSymbol,
     networkSymbol: 'base',
-    contractAddress: testContractAddress,
-    tokenContractAddress: testContractAddress,
+    underlyingTokenContract: testUnderlyingTokenContract,
+    receiptTokenContract: testReceiptTokenContract,
+    contractAddress: testReceiptTokenContract,
+    tokenContractAddress: testUnderlyingTokenContract,
     accountKey: 'usdc-account-2' as AccountKey,
     accountLabel: 'Base Ethereum #1',
     tokenBalance: '600',
@@ -90,11 +97,14 @@ const secondStablecoinYieldActiveItem: StablecoinYieldEarnItem = {
 const invalidStablecoinYieldActiveItem: StablecoinYieldEarnItem = {
     id: 'invalid-steakhouse-usdc',
     type: 'stablecoin-yield',
+    yieldId: 'invalid-steakhouse-usdc',
     vaultName: 'Invalid Steakhouse USDC Vault',
     tokenSymbol: testTokenSymbol,
     networkSymbol: 'eth',
-    contractAddress: testContractAddress,
-    tokenContractAddress: testContractAddress,
+    underlyingTokenContract: testUnderlyingTokenContract,
+    receiptTokenContract: testReceiptTokenContract,
+    contractAddress: testReceiptTokenContract,
+    tokenContractAddress: testUnderlyingTokenContract,
     accountKey: null,
     accountLabel: 'Ethereum invalid',
     tokenBalance: '400',
@@ -168,8 +178,8 @@ describe('useEarnDepositsCardData', () => {
             title: 'Steakhouse USDC Vault',
             networkSymbol: 'eth',
             tokenSymbol: 'USDC',
-            contractAddress: testContractAddress,
-            tokenContractAddress: testContractAddress,
+            contractAddress: testReceiptTokenContract,
+            tokenContractAddress: testUnderlyingTokenContract,
             accountKey: 'usdc-account',
             accountLabel: 'Ethereum #3',
             balance: '400',

--- a/suite-native/module-earn/src/hooks/useStablecoinYieldListData.ts
+++ b/suite-native/module-earn/src/hooks/useStablecoinYieldListData.ts
@@ -69,8 +69,11 @@ export const useStablecoinYieldListData = () => {
                 ? Number((vault.rewardRate.total * 100).toFixed(2))
                 : null;
 
-            const tokenContractAddress = toTokenAddress(vault.token.address);
-            const outputTokenAddress = vault.outputToken?.address?.toLowerCase();
+            const underlyingTokenContract = toTokenAddress(vault.token.address);
+            const receiptTokenContract = vault.outputToken?.address
+                ? toTokenAddress(vault.outputToken.address)
+                : null;
+            const outputTokenAddress = receiptTokenContract?.toLowerCase();
 
             const accountsWithPosition = outputTokenAddress
                 ? accounts.filter(account => {
@@ -87,11 +90,14 @@ export const useStablecoinYieldListData = () => {
             const defaultYieldItem: StablecoinYieldEarnItem = {
                 id: vault.id,
                 type: 'stablecoin-yield',
+                yieldId: vault.id,
                 vaultName: vault.outputToken?.name ?? '',
                 tokenSymbol: stablecoinSymbol,
                 networkSymbol: network.symbol,
-                contractAddress: tokenContractAddress,
-                tokenContractAddress,
+                underlyingTokenContract,
+                receiptTokenContract,
+                contractAddress: underlyingTokenContract,
+                tokenContractAddress: underlyingTokenContract,
                 accountKey: null,
                 accountLabel: undefined,
                 tokenBalance: null,

--- a/suite-native/module-earn/src/hooks/useStablecoinYieldPromoNavigation.ts
+++ b/suite-native/module-earn/src/hooks/useStablecoinYieldPromoNavigation.ts
@@ -1,0 +1,164 @@
+import { useCallback, useState } from 'react';
+import { useSelector } from 'react-redux';
+
+import { useNavigation } from '@react-navigation/native';
+
+import { selectIsDeviceInViewOnlyMode } from '@suite-common/device';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { selectVisibleDeviceAccounts } from '@suite-common/wallet-core';
+import { type Account } from '@suite-common/wallet-types';
+import { useAccountAlerts } from '@suite-native/accounts';
+import { type BottomSheetModalRef, useBottomSheetModal } from '@suite-native/atoms';
+import {
+    AddCoinAccountStackRoutes,
+    type RootStackParamList,
+    RootStackRoutes,
+    type StackNavigationProps,
+} from '@suite-native/navigation';
+
+import { useEarnPortfolioTrackerGuard } from '../components/EarnPortfolioTrackerGuard';
+import { type StablecoinYieldPromoNavigationItem } from '../types';
+import { navigateByYieldAccountState } from '../utils/navigateByYieldAccountState';
+
+type UseStablecoinYieldPromoNavigationReturn = {
+    handleStablecoinYieldPromoPress: (item: StablecoinYieldPromoNavigationItem) => void;
+    handleAccountSelected: (account: Account) => void;
+    handleChooseAccountDismiss: () => void;
+    handleEnableNetworkPress: () => void;
+    handleEnableNetworkDismiss: () => void;
+    chosenAccounts: Account[];
+    pendingEnableSymbol: NetworkSymbol | null;
+    chooseAccountSheetRef: BottomSheetModalRef;
+    enableNetworkSheetRef: BottomSheetModalRef;
+    closeChooseAccountModal: () => void;
+};
+
+export const useStablecoinYieldPromoNavigation = (): UseStablecoinYieldPromoNavigationReturn => {
+    const navigation =
+        useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes.YieldNavigator>>();
+    const accounts = useSelector(selectVisibleDeviceAccounts);
+    const isDeviceInViewOnlyMode = useSelector(selectIsDeviceInViewOnlyMode);
+    const { showViewOnlyAddAccountAlert } = useAccountAlerts();
+    const { isPortfolioTrackerDevice, openPortfolioTrackerSheet } = useEarnPortfolioTrackerGuard();
+
+    const {
+        bottomSheetRef: chooseAccountSheetRef,
+        openModal: openChooseAccountModal,
+        closeModal: closeChooseAccountModal,
+    } = useBottomSheetModal();
+
+    const {
+        bottomSheetRef: enableNetworkSheetRef,
+        openModal: openEnableNetworkModal,
+        closeModal: closeEnableNetworkModal,
+    } = useBottomSheetModal();
+
+    const [chosenAccounts, setChosenAccounts] = useState<Account[]>([]);
+    const [chosenYieldItem, setChosenYieldItem] =
+        useState<StablecoinYieldPromoNavigationItem | null>(null);
+    const [pendingEnableSymbol, setPendingEnableSymbol] = useState<NetworkSymbol | null>(null);
+
+    const handleChooseAccountDismiss = useCallback(() => {
+        setChosenAccounts([]);
+        setChosenYieldItem(null);
+    }, []);
+
+    const handleAccountSelected = useCallback(
+        (account: Account) => {
+            if (!chosenYieldItem) {
+                return;
+            }
+
+            closeChooseAccountModal();
+            navigateByYieldAccountState(account, chosenYieldItem, navigation.navigate);
+            setChosenAccounts([]);
+            setChosenYieldItem(null);
+        },
+        [chosenYieldItem, closeChooseAccountModal, navigation.navigate],
+    );
+
+    const handleEnableNetworkPress = useCallback(() => {
+        if (!pendingEnableSymbol) {
+            return;
+        }
+
+        closeEnableNetworkModal();
+
+        if (isDeviceInViewOnlyMode) {
+            showViewOnlyAddAccountAlert();
+
+            return;
+        }
+
+        navigation.navigate(RootStackRoutes.AddCoinAccountStack, {
+            screen: AddCoinAccountStackRoutes.AddCoinDiscoveryRunning,
+            params: {
+                networkSymbol: pendingEnableSymbol,
+                flowType: 'earn',
+            },
+        });
+    }, [
+        pendingEnableSymbol,
+        closeEnableNetworkModal,
+        isDeviceInViewOnlyMode,
+        showViewOnlyAddAccountAlert,
+        navigation,
+    ]);
+
+    const handleEnableNetworkDismiss = useCallback(() => {
+        setPendingEnableSymbol(null);
+    }, []);
+
+    const handleStablecoinYieldPromoPress = useCallback(
+        (item: StablecoinYieldPromoNavigationItem) => {
+            if (isPortfolioTrackerDevice) {
+                openPortfolioTrackerSheet();
+
+                return;
+            }
+
+            const accountsForNetwork = accounts.filter(
+                account => account.symbol === item.networkSymbol,
+            );
+
+            if (accountsForNetwork.length === 0) {
+                setPendingEnableSymbol(item.networkSymbol);
+                openEnableNetworkModal();
+
+                return;
+            }
+
+            const singleAccount = accountsForNetwork[0];
+            if (accountsForNetwork.length === 1 && singleAccount) {
+                navigateByYieldAccountState(singleAccount, item, navigation.navigate);
+
+                return;
+            }
+
+            setChosenAccounts(accountsForNetwork);
+            setChosenYieldItem(item);
+            openChooseAccountModal();
+        },
+        [
+            accounts,
+            isPortfolioTrackerDevice,
+            navigation.navigate,
+            openChooseAccountModal,
+            openEnableNetworkModal,
+            openPortfolioTrackerSheet,
+        ],
+    );
+
+    return {
+        handleStablecoinYieldPromoPress,
+        handleAccountSelected,
+        handleChooseAccountDismiss,
+        handleEnableNetworkPress,
+        handleEnableNetworkDismiss,
+        chosenAccounts,
+        pendingEnableSymbol,
+        chooseAccountSheetRef,
+        enableNetworkSheetRef,
+        closeChooseAccountModal,
+    };
+};

--- a/suite-native/module-earn/src/index.ts
+++ b/suite-native/module-earn/src/index.ts
@@ -1,4 +1,5 @@
 export { StakingInsufficientBalanceScreen } from './screens/StakingInsufficientBalanceScreen';
+export { YieldInsufficientBalanceScreen } from './screens/YieldInsufficientBalanceScreen';
 export { StakingManagementScreen } from './screens/StakingManagementScreen';
 export { EarnTransactionDataReviewScreen } from './screens/EarnTransactionDataReviewScreen';
 export { EarnConsentsScreen } from './screens/EarnConsentsScreen';

--- a/suite-native/module-earn/src/screens/EarnScreen.tsx
+++ b/suite-native/module-earn/src/screens/EarnScreen.tsx
@@ -17,8 +17,10 @@ import { EarnPoweredByProvider } from '../components/EarnPoweredByProvider';
 import { EarnPromoListHeader } from '../components/EarnPromoListHeader';
 import { EarnPromoListRow } from '../components/EarnPromoListRow';
 import { EarnScreenListHeader } from '../components/EarnScreenListHeader';
-import { EnableNetworkForStakingBottomSheet } from '../components/EnableNetworkForStakingBottomSheet';
+import { EnableNetworkForEarnBottomSheet } from '../components/EnableNetworkForEarnBottomSheet';
+import { useStablecoinYieldFlag } from '../hooks/useStablecoinYieldFlag';
 import { useStablecoinYieldListData } from '../hooks/useStablecoinYieldListData';
+import { useStablecoinYieldPromoNavigation } from '../hooks/useStablecoinYieldPromoNavigation';
 import { useStakingListData } from '../hooks/useStakingListData';
 import { useStakingPromoNavigation } from '../hooks/useStakingPromoNavigation';
 import { type EarnPromoItem, type EarnPromoListDataItem } from '../types';
@@ -36,6 +38,7 @@ const EarnScreenContent = () => {
     const { analytics } = useServices(selectNativeAnalyticsDep);
     const { bottomSheetRef: stablecoinYieldBottomSheetRef, openModal: openStablecoinYieldModal } =
         useBottomSheetModal();
+    const isStablecoinYieldEnabled = useStablecoinYieldFlag();
 
     const {
         promoListData: stakingPromoItems,
@@ -48,19 +51,10 @@ const EarnScreenContent = () => {
         isLoading: isYieldLoading,
     } = useStablecoinYieldListData();
 
-    const {
-        handleStakingPromoPress,
-        handleAccountSelected,
-        handleEnableNetworkPress,
-        handleChooseAccountDismiss,
-        handleEnableNetworkDismiss,
-        chosenAccounts,
-        pendingEnableSymbol,
-        infoSheetRef,
-        chooseAccountSheetRef,
-        enableNetworkSheetRef,
-        closeChooseAccountModal,
-    } = useStakingPromoNavigation();
+    const staking = useStakingPromoNavigation();
+    const stablecoinYield = useStablecoinYieldPromoNavigation();
+    const { handleStakingPromoPress } = staking;
+    const { handleStablecoinYieldPromoPress } = stablecoinYield;
 
     const earnListData = useMemo(
         (): EarnPromoListDataItem[] => [...stakingPromoItems, ...stablecoinYieldPromoItems],
@@ -80,7 +74,11 @@ const EarnScreenContent = () => {
                     type: events.earnStablecoinYieldTilePressedEvent.name,
                 });
 
-                openStablecoinYieldModal();
+                if (isStablecoinYieldEnabled) {
+                    handleStablecoinYieldPromoPress(item);
+                } else {
+                    openStablecoinYieldModal();
+                }
 
                 return;
             }
@@ -91,7 +89,13 @@ const EarnScreenContent = () => {
 
             handleStakingPromoPress(item);
         },
-        [analytics, handleStakingPromoPress, openStablecoinYieldModal],
+        [
+            analytics,
+            handleStablecoinYieldPromoPress,
+            handleStakingPromoPress,
+            isStablecoinYieldEnabled,
+            openStablecoinYieldModal,
+        ],
     );
 
     const renderItem = useCallback(
@@ -147,20 +151,34 @@ const EarnScreenContent = () => {
                     renderItem={renderItem}
                 />
 
-                <EarnItemInfoModal ref={infoSheetRef} type="staking" />
+                <EarnItemInfoModal ref={staking.infoSheetRef} type="staking" />
                 <EarnItemInfoModal ref={stablecoinYieldBottomSheetRef} type="stablecoin-yield" />
                 <ChooseStakingAccountBottomSheet
-                    ref={chooseAccountSheetRef}
-                    accounts={chosenAccounts}
-                    onAccountSelected={handleAccountSelected}
-                    onClose={closeChooseAccountModal}
-                    onDismiss={handleChooseAccountDismiss}
+                    ref={staking.chooseAccountSheetRef}
+                    accounts={staking.chosenAccounts}
+                    onAccountSelected={staking.handleAccountSelected}
+                    onClose={staking.closeChooseAccountModal}
+                    onDismiss={staking.handleChooseAccountDismiss}
                 />
-                <EnableNetworkForStakingBottomSheet
-                    ref={enableNetworkSheetRef}
-                    symbol={pendingEnableSymbol}
-                    onEnablePress={handleEnableNetworkPress}
-                    onDismiss={handleEnableNetworkDismiss}
+                <EnableNetworkForEarnBottomSheet
+                    ref={staking.enableNetworkSheetRef}
+                    symbol={staking.pendingEnableSymbol}
+                    onEnablePress={staking.handleEnableNetworkPress}
+                    onDismiss={staking.handleEnableNetworkDismiss}
+                />
+                <ChooseStakingAccountBottomSheet
+                    ref={stablecoinYield.chooseAccountSheetRef}
+                    accounts={stablecoinYield.chosenAccounts}
+                    onAccountSelected={stablecoinYield.handleAccountSelected}
+                    onClose={stablecoinYield.closeChooseAccountModal}
+                    onDismiss={stablecoinYield.handleChooseAccountDismiss}
+                />
+                <EnableNetworkForEarnBottomSheet
+                    ref={stablecoinYield.enableNetworkSheetRef}
+                    symbol={stablecoinYield.pendingEnableSymbol}
+                    type="stablecoin-yield"
+                    onEnablePress={stablecoinYield.handleEnableNetworkPress}
+                    onDismiss={stablecoinYield.handleEnableNetworkDismiss}
                 />
             </VStack>
         </Screen>

--- a/suite-native/module-earn/src/screens/StakingInsufficientBalanceScreen.tsx
+++ b/suite-native/module-earn/src/screens/StakingInsufficientBalanceScreen.tsx
@@ -1,82 +1,48 @@
-import { type RouteProp, useNavigation, useRoute } from '@react-navigation/native';
+import { type RouteProp, useRoute } from '@react-navigation/native';
 
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { getStakingLimitsByNetworkSymbol, parseAccountKey } from '@suite-common/wallet-utils';
-import { Box, Button, Pictogram, Text, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
-    AppTabsRoutes,
     type RootStackParamList,
-    RootStackRoutes,
+    type RootStackRoutes,
     Screen,
     ScreenHeader,
-    type StackNavigationProps,
-    TradingStackRoutes,
 } from '@suite-native/navigation';
 
-type NavigationProp = StackNavigationProps<
-    RootStackParamList,
-    RootStackRoutes.StakingInsufficientBalance
->;
+import { EarnInsufficientBalanceContent } from '../components/EarnInsufficientBalanceContent';
 
 export const StakingInsufficientBalanceScreen = () => {
     const route =
         useRoute<RouteProp<RootStackParamList, RootStackRoutes.StakingInsufficientBalance>>();
-    const navigation = useNavigation<NavigationProp>();
     const { accountKey } = route.params;
     const { networkSymbol } = parseAccountKey(accountKey);
     const displaySymbol = getNetworkDisplaySymbol(networkSymbol);
     const limits = getStakingLimitsByNetworkSymbol(networkSymbol);
     const minAmount = limits?.MIN_AMOUNT_FOR_STAKING?.toString() ?? '0';
 
-    const handleGetCoin = () => {
-        navigation.navigate(RootStackRoutes.AppTabs, {
-            screen: AppTabsRoutes.TradeStack,
-            params: {
-                screen: TradingStackRoutes.Trading,
-                params: { tradingType: 'exchange' },
-            },
-        });
-    };
-
-    const handleCancel = () => {
-        navigation.goBack();
-    };
-
     return (
         <Screen header={<ScreenHeader closeActionType="back" />}>
-            <VStack flex={1} justifyContent="space-between">
-                <Box flex={1} justifyContent="center" alignItems="center">
-                    <VStack spacing="sp24" alignItems="center">
-                        <Pictogram variant="success" icon="coinSlash" />
-                        <VStack spacing="sp12" alignItems="center">
-                            <Text variant="headline-md" textAlign="center">
-                                <Translation
-                                    id="earn.stakingInsufficientBalance.title"
-                                    values={{ displaySymbol }}
-                                />
-                            </Text>
-                            <Text variant="body-md" color="contentSecondary" textAlign="center">
-                                <Translation
-                                    id="earn.stakingInsufficientBalance.subtitle"
-                                    values={{ minAmount, displaySymbol }}
-                                />
-                            </Text>
-                        </VStack>
-                    </VStack>
-                </Box>
-                <VStack spacing="sp12">
-                    <Button onPress={handleGetCoin}>
-                        <Translation
-                            id="earn.stakingInsufficientBalance.getButton"
-                            values={{ displaySymbol }}
-                        />
-                    </Button>
-                    <Button intent="neutral" priority="secondary" onPress={handleCancel}>
-                        <Translation id="generic.buttons.cancel" />
-                    </Button>
-                </VStack>
-            </VStack>
+            <EarnInsufficientBalanceContent
+                title={
+                    <Translation
+                        id="earn.stakingInsufficientBalance.title"
+                        values={{ displaySymbol }}
+                    />
+                }
+                subtitle={
+                    <Translation
+                        id="earn.stakingInsufficientBalance.subtitle"
+                        values={{ minAmount, displaySymbol }}
+                    />
+                }
+                primaryButtonContent={
+                    <Translation
+                        id="earn.stakingInsufficientBalance.getButton"
+                        values={{ displaySymbol }}
+                    />
+                }
+            />
         </Screen>
     );
 };

--- a/suite-native/module-earn/src/screens/YieldInsufficientBalanceScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldInsufficientBalanceScreen.tsx
@@ -1,0 +1,48 @@
+import { type RouteProp, useRoute } from '@react-navigation/native';
+
+import { Translation } from '@suite-native/intl';
+import {
+    type RootStackParamList,
+    type RootStackRoutes,
+    Screen,
+    ScreenHeader,
+} from '@suite-native/navigation';
+
+import { EarnInsufficientBalanceContent } from '../components/EarnInsufficientBalanceContent';
+import { useResolvedYieldFlowData } from '../hooks/useResolvedYieldFlowData';
+
+type RouteProps = RouteProp<RootStackParamList, RootStackRoutes.YieldInsufficientBalance>;
+
+export const YieldInsufficientBalanceScreen = () => {
+    const route = useRoute<RouteProps>();
+    const { resolutionStatus, tokenSymbol } = useResolvedYieldFlowData(route.params);
+
+    if (resolutionStatus !== 'resolved') {
+        return null;
+    }
+
+    return (
+        <Screen header={<ScreenHeader closeActionType="back" />}>
+            <EarnInsufficientBalanceContent
+                title={
+                    <Translation
+                        id="earn.yieldInsufficientBalance.title"
+                        values={{ tokenSymbol }}
+                    />
+                }
+                subtitle={
+                    <Translation
+                        id="earn.yieldInsufficientBalance.subtitle"
+                        values={{ tokenSymbol }}
+                    />
+                }
+                primaryButtonContent={
+                    <Translation
+                        id="earn.yieldInsufficientBalance.getButton"
+                        values={{ tokenSymbol }}
+                    />
+                }
+            />
+        </Screen>
+    );
+};

--- a/suite-native/module-earn/src/types.ts
+++ b/suite-native/module-earn/src/types.ts
@@ -23,9 +23,12 @@ export type StakingEarnItem = {
 export type StablecoinYieldEarnItem = {
     id: string;
     type: 'stablecoin-yield';
+    yieldId: string;
     vaultName: string;
     tokenSymbol: TokenSymbol;
     networkSymbol: NetworkSymbol;
+    underlyingTokenContract: TokenAddress;
+    receiptTokenContract: TokenAddress | null;
     contractAddress: TokenAddress;
     tokenContractAddress: TokenAddress;
     accountKey: AccountKey | null;

--- a/suite-native/module-earn/src/types.ts
+++ b/suite-native/module-earn/src/types.ts
@@ -37,6 +37,14 @@ export type StablecoinYieldEarnItem = {
     apy: number | null;
 };
 
+export type StablecoinYieldNavigationItem = Pick<
+    StablecoinYieldEarnItem,
+    'yieldId' | 'underlyingTokenContract' | 'receiptTokenContract'
+>;
+
+export type StablecoinYieldPromoNavigationItem = StablecoinYieldNavigationItem &
+    Pick<StablecoinYieldEarnItem, 'networkSymbol'>;
+
 export type EarnPromoItem = StakingEarnItem | StablecoinYieldEarnItem;
 
 export type EarnPromoSectionType = EarnPromoItem['type'];

--- a/suite-native/module-earn/src/utils/navigateByYieldAccountState.ts
+++ b/suite-native/module-earn/src/utils/navigateByYieldAccountState.ts
@@ -1,0 +1,75 @@
+import { type Account } from '@suite-common/wallet-types';
+import { getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils';
+import {
+    type RootStackParamList,
+    RootStackRoutes,
+    type StackNavigationProps,
+    YieldStackRoutes,
+} from '@suite-native/navigation';
+import { BigNumber } from '@trezor/utils';
+
+import { type StablecoinYieldNavigationItem } from '../types';
+
+type YieldNavigateFn = StackNavigationProps<
+    RootStackParamList,
+    RootStackRoutes.YieldNavigator
+>['navigate'];
+
+const hasPositiveTokenBalance = (account: Account, tokenContract: string | null) => {
+    if (!tokenContract) {
+        return false;
+    }
+
+    const normalizedContract = getContractAddressForNetworkSymbol(account.symbol, tokenContract);
+
+    return (
+        account.tokens?.some(token => {
+            const normalizedAccountTokenContract = getContractAddressForNetworkSymbol(
+                account.symbol,
+                token.contract,
+            );
+
+            return (
+                normalizedAccountTokenContract === normalizedContract &&
+                new BigNumber(token.balance ?? '0').gt(0)
+            );
+        }) ?? false
+    );
+};
+
+export const navigateByYieldAccountState = (
+    account: Account,
+    item: StablecoinYieldNavigationItem,
+    navigate: YieldNavigateFn,
+) => {
+    const { yieldId, underlyingTokenContract, receiptTokenContract } = item;
+
+    if (receiptTokenContract && hasPositiveTokenBalance(account, receiptTokenContract)) {
+        navigate(RootStackRoutes.AccountDetail, {
+            accountKey: account.key,
+            tokenContract: receiptTokenContract,
+            closeActionType: 'back',
+        });
+
+        return;
+    }
+
+    if (hasPositiveTokenBalance(account, underlyingTokenContract)) {
+        navigate(RootStackRoutes.YieldNavigator, {
+            screen: YieldStackRoutes.HowYieldWorks,
+            params: {
+                accountKey: account.key,
+                tokenContract: underlyingTokenContract,
+                yieldId,
+            },
+        });
+
+        return;
+    }
+
+    navigate(RootStackRoutes.YieldInsufficientBalance, {
+        accountKey: account.key,
+        tokenContract: underlyingTokenContract,
+        yieldId,
+    });
+};

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -91,6 +91,12 @@ export type YieldFlowParams = {
     yieldId?: string;
 };
 
+export type YieldInsufficientBalanceParams = {
+    accountKey: AccountKey;
+    tokenContract: TokenAddress;
+    yieldId: string;
+};
+
 export type YieldDepositApprovalReviewParams = YieldFlowParams & {
     amount: string;
     approvalLimitType: 'per-deposit' | 'unlimited';
@@ -419,6 +425,7 @@ export type RootStackParamList = {
         symbol: NetworkSymbol;
     };
     [RootStackRoutes.YieldNavigator]: NavigatorScreenParams<YieldStackParamList>;
+    [RootStackRoutes.YieldInsufficientBalance]: YieldInsufficientBalanceParams;
     [RootStackRoutes.EarnForm]: {
         accountKey: AccountKey;
     };

--- a/suite-native/navigation/src/routes.ts
+++ b/suite-native/navigation/src/routes.ts
@@ -11,6 +11,7 @@ export enum RootStackRoutes {
     StakingInsufficientBalance = 'StakingInsufficientBalance',
     HowStakeWorksScreen = 'HowStakeWorksScreen',
     YieldNavigator = 'YieldNavigator',
+    YieldInsufficientBalance = 'YieldInsufficientBalance',
     EarnForm = 'EarnForm',
     EarnConsents = 'EarnConsents',
     EarnTransactionDataReview = 'EarnTransactionDataReview',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

add proper routing actions to promo items on Earn page

## Notes for QA

- network is not enabled -> display "enable network" modal
- network is enabled -> open account list :
   - account has deposit -> redirect to token detail
   - account does not have deposit but has sufficient funds -> open deposit flow
   - account does not have deposit and sufficient funds -> open insufficient balance screen

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27940

## Screenshots:

https://github.com/user-attachments/assets/c1a6ab57-4e6f-4ff5-bf5a-d68b96725991


https://github.com/user-attachments/assets/1376c072-1663-41ce-9ed4-cebe5d41a27e


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/yield-earn-routing&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->