### PR TITLE
fix(suite-desktop): explicitly require refresh_token in google oauth

### DIFF
--- a/suite/metadata/src/google.ts
+++ b/suite/metadata/src/google.ts
@@ -196,6 +196,7 @@ class Client {
             url.searchParams.set('code_challenge', challenge);
             url.searchParams.set('code_challenge_method', 'plain');
             url.searchParams.set('response_type', 'code');
+            url.searchParams.set('access_type', 'offline');
         } else {
             // implicit flow
             url.searchParams.set('response_type', 'token');


### PR DESCRIPTION
## Description

Explicitely add `access_type=offline` which should be necessary to get `refresh_token`.
When testing Suite locally with Oauth credential generated in my testing account, it does not work without this parameter!
Yet in production there is no problem.
Likely some backwards compatiblity, but it is safer to add the parameter explicitely.

https://developers.google.com/identity/protocols/oauth2/web-server#httprest_1
https://developers.google.com/identity/protocols/oauth2/web-server#offline


## Notes for QA

On Suite Desktop:
- Turn on legacy labelling and initiate fresh authentication with google drive provider
  - Test that you can create a label
- Reopen the app in more than 60 minutes and verify it still works
  - The previous label loads, can create a label

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to suite/metadata/src/google.ts, which is the Google metadata/labeling provider implementation. The highest risk is to tests that directly use the Google provider for reading, writing, and error handling of metadata labels. Five tests explicitly use MetadataProvider.GOOGLE and should be run unconditionally. Two additional tests using Dropbox but sharing the metadata provider abstraction layer are medium priority. No static coverage mapping was available, so all recommendations are inferred from LLM analysis of test behaviors and source hints.

<details><summary><b>Changed files (1)</b></summary>

- `suite/metadata/src/google.ts`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/metadata/legacy/google-api-errors.test.ts` — This test directly exercises the Google metadata provider's error handling, including 401 'Invalid Credentials' responses and retry logic. Changes to suite/metadata/src/google.ts could break error handling, token management, or retry behavior tested here.
- `suite/e2e/tests/metadata/legacy/address-metadata.test.ts` — This test explicitly uses the Google metadata provider (MetadataProvider.GOOGLE) to add and edit address labels. Any change to the Google provider implementation in google.ts directly affects the read/write operations exercised by this test.
- `suite/e2e/tests/metadata/legacy/interval-fetching.test.ts` — This test verifies automatic periodic fetching of metadata labels from cloud providers including Google. Changes to google.ts could affect how metadata files are fetched, parsed, or decrypted during interval polling.
- `suite/e2e/tests/metadata/legacy/remembered-device.test.ts` — This test uses the Google metadata provider to verify label loading, disconnecting/reconnecting the provider, and re-initiating metadata flow using saved device keys. It directly exercises Google provider connect/disconnect/reconnect lifecycle.
- `suite/e2e/tests/metadata/legacy/switching-providers.test.ts` — This test switches from Dropbox to Google as the metadata provider mid-session, verifying that the Google provider modal appears and labels can be added via Google. Changes to google.ts could break provider initialization or label saving when switching to Google.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/metadata/legacy/account-metadata.test.ts` — While this test uses Dropbox as its provider, the metadata infrastructure is shared across providers. Changes to google.ts could indicate broader metadata module refactoring that affects the common provider abstraction used here.
- `suite/e2e/tests/metadata/legacy/metadata-lifecycle.test.ts` — This test covers the full lifecycle of metadata labeling including enable/disable/re-enable across wallet switches. While it uses Dropbox, the metadata provider abstraction layer that google.ts implements is part of this lifecycle flow.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/metadata/legacy/dropbox-api-errors.test.ts` — Uses Dropbox rather than Google, but if the change to google.ts involved refactoring shared metadata provider interfaces (e.g., file upload/download abstractions, error handling patterns), this test could be indirectly affected.

</details>

_Updated: 2026-06-02T07:55:45.920Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/explicitely-refresh_token&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/explicitely-refresh_token&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-02T08:00:12.034Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-02T07:58:45.450Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/explicitely-refresh_token/web/](https://dev.suite.sldev.cz/suite-web/fix/explicitely-refresh_token/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->