### PR TITLE
fix(suite): missing supply apy desc

### DIFF
--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyBreakdown.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyBreakdown.tsx
@@ -16,11 +16,15 @@ type EarnYieldApyBreakdownProps = {
     underlyingToken: TokenDto | undefined;
 };
 
-const getYieldSourceTranslationId = (yieldSource: RewardDtoYieldSource): TranslationKey | null => {
+// Translatable explainer rendered as the secondary text of a reward row. Unknown sources return
+// null so we never render the raw, untranslated description coming from the API.
+const getYieldSourceDescriptionId = (yieldSource: RewardDtoYieldSource): TranslationKey | null => {
     switch (yieldSource) {
+        case 'lending':
         case 'lending_interest':
             return 'TR_EARN_YIELD_APY_SOURCE_LENDING_INTEREST';
         case 'protocol_incentive':
+        case 'campaign_incentive':
             return 'TR_EARN_YIELD_APY_SOURCE_PROTOCOL_INCENTIVE';
         default:
             return null;
@@ -36,12 +40,7 @@ export const EarnYieldApyBreakdown = ({
         {sortRewardsByUnderlyingToken(rewards, underlyingToken).map((reward, index) => {
             const ratePercent = getApyPercent(reward.rate);
             const hasRatePercent = ratePercent !== null && ratePercent > 0;
-            const translationId = getYieldSourceTranslationId(reward.yieldSource);
-            const description = translationId ? (
-                <Translation id={translationId} />
-            ) : (
-                reward.description
-            );
+            const descriptionId = getYieldSourceDescriptionId(reward.yieldSource);
 
             return (
                 <Row key={index} gap={8} alignItems="center">
@@ -55,9 +54,9 @@ export const EarnYieldApyBreakdown = ({
                     />
                     <Column flex="1">
                         <Text typographyStyle="body-sm">{reward.token.symbol}</Text>
-                        {description && (
+                        {descriptionId && (
                             <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
-                                {description}
+                                <Translation id={descriptionId} />
                             </Text>
                         )}
                     </Column>

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/TransactionRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/TransactionRenderer.tsx
@@ -1,6 +1,6 @@
 import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
-import { getTxAnchor, goto, selectRouteName } from '@suite/router';
+import { getTxAnchor, goto, selectRouteName, selectRouterApp } from '@suite/router';
 import { selectDevices, selectSelectedDevice } from '@suite-common/device';
 import {
     selectAccounts,
@@ -40,6 +40,7 @@ export const TransactionRenderer = ({ render: View, ...props }: TransactionRende
     const devices = useSelector(selectDevices);
     const currentDevice = useSelector(selectSelectedDevice);
     const routeName = useSelector(selectRouteName);
+    const routerApp = useSelector(selectRouterApp);
     const dispatch = useDispatch();
 
     const networkAccounts = findAccountsByNetwork(symbol, accounts);
@@ -56,6 +57,9 @@ export const TransactionRenderer = ({ render: View, ...props }: TransactionRende
         ? 'wallet-staking'
         : 'wallet-index';
     const isTradingRoute = !!routeName?.includes('wallet-trading');
+    // Keep the user inside the yield flow: the toast action navigates away (goto) which makes
+    // users think the approve step is the whole transaction. Mirror the trading behavior above.
+    const isYieldRoute = routerApp === 'earn-yield';
     const transactionToken = 'token' in props.notification ? props.notification.token : undefined;
     const toastTestIdPrefix = `@toast/${props.notification.type}`;
 
@@ -143,7 +147,7 @@ export const TransactionRenderer = ({ render: View, ...props }: TransactionRende
                 ),
             }}
             action={
-                tx && !isTradingRoute
+                tx && !isTradingRoute && !isYieldRoute
                     ? {
                           onClick: handleTransactionClick,
                           label: 'TOAST_TX_BUTTON',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- do not show button in notificaiton to avoid taking user to account tx history
- fix missing yield source id in apy tooltip

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #28263 
Resolve #28262

## Screenshots:

<img width="1179" height="780" alt="Screenshot 2026-06-02 at 9 15 13" src="https://github.com/user-attachments/assets/af8bff76-32a8-4c3f-a03d-2b89e38297ad" />
<img width="629" height="295" alt="Screenshot 2026-06-02 at 9 14 22" src="https://github.com/user-attachments/assets/5840e621-1ac0-487d-8aa2-321f427c8b36" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies two components: EarnYieldApyBreakdown (staking yield display) and TransactionRenderer (notification rendering for transactions). TransactionRenderer maps to 121 tests as a broadly imported component, so only tests that specifically assert on transaction toast notifications or transaction rendering behavior are included. EarnYieldApyBreakdown has no static test coverage but is likely rendered in ETH staking dashboard views, so those staking tests are prioritized. The highest risk is in staking flows that both display the yield breakdown and assert on transaction toast content.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/components/earn/dashboard/yield/EarnYieldApyBreakdown.tsx`
- `packages/suite/src/components/suite/notifications/NotificationRenderer/TransactionRenderer.tsx`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/staking/eth/unstake.test.ts` — This test exercises the full ETH unstaking and claiming flow, which includes toast notifications showing transaction amounts and accounts (TransactionRenderer). It also interacts with the staking dashboard where EarnYieldApyBreakdown may render. Changes to TransactionRenderer could break the toast confirmations that this test asserts on.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test verifies the initial ETH staking flow including a success toast notification showing the staked amount and account name, which directly exercises TransactionRenderer. It also views the staking dashboard where EarnYieldApyBreakdown could appear.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — This test verifies staking additional ETH and asserts on toast notifications containing account name and staked amount after the transaction, directly exercising TransactionRenderer. The staking dashboard view may also render EarnYieldApyBreakdown.

</details>

<details><summary>🟡 <b>Medium priority (8)</b></summary>

- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — This test asserts on a success toast notification after SOL staking with correct account and amount, which exercises TransactionRenderer. The staking dashboard is also viewed.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — Asserts on staking success toast notifications with account name and amount for SOL stake-more flow, directly exercising TransactionRenderer.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — Asserts on toast notifications for both unstaking and claiming SOL transactions, which render via TransactionRenderer.
- `suite/e2e/tests/staking/ada/claim.test.ts` — Asserts on a toast notification confirming ADA reward claim with account name and claimed amount, exercising TransactionRenderer.
- `suite/e2e/tests/staking/ada/stake.test.ts` — Asserts on a success toast notification after ADA staking with account name and staked amount, exercising TransactionRenderer.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — Asserts on a toast notification confirming ADA unstaking with account name and amount, exercising TransactionRenderer.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — This test verifies transaction list rendering including pending/confirmed transaction labels and grouping. TransactionRenderer changes could affect how transaction notifications (e.g., TR_SENDING_SYMBOL, TR_SENT_SYMBOL) are displayed.
- `suite/e2e/tests/wallet/send-base.test.ts` — Asserts on '@toast/tx-sent' toast notification after sending a Base transaction and verifies confirmed transaction status, which involves TransactionRenderer.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/trading/sell-solana.test.ts` — Asserts on '@toast/tx-sent' toast notification containing transaction amount and account after sending crypto to a swap provider, which exercises TransactionRenderer.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/components/earn/dashboard/yield/EarnYieldApyBreakdown.tsx`

_Updated: 2026-06-02T07:19:50.650Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/yield-fixes&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/yield-fixes&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-02T07:25:00.677Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-02T07:22:26.136Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/yield-fixes/web/](https://dev.suite.sldev.cz/suite-web/chore/yield-fixes/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->