### PR TITLE
fix(suite-desktop): clean up accumulated Electron listeners on re-init

### DIFF
--- a/packages/suite-desktop-core/src/modules/power-monitor.ts
+++ b/packages/suite-desktop-core/src/modules/power-monitor.ts
@@ -5,19 +5,18 @@ import type { ModuleInit } from './module';
 export const SERVICE_NAME = 'power-monitor';
 
 export const init: ModuleInit = ({ mainWindowProxy }) => {
-    mainWindowProxy.on('init', mainWindow => {
-        powerMonitor.on('lock-screen', () => {
-            logger.info('power-monitor', 'Lock screen event detected');
-        });
-        powerMonitor.on('unlock-screen', () => {
-            logger.info('power-monitor', 'Unlock screen event detected');
-        });
-        powerMonitor.on('suspend', () => {
-            logger.info('power-monitor', 'Suspend event detected');
-            mainWindow.webContents.send('power-monitor/suspend');
-        });
-        powerMonitor.on('resume', () => {
-            logger.info('power-monitor', 'Resume event detected');
-        });
+    powerMonitor.on('lock-screen', () => {
+        logger.info('power-monitor', 'Lock screen event detected');
+    });
+    powerMonitor.on('unlock-screen', () => {
+        logger.info('power-monitor', 'Unlock screen event detected');
+    });
+    // Use getInstance() so this always targets the current window, even if the window is recreated.
+    powerMonitor.on('suspend', () => {
+        logger.info('power-monitor', 'Suspend event detected');
+        mainWindowProxy.getInstance()?.webContents.send('power-monitor/suspend');
+    });
+    powerMonitor.on('resume', () => {
+        logger.info('power-monitor', 'Resume event detected');
     });
 };

--- a/packages/suite-desktop-ui/src/support/DesktopUpdater.tsx
+++ b/packages/suite-desktop-ui/src/support/DesktopUpdater.tsx
@@ -54,30 +54,40 @@ export const DesktopUpdater = () => {
             dispatch(desktopUpdateActions.setAutomaticUpdates({ isEnabled })),
         );
 
-        if (!desktopUpdate.enabled) {
-            return;
+        let checkForUpdatesInterval: ReturnType<typeof setInterval> | undefined;
+
+        if (desktopUpdate.enabled) {
+            desktopApi.on('update/checking', () => dispatch(desktopUpdateActions.checking()));
+            desktopApi.on('update/available', params => dispatch(availableThunk(params)));
+            desktopApi.on('update/not-available', params => dispatch(notAvailableThunk(params)));
+            desktopApi.on('update/downloaded', params => dispatch(readyThunk(params)));
+            desktopApi.on('update/downloading', params =>
+                dispatch(desktopUpdateActions.downloading(params)),
+            );
+            desktopApi.on('update/error', () => dispatch(errorThunk()));
+
+            // Initial check for updates
+            desktopApi.checkForUpdates({ isManual: false });
+            // Check for updates every hour
+            checkForUpdatesInterval = setInterval(
+                () => {
+                    desktopApi.checkForUpdates({ isManual: false });
+                },
+                60 * 60 * 1000,
+            );
         }
 
-        desktopApi.on('update/checking', () => dispatch(desktopUpdateActions.checking()));
-        desktopApi.on('update/available', params => dispatch(availableThunk(params)));
-        desktopApi.on('update/not-available', params => dispatch(notAvailableThunk(params)));
-        desktopApi.on('update/downloaded', params => dispatch(readyThunk(params)));
-        desktopApi.on('update/downloading', params =>
-            dispatch(desktopUpdateActions.downloading(params)),
-        );
-        desktopApi.on('update/error', () => dispatch(errorThunk()));
-
-        // Initial check for updates
-        desktopApi.checkForUpdates({ isManual: false });
-        // Check for updates every hour
-        const checkForUpdatesInterval = setInterval(
-            () => {
-                desktopApi.checkForUpdates({ isManual: false });
-            },
-            60 * 60 * 1000,
-        );
-
-        return () => clearInterval(checkForUpdatesInterval);
+        return () => {
+            clearInterval(checkForUpdatesInterval);
+            desktopApi.removeAllListeners('update/allow-prerelease');
+            desktopApi.removeAllListeners('update/set-automatic-update-enabled');
+            desktopApi.removeAllListeners('update/checking');
+            desktopApi.removeAllListeners('update/available');
+            desktopApi.removeAllListeners('update/not-available');
+            desktopApi.removeAllListeners('update/downloaded');
+            desktopApi.removeAllListeners('update/downloading');
+            desktopApi.removeAllListeners('update/error');
+        };
     }, [desktopUpdate.enabled, dispatch]);
 
     const hideWindow = useCallback(() => {

--- a/packages/suite/src/support/suite/Protocol.tsx
+++ b/packages/suite/src/support/suite/Protocol.tsx
@@ -45,6 +45,8 @@ const Protocol = () => {
 
         if (isDesktop()) {
             desktopApi.on('protocol/open', handleProtocolRequest);
+
+            return () => desktopApi.removeAllListeners('protocol/open');
         }
     }, [handleProtocolRequest]);
 


### PR DESCRIPTION
## Summary

Two isolated Electron listener-cleanup fixes, split out of the broader audit in #27978 so they can be reviewed independently of the transport/connect changes. Both are single-concern and touch only desktop packages.

## Fixes

- **`@trezor/suite-desktop-core` — `power-monitor`**
  Listeners (`lock-screen`/`unlock-screen`/`suspend`/`resume`) were registered inside `mainWindowProxy.on('init', …)`, which fires again on every `reactivateWindow()` after the window is destroyed — so each window recreation stacked another full set of `powerMonitor` listeners on the global Electron singleton. Moved registration out of the `init` callback (runs once per module init) and switched the `suspend` handler to `mainWindowProxy.getInstance()?.webContents.send(...)` so it always targets the current window.

  Beyond the leak, the old code was also a latent crash: the `suspend` handler captured the `mainWindow` reference from the `init` callback, so once the original window was destroyed and recreated, `mainWindow.webContents.send(...)` targeted a destroyed `webContents` and would throw `Object has been destroyed`. This likely matches the `Object has been destroyed` exceptions we've been seeing in Sentry. `getInstance()` always resolves the current window, and the optional chaining no-ops when no window exists.

- **`@trezor/suite-desktop-ui` — `DesktopUpdater` / `Protocol`**
  `DesktopUpdater.tsx` registered 8 `desktopApi` update-channel listeners but only cleaned up the interval; toggling `desktopUpdate.enabled` re-ran the effect and leaked the previous listeners. Now the effect removes all update listeners on cleanup. `Protocol.tsx` adds the missing `removeAllListeners('protocol/open')` cleanup.

## Why split out

These are in packages no other PR in the leak-audit stream touches, each is a self-contained "add the missing cleanup" change, and each is independently revertible — so they don't need to wait on the transport/connect review.

## Related PRs (listener-leak audit stream)

- #27978 — `fix: audit and patch event listener leaks across transport/connect/desktop packages` (origin of these commits)
- #27982 — `feat(utils): introduce listener disposer helper for Connect/transport sites`
- This PR cherry-picks the two desktop commits out of #27978 for isolated review. Sibling PR #28242 splits out three more isolated single-file fixes (connect-common / react-native-usb / connect-explorer).

## Test plan

- [x] `lint:js` clean on all three changed files
- [ ] CI type-check + unit (full monorepo build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The three changed files have very limited E2E test relevance. `power-monitor.ts` (desktop power monitoring) and `DesktopUpdater.tsx` (desktop auto-updater UI) are desktop-core/desktop-UI modules with no static test coverage and no E2E tests that exercise power monitoring or update flows. `Protocol.tsx` is a broadly imported support component (URI/deep-link protocol handler) that maps to 121 tests — but none of the 142 analyzed tests specifically exercise protocol/deep-link handling behavior, meaning the static mapping is purely transitive. Since no test directly exercises the changed functionality (power monitor behavior, desktop updater UI, or protocol URI handling), no E2E tests are recommended. The risk is low for user-facing regressions detectable by these E2E tests; manual or unit-level testing of these modules would be more appropriate.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite-desktop-core/src/modules/power-monitor.ts`
- `packages/suite-desktop-ui/src/support/DesktopUpdater.tsx`
- `packages/suite/src/support/suite/Protocol.tsx`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (3)**
- `packages/suite-desktop-core/src/modules/power-monitor.ts`
- `packages/suite-desktop-ui/src/support/DesktopUpdater.tsx`
- `packages/suite/src/support/suite/Protocol.tsx`

_Updated: 2026-06-01T15:02:08.157Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/desktop-listener-cleanup&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/desktop-listener-cleanup&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-01T15:08:40.352Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-01T15:05:23.654Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/desktop-listener-cleanup/web/](https://dev.suite.sldev.cz/suite-web/mroz22/desktop-listener-cleanup/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->
