### PR TITLE
28252 track get trezor suite desktop

### DIFF
--- a/packages/suite/src/views/dashboard/DashboardFooter.tsx
+++ b/packages/suite/src/views/dashboard/DashboardFooter.tsx
@@ -215,6 +215,7 @@ export const DashboardFooter = () => {
                             onClick={() =>
                                 analytics.report({
                                     type: events.promoDesktopEvent.name,
+                                    payload: { placement: 'footer' },
                                 })
                             }
                         >

--- a/packages/suite/src/views/settings/SettingsGeneral/DesktopSuiteBanner.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/DesktopSuiteBanner.tsx
@@ -115,6 +115,7 @@ export const DesktopSuiteBanner = () => {
                                 onClick={() =>
                                     analytics.report({
                                         type: events.promoDesktopEvent.name,
+                                        payload: { placement: 'settings' },
                                     })
                                 }
                             >

--- a/suite/analytics/src/events/promoDesktopEvent.ts
+++ b/suite/analytics/src/events/promoDesktopEvent.ts
@@ -1,13 +1,24 @@
-import type { EventDef } from '@suite-common/analytics';
+import type { AttributeDef, EventDef } from '@suite-common/analytics';
 
 import { EventType } from '../constants';
 
-type Attributes = Record<never, never>;
+type Attributes = {
+    placement?: AttributeDef<'footer' | 'settings'>;
+};
 
 export const promoDesktopEvent: EventDef<Attributes, EventType.PromoDesktop> = {
     name: EventType.PromoDesktop,
     descriptionTrigger: 'A user clicks the desktop promo banner',
     changelog: [{ version: '23.5.2', notes: 'added' }],
 
-    attributes: {},
+    attributes: {
+        placement: {
+            changelog: [
+                {
+                    version: '26.6.0',
+                    notes: 'added — distinguishes the dashboard footer CTA from the settings banner CTA',
+                },
+            ],
+        },
+    },
 };


### PR DESCRIPTION
## Description
dds privacy-safe analytics for the "Get Trezor Suite desktop app" CTA on Suite Web.
Tracks two placements as separate events, each emitting `shown` (on mount) and `click`:

- `suite-web/get-desktop-app/dashboard-footer` — dashboard footer
- `suite-web/get-desktop-app/settings-banner` — Settings → Application banner

Payload per event: `action` (`shown` | `click`), `ctaId` (`get-desktop-app`), `destinationUrl`. `variant` is defined as optional and omitted (no variants yet). No dismiss/close tracking, no PII. The shown effect fires on component mount, not on every re-render. CTR is computable per placement as `click / shown` on the event name.

Also adds `suite-web` to the allowed analytics-event-name lint domains.

## Notes for QA

- Open the dashboard on Suite Web (above tablet width) → footer renders `Get the Trezor Suite desktop app` button → expect one `suite-web/get-desktop-app/dashboard-footer` event with `action=shown` in the analytics log. Click it → expect a second event with `action=click`.
- Open Settings → Application banner (must be enabled via `showSettingsDesktopAppPromoBanner` flag) → expect one `suite-web/get-desktop-app/settings-banner` with `action=shown`. Click the button → expect another with `action=click`. Closing the banner via the X must NOT emit an event.
- Re-rendering the dashboard/settings page without remounting the CTA component must not produce extra `shown` events.


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/git#event-26208998948

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change adds two new analytics events (suiteWebGetDesktopAppDashboardFooterEvent and suiteWebGetDesktopAppSettingsBannerEvent) with corresponding UI changes in DashboardFooter.tsx and DesktopSuiteBanner.tsx, plus modifications to the analytics constants and barrel export. The primary risk is breaking existing analytics event infrastructure (constants, event type matching) or causing rendering issues in the dashboard/settings pages. The DashboardFooter and DesktopSuiteBanner files map to 90+ tests each because they're rendered on widely-used pages, but most tests don't interact with these components directly. Testing should focus on analytics event validation tests and the dashboard/settings pages where these components render.

<details><summary><b>Changed files (7)</b></summary>

- `eslint-local-rules/rules.ts`
- `packages/suite/src/views/dashboard/DashboardFooter.tsx`
- `packages/suite/src/views/settings/SettingsGeneral/DesktopSuiteBanner.tsx`
- `suite/analytics/src/constants.ts`
- `suite/analytics/src/events/index.ts`
- `suite/analytics/src/events/suiteWebGetDesktopAppDashboardFooterEvent.ts`
- `suite/analytics/src/events/suiteWebGetDesktopAppSettingsBannerEvent.ts`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — This test directly validates SuiteReady and other analytics events, checking event payloads and constants. The changes to suite/analytics/src/constants.ts, events/index.ts, and the two new event files (suiteWebGetDesktopAppDashboardFooterEvent, suiteWebGetDesktopAppSettingsBannerEvent) modify the analytics events module that this test exercises. Any breakage in the analytics event barrel export or constants would surface here.
- `suite/e2e/tests/analytics/toggle.test.ts` — This test validates analytics enable/disable lifecycle, event firing, and session management. Changes to the analytics constants and events barrel export could break event type matching or cause unexpected events to appear/disappear, which this test would catch.
- `suite/e2e/tests/settings/general.test.ts` — This test navigates to the Settings application page where DesktopSuiteBanner.tsx is rendered, and validates analytics events fired from settings changes. The new suiteWebGetDesktopAppSettingsBannerEvent would be triggered from this banner component. This test also checks settingsAnalyticsEvent and other analytics constants that are modified.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — This test exercises the dashboard page where DashboardFooter.tsx is rendered. The new suiteWebGetDesktopAppDashboardFooterEvent fires from this footer component. While the test doesn't directly assert on the footer, rendering errors in DashboardFooter could break the dashboard page.
- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — This test operates on the dashboard page and validates analytics events (menuToggleDiscreetEvent). DashboardFooter.tsx renders on this page; a rendering crash there could break the dashboard. It also validates analytics event infrastructure that shares the modified constants/events modules.
- `suite/e2e/tests/analytics/promo-banner-events.test.ts` — This test validates analytics event payloads on the dashboard, which renders DashboardFooter.tsx. It also uses the analytics events infrastructure (EventType constants) which is being modified in constants.ts and events/index.ts.
- `suite/e2e/tests/analytics/staking-events.test.ts` — This test validates StakingNavigate analytics events using EventType constants from the analytics module. Changes to constants.ts and the events barrel export could affect event type resolution.
- `suite/e2e/tests/analytics/wallet-connect-events.test.ts` — This test validates WalletConnect analytics events using EventType constants. Changes to the analytics constants and events index could break event type matching used in this test's assertions.

</details>

⚠️ **Changes with no test coverage (3)**
- `eslint-local-rules/rules.ts`
- `suite/analytics/src/events/suiteWebGetDesktopAppDashboardFooterEvent.ts`
- `suite/analytics/src/events/suiteWebGetDesktopAppSettingsBannerEvent.ts`

_Updated: 2026-06-02T08:10:43.383Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=28252-track-get-trezor-suite-desktopa--p&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=28252-track-get-trezor-suite-desktopa--p&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-03T07:19:53.691Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-03T07:16:58.303Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/28252-track-get-trezor-suite-desktopa--p/web/](https://dev.suite.sldev.cz/suite-web/28252-track-get-trezor-suite-desktopa--p/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->](https://github.com/trezor/trezor-suite/pull/28268#issue-4569669705)