### PR TITLE
refactor(address-validator): replace deprecated substr with slice

### DIFF
--- a/packages/address-validator/src/crypto/utils.ts
+++ b/packages/address-validator/src/crypto/utils.ts
@@ -118,7 +118,7 @@ export function sha256x2(hexPayload: string): string {
 }
 
 export function sha256Checksum(hexPayload: string): string {
-    return sha256(sha256(hexPayload)).substr(0, 8);
+    return sha256(sha256(hexPayload)).slice(0, 8);
 }
 
 export function blake256(hexString: string): string {
@@ -126,7 +126,7 @@ export function blake256(hexString: string): string {
 }
 
 export function blake256Checksum(payload: string): string {
-    return blake256(blake256(payload)).substr(0, 8);
+    return blake256(blake256(payload)).slice(0, 8);
 }
 
 export function blake2b(hexString: string, outlen: number): string {
@@ -140,7 +140,7 @@ export function keccak256(hexString: string): string {
 export function keccak256Checksum(payload: string | Buffer | Uint8Array): string {
     return keccak256Fn(payload as any)
         .toString()
-        .substr(0, 8);
+        .slice(0, 8);
 }
 
 export function blake2b256(hexString: string): string {


### PR DESCRIPTION
## Description

Follow-up to a review comment on #27535: https://github.com/trezor/trezor-suite/pull/27535#discussion_r3214817329

`substr()` is legacy/deprecated. This swaps it for `slice(0, 8)` in the checksum helpers of `@trezor/address-validator`. For a non-negative start index, `substr(0, 8)` and `slice(0, 8)` are behaviorally identical, so this is a pure cleanup that removes the deprecated API usage.

Applied to all three checksum helpers that used the pattern for consistency:
- `sha256Checksum` (the one called out in the review)
- `blake256Checksum`
- `keccak256Checksum`

The remaining `substr` usages live in vendored math code (`crypto/biginteger.ts`) and are left untouched.

## Related Issue

Follow-up to #27535

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is in packages/address-validator/src/crypto/utils.ts, a utility file within the address validation package. No static coverage mapping exists for this file, so all recommendations are inferred from LLM analysis of test behaviors. The primary risk is that address validation, formatting, or checksum logic changes could break address display, verification, or input acceptance across multiple coin types. The recommended strategy focuses on tests that directly validate addresses (receive flows, passphrase address verification) across different cryptocurrencies, as these are most likely to exercise the changed crypto utility functions.

<details><summary><b>Changed files (1)</b></summary>

- `packages/address-validator/src/crypto/utils.ts`

</details>

**Recommended tests (6)**

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/wallet/receive.test.ts` — The address-validator/crypto/utils.ts likely contains address validation or formatting utilities. The receive test validates addresses for BTC, ETH, SOL, and TRX against expected regex formats and compares device-displayed addresses with clipboard-captured addresses. Changes to crypto utility functions could affect address validation or formatting in the receive flow.
- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts` — This test verifies Cardano address formatting and validation behind a passphrase wallet, including comparing revealed addresses against expected values. Address validator crypto utils could be involved in Cardano address validation or format checking.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — This test verifies BTC receive addresses for multiple passphrase wallets and checks exact address matches. If crypto/utils.ts is used in address validation during the receive/reveal flow, changes could affect address verification behavior.
- `suite/e2e/tests/wallet/cardano.test.ts` — Tests Cardano account details including address reveal and verification. The address-validator crypto utils may be involved in Cardano-specific address format validation, which this test exercises during the receive flow.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — The send form accepts recipient addresses which likely pass through address validation. Changes to crypto/utils.ts could affect whether addresses are accepted or rejected in the send form input validation.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test exercises both global receive (address reveal/verification for ETH) and global send (BTC address input) flows. Address validation utilities from crypto/utils.ts could be used in either the address display or send address input validation paths.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/address-validator/src/crypto/utils.ts`

_Updated: 2026-06-01T11:34:57.703Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/address-validator-slice&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/address-validator-slice&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-01T15:15:20.188Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-01T13:32:13.405Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/address-validator-slice/web/](https://dev.suite.sldev.cz/suite-web/mroz22/address-validator-slice/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->