### PR TITLE
chore(utxo-lib): int64-buffer → native Buffer BigInt + bump buffer polyfill to 6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,8 @@
         "electron": "41.3.0",
         "@types/node": "22.13.10",
         "bn.js": "5.2.3",
+        "### Force buffer >=6 so the browser polyfill has writeBig(U)Int64LE etc. (5.x lacks them, see suite-build)": "1.0.0",
+        "buffer": "^6.0.3",
         "node-addon-api": "8.5.0",
         "node-gyp": "12.2.0",
         "reselect": "5.1.1",

--- a/packages/suite-build/.depcheckrc.json
+++ b/packages/suite-build/.depcheckrc.json
@@ -1,4 +1,10 @@
 {
     "ignore-patterns": ["libDev", "lib"],
-    "ignores": ["raw-loader", "babel-loader", "babel-plugin-styled-components", "worker-loader"]
+    "ignores": [
+        "raw-loader",
+        "babel-loader",
+        "babel-plugin-styled-components",
+        "worker-loader",
+        "buffer"
+    ]
 }

--- a/packages/suite-build/package.json
+++ b/packages/suite-build/package.json
@@ -30,6 +30,7 @@
         "@trezor/bundler-security": "workspace:*",
         "babel-loader": "^10.1.1",
         "babel-plugin-styled-components": "^2.1.4",
+        "buffer": "^6.0.3",
         "copy-webpack-plugin": "^14.0.0",
         "crypto-browserify": "3.12.1",
         "css-minimizer-webpack-plugin": "^7.0.4",

--- a/packages/utxo-lib/package.json
+++ b/packages/utxo-lib/package.json
@@ -54,7 +54,6 @@
         "@sinclair/typebox": "^0.34.49",
         "@trezor/utils": "workspace:*",
         "cashaddrjs": "0.4.4",
-        "int64-buffer": "^1.1.0",
         "varuint-bitcoin": "2.0.0",
         "wif": "^5.0.0"
     },

--- a/packages/utxo-lib/src/bufferutils.ts
+++ b/packages/utxo-lib/src/bufferutils.ts
@@ -5,7 +5,6 @@
 // - added `BufferWritter` "writeInt64", "writeUInt16" methods.
 // - `BufferWritter.writeUInt64` is accepting string or number.
 
-import { Int64LE } from 'int64-buffer';
 import * as varuint from 'varuint-bitcoin';
 
 import { bufferUtils } from '@trezor/utils';
@@ -67,22 +66,16 @@ export function writeUInt64LEasString(buffer: Buffer, value: string | number, of
     if (typeof value !== 'string') {
         return writeUInt64LE(buffer, value, offset);
     }
-    const v = new Int64LE(value);
-    v.toBuffer().copy(buffer, offset);
 
-    return offset + 8;
+    if (value.trim() === '') {
+        throw new Error('cannot write an empty string as a number');
+    }
+
+    return buffer.writeBigUInt64LE(BigInt(value), offset);
 }
 
 export function writeInt64LE(buffer: Buffer, value: number, offset: number) {
-    const v = new Int64LE(value);
-    const a = v.toArray();
-    for (let i = 0; i < 8; i++) {
-        // @ts-expect-error: indexing with noUncheckedIndexedAccess
-        const byte: number = a[i];
-        buffer.writeUInt8(byte, offset + i);
-    }
-
-    return offset + 8;
+    return buffer.writeBigInt64LE(BigInt(value), offset);
 }
 
 export function readVarInt(buffer: Buffer, offset: number) {

--- a/packages/utxo-lib/tests/bufferutils.test.ts
+++ b/packages/utxo-lib/tests/bufferutils.test.ts
@@ -216,28 +216,18 @@ describe('bufferutils', () => {
             });
         });
 
-        // int64-buffer silently coerces unparseable strings and overflows modulo 2^64
-        // without throwing. These snapshots pin that behavior so a future library swap
-        // (e.g. to viem / @noble) surfaces the change instead of corrupting silently.
-        // FIXME(bigint-migration): silent coercion is a latent bug — once int64-buffer
-        // is replaced, flip these expectations to `toThrow` for invalid inputs.
-        describe('invalid string input (regression guard)', () => {
+        describe('invalid string input', () => {
             [
-                { description: 'non-numeric string', input: 'abc', hex: '0000000000000000' },
-                { description: 'empty string', input: '', hex: '0000000000000000' },
-                {
-                    description: 'overflow > UINT64_MAX',
-                    input: '99999999999999999999',
-                    hex: 'ffff0f632d5ec76b',
-                },
+                { description: 'non-numeric string', input: 'abc' },
+                { description: 'empty string', input: '' },
+                { description: 'overflow > UINT64_MAX', input: '99999999999999999999' },
             ].forEach(f => {
-                it(`writes deterministic bytes for ${f.description}`, () => {
+                it(`throws for ${f.description}`, () => {
                     const buffer = Buffer.alloc(8, 0);
 
-                    const n = bufferutils.writeUInt64LEasString(buffer, f.input, 0);
-
-                    expect(buffer.toString('hex')).toEqual(f.hex);
-                    expect(n).toEqual(8);
+                    expect(() => {
+                        bufferutils.writeUInt64LEasString(buffer, f.input, 0);
+                    }).toThrow();
                 });
             });
         });
@@ -278,39 +268,27 @@ describe('bufferutils', () => {
                 });
             });
 
-        it('overflows for INT64_MIN due to JS number precision loss', () => {
-            // The JS Number literal -9223372036854775808 rounds to -9223372036854776000,
-            // which int64-buffer wraps modulo 2^64 to INT64_MAX. This regression test
-            // pins the current (buggy) behavior so future migrations of int64-buffer
-            // surface the change instead of silently corrupting amounts.
-            // FIXME(bigint-migration): once arithmetic moves to BigInt, expect either
-            // the correct INT64_MIN encoding (0000000000000080) or a thrown range error.
+        it('encodes INT64_MIN correctly', () => {
             const buffer = Buffer.alloc(8, 0);
 
-            bufferutils.writeInt64LE(buffer, -9223372036854775808, 0);
+            const n = bufferutils.writeInt64LE(buffer, -9223372036854775808, 0);
 
-            expect(buffer.toString('hex')).not.toEqual('0000000000000080');
-            expect(buffer.toString('hex')).toEqual('ffffffffffffff7f');
+            expect(buffer.toString('hex')).toEqual('0000000000000080');
+            expect(n).toEqual(8);
         });
 
-        // int64-buffer silently coerces NaN / Infinity to deterministic bytes
-        // without throwing. These snapshots pin that behavior so a future library swap
-        // surfaces the change instead of corrupting silently.
-        // FIXME(bigint-migration): silent coercion is a latent bug — once int64-buffer
-        // is replaced, flip these expectations to `toThrow` for invalid inputs.
-        describe('invalid number input (regression guard)', () => {
+        describe('invalid number input', () => {
             [
-                { description: 'NaN', input: NaN, hex: '0000000000000000' },
-                { description: 'Infinity', input: Infinity, hex: '0000000000000000' },
-                { description: '-Infinity', input: -Infinity, hex: 'ffffffffffffffff' },
+                { description: 'NaN', input: NaN },
+                { description: 'Infinity', input: Infinity },
+                { description: '-Infinity', input: -Infinity },
             ].forEach(f => {
-                it(`writes deterministic bytes for ${f.description}`, () => {
+                it(`throws for ${f.description}`, () => {
                     const buffer = Buffer.alloc(8, 0);
 
-                    const n = bufferutils.writeInt64LE(buffer, f.input, 0);
-
-                    expect(buffer.toString('hex')).toEqual(f.hex);
-                    expect(n).toEqual(8);
+                    expect(() => {
+                        bufferutils.writeInt64LE(buffer, f.input, 0);
+                    }).toThrow();
                 });
             });
         });

--- a/scripts/list-outdated-dependencies/wallet-dependencies.txt
+++ b/scripts/list-outdated-dependencies/wallet-dependencies.txt
@@ -32,7 +32,6 @@ cashaddrjs
 event-target-shim
 golomb
 immer
-int64-buffer
 json-schema-to-typescript
 jws
 minimaldata

--- a/yarn.lock
+++ b/yarn.lock
@@ -16094,6 +16094,7 @@ __metadata:
     "@vitejs/plugin-react": "npm:^6.0.1"
     babel-loader: "npm:^10.1.1"
     babel-plugin-styled-components: "npm:^2.1.4"
+    buffer: "npm:^6.0.3"
     copy-webpack-plugin: "npm:^14.0.0"
     crypto-browserify: "npm:3.12.1"
     css-minimizer-webpack-plugin: "npm:^7.0.4"
@@ -16723,7 +16724,6 @@ __metadata:
     "@trezor/eslint": "workspace:*"
     "@trezor/utils": "workspace:*"
     cashaddrjs: "npm:0.4.4"
-    int64-buffer: "npm:^1.1.0"
     minimaldata: "npm:^1.0.2"
     varuint-bitcoin: "npm:2.0.0"
     wif: "npm:^5.0.0"
@@ -21019,16 +21019,6 @@ __metadata:
   version: 1.0.3
   resolution: "buffer-xor@npm:1.0.3"
   checksum: 10/4a63d48b5117c7eda896d81cd3582d9707329b07c97a14b0ece2edc6e64220ea7ea17c94b295e8c2cb7b9f8291e2b079f9096be8ac14be238420a43e06ec66e2
-  languageName: node
-  linkType: hard
-
-"buffer@npm:5.7.1, buffer@npm:^5.1.0, buffer@npm:^5.4.3, buffer@npm:^5.5.0, buffer@npm:^5.7.1":
-  version: 5.7.1
-  resolution: "buffer@npm:5.7.1"
-  dependencies:
-    base64-js: "npm:^1.3.1"
-    ieee754: "npm:^1.1.13"
-  checksum: 10/997434d3c6e3b39e0be479a80288875f71cd1c07d75a3855e6f08ef848a3c966023f79534e22e415ff3a5112708ce06127277ab20e527146d55c84566405c7c6
   languageName: node
   linkType: hard
 
@@ -29867,7 +29857,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ieee754@npm:1.2.1, ieee754@npm:^1.1.13, ieee754@npm:^1.2.1":
+"ieee754@npm:1.2.1, ieee754@npm:^1.2.1":
   version: 1.2.1
   resolution: "ieee754@npm:1.2.1"
   checksum: 10/d9f2557a59036f16c282aaeb107832dc957a93d73397d89bbad4eb1130560560eb695060145e8e6b3b498b15ab95510226649a0b8f52ae06583575419fe10fc4
@@ -30066,13 +30056,6 @@ __metadata:
     strip-ansi: "npm:^6.0.0"
     through: "npm:^2.3.6"
   checksum: 10/052c6fce2d467343ced6500080b4b70eaf2ca996933fc3b5c9b0dd1ea275dd9c2a1070880f5f163f42bd13acf25c1ab8ab384444c1a413050db34aab69112583
-  languageName: node
-  linkType: hard
-
-"int64-buffer@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "int64-buffer@npm:1.1.0"
-  checksum: 10/00619b84074ae49468b903dc1426c919e0eec38d33b1a85d73e62b1214ea91e66d0fb2785a8a30cde6d7c9326c2a32d2155fcc5c2e1dc09b22733b0d5c8c2078
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
> **Alternative to #27538.** Same goal (drop the unmaintained `int64-buffer` from `@trezor/utxo-lib`, part of #27403), opposite strategy. Pick one, close the other.

## The two options

| | #27538 (DataView) | **this PR (native Buffer)** |
|---|---|---|
| 64-bit writes | `DataView.setBig(U)int64` | `Buffer.writeBig(U)Int64LE` |
| Browser Buffer polyfill | untouched (`buffer@5.x`) | **bumped to `buffer@6.x`** |
| Dependency surface | no dep changes | resolutions + 1 explicit dep |

## Why a polyfill bump is required here

`Buffer.writeBigInt64LE` / `writeBigUInt64LE` are the obvious native replacement for `int64-buffer`, but they were added to the [`buffer`](https://github.com/feross/buffer) package only in **6.0.0**. The Suite Web browser bundle polyfills `Buffer` with **`buffer@5.7.1`** (pulled in via `node-stdlib-browser` → `vite-plugin-node-polyfills`), which lacks those methods. So they work under Node (unit tests are green) but throw `… is not a function` in the browser — which is exactly how the original swap broke BTC transaction signing in Suite Web (caught only by the `trading/sell-bitcoin` + `trading/swap-fees-bitcoin` e2e tests).

This PR fixes that at the root instead of working around it:

- **`chore(deps)`** — force `buffer@^6.0.3` via root `resolutions` so every transitive consumer (incl. `node-stdlib-browser`) resolves to 6.x, and declare `buffer` explicitly in `@trezor/suite-build` next to the other browser polyfills (`crypto-`/`stream-`/`vm-browserify`) so the version Suite Web bundles is pinned there rather than picked up by hoisting.
- **`chore(utxo-lib)`** — `int64-buffer` → native `Buffer.writeBig(U)Int64LE` at the two `bufferutils.ts` callsites.

Bumping the polyfill also closes the whole class of "works in Node, throws in the browser" bugs around Buffer APIs newer than 5.x, not just these two callsites.

## Summary

- `bufferutils.ts`:
  - `writeUInt64LEasString` (string path) → `buffer.writeBigUInt64LE(BigInt(value), offset)`
  - `writeInt64LE` (number path) → `buffer.writeBigInt64LE(BigInt(value), offset)`
- The function names already implied UInt vs Int, but the previous code used `Int64LE` (signed) for both. Native Buffer methods restore that distinction — the unsigned helper now rejects negative / out-of-range inputs instead of silently wrapping.
- `string | number` API on `BufferWriter.writeUInt64` / `writeInt64` is preserved.
- `package.json` (utxo-lib): `int64-buffer` removed.
- `package.json` (root): `buffer` pinned to `^6.0.3` via resolutions.
- `package.json` (suite-build): explicit `buffer@^6.0.3` dependency.
- `scripts/list-outdated-dependencies/wallet-dependencies.txt`: `int64-buffer` entry removed.
- `yarn.lock`: `int64-buffer` dropped, all `buffer` descriptors now resolve to a single `6.0.3`, deduped.

## Test plan

- [ ] CI — utxo-lib `test:unit` (the updated `bufferutils.test.ts` asserts the native methods throw on invalid / out-of-range input; round-trips covered by transaction/coinselect fixtures)
- [ ] CI — Suite Web e2e, specifically `trading/sell-bitcoin` + `trading/swap-fees-bitcoin` (the BTC-signing paths that exposed the polyfill gap) must pass in the real browser bundle now on `buffer@6.x`
- [ ] CI — connect e2e (web) on the bumped polyfill
- [ ] Verify no `buffer@5.x` remains in the resolved tree and that Suite Web / desktop / native builds are unaffected by the 5.x → 6.x bump

## Related

- #27538 — alternative implementation (DataView, no polyfill bump) ← pick one
- #27403 — umbrella issue (modernize `@trezor/utxo-lib` / `@trezor/address-validator` deps)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set modifies `bufferutils.ts` in `@trezor/utxo-lib`, which is a low-level utility for reading/writing binary data in Bitcoin-like transaction serialization. While this file is transitively imported by 121+ E2E tests, the actual risk is concentrated in tests that construct, sign, or parse UTXO-based (Bitcoin/LTC/DOGE) transactions. The package.json changes are likely version bumps or dependency updates with no direct functional impact. The recommended strategy focuses on Bitcoin/UTXO transaction construction tests, with the unit test (`bufferutils.test.ts`) providing the primary safety net for the actual logic change.

<details><summary><b>Changed files (5)</b></summary>

- `package.json`
- `packages/suite-build/package.json`
- `packages/utxo-lib/package.json`
- `packages/utxo-lib/src/bufferutils.ts`
- `packages/utxo-lib/tests/bufferutils.test.ts`

</details>

**Recommended tests (8)**

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test exercises Bitcoin transaction construction on regtest (multiple outputs, locktime, OP_RETURN, satoshi units) which directly uses utxo-lib's buffer utilities for transaction serialization. Changes to bufferutils.ts could affect how transaction data is encoded/decoded.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — This test sends multiple Bitcoin transactions on regtest and verifies pending/confirmed states. Transaction construction relies on utxo-lib buffer serialization, making it a plausible regression target for bufferutils changes.
- `suite/e2e/tests/wallet/send-doge.test.ts` — Tests sending DOGE with amounts exceeding MAX_SAFE_INTEGER, which specifically exercises large number serialization in transaction construction. bufferutils.ts handles reading/writing integers and varints used in UTXO-based transaction encoding.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — Tests sending LTC with a MimbleWimble peg-out output, which exercises UTXO transaction construction. bufferutils changes could affect how LTC transaction inputs/outputs are serialized.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Tests BTC-to-ETH swap with custom fee settings, verifying fee rate and total amount on device. Bitcoin transaction composition uses utxo-lib serialization where bufferutils changes could affect fee/amount calculations.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — The sell BTC flow constructs a Bitcoin transaction for sending to the provider, which relies on utxo-lib for transaction serialization. The device prompt verifies crypto amounts and fee which depend on correct buffer encoding.
- `suite/e2e/tests/wallet/sign-and-verify.test.ts` — Sign and verify for Bitcoin uses utxo-lib for message signing which involves buffer operations for address derivation and signature encoding. A bufferutils regression could produce incorrect signatures.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — Tests BTC regtest balance detection after receiving transactions. Transaction parsing during discovery uses utxo-lib buffer utilities, so a regression could affect balance calculation.

</details>

⚠️ **Changes with no test coverage (4)**
- `package.json`
- `packages/suite-build/package.json`
- `packages/utxo-lib/package.json`
- `packages/utxo-lib/tests/bufferutils.test.ts`

_Updated: 2026-06-01T09:23:46.730Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/issue-27403-int64-native-buffer&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/issue-27403-int64-native-buffer&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-01T09:29:22.890Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-01T09:27:21.268Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/issue-27403-int64-native-buffer/web/](https://dev.suite.sldev.cz/suite-web/mroz22/issue-27403-int64-native-buffer/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->