### PR TITLE
feat(suite): Search EVM transaction by function selector

### DIFF
--- a/suite-common/transaction-search/src/__fixtures__/searchTransactions.fixture.ts
+++ b/suite-common/transaction-search/src/__fixtures__/searchTransactions.fixture.ts
@@ -152,6 +152,7 @@ export const searchTransactionsFixture = [
         result: [
             '62431e78bb13a4fdd9c87517db1ea70b4cb5763227327da35748c96497c6ea9a', // 2020-12-27
             'f5cea29dec1d4e8b83a81b61627caf36adc33085284bde2969ae5beb75bd413c', // 2020-12-14
+            '0xb2e15b2029bfecb74f8cfddafa35bd09f72c1c003f725c6c8391169d726f6c30', // 2026-06-02 - EVM Claim tx
         ],
     },
     {
@@ -194,5 +195,17 @@ export const searchTransactionsFixture = [
             'f5cea29dec1d4e8b83a81b61627caf36adc33085284bde2969ae5beb75bd413c', // 2020-12-14 - 0.01 TEST
             '5be0cfd5b439c3112cfaea3cd05fdcea387433990885c86937d2488c59f1e692', // 2020-12-03 - 0.00019199 TEST
         ],
+    },
+    {
+        description: 'EVM function label search',
+        search: 'claim',
+        results: [
+            '0xb2e15b2029bfecb74f8cfddafa35bd09f72c1c003f725c6c8391169d726f6c30', // 2026-06-02 - EVM Claim tx
+        ],
+    },
+    {
+        description: 'AND operator (EVM func Claim + < July)',
+        search: 'claim & < 2026-06-01',
+        results: [],
     },
 ];

--- a/suite-common/transaction-search/src/__fixtures__/searchTransactions.json
+++ b/suite-common/transaction-search/src/__fixtures__/searchTransactions.json
@@ -12045,6 +12045,78 @@
                 "totalInput": "130000000",
                 "totalOutput": "129999867"
             }
+        },
+        {
+            "descriptor": "0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3",
+            "deviceState": "mgpdqcar9VSuvXnX1dnf94adSgnfAMn42Q@3B2B576D5EA7D8BD25E74C8B:2",
+            "symbol": "eth",
+            "type": "sent",
+            "txid": "0xb2e15b2029bfecb74f8cfddafa35bd09f72c1c003f725c6c8391169d726f6c30",
+            "blockTime": 1780380791,
+            "blockHeight": 25227831,
+            "blockHash": "0xfb09f9317d2fc79cbe18fcef1f51413f7be3e4a02b5979577df7f48ba3f9ec5c",
+            "totalSpent": "0",
+            "amount": "0",
+            "fee": "25428986493708",
+            "targets": [],
+            "tokens": [],
+            "rbf": true,
+            "ethereumSpecific": {
+                "status": 1,
+                "nonce": 1311,
+                "gasLimit": 275349,
+                "gasUsed": 220773,
+                "gasPrice": "115181596",
+                "maxPriorityFeePerGas": "266666",
+                "maxFeePerGas": "163369719",
+                "baseFeePerGas": "114914930",
+                "data": "0xdeadbeefseed",
+                "parsedData": {
+                    "methodId": "0x71ee95c0",
+                    "name": "Claim",
+                    "function": "claim(address[], address[], uint256[], bytes32[][])",
+                    "params": [
+                        {
+                            "type": "address[]",
+                            "values": []
+                        },
+                        {
+                            "type": "address[]",
+                            "values": []
+                        },
+                        {
+                            "type": "uint256[]",
+                            "values": []
+                        },
+                        {
+                            "type": "bytes32[][]",
+                            "values": []
+                        }
+                    ]
+                }
+            },
+            "details": {
+                "vin": [
+                    {
+                        "n": 0,
+                        "addresses": ["0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3"],
+                        "isAddress": true,
+                        "isOwn": true,
+                        "isAccountOwned": true
+                    }
+                ],
+                "vout": [
+                    {
+                        "value": "0",
+                        "n": 0,
+                        "addresses": ["0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae"],
+                        "isAddress": true
+                    }
+                ],
+                "size": 0,
+                "totalInput": "0",
+                "totalOutput": "0"
+            }
         }
     ]
 }

--- a/suite-common/transaction-search/src/simpleSearchTransactions.ts
+++ b/suite-common/transaction-search/src/simpleSearchTransactions.ts
@@ -1,5 +1,8 @@
 import { type WalletAccountTransaction } from '@suite-common/wallet-types';
-import { isTokenTransferMatchesSearch } from '@suite-common/wallet-utils';
+import {
+    isFunctionSelectorMatchesSearch,
+    isTokenTransferMatchesSearch,
+} from '@suite-common/wallet-utils';
 import { BigNumber, typedObjectKeys, unique } from '@trezor/utils';
 
 import { getTargetAmounts } from './getTargetAmounts';
@@ -199,6 +202,20 @@ export const simpleSearchTransactions = (
         return [];
     });
     txsToSearch.push(...foundTxsForToken);
+
+    // Find by evm parsed function selector
+    const foundTxsForFunctionSelector = transactions.flatMap(transaction => {
+        const hasMatchingFunctionSelector =
+            transaction.ethereumSpecific &&
+            isFunctionSelectorMatchesSearch(transaction.ethereumSpecific, search.toLowerCase());
+
+        if (hasMatchingFunctionSelector) {
+            return transaction.txid;
+        }
+
+        return [];
+    });
+    txsToSearch.push(...foundTxsForFunctionSelector);
 
     // Remove duplicate txIDs
     return transactions.filter(

--- a/suite-common/wallet-utils/src/tokenUtils.ts
+++ b/suite-common/wallet-utils/src/tokenUtils.ts
@@ -7,6 +7,7 @@ import {
     getNetworkType,
 } from '@suite-common/wallet-config';
 import {
+    type EthereumSpecific,
     type TokenInfo,
     type TokenStandard,
     type TokenTransfer,
@@ -112,6 +113,12 @@ export const isNftMatchesSearch = (token: TokenInfo, search: string) =>
     token.symbol?.toLowerCase().includes(search) ||
     token.name?.toLowerCase().includes(search) ||
     token.contract?.toLowerCase().includes(search);
+
+export const isFunctionSelectorMatchesSearch = (evmSpecific: EthereumSpecific, search: string) => {
+    if (evmSpecific?.parsedData?.name.toLowerCase().includes(search.toLowerCase())) return true;
+
+    return false;
+};
 
 const PRESERVE_TOKEN_SYMBOL_CASE_STANDARDS: ReadonlySet<TokenStandard> = new Set([
     'ERC20',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR introduces search for EVM transaction (on a paginated page) using a function selector string.

## Notes for QA

0) Search doesn't show all results and only the ones on the current page
1) Search is by assinged label not the function selector itself
~2) Should work the same ~on mobile and~ desktop.~

## Related Issue

Resolve https://github.com/issues/assigned?issue=trezor%7Ctrezor-suite%7C26832

## Screenshots:

<img width="957" height="445" alt="Screenshot 2026-06-02 at 10 15 05" src="https://github.com/user-attachments/assets/fd612dfe-3b9d-43bd-825a-5ce7621c8d5a" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect two distinct areas: (1) transaction search logic (simpleSearchTransactions.ts and its test fixtures), and (2) token utilities (tokenUtils.ts). The transaction search changes carry moderate-to-high risk for any UI that filters or searches transactions/accounts, with the fixtures suggesting unit test changes that may accompany behavioral changes in the search algorithm. The tokenUtils.ts change maps to 121 tests but is a broad utility — only tests that directly exercise token-specific flows (token swaps, token sells, token buys, token navigation) warrant E2E coverage. The recommended strategy focuses on the 3 tests that directly exercise search/filter behavior, plus a handful of token-centric trading tests.

<details><summary><b>Changed files (4)</b></summary>

- `suite-common/transaction-search/src/__fixtures__/searchTransactions.fixture.ts`
- `suite-common/transaction-search/src/__fixtures__/searchTransactions.json`
- `suite-common/transaction-search/src/simpleSearchTransactions.ts`
- `suite-common/wallet-utils/src/tokenUtils.ts`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/wallet/transactions.test.ts` — This test directly exercises transaction searching — it finds the latest transaction address and searches for it by its address characters. The changed simpleSearchTransactions.ts is the core search logic, and this test's transactionSearch behavior would break if the search algorithm regressed.
- `suite/e2e/tests/metadata/legacy/account-metadata.test.ts` — This test explicitly searches/filters accounts by their metadata label text (searching 'even cooler' and 'non matching query'), which exercises the transaction/account search functionality powered by simpleSearchTransactions. A regression in search logic would directly break the account filtering assertions.
- `suite/e2e/tests/wallet/account-search.test.ts` — This test searches for accounts by typing 'bitcoin' into the account search field and verifies filtering behavior. The account search likely uses simpleSearchTransactions or related search utilities, making it directly affected by changes to the search logic.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — This test involves swapping a Solana-based USDT token to Bitcoin. Changes to tokenUtils.ts could affect how token identifiers, symbols, or amounts are resolved during the swap flow, particularly when displaying token amounts in the device prompt and toast notifications.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — This test swaps SPL tokens (USDT to USDC) which directly exercises token handling logic. tokenUtils.ts changes could affect token symbol resolution, amount formatting, or token identification during the swap form and confirmation flow.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — This test sells an ERC-20 token (USDC on Ethereum), which requires token utilities for resolving token metadata, formatting amounts, and identifying the token contract. Changes to tokenUtils.ts could affect how the token is displayed in the sell confirmation flow.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — This test buys a specific Solana token (Jupiter/JUP) via the asset picker with search filters. Token identification and display depends on tokenUtils.ts, and changes there could affect how the token is resolved in the buy flow.
- `suite/e2e/tests/trading/navigation.test.ts` — This test navigates to trading forms for specific ERC-20 tokens (TrueUSD, USDC) and verifies the correct token is pre-filled. tokenUtils.ts changes could affect token identification when opening buy/sell/swap forms for specific tokens.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — This test creates and tracks pending transactions with multiple outputs, verifying transaction labels and grouping. Changes to simpleSearchTransactions.ts could affect how transactions are searched or filtered in the transaction list view.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-common/transaction-search/src/__fixtures__/searchTransactions.fixture.ts`
- `suite-common/transaction-search/src/__fixtures__/searchTransactions.json`

_Updated: 2026-06-02T08:18:07.450Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/search-evm-tx&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/search-evm-tx&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/search-evm-tx&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-02T08:23:00.965Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-02T08:20:45.441Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/search-evm-tx/web/](https://dev.suite.sldev.cz/suite-web/feat/search-evm-tx/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->