### PR TITLE
chore(message-system): increasing priority of stablecoin yield banner

### DIFF
--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1,7 +1,7 @@
 {
     "version": 1,
-    "timestamp": "2026-05-28T00:00:00+00:00",
-    "sequence": 140,
+    "timestamp": "2026-06-01T00:00:00+00:00",
+    "sequence": 141,
     "actions": [
         {
             "conditions": [
@@ -1560,7 +1560,7 @@
             ],
             "message": {
                 "id": "ab805171-6266-4618-be4f-a7c25d4c19ce",
-                "priority": 2,
+                "priority": 3,
                 "dismissible": true,
                 "variant": "info",
                 "category": "feature",


### PR DESCRIPTION
## Description

Increasing priority of stablecoin yield promo banner on the dashboard.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is `suite-common/message-system/config/config.v1.json`, which is a JSON configuration file for the message system (remote messaging/banners/notifications). None of the 109 candidate E2E tests directly exercise the message system configuration — the closest reference is `mockRemoteMessageSystem` in the TrezorConnect webextension test, but that mocks the system entirely rather than relying on the actual config file's content. Since this is a data-only config change with no code logic modifications and no tests statically or behaviorally depend on the specific contents of this config, no E2E tests are recommended. The risk is low: message system config changes affect which banners/messages are shown to users, but this is not covered by any existing E2E test.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/message-system/config/config.v1.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `suite-common/message-system/config/config.v1.json`

_Updated: 2026-06-01T19:23:47.961Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/message-system-st-yield-banner-prio-increase&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/message-system-st-yield-banner-prio-increase&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/message-system-st-yield-banner-prio-increase&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-01T19:29:40.240Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-01T19:27:12.833Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/message-system-st-yield-banner-prio-increase/web/](https://dev.suite.sldev.cz/suite-web/chore/message-system-st-yield-banner-prio-increase/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->