### PR TITLE
refactor(utils): move Logger interface to @trezor/utils and remove transport-common re-export

### DIFF
--- a/packages/transport-bluetooth/src/client/types.ts
+++ b/packages/transport-bluetooth/src/client/types.ts
@@ -1,7 +1,6 @@
-import type { Logger } from '@trezor/transport-common';
-import type { TypedEmitter } from '@trezor/utils';
+import type { Logger, TypedEmitter } from '@trezor/utils';
 
-export type { Logger } from '@trezor/transport-common';
+export type { Logger } from '@trezor/utils';
 
 export interface TrezorBluetoothSettings {
     url: string;

--- a/packages/transport-common/src/api/abstract.ts
+++ b/packages/transport-common/src/api/abstract.ts
@@ -1,4 +1,5 @@
 import { TypedEmitter, getSynchronize } from '@trezor/utils';
+import type { Logger } from '@trezor/utils';
 
 import { type TRANSPORT } from '../constants';
 import * as ERRORS from '../errors';
@@ -7,7 +8,6 @@ import type {
     ApiType,
     AsyncResultWithTypedError,
     DescriptorApiLevel,
-    Logger,
     PathInternal,
 } from '../types';
 import { error, success, unknownError } from '../utils/result';

--- a/packages/transport-common/src/thp/receiveExpectedMessage.ts
+++ b/packages/transport-common/src/thp/receiveExpectedMessage.ts
@@ -6,9 +6,9 @@ import {
 } from '@trezor/protocol';
 import { THP_CONTROL_BYTE } from '@trezor/protocol/src/protocol-v2/constants';
 import { SCHEDULE_ACTION_TIMEOUT_ERROR_MESSAGE, scheduleAction } from '@trezor/utils';
+import type { Logger } from '@trezor/utils';
 
 import type { AbstractApi } from '../api/abstract';
-import { type Logger } from '../types';
 import { receive } from '../utils/receive';
 import { error } from '../utils/result';
 

--- a/packages/transport-common/src/transports/abstract.ts
+++ b/packages/transport-common/src/transports/abstract.ts
@@ -1,5 +1,6 @@
 import { type PROTOCOL_MALFORMED, type ThpState, type TransportProtocol } from '@trezor/protocol';
 import {
+    type Logger,
     type ScheduleActionParams,
     type ScheduledAction,
     TypedEmitter,
@@ -15,7 +16,6 @@ import type {
     AsyncResultWithTypedError,
     BridgeCommonErrors,
     Descriptor,
-    Logger,
     MessageResponse,
     PathPublic,
     ResultWithTypedError,

--- a/packages/transport-common/src/types/index.ts
+++ b/packages/transport-common/src/types/index.ts
@@ -40,15 +40,3 @@ export type Descriptor = Omit<DescriptorApiLevel, 'path'> & {
     /** only reported by old bridge */
     debug?: boolean;
 };
-
-export interface Logger {
-    info(...args: unknown[]): void;
-
-    debug(...args: unknown[]): void;
-
-    log(...args: unknown[]): void;
-
-    warn(...args: unknown[]): void;
-
-    error(...args: unknown[]): void;
-}

--- a/packages/utils/src/logs.ts
+++ b/packages/utils/src/logs.ts
@@ -9,7 +9,17 @@ export type LogWriter = {
     add: (message: LogMessage) => void;
 };
 
-export class Log {
+// Defines the minimal logger contract shared across the codebase.
+// Consumers can use an app-specific logger adapter instead of the concrete `Log` class.
+export interface Logger {
+    info(...args: unknown[]): void;
+    debug(...args: unknown[]): void;
+    log(...args: unknown[]): void;
+    warn(...args: unknown[]): void;
+    error(...args: unknown[]): void;
+}
+
+export class Log implements Logger {
     prefix: string;
     enabled: boolean;
     css: string = '';


### PR DESCRIPTION
## Description

Small, type-only prerequisite for #28256 (and therefore #27842): move the `Logger` interface to `@trezor/utils`.

The `Logger` interface lived in `@trezor/transport-common`, but **logging is not a transport concern**. Its sibling primitives — `Log`, `LogMessage`, `LogWriter`, `LogsManager` — already live in `@trezor/utils`, and the `Log` class there already implements that exact shape (`info/debug/log/warn/error`), just without declaring it.

This PR:
- moves the `Logger` interface into `@trezor/utils` (`logs.ts`), next to `Log`;
- declares **`Log implements Logger`**, so the compiler enforces that the in-repo implementation stays in sync with the contract;
- updates every consumer to import `Logger` **directly from `@trezor/utils`** (transport-common's `AbstractTransport` / `AbstractApi` / thp, and `transport-bluetooth`); `@trezor/transport-common` no longer defines or re-exports it.

## Why an interface, not the `Log` class

Consumers depend on the minimal `Logger` interface rather than the concrete `Log` class on purpose: hosts may supply their **own** logger implementation (e.g. a POJO adapter over an app-wide logger — suite-desktop already does this for Bluetooth via `desktopLogger`). The `Log` class carries implementation details (`messages`, `setWriter`, `css`, …) that consumers must not see or require.

## Why this is a prerequisite

#28256 gives `@trezor/connect` an injected logger factory (`createLogger: (prefix) => Logger`). With this change, connect (and other packages) can depend on a **general-purpose `Logger` from `@trezor/utils`** instead of importing it from `@trezor/transport-common`, which semantically suggested a false dependency on transports. After this merges, #28256 will switch its `Logger` imports to `@trezor/utils`.

Chain: **this PR** → #28266 (injected logger, implements #28256) → #27842 (simplification) → instance-only transports.

## Notes

- `any[]` vs `unknown[]`: `Log`'s methods use `...args: any[]`; the `Logger` interface uses `...args: unknown[]`. `Log implements Logger` is satisfied (bivariant method params), and call sites typed as `Logger` get the safer `unknown[]` contract.
- Purely type-level, additive, no runtime change.

Ref #28256, #27842

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/logger-interface-to-utils&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/logger-interface-to-utils&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-02T12:04:58.073Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-02T12:02:35.021Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/logger-interface-to-utils/web/](https://dev.suite.sldev.cz/suite-web/mroz22/logger-interface-to-utils/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->