### PR TITLE
refactor(connect-common): guard and clean up onConnect listener in ServiceWorkerWindowChannel

### DIFF
--- a/packages/connect-common/src/messageChannel/serviceworker-window.ts
+++ b/packages/connect-common/src/messageChannel/serviceworker-window.ts
@@ -16,6 +16,7 @@ export class ServiceWorkerWindowChannel<
     private name: string;
     private allowSelfOrigin: boolean;
     private currentId?: () => number | undefined;
+    private onConnectListener?: (port: chrome.runtime.Port) => void;
 
     constructor({
         name,
@@ -45,7 +46,8 @@ export class ServiceWorkerWindowChannel<
     }
 
     connect() {
-        chrome.runtime.onConnect.addListener(port => {
+        if (this.onConnectListener) return;
+        this.onConnectListener = port => {
             if (port.name !== this.name) return;
             // Ignore port if name does match, but port created by different popup
             if (this.currentId?.() && this.currentId?.() !== port.sender?.tab?.id) return;
@@ -108,12 +110,17 @@ export class ServiceWorkerWindowChannel<
 
                 this.onMessage(message);
             });
-        });
+        };
+        chrome.runtime.onConnect.addListener(this.onConnectListener);
         this.isConnected = true;
     }
 
     disconnect() {
         if (!this.isConnected) return;
+        if (this.onConnectListener) {
+            chrome.runtime.onConnect.removeListener(this.onConnectListener);
+            this.onConnectListener = undefined;
+        }
         this.port?.disconnect();
         this.clear();
         this.isConnected = false;


### PR DESCRIPTION
## Description

`ServiceWorkerWindowChannel.connect()` added a `chrome.runtime.onConnect` listener through an inline closure that `disconnect()` never removed, and `connect()` had no guard against registering it twice. `onConnect` is a **global** Chrome event (unlike `port.onMessage`, which is port-scoped and dies with its port), so without explicit cleanup the listener can outlive the channel and repeated `connect()` calls stack duplicates.

The fix stores the listener on the instance, skips registration when one already exists, and removes it in `disconnect()` — making `connect()`/`disconnect()` symmetric and idempotent.

### This is mostly defensive hardening

In the only production consumer (`connect-webextension`'s `initProxyChannel()`), the channel is created once at service-worker startup, `connect()` runs once from the constructor, and `disconnect()` is never called. So today the guard never trips and the listener legitimately lives for the whole service-worker lifetime — there is no observed runtime leak on this path. The value of the change is correctness if `disconnect()` / repeated `connect()` are ever used, and consistency: it brings `ServiceWorkerWindowChannel` in line with its sibling `ServiceWorkerWindowExtConnectableChannel`, which already follows exactly this stored-listener + guard + `removeListener` pattern.

### Listener-leak audit stream

Split out of #27978 so it can be reviewed independently. Siblings:
- #27978 — original audit (open)
- #28860 — connect-explorer BroadcastChannel (merged)
- #28241 — suite-desktop Electron listeners (merged)
- #28329 — react-native-usb WebUSB subscriptions (open)
- #27982 — listener disposer helper (open)

## Notes for QA

No user-facing change and no QA needed. This only touches the connect web-extension service-worker proxy channel; the shipped extension behaves exactly as before (the listener is registered once at startup, as it always was). Verified by type-check.

## Related Issue

Part of #27978 (listener-leak audit); no separate issue.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is to the serviceworker-window message channel in connect-common, which is infrastructure for cross-context communication between service workers (e.g., browser extensions) and window contexts (e.g., Suite popup). The highest risk is in webextension and web popup TrezorConnect flows, which directly rely on this message channel for bidirectional communication. Other TrezorConnect tests that use coreMode 'suite-desktop' are at moderate risk since they share the broader message channel infrastructure. No static coverage mapping was available, so all recommendations are inferred from the LLM analysis of test behaviors and source hints.

<details><summary><b>Changed files (1)</b></summary>

- `packages/connect-common/src/messageChannel/serviceworker-window.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — The changed file is a service worker-to-window message channel in connect-common. Webextension tests exercise exactly this communication path — TrezorConnect calls from a service worker context (browser extension) communicate with the Suite Web popup window. This is the most direct consumer of serviceworker-window message channel infrastructure.
- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — The Connect popup web tests exercise TrezorConnect communication between a calling web page and the Suite popup window. The serviceworker-window message channel is part of the connect-common messageChannel infrastructure that facilitates this cross-context communication, including popup lifecycle management (open, close, cancel, blocked scenarios).

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Permissions tests exercise TrezorConnect.getAddress calls with remembered permissions, which rely on the message channel between the calling context and Suite's connect infrastructure. Changes to the serviceworker-window channel could affect how permission grants and subsequent silent calls are communicated.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — Silent mode tests verify that TrezorConnect calls in silent mode suppress window focus. This relies on the message channel between the calling application and Suite's connect layer. The serviceworker-window channel is part of this infrastructure and changes could affect how silent mode messages are propagated.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — getAddress tests exercise the TrezorConnect API flow including permissions modal and address confirmation, which use the connect-common message channel to communicate between the calling context and Suite. A regression in the message channel could break address export flows.
- `suite/e2e/tests/trezor-connect/selectAccount.test.ts` — selectAccount tests exercise TrezorConnect.selectAccount which communicates between a calling application and Suite's desktop connect layer via message channels. Changes to the serviceworker-window channel could affect how account selection responses are delivered.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/trezor-connect/error.test.ts` — Error handling test exercises TrezorConnect with an invalid path, which relies on the message channel to communicate the error back from the connect layer. A change in the serviceworker-window channel could affect error propagation.

</details>

_Updated: 2026-07-10T16:24:26.141Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/isolated-listener-leaks&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/isolated-listener-leaks&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-10T16:28:03.372Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-10T16:28:01.732Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/isolated-listener-leaks/web/](https://dev.suite.sldev.cz/suite-web/mroz22/isolated-listener-leaks/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

