### PR TITLE
fix(suite-native): allow text values in destinationTag for tron

### DIFF
--- a/suite-native/module-send/src/sendOutputsFormSchema.ts
+++ b/suite-native/module-send/src/sendOutputsFormSchema.ts
@@ -292,7 +292,7 @@ export const sendOutputsFormValidationSchema = yup.object({
 
                 if (!symbol) return true;
                 const networkType = getNetworkType(symbol);
-                if (networkType === 'stellar' || networkType === 'solana') return true;
+                if (['solana', 'stellar', 'tron'].includes(networkType)) return true;
 
                 if (!value) return true;
 


### PR DESCRIPTION
## Description

In the recent refactor in #28184, the `destinationTag` form field was reused for Tron notes. The mobile form schema was missed. It still rejects non-numeric values for Tron, causing text notes to fail the validation.

This fix adds Tron to the expections.

## Notes for QA

- Add note with text content → fee shows, submit enabled


## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/tron-note-mobile&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->