### PR TITLE
fix(ttrx): address validation crash and duplicate account key

### DIFF
--- a/packages/address-validator/src/currencies.ts
+++ b/packages/address-validator/src/currencies.ts
@@ -78,7 +78,7 @@ const CURRENCIES: Currency[] = [
     {
         name: 'Tron',
         symbol: 'trx',
-        addressTypes: { prod: [0x41], testnet: [0xa0] },
+        addressTypes: { prod: [0x41], testnet: [0x41] },
         validator: TRXValidator,
     },
     {

--- a/packages/address-validator/tests/wallet_address_validator.test.ts
+++ b/packages/address-validator/tests/wallet_address_validator.test.ts
@@ -393,7 +393,7 @@ describe('WAValidator.validate()', function () {
 
         it('should return true for correct trx addresses', function () {
             valid('TNDzfERDpxLDS2w1q6yaFC7pzqaSQ3Bg3r', 'trx');
-            valid('27bLJCYjbH6MT8DBF9xcrK6yZnm43vx7MNQ', 'trx', 'testnet');
+            valid('TNDzfERDpxLDS2w1q6yaFC7pzqaSQ3Bg3r', 'trx', 'testnet');
         });
 
         it('should return true for correct stellar addresses', function () {

--- a/packages/connect-common/src/types/api/discoverAccounts.ts
+++ b/packages/connect-common/src/types/api/discoverAccounts.ts
@@ -43,7 +43,6 @@ export const ACCOUNT_TYPES = [
     { symbol: 'trx', type: 'normal', path: "m/44'/195'/0'/0/i" },
     { symbol: 'trx', type: 'ledger', path: "m/44'/195'/i'/0/0" },
     { symbol: 'ttrx', type: 'normal', path: "m/44'/195'/0'/0/i" },
-    { symbol: 'ttrx', type: 'ledger', path: "m/44'/195'/i'/0/0" },
     { symbol: 'ada', type: 'normal', path: "m/1852'/1815'/i'" },
     { symbol: 'ada', type: 'legacy', path: "m/1852'/1815'/i'" },
     { symbol: 'ada', type: 'ledger', path: "m/1852'/1815'/i'" },

--- a/suite-common/address/src/__tests__/isAddressValid.test.ts
+++ b/suite-common/address/src/__tests__/isAddressValid.test.ts
@@ -87,4 +87,13 @@ describe('isAddressValid', () => {
         expect(isAddressValid('rDTXLQ7ZKZVKz33zJbHjgVShjsBnqMBhmN', 'txrp')).toEqual(true);
         expect(isAddressValid('r3kmLJN5D28dHuH8vZNUZpMC43pEHpaocV0', 'xrp')).toEqual(false);
     });
+
+    it('TRX, tTRX', () => {
+        expect(isAddressValid('TNDzfERDpxLDS2w1q6yaFC7pzqaSQ3Bg3r', 'trx')).toEqual(true);
+        expect(isAddressValid('TNDzfERDpxLDS2w1q6yaFC7pzqaSQ3Bg3r', 'ttrx')).toEqual(true);
+        expect(isAddressValid('TKWJhMU8NAviZ9TN5hroaFQPZ83FNctzz4', 'trx')).toEqual(true);
+        expect(isAddressValid('TKWJhMU8NAviZ9TN5hroaFQPZ83FNctzz4', 'ttrx')).toEqual(true);
+        expect(isAddressValid('TNDzfERDpxLDS2w1q6yaFC7pzqaSQ3Bg31', 'trx')).toEqual(false);
+        expect(isAddressValid('TNDzfERDpxLDS2w1q6yaFC7pzqaSQ3Bg31', 'ttrx')).toEqual(false);
+    });
 });

--- a/suite-common/address/src/addressUtils.ts
+++ b/suite-common/address/src/addressUtils.ts
@@ -23,6 +23,8 @@ export const getCoinFromTestnet = (symbol: NetworkSymbol) => {
         case 'tsep':
         case 'thod':
             return 'eth';
+        case 'ttrx':
+            return 'trx';
         default:
             return symbol;
     }


### PR DESCRIPTION
## Description

- Updated tron address prefix for testnet to match mainnet. It was causing a crash on tTRX address validation.
- Dropped ledger account type for `ttrx` from `connect-common`. It is not supported in the UI and was producing duplicate `account.key` entries.

## Notes for QA

- Tron testnet token dashboard on mobile shouldn't produce any 'duplicated key' errors/warning in console
- Portfolio tracker on mobile should work correctly when importing tron testnet account

## Related Issue

Resolve #28261

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect address validation infrastructure: addressUtils.ts (the main address validation utility), currencies.ts in the address-validator package (currency/address format definitions), and related unit tests. There's also a type change in connect-common for discoverAccounts. Since no static coverage mapping exists for these files, test recommendations are inferred from behavioral analysis. The primary risk is that address validation or formatting regressions could break send/receive flows across multiple coin types. The recommended strategy focuses on receive and send tests across different networks (BTC, ETH, SOL, ADA) that directly exercise address validation paths.

<details><summary><b>Changed files (5)</b></summary>

- `packages/address-validator/src/currencies.ts`
- `packages/address-validator/tests/wallet_address_validator.test.ts`
- `packages/connect-common/src/types/api/discoverAccounts.ts`
- `suite-common/address/src/__tests__/isAddressValid.test.ts`
- `suite-common/address/src/addressUtils.ts`

</details>

**Recommended tests (7)**

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/wallet/receive.test.ts` — The addressUtils.ts change in suite-common/address directly affects address validation logic. The receive test verifies that receive addresses conform to expected formats (BTC, ETH, SOL, TRX) and are displayed correctly, which exercises address validation paths that may use the changed address utility.
- `suite/e2e/tests/wallet/cardano.test.ts` — Cardano receive address flow involves address validation and display. Changes to addressUtils.ts and the address-validator currencies could affect Cardano address handling, and this test explicitly verifies receiving and copying a Cardano address.
- `suite/e2e/tests/wallet/send-sol.test.ts` — The send SOL test validates recipient address formatting and display in both Suite UI and on the device. Changes to address validation utilities (addressUtils.ts, currencies.ts) could affect whether SOL addresses are accepted or formatted correctly in the send form.
- `suite/e2e/tests/wallet/send-eth.test.ts` — This test verifies Ethereum send flow including recipient address display and validation. Changes to address validation logic in addressUtils.ts and currency definitions could affect ETH address acceptance in the send form.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — The regtest send form test fills in BTC addresses and submits transactions. Address validation changes could affect whether addresses are accepted in the send form, though regtest addresses may follow different validation paths.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test exercises both global receive (address reveal/copy for ETH) and global send (BTC address entry) flows, both of which rely on address validation and formatting that may be affected by the changed files.
- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts` — Verifies Cardano address display and validation behind a passphrase wallet. Address validation changes could affect how Cardano addresses are validated or formatted in the receive flow.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/address-validator/tests/wallet_address_validator.test.ts`
- `packages/connect-common/src/types/api/discoverAccounts.ts`
- `suite-common/address/src/__tests__/isAddressValid.test.ts`

_Updated: 2026-06-02T11:06:41.813Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/ttrx-address-validation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/ttrx-address-validation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/ttrx-address-validation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-02T11:12:24.021Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-02T11:10:07.323Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/ttrx-address-validation/web/](https://dev.suite.sldev.cz/suite-web/fix/ttrx-address-validation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->