### PR TITLE
fix(suite): fix device connected tooltip

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceSelector.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceSelector.tsx
@@ -96,7 +96,7 @@ export const DeviceSelector = () => {
         <Tooltip
             isOpen={recentlyConnectedDevice !== undefined}
             content={<RecentlyConnectedDeviceTooltipContent />}
-            placement="right-end"
+            placement="right"
             zIndex={zIndices.popover /* to prevent it from appearing above modals */}
         >
             <Wrapper $isSidebarCollapsed={isSidebarCollapsed}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

before
<img width="415" height="181" alt="image" src="https://github.com/user-attachments/assets/2f634ad3-dba1-411d-b25b-f6caf56f1e03" />


after
<img width="414" height="199" alt="Screenshot 2026-06-02 at 14 04 33" src="https://github.com/user-attachments/assets/2aa9087d-72dd-4a13-947a-849d790fd08d" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is to DeviceSelector.tsx, a widely-imported layout component that renders the device switcher UI in the Suite header. Since it maps to 121 tests (indicating a global/shared component), only tests that specifically exercise the device switcher panel — wallet listing, wallet labels, device status display, session management, and wallet add/eject flows — are recommended. The highest-risk tests are those that directly interact with the device switcher UI elements (multiple sessions, passphrase numbering/wallets). Medium-priority tests cover secondary device switcher interactions like discreet mode balance display, metadata labels in the switcher, and wallet reconnection flows.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceSelector.tsx`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test directly exercises the DeviceSelector component through device switching, session status display (TR_USE_HERE, TR_CONNECTED), and the device switching panel (deviceSwitchingOpenButton, deviceSwitchingCloseButton, deviceStatusOnSwitchDevice, walletAtIndex). Changes to DeviceSelector.tsx would directly affect these UI elements and behaviors.
- `suite/e2e/tests/passphrase/passphrase-numbering.test.ts` — This test validates wallet listing, numbering, and labeling within the device switcher panel (walletAtIndex, TR_NO_PASSPHRASE_WALLET, TR_PASSPHRASE_WALLET). The DeviceSelector component renders the device switcher UI where wallet indices and labels are displayed, making this a direct test of the changed component.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — This test interacts with the device switcher to add hidden wallets, verify wallet labels at specific indices, and check analytics events for wallet type selection. The DeviceSelector is the entry point for opening the device switcher and managing wallet selection flows.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — This test verifies that the wallet fiat amount in the device switcher shows hidden/revealed values in discreet mode (walletAtIndexFiatAmount, deviceSwitchingOpenButton). The DeviceSelector component likely renders wallet balance information that is affected by discreet mode.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — This test uses the device switcher to eject and re-add wallets (dashboardPage device switcher, eject wallet, add standard wallet). These operations directly involve the DeviceSelector component's wallet management UI.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — This test verifies that after device reconnection, the passphrase wallet remains visible in the device switcher with correct labeling (walletAtIndex with TR_PASSPHRASE_WALLET). The DeviceSelector component handles the device switcher panel where this state is displayed.
- `suite/e2e/tests/passphrase/passphrase-duplicate.test.ts` — This test adds hidden wallets through the device switcher (openDeviceSwitcher, addHiddenWallet, addUnusedHiddenWallet) and checks for duplicate passphrase warnings. The DeviceSelector is the component that provides the device switcher entry point.
- `suite/e2e/tests/metadata/legacy/wallet-metadata.test.ts` — This test manages wallet labels through the device switcher panel, adding hidden wallets and editing labels that are displayed within the DeviceSelector-driven switcher UI. Label persistence and display in the device switcher are directly tested.
- `suite/e2e/tests/metadata/legacy/metadata-lifecycle.test.ts` — This test exercises device switching, wallet management (add hidden wallet, forget devices), and label state through the device switcher. The DeviceSelector component is the primary UI for these device/wallet management interactions.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/suite/safety-checks-warning.test.ts` — The safety checks warning banner appears in the main layout where DeviceSelector resides. While the banner itself is separate, layout changes in the DeviceSelector area could affect banner positioning or visibility.

</details>

_Updated: 2026-06-02T12:08:31.469Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-device-connected-tooltip&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-device-connected-tooltip&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-02T12:13:52.003Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-02T12:11:22.254Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-device-connected-tooltip/web/](https://dev.suite.sldev.cz/suite-web/fix-device-connected-tooltip/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->