### PR TITLE
chore(address-validator): bump crc v3 → v4, import calculators directly

### DIFF
--- a/packages/address-validator/package.json
+++ b/packages/address-validator/package.json
@@ -31,7 +31,7 @@
         "@noble/hashes": "^2.0.1",
         "@scure/base": "^2.0.0",
         "cbor": "^10.0.12",
-        "crc": "^3.8.0"
+        "crc": "^4.3.2"
     },
     "devDependencies": {
         "@trezor/eslint": "workspace:*"

--- a/packages/address-validator/src/ada_validator.ts
+++ b/packages/address-validator/src/ada_validator.ts
@@ -1,6 +1,6 @@
 import { bech32 } from '@scure/base';
 import * as cbor from 'cbor';
-import CRC from 'crc';
+import crc32 from 'crc/calculators/crc32';
 
 import * as base58 from './crypto/base58';
 import { addressType } from './crypto/utils';
@@ -29,7 +29,8 @@ function isValidLegacyAddress(address: string): boolean {
     if (typeof validCrc !== 'number') {
         return false;
     }
-    const crc = CRC.crc32(tagged.value);
+    // crc/calculators/crc32 returns a signed 32-bit int; coerce to unsigned to match the CBOR-decoded checksum
+    const crc = crc32(tagged.value) >>> 0;
 
     return crc === validCrc;
 }

--- a/packages/address-validator/src/stellar_validator.ts
+++ b/packages/address-validator/src/stellar_validator.ts
@@ -1,5 +1,5 @@
 import { utils } from '@scure/base';
-import crc from 'crc';
+import crc16xmodem from 'crc/calculators/crc16xmodem';
 
 import * as cryptoUtils from './crypto/utils';
 import { addressType } from './crypto/utils';
@@ -26,7 +26,7 @@ function verifyChecksum(address: string): boolean {
 
     const payload = bytes.slice(0, -2);
     const checksum = cryptoUtils.toHex(bytes.slice(-2));
-    const computedChecksum = cryptoUtils.numberToHex(swap16(crc.crc16xmodem(payload)), 2);
+    const computedChecksum = cryptoUtils.numberToHex(swap16(crc16xmodem(payload)), 2);
 
     return computedChecksum === checksum;
 }

--- a/packages/address-validator/src/types.d.ts
+++ b/packages/address-validator/src/types.d.ts
@@ -1,1 +1,0 @@
-declare module 'crc';

--- a/yarn.lock
+++ b/yarn.lock
@@ -15296,7 +15296,7 @@ __metadata:
     "@scure/base": "npm:^2.0.0"
     "@trezor/eslint": "workspace:*"
     cbor: "npm:^10.0.12"
-    crc: "npm:^3.8.0"
+    crc: "npm:^4.3.2"
   peerDependencies:
     tslib: ^2.6.2
   languageName: unknown
@@ -22685,6 +22685,18 @@ __metadata:
   dependencies:
     buffer: "npm:^5.1.0"
   checksum: 10/3a43061e692113d60fbaf5e438c5f6aa3374fe2368244a75cc083ecee6762513bcee8583f67c2c56feea0b0c72b41b7304fbd3c1e26cfcfaec310b9a18543fa8
+  languageName: node
+  linkType: hard
+
+"crc@npm:^4.3.2":
+  version: 4.3.2
+  resolution: "crc@npm:4.3.2"
+  peerDependencies:
+    buffer: ">=6.0.3"
+  peerDependenciesMeta:
+    buffer:
+      optional: true
+  checksum: 10/daa5c340de4ccb0d248ad579d1ca1317efe89d2b3f68a124850a140e9afc17d595cdfc058bd14ea78325c0a706ac73ad94962c1efede6a2a1abf58a48ebbb9da
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Final dependency slice of #27403 — modernize `@trezor/address-validator` and `@trezor/utxo-lib` dependencies.

## Why

`crc` v3.8.0 was CommonJS-only and pulled in a [`buffer`](https://www.npmjs.com/package/buffer) polyfill as a **hard dependency**. [`crc` v4](https://www.npmjs.com/package/crc) fixes both concerns:

- ships **dual ESM/CJS** via an `exports` map,
- has **zero runtime dependencies** (`buffer` is now an *optional* peer we never reach), and
- is `sideEffects: false`, so it tree-shakes cleanly.

`@trezor/address-validator` uses just two variants — **CRC16-XModem** (Stellar checksum) and **CRC32** (Cardano Byron legacy address checksum) — so they are imported directly from the per-calculator entry points the package exposes for minimal bundle size.

> An earlier revision of this PR inlined both algorithms. That was reverted: the inline's only justification (avoiding the buffer polyfill / CJS) no longer holds for v4, and bumping keeps a maintained, tested upstream instead of vendoring crypto we'd have to own.

## Summary

- **`stellar_validator.ts`** — `import crc16xmodem from 'crc/calculators/crc16xmodem'`.
- **`ada_validator.ts`** — `import crc32 from 'crc/calculators/crc32'`. The bare calculator [returns a **signed** 32-bit int](https://github.com/alexgorbatchev/node-crc/blob/v4.3.2/src/calculators/crc32.ts#L51) (`return crc ^ -1`); the unsigned `>>> 0` coercion lives in the [`define_crc` wrapper](https://github.com/alexgorbatchev/node-crc/blob/v4.3.2/src/define_crc.ts#L5) behind `crc/crc32`, which the direct calculator import bypasses. So the result is coerced with `>>> 0` to match the CBOR-decoded checksum.
- **`package.json`** — `crc` bumped `^3.8.0` → `^4.3.2`.
- **`src/types.d.ts`** — removed; v4 ships its own type definitions, so the `declare module 'crc'` shim is gone.
- **`yarn.lock`** deduped. (`crc@3.8.0` remains in the lockfile only as a transitive dep of `dmg-license`, an electron-builder macOS dependency.)

## Test status

Both CRC paths are checksum-verifying, so an incorrect call would reject otherwise-valid addresses and fail the fixtures:

- `tests/wallet_address_validator.test.ts` — 11 valid Stellar addresses exercise `crc16xmodem`; Byron-era Cardano addresses (e.g. `Ae2tdPwUPEYxYNJw1He1esdZYvjmr4NtPzUsGTiqL9zd8ohjZYQcwu6kom7`) exercise `crc32`, with a one-character-mutated negative case confirming rejection. The signed→unsigned coercion is directly covered by these Cardano cases.
- Aggregate: address-validator `test:unit` = **49 / 49 passing**.

**Change safety: low risk.** Drop-in replacement of a maintained dependency; the only behavioral nuance (calculator signedness) is covered by the Cardano fixtures.

## Test plan

- [x] `yarn workspace @trezor/address-validator test:unit` — 49/49 pass
- [x] `yarn workspace @trezor/address-validator type-check` — subpath `crc/calculators/*` imports resolve via the v4 `exports` map
- [x] `yarn workspace @trezor/address-validator lint:js`
- [x] `yarn workspace @trezor/address-validator depcheck` — no issues
- [x] `yarn dedupe` + `yarn install --immutable`

## Related PRs (issue #27403)

- #27535 — chore: jssha → @noble/hashes
- #27536 — refactor: drop unused `format` parameter
- #27537 — chore: inline bitcoin-ops + pushdata-bitcoin
- #27540 — chore: base-x → @scure/base
- #27543 — chore: browserify-bignum → native BigInt
- #27544 — chore: bip66 → @noble/curves DER utils
- #28219 — chore: int64-buffer → native Buffer BigInt
- #28135 — chore: cbor → cborg (still open)
- #28230 — chore: bump crc v3 → v4, import calculators directly (← this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/issue-27403-crc&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/issue-27403-crc&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-01T11:57:52.905Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-01T11:55:38.932Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/issue-27403-crc/web/](https://dev.suite.sldev.cz/suite-web/mroz22/issue-27403-crc/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->