### PR TITLE
fix(suite-desktop): filter out empty tokens for sidebar search

### DIFF
--- a/suite-common/wallet-types/mocks/index.ts
+++ b/suite-common/wallet-types/mocks/index.ts
@@ -6,3 +6,4 @@ export {
     networkSpecificDefaultCardano,
     networkSpecificDefaultStellar,
 } from './mockWalletAccount';
+export { mockAccountToken } from './mockAccountToken';

--- a/suite-common/wallet-types/mocks/mockAccountToken.ts
+++ b/suite-common/wallet-types/mocks/mockAccountToken.ts
@@ -1,0 +1,16 @@
+import { AccountBase } from '../src/account';
+
+type TokenMock = NonNullable<AccountBase['tokens']>[number];
+
+const defaultToken: TokenMock = {
+    name: 'default-token-name',
+    symbol: 'DTN',
+    contract: '0x' + 'f'.repeat(40),
+    standard: 'ERC20',
+    decimals: 18,
+};
+
+export const mockAccountToken = (token: Partial<TokenMock>): TokenMock => ({
+    ...defaultToken,
+    ...token,
+});

--- a/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
@@ -1,7 +1,7 @@
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { type NetworkFeature } from '@suite-common/wallet-config';
 import { type Account, asAccountDescriptor, createAccountKey } from '@suite-common/wallet-types';
-import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+import { mockAccountToken, mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
 import * as fixtures from '../__fixtures__/accountUtils';
 import {
@@ -201,6 +201,19 @@ describe('account utils', () => {
             ),
         ).toBe(true);
         expect(accountSearchFn(btcAcc, '#1', { accountLabel: 'Bitcoin #1' })).toBe(true);
+    });
+
+    it('accountSearchFn empty tokens', () => {
+        const ethAcc = mockWalletAccount({
+            symbol: 'eth',
+            tokens: [
+                mockAccountToken({ balance: '0.000069', name: 'test' }),
+                mockAccountToken({ balance: '0.0', name: 'test2' }),
+            ],
+        });
+
+        expect(accountSearchFn(ethAcc, 'test', { accountLabel: '' })).toBe(true);
+        expect(accountSearchFn(ethAcc, 'test2', { accountLabel: '' })).toBe(false);
     });
 
     it('getNetworkAccountFeatures', () => {

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -851,10 +851,13 @@ export const accountSearchFn = (
 
     const accountLabelMatch = accountLabel.toLowerCase().includes(searchString);
 
+    // filter tokens by search string and balance greater than zero
     const filterTokens = (token: TokenInfo) =>
-        token.name?.toLowerCase().includes(searchString) ||
-        token.symbol?.toLowerCase().includes(searchString) ||
-        token.contract.toLowerCase().includes(searchString);
+        [token.name, token.symbol, token.contract].some(
+            field =>
+                field?.toLowerCase().includes(searchString) &&
+                new BigNumber(token.balance || '0').gt(0),
+        );
 
     const tokenMatch = tokensMatch && !!account.tokens?.some(filterTokens);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR improves searching by token name || address and excludes tokens with 0 balance

## Notes for QA

For all the cases when users were able to navigate to specific wallet because they ever **had** a specific token name "MAGIC", "TEST" etc. it would not be possible anymore and matching account is only shown if token balance is greater than zero. 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/28125

## Screenshots:
<img width="1235" height="602" alt="Screenshot 2026-06-02 at 12 02 32" src="https://github.com/user-attachments/assets/afa71069-3465-4976-9058-cef30467928e" />
<img width="1257" height="725" alt="Screenshot 2026-06-02 at 12 02 21" src="https://github.com/user-attachments/assets/1848b5f8-d813-4461-83e3-ac829fdf8424" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are concentrated in accountUtils.ts (a broad utility used by 121 tests) along with its unit test and mock files for wallet types. Since accountUtils.ts is a widely-shared utility, the unit test changes (accountUtils.test.ts) provide the primary safety net. For E2E coverage, only tests that directly exercise account-specific functionality (account types, search, discovery, public keys) are recommended at medium priority. The risk is moderate — changes to account utilities could affect account display, grouping, or discovery across the app, but the broad usage pattern means most tests only transitively depend on this code.

<details><summary><b>Changed files (4)</b></summary>

- `suite-common/wallet-types/mocks/index.ts`
- `suite-common/wallet-types/mocks/mockAccountToken.ts`
- `suite-common/wallet-utils/src/__tests__/accountUtils.test.ts`
- `suite-common/wallet-utils/src/accountUtils.ts`

</details>

**Recommended tests (6)**

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/wallet/add-account-types.test.ts` — This test exercises adding different account types (normal, taproot, segwit, legacy) for multiple coins and verifies account counts in type groups. accountUtils.ts likely contains the account type grouping and counting logic (getAccountsInTypeGroupCount) that this test directly validates.
- `suite/e2e/tests/wallet/account-search.test.ts` — This test verifies account search/filtering functionality where accounts are filtered by name. accountUtils.ts likely contains account filtering or matching logic used by the account search feature.
- `suite/e2e/tests/wallet/discovery.test.ts` — This test verifies wallet discovery across multiple coin types and checks that all activated coins have visible account balances. accountUtils.ts contains core account discovery and account management utilities that this test exercises end-to-end.
- `suite/e2e/tests/wallet/public-keys.test.ts` — This test navigates to account details and displays XPUBs for multiple coin types (BTC, LTC, ADA). accountUtils.ts likely provides account detail retrieval and derivation path logic used in the account details tab.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/general/wallet-discovery.test.ts` — This test verifies standard wallet discovery after ejecting and re-adding a wallet, which exercises account discovery logic in accountUtils. The change could affect how accounts are discovered or displayed post-rediscovery.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test verifies account discovery completes with custom blockbook backends for BTC and LTC. accountUtils.ts provides core account utilities that are exercised during the discovery process.

</details>

⚠️ **Changes with no test coverage (3)**
- `suite-common/wallet-types/mocks/index.ts`
- `suite-common/wallet-types/mocks/mockAccountToken.ts`
- `suite-common/wallet-utils/src/__tests__/accountUtils.test.ts`

_Updated: 2026-06-02T10:13:09.673Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/sidebar-empty-tokens&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/sidebar-empty-tokens&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/sidebar-empty-tokens&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-02T10:18:41.957Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-02T10:15:50.089Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/sidebar-empty-tokens/web/](https://dev.suite.sldev.cz/suite-web/fix/sidebar-empty-tokens/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->