### PR TITLE
feat(connect): inject logger factory into core, remove internal initLog

### DIFF
--- a/packages/connect-cli/src/index.ts
+++ b/packages/connect-cli/src/index.ts
@@ -5,6 +5,7 @@ import TrezorConnect, {
     type Device,
     ThpPairingMethod,
     type UiRequestThpPairing,
+    initLog,
 } from '@trezor/connect';
 
 import { HELP, args } from './args';
@@ -289,6 +290,9 @@ const run = async () => {
         transports: [transport],
         pendingTransportEvent: false,
         debug: args.debug,
+        // connect runs in-process here, so supply the core logger factory directly.
+        // TODO(logger-unification): build from a unified app-wide logger instead of initLog.
+        createLogger: (prefix: string) => initLog(prefix, !!args.debug),
         thp: {
             appName: 'TrezorConnect Cli',
             hostName: 'localhost',

--- a/packages/connect-common/src/data/connectSettings.ts
+++ b/packages/connect-common/src/data/connectSettings.ts
@@ -82,6 +82,11 @@ export const parseConnectSettings = (input: Partial<ConnectSettings> = {}) => {
         }
     }
 
+    // Runtime function supplied by the host composition root; passthrough (not validated).
+    if (typeof input.createLogger === 'function') {
+        settings.createLogger = input.createLogger;
+    }
+
     if (typeof input.transportReconnect === 'boolean') {
         settings.transportReconnect = input.transportReconnect;
     }

--- a/packages/connect-common/src/types/settings.ts
+++ b/packages/connect-common/src/types/settings.ts
@@ -5,6 +5,7 @@ import type { Static } from '@trezor/schema-utils';
 import { Type } from '@trezor/schema-utils';
 import type { Transport } from '@trezor/transport-common';
 import type { PartialRecord } from '@trezor/type-utils';
+import type { Logger } from '@trezor/utils';
 
 import type { FirmwareChannel } from './firmware';
 
@@ -40,9 +41,22 @@ export type ConnectSettingsTransport =
     | Transport
     | (new (...args: any[]) => Transport);
 
+export type CreateLogger = (prefix: string) => Logger;
+
 export interface ConnectSettingsPublic {
     manifest?: Manifest;
+    // Enables connect logs. NOTE: connect core no longer uses this to gate its COMPONENT loggers
+    // (Core/Device/DeviceCommands/@trezor/transport) — those are driven by `createLogger`. It is still
+    // read by core's backend layer (BackendManager → BlockchainLink worker debug logging), by the
+    // connect-web/connect-mobile host wrappers (their own `@trezor/connect-web` logger + popup URL),
+    // and serves as the desktop IPC enabled hint that suite-desktop-core's trezor-connect.ts uses to
+    // build the core's `createLogger` factory.
     debug?: boolean;
+    // Logger factory supplied by the host composition root. Core expands it to logger instances for
+    // internal components instead of creating its own loggers. When omitted, connect does not log
+    // (no-op) — there is no internal fallback.
+    // TODO(logger-unification): unify connect's logger with the rest of the app's loggers.
+    createLogger?: CreateLogger;
     transportReconnect?: boolean;
     transports?: ConnectSettingsTransport[];
     pendingTransportEvent?: boolean;

--- a/packages/connect-common/src/utils/debug.ts
+++ b/packages/connect-common/src/utils/debug.ts
@@ -1,4 +1,6 @@
-import { LogsManager } from '@trezor/utils';
+import { type Logger, LogsManager } from '@trezor/utils';
+
+import type { CreateLogger } from '../types/settings';
 
 const green = '#bada55';
 const blue = '#20abd8';
@@ -26,5 +28,15 @@ export const setLogWriter = logsManager.setLogWriter.bind(logsManager);
 export const enableLog = logsManager.enableLog.bind(logsManager);
 export const enableLogByPrefix = logsManager.enableLogByPrefix.bind(logsManager);
 export const getLog = logsManager.getLog.bind(logsManager);
+
+export const noopLogger: Logger = {
+    info: () => {},
+    debug: () => {},
+    log: () => {},
+    warn: () => {},
+    error: () => {},
+};
+
+export const noopCreateLogger: CreateLogger = () => noopLogger;
 
 export type { LogMessage, LogWriter, Log } from '@trezor/utils';

--- a/packages/connect/src/core/__tests__/onCallFirmwareUpdate.test.ts
+++ b/packages/connect/src/core/__tests__/onCallFirmwareUpdate.test.ts
@@ -1,4 +1,5 @@
 import { parseConnectSettings } from '@trezor/connect-common/src/data/connectSettings';
+import { noopCreateLogger } from '@trezor/connect-common/src/utils/debug';
 import { DeviceModelInternal, FirmwareType } from '@trezor/device-utils';
 import { v1 as protocolV1 } from '@trezor/protocol';
 import { buildMessage } from '@trezor/transport-common';
@@ -188,7 +189,7 @@ const calculateFirmwareHashMock = (hash?: string) => ({
 const setupTest = () => {
     const deviceList = new DeviceList({
         ...settingsStore.get(),
-        // debug: true,
+        createLogger: noopCreateLogger,
     });
 
     const fixtures: ResponseFixture[] = [];

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -27,14 +27,15 @@ import type {
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import type { TrezorError } from '@trezor/connect-common/src/constants/errors';
 import { parseLocalFirmwares } from '@trezor/connect-common/src/data/connectSettings';
+import type { CreateLogger } from '@trezor/connect-common/src/types/settings';
 import {
     type LogWriter,
-    enableLog,
-    initLog,
+    noopCreateLogger,
+    noopLogger,
     setLogWriter,
 } from '@trezor/connect-common/src/utils/debug';
 import { TRANSPORT, TRANSPORT_ERROR } from '@trezor/transport-common';
-import { createDeferred, createLazy, getSynchronize, throwError } from '@trezor/utils';
+import { type Logger, createDeferred, createLazy, getSynchronize, throwError } from '@trezor/utils';
 
 import type { AbstractMethod } from './AbstractMethod';
 import { getMethod } from './method';
@@ -50,9 +51,6 @@ import type { IDeviceList } from '../device/DeviceList';
 import { DeviceList, assertDeviceListConnected } from '../device/DeviceList';
 import { validateState } from '../device/workflow/validateState';
 import { createUiPromiseManager } from '../utils/uiPromiseManager';
-
-// custom log
-const _log = initLog('Core');
 
 type CoreContext = ReturnType<Core['getCoreContext']>;
 
@@ -199,6 +197,7 @@ const onCall = async (context: CoreContext, message: CoreCallMessage) => {
         methodSynchronize,
         resolveWaitForFirstMethod,
         sendCoreMessage,
+        logger,
     } = context;
     const responseID = message.id;
 
@@ -206,9 +205,9 @@ const onCall = async (context: CoreContext, message: CoreCallMessage) => {
     let method: AbstractMethod<any>;
     try {
         method = await methodSynchronize(async () => {
-            _log.debug('loading method...');
+            logger.debug('loading method...');
             const method2 = await getMethod(message);
-            _log.debug('method selected', method2.name);
+            logger.debug('method selected', method2.name);
 
             await method2.initAsync?.();
 
@@ -265,7 +264,7 @@ const onCallDevice = async (
     message: CoreCallMessage,
     method: AbstractMethod<any>,
 ): Promise<void> => {
-    const { deviceList, callMethods, sendCoreMessage } = context;
+    const { deviceList, callMethods, sendCoreMessage, logger } = context;
     const responseID = message.id;
     const { env, transports, pendingTransportEvent } = settingsStore.get();
 
@@ -369,7 +368,7 @@ const onCallDevice = async (
     } catch (error) {
         // just a log proving that cause propagates all the way up
         if (error.cause) {
-            _log.debug('device.run error caught, caused by:', error.cause);
+            logger.debug('device.run error caught, caused by:', error.cause);
         }
         // corner case: Device was disconnected during authorization
         // this device_id needs to be stored and penalized with delay on future connection
@@ -432,9 +431,9 @@ const onCallDevice = async (
  * @returns {void}
  * @memberof Core
  */
-const cleanup = ({ uiPromises }: CoreContext) => {
+const cleanup = ({ uiPromises, logger }: CoreContext) => {
     uiPromises.clear();
-    _log.debug('Cleanup...');
+    logger.debug('Cleanup...');
 };
 
 /**
@@ -729,7 +728,7 @@ const onCallCancel = (context: CoreContext, reason?: string, callId?: string) =>
 };
 
 const initDeviceList = (context: CoreContext) => {
-    const { deviceList, sendCoreMessage } = context;
+    const { deviceList, sendCoreMessage, logger } = context;
 
     deviceList.on(DEVICE.CONNECT, device => {
         sendCoreMessage(createDeviceMessage(DEVICE.CONNECT, device.toMessageObject()));
@@ -762,7 +761,7 @@ const initDeviceList = (context: CoreContext) => {
     );
 
     deviceList.on(TRANSPORT.ERROR, error => {
-        _log.warn('TRANSPORT.ERROR', error.error);
+        logger.warn('TRANSPORT.ERROR', error.error);
         sendCoreMessage(createTransportMessage(TRANSPORT.ERROR, error));
     });
 };
@@ -777,6 +776,9 @@ export class Core extends EventEmitter {
     private callMethods: AbstractMethod<any>[] = []; // generic type is irrelevant. only common functions are called at this level
     private methodSynchronize = getSynchronize();
     private uiPromises = createUiPromiseManager();
+
+    private createLogger: CreateLogger = noopCreateLogger;
+    private coreLogger: Logger = noopLogger;
 
     private waitForFirstMethod = createDeferred();
 
@@ -803,6 +805,7 @@ export class Core extends EventEmitter {
             signal: this.abortController.signal,
             uiPromises: this.uiPromises,
             deviceList: this.deviceList,
+            logger: this.coreLogger,
             callMethods: this.callMethods,
             methodSynchronize: this.methodSynchronize,
             sendCoreMessage: this.sendCoreMessage.bind(this),
@@ -816,7 +819,7 @@ export class Core extends EventEmitter {
     }
 
     handleMessage(message: CoreRequestMessage) {
-        _log.debug('handleMessage', message.type);
+        this.coreLogger.debug('handleMessage', message.type);
 
         switch (message.type) {
             case POPUP.CLOSED:
@@ -892,7 +895,7 @@ export class Core extends EventEmitter {
                             deviceList: this.deviceList,
                             postMessage: sendCoreMessageWithCallId,
                             selectDevice: path => selectDevice(coreContext, { path }),
-                            log: _log,
+                            log: this.coreLogger,
                             abortSignal: this.abortController.signal,
                             registerEvents: registerDeviceEvents(coreContext),
                             uiPromises: coreContext.uiPromises,
@@ -905,11 +908,11 @@ export class Core extends EventEmitter {
                             this.sendCoreMessage(
                                 createResponseMessage(message.id, false, { error }),
                             );
-                            _log.error('onCallFirmwareUpdate', error);
+                            this.coreLogger.error('onCallFirmwareUpdate', error);
                         });
                 } else {
                     onCall(this.getCoreContext(), message).catch(error => {
-                        _log.error('onCall', error);
+                        this.coreLogger.error('onCall', error);
                     });
                 }
         }
@@ -949,6 +952,11 @@ export class Core extends EventEmitter {
             setLogWriter(logWriterFactory);
         }
 
+        // Logger factory comes from the host composition root and must be ready before DeviceList
+        // is created because device discovery/handshake can log during init.
+        this.createLogger = settings.createLogger ?? noopCreateLogger;
+        this.coreLogger = this.createLogger('Core');
+
         // do not send any event until Core is fully loaded
         // DeviceList emits TRANSPORT and DEVICE events if pendingTransportEvent is set
         const throttlePromise = createDeferred();
@@ -969,21 +977,19 @@ export class Core extends EventEmitter {
                 localFirmwareStore.set(localFirmwares);
             }
             await loadProtobufModules();
-            const { debug, priority, manifest } = settingsStore.get();
-
-            enableLog(debug);
+            const { priority, manifest } = settingsStore.get();
 
             this._deviceList = new DeviceList({
-                debug,
                 priority,
                 manifest,
+                createLogger: this.createLogger,
             });
             initDeviceList(this.getCoreContext());
 
             this.on(CORE_EVENT, onCoreEventThrottled);
         } catch (error) {
             // TODO: kill app
-            _log.error('init', error);
+            this.coreLogger.error('init', error);
             throttlePromise.reject(error);
             throw error;
         }

--- a/packages/connect/src/core/onCallFirmwareUpdate.ts
+++ b/packages/connect/src/core/onCallFirmwareUpdate.ts
@@ -8,10 +8,9 @@ import type {
 } from '@trezor/connect-common';
 import { FirmwareType, UI_REQUEST, UI_RESPONSE, createUiMessage } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
-import type { Log } from '@trezor/connect-common/src/utils/debug';
 import { getFirmwareOrBootloaderVersionArray } from '@trezor/device-utils';
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
-import { resolveAfter } from '@trezor/utils';
+import { type Logger, resolveAfter } from '@trezor/utils';
 import { isEqual, isNewer } from '@trezor/utils/src/versionUtils';
 
 import {
@@ -41,7 +40,7 @@ type ReconnectContext = {
     device: Device;
     registerEvents: (device: Device) => void;
     postMessage: PostMessage;
-    log: Log;
+    log: Logger;
     abortSignal: AbortSignal;
     uiPromises: { create: UiPromiseCreator; rejectAll: (e: Error) => void };
 };
@@ -324,7 +323,7 @@ type BinaryHelperParams = {
     params: Params;
     firmwareType: FirmwareType;
     isIntermediary: boolean;
-    log: Log;
+    log: Logger;
 };
 
 const getBinaryHelper = async ({
@@ -393,7 +392,7 @@ type Context = {
     registerEvents: (device: Device) => void;
     postMessage: PostMessage;
     selectDevice: (path?: DeviceUniquePath) => Device;
-    log: Log;
+    log: Logger;
     abortSignal: AbortSignal;
     uiPromises: ReconnectContext['uiPromises'];
 };

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -16,7 +16,7 @@ import type {
     UnavailableCapabilities,
 } from '@trezor/connect-common';
 import { DEVICE, ERRORS, FIRMWARE, UI_REQUEST } from '@trezor/connect-common';
-import { initLog } from '@trezor/connect-common/src/utils/debug';
+import type { CreateLogger } from '@trezor/connect-common/src/types/settings';
 import type { FirmwareRelease } from '@trezor/device-utils';
 import {
     DeviceModelInternal,
@@ -34,7 +34,7 @@ import {
     type Transport,
     type TransportDeviceEvent,
 } from '@trezor/transport-common';
-import type { Deferred } from '@trezor/utils';
+import type { Deferred, Logger } from '@trezor/utils';
 import { TypedEmitter, createDeferred, isArrayMember, versionUtils } from '@trezor/utils';
 import type { VersionArray } from '@trezor/utils/src/versionUtils';
 
@@ -62,15 +62,13 @@ import { changeLanguage } from './workflow/changeLanguage';
 import { checkFirmwareHashWithRetries } from './workflow/checkFirmwareHashWithRetries';
 import { handshakeCancel } from './workflow/handshake';
 
-// custom log
-const _log = initLog('Device');
-
 export { type DeviceEvents } from '../types/idevice';
 
 type DeviceParams = {
     id: DeviceUniquePath;
     transport: Transport;
     descriptor: Descriptor;
+    createLogger: CreateLogger;
 };
 
 export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
@@ -167,14 +165,19 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
 
     private readonly uniquePath;
 
+    private readonly createLogger: CreateLogger;
+    private readonly logger: Logger;
+
     readonly lifecycle = new TypedEmitter<DeviceLifecycleEvents>();
 
     private sessionDfd?: Deferred<Session | null>;
 
-    constructor({ id, transport, descriptor }: DeviceParams) {
+    constructor({ id, transport, descriptor, createLogger }: DeviceParams) {
         super();
 
         this._protocol = protocolV1;
+        this.createLogger = createLogger;
+        this.logger = createLogger('Device');
 
         // === immutable properties
         this.uniquePath = id;
@@ -263,6 +266,7 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
                         this,
                         this.transport,
                         this.sessionAcquired,
+                        this.createLogger('DeviceCommands'),
                     );
 
                     return result;
@@ -278,7 +282,7 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
     }
 
     reset() {
-        _log.info(`Resetting Features and ThpState`);
+        this.logger.info(`Resetting Features and ThpState`);
         // @ts-expect-error
         this._features = undefined;
         this._protocol = protocolV1;
@@ -315,7 +319,7 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
     }
 
     setupThp() {
-        _log.info('Setup THP device');
+        this.logger.info('Setup THP device');
         this._protocol = protocolV2;
 
         if (
@@ -343,7 +347,7 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
         try {
             await this.run();
         } catch (error) {
-            _log.warn(`device.run error.message: ${error.message}, code: ${error.code}`);
+            this.logger.warn(`device.run error.message: ${error.message}, code: ${error.code}`);
 
             if (
                 error.code === 'Device_NotFound' ||
@@ -393,13 +397,13 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
     }
 
     startPiggybackAck() {
-        _log.debug('start PiggybackAck');
+        this.logger.debug('start PiggybackAck');
         this.thp?.enablePiggybackAck(true);
     }
 
     async stopPiggybackAck() {
         if (this.currentSession && this.thp?.isPiggybackAckEnabled) {
-            _log.debug('stop PiggybackAck');
+            this.logger.debug('stop PiggybackAck');
             // send ThpAck for previously seen message
             await this.currentSession.send('ThpAck', {});
             this.thp?.enablePiggybackAck(false);
@@ -409,7 +413,7 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
     // TODO empty fn variant can be split/removed
     run(fn?: () => Promise<void>, options: RunOptions = {}) {
         if (this.runPromise) {
-            _log.warn('Previous call is still running');
+            this.logger.warn('Previous call is still running');
             throw ERRORS.TypedError('Device_CallInProgress');
         }
 
@@ -473,7 +477,7 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
         this.transport.releaseDevice(this.sessionAcquired);
         this.sessionAcquired = null;
 
-        _log.debug('interruptionFromOutside');
+        this.logger.debug('interruptionFromOutside');
 
         this.runAbort?.abort(ERRORS.TypedError('Device_UsedElsewhere'));
     }
@@ -502,7 +506,7 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
         if (acquireNeeded || !staticSessionId || (!deriveCardano && options.useCardanoDerivation)) {
             // update features
             try {
-                await handshakeCancel({ device: this, logger: _log, signal: abortSignal });
+                await handshakeCancel({ device: this, logger: this.logger, signal: abortSignal });
 
                 if (this.protocol.name === 'v2') {
                     const withInteraction = !!fn;
@@ -517,7 +521,7 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
                     await this.getFeatures();
                 }
             } catch (error) {
-                _log.warn('Device._runInner error: ', error.message);
+                this.logger.warn('Device._runInner error: ', error.message);
 
                 if (error.code === 'Failure_Busy') {
                     this.busy = 'busy';
@@ -547,7 +551,7 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
         }
 
         if (!options.skipFirmwareChecks) {
-            await checkFirmwareHashWithRetries({ device: this, logger: _log });
+            await checkFirmwareHashWithRetries({ device: this, logger: this.logger });
             await this.checkFirmwareRevisionWithRetries();
         }
 
@@ -557,12 +561,12 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
             !this.features.language_version_matches &&
             this.atLeast('2.7.0')
         ) {
-            _log.info('language version mismatch. silently updating...');
+            this.logger.info('language version mismatch. silently updating...');
 
             try {
                 await changeLanguage({ device: this, language: this.features.language });
             } catch (err) {
-                _log.error('change language failed silently', err);
+                this.logger.error('change language failed silently', err);
             }
         }
 
@@ -885,7 +889,7 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
     }
 
     private disconnect() {
-        _log.debug('Disconnect cleanup');
+        this.logger.debug('Disconnect cleanup');
 
         this.transport.off(TRANSPORT.STOPPED, this.onTransportStopped);
         this.transport.deviceEvents.off(this.descriptor.path, this.onTransportDeviceEvent);

--- a/packages/connect/src/device/DeviceCurrentSession.ts
+++ b/packages/connect/src/device/DeviceCurrentSession.ts
@@ -2,7 +2,6 @@
 
 import { DEVICE } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
-import { initLog } from '@trezor/connect-common/src/utils/debug';
 import { MessagesSchema as Messages } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 import {
@@ -12,7 +11,7 @@ import {
     type Transport,
     isErrorWithoutDeviceInteraction,
 } from '@trezor/transport-common';
-import { scheduleAction } from '@trezor/utils';
+import { type Logger, scheduleAction } from '@trezor/utils';
 
 import type { IDevice } from '../types/idevice';
 import type { TypedCallProvider } from '../types/typed-call-provider';
@@ -57,8 +56,6 @@ const filterForLog = (type: string, msg: any) =>
         ? '(redacted...)'
         : (blacklist[type] ?? []).reduce((prev, cur) => ({ ...prev, [cur]: '(redacted...)' }), msg);
 
-const logger = initLog('DeviceCommands');
-
 const isExpectedResponse = <Key extends Messages.MessageKey | Messages.MessageKey[]>(
     response: Pick<MessageResponse, 'type'>,
     expected: Key,
@@ -77,15 +74,17 @@ export class DeviceCurrentSession implements TypedCallProvider {
     private readonly device: IDevice;
     private readonly transport: Transport;
     private readonly session: Session;
+    private readonly logger: Logger;
 
     private disposed?: Error;
     private callPromise?: Promise<unknown>;
     private abortController?: AbortController;
 
-    constructor(device: IDevice, transport: Transport, session: Session) {
+    constructor(device: IDevice, transport: Transport, session: Session, logger: Logger) {
         this.device = device;
         this.transport = transport;
         this.session = session;
+        this.logger = logger;
 
         transport.deviceEvents.once(device.transportPath, e => {
             if (!this.disposed) {
@@ -300,7 +299,7 @@ export class DeviceCurrentSession implements TypedCallProvider {
     async call(name: string, data: Record<string, unknown>, options: AbortableOptions = {}) {
         if (this.disposed) return Promise.resolve(nestedError(this.disposed));
 
-        logger.debug('Sending', name, filterForLog(name, data));
+        this.logger.debug('Sending', name, filterForLog(name, data));
 
         const result = await this.transport.call({
             name,
@@ -313,10 +312,10 @@ export class DeviceCurrentSession implements TypedCallProvider {
 
         if (result.success) {
             const { type, message } = result.payload;
-            logger.debug('Received', type, filterForLog(type, message));
+            this.logger.debug('Received', type, filterForLog(type, message));
         } else {
             // result.error.message is not propagated to higher levels, only logged here. webusb/node-bridge may return message with additional information
-            logger.warn('Received transport error', result.error.code, result.error.message);
+            this.logger.warn('Received transport error', result.error.code, result.error.message);
         }
 
         return result.success

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -10,7 +10,7 @@ import type {
     TransportInfo,
 } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
-import { initLog } from '@trezor/connect-common/src/utils/debug';
+import type { CreateLogger } from '@trezor/connect-common/src/types/settings';
 import { parseStaticSessionId } from '@trezor/device-utils';
 import {
     type Descriptor,
@@ -98,7 +98,9 @@ export const assertDeviceListConnected: (
     }
 };
 
-type ConstructorParams = Pick<ConnectSettings, 'priority' | 'debug' | 'manifest'>;
+type ConstructorParams = Pick<ConnectSettings, 'priority' | 'manifest'> & {
+    createLogger: CreateLogger;
+};
 type InitParams = Pick<
     ConnectSettings,
     'transports' | 'pendingTransportEvent' | 'transportReconnect'
@@ -114,6 +116,7 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
 
     private readonly handshakeLock;
     private readonly authPenaltyManager;
+    private readonly createLogger: CreateLogger;
 
     private updateTransports;
 
@@ -139,15 +142,14 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
         return this.getConnectedTransports().map(getTransportInfo);
     }
 
-    constructor({ priority, debug, manifest }: ConstructorParams) {
+    constructor({ priority, manifest, createLogger }: ConstructorParams) {
         super();
 
-        const transportLogger = initLog('@trezor/transport', debug);
-
+        this.createLogger = createLogger;
         this.handshakeLock = getSynchronize();
         this.authPenaltyManager = createAuthPenaltyManager(priority);
         this.updateTransports = createTransportList({
-            logger: transportLogger,
+            logger: createLogger('@trezor/transport'),
             id: manifest?.appName || manifest?.appUrl || 'unknown app',
         });
     }
@@ -173,7 +175,12 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
 
     private async onDeviceConnected(descriptor: Descriptor, transport: Transport) {
         const id = (this.deviceCounter++).toString(16).slice(-8);
-        const device = new Device({ id: asDeviceUniquePath(id), transport, descriptor });
+        const device = new Device({
+            id: asDeviceUniquePath(id),
+            transport,
+            descriptor,
+            createLogger: this.createLogger,
+        });
 
         const similarUsedDevices = this.getSimilarDevices(device).some(
             d => d.isUsed() || d.getBusy() === 'rebooting',

--- a/packages/connect/src/device/__tests__/DeviceList.test.ts
+++ b/packages/connect/src/device/__tests__/DeviceList.test.ts
@@ -1,4 +1,5 @@
 import { parseConnectSettings } from '@trezor/connect-common/src/data/connectSettings';
+import { noopCreateLogger, noopLogger } from '@trezor/connect-common/src/utils/debug';
 
 import { initializeFirmwareConfig } from '../../data/firmwareInfo';
 import * as firmwareReleaseStore from '../../data/firmwareReleaseStore';
@@ -39,6 +40,7 @@ describe('DeviceList', () => {
         list = new DeviceList({
             ...parseConnectSettings({}),
             priority: 0,
+            createLogger: noopCreateLogger,
         });
         eventsSpy = jest.fn();
         list.on('transport-start', ({ apiType }) => eventsSpy('transport-start', apiType));
@@ -59,6 +61,19 @@ describe('DeviceList', () => {
 
     afterEach(() => {
         list.dispose();
+    });
+
+    it('builds the transport logger through injected createLogger', () => {
+        const createLogger = jest.fn(() => noopLogger);
+        const local = new DeviceList({
+            ...parseConnectSettings({}),
+            priority: 0,
+            createLogger,
+        });
+
+        expect(createLogger).toHaveBeenCalledWith('@trezor/transport');
+
+        return local.dispose();
     });
 
     it('.init() throws error on unknown transport (string)', async () => {

--- a/packages/connect/src/device/__tests__/checkFirmwareHash.test.ts
+++ b/packages/connect/src/device/__tests__/checkFirmwareHash.test.ts
@@ -20,6 +20,7 @@ const getMockedDevice = (typedCallMock?: TypedCallProvider['typedCall']): Device
         id: 'mock-device-id' as DeviceUniquePath,
         transport,
         descriptor: {} as Descriptor,
+        createLogger: () => logger,
     });
 
     device.getCurrentSession = () => ({ typedCall: typedCallMock }) as TypedCallProvider;

--- a/packages/connect/src/device/__tests__/checkFirmwareHashWithRetries.test.ts
+++ b/packages/connect/src/device/__tests__/checkFirmwareHashWithRetries.test.ts
@@ -23,6 +23,7 @@ const getMockedDevice = (): Device => {
         id: 'mock-device-id' as DeviceUniquePath,
         transport,
         descriptor: {} as Descriptor,
+        createLogger: () => logger,
     });
 
     device.setAuthenticityChecks = jest.fn(device.setAuthenticityChecks);

--- a/packages/connect/src/device/__tests__/handshakeWorkflow.test.ts
+++ b/packages/connect/src/device/__tests__/handshakeWorkflow.test.ts
@@ -1,4 +1,5 @@
 import { parseConnectSettings } from '@trezor/connect-common/src/data/connectSettings';
+import { noopCreateLogger } from '@trezor/connect-common/src/utils/debug';
 
 import { initializeFirmwareConfig } from '../../data/firmwareInfo';
 import * as firmwareReleaseStore from '../../data/firmwareReleaseStore';
@@ -34,6 +35,7 @@ const getAcquiredDevice = async (apiMethods: any = {}) => {
         id: 'ABCD' as any, // any = DeviceUniquePath
         transport,
         descriptor: { path: '1' as any, type: 1, session: null, apiType: 'usb' }, // any = PathPublic
+        createLogger: noopCreateLogger,
     });
     await device.acquire();
 

--- a/packages/connect/src/device/workflow/checkFirmwareHash.ts
+++ b/packages/connect/src/device/workflow/checkFirmwareHash.ts
@@ -1,8 +1,7 @@
 import { randomBytes } from '@noble/hashes/utils.js';
 
 import type { FirmwareHashCheckError, FirmwareHashCheckResult } from '@trezor/connect-common';
-import type { Log } from '@trezor/connect-common/src/utils/debug';
-import { serializeError } from '@trezor/utils';
+import { type Logger, serializeError } from '@trezor/utils';
 
 import { calculateFirmwareHash, getBinaryOptional, stripFwHeaders } from '../../api/firmware';
 import { getFirmwareLocation, getReleaseByVersion } from '../../data/firmwareInfo';
@@ -18,7 +17,7 @@ const createFailResult = (error: FirmwareHashCheckError, errorPayload?: unknown)
 
 type Context = {
     device: IDevice;
-    logger: Log;
+    logger: Logger;
 };
 
 export const checkFirmwareHash = async ({

--- a/packages/connect/src/device/workflow/checkFirmwareHashWithRetries.ts
+++ b/packages/connect/src/device/workflow/checkFirmwareHashWithRetries.ts
@@ -1,13 +1,12 @@
 import { FIRMWARE } from '@trezor/connect-common';
-import type { Log } from '@trezor/connect-common/src/utils/debug';
-import { isArrayMember } from '@trezor/utils';
+import { type Logger, isArrayMember } from '@trezor/utils';
 
 import { checkFirmwareHash } from './checkFirmwareHash';
 import type { IDevice } from '../../types/idevice';
 
 type Context = {
     device: IDevice;
-    logger: Log;
+    logger: Logger;
 };
 
 const PROBE_CHECK_TIME_RETRIES = 4;

--- a/packages/connect/src/device/workflow/handshake.ts
+++ b/packages/connect/src/device/workflow/handshake.ts
@@ -1,8 +1,7 @@
 import { TypedError } from '@trezor/connect-common/src/constants/errors';
-import type { Log } from '@trezor/connect-common/src/utils/debug';
 import { PROTOCOL_MALFORMED } from '@trezor/protocol/src/errors';
 import { TRANSPORT_ERROR } from '@trezor/transport-common';
-import { resolveAfter, versionUtils } from '@trezor/utils';
+import { type Logger, resolveAfter, versionUtils } from '@trezor/utils';
 
 import type { WorkflowContext } from '../../types/workflow';
 
@@ -12,7 +11,7 @@ const ATTEMPTS_LIMIT = 10;
 type Context = {
     device: WorkflowContext['device'];
     signal: AbortSignal;
-    logger?: Log;
+    logger?: Logger;
 };
 
 const isLegacyBridge = (transport: Context['device']['transport']) =>

--- a/packages/connect/src/impl/core-in-module.ts
+++ b/packages/connect/src/impl/core-in-module.ts
@@ -27,9 +27,9 @@ import {
     type CancelParams,
     normalizeCancelParams,
 } from '@trezor/connect-common/src/utils/cancelParams';
-import { initLog } from '@trezor/connect-common/src/utils/debug';
+import { noopLogger } from '@trezor/connect-common/src/utils/debug';
 import { TRANSPORT } from '@trezor/transport-common';
-import { cloneObject, createDeferredManager } from '@trezor/utils';
+import { type Logger, cloneObject, createDeferredManager } from '@trezor/utils';
 
 import { initCoreState } from '../core';
 
@@ -38,7 +38,7 @@ export abstract class CoreInModule implements ConnectFactoryDependencies<Connect
 
     private settings;
     private coreManager;
-    private log;
+    private log: Logger;
     private messagePromises;
 
     private readonly boundOnCoreEvent = this.onCoreEvent.bind(this);
@@ -47,7 +47,8 @@ export abstract class CoreInModule implements ConnectFactoryDependencies<Connect
 
     public constructor() {
         this.settings = parseConnectSettings();
-        this.log = initLog('@trezor/connect');
+        // No-op until init() resolves the host logger settings.
+        this.log = noopLogger;
         this.coreManager = initCoreState();
         this.messagePromises = createDeferredManager<
             Omit<MethodResponseMessage, 'event' | 'type'>,
@@ -124,7 +125,8 @@ export abstract class CoreInModule implements ConnectFactoryDependencies<Connect
             this.settings.transports = this.defaultTransports;
         }
 
-        this.log.enabled = !!this.settings.debug;
+        // `createLogger` is optional. Without it, connect stays silent.
+        this.log = this.settings.createLogger?.('@trezor/connect') ?? noopLogger;
 
         await this.coreManager.getOrInit(this.settings, this.boundOnCoreEvent);
     }

--- a/packages/suite-desktop-core/src/modules/trezor-connect.ts
+++ b/packages/suite-desktop-core/src/modules/trezor-connect.ts
@@ -7,6 +7,7 @@ import TrezorConnect, {
     UI_REQUEST,
     UI_RESPONSE,
 } from '@trezor/connect';
+import { initLog } from '@trezor/connect-common';
 import { type IpcProxyHandlerOptions, createIpcProxyHandler } from '@trezor/ipc-proxy';
 import { parseElectrumUrl } from '@trezor/utils';
 
@@ -95,6 +96,10 @@ export const initBackground: ModuleInitBackground = ({ mainThreadEmitter, store 
                         settings.localFirmwares = localFirmwares.payload;
                     }
                     settings.transports = getTransportsParam(settings.transports);
+                    // Core runs in this (main) process; the renderer cannot send a logger factory
+                    // across IPC, so build it here from the serializable `debug` enabled hint.
+                    // TODO(logger-unification): build from a unified app-wide logger instead of initLog.
+                    settings.createLogger = (prefix: string) => initLog(prefix, !!settings.debug);
 
                     const response = await TrezorConnect.init(settings);
                     await setProxy();

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -24,6 +24,7 @@ import TrezorConnect, {
     DEVICE_EVENT,
     TRANSPORT_EVENT,
     UI_EVENT,
+    initLog,
 } from '@trezor/connect';
 import { isDesktop, isWeb } from '@trezor/env-utils';
 import { DATA_URL } from '@trezor/urls';
@@ -152,6 +153,14 @@ export const connectInitThunk = createThunk<void, void, void>(
             thp.hostName = capitalizeFirstLetter(getBrowserName());
         }
 
+        // Logger factory supplied to @trezor/connect from this composition root. On desktop the core
+        // runs in the main process, so the factory (a function) cannot cross the IPC boundary — it is
+        // injected there instead (see suite-desktop-core's trezor-connect.ts), driven by showConnectLogs.
+        // TODO(logger-unification): build the logger from a unified app-wide logger instead of initLog.
+        const createLogger = isDesktop()
+            ? undefined
+            : (prefix: string) => initLog(prefix, showConnectLogs);
+
         try {
             await TrezorConnect.init({
                 ...connectInitSettings,
@@ -160,6 +169,7 @@ export const connectInitThunk = createThunk<void, void, void>(
                 transports,
                 thp,
                 debug: showConnectLogs,
+                createLogger,
                 firmwareHashCheckTimeouts,
                 firmwareChannel: getEffectiveFirmwareChannel(getState()),
             });


### PR DESCRIPTION
## Description

Closes the first step of #28256: give `@trezor/connect` a **single way of working with a logger**.

This is a **prerequisite for simplifying #27842**. Moving connect's logger to an injected logger setup makes the logger — the only connect-internal blocker — available in the composition root, which unlocks narrowing transports to instance-only and removes the class-vs-instance branching that complicates #27842.

> Built after #28269, which moved the `Logger` interface to `@trezor/utils`.

Today connect core creates **5 of its own loggers** via `initLog(prefix)`. This PR removes all of those: connect core no longer calls `initLog` and instead accepts a **`createLogger: (prefix) => Logger`** factory in `ConnectSettings`. `Core.init` stores that factory, builds the `Core` logger from it, and passes the same factory down to `DeviceList` and `Device`; each layer creates only the prefixed logger it owns.

**All-or-nothing:** if no factory is supplied, connect logs nothing (`noopCreateLogger` returns the shared no-op logger) — there is no internal `initLog` fallback. Logs emitted before the factory is available (pre-init) are intentionally dropped.

## What changed

- **Connect core** (`core/index.ts`, `DeviceList`, `Device`, `DeviceCurrentSession`, `core-in-module`): no `initLog`; prefixed loggers come from the injected factory as the factory is drilled down through connect internals. `Core.init` assigns the factory **before** constructing `DeviceList` (device handshake logs during init). Workflow helpers + `onCallFirmwareUpdate` now type their `logger` param as the `Logger` interface (from `@trezor/utils`) instead of the concrete `Log` class.
- **Composition roots** supply the factory at every in-repo, in-process Core entry point:
  - suite web / native → `connectInitThunks.ts` (`undefined` on desktop — a function cannot cross IPC)
  - suite desktop → `suite-desktop-core` `trezor-connect.ts` main process (built locally from `settings.debug`)
  - `connect-cli`
  - _(connect-web/connect-mobile popup Core runs in a hosted build outside this repo and is out of scope; its host-side `@trezor/connect-web` logger is unaffected.)_
- **New shared pieces:** `noopLogger`, `noopCreateLogger`, and `CreateLogger` in `connect-common`.

## `debug` is intentionally kept

Connect core no longer uses `debug` to gate its component loggers (`enableLog` removed), which is the core of the issue. But `debug` still has legitimate uses and is **kept** in `ConnectSettings`:
- connect-web / connect-mobile dynamic host wrappers (their own `@trezor/connect-web` logger + popup URL)
- `BackendManager` → `BlockchainLink` worker debug logging
- the desktop IPC enabled hint (renderer → main) used to build the factory

Removing `debug` entirely (refactoring connect-web + BlockchainLink logging) is a separate follow-up.

## Verification

- ✅ `yarn workspace @trezor/connect-common type-check`
- ✅ `yarn workspace @trezor/connect lint:js`
- ✅ `yarn workspace @trezor/connect-common lint:js`
- ✅ `yarn workspace @trezor/transport-common lint:js`
- ✅ Targeted `@trezor/connect` unit tests passed after rebasing on #28269 and returning to factory drill-down:
  - `core/__tests__/onCallFirmwareUpdate.test.ts`
  - `device/__tests__/DeviceList.test.ts`
  - `device/__tests__/checkFirmwareHash.test.ts`
  - `device/__tests__/checkFirmwareHashWithRetries.test.ts`
  - `device/__tests__/handshakeWorkflow.test.ts`

## Follow-ups (not in this PR)

- Remove `debug` (refactor connect-web + BlockchainLink logging)
- Logger unification — replace the temporary `initLog` import in factories with one shared app-wide logger
- Instance-only transports (this PR unlocks it)

Ref #28256

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/connect-injected-logger/web/](https://dev.suite.sldev.cz/suite-web/mroz22/connect-injected-logger/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are concentrated in the @trezor/connect core layer: device session management (Device.ts, DeviceCurrentSession.ts, DeviceList.ts), firmware hash checking workflows, handshake logic, connect settings types, the suite-desktop connect module, and connect initialization thunks. Since these are foundational infrastructure files mapped to 121+ tests each, the testing strategy focuses on tests that specifically exercise TrezorConnect API calls, device session lifecycle, firmware verification, and the desktop bridge integration — rather than broadly testing every Suite feature that transitively depends on connect. The highest risk areas are direct TrezorConnect API tests (getAddress, signTransaction, permissions), firmware-related flows, device session management (multiple sessions), and the desktop bridge spawning.

<details><summary><b>Changed files (20)</b></summary>

- `packages/connect-cli/src/index.ts`
- `packages/connect-common/src/data/connectSettings.ts`
- `packages/connect-common/src/types/settings.ts`
- `packages/connect-common/src/utils/debug.ts`
- `packages/connect/src/core/__tests__/onCallFirmwareUpdate.test.ts`
- `packages/connect/src/core/index.ts`
- `packages/connect/src/core/onCallFirmwareUpdate.ts`
- `packages/connect/src/device/Device.ts`
- `packages/connect/src/device/DeviceCurrentSession.ts`
- `packages/connect/src/device/DeviceList.ts`
- `packages/connect/src/device/__tests__/DeviceList.test.ts`
- `packages/connect/src/device/__tests__/checkFirmwareHash.test.ts`
- `packages/connect/src/device/__tests__/checkFirmwareHashWithRetries.test.ts`
- `packages/connect/src/device/__tests__/handshakeWorkflow.test.ts`
- `packages/connect/src/device/workflow/checkFirmwareHash.ts`
- `packages/connect/src/device/workflow/checkFirmwareHashWithRetries.ts`
- `packages/connect/src/device/workflow/handshake.ts`
- `packages/connect/src/impl/core-in-module.ts`
- `packages/suite-desktop-core/src/modules/trezor-connect.ts`
- `suite-common/connect-init/src/connectInitThunks.ts`

</details>

**Recommended tests (18)**

<details><summary>🔴 <b>High priority (7)</b></summary>

- `suite/e2e/tests/firmware/custom-firmware.test.ts` — Changes to checkFirmwareHash.ts, checkFirmwareHashWithRetries.ts, handshake.ts, and onCallFirmwareUpdate.ts directly affect firmware installation and verification workflows. This test exercises custom firmware installation on a device, which relies on the firmware update call path and device handshake/session management that were modified.
- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test directly exercises TrezorConnect.getAddress through the connect popup, testing the core connect flow including permissions, device handshake, and session management. Changes to core/index.ts, Device.ts, DeviceList.ts, DeviceCurrentSession.ts, and connectInitThunks.ts all affect this critical integration path.
- `suite/e2e/tests/trezor-connect/error.test.ts` — Tests TrezorConnect error handling with invalid derivation paths in suite-desktop core mode. Changes to core/index.ts, core-in-module.ts, and the suite-desktop-core trezor-connect module directly affect how connect errors are surfaced in the desktop app.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Directly tests TrezorConnect.getAddress with device confirmation, bundle exports, and device rejection flows in suite-desktop core mode. The changed Device.ts, DeviceCurrentSession.ts, handshake.ts, and core-in-module.ts are all on the critical path for address export operations.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Tests TrezorConnect permissions grant/revoke lifecycle in suite-desktop mode. Changes to connect settings types, core/index.ts, and the suite-desktop-core trezor-connect module directly affect how connect sessions and permissions are managed.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — Tests Bitcoin transaction signing via TrezorConnect API with multi-step device confirmation. Changes to Device.ts, DeviceCurrentSession.ts, and the handshake workflow directly affect the device session used during transaction signing.
- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — Tests the Electron app spawning the bridge, device connection after bridge restart, and dashboard visibility. Changes to suite-desktop-core/modules/trezor-connect.ts directly affect how the desktop app initializes the connect module alongside the bridge.

</details>

<details><summary>🟡 <b>Medium priority (11)</b></summary>

- `suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts` — Tests Ethereum message signing through TrezorConnect in suite-desktop mode. Device session management (DeviceCurrentSession.ts) and core connect initialization are on the critical path for this operation.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Tests Ethereum transaction signing via TrezorConnect with multi-step device confirmation in suite-desktop mode. Changes to device session handling and core connect module affect transaction signing flows.
- `suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — Tests TrezorConnect.getAccountInfo with account selection in suite-desktop mode. The connect core initialization and device session changes affect how account info is retrieved.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — Tests TrezorConnect silent mode which controls whether the Suite window is focused during connect calls. Changes to connect settings types and the desktop trezor-connect module affect silent mode behavior.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — Tests TrezorConnect.getAddress through a webextension popup, covering the connect popup lifecycle including permissions and address confirmation. Core connect changes and device session handling affect this flow.
- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — Tests daemon-mode bridge spawning and multi-instance behavior. Changes to suite-desktop-core trezor-connect module could affect how the bridge daemon interacts with connect initialization.
- `suite/e2e/tests/onboarding/firmware-check.test.ts` — Tests firmware readiness detection during onboarding across multiple device models. Changes to checkFirmwareHash.ts, checkFirmwareHashWithRetries.ts, and handshake.ts directly affect how firmware status is determined during the onboarding flow.
- `suite/e2e/tests/suite/initial-run.test.ts` — Tests the initial onboarding flow including firmware hash check error dismissal and device connection persistence across reloads. Changes to handshake.ts and checkFirmwareHash* files affect the firmware hash check modal that this test explicitly handles.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — Tests Bridge session stealing and reclamation scenarios. Changes to DeviceList.ts and DeviceCurrentSession.ts directly affect device session acquisition and management, which is the core functionality this test validates.
- `suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts` — Tests entropy check failure handling during wallet creation, including device compromised modal. Changes to Device.ts and handshake.ts affect the device initialization and entropy check pathways that this test exercises.
- `suite/e2e/tests/wallet/discovery.test.ts` — Tests wallet discovery with page reload interruption and recovery. Changes to Device.ts, DeviceCurrentSession.ts, and DeviceList.ts affect how the device session is maintained during discovery, and connectInitThunks.ts affects how connect re-initializes after reload.

</details>

⚠️ **Changes with no test coverage (8)**
- `packages/connect-cli/src/index.ts`
- `packages/connect-common/src/data/connectSettings.ts`
- `packages/connect-common/src/utils/debug.ts`
- `packages/connect/src/core/__tests__/onCallFirmwareUpdate.test.ts`
- `packages/connect/src/device/__tests__/DeviceList.test.ts`
- `packages/connect/src/device/__tests__/checkFirmwareHash.test.ts`
- `packages/connect/src/device/__tests__/checkFirmwareHashWithRetries.test.ts`
- `packages/connect/src/device/__tests__/handshakeWorkflow.test.ts`

_Updated: 2026-06-15T09:35:49.989Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/connect-injected-logger&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/connect-injected-logger&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-15T09:40:25.254Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-15T09:39:01.180Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->