### PR TITLE
refactor(transport): AbstractApi `read` and `write` with options

### DIFF
--- a/packages/connect/src/device/__tests__/handshakeWorkflow.test.ts
+++ b/packages/connect/src/device/__tests__/handshakeWorkflow.test.ts
@@ -10,6 +10,8 @@ import { handshakeCancel } from '../workflow/handshake';
 
 const { createTestTransport } = global.JestMocks;
 
+type ReadWriteOptions = { signal?: AbortSignal };
+
 const getAcquiredDevice = async (apiMethods: any = {}) => {
     let emitTransportEvent: (d: any[]) => void = () => {};
     const transport = createTestTransport({
@@ -91,13 +93,13 @@ describe('workflow/handshake', () => {
         let readAttempt = 0;
         const abortSpy = jest.fn();
         const readMock = jest.fn(
-            (_, signal) =>
+            (_, { signal }: ReadWriteOptions) =>
                 new Promise(resolve => {
                     const timeout = setTimeout(
                         () => resolve({ success: true, payload: Buffer.alloc(readAttempt) }),
                         500 * readAttempt, // increase respond time on each attempt, should timeout on 3rd
                     );
-                    signal.addEventListener('abort', () => {
+                    signal?.addEventListener('abort', () => {
                         abortSpy();
                         clearTimeout(timeout);
                         resolve({ success: false });
@@ -121,10 +123,10 @@ describe('workflow/handshake', () => {
 
         const abortSpy = jest.fn();
         const readMock = jest.fn(
-            (_, signal) =>
+            (_, { signal }: ReadWriteOptions) =>
                 new Promise(resolve => {
                     const timeout = setTimeout(() => resolve({ success: false }), 2000);
-                    signal.addEventListener('abort', () => {
+                    signal?.addEventListener('abort', () => {
                         abortSpy();
                         clearTimeout(timeout);
                         resolve({ success: false });
@@ -177,10 +179,10 @@ describe('workflow/handshake', () => {
 
         const abortSpy = jest.fn();
         const writeMock = jest.fn(
-            (_a, _b, signal) =>
+            (_a, _b, { signal }: ReadWriteOptions) =>
                 new Promise(resolve => {
                     const timeout = setTimeout(() => resolve({ success: false }), 2000);
-                    signal.addEventListener('abort', () => {
+                    signal?.addEventListener('abort', () => {
                         abortSpy();
                         clearTimeout(timeout);
                         resolve({ success: false });
@@ -208,10 +210,10 @@ describe('workflow/handshake', () => {
 
         const abortSpy = jest.fn();
         const writeMock = jest.fn(
-            (_a, _b, signal) =>
+            (_a, _b, { signal }: ReadWriteOptions) =>
                 new Promise(resolve => {
                     const timeout = setTimeout(() => resolve({ success: false }), 2000);
-                    signal.addEventListener('abort', () => {
+                    signal?.addEventListener('abort', () => {
                         abortSpy();
                         clearTimeout(timeout);
                         resolve({ success: false });

--- a/packages/transport-bluetooth/src/client/bluetooth-api.ts
+++ b/packages/transport-bluetooth/src/client/bluetooth-api.ts
@@ -1,9 +1,9 @@
 import {
     AbstractApi,
+    type AbstractApiArgs,
     type AbstractApiConstructorParams,
     DEVICE_TYPE,
     TRANSPORT_ERROR as ERRORS,
-    type OpenDeviceChannel,
     type PathInternal,
     error,
     getBLEDescriptorModel,
@@ -100,11 +100,11 @@ export class BluetoothApi extends AbstractApi {
         return this.api.disconnect();
     }
 
-    read(path: string, signal?: AbortSignal) {
-        return this.readBuffer.read(path, signal);
+    read(...[path, options]: AbstractApiArgs<'read'>) {
+        return this.readBuffer.read(path, options?.signal);
     }
 
-    write(path: string, buffer: Buffer) {
+    write(...[path, buffer]: AbstractApiArgs<'write'>) {
         const chunk = Buffer.alloc(this.chunkSize);
         buffer.copy(chunk);
 
@@ -114,7 +114,7 @@ export class BluetoothApi extends AbstractApi {
             .catch(e => error({ code: ERRORS.INTERFACE_DATA_TRANSFER, message: e.message }));
     }
 
-    openDevice(path: string, options?: { channel?: OpenDeviceChannel }) {
+    openDevice(...[path, options]: AbstractApiArgs<'openDevice'>) {
         const isReadChannel = !options?.channel || options.channel === 'read';
         if (isReadChannel) {
             this.readBuffer.cancelRead(path);
@@ -134,7 +134,7 @@ export class BluetoothApi extends AbstractApi {
             );
     }
 
-    closeDevice(path: string, options?: { channel?: OpenDeviceChannel }) {
+    closeDevice(...[path, options]: AbstractApiArgs<'closeDevice'>) {
         const isReadChannel = !options?.channel || options.channel === 'read';
         if (isReadChannel) {
             // do not close subscriptions to TX (read) characteristics

--- a/packages/transport-bridge/src/core.ts
+++ b/packages/transport-bridge/src/core.ts
@@ -98,7 +98,7 @@ export const createCore = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) =>
         }
 
         const chunks = createChunks(encodedMessage, chunkHeader, api.chunkSize);
-        const apiWrite = (chunk: Buffer) => api.write(path, chunk, signal);
+        const apiWrite = (chunk: Buffer) => api.write(path, chunk, { signal });
         const sendResult = await sendChunks(chunks, apiWrite);
 
         return sendResult;
@@ -116,7 +116,7 @@ export const createCore = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) =>
         logger?.debug(`core: readUtil protocol ${protocol.name}`);
         try {
             const receiveProtocol = protocol.name === 'bridge' ? protocolV1 : protocol;
-            const res = await receiveUtil(() => api.read(path, signal), receiveProtocol);
+            const res = await receiveUtil(() => api.read(path, { signal }), receiveProtocol);
             if (!res.success) return res;
             const { messageType, payload } = res.payload;
             logger?.debug(
@@ -269,14 +269,16 @@ export const createCore = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) =>
                 const [, chunkHeader] = protocol.getHeaders(bytes);
                 const chunks = createChunks(bytes, chunkHeader, api.chunkSize);
 
-                const apiWrite = (chunk: Buffer, attemptSignal?: AbortSignal) =>
-                    api.write(path, chunk, attemptSignal || signal);
-
                 const message = await callThpMessage({
                     thpState: state,
                     chunks,
-                    apiWrite,
-                    apiRead: attemptSignal => api.read(path, attemptSignal || signal),
+                    apiWrite: (chunk, options) =>
+                        api.write(path, chunk, {
+                            ...options,
+                            signal: options?.signal || signal,
+                        }),
+                    apiRead: options =>
+                        api.read(path, { ...options, signal: options?.signal || signal }),
                     signal,
                     logger,
                 });
@@ -343,8 +345,10 @@ export const createCore = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) =>
             const writeResult = await sendThpMessage({
                 thpState: state,
                 chunks,
-                apiWrite: (chunk, attemptSignal) => api.write(path, chunk, attemptSignal || signal),
-                apiRead: attemptSignal => api.read(path, attemptSignal || signal),
+                apiWrite: (chunk, options) =>
+                    api.write(path, chunk, { ...options, signal: options?.signal || signal }),
+                apiRead: options =>
+                    api.read(path, { ...options, signal: options?.signal || signal }),
                 signal,
                 logger,
                 skipAck: true,
@@ -392,9 +396,13 @@ export const createCore = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) =>
 
                 const message = await receiveThpMessage({
                     thpState: state,
-                    apiWrite: (chunk, attemptSignal) =>
-                        api.write(path, chunk, attemptSignal || signal),
-                    apiRead: attemptSignal => api.read(path, attemptSignal || signal),
+                    apiWrite: (chunk, options) =>
+                        api.write(path, chunk, {
+                            ...options,
+                            signal: options?.signal || signal,
+                        }),
+                    apiRead: options =>
+                        api.read(path, { ...options, signal: options?.signal || signal }),
                     signal,
                     logger,
                     skipAck: true,

--- a/packages/transport-bridge/tests/http.test.ts
+++ b/packages/transport-bridge/tests/http.test.ts
@@ -3,7 +3,7 @@ import EventEmitter from 'events';
 import { getFreePort } from '@trezor/node-utils';
 import { bridgeApiCall } from '@trezor/transport';
 import { UdpApi } from '@trezor/transport/src/api/udp';
-import { AbstractApi } from '@trezor/transport-common';
+import { AbstractApi, AbstractApiArgs } from '@trezor/transport-common';
 import { resolveAfter } from '@trezor/utils';
 
 import { TrezordNode } from '../src/http';
@@ -544,12 +544,12 @@ describe('http', () => {
 
         it('/call aborted', async () => {
             const writeSpy = jest.fn(
-                (_p: any, _d: any, signal: AbortSignal) =>
+                (...[, , options]: AbstractApiArgs<'write'>) =>
                     new Promise(resolve => {
                         // simulate some api work
                         setTimeout(() => {
                             // and when done check if it was not aborted
-                            if (signal.aborted) {
+                            if (options?.signal?.aborted) {
                                 resolve({ success: false, error: 'Aborted' });
                             } else {
                                 resolve({ success: true, payload: [] });

--- a/packages/transport-common/src/api/abstract.ts
+++ b/packages/transport-common/src/api/abstract.ts
@@ -68,7 +68,9 @@ export abstract class AbstractApi extends TypedEmitter<{
      */
     abstract read(
         path: PathInternal,
-        signal?: AbortSignal,
+        options?: {
+            signal?: AbortSignal;
+        },
     ): AsyncResultWithTypedError<
         Buffer,
         | typeof ERRORS.DEVICE_NOT_FOUND
@@ -86,7 +88,9 @@ export abstract class AbstractApi extends TypedEmitter<{
     abstract write(
         path: PathInternal,
         buffers: Buffer,
-        signal?: AbortSignal,
+        options?: {
+            signal?: AbortSignal;
+        },
     ): AsyncResultWithTypedError<
         undefined,
         | typeof ERRORS.DEVICE_NOT_FOUND
@@ -212,3 +216,12 @@ export type AbstractApiAwaitedResult<K extends keyof AbstractApi> = AbstractApi[
 ) => any
     ? Awaited<ReturnType<AbstractApi[K]>>
     : never;
+
+export type AbstractApiArgs<K extends keyof AbstractApi> = AbstractApi[K] extends (
+    ...args: any[]
+) => any
+    ? Parameters<AbstractApi[K]>
+    : never;
+
+export type AbstractApiArgsOmitPath<K extends keyof AbstractApi> =
+    AbstractApiArgs<K> extends [any, ...infer Rest] ? Rest : never;

--- a/packages/transport-common/src/api/usb.ts
+++ b/packages/transport-common/src/api/usb.ts
@@ -1,6 +1,6 @@
 import { arrayPartition, createDeferred, getSynchronize, resolveAfter } from '@trezor/utils';
 
-import { AbstractApi, type AbstractApiConstructorParams } from './abstract';
+import { AbstractApi, type AbstractApiArgs, type AbstractApiConstructorParams } from './abstract';
 import {
     CONFIGURATION_ID,
     DEBUGLINK_ENDPOINT_ID,
@@ -224,7 +224,7 @@ export class UsbApi extends AbstractApi {
         return pending;
     }
 
-    public async read(path: string, signal?: AbortSignal) {
+    public async read(...[path, options]: AbstractApiArgs<'read'>) {
         const device = this.findDevice(path);
         if (!device) {
             return error({ code: ERRORS.DEVICE_NOT_FOUND });
@@ -233,7 +233,7 @@ export class UsbApi extends AbstractApi {
         try {
             this.logger?.debug('usb: device.transferIn');
             const res = await this.abortableMethod(() => this.getTransferIn(device), {
-                signal,
+                signal: options?.signal,
                 onAbort: () => this.resetDevice(path),
             });
             this.logger?.debug(
@@ -254,7 +254,7 @@ export class UsbApi extends AbstractApi {
         }
     }
 
-    public async write(path: string, buffer: Buffer, signal?: AbortSignal) {
+    public async write(...[path, buffer, options]: AbstractApiArgs<'write'>) {
         const device = this.findDevice(path);
         if (!device) {
             return error({ code: ERRORS.DEVICE_NOT_FOUND });
@@ -284,7 +284,7 @@ export class UsbApi extends AbstractApi {
                         this.debugLink ? DEBUGLINK_ENDPOINT_ID : ENDPOINT_ID,
                         newArray,
                     ),
-                { signal, onAbort: () => this.resetDevice(path) },
+                { signal: options?.signal, onAbort: () => this.resetDevice(path) },
             );
             this.logger?.debug(`usb: device.transferOut done.`);
             if (result.status !== 'ok') {
@@ -300,7 +300,7 @@ export class UsbApi extends AbstractApi {
         }
     }
 
-    public async openDevice(path: string, options: { reset: boolean; signal?: AbortSignal }) {
+    public async openDevice(...[path, options]: AbstractApiArgs<'openDevice'>) {
         // note: multiple retries to open device. reason:  when another window acquires device, changed session
         // is broadcasted to other clients. they are responsible for releasing interface, which takes some time.
         // if there is only one client working with device, this will succeed using only one attempt.
@@ -310,7 +310,7 @@ export class UsbApi extends AbstractApi {
         for (let i = 0; i < 5; i++) {
             this.logger?.debug(`usb: openDevice attempt ${i}`);
             const res = await this.openInternal(path, options);
-            if (res.success || options.signal?.aborted) {
+            if (res.success || options?.signal?.aborted) {
                 return res;
             }
 
@@ -320,10 +320,8 @@ export class UsbApi extends AbstractApi {
         return this.openInternal(path, options);
     }
 
-    private async openInternal(
-        path: string,
-        { reset, signal }: { reset: boolean; signal?: AbortSignal },
-    ) {
+    private async openInternal(...[path, options]: AbstractApiArgs<'openDevice'>) {
+        const { signal, reset } = options || { reset: false };
         const device = this.findDevice(path);
         if (!device) {
             return error({ code: ERRORS.DEVICE_NOT_FOUND });
@@ -393,7 +391,7 @@ export class UsbApi extends AbstractApi {
         return success(undefined);
     }
 
-    public async closeDevice(path: string) {
+    public async closeDevice(...[path]: AbstractApiArgs<'closeDevice'>) {
         let device = this.findDevice(path);
         if (!device) {
             return error({ code: ERRORS.DEVICE_NOT_FOUND });

--- a/packages/transport-common/src/index.ts
+++ b/packages/transport-common/src/index.ts
@@ -41,6 +41,8 @@ export type {
 export { AbstractApiTransport } from './transports/abstractApi';
 export { AbstractApi } from './api/abstract';
 export type {
+    AbstractApiArgs,
+    AbstractApiArgsOmitPath,
     AbstractApiAwaitedResult,
     AbstractApiConstructorParams,
     OpenDeviceChannel,

--- a/packages/transport-common/src/thp/loop.ts
+++ b/packages/transport-common/src/thp/loop.ts
@@ -221,7 +221,7 @@ export const thpLoop = async ({
                 debug('SEND_RECENT_ACK');
 
                 const chunk = protocolThp.encodePreviousAck(thpState);
-                const ackResult = await apiWrite(chunk, signal);
+                const ackResult = await apiWrite(chunk, { signal });
                 if (!ackResult.success) {
                     return ackResult;
                 }
@@ -239,7 +239,7 @@ export const thpLoop = async ({
                 debug(`SEND_ACK ${isAckExpected} with piggyback ${thpState.isPiggybackAckEnabled}`);
 
                 if (!skipAck && isAckExpected && !thpState.isPiggybackAckEnabled) {
-                    const ack = await apiWrite(protocolThp.encodeAck(thpState), signal);
+                    const ack = await apiWrite(protocolThp.encodeAck(thpState), { signal });
                     if (!ack.success) {
                         return ack;
                     }

--- a/packages/transport-common/src/thp/receiveExpectedMessage.ts
+++ b/packages/transport-common/src/thp/receiveExpectedMessage.ts
@@ -8,7 +8,7 @@ import { THP_CONTROL_BYTE } from '@trezor/protocol/src/protocol-v2/constants';
 import { SCHEDULE_ACTION_TIMEOUT_ERROR_MESSAGE, scheduleAction } from '@trezor/utils';
 import type { Logger } from '@trezor/utils';
 
-import type { AbstractApi } from '../api/abstract';
+import type { AbstractApi, AbstractApiArgsOmitPath } from '../api/abstract';
 import { receive } from '../utils/receive';
 import { error } from '../utils/result';
 
@@ -32,8 +32,8 @@ type ReceiveExpectedMessageError = ReturnType<
 >;
 
 export type CommonProps = {
-    apiWrite: (chunk: Buffer, signal?: AbortSignal) => ReturnType<AbstractApi['write']>;
-    apiRead: (signal?: AbortSignal) => ReturnType<AbstractApi['read']>;
+    apiWrite: (...args: AbstractApiArgsOmitPath<'write'>) => ReturnType<AbstractApi['write']>;
+    apiRead: (...args: AbstractApiArgsOmitPath<'read'>) => ReturnType<AbstractApi['read']>;
     thpState?: ThpState;
     skipAck?: boolean;
     signal?: AbortSignal;
@@ -60,7 +60,7 @@ export const receiveExpectedMessage = async (
 ): Promise<ReceiveResult | ReceiveExpectedMessageError> => {
     // scheduleAction returns wrapped error from the apiRead or throws error from itself (timeout, deadline, signal)
     const receiveResult = await scheduleAction(
-        attemptSignal => receive(() => apiRead(attemptSignal), protocolV2),
+        attemptSignal => receive(() => apiRead({ signal: attemptSignal }), protocolV2),
         {
             signal,
             graceful: true,

--- a/packages/transport-common/src/transports/abstractApi.ts
+++ b/packages/transport-common/src/transports/abstractApi.ts
@@ -5,7 +5,11 @@ import {
     type AbstractTransportMethodParams,
     type AbstractTransportParams,
 } from './abstract';
-import { type AbstractApi, type OpenDeviceChannel } from '../api/abstract';
+import {
+    type AbstractApi,
+    type AbstractApiArgsOmitPath,
+    type OpenDeviceChannel,
+} from '../api/abstract';
 import { TRANSPORT } from '../constants';
 import * as ERRORS from '../errors';
 import { SessionsBackground } from '../sessions/background';
@@ -257,17 +261,20 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                     this.api.nativeWriteChunking ? 0 : this.api.chunkSize,
                 );
                 let progress = 0;
-                const apiWrite = (chunk: Buffer, attemptSignal?: AbortSignal) => {
+                const apiWrite = (...[chunk, options]: AbstractApiArgsOmitPath<'write'>) => {
                     if (chunks.length > 1) {
                         progress++;
                         this.emit(TRANSPORT.SEND_MESSAGE_PROGRESS, progress / chunks.length);
                     }
 
-                    return this.api.write(path, chunk, attemptSignal || signal);
+                    return this.api.write(path, chunk, {
+                        ...options,
+                        signal: options?.signal || signal,
+                    });
                 };
 
-                const apiRead = (attemptSignal?: AbortSignal) =>
-                    this.api.read(path, attemptSignal || signal);
+                const apiRead = (...[options]: AbstractApiArgsOmitPath<'read'>) =>
+                    this.api.read(path, { ...options, signal: options?.signal || signal });
 
                 if (protocol.name === 'v2') {
                     const prevNonce = thpState?.sendNonce;
@@ -353,14 +360,20 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                     this.api.nativeWriteChunking ? 0 : this.api.chunkSize,
                 );
                 let progress = 0;
-                const apiWrite = (chunk: Buffer) => {
+                const apiWrite = (...[chunk, options]: AbstractApiArgsOmitPath<'write'>) => {
                     if (chunks.length > 1) {
                         progress++;
                         this.emit(TRANSPORT.SEND_MESSAGE_PROGRESS, progress / chunks.length);
                     }
 
-                    return this.api.write(path, chunk, signal);
+                    return this.api.write(path, chunk, {
+                        ...options,
+                        signal: options?.signal || signal,
+                    });
                 };
+                const apiRead = (...[options]: AbstractApiArgsOmitPath<'read'>) =>
+                    this.api.read(path, { ...options, signal: options?.signal || signal });
+
                 let sendResult;
                 if (protocol.name === 'v2') {
                     sendResult = await sendThpMessage({
@@ -368,7 +381,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                         skipAck: true,
                         chunks,
                         apiWrite,
-                        apiRead: attemptSignal => this.api.read(path, attemptSignal || signal),
+                        apiRead,
                         signal,
                         logger: this.logger,
                     });
@@ -411,16 +424,21 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                 }
                 const { path } = getPathBySessionResponse.payload;
 
-                const apiRead = (attemptSignal?: AbortSignal) =>
-                    this.api.read(path, attemptSignal || signal);
+                const apiRead = (...[options]: AbstractApiArgsOmitPath<'read'>) =>
+                    this.api.read(path, { ...options, signal: options?.signal || signal });
+
+                const apiWrite = (...[chunk, options]: AbstractApiArgsOmitPath<'write'>) =>
+                    this.api.write(path, chunk, {
+                        ...options,
+                        signal: options?.signal || signal,
+                    });
 
                 const protocol = customProtocol || v1Protocol;
                 if (protocol.name === 'v2') {
                     const decoded = await receiveThpMessage({
                         thpState,
                         skipAck: true,
-                        apiWrite: (chunk, attemptSignal) =>
-                            this.api.write(path, chunk, attemptSignal || signal),
+                        apiWrite,
                         apiRead,
                         signal,
                         logger: this.logger,

--- a/packages/transport-common/tests/apiUsb.test.ts
+++ b/packages/transport-common/tests/apiUsb.test.ts
@@ -1,6 +1,7 @@
 import { createDeferred } from '@trezor/utils';
 
 import { UsbApi } from '../src/api/usb';
+import { PathInternal } from '../src/types';
 import type {
     UsbDeviceLike,
     UsbInTransferResultLike,
@@ -57,6 +58,8 @@ describe('api/usb', () => {
 
     afterAll(async () => {});
 
+    const devicePath = PathInternal('123');
+
     it('read aborted', async () => {
         const reset = jest.fn(() => Promise.resolve());
         const api = new UsbApi({
@@ -79,7 +82,7 @@ describe('api/usb', () => {
 
         const abortController = new AbortController();
         await api.enumerate(abortController.signal);
-        const promise = api.read('123', abortController.signal);
+        const promise = api.read(devicePath, { signal: abortController.signal });
         abortController.abort();
 
         const result = await promise;
@@ -107,7 +110,9 @@ describe('api/usb', () => {
 
         const abortController = new AbortController();
         await api.enumerate(abortController.signal);
-        const promise = api.write('123', Buffer.alloc(api.chunkSize), abortController.signal);
+        const promise = api.write(devicePath, Buffer.alloc(api.chunkSize), {
+            signal: abortController.signal,
+        });
         abortController.abort();
 
         const result = await promise;
@@ -147,7 +152,10 @@ describe('api/usb', () => {
 
         const abortController = new AbortController();
         await api.enumerate(abortController.signal);
-        const promise = api.openDevice('123', { reset: true, signal: abortController.signal });
+        const promise = api.openDevice(devicePath, {
+            reset: true,
+            signal: abortController.signal,
+        });
         abortController.abort();
 
         const result = await promise;
@@ -219,13 +227,15 @@ describe('api/usb', () => {
         const abortController = new AbortController();
         await api.enumerate(abortController.signal);
         for (let i = 0; i < 11; i++) {
-            await api.write('123', Buffer.alloc(0), abortController.signal);
-            await api.read('123', abortController.signal);
+            await api.write(devicePath, Buffer.alloc(0), {
+                signal: abortController.signal,
+            });
+            await api.read(devicePath, { signal: abortController.signal });
         }
 
         // this should not trigger onAbort (device.reset)
         abortController.abort();
-        await api.write('123', Buffer.alloc(0), abortController.signal);
+        await api.write(devicePath, Buffer.alloc(0), { signal: abortController.signal });
 
         expect(reset).toHaveBeenCalledTimes(0);
     });

--- a/packages/transport-common/tests/thp.test.ts
+++ b/packages/transport-common/tests/thp.test.ts
@@ -11,6 +11,8 @@ import {
 
 protobufManager.load([thpProto]);
 
+type ApiReadOptions = { signal?: AbortSignal };
+
 describe('thp', () => {
     const HANDSHAKE_COMP_RES = Buffer.from(
         '13094b0015cc41d620b1ea28111d64e2faf6d34e06e371dd3c4f0000000000000000000000000000000000000000000000000000000000000000000000000000',
@@ -21,16 +23,17 @@ describe('thp', () => {
 
     const thpState = new protocolThp.ThpState();
     const apiRead = jest.fn(
-        signal =>
+        (options: ApiReadOptions = {}) =>
             new Promise<any>((resolve, reject) => {
+                const { signal } = options;
                 const listener = () => {
-                    signal.removeEventListener('abort', listener);
+                    signal?.removeEventListener('abort', listener);
                     reject(new Error('Aborted'));
                 };
                 signal?.addEventListener('abort', listener);
 
                 setTimeout(() => {
-                    signal.removeEventListener('abort', listener);
+                    signal?.removeEventListener('abort', listener);
                     resolve({ success: true, payload: THP_ACK });
                 }, 100);
             }),
@@ -49,12 +52,12 @@ describe('thp', () => {
             const abortController = new AbortController();
             let attempt = 0;
             const apiRead = jest.fn(
-                signal =>
+                (options: ApiReadOptions = {}) =>
                     new Promise<any>(resolve => {
                         if (++attempt < 5) {
                             resolve({ success: true, payload: Buffer.alloc(32) });
                         } else {
-                            signal?.addEventListener('abort', () => {
+                            options.signal?.addEventListener('abort', () => {
                                 resolve({
                                     success: false,
                                     error: { code: 'Aborted by signal in API' },
@@ -192,13 +195,13 @@ describe('thp', () => {
             jest.useFakeTimers();
 
             const apiRead = jest.fn(
-                signal =>
+                (options: ApiReadOptions = {}) =>
                     new Promise<any>((_resolve, reject) => {
                         const listener = () => {
-                            signal.removeEventListener('abort', listener);
+                            options.signal?.removeEventListener('abort', listener);
                             reject(new Error('Aborted by signal inside API'));
                         };
-                        signal?.addEventListener('abort', listener);
+                        options.signal?.addEventListener('abort', listener);
                     }),
             );
 
@@ -290,13 +293,13 @@ describe('thp', () => {
                     ),
                 ],
                 apiWrite,
-                apiRead: (signal?: AbortSignal) =>
+                apiRead: (options: ApiReadOptions = {}) =>
                     new Promise<any>((_resolve, reject) => {
                         const listener = () => {
-                            signal?.removeEventListener('abort', listener);
+                            options.signal?.removeEventListener('abort', listener);
                             reject(new Error('Aborted in api'));
                         };
-                        signal?.addEventListener('abort', listener);
+                        options.signal?.addEventListener('abort', listener);
                     }),
                 signal: abortController.signal,
             });

--- a/packages/transport-native-bluetooth/src/api/BluetoothApi.ts
+++ b/packages/transport-native-bluetooth/src/api/BluetoothApi.ts
@@ -2,12 +2,11 @@ import { type Subscription } from 'react-native-ble-plx';
 
 import {
     AbstractApi,
+    type AbstractApiArgs,
     type AbstractApiConstructorParams,
-    type AsyncResultWithTypedError,
     DEVICE_TYPE,
     type DescriptorApiLevel,
     TRANSPORT_ERROR as ERRORS,
-    type OpenDeviceChannel,
     type PathInternal,
     error,
     success,
@@ -72,19 +71,7 @@ export class BluetoothApi extends AbstractApi {
         this.logger?.debug('listen', 'method not implemented');
     }
 
-    public async read(
-        path: string,
-        signal?: AbortSignal,
-    ): AsyncResultWithTypedError<
-        Buffer,
-        | typeof ERRORS.DEVICE_NOT_FOUND
-        | typeof ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE
-        | typeof ERRORS.INTERFACE_DATA_TRANSFER
-        | typeof ERRORS.DEVICE_DISCONNECTED_DURING_ACTION
-        | typeof ERRORS.UNEXPECTED_ERROR
-        | typeof ERRORS.ABORTED_BY_SIGNAL
-        | typeof ERRORS.ABORTED_BY_TIMEOUT
-    > {
+    public async read(...[path, options]: AbstractApiArgs<'read'>) {
         this.logger?.debug('read');
 
         if (!bluetoothManager.isDeviceConnected(path)) {
@@ -92,7 +79,7 @@ export class BluetoothApi extends AbstractApi {
         }
 
         try {
-            const result = await bluetoothManager.read(path, signal);
+            const result = await bluetoothManager.read(path, options?.signal);
             if (!result.success) {
                 return error({ code: ERRORS.INTERFACE_DATA_TRANSFER });
             }
@@ -105,7 +92,7 @@ export class BluetoothApi extends AbstractApi {
         }
     }
 
-    public async write(path: string, buffer: Buffer) {
+    public async write(...[path, buffer]: AbstractApiArgs<'write'>) {
         this.logger?.debug('write', buffer);
 
         if (!bluetoothManager.isDeviceConnected(path)) {
@@ -126,7 +113,7 @@ export class BluetoothApi extends AbstractApi {
         }
     }
 
-    public async openDevice(path: string, options?: { channel?: OpenDeviceChannel }) {
+    public async openDevice(...[path, options]: AbstractApiArgs<'openDevice'>) {
         this.logger?.debug('openDevice', path, options);
 
         if (options?.channel === 'trezor-push-notification') {
@@ -139,7 +126,7 @@ export class BluetoothApi extends AbstractApi {
         return success(undefined);
     }
 
-    public async closeDevice(path: string, options?: { channel?: OpenDeviceChannel }) {
+    public async closeDevice(...[path, options]: AbstractApiArgs<'closeDevice'>) {
         this.logger?.debug('closeDevice', path, options);
 
         if (options?.channel === 'read') {

--- a/packages/transport-test/e2e/api/api.test.ts
+++ b/packages/transport-test/e2e/api/api.test.ts
@@ -2,6 +2,7 @@
 // not pull THP code (and its transitive `@trezor/protocol/protocol-thp/crypto`
 // node-only `crypto` import) into the browser bundle.
 import { UsbApi } from '@trezor/transport-common/src/api/usb';
+import type { PathInternal } from '@trezor/transport-common/src/types';
 import type { UsbInterfaceApi } from '@trezor/transport-common/src/types/usbInterface';
 
 import { debug, error, info, sharedTest, success } from './shared';
@@ -53,7 +54,7 @@ const runTests = async () => {
         info(`Running tests for ${f.description}`);
 
         const { api } = f;
-        let path: string;
+        let path: PathInternal;
 
         const getConnectedDevicePath = async () => {
             info('getConnectedDevicePath...');
@@ -114,7 +115,7 @@ const runTests = async () => {
 
             const abortController = new AbortController();
             debug('read with abort signal');
-            const readPromise = api.read(path, abortController.signal);
+            const readPromise = api.read(path, { signal: abortController.signal });
             debug('trigger abort');
             abortController.abort();
             const abortedResponse = await readPromise;

--- a/packages/transport/src/api/udp.ts
+++ b/packages/transport/src/api/udp.ts
@@ -2,6 +2,7 @@ import UDP from 'dgram';
 
 import {
     AbstractApi,
+    type AbstractApiArgs,
     type AbstractApiAwaitedResult,
     type AbstractApiConstructorParams,
     DEVICE_TYPE,
@@ -63,12 +64,13 @@ export class UdpApi extends AbstractApi {
         }
     }
 
-    public write(path: string, buffer: Buffer, signal?: AbortSignal) {
+    public write(...[path, buffer, options]: AbstractApiArgs<'write'>) {
         const parts = path.split(':');
         // @ts-expect-error: indexing with noUncheckedIndexedAccess
         const hostname: string = parts[0];
         // @ts-expect-error: indexing with noUncheckedIndexedAccess
         const port: string = parts[1];
+        const signal = options?.signal;
 
         return new Promise<AbstractApiAwaitedResult<'write'>>(resolve => {
             const listener = () => {
@@ -113,12 +115,12 @@ export class UdpApi extends AbstractApi {
         });
     }
 
-    public read(path: string, signal?: AbortSignal) {
-        return this.readBuffer.read(path, signal);
+    public read(...[path, options]: AbstractApiArgs<'read'>) {
+        return this.readBuffer.read(path, options?.signal);
     }
 
-    private async ping(path: string, signal?: AbortSignal) {
-        await this.write(path, PING, signal);
+    private async ping(path: PathInternal, signal?: AbortSignal) {
+        await this.write(path, PING, { signal });
         if (signal?.aborted) {
             throw new Error(ERRORS.ABORTED_BY_SIGNAL);
         }
@@ -208,12 +210,12 @@ export class UdpApi extends AbstractApi {
         }
     }
 
-    public openDevice(_path: string) {
+    public openDevice(...[_path]: AbstractApiArgs<'openDevice'>) {
         // todo: maybe ping?
         return Promise.resolve(success(undefined));
     }
 
-    public closeDevice(path: string) {
+    public closeDevice(...[path]: AbstractApiArgs<'closeDevice'>) {
         this.readBuffer.cancelRead(path);
 
         return Promise.resolve(success(undefined));

--- a/packages/transport/tests/apiUdp.test.ts
+++ b/packages/transport/tests/apiUdp.test.ts
@@ -1,5 +1,7 @@
 import UDP from 'dgram';
 
+import { PathInternal } from '@trezor/transport-common';
+
 import { UdpApi } from '../src/api/udp';
 
 // mock dgram api
@@ -26,6 +28,8 @@ describe('api/udp', () => {
         jest.clearAllMocks();
     });
 
+    const devicePath = PathInternal('1');
+
     it('read aborted', async () => {
         jest.spyOn(UDP, 'createSocket').mockImplementation(() => createUdpSocketMock());
 
@@ -33,7 +37,7 @@ describe('api/udp', () => {
 
         const abortController = new AbortController();
         await api.enumerate(abortController.signal);
-        const promise = api.read('1', abortController.signal);
+        const promise = api.read(devicePath, { signal: abortController.signal });
         abortController.abort();
         const result = await promise;
         if (result.success) throw new Error('Unexpected success');
@@ -60,7 +64,9 @@ describe('api/udp', () => {
 
         const abortController = new AbortController();
         await api.enumerate(abortController.signal);
-        const promise = api.write('1', Buffer.alloc(api.chunkSize), abortController.signal);
+        const promise = api.write(devicePath, Buffer.alloc(api.chunkSize), {
+            signal: abortController.signal,
+        });
         abortController.abort();
 
         const result = await promise;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Change AbstractApi `read` and `write` args from signal?: AbortSignal to options object `options?: { signal?: AbortSignal }` for future extensibility. Example (passing `write(... { withResponse: true })` or `read(..., { cancelRead: true })`
- Add `AbstractApiArgs<K>` and `AbstractApiArgsOmitPath<K>` helpers to derive implementation args from the abstract class keeping all implementations in sync
- Apply `AbstractApiArgsOmitPath` to all apiRead/apiWrite callback types (THP layer, bridge core, abstractApi transport) and use the spread pattern { ...options, signal: options?.signal || signal } for forwarding options

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/transport-with-options&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/transport-with-options&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/transport-with-options&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-30T15:02:53.376Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-06-30T15:02:50.193Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/transport-with-options/web/](https://dev.suite.sldev.cz/suite-web/feat/transport-with-options/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are concentrated in low-level transport infrastructure: bridge core logic, abstract transport APIs, USB/UDP/Bluetooth transport implementations, and THP protocol handling. These are foundational layers that underpin device communication but are largely abstracted away from most E2E test scenarios. The highest risk is to tests that directly exercise bridge lifecycle (spawn-bridge tests) and session management (multiple-sessions). Most E2E tests use the transport layer implicitly through the emulator and would only be affected by breaking changes to the communication protocol itself. The recommended strategy focuses on bridge-specific and transport-sensitive tests while keeping coverage targeted.

<details><summary><b>Changed files (16)</b></summary>

- `packages/connect/src/device/__tests__/handshakeWorkflow.test.ts`
- `packages/transport-bluetooth/src/client/bluetooth-api.ts`
- `packages/transport-bridge/src/core.ts`
- `packages/transport-bridge/tests/http.test.ts`
- `packages/transport-common/src/api/abstract.ts`
- `packages/transport-common/src/api/usb.ts`
- `packages/transport-common/src/index.ts`
- `packages/transport-common/src/thp/loop.ts`
- `packages/transport-common/src/thp/receiveExpectedMessage.ts`
- `packages/transport-common/src/transports/abstractApi.ts`
- `packages/transport-common/tests/apiUsb.test.ts`
- `packages/transport-common/tests/thp.test.ts`
- `packages/transport-native-bluetooth/src/api/BluetoothApi.ts`
- `packages/transport-test/e2e/api/api.test.ts`
- `packages/transport/src/api/udp.ts`
- `packages/transport/tests/apiUdp.test.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — This test directly exercises bridge spawning, lifecycle management, and device reconnection after bridge restart. Changes to packages/transport-bridge/src/core.ts modify the bridge core logic, and changes to transport-common's abstract API and transport layer could affect how Suite communicates with the bridge process.
- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — This test validates the bridge daemon mode, checking that the bridge process starts, stays running, and stops correctly. Direct changes to transport-bridge/src/core.ts affect daemon bridge behavior, and transport-common changes could affect bridge communication.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test exercises Bridge session acquisition, stealing, and reclaiming across multiple browser tabs. Changes to transport-bridge core and transport-common's abstract transport/API layers could affect session management and device enumeration behavior.
- `suite/e2e/tests/suite/bridge.test.ts` — This test navigates to the Bridge page and verifies WebUSB fallback and connect device prompt behavior. Changes to transport-bridge core and transport-common could affect how the bridge page functions and how transport is negotiated.
- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — TrezorConnect popup tests exercise the full device communication path including transport initialization. Changes to THP protocol handling (loop.ts, receiveExpectedMessage.ts) and abstract transport API could affect how Connect establishes device sessions through the popup flow.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/settings/forget-device.test.ts` — The forget device flow includes Bluetooth unpairing logic for TS7 devices. Changes to transport-bluetooth/src/client/bluetooth-api.ts and transport-native-bluetooth could affect the Bluetooth forget/unpair path tested here.
- `suite/e2e/tests/suite/initial-run.test.ts` — Initial run tests include THP pairing code flow for devices using Trezor Host Protocol. Changes to THP loop and message receiving logic could affect whether THP pairing succeeds during initial onboarding.

</details>

⚠️ **Changes with no test coverage (11)**
- `packages/connect/src/device/__tests__/handshakeWorkflow.test.ts`
- `packages/transport-bridge/tests/http.test.ts`
- `packages/transport-common/src/api/usb.ts`
- `packages/transport-common/src/index.ts`
- `packages/transport-common/tests/apiUsb.test.ts`
- `packages/transport-common/tests/thp.test.ts`
- `packages/transport-native-bluetooth/src/api/BluetoothApi.ts`
- `packages/transport-test/e2e/api/api.test.ts`
- `packages/transport/src/api/udp.ts`
- `packages/transport/tests/apiUdp.test.ts`
- `packages/transport-bluetooth/src/client/bluetooth-api.ts`

_Updated: 2026-06-23T11:47:27.032Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->