### PR TITLE
fix(connect): AuthenticateDevice  ts noUncheckedIndexedAccess

### DIFF
--- a/packages/connect/src/api/authenticateDevice.ts
+++ b/packages/connect/src/api/authenticateDevice.ts
@@ -114,8 +114,8 @@ export default class AuthenticateDevice extends AbstractMethod<
 
         // 2. Fetch all certificates and signatures based on sizes received in the first response.
         for (const { name, type, certSizes, sigSize } of proofTypes) {
-            for (let i = 0; i < certSizes.length; i++) {
-                const cert = await getChunk({ proof_type: type, index: i }, certSizes[i]);
+            for (const [i, certSize] of certSizes.entries()) {
+                const cert = await getChunk({ proof_type: type, index: i }, certSize);
                 (authenticityProof[`${name}_certificates`] as string[]).push(cert);
             }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

fix noUncheckedIndexedAccess


<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/auth-device-ts-check/web/](https://dev.suite.sldev.cz/suite-web/fix/auth-device-ts-check/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/auth-device-ts-check&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/auth-device-ts-check&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-01T09:55:33.456Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->