### PR TITLE
test(fix-bot): add Slack notify job

### DIFF
--- a/.github/workflows/test-suite-nightly-fix-agent.yml
+++ b/.github/workflows/test-suite-nightly-fix-agent.yml
@@ -65,11 +65,20 @@ jobs:
           fi
 
       - name: Upload report
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: fix-agent-report
           path: packages/e2e-utils/src/fixBot/reports/
           if-no-files-found: error
+
+      - name: Upload analyze cost artifact
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: slack-analyze-cost
+          path: /tmp/llm-token-usage.json
+          if-no-files-found: warn
 
   prepare-matrix:
     needs: [analyze]
@@ -188,7 +197,7 @@ jobs:
           restore-keys: node_modules-
 
       - name: Install dependencies
-        run: yarn workspaces focus @trezor/suite-e2e @trezor/e2e-utils @trezor/suite-web
+        run: yarn workspaces focus @trezor/suite-e2e @trezor/e2e-utils @trezor/suite-web @trezor/suite-desktop
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6
@@ -263,6 +272,7 @@ jobs:
           TASK_ID: ${{ matrix.task-id }}
           AGENT_GITHUB_ACTION: true
           REPORT_PATH: ${{ github.workspace }}/report-download/report.json
+          ELECTRON_DISABLE_SANDBOX: 1
         run: yarn workspace @trezor/e2e-utils fix-bot:fix
 
       - name: Store token usage record to S3
@@ -296,9 +306,72 @@ jobs:
           GH_TOKEN: ${{ steps.trezor-bot-token.outputs.token }}
         run: yarn workspace @trezor/e2e-utils fix-bot:publish
 
+      - name: Upload Slack fix summary artifact
+        if: ${{ !cancelled() && steps.run-fix-agent.outcome != 'skipped' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: slack-fix-summary-${{ matrix.task-id }}
+          path: slack-fix-summary-${{ matrix.task-id }}.json
+          if-no-files-found: warn
+
       - name: Docker Compose Down
         if: always()
         run: docker compose down
+
+  notify:
+    needs: [analyze, fix]
+    if: always() && github.repository == 'trezor/trezor-suite' && needs.analyze.result != 'cancelled'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: yarn
+
+      - name: Cache node_modules
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: node_modules
+          key: node_modules-${{ hashFiles('yarn.lock') }}
+          restore-keys: node_modules-
+
+      - name: Install dependencies
+        run: yarn workspaces focus @trezor/e2e-utils
+
+      - name: Download report artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: fix-agent-report
+          path: report-download/
+
+      - name: Download analyze cost artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: slack-analyze-cost
+          path: analyze-cost-download/
+        continue-on-error: true
+
+      - name: Download Slack fix summary artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: slack-fix-summary-*
+          path: summaries/
+          merge-multiple: true
+        continue-on-error: true
+
+      - name: Send Slack notification
+        env:
+          REPORT_PATH: ${{ github.workspace }}/report-download/report.json
+          SUMMARIES_DIR: ${{ github.workspace }}/summaries
+          ANALYZE_COST_FILE: ${{ github.workspace }}/analyze-cost-download/llm-token-usage.json
+          SLACK_FIX_AGENT_WEBHOOK: ${{ secrets.SLACK_FIX_AGENT_WEBHOOK }}
+        run: yarn workspace @trezor/e2e-utils fix-bot:notify
 
   aggregate:
     needs: [analyze, fix]

--- a/packages/e2e-utils/package.json
+++ b/packages/e2e-utils/package.json
@@ -17,7 +17,8 @@
         "generate-usage-dashboard": "tsx ./src/llmUsageDashboard/index.ts",
         "fix-bot:analyze": "tsx src/fixBot/analyze.ts",
         "fix-bot:fix": "tsx src/fixBot/fix.ts",
-        "fix-bot:publish": "tsx src/fixBot/publish.ts"
+        "fix-bot:publish": "tsx src/fixBot/publish.ts",
+        "fix-bot:notify": "tsx src/fixBot/notify.ts"
     },
     "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",

--- a/packages/e2e-utils/src/fixBot/ANALYSIS_AGENT.md
+++ b/packages/e2e-utils/src/fixBot/ANALYSIS_AGENT.md
@@ -152,14 +152,21 @@ belong in one fix task, regardless of which platform, device group, or spec file
 Use your judgment: errors may differ in wording across platforms or tests and still point to the
 same fix. Only split into separate tasks when the required changes are genuinely independent.
 
-For each fix task assign:
+**First, decide where each cluster goes:**
+
+- Can the fix be made entirely inside `suite/e2e/`? → `fixScope: TEST_CODE` → **fix_task**
+- Can the fix be made by adding `data-testid` attributes (plus test changes)? → `fixScope: LOCATOR_ADD` → **fix_task**
+- Does the fix require changing product logic or behavior? → **skipped**, `reason: "PRODUCT_BUG — <brief explanation>"`
+- Does the fix require infrastructure or environment changes? → **skipped**, `reason: "INFRA — <brief explanation>"`
+
+For each **fix_task** assign:
 
 - **`id`** — sequential string: `"fix-001"`, `"fix-002"`, …
 - **`branch`** — `"fix/nightly-<YYYY-MM-DD>-<slug>"` where `<slug>` is a short kebab-case
   summary of the root cause (e.g. `send-button-locator`, `receive-address-timeout`).
   Use today's date. Keep the slug under 40 characters.
 - **`rootCause`** — one sentence describing the underlying problem
-- **`fixScope`** — one of: `TEST_CODE`, `LOCATOR_ADD`, `PRODUCT_BUG`, `INFRA`
+- **`fixScope`** — `TEST_CODE` or `LOCATOR_ADD`
 - **`confidence`** — `HIGH`, `MEDIUM`, or `LOW`
 - **`fixDescription`** — concrete description of what needs to change and where
 - **`diagnosis`** — the full MD prose from Step 6 for every test that belongs to this fix
@@ -181,37 +188,11 @@ For each fix task assign:
 Do **not** write `report.json` to disk — the harness captures your final answer and writes
 it. Return a JSON object (validated against a matching JSON Schema) with:
 
-```json
-{
-    "runDate": "<YYYY-MM-DD>",
-    "webRunId": "<runId or null>",
-    "desktopRunId": "<runId or null>",
-    "fixTasks": [
-        {
-            "id": "fix-001",
-            "branch": "fix/nightly-<YYYY-MM-DD>-<slug>",
-            "rootCause": "<one sentence>",
-            "fixScope": "TEST_CODE | LOCATOR_ADD",
-            "confidence": "HIGH | MEDIUM | LOW",
-            "fixDescription": "<what to change and where>",
-            "validations": [
-                {
-                    "platform": "web | desktop",
-                    "group": "T3W1 | T3T1 | ...",
-                    "spec": "suite/e2e/tests/..."
-                }
-            ]
-        }
-    ],
-    "skipped": [
-        {
-            "rootCause": "<one sentence>",
-            "reason": "<fixScope> — <brief explanation>",
-            "affectedTests": ["suite/e2e/tests/..."]
-        }
-    ]
-}
-```
+- **`runDate`** — today's date, `YYYY-MM-DD`
+- **`webRunId`** / **`desktopRunId`** — the `runId`s from Step 1, or `null` if that platform had no run
+- **`fixTasks`** — the fix tasks from Step 7, each with the fields listed there
+- **`skipped`** — one entry per skipped cluster: `rootCause` (one sentence), `reason`
+  (`PRODUCT_BUG`/`INFRA` — brief explanation), `affectedTests` (spec paths)
 
 ---
 

--- a/packages/e2e-utils/src/fixBot/analyze.ts
+++ b/packages/e2e-utils/src/fixBot/analyze.ts
@@ -86,7 +86,7 @@ function main(): void {
 
     log('Agent done.');
 
-    process.exit(status);
+    process.exit(status ?? 1);
 }
 
 main();

--- a/packages/e2e-utils/src/fixBot/common.ts
+++ b/packages/e2e-utils/src/fixBot/common.ts
@@ -3,6 +3,7 @@ import { closeSync, openSync, readFileSync, unlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { log, warn } from '../logger';
 import { reportTokenUsage } from '../tokenUsage';
 import { type ClaudeResult, ClaudeResultSchema } from './schemas';
 
@@ -22,6 +23,7 @@ export function runClaude(opts: {
     const { root, args, input, tmpPrefix } = opts;
 
     const env = { ...process.env };
+    // Prevents an internal Claude Code setting from accidentally being inherited
     delete env['MCP_CONNECTION_NONBLOCKING'];
 
     const tmpFile = join(tmpdir(), `${tmpPrefix}-${Date.now()}.json`);
@@ -64,7 +66,7 @@ export function processAgentOutput(
     try {
         result = parseClaudeOutput(rawOutput);
     } catch {
-        process.stderr.write(`[${agent}] agent output unparsable (${rawOutput.length} bytes)\n`);
+        warn(`[${agent}] agent output unparsable (${rawOutput.length} bytes)`);
 
         return null;
     }
@@ -73,8 +75,8 @@ export function processAgentOutput(
     const text = result.result ?? '';
     const preview = text.length > 800 ? `${text.slice(0, 800)}…` : text;
 
-    process.stderr.write(`[${agent}] subtype=${subtype}\n`);
-    if (preview) process.stderr.write(`${preview}\n`);
+    log(`[${agent}] subtype=${subtype}`);
+    if (preview) log(preview);
 
     reportTokenUsage({
         timestamp: new Date().toISOString(),

--- a/packages/e2e-utils/src/fixBot/fix.ts
+++ b/packages/e2e-utils/src/fixBot/fix.ts
@@ -91,7 +91,7 @@ function main(): void {
     writeFileSync(join(root, 'fix-result.json'), `${JSON.stringify(fixResult.data, null, 2)}\n`);
 
     log('Agent done.');
-    process.exit(status);
+    process.exit(status ?? 1);
 }
 
 main();

--- a/packages/e2e-utils/src/fixBot/notify.ts
+++ b/packages/e2e-utils/src/fixBot/notify.ts
@@ -1,0 +1,223 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { error, log, warn } from '../logger';
+import {
+    type AnalysisReport,
+    AnalysisReportSchema,
+    type SlackFixSummary,
+    SlackFixSummarySchema,
+} from './schemas';
+
+const DIVIDER = '──────────────────────────────────────';
+
+const RESULT_ICON: Record<SlackFixSummary['result'], string> = {
+    pass: '✅',
+    partial: '⚠️',
+    fail: '❌',
+    not_duplicated: '🔵',
+};
+
+function formatCost(usd: number): string {
+    return `$${usd.toFixed(2)}`;
+}
+
+function readSummaries(summariesDir: string): SlackFixSummary[] {
+    if (!existsSync(summariesDir)) return [];
+
+    const parsedSummaries: SlackFixSummary[] = [];
+    const allSummariesFiles = readdirSync(summariesDir).filter(
+        n => n.startsWith('slack-fix-summary-') && n.endsWith('.json'),
+    );
+    for (const filename of allSummariesFiles) {
+        const parsed = SlackFixSummarySchema.safeParse(
+            JSON.parse(readFileSync(join(summariesDir, filename), 'utf-8')),
+        );
+
+        if (!parsed.success) {
+            warn(`[notify] Failed to parse ${filename}: ${parsed.error.message}`);
+            continue;
+        }
+
+        parsedSummaries.push(parsed.data);
+    }
+
+    return parsedSummaries;
+}
+
+function readAnalysisCost(costFile: string | undefined): number | null {
+    if (!costFile || !existsSync(costFile)) return null;
+    try {
+        const usage = JSON.parse(readFileSync(costFile, 'utf-8'));
+
+        return typeof usage.total_cost_usd === 'number' ? usage.total_cost_usd : null;
+    } catch {
+        return null;
+    }
+}
+
+function extractReasonType(reason: string): string {
+    const idx = reason.indexOf(' — ');
+
+    return idx !== -1 ? reason.slice(0, idx) : reason;
+}
+
+function formatFixTestRef(validations: AnalysisReport['fixTasks'][number]['validations']): string {
+    const first = validations[0];
+    if (!first) return 'Test reference not available';
+    const extrasPart = validations.length > 1 ? ` (+${validations.length - 1})` : '';
+
+    return `    ${first.spec} [${first.group}]${extrasPart}`;
+}
+
+function formatSkippedTestRef(affectedTests: string[]): string {
+    const first = affectedTests[0];
+    if (!first) return 'Test reference not available';
+    const extrasPart = affectedTests.length > 1 ? ` (+${affectedTests.length - 1})` : '';
+
+    return `    ${first}${extrasPart}`;
+}
+
+function buildMessage(
+    report: AnalysisReport,
+    summaries: SlackFixSummary[],
+    analyzeCost: number | null,
+): string {
+    const runId = process.env.GITHUB_RUN_ID ?? '';
+    const repo = process.env.GITHUB_REPOSITORY ?? 'trezor/trezor-suite';
+    const runUrl = `https://github.com/${repo}/actions/runs/${runId}`;
+
+    const summaryById = new Map(summaries.map(s => [s.taskId, s]));
+
+    const lines: string[] = [];
+
+    // Header
+    lines.push(`🤖 *Nightly Fix Agent — ${report.runDate}*  <${runUrl}|GHA Run>`);
+    lines.push('');
+
+    // Analyzer summary line
+    const fixable = report.fixTasks.length;
+    const skipped = report.skipped.length;
+    lines.push(`*Analyzer* — ${fixable} fixable · ${skipped} skipped`);
+
+    // Fix agents summaries
+    if (report.fixTasks.length > 0) {
+        lines.push('');
+        lines.push(DIVIDER);
+
+        for (const task of report.fixTasks) {
+            const summary = summaryById.get(task.id);
+            lines.push('');
+
+            if (!summary) {
+                // Job was cancelled before publish.ts wrote the summary
+                lines.push(`❓ *${task.rootCause}*`);
+                lines.push(formatFixTestRef(task.validations));
+                lines.push(`    ${task.id} · ${task.fixScope} · job did not complete`);
+                continue;
+            }
+
+            const { result, passed, failed, iterations, prUrl } = summary;
+            const total = passed.length + failed.length;
+            const icon = RESULT_ICON[result];
+            const iterStr = `${iterations} iter${iterations === 1 ? '' : 's'}`;
+            const countStr = `${passed.length}/${total}`;
+            const costPart = `${summary.costUsd !== null ? formatCost(summary.costUsd) : 'N/A'}`;
+
+            lines.push(`${icon} *${task.rootCause}*`);
+            lines.push(formatFixTestRef(task.validations));
+
+            if (result === 'not_duplicated') {
+                lines.push(
+                    `    ${task.id} · ${task.fixScope} · preflight passed — not flaky · ${costPart}`,
+                );
+            } else {
+                const prPart = prUrl ? `<${prUrl}|PR link>` : 'no PR';
+                lines.push(
+                    `    ${task.id} · ${task.fixScope} · ${prPart} · ${iterStr} · ${countStr} · ${costPart}`,
+                );
+            }
+        }
+    }
+
+    // Skipped
+    if (report.skipped.length > 0) {
+        lines.push('');
+        lines.push(DIVIDER);
+
+        for (const skip of report.skipped) {
+            lines.push('');
+            lines.push(`⛔ *${extractReasonType(skip.reason)}* — ${skip.rootCause}`);
+            const testRef = formatSkippedTestRef(skip.affectedTests);
+            if (testRef) lines.push(testRef);
+        }
+    }
+
+    // Cost footer
+    const fixCosts = summaries.map(s => s.costUsd).filter((c): c is number => c !== null);
+    const totalFixCost = fixCosts.reduce((a, b) => a + b, 0);
+    const hasCost = analyzeCost !== null || fixCosts.length > 0;
+
+    if (hasCost) {
+        const totalCost = (analyzeCost ?? 0) + totalFixCost;
+        const parts: string[] = [];
+
+        if (analyzeCost !== null) parts.push(`analysis ${formatCost(analyzeCost)}`);
+        if (fixCosts.length > 0) parts.push(`fixes ${formatCost(totalFixCost)}`);
+
+        lines.push('');
+        lines.push(DIVIDER);
+        lines.push(`💰 ~${formatCost(totalCost)} (${parts.join(' · ')})`);
+    }
+
+    return lines.join('\n');
+}
+
+async function sendSlackNotification(message: string): Promise<void> {
+    const webhook = process.env.SLACK_FIX_AGENT_WEBHOOK;
+
+    if (!webhook) {
+        log('[notify] No SLACK_FIX_AGENT_WEBHOOK configured, skipping notification.');
+        log(`[notify] Message would have been:\n${message}`);
+
+        return;
+    }
+
+    const res = await fetch(webhook, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: message }),
+    });
+
+    if (!res.ok) {
+        warn(`[notify] Failed to send Slack notification: ${res.status}`);
+    } else {
+        log('[notify] Slack notification sent.');
+    }
+}
+
+async function main(): Promise<void> {
+    const reportPath = process.env.REPORT_PATH;
+    const summariesDir = process.env.SUMMARIES_DIR;
+    const analyzeCostFile = process.env.ANALYZE_COST_FILE;
+
+    if (!reportPath) {
+        error('REPORT_PATH env var is required');
+        process.exit(1);
+    }
+
+    const report = AnalysisReportSchema.parse(JSON.parse(readFileSync(reportPath, 'utf-8')));
+    const summaries = summariesDir ? readSummaries(summariesDir) : [];
+    const analyzeCost = readAnalysisCost(analyzeCostFile);
+
+    log(`[notify] ${report.fixTasks.length} fix tasks · ${summaries.length} summaries loaded`);
+
+    const message = buildMessage(report, summaries, analyzeCost);
+
+    await sendSlackNotification(message);
+}
+
+main().catch(err => {
+    error(`[notify] Unhandled error: ${String(err)}`);
+    process.exit(1);
+});

--- a/packages/e2e-utils/src/fixBot/publish.ts
+++ b/packages/e2e-utils/src/fixBot/publish.ts
@@ -1,9 +1,9 @@
 import { execFileSync } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { appendFileSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { error, log } from '../logger';
-import { type FixResult, FixResultSchema } from './schemas';
+import { type FixResult, FixResultSchema, type SlackFixSummary } from './schemas';
 
 const BASE_BRANCH = 'develop';
 const GIT_REMOTE = 'origin';
@@ -15,6 +15,25 @@ const ICONS: Record<FixResult['result'], string> = {
     fail: '❌',
     not_duplicated: '🔵',
 };
+
+function writeSummary(root: string, summary: SlackFixSummary): void {
+    writeFileSync(
+        join(root, `slack-fix-summary-${summary.taskId}.json`),
+        JSON.stringify(summary, null, 2),
+    );
+    log('Slack summary written.');
+}
+
+function readCostUsd(): number | null {
+    const path = process.env.LLM_TOKEN_USAGE_FILE ?? '/tmp/llm-token-usage.json';
+    try {
+        const usage = JSON.parse(readFileSync(path, 'utf-8'));
+
+        return typeof usage.total_cost_usd === 'number' ? usage.total_cost_usd : null;
+    } catch {
+        return null;
+    }
+}
 
 function publishPR(): void {
     const branch = process.env.BRANCH;
@@ -36,9 +55,10 @@ function publishPR(): void {
         return;
     }
 
-    const { result, passed, failed, iterations, prTitle } = FixResultSchema.parse(
+    const { result, passed, failed, iterations, prTitle, taskId } = FixResultSchema.parse(
         JSON.parse(readFileSync(resultFile, 'utf-8')),
     );
+    const costUsd = readCostUsd();
 
     log(
         `Result: ${ICONS[result] ?? '?'} ${result}  passed=${passed.length}  failed=${failed.length}  iterations=${iterations}`,
@@ -50,6 +70,16 @@ function publishPR(): void {
                 ? '  → No branch pushed (zero validations pass).'
                 : '  → No branch pushed (failure not reproduced in pre-flight).',
         );
+        writeSummary(root, {
+            taskId,
+            result,
+            passed,
+            failed,
+            iterations,
+            prTitle,
+            prUrl: null,
+            costUsd,
+        });
 
         return;
     }
@@ -61,7 +91,12 @@ function publishPR(): void {
     const prDescriptionFile = join(root, 'pr-description.md');
     const prArgs = ['pr', 'create', '--title', prTitle, '--head', branch, '--base', BASE_BRANCH];
 
-    if (existsSync(prDescriptionFile)) prArgs.push('--body-file', prDescriptionFile);
+    if (existsSync(prDescriptionFile)) {
+        if (costUsd !== null) {
+            appendFileSync(prDescriptionFile, `\n\n### Agent cost\n~$${costUsd.toFixed(2)}\n`);
+        }
+        prArgs.push('--body-file', prDescriptionFile);
+    }
 
     // TODO: if 'gh pr create' errors because a PR for this branch already exists, catch it
     // and print the existing PR URL instead (e.g. via `gh pr list --head <branch> --json url`)
@@ -78,6 +113,17 @@ function publishPR(): void {
     } catch (err) {
         error(`Failed to assign PR to QA and Test Automation project: ${err}`);
     }
+
+    writeSummary(root, {
+        taskId,
+        result,
+        passed,
+        failed,
+        iterations,
+        prTitle,
+        prUrl,
+        costUsd,
+    });
 }
 
 publishPR();

--- a/packages/e2e-utils/src/fixBot/schemas.ts
+++ b/packages/e2e-utils/src/fixBot/schemas.ts
@@ -64,8 +64,23 @@ export const ClaudeResultSchema = z.object({
     duration_ms: z.number().optional(),
 });
 
+export const SlackFixSummarySchema = FixResultSchema.extend({
+    prUrl: z.string().nullable(),
+    costUsd: z.number().nullable(),
+});
+
+export type AnalysisReport = z.infer<typeof AnalysisReportSchema>;
 export type FixResult = z.infer<typeof FixResultSchema>;
+export type SlackFixSummary = z.infer<typeof SlackFixSummarySchema>;
 export type ClaudeResult = z.infer<typeof ClaudeResultSchema>;
 
-export const AnalysisReportJsonSchema = z.toJSONSchema(AnalysisReportSchema);
-export const FixResultJsonSchema = z.toJSONSchema(FixResultSchema);
+// Strip the top-level `$schema` which breaks Agent's attempt of JSON output
+const toCliJsonSchema = (schema: z.ZodType) => {
+    const jsonSchema = z.toJSONSchema(schema);
+    delete jsonSchema.$schema;
+
+    return jsonSchema;
+};
+
+export const AnalysisReportJsonSchema = toCliJsonSchema(AnalysisReportSchema);
+export const FixResultJsonSchema = toCliJsonSchema(FixResultSchema);


### PR DESCRIPTION
Adds aggregation of summaries from all jobs and send this overview to slack channel.

Example:

:robot_face: Nightly Fix Agent — 2026-06-05  [GHA Run](https://github.com/trezor/trezor-suite/actions/runs/27015216613)

Analyzer — 4 fixable · 2 skipped

──────────────────────────────────────

:white_check_mark: Missing stealBridgeSession() call before step 3 ('After reloading inactive suite session does not take Bridge session back'). Step 2 explicitly restores the session via solveIssuesButton, so by the time step 3 runs the device status is 'Connected', not 'Use here'. No second steal is performed to create the precondition the assertion requires.
    suite/e2e/tests/suite/multiple-sessions.test.ts [T3T1] (+1)
    fix-001 · TEST_CODE · [PR link](https://github.com/trezor/trezor-suite/pull/28426) · 3 iters · 2/2 · $6.09

:white_check_mark: Firmware changed EVM address display from fourTetragrams format ('0xdc aB74 E62b 9D08') to evmTetragrams format ('  0x dcaB 74E6 2b9D'). Both test cases call transformAddress(sendAddress) without specifying lineFormat, which defaults to 'fourTetragrams', causing toShowOnDisplay body mismatch.
    suite/e2e/tests/wallet/send-base.test.ts [T3W1]
    fix-002 · TEST_CODE · [PR link](https://github.com/trezor/trezor-suite/pull/28419) · 1 iter · 1/1 · $0.19

:white_check_mark: Default Playwright 5 s auto-wait is insufficient for @account-menu/btc/normal/0 to appear after indexedDb.seedFromDump() + page reload. IndexedDB hydration into Redux (accounts, devices, discovery) takes >5 s in CI but the element does appear before 20 s, as evidenced by the post-failure screenshot showing the BTC account already rendered.
    suite/e2e/tests/trading/remembered-wallet-loading.test.ts [no_device]
    fix-003 · TEST_CODE · [PR link](https://github.com/trezor/trezor-suite/pull/28418) · 1 iter · 1/1 · $0.19

:white_check_mark: data-testid='@dashboard/wallet-ready' is absent from the EmptyWallet component's DOM at the time the t1b1-create-wallet test asserts it. The visible text ('Start using your wallet') confirms EmptyWallet is mounted, but the testid attribute is missing — likely removed or displaced in a recent refactor of PortfolioCard/EmptyWallet.tsx.
    suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts [T1B1]
    fix-004 · LOCATOR_ADD · [PR link](https://github.com/trezor/trezor-suite/pull/28420) · 1 iter · 1/1 · $2.50

──────────────────────────────────────

:no_entry: Product code change required in AddAccountButton.tsx to emit the event in the onAddNewAccount path. Outside TEST_CODE / LOCATOR_ADD scope. — accounts/new-account analytics event is only emitted in the onEnableAccount branch of AddAccountButton.tsx. When the modal calls onAddNewAccount() (path taken for adding a second account on a coin), no analytics event is fired. analytics.findAnalyticsEventByType() throws because the event is absent from the intercepted requests.
    suite/e2e/tests/wallet/add-account-types.test.ts > Add account types ada (+1)

:no_entry: Emulator/infra issue — Emulator device hangs on a 'Confirm on Trezor' prompt during metadataPage.enableSuiteSync(). The SuiteSync enablement flow requires a hardware confirmation that the emulator does not complete, so the migration never runs and the TR_LABELING_MIGRATION_SUCCESS toast never appears.
    suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts > Migration from local file

──────────────────────────────────────
:moneybag: ~$11.78 (analysis $2.82 · fixes $8.97)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=nightly-agent-fixer-10&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=nightly-agent-fixer-10&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-05T12:39:00.879Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-05T12:36:10.432Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/nightly-agent-fixer-10/web/](https://dev.suite.sldev.cz/suite-web/nightly-agent-fixer-10/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->