### PR TITLE
wip

### DIFF
--- a/packages/request-manager/src/interceptor/__tests__/overloadHttpRequest.test.ts
+++ b/packages/request-manager/src/interceptor/__tests__/overloadHttpRequest.test.ts
@@ -1,0 +1,233 @@
+import type http from 'http';
+
+import type { InterceptorContext } from '../interceptorTypes';
+import { overloadHttpRequest } from '../overloadHttpRequest';
+
+const createContext = (overrides: Partial<InterceptorContext> = {}): InterceptorContext => {
+    const torIdentitiesStub = {
+        getIdentity: jest.fn(() => ({ __mockAgent: true })),
+        removeIdentity: jest.fn(),
+    };
+
+    return {
+        handler: jest.fn(),
+        getTorSettings: jest.fn(() => ({ running: true, host: '127.0.0.1', port: 9050 })),
+        getWhitelistedDomains: jest.fn(() => []),
+        notRequiredTorDomainsList: [],
+        allowTorBypass: false,
+        requestPool: jest.fn() as unknown as InterceptorContext['requestPool'],
+        torIdentities: torIdentitiesStub as unknown as InterceptorContext['torIdentities'],
+        ...overrides,
+    };
+};
+
+describe(overloadHttpRequest.name, () => {
+    const validateRequest = jest.fn();
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('attaches Tor agent for signature: request(options)', () => {
+        const context = createContext();
+        const options: http.RequestOptions = {
+            hostname: 'data.trezor.io',
+            path: '/firmware/test.dat',
+            method: 'GET',
+            headers: { Accept: '*/*' },
+        };
+
+        const result = overloadHttpRequest({
+            context,
+            protocol: 'https',
+            url: options,
+            options: undefined,
+            callback: undefined,
+            validateRequest,
+        });
+
+        expect(result).toBeDefined();
+        expect(options.agent).toEqual({ __mockAgent: true });
+        expect(context.torIdentities.getIdentity).toHaveBeenCalledWith(
+            'default',
+            undefined,
+            'https',
+        );
+
+        // returned tuple matches signature 1: [identity, options, callback]
+        const [, ...args] = result!;
+        expect(args).toEqual([options, undefined]);
+    });
+
+    it('attaches Tor agent for signature: request(urlString, options) — node-fetch v3 case', () => {
+        const context = createContext();
+        const url = 'https://data.trezor.io/firmware/test.dat';
+        const options: http.RequestOptions = {
+            path: '/firmware/test.dat',
+            method: 'GET',
+            headers: { Accept: '*/*' },
+        };
+
+        const result = overloadHttpRequest({
+            context,
+            protocol: 'https',
+            url,
+            options,
+            callback: undefined,
+            validateRequest,
+        });
+
+        expect(result).toBeDefined();
+        expect(options.agent).toEqual({ __mockAgent: true });
+        expect(context.torIdentities.getIdentity).toHaveBeenCalledWith(
+            'default',
+            undefined,
+            'https',
+        );
+
+        // returned tuple preserves signature 3: [identity, url, options, callback]
+        const [, ...args] = result!;
+        expect(args).toEqual([url, options, undefined]);
+    });
+
+    it('attaches Tor agent for signature: request(URL, options)', () => {
+        const context = createContext();
+        const url = new URL('https://sol.trezor.io/');
+        const options: http.RequestOptions = {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+        };
+
+        const result = overloadHttpRequest({
+            context,
+            protocol: 'https',
+            url,
+            options,
+            callback: undefined,
+            validateRequest,
+        });
+
+        expect(result).toBeDefined();
+        expect(options.agent).toEqual({ __mockAgent: true });
+        const [, ...args] = result!;
+        expect(args).toEqual([url, options, undefined]);
+    });
+
+    it('skips Tor agent when host is in notRequiredTorDomainsList', () => {
+        const context = createContext({
+            notRequiredTorDomainsList: ['data.trezor.io'],
+        });
+        const url = 'https://data.trezor.io/firmware/test.dat';
+        const options: http.RequestOptions = {
+            method: 'GET',
+            headers: { Accept: '*/*' },
+        };
+
+        const result = overloadHttpRequest({
+            context,
+            protocol: 'https',
+            url,
+            options,
+            callback: undefined,
+            validateRequest,
+        });
+
+        expect(result).toBeUndefined();
+        expect(options.agent).toBeUndefined();
+        expect(context.torIdentities.getIdentity).not.toHaveBeenCalled();
+    });
+
+    it('attaches Tor agent for signature: request(urlString)', () => {
+        const context = createContext();
+        const url = 'https://data.trezor.io/firmware/test.dat';
+
+        const result = overloadHttpRequest({
+            context,
+            protocol: 'https',
+            url,
+            options: undefined,
+            callback: undefined,
+            validateRequest,
+        });
+
+        expect(result).toBeDefined();
+        expect(context.torIdentities.getIdentity).toHaveBeenCalledWith(
+            'default',
+            undefined,
+            'https',
+        );
+
+        // returned tuple uses URL + synthesized options: [identity, url, options, callback]
+        const [, ...args] = result!;
+        expect(args).toHaveLength(3);
+        expect(args[0]).toBe(url);
+        expect(args[1]).toMatchObject({ agent: { __mockAgent: true } });
+        expect(args[2]).toBeUndefined();
+    });
+
+    it('attaches Tor agent for signature: request(urlString, callback)', () => {
+        const context = createContext();
+        const url = 'https://data.trezor.io/firmware/test.dat';
+        const callback = jest.fn();
+
+        const result = overloadHttpRequest({
+            context,
+            protocol: 'https',
+            url,
+            options: callback,
+            callback: undefined,
+            validateRequest,
+        });
+
+        expect(result).toBeDefined();
+        expect(context.torIdentities.getIdentity).toHaveBeenCalledWith(
+            'default',
+            undefined,
+            'https',
+        );
+
+        const [, ...args] = result!;
+        expect(args).toHaveLength(3);
+        expect(args[0]).toBe(url);
+        expect(args[1]).toMatchObject({ agent: { __mockAgent: true } });
+        expect(args[2]).toBe(callback);
+    });
+
+    it('always validates the hostname (whitelist check)', () => {
+        const context = createContext();
+
+        overloadHttpRequest({
+            context,
+            protocol: 'https',
+            url: 'https://data.trezor.io/firmware/test.dat',
+            options: { headers: {} },
+            callback: undefined,
+            validateRequest,
+        });
+
+        expect(validateRequest).toHaveBeenCalledWith({ hostname: 'data.trezor.io' });
+    });
+
+    it('blocks requests with Proxy-Authorization header when Tor is disabled and bypass is not allowed', () => {
+        const context = createContext({
+            getTorSettings: jest.fn(() => ({ running: false, host: '127.0.0.1', port: 9050 })),
+            allowTorBypass: false,
+        });
+        const url = 'https://data.trezor.io/';
+        const options: http.RequestOptions = {
+            method: 'GET',
+            headers: { 'Proxy-Authorization': 'Basic identity-name' },
+        };
+
+        expect(() =>
+            overloadHttpRequest({
+                context,
+                protocol: 'https',
+                url,
+                options,
+                callback: undefined,
+                validateRequest,
+            }),
+        ).toThrow('Blocked request with Proxy-Authorization. TOR not enabled.');
+    });
+});

--- a/packages/request-manager/src/interceptor/interceptHttp.ts
+++ b/packages/request-manager/src/interceptor/interceptHttp.ts
@@ -23,7 +23,10 @@ export const interceptHttp: Interceptor = ({ context, validateRequest }) => {
         if (overload) {
             const [identity, ...overloadedArgs] = overload;
 
-            return context.requestPool(originalHttpRequest(...overloadedArgs), identity);
+            return context.requestPool(
+                originalHttpRequest(...(overloadedArgs as Parameters<typeof http.request>)),
+                identity,
+            );
         }
 
         // In cases that are not considered above we pass the args as they came.
@@ -47,7 +50,10 @@ export const interceptHttp: Interceptor = ({ context, validateRequest }) => {
         if (overload) {
             const [identity, ...overloadedArgs] = overload;
 
-            return context.requestPool(originalHttpGet(...overloadedArgs), identity);
+            return context.requestPool(
+                originalHttpGet(...(overloadedArgs as Parameters<typeof http.get>)),
+                identity,
+            );
         }
 
         return originalHttpGet(...(args as Parameters<typeof https.get>));

--- a/packages/request-manager/src/interceptor/interceptHttps.ts
+++ b/packages/request-manager/src/interceptor/interceptHttps.ts
@@ -22,7 +22,10 @@ export const interceptHttps: Interceptor = ({ context, validateRequest }) => {
         if (overload) {
             const [identity, ...overloadedArgs] = overload;
 
-            return context.requestPool(originalHttpsRequest(...overloadedArgs), identity);
+            return context.requestPool(
+                originalHttpsRequest(...(overloadedArgs as Parameters<typeof https.request>)),
+                identity,
+            );
         }
 
         // In cases that are not considered above we pass the args as they came.
@@ -46,7 +49,10 @@ export const interceptHttps: Interceptor = ({ context, validateRequest }) => {
         if (overload) {
             const [identity, ...overloadedArgs] = overload;
 
-            return context.requestPool(originalHttpsGet(...overloadedArgs), identity);
+            return context.requestPool(
+                originalHttpsGet(...(overloadedArgs as Parameters<typeof https.get>)),
+                identity,
+            );
         }
 
         return originalHttpsGet(...(args as Parameters<typeof https.get>));

--- a/packages/request-manager/src/interceptor/overloadHttpRequest.ts
+++ b/packages/request-manager/src/interceptor/overloadHttpRequest.ts
@@ -1,4 +1,5 @@
 import type http from 'http';
+import { urlToHttpOptions } from 'url';
 
 import { getWeakRandomId, isWhitelistedHost } from '@trezor/utils';
 
@@ -44,9 +45,25 @@ const resolveHostname = (url: string | URL | http.RequestOptions) => {
     return new URL(url).hostname;
 };
 
+const getOptionsFromUrl = (url: string | URL) => {
+    const normalizedUrl = typeof url === 'string' ? new URL(url) : url;
+
+    return urlToHttpOptions(normalizedUrl);
+};
+
 /**
- * http(s).request could have different arguments according to its types definition,
- * but we only care when second argument (url) is object containing RequestOptions.
+ * http(s).request supports several call signatures:
+ *   1. request(options[, callback])
+ *   2. request(url[, callback])
+ *   3. request(url, options[, callback])
+ *
+ * We need to attach the Tor agent (or apply Proxy-Authorization rules) to the
+ * RequestOptions object regardless of how the caller invoked the function.
+ *
+ * Historically only signature 1 was handled, which broke when libraries like
+ * `node-fetch@3` started using signature 3 (`request(urlString, options)`),
+ * because the function returned early without attaching the Tor agent and the
+ * request silently bypassed Tor.
  */
 export const overloadHttpRequest = ({
     context,
@@ -60,56 +77,94 @@ export const overloadHttpRequest = ({
 
     validateRequest({ hostname });
 
+    // Resolve which argument is the RequestOptions object (the one we need to
+    // mutate to attach the Tor agent / inspect for Proxy-Authorization).
+    let overloadedUrl: string | URL | undefined;
+    let overloadedOptions: http.RequestOptions | undefined;
+    let overloadedCallback: unknown;
+
     if (
-        !callback &&
         typeof url === 'object' &&
+        url !== null &&
+        !(url instanceof URL) &&
         'headers' in url &&
-        !isWhitelistedHost(hostname, context.notRequiredTorDomainsList) &&
         (!options || typeof options === 'function')
     ) {
-        const isTorEnabled = context.getTorSettings().running;
-        const isTorRequired = getIsTorRequired(url);
-        const overloadedOptions = url;
-        const overloadedCallback = options;
-        const { host, path } = overloadedOptions;
-        let identity: string | undefined;
-
-        if (isTorEnabled) {
-            // Create proxy agent for the request (from Proxy-Authorization or default)
-            // get authorization data from request headers
-            identity = getIdentityForAgent(overloadedOptions) || 'default';
-            overloadedOptions.agent = context.torIdentities.getIdentity(
-                identity,
-                overloadedOptions.timeout,
-                protocol,
-            );
-        } else if (isTorRequired) {
-            // Block requests that explicitly requires TOR using Proxy-Authorization
-            if (context.allowTorBypass) {
-                context.handler({
-                    type: 'INTERCEPTED_REQUEST',
-                    method: 'http.request',
-                    details: `Conditionally allowed request with Proxy-Authorization ${host}`,
-                });
-            } else {
-                context.handler({
-                    type: 'INTERCEPTED_REQUEST',
-                    method: 'http.request',
-                    details: `Request blocked ${host}`,
-                });
-                throw new Error('Blocked request with Proxy-Authorization. TOR not enabled.');
-            }
-        }
-
-        context.handler({
-            type: 'INTERCEPTED_REQUEST',
-            method: 'http.request',
-            details: `${host}${path} with agent ${!!overloadedOptions.agent}`,
-        });
-
-        delete overloadedOptions.headers?.['Proxy-Authorization'];
-
-        // return tuple of params for original request
-        return [identity, overloadedOptions, overloadedCallback] as const;
+        // signature 1: request(options[, callback])
+        overloadedOptions = url;
+        overloadedCallback = options;
+    } else if (
+        (typeof url === 'string' || url instanceof URL) &&
+        (!options || typeof options === 'function')
+    ) {
+        // signature 2: request(url[, callback])
+        overloadedUrl = url;
+        overloadedOptions = getOptionsFromUrl(url);
+        overloadedCallback = options;
+    } else if (
+        (typeof url === 'string' || url instanceof URL) &&
+        typeof options === 'object' &&
+        options !== null &&
+        'headers' in options
+    ) {
+        // signature 3: request(url, options[, callback])
+        overloadedUrl = url;
+        overloadedOptions = options;
+        overloadedCallback = callback;
     }
+
+    if (!overloadedOptions || isWhitelistedHost(hostname, context.notRequiredTorDomainsList)) {
+        return;
+    }
+
+    const isTorEnabled = context.getTorSettings().running;
+    const isTorRequired = getIsTorRequired(overloadedOptions);
+    // Fall back to the resolved hostname when the caller passed the URL as the
+    // first argument (in that case `options.host` is typically not set).
+    const host = overloadedOptions.host ?? hostname;
+    const path = overloadedOptions.path ?? '';
+    let identity: string | undefined;
+
+    if (isTorEnabled) {
+        // Create proxy agent for the request (from Proxy-Authorization or default)
+        // get authorization data from request headers
+        identity = getIdentityForAgent(overloadedOptions) || 'default';
+        overloadedOptions.agent = context.torIdentities.getIdentity(
+            identity,
+            overloadedOptions.timeout,
+            protocol,
+        );
+    } else if (isTorRequired) {
+        // Block requests that explicitly requires TOR using Proxy-Authorization
+        if (context.allowTorBypass) {
+            context.handler({
+                type: 'INTERCEPTED_REQUEST',
+                method: 'http.request',
+                details: `Conditionally allowed request with Proxy-Authorization ${host}`,
+            });
+        } else {
+            context.handler({
+                type: 'INTERCEPTED_REQUEST',
+                method: 'http.request',
+                details: `Request blocked ${host}`,
+            });
+            throw new Error('Blocked request with Proxy-Authorization. TOR not enabled.');
+        }
+    }
+
+    context.handler({
+        type: 'INTERCEPTED_REQUEST',
+        method: 'http.request',
+        details: `${host}${path} with agent ${!!overloadedOptions.agent}`,
+    });
+
+    delete overloadedOptions.headers?.['Proxy-Authorization'];
+
+    // Return a tuple of params matching the original call signature so that
+    // `originalRequest(...overloadedArgs)` preserves the caller's intent.
+    if (overloadedUrl !== undefined) {
+        return [identity, overloadedUrl, overloadedOptions, overloadedCallback] as const;
+    }
+
+    return [identity, overloadedOptions, overloadedCallback] as const;
 };


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Historically only signature 1 was handled, which broke when libraries like `node-fetch@3` started using signature 3 (`request(urlString, options)`),  because the function returned early without attaching the Tor agent and the request silently bypassed Tor.


## Notes for QA

Test Desktop app with all the networks and test that all the calls are going throw Tor.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are confined to the request-manager's HTTP/HTTPS interceptor module, which handles overloading of Node.js http/https request functions — primarily used for Tor proxy routing in the Electron app. No E2E tests have static coverage mapping to these files. The risk is moderate: a regression could affect any outbound HTTP/HTTPS request made through the Electron main process (bridge communication, Tor-proxied requests), but most E2E tests run against a web build or use mocked backends that bypass this interceptor. Only tests that exercise real HTTP networking in the Electron context are meaningfully at risk. The unit test file included in the changeset provides the primary coverage.

<details><summary><b>Changed files (4)</b></summary>

- `packages/request-manager/src/interceptor/__tests__/overloadHttpRequest.test.ts`
- `packages/request-manager/src/interceptor/interceptHttp.ts`
- `packages/request-manager/src/interceptor/interceptHttps.ts`
- `packages/request-manager/src/interceptor/overloadHttpRequest.ts`

</details>

**Recommended tests (2)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — The changed files in packages/request-manager/src/interceptor modify HTTP/HTTPS request interception logic, which is used for Tor proxy routing. The bridge-daemon test exercises the Electron app's network layer including bridge HTTP health checks, which could be affected if HTTP request interception behavior changes.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test makes many outbound HTTP requests to validate hyperlinks across the application. Changes to the HTTP/HTTPS request interceptor could affect how these outbound requests are routed or handled, potentially causing false link failures if the interception logic has a regression.

</details>

⚠️ **Changes with no test coverage (4)**
- `packages/request-manager/src/interceptor/__tests__/overloadHttpRequest.test.ts`
- `packages/request-manager/src/interceptor/interceptHttp.ts`
- `packages/request-manager/src/interceptor/interceptHttps.ts`
- `packages/request-manager/src/interceptor/overloadHttpRequest.ts`

_Updated: 2026-06-01T12:33:34.123Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/request-manager-update/web/](https://dev.suite.sldev.cz/suite-web/fix/request-manager-update/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/request-manager-update&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/request-manager-update&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-01T13:50:16.809Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-01T18:10:21.610Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->