### PR TITLE
refactor(request-manager): overloadHttpRequest to cover all signatures

### DIFF
--- a/packages/request-manager/src/interceptor/interceptHttp.ts
+++ b/packages/request-manager/src/interceptor/interceptHttp.ts
@@ -21,9 +21,14 @@ export const interceptHttp: Interceptor = ({ context, validateRequest }) => {
         });
 
         if (overload) {
-            const [identity, ...overloadedArgs] = overload;
+            const { identity, requestArgs } = overload;
 
-            return context.requestPool(originalHttpRequest(...overloadedArgs), identity);
+            return context.requestPool(
+                (originalHttpRequest as (...a: typeof requestArgs) => http.ClientRequest)(
+                    ...requestArgs,
+                ),
+                identity,
+            );
         }
 
         // In cases that are not considered above we pass the args as they came.
@@ -45,9 +50,14 @@ export const interceptHttp: Interceptor = ({ context, validateRequest }) => {
         });
 
         if (overload) {
-            const [identity, ...overloadedArgs] = overload;
+            const { identity, requestArgs } = overload;
 
-            return context.requestPool(originalHttpGet(...overloadedArgs), identity);
+            return context.requestPool(
+                (originalHttpGet as (...a: typeof requestArgs) => http.ClientRequest)(
+                    ...requestArgs,
+                ),
+                identity,
+            );
         }
 
         return originalHttpGet(...(args as Parameters<typeof https.get>));

--- a/packages/request-manager/src/interceptor/interceptHttps.ts
+++ b/packages/request-manager/src/interceptor/interceptHttps.ts
@@ -20,9 +20,16 @@ export const interceptHttps: Interceptor = ({ context, validateRequest }) => {
         });
 
         if (overload) {
-            const [identity, ...overloadedArgs] = overload;
+            const { identity, requestArgs } = overload;
 
-            return context.requestPool(originalHttpsRequest(...overloadedArgs), identity);
+            return context.requestPool(
+                (
+                    originalHttpsRequest as (
+                        ...a: typeof requestArgs
+                    ) => ReturnType<typeof originalHttpsRequest>
+                )(...requestArgs),
+                identity,
+            );
         }
 
         // In cases that are not considered above we pass the args as they came.
@@ -44,9 +51,16 @@ export const interceptHttps: Interceptor = ({ context, validateRequest }) => {
         });
 
         if (overload) {
-            const [identity, ...overloadedArgs] = overload;
+            const { identity, requestArgs } = overload;
 
-            return context.requestPool(originalHttpsGet(...overloadedArgs), identity);
+            return context.requestPool(
+                (
+                    originalHttpsGet as (
+                        ...a: typeof requestArgs
+                    ) => ReturnType<typeof originalHttpsGet>
+                )(...requestArgs),
+                identity,
+            );
         }
 
         return originalHttpsGet(...(args as Parameters<typeof https.get>));

--- a/packages/request-manager/src/interceptor/overloadHttpRequest.ts
+++ b/packages/request-manager/src/interceptor/overloadHttpRequest.ts
@@ -27,11 +27,13 @@ const getIdentityForAgent = (options?: Readonly<http.RequestOptions>) => {
     }
 };
 
+type RequestCallback = (response: http.IncomingMessage) => void;
+
 type OverloadHttpRequestParams = {
     context: InterceptorContext;
     protocol: 'http' | 'https';
     url: string | URL | http.RequestOptions;
-    options?: http.RequestOptions | ((r: http.IncomingMessage) => void);
+    options?: http.RequestOptions | RequestCallback;
     callback?: unknown;
     validateRequest: (params: { hostname: string }) => void;
 };
@@ -42,6 +44,58 @@ const resolveHostname = (url: string | URL | http.RequestOptions) => {
     }
 
     return new URL(url).hostname;
+};
+
+const isRequestOptions = (
+    value: string | URL | http.RequestOptions | RequestCallback | undefined,
+): value is http.RequestOptions =>
+    typeof value === 'object' && value !== null && !(value instanceof URL);
+
+type ParsedRequestArgs = {
+    requestUrl?: string | URL;
+    requestOptions: http.RequestOptions;
+    requestCallback?: RequestCallback;
+};
+
+/**
+ * http(s).request supports several call signatures:
+ *   1. request(options[, callback])
+ *   2. request(url[, callback])
+ *   3. request(url, options[, callback])
+ *
+ * They are normalized into a single mutable RequestOptions object (creating an empty one when
+ * the call only carried a url) plus the optional url and callback, so the same Tor/proxy logic
+ * can be applied regardless of how the request was originally called.
+ */
+const parseRequestArgs = ({
+    url,
+    options,
+    callback,
+}: Pick<OverloadHttpRequestParams, 'url' | 'options' | 'callback'>): ParsedRequestArgs => {
+    // Signature 1: request(options[, callback])
+    if (isRequestOptions(url)) {
+        return {
+            requestOptions: url,
+            requestCallback: typeof options === 'function' ? options : undefined,
+        };
+    }
+
+    // Signature 3: request(url, options[, callback])
+    if (isRequestOptions(options)) {
+        return {
+            requestUrl: url,
+            requestOptions: options,
+            requestCallback:
+                typeof callback === 'function' ? (callback as RequestCallback) : undefined,
+        };
+    }
+
+    // Signature 2: request(url[, callback])
+    return {
+        requestUrl: url,
+        requestOptions: {},
+        requestCallback: typeof options === 'function' ? options : undefined,
+    };
 };
 
 const reportInterceptedRequest = (context: InterceptorContext, details: string) => {
@@ -87,8 +141,10 @@ const enforceTorRequirement = (context: InterceptorContext, host?: string | null
 };
 
 /**
- * http(s).request could have different arguments according to its types definition,
- * but we only care when second argument (url) is object containing RequestOptions.
+ * Intercepts http(s).request regardless of which of its call signatures was used and, for
+ * non-whitelisted hosts, routes the request through the appropriate Tor identity (or blocks it
+ * when Tor is required but disabled). Returns the reconstructed params for the original request,
+ * preserving the original call signature, or `undefined` when the request is left untouched.
  */
 export const overloadHttpRequest = ({
     context,
@@ -102,34 +158,34 @@ export const overloadHttpRequest = ({
 
     validateRequest({ hostname });
 
-    const isOverloadableUrl = typeof url === 'object' && 'headers' in url;
-    const isOverloadableOptions = !options || typeof options === 'function';
-
-    if (
-        !!callback ||
-        !isOverloadableUrl ||
-        !isOverloadableOptions ||
-        isWhitelistedHost(hostname, context.notRequiredTorDomainsList)
-    ) {
+    if (isWhitelistedHost(hostname, context.notRequiredTorDomainsList)) {
         return;
     }
 
-    const overloadedOptions = url;
-    const overloadedCallback = options;
-    const { host, path } = overloadedOptions;
+    const { requestUrl, requestOptions, requestCallback } = parseRequestArgs({
+        url,
+        options,
+        callback,
+    });
 
     let identity: string | undefined;
 
     if (context.getTorSettings().running) {
-        identity = assignTorAgent({ context, options: overloadedOptions, protocol });
-    } else if (getIsTorRequired(url)) {
-        enforceTorRequirement(context, host);
+        identity = assignTorAgent({ context, options: requestOptions, protocol });
+    } else if (getIsTorRequired(requestOptions)) {
+        enforceTorRequirement(context, requestOptions.host ?? hostname);
     }
 
-    reportInterceptedRequest(context, `${host}${path} with agent ${!!overloadedOptions.agent}`);
+    const target = requestUrl ?? `${requestOptions.host ?? ''}${requestOptions.path ?? ''}`;
+    reportInterceptedRequest(context, `${target} with agent ${!!requestOptions.agent}`);
 
-    delete overloadedOptions.headers?.['Proxy-Authorization'];
+    delete requestOptions.headers?.['Proxy-Authorization'];
 
-    // Tuple of params for the original request.
-    return [identity, overloadedOptions, overloadedCallback] as const;
+    // Params for the original request, preserving the original call signature.
+    const requestArgs: Array<string | URL | http.RequestOptions | RequestCallback | undefined> =
+        requestUrl !== undefined
+            ? [requestUrl, requestOptions, requestCallback]
+            : [requestOptions, requestCallback];
+
+    return { identity, requestArgs };
 };

--- a/packages/request-manager/src/interceptor/overloadHttpRequest.ts
+++ b/packages/request-manager/src/interceptor/overloadHttpRequest.ts
@@ -44,6 +44,48 @@ const resolveHostname = (url: string | URL | http.RequestOptions) => {
     return new URL(url).hostname;
 };
 
+const reportInterceptedRequest = (context: InterceptorContext, details: string) => {
+    context.handler({ type: 'INTERCEPTED_REQUEST', method: 'http.request', details });
+};
+
+/**
+ * Assigns a Tor proxy agent to the request and returns the identity used for it.
+ * The identity comes from the Proxy-Authorization header or falls back to 'default'.
+ */
+const assignTorAgent = ({
+    context,
+    options,
+    protocol,
+}: {
+    context: InterceptorContext;
+    options: http.RequestOptions;
+    protocol: 'http' | 'https';
+}) => {
+    const identity = getIdentityForAgent(options) || 'default';
+
+    options.agent = context.torIdentities.getIdentity(identity, options.timeout, protocol);
+
+    return identity;
+};
+
+/**
+ * Handles a request that explicitly requires Tor (via Proxy-Authorization) while Tor is off.
+ * It is either conditionally allowed or blocked by throwing.
+ */
+const enforceTorRequirement = (context: InterceptorContext, host?: string | null) => {
+    if (context.allowTorBypass) {
+        reportInterceptedRequest(
+            context,
+            `Conditionally allowed request with Proxy-Authorization ${host}`,
+        );
+
+        return;
+    }
+
+    reportInterceptedRequest(context, `Request blocked ${host}`);
+    throw new Error('Blocked request with Proxy-Authorization. TOR not enabled.');
+};
+
 /**
  * http(s).request could have different arguments according to its types definition,
  * but we only care when second argument (url) is object containing RequestOptions.
@@ -60,56 +102,34 @@ export const overloadHttpRequest = ({
 
     validateRequest({ hostname });
 
+    const isOverloadableUrl = typeof url === 'object' && 'headers' in url;
+    const isOverloadableOptions = !options || typeof options === 'function';
+
     if (
-        !callback &&
-        typeof url === 'object' &&
-        'headers' in url &&
-        !isWhitelistedHost(hostname, context.notRequiredTorDomainsList) &&
-        (!options || typeof options === 'function')
+        !!callback ||
+        !isOverloadableUrl ||
+        !isOverloadableOptions ||
+        isWhitelistedHost(hostname, context.notRequiredTorDomainsList)
     ) {
-        const isTorEnabled = context.getTorSettings().running;
-        const isTorRequired = getIsTorRequired(url);
-        const overloadedOptions = url;
-        const overloadedCallback = options;
-        const { host, path } = overloadedOptions;
-        let identity: string | undefined;
-
-        if (isTorEnabled) {
-            // Create proxy agent for the request (from Proxy-Authorization or default)
-            // get authorization data from request headers
-            identity = getIdentityForAgent(overloadedOptions) || 'default';
-            overloadedOptions.agent = context.torIdentities.getIdentity(
-                identity,
-                overloadedOptions.timeout,
-                protocol,
-            );
-        } else if (isTorRequired) {
-            // Block requests that explicitly requires TOR using Proxy-Authorization
-            if (context.allowTorBypass) {
-                context.handler({
-                    type: 'INTERCEPTED_REQUEST',
-                    method: 'http.request',
-                    details: `Conditionally allowed request with Proxy-Authorization ${host}`,
-                });
-            } else {
-                context.handler({
-                    type: 'INTERCEPTED_REQUEST',
-                    method: 'http.request',
-                    details: `Request blocked ${host}`,
-                });
-                throw new Error('Blocked request with Proxy-Authorization. TOR not enabled.');
-            }
-        }
-
-        context.handler({
-            type: 'INTERCEPTED_REQUEST',
-            method: 'http.request',
-            details: `${host}${path} with agent ${!!overloadedOptions.agent}`,
-        });
-
-        delete overloadedOptions.headers?.['Proxy-Authorization'];
-
-        // return tuple of params for original request
-        return [identity, overloadedOptions, overloadedCallback] as const;
+        return;
     }
+
+    const overloadedOptions = url;
+    const overloadedCallback = options;
+    const { host, path } = overloadedOptions;
+
+    let identity: string | undefined;
+
+    if (context.getTorSettings().running) {
+        identity = assignTorAgent({ context, options: overloadedOptions, protocol });
+    } else if (getIsTorRequired(url)) {
+        enforceTorRequirement(context, host);
+    }
+
+    reportInterceptedRequest(context, `${host}${path} with agent ${!!overloadedOptions.agent}`);
+
+    delete overloadedOptions.headers?.['Proxy-Authorization'];
+
+    // Tuple of params for the original request.
+    return [identity, overloadedOptions, overloadedCallback] as const;
 };


### PR DESCRIPTION
## Description

Historically only signature 1 was handled, which broke when libraries like node-fetch@3 started using different function  signature  (request(urlString, options)), because the function returned early without attaching the Tor agent and the request silently bypassed Tor.

This PR adds 2 missing signatures to http request overload.

## Notes for QA

Test Desktop app with all the networks and test that all the calls are going throw Tor.




<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to `overloadHttpRequest.ts` in the `request-manager` package, which handles HTTP request interception (likely for Tor proxy routing). There is no static test coverage mapping available for this file, so all recommendations are inferred. The bridge/tor test is the most directly relevant since it exercises network infrastructure closest to the request-manager's domain. Trading tests are included at low priority as they exercise HTTP API calls that could be affected by request interception changes. Overall risk is moderate — the change could silently affect any outgoing HTTP request behavior, but without knowing the exact nature of the change, targeted testing of network-dependent features is the best strategy.

<details><summary><b>Changed files (1)</b></summary>

- `packages/request-manager/src/interceptor/overloadHttpRequest.ts`

</details>

**Recommended tests (3)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — The changed file `overloadHttpRequest.ts` in `packages/request-manager` is part of the HTTP request interception/proxy layer, which is closely related to Tor and bridge connectivity infrastructure. This test exercises the bridge daemon spawning and HTTP health checks against the bridge endpoint, which could be affected if HTTP request overloading behavior changes.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — The request-manager's HTTP interceptor could affect how outgoing API requests to the Invity trading backend are handled. This test makes multiple mocked HTTP requests (buyQuotes, buyTrade, buyWatch) and verifies payloads, making it sensitive to changes in HTTP request interception behavior.
- `suite/e2e/tests/trading/swap-coins.test.ts` — This swap test involves multiple HTTP requests to Invity swap endpoints and watch polling, exercising the HTTP request pipeline that `overloadHttpRequest.ts` intercepts. Changes to request overloading could affect how swap API calls are routed or proxied.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/request-manager/src/interceptor/overloadHttpRequest.ts`

_Updated: 2026-06-01T19:02:14.514Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/request-manager-update-second&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/request-manager-update-second&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-01T19:08:08.643Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-01T19:05:51.913Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/request-manager-update-second/web/](https://dev.suite.sldev.cz/suite-web/fix/request-manager-update-second/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->