### PR TITLE
chore(trading): add request correlation header to trade api calls

### DIFF
--- a/suite-common/trading/src/invityAPI.ts
+++ b/suite-common/trading/src/invityAPI.ts
@@ -130,6 +130,10 @@ class InvityAPI {
         this.serverEnvironment = serverEnvironment;
     }
 
+    private getSuiteTraceHeader() {
+        return createHash('sha256').update(this.getInvityAPIKey()).digest('hex');
+    }
+
     private getOptionAPIHeader() {
         if (isNative()) return 'X-SuiteN-Api';
         if (isDesktop()) return 'X-SuiteA-Api';
@@ -150,6 +154,7 @@ class InvityAPI {
             mode: 'cors',
             headers: {
                 [apiHeader]: apiHeaderValue || this.getInvityAPIKey(),
+                'X-Trace-Id': this.getSuiteTraceHeader(),
                 'X-Suite-Version': getSuiteVersion(),
                 'X-Suite-Platform': getOsName(),
                 ...(method === 'POST' && {


### PR DESCRIPTION
Add request correlation header


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to suite-common/trading/src/invityAPI.ts, which is the core Invity API client used for buy, sell, and swap trading operations. Despite static analysis mapping this file to 121 tests (indicating it's a broadly imported module), the actual risk is concentrated in the trading-related tests that directly exercise Invity API endpoints for quotes, trades, and transaction watching. The recommended strategy prioritizes all buy/sell/swap E2E tests at high priority since they directly exercise the API client's core methods, with form validation and fee-specific tests at medium priority. Non-trading tests (analytics, backup, onboarding, metadata, etc.) are omitted as they have no concrete dependency on the Invity API's behavior despite the transitive import.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/trading/src/invityAPI.ts`

</details>

**Recommended tests (17)**

<details><summary>🔴 <b>High priority (10)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — This test directly exercises the Invity buy quotes and buy trade API endpoints, which are core to invityAPI.ts. It mocks invityEndpoint.buyQuotes and buyTrade, verifies trade request payloads, and tests the full buy flow including watch polling — all of which depend on the Invity API client.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — Tests the Ethereum buy flow using Invity API endpoints (buyQuotes, buyTrade). Changes to invityAPI.ts could affect how quotes are fetched, trade payloads are constructed, or responses are parsed for ETH assets.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — Tests buying a Solana SPL token (JUP) through the Invity API. It verifies buy quote display, trade request payload construction, and transaction detail success — all directly dependent on invityAPI.ts functionality.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — Tests the full BTC sell flow using Invity sell API endpoints (sellQuotes, sellTrade, sellWatch). Verifies trade payload construction, quote display, and transaction status polling — all core invityAPI.ts operations.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Exercises the Ethereum sell flow through Invity API endpoints. Verifies sell quotes, trade confirmation, and device prompt details — directly dependent on invityAPI.ts for API communication.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Tests Solana sell flow with Invity API endpoints including sellQuotes, sellTrade, sellWatch, and swap watch polling with status transitions. Directly exercises invityAPI.ts trade and watch functionality.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Tests SOL-to-BTC swap using Invity swap API endpoints (swapQuotes, swapWatch). Verifies full swap lifecycle including status transitions (SENDING→CONFIRMING→CONVERTING→SUCCESS), which depend on invityAPI.ts swap methods.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Tests SOL-to-USDC swap flow using Invity swap quotes and trade endpoints. Verifies quote fetching, trade execution, and success status — all core invityAPI.ts swap operations.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Tests swapping USDT token to BTC through Invity swap API. Verifies swap quote display, trade confirmation payload, and transaction success status directly through invityAPI.ts.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Tests USDT-to-USDC SPL token swap using Invity swap endpoints. Exercises quote fetching, trade execution, and success verification — all dependent on invityAPI.ts swap methods.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/trading/buy-negative.test.ts` — Tests negative/edge cases in the buy flow including API returning empty quotes, min/max limit validation. Changes to invityAPI.ts could affect how error responses and empty quote arrays are handled.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Tests selling an ERC-20 token (USDC) through Invity sell API. While similar to other sell tests, it covers the token-specific path which may exercise different serialization logic in invityAPI.ts.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Tests sell form input validation and fee calculations. While primarily UI-focused, it does interact with the trading infrastructure that invityAPI.ts supports, particularly around amount formatting.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Tests BTC-to-ETH swap with custom fee settings, using Invity swap quotes endpoint. Verifies that fee data flows correctly through the swap API interaction layer in invityAPI.ts.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests ETH-to-BTC swap with custom Ethereum gas fees through Invity swap API. Verifies fee parameters are correctly passed, which depends on invityAPI.ts swap quote handling.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — Tests swap quotes for a disabled network target (XLM), verifying that invityAPI.ts correctly returns and displays provider info even when the buy asset network is not enabled.
- `suite/e2e/tests/trading/navigation.test.ts` — Tests navigation to buy/sell/swap forms from various entry points. While primarily UI navigation, it relies on the trading infrastructure initialized by invityAPI.ts to render forms correctly.

</details>

_Updated: 2026-06-01T22:09:23.767Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/trading-add-traces&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/trading-add-traces&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/trading-add-traces&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-01T22:14:11.322Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-01T22:12:08.073Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/trading-add-traces/web/](https://dev.suite.sldev.cz/suite-web/feat/trading-add-traces/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->