### PR TITLE
Fix: auth server build, security tightening

### DIFF
--- a/packages/auth-server/package.json
+++ b/packages/auth-server/package.json
@@ -15,7 +15,8 @@
     },
     "dependencies": {
         "cors": "^2.8.6",
-        "express": "^5.2.1"
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.5.2"
     },
     "devDependencies": {
         "@types/cors": "^2.8.17"

--- a/packages/auth-server/package.json
+++ b/packages/auth-server/package.json
@@ -10,6 +10,7 @@
         "type-check": "yarn g:tsc --build",
         "dev": "yarn g:tsx watch ./src/index.ts",
         "start": "node ./lib/index.js",
+        "build": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
     },
     "dependencies": {

--- a/packages/auth-server/src/index.ts
+++ b/packages/auth-server/src/index.ts
@@ -1,5 +1,6 @@
 import cors, { type CorsOptions } from 'cors';
 import express, { type ErrorRequestHandler } from 'express';
+import { rateLimit } from 'express-rate-limit';
 
 const app = express();
 
@@ -21,6 +22,8 @@ const { GOOGLE_CLIENT_SECRET } = process.env; // generate testing credentials fo
 const GOOGLE_OAUTH_LOOPBACK_HOSTNAMES = ['localhost', '127.0.0.1', '[::1]'] as const;
 const GOOGLE_OAUTH_LOOPBACK_PORT = '21335';
 const GOOGLE_OAUTH_LOOPBACK_PATHNAME = '/oauth';
+const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
+const RATE_LIMIT_MAX_REQUESTS_PER_IP = 100;
 
 const checkResponse = (responseBody: object, expectedProperties: string[]) => {
     expectedProperties.forEach(property => {
@@ -96,6 +99,16 @@ app.get('/', (_req, res) => {
 app.get('/status', (_req, res) => {
     res.send({ status: 'ok' });
 });
+
+app.use(
+    rateLimit({
+        windowMs: RATE_LIMIT_WINDOW_MS,
+        limit: RATE_LIMIT_MAX_REQUESTS_PER_IP,
+        standardHeaders: true,
+        legacyHeaders: false,
+        message: 'Too many requests.',
+    }),
+);
 
 /**
  * Exchange authorization code for refresh token and access token.

--- a/packages/auth-server/src/index.ts
+++ b/packages/auth-server/src/index.ts
@@ -1,5 +1,5 @@
 import cors, { type CorsOptions } from 'cors';
-import express from 'express';
+import express, { type ErrorRequestHandler } from 'express';
 
 const app = express();
 
@@ -24,6 +24,39 @@ const checkResponse = (responseBody: object, expectedProperties: string[]) => {
             throw new Error('Unexpected response from authentication server.');
         }
     });
+};
+
+const getErrorStatusCode = (error: unknown): number => {
+    if (typeof error !== 'object' || error === null) return 500;
+    if ('status' in error && typeof error.status === 'number') return error.status;
+    if ('statusCode' in error && typeof error.statusCode === 'number') return error.statusCode;
+
+    return 500;
+};
+
+const sanitizeExpressError: ErrorRequestHandler = (error, _req, res, next) => {
+    // Once headers are sent, the server can no longer safely change the response body.
+    if (res.headersSent) {
+        next(error);
+
+        return;
+    }
+
+    const statusCode = getErrorStatusCode(error);
+
+    if (statusCode === 400) {
+        res.status(statusCode).json('Invalid request body.');
+
+        return;
+    }
+
+    if (statusCode === 401) {
+        res.status(statusCode).json('Authentication failed.');
+
+        return;
+    }
+
+    res.status(statusCode >= 400 && statusCode < 600 ? statusCode : 500).json('Request failed.');
 };
 
 /**
@@ -59,8 +92,8 @@ app.post('/google-oauth-init', async (req, res) => {
         const json = await response.json();
         checkResponse(json, ['refresh_token', 'access_token']);
         res.status(response.status).send(json);
-    } catch (error) {
-        res.status(401).json(`Authorization failed: ${error}`);
+    } catch {
+        res.status(401).json('Authorization failed.');
     }
 });
 
@@ -81,10 +114,12 @@ app.post('/google-oauth-refresh', async (req, res) => {
         const json = await response.json();
         checkResponse(json, ['access_token']);
         res.status(response.status).send(json);
-    } catch (error) {
-        res.status(401).json(`Refresh failed: ${error}`);
+    } catch {
+        res.status(401).json('Refresh failed.');
     }
 });
+
+app.use(sanitizeExpressError);
 
 app.listen(PORT, () => {
     // eslint-disable-next-line no-console

--- a/packages/auth-server/src/index.ts
+++ b/packages/auth-server/src/index.ts
@@ -18,6 +18,10 @@ app.use(cors(corsOptions));
 const PORT = process.env.PORT || 3005;
 const { GOOGLE_CLIENT_SECRET } = process.env; // generate testing credentials for development
 
+const GOOGLE_OAUTH_LOOPBACK_HOSTNAMES = ['localhost', '127.0.0.1', '[::1]'] as const;
+const GOOGLE_OAUTH_LOOPBACK_PORT = '21335';
+const GOOGLE_OAUTH_LOOPBACK_PATHNAME = '/oauth';
+
 const checkResponse = (responseBody: object, expectedProperties: string[]) => {
     expectedProperties.forEach(property => {
         if (!Object.prototype.hasOwnProperty.call(responseBody, property)) {
@@ -60,6 +64,26 @@ const sanitizeExpressError: ErrorRequestHandler = (error, _req, res, next) => {
 };
 
 /**
+ * Only allow loopback OAuth receiver (redirect URI) for Trezor Suite, which is expected to be 127.0.0.1:21335/oauth
+ */
+const isGoogleOAuthRedirectUriValid = (redirectUri: unknown): boolean => {
+    if (typeof redirectUri !== 'string' || !URL.canParse(redirectUri)) return false;
+
+    const parsedRedirectUri = new URL(redirectUri);
+
+    return (
+        parsedRedirectUri.protocol === 'http:' &&
+        GOOGLE_OAUTH_LOOPBACK_HOSTNAMES.some(hostname => hostname === parsedRedirectUri.hostname) &&
+        parsedRedirectUri.port === GOOGLE_OAUTH_LOOPBACK_PORT &&
+        parsedRedirectUri.pathname === GOOGLE_OAUTH_LOOPBACK_PATHNAME &&
+        parsedRedirectUri.username === '' &&
+        parsedRedirectUri.password === '' &&
+        parsedRedirectUri.search === '' &&
+        parsedRedirectUri.hash === ''
+    );
+};
+
+/**
  * Root URL should return 200 for health check.
  */
 app.get('/', (_req, res) => {
@@ -77,13 +101,21 @@ app.get('/status', (_req, res) => {
  * Exchange authorization code for refresh token and access token.
  */
 app.post('/google-oauth-init', async (req, res) => {
+    const redirectUri = req.body?.redirectUri;
+
+    if (!isGoogleOAuthRedirectUriValid(redirectUri)) {
+        res.status(400).json('Invalid request body.');
+
+        return;
+    }
+
     try {
         const response = await fetch('https://oauth2.googleapis.com/token', {
             body: JSON.stringify({
                 code: req.body.code,
                 client_secret: GOOGLE_CLIENT_SECRET,
                 client_id: req.body.clientId,
-                redirect_uri: req.body.redirectUri,
+                redirect_uri: redirectUri,
                 grant_type: 'authorization_code',
                 code_verifier: req.body.codeVerifier,
             }),

--- a/packages/auth-server/tsconfig.lib.json
+++ b/packages/auth-server/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+    "extends": "../../tsconfig.lib.json",
+    "include": ["./src"],
+    "compilerOptions": {
+        "outDir": "./lib",
+        "module": "commonjs",
+        "moduleResolution": "node"
+    },
+    "references": []
+}

--- a/packages/suite-desktop-core/src/libs/http-receiver.ts
+++ b/packages/suite-desktop-core/src/libs/http-receiver.ts
@@ -64,6 +64,7 @@ const applyTemplate = (content = 'You may now close this window.', options?: Tem
 };
 
 export const createHttpReceiver = (options?: { port?: number }) => {
+    // Note that if we override the `address` to something else than 127.0.0.1 or localhost, it might break google oauth
     const httpReceiver = new HttpServer<Events>({
         logger: convertILoggerToLog(global.logger, { serviceName: 'http-receiver' }),
         port: options?.port ?? 21335,

--- a/packages/suite-desktop-core/src/modules/http-receiver.ts
+++ b/packages/suite-desktop-core/src/modules/http-receiver.ts
@@ -34,7 +34,8 @@ export const initBackground: ModuleInitBackground = ({
         if (httpReceiver) {
             return httpReceiver.getInfo();
         }
-        // External request handler
+        // External request handler.
+        // Note that if we override the `port` to something else than 21335, it might break google oauth
         const receiver = createHttpReceiver();
         httpReceiver = receiver;
 

--- a/scripts/list-outdated-dependencies/foundation-dependencies.txt
+++ b/scripts/list-outdated-dependencies/foundation-dependencies.txt
@@ -52,6 +52,7 @@ expo-sqlite
 expo-file-system
 expo-sharing
 express
+express-rate-limit
 fake-indexeddb
 file-saver
 globals

--- a/yarn.lock
+++ b/yarn.lock
@@ -15357,6 +15357,7 @@ __metadata:
     "@types/cors": "npm:^2.8.17"
     cors: "npm:^2.8.6"
     express: "npm:^5.2.1"
+    express-rate-limit: "npm:^8.5.2"
   peerDependencies:
     tslib: ^2.6.2
   languageName: unknown
@@ -27080,14 +27081,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"express-rate-limit@npm:^8.2.1":
-  version: 8.2.1
-  resolution: "express-rate-limit@npm:8.2.1"
+"express-rate-limit@npm:^8.2.1, express-rate-limit@npm:^8.5.2":
+  version: 8.5.2
+  resolution: "express-rate-limit@npm:8.5.2"
   dependencies:
-    ip-address: "npm:10.0.1"
+    ip-address: "npm:^10.2.0"
   peerDependencies:
     express: ">= 4.11"
-  checksum: 10/7cbf70df2e88e590e463d2d8f93380775b2ea181d97f2c50c2ff9f2c666c247f83109a852b21d9c99ccc5762119101f281f54a27252a2f1a0a918be6d71f955b
+  checksum: 10/de2aa4582d3b1b1d242fdb8dba7b3b1c64e3a58dfa7a40d370681c175a61321fb550c6b190d755f47cefdf28f35eaad6c99ea196f99caec8caaffc2462fea1ae
   languageName: node
   linkType: hard
 
@@ -30174,10 +30175,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-address@npm:10.0.1":
-  version: 10.0.1
-  resolution: "ip-address@npm:10.0.1"
-  checksum: 10/09731acda32cd8e14c46830c137e7e5940f47b36d63ffb87c737331270287d631cf25aa95570907a67d3f919fdb25f4470c404eda21e62f22e0a55927f4dd0fb
+"ip-address@npm:^10.2.0":
+  version: 10.2.0
+  resolution: "ip-address@npm:10.2.0"
+  checksum: 10/12fec399e1af5753ac322e47a6d81a50d3a528b3abb17c09525b2a2edcaedcca628c40520706f7037bc4d8e951b0296c47e7b86d0a8e6e2335c8f0ba4afcfac1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

CR commit by commit recommended

- Partially revert 0a86a83a3196ca71c3ed9e01ed05836cfcb419b7 – add build process for auth server removed by mistake
- Redact error stack traces from backend
- Restrict loopback OAuth receiver to be that of Trezor Suite (`localhost:21335`)
- Add rate limiting
  - [Requested by CodeQL on this PR](https://github.com/trezor/trezor-suite/security/code-scanning/314), it's false positive because it is a preexisting issue not introduced by this PR, but low hanging fruit so I had it implemented

## Notes for QA

No changes in Suite runtime code – the `auth-server` is deployed manaually, separately, it doesn't directly influence Suite in any way.

Must be tested when the server is deployed on staging, and then production, please coordinate with @Lemonexe .

On Suite Desktop (any version, the changes are only in the backend that is deployed independently):
- Turn on legacy labelling and initiate fresh authentication with google drive provider
  - Test that you can create a label
- Reopen the app in more than 60 minutes and verify it still works
  - The previous label loads, can create a label


## Related Issue

Resolve https://github.com/trezor/trezor-suite-private/issues/5
Resolve https://github.com/trezor/trezor-suite-private/issues/7
Resolve https://github.com/trezor/trezor-suite/security/code-scanning/314

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect the auth-server package (OAuth/authentication server) and suite-desktop-core's http-receiver module (handles HTTP callbacks in the Electron desktop app). These are infrastructure components primarily used for OAuth callback handling during metadata provider authentication (Google, Dropbox) and potentially TrezorConnect communication flows. Since no static test coverage mapping exists for these files, recommendations are inferred from LLM analysis. The risk is moderate — changes to HTTP receiver and auth server could break OAuth flows for metadata providers, but the E2E tests use mocked providers which may bypass parts of the real auth flow. Most of the auth-server and http-receiver changes likely lack direct E2E coverage.

<details><summary><b>Changed files (5)</b></summary>

- `packages/auth-server/package.json`
- `packages/auth-server/src/index.ts`
- `packages/auth-server/tsconfig.lib.json`
- `packages/suite-desktop-core/src/libs/http-receiver.ts`
- `packages/suite-desktop-core/src/modules/http-receiver.ts`

</details>

**Recommended tests (5)**

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — The http-receiver module in suite-desktop-core handles OAuth callbacks and other HTTP-based communication flows. The TrezorConnect webextension popup test exercises Suite Web's connect flow which may rely on HTTP receiver infrastructure for handling callbacks between the extension and Suite. Changes to http-receiver could affect this communication path.
- `suite/e2e/tests/metadata/legacy/dropbox-api-errors.test.ts` — The http-receiver module is used for OAuth callback handling in the desktop app, which is critical for metadata provider authentication (Dropbox, Google). Changes to http-receiver.ts could affect how OAuth tokens are received during metadata provider connection flows tested here.
- `suite/e2e/tests/metadata/legacy/google-api-errors.test.ts` — Similar to Dropbox errors test — the Google metadata provider connection relies on OAuth flow which uses the http-receiver for handling authentication callbacks in the desktop app. Changes here could affect provider initialization.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/metadata/legacy/remembered-device.test.ts` — This test exercises metadata provider connection/disconnection cycles with Google provider, which involves OAuth callback handling through http-receiver. The auth-server changes could affect the token exchange flow used during provider initialization.
- `suite/e2e/tests/metadata/legacy/interval-fetching.test.ts` — This test enables legacy labeling with Google/Dropbox providers which requires OAuth authentication. The http-receiver and auth-server changes could affect the initial provider authentication that precedes the interval fetching behavior.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/auth-server/package.json`
- `packages/auth-server/src/index.ts`
- `packages/auth-server/tsconfig.lib.json`

_Updated: 2026-06-02T08:21:02.755Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/auth-server&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/auth-server&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-02T08:55:59.148Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-02T09:43:22.623Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/auth-server/web/](https://dev.suite.sldev.cz/suite-web/fix/auth-server/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->