### PR TITLE
chore(intl): remove unused translation strings

### DIFF
--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -3156,10 +3156,6 @@ export const messages = defineMessages({
         defaultMessage: "Device settings can't be changed in the current state",
         id: 'TR_SETTINGS_DEVICE_BANNER_DESCRIPTION_UNAVAILABLE',
     },
-    TR_SETTINGS_COINS_BANNER_DESCRIPTION_REMEMBERED_DISCONNECTED: {
-        defaultMessage: 'Connect & unlock your Trezor to change settings.',
-        id: 'TR_SETTINGS_COINS_BANNER_DESCRIPTION_REMEMBERED_DISCONNECTED',
-    },
     TR_SETTINGS_DEVICE_BANNER_TITLE_BOOTLOADER: {
         defaultMessage: 'Other settings are unavailable in bootloader mode',
         id: 'TR_SETTINGS_DEVICE_BANNER_TITLE_BOOTLOADER',
@@ -3378,10 +3374,6 @@ export const messages = defineMessages({
     TR_TESTNET_COINS: {
         defaultMessage: 'Testnet',
         id: 'TR_TESTNET_COINS',
-    },
-    TR_TESTNET_COINS_DESCRIPTION: {
-        defaultMessage: 'These assets are for testing purposes only and have no real value.',
-        id: 'TR_TESTNET_COINS_DESCRIPTION',
     },
     TR_TESTNET_COINS_LABEL: {
         defaultMessage: 'TEST COIN',
@@ -4430,10 +4422,6 @@ export const messages = defineMessages({
         defaultMessage:
             "This wallet backup check is precisely the same as the normal recovery process. You should only trust the information and instructions displayed on your Trezor's screen.",
     },
-    TR_ACCOUNT_TYPE: {
-        id: 'TR_ACCOUNT_TYPE',
-        defaultMessage: 'Account type',
-    },
     TR_ACTIVATED_COINS: {
         id: 'TR_ACTIVATED_COINS',
         defaultMessage: 'Active assets',
@@ -4516,10 +4504,6 @@ export const messages = defineMessages({
     TR_DASHBOARD_GET_STARTED: {
         id: 'TR_DASHBOARD_GET_STARTED',
         defaultMessage: 'Get started',
-    },
-    TR_SELECT_COIN_FOR_SETTINGS: {
-        id: 'TR_SELECT_COIN_FOR_SETTINGS',
-        defaultMessage: 'Select active asset to change settings',
     },
     FW_CAPABILITY_UPDATE_REQUIRED: {
         id: 'FW_CAPABILITY_UPDATE_REQUIRED',


### PR DESCRIPTION
## Summary
Removes unused translation strings from `messages.ts` that are no longer referenced in the codebase.

**Keys removed (4):**
- `TR_SETTINGS_COINS_BANNER_DESCRIPTION_REMEMBERED_DISCONNECTED`
- `TR_TESTNET_COINS_DESCRIPTION`
- `TR_ACCOUNT_TYPE`
- `TR_SELECT_COIN_FOR_SETTINGS`

Identified by the `translations:list-unused` CI check.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change to suite/intl/src/messages.ts affects the central internationalization message definitions used across the entire Trezor Suite application. Since this is a foundational file with extremely broad reach, the risk depends entirely on which specific messages were modified. Tests that directly assert on translation key content (via toHaveTranslation matchers or text content checks) are most at risk. The recommended strategy focuses on tests with explicit, known translation key assertions — particularly settings, staking form validation, trading form validation, and device modal content tests — rather than every test that transitively imports the intl module.

<details><summary><b>Changed files (1)</b></summary>

- `suite/intl/src/messages.ts`

</details>

**Recommended tests (16)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/settings/autodetect.test.ts` — This test directly asserts on translated message content (TR_ONBOARDING_DATA_COLLECTION_HEADING) from @suite/intl messages. Changes to messages.ts could alter the default message text, breaking the heading text assertion and localized string comparisons.
- `suite/e2e/tests/settings/general.test.ts` — This test asserts on multiple translation keys for settings changes (settingsGeneralChangeLanguageEvent, theme labels, analytics toggle). It also verifies language change from English to Spanish, directly depending on message definitions in messages.ts.

</details>

<details><summary>🟡 <b>Medium priority (11)</b></summary>

- `suite/e2e/tests/settings/forget-device.test.ts` — This test asserts on multiple specific translation keys (TR_FORGET_DEVICE_MODAL_HEADING, TR_FORGET_DEVICE_MODAL_FINISH_HEADING, TR_FORGET_DEVICE_MODAL_BULLET_FORGET, etc.) for modal content verification. Changes to these message definitions could break assertions.
- `suite/e2e/tests/settings/coins.test.ts` — Asserts on translation keys TR_YOUR_WALLET_IS_READY_WHAT, TR_DASHBOARD_ACTIVATE_ASSETS_DESC, TR_DASHBOARD_GET_STARTED, and TR_CUSTOM_BACKEND. Changes to these message definitions in messages.ts would directly break these assertions.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — Asserts on translation keys TR_CUSTOM_BACKEND, TR_ACCOUNT_IS_EMPTY_TITLE, and TR_ACCOUNT_EXCEPTION_DISCOVERY_ERROR. If these message definitions change in messages.ts, the test assertions would fail.
- `suite/e2e/tests/staking/staking-form.test.ts` — Asserts on multiple translation keys for form validation (TR_BUY_VALIDATION_ERROR_MINIMUM_CRYPTO, AMOUNT_IS_NOT_IN_RANGE_DECIMALS, AMOUNT_IS_NOT_ENOUGH, AMOUNT_IS_NOT_SET, TR_STAKE_LEFT_AMOUNT_FOR_WITHDRAWAL). These are sourced from @suite/intl messages.
- `suite/e2e/tests/staking/ada/stake.test.ts` — Asserts on translation keys TR_EARN_STAKING_IN_A_NUTSHELL, TR_EARN_YOUR_FUNDS_STAY_ACCESSIBLE, TR_EARN_STAKE_TOKEN, and TR_STAKE_FULL_BALANCE from the intl messages module. Changes could break modal and staking UI assertions.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Asserts on the TR_GAS_LIMIT translation key from @suite/intl messages for the device prompt display. A change to this message definition would break the gas limit label assertion.
- `suite/e2e/tests/wallet/send-base.test.ts` — Asserts on TR_GAS_LIMIT translation from @suite/intl messages for Base network send flow device prompt. Shares the same translation dependency as the ETH send test.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — Asserts on TR_PASSPHRASE_MISMATCH, TR_PASSPHRASE_MISMATCH_DESCRIPTION, and TR_PASSPHRASE_WALLET translation keys. Changes to these messages would break the passphrase error and wallet label assertions.
- `suite/e2e/tests/suite/db-locale-migration.test.ts` — Tests language persistence across database migration using Spanish locale. The test relies on language label display from the settings page which depends on message definitions in messages.ts.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Asserts on translation keys AMOUNT_IS_NOT_IN_RANGE_DECIMALS, AMOUNT_IS_NOT_ENOUGH, and TR_TRADING_COUNTRY_WORLD from @suite/intl messages for sell form validation errors and country selector.
- `suite/e2e/tests/trading/swap-history.test.ts` — Asserts on multiple translation keys (TR_TRADING_LAST_TRANSACTIONS, TR_TRADING_SWAP_COUNTER, TR_EXCHANGE_STATUS_SUCCESS, TR_EXCHANGE_STATUS_ERROR, TR_EXCHANGE_DETAIL_SUCCESS_TITLE, TR_TRADING_TRANS_ID) from @suite/intl messages for swap history display.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — Asserts on TR_SUITE_SYNC_KEYS_NEEDED_BANNER translation key for the Suite Sync banner visibility check. A change to this specific message would break the banner assertion.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts` — Asserts on TR_YOU_WERE_DISCONNECTED_DOT translation key for the offline disconnection banner. A change to this specific message definition could break the banner text assertion.
- `suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts` — Asserts on TR_LABELING_MIGRATION_SUCCESS translation key in the toast notification after migration. A change to this specific message could break the migration success assertion.

</details>

_Updated: 2026-06-02T05:59:52.618Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/remove-unused-strings-20260602&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/remove-unused-strings-20260602&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-02T06:04:28.663Z • 8 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-02T06:02:11.003Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/remove-unused-strings-20260602/web/](https://dev.suite.sldev.cz/suite-web/chore/remove-unused-strings-20260602/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->