### PR TITLE
fix(e2e): Fixed bridge in db migration tests

### DIFF
--- a/packages/trezor-user-env-link/src/api.ts
+++ b/packages/trezor-user-env-link/src/api.ts
@@ -82,7 +82,7 @@ export interface ReadAndConfirmAtomicShamirMnemonicEmu {
     threshold: number;
 }
 
-type StartBridgeVersion = 'node-bridge';
+type StartBridgeVersion = 'node-bridge' | '2.0.33' | '2.0.32';
 
 export const MNEMONICS = {
     mnemonic_all: 'all all all all all all all all all all all all',

--- a/suite/e2e/tests/suite/db-locale-migration.test.ts
+++ b/suite/e2e/tests/suite/db-locale-migration.test.ts
@@ -1,4 +1,5 @@
 import { TestCategory, TestPriority } from '@trezor/e2e-utils';
+import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
 import { expect, test } from '../../support/fixtures';
 import { Language, languageMap } from '../../support/pageObjects/settings/settingsPage';
@@ -12,6 +13,7 @@ test.describe(
     'Database migration',
     // This test is run only on web nightly builds, it works with web instances of 25.7 and develop branch
     // On PR and release CI run it would provide no value and potentially false failures
+    // Note: Trezor user env doesn't support legacy bridge versions on macOs, which is needed to connect the device to the old Suite version. Use linux or only run in CI.
     { tag: ['@webOnly', '@nightlyOnly', '@T3T1'] },
     () => {
         test.use({
@@ -30,6 +32,8 @@ test.describe(
             },
             async ({ onboardingPage, page }) => {
                 await test.step(`Load suite in old version ${migrateFromVersion}`, async () => {
+                    await TrezorUserEnvLink.stopBridge();
+                    await TrezorUserEnvLink.startBridge('2.0.33');
                     await page.goto(`${suiteDevInstance}/${migrateFromVersion}`);
                     await onboardingPage.disableNecessaryFirmwareChecks();
                     await page.locator('[data-testid="@analytics/toggle-switch"]').click();
@@ -48,6 +52,8 @@ test.describe(
                 });
 
                 await test.step(`Navigate to new version ${migrateToVersion} and check locale status`, async () => {
+                    await TrezorUserEnvLink.stopBridge();
+                    await TrezorUserEnvLink.startBridge();
                     await page.goto(`${suiteDevInstance}/${migrateToVersion}`);
                     await onboardingPage.disableNecessaryFirmwareChecks();
 

--- a/suite/e2e/tests/suite/db-migration.test.ts
+++ b/suite/e2e/tests/suite/db-migration.test.ts
@@ -1,5 +1,6 @@
 import { TestCategory, TestPriority } from '@trezor/e2e-utils';
 import { colorVariants } from '@trezor/theme';
+import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 import { hexToRgba } from '@trezor/utils';
 
 import { expect, test } from '../../support/fixtures';
@@ -16,6 +17,7 @@ test.describe(
     'Database migration',
     // This test is run only on web nightly builds, it works with web instances of 22.5 and develop branch
     // On PR and release CI run it would provide no value and potentially false failures
+    // Note: Trezor user env doesn't support legacy bridge versions on macOs, which is needed to connect the device to the old Suite version. Use linux or only run in CI.
     { tag: ['@webOnly', '@nightlyOnly', '@T3T1'] },
     () => {
         test.use({
@@ -61,6 +63,8 @@ test.describe(
                 );
 
                 await test.step(`Load suite in old version ${migrateFromVersion}`, async () => {
+                    await TrezorUserEnvLink.stopBridge();
+                    await TrezorUserEnvLink.startBridge('2.0.33');
                     await page.goto(`${suiteDevInstance}/${migrateFromVersion}`);
                     await page.locator('[data-test="@onboarding/continue-button"]').click();
                     await page.locator('[data-test="@onboarding/exit-app-button"]').click();
@@ -131,6 +135,8 @@ test.describe(
                 });
 
                 await test.step(`Navigate to new version ${migrateToVersion} and check wallet status`, async () => {
+                    await TrezorUserEnvLink.stopBridge();
+                    await TrezorUserEnvLink.startBridge();
                     await page.goto(`${suiteDevInstance}/${migrateToVersion}`);
                     // PR#26782 No coins activated after onboarding
                     await test.step('Verify "wallet is ready"', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies three files: two test files (db-locale-migration and db-migration) and the trezor-user-env-link API module. The two test files must be run directly as they were changed. The trezor-user-env-link API is a shared utility providing device emulator control and regtest RPC functions used across many E2E tests, but only tests that heavily exercise specific API functions (device interaction, bridge management, regtest mining) are recommended at medium priority. The risk is moderate — test file changes are self-contained, while the API change could have broader impact but is best validated through representative tests covering device control, bridge lifecycle, and regtest operations.

<details><summary><b>Changed files (3)</b></summary>

- `packages/trezor-user-env-link/src/api.ts`
- `suite/e2e/tests/suite/db-locale-migration.test.ts`
- `suite/e2e/tests/suite/db-migration.test.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/suite/db-locale-migration.test.ts` — This test file was directly changed. It must be run to verify the modifications to the database locale migration test itself are correct and pass.
- `suite/e2e/tests/suite/db-migration.test.ts` — This test file was directly changed. It must be run to verify the modifications to the database migration test itself are correct and pass.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-success.test.ts` — trezor-user-env-link/src/api.ts provides the device emulator control API (pressYes, type, selectNumberOfWords, powerOn/powerOff) used heavily in this recovery test. Changes to the API could break device interaction commands during mnemonic entry and recovery flow.
- `suite/e2e/tests/recovery/dry-run.test.ts` — This test uses trezorUserEnv for bridge start/stop and device emulator control (pressYes, type, selectNumberOfWords) during recovery dry runs, plus disconnect/reconnect scenarios that exercise the API's bridge management functions.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — This test directly calls trezorUserEnv.sendToAddressAndMineBlock (from trezor-user-env-link API) to fund regtest accounts and verify balance updates. Changes to the API could break the regtest RPC interaction.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — This test uses trezorUserEnv utilities (sendToAddressAndMineBlock, mineBlocks, generateBlock) from the changed API to create and mine regtest transactions, testing pending-to-confirmed transitions.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — This test uses trezorUserEnv for bridge start/stop operations and emulator control. Changes to the API's bridge management functions could affect the bridge lifecycle assertions in this test.

</details>

_Updated: 2026-06-01T10:56:01.148Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-db-migration&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-db-migration&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-01T13:27:03.485Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-01T10:59:38.146Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-e2e-db-migration/web/](https://dev.suite.sldev.cz/suite-web/fix-e2e-db-migration/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->