### PR TITLE
test(suite): config Cardano tests to run on nightly only

### DIFF
--- a/suite/e2e/tests/passphrase/passphrase-cardano.test.ts
+++ b/suite/e2e/tests/passphrase/passphrase-cardano.test.ts
@@ -5,7 +5,7 @@ const correctPassphraseAddr =
     'addr1qx3ufjpwcx30ee73a7r29surauze6yt0jvr7c3rnahw0hnppg7qp5xvslcfucsqqayrtjhm4u66xsw987ae6ugydlzzsqdsfz4';
 const passphrase = 'secret passphrase A';
 
-test.describe('Passphrase with cardano', { tag: ['@T3W1', '@T3T1'] }, () => {
+test.describe('Passphrase with cardano', { tag: ['@nightlyOnly', '@T3W1', '@T3T1'] }, () => {
     test.use({ deviceSetup: { mnemonic: 'mnemonic_all', passphrase_protection: true } });
     test.beforeEach(async ({ onboardingPage }) => {
         await onboardingPage.completeOnboarding();

--- a/suite/e2e/tests/wallet/add-account-types.test.ts
+++ b/suite/e2e/tests/wallet/add-account-types.test.ts
@@ -74,6 +74,55 @@ test.describe('Account types suite', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () =
         },
     );
 
+    const runNonBtcCoinsTest = async (
+        coins: { symbol: NetworkSymbol; path: string }[],
+        {
+            dashboardPage,
+            settingsPage,
+            walletPage,
+            analytics,
+        }: Pick<
+            Parameters<Parameters<typeof test>[2]>[0],
+            'dashboardPage' | 'settingsPage' | 'walletPage' | 'analytics'
+        >,
+    ) => {
+        const symbolsToEnable = [...new Set(['eth' as NetworkSymbol, ...coins.map(c => c.symbol)])];
+        await settingsPage.changeNetworks({ enableNetworks: symbolsToEnable });
+
+        await dashboardPage.dashboardMenuButton.click();
+        await walletPage.openAccount({ symbol: 'eth', type: 'normal', atIndex: 0 });
+
+        analytics.interceptAnalytics();
+        await walletPage.filterAccountsButton.click();
+        for (const coin of coins) {
+            await test.step(`Add and verify ${coin.symbol} account`, async () => {
+                analytics.requests = [];
+                await walletPage.walletFilter(coin.symbol).click();
+                const numberOfAccountsBefore = await walletPage.getAccountsForCoinInTypeGroupCount(
+                    'normal',
+                    coin.symbol,
+                );
+
+                await walletPage.addAccountButton.click();
+                await expect(settingsPage.modal).toBeVisible();
+                await settingsPage.coinsTab.networkAddButton(coin.symbol).click();
+
+                const numberOfAccountsAfter = await walletPage.getAccountsForCoinInTypeGroupCount(
+                    'normal',
+                    coin.symbol,
+                );
+                expect(numberOfAccountsAfter).toEqual(numberOfAccountsBefore + 1);
+
+                const newAccountEvent = analytics.findAnalyticsEventByType<
+                    ExtractByEventType<(typeof events.accountsNewAccountEvent)['name']>
+                >(events.accountsNewAccountEvent.name);
+                expect(newAccountEvent.symbol).toEqual(coin.symbol);
+                expect(newAccountEvent.path).toEqual(coin.path);
+                expect(newAccountEvent.type).toEqual('normal');
+            });
+        }
+    };
+
     test(
         'Add-account-types-non-BTC-coins',
         {
@@ -84,45 +133,33 @@ test.describe('Account types suite', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () =
             }),
         },
         async ({ dashboardPage, settingsPage, walletPage, analytics }) => {
-            const coins: { symbol: NetworkSymbol; path: string }[] = [
-                { symbol: 'ada', path: `m/1852'/1815'/1'` },
-                { symbol: 'eth', path: `m/44'/60'/0'/0/1` },
-                { symbol: 'base', path: `m/44'/60'/0'/0/1` },
-            ];
+            await runNonBtcCoinsTest(
+                [
+                    { symbol: 'eth', path: `m/44'/60'/0'/0/1` },
+                    { symbol: 'base', path: `m/44'/60'/0'/0/1` },
+                ],
+                { dashboardPage, settingsPage, walletPage, analytics },
+            );
+        },
+    );
 
-            const symbolsToEnable = coins.map(c => c.symbol) as NetworkSymbol[];
-            await settingsPage.changeNetworks({
-                enableNetworks: symbolsToEnable,
+    test(
+        'Add account types ada',
+        {
+            tag: ['@nightlyOnly'],
+            annotation: createTestAnnotation({
+                testCase: 'Verifies that a user can add different account types for non-BTC coins.',
+                category: TestCategory.Accounts,
+                priority: TestPriority.High,
+            }),
+        },
+        async ({ dashboardPage, settingsPage, walletPage, analytics }) => {
+            await runNonBtcCoinsTest([{ symbol: 'ada', path: `m/1852'/1815'/1'` }], {
+                dashboardPage,
+                settingsPage,
+                walletPage,
+                analytics,
             });
-
-            await dashboardPage.dashboardMenuButton.click();
-            await walletPage.openAccount({ symbol: 'eth', type: 'normal', atIndex: 0 });
-
-            analytics.interceptAnalytics();
-            await walletPage.filterAccountsButton.click();
-            for (const coin of coins) {
-                await test.step(`Add and verify ${coin.symbol} account`, async () => {
-                    analytics.requests = [];
-                    await walletPage.walletFilter(coin.symbol).click();
-                    const numberOfAccountsBefore =
-                        await walletPage.getAccountsForCoinInTypeGroupCount('normal', coin.symbol);
-
-                    await walletPage.addAccountButton.click();
-                    await expect(settingsPage.modal).toBeVisible();
-                    await settingsPage.coinsTab.networkAddButton(coin.symbol).click();
-
-                    const numberOfAccountsAfter =
-                        await walletPage.getAccountsForCoinInTypeGroupCount('normal', coin.symbol);
-                    expect(numberOfAccountsAfter).toEqual(numberOfAccountsBefore + 1);
-
-                    const newAccountEvent = analytics.findAnalyticsEventByType<
-                        ExtractByEventType<(typeof events.accountsNewAccountEvent)['name']>
-                    >(events.accountsNewAccountEvent.name);
-                    expect(newAccountEvent.symbol).toEqual(coin.symbol);
-                    expect(newAccountEvent.path).toEqual(coin.path);
-                    expect(newAccountEvent.type).toEqual('normal');
-                });
-            }
         },
     );
 });

--- a/suite/e2e/tests/wallet/cardano.test.ts
+++ b/suite/e2e/tests/wallet/cardano.test.ts
@@ -10,7 +10,7 @@ const receiveAddress =
 // todo: setup emu with 24 words mnemonic so that we can test different cardano derivation and its 'auto-discovery; feature
 //mnemonic: 'clot trim improve bag pigeon party wave mechanic beyond clean cake maze protect left assist carry guitar bridge nest faith critic excuse tooth dutch',
 
-test.describe('Cardano', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () => {
+test.describe('Cardano', { tag: ['@nightlyOnly', '@T3W1', '@T3T1', '@smoke'] }, () => {
     test.beforeEach(async ({ onboardingPage, settingsPage }) => {
         await onboardingPage.completeOnboarding();
         await settingsPage.changeNetworks({ enableNetworks: ['ada'] });

--- a/suite/e2e/tests/wallet/export-transactions.test.ts
+++ b/suite/e2e/tests/wallet/export-transactions.test.ts
@@ -17,6 +17,40 @@ test.describe('Export transactions', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, ()
         await onboardingPage.completeOnboarding();
     });
 
+    const runExport = async (
+        symbols: NetworkSymbol[],
+        {
+            page,
+            settingsPage,
+            walletPage,
+            onboardingPage,
+        }: Pick<
+            Parameters<Parameters<typeof test>[2]>[0],
+            'page' | 'settingsPage' | 'walletPage' | 'onboardingPage'
+        >,
+    ) => {
+        await settingsPage.changeNetworks({ enableNetworks: symbols });
+
+        for (const symbol of symbols) {
+            await walletPage.openAccount({ symbol });
+
+            const typesOfExport: ExportType[] = ['pdf', 'csv', 'json'];
+            await onboardingPage.completeTransactionOnboarding();
+            for (const type of typesOfExport) {
+                await walletPage.exportTransactions(type);
+                const download = await page.waitForEvent('download');
+                expect(await download.failure()).toBeNull();
+
+                const fileName = download.suggestedFilename();
+                expect(fileName).toMatch(new RegExp(`.(${type})`));
+
+                const downloadPath = await download.path();
+                const stats = fs.statSync(downloadPath);
+                expect(stats.size).toBeGreaterThan(0);
+            }
+        }
+    };
+
     test(
         'Go to account and try to export all possible variants (pdf, csv, json)',
         {
@@ -27,27 +61,27 @@ test.describe('Export transactions', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, ()
             }),
         },
         async ({ page, settingsPage, walletPage, onboardingPage }) => {
-            const symbols: NetworkSymbol[] = ['btc', 'ltc', 'eth', 'ada'];
-            await settingsPage.changeNetworks({ enableNetworks: symbols });
+            await runExport(['btc', 'ltc', 'eth'], {
+                page,
+                settingsPage,
+                walletPage,
+                onboardingPage,
+            });
+        },
+    );
 
-            for (const symbol of symbols) {
-                await walletPage.openAccount({ symbol });
-
-                const typesOfExport: ExportType[] = ['pdf', 'csv', 'json'];
-                await onboardingPage.completeTransactionOnboarding();
-                for (const type of typesOfExport) {
-                    await walletPage.exportTransactions(type);
-                    const download = await page.waitForEvent('download');
-                    expect(await download.failure()).toBeNull();
-
-                    const fileName = download.suggestedFilename();
-                    expect(fileName).toMatch(new RegExp(`.(${type})`));
-
-                    const downloadPath = await download.path();
-                    const stats = fs.statSync(downloadPath);
-                    expect(stats.size).toBeGreaterThan(0);
-                }
-            }
+    test(
+        'Go to account and try to export all possible variants (pdf, csv, json) - ada',
+        {
+            tag: ['@nightlyOnly'],
+            annotation: createTestAnnotation({
+                testCase: 'Verify that a user can successfully export transactions in all formats.',
+                category: TestCategory.Wallets,
+                priority: TestPriority.Medium,
+            }),
+        },
+        async ({ page, settingsPage, walletPage, onboardingPage }) => {
+            await runExport(['ada'], { page, settingsPage, walletPage, onboardingPage });
         },
     );
 });

--- a/suite/e2e/tests/wallet/public-keys.test.ts
+++ b/suite/e2e/tests/wallet/public-keys.test.ts
@@ -29,29 +29,34 @@ test.describe('Public Keys', { tag: ['@T3W1', '@T3T1'] }, () => {
     });
 
     testCases.forEach(({ symbol, xpub }) => {
-        test(`Check ${symbol} XPUB`, async ({ settingsPage, walletPage, devicePrompt }) => {
-            await test.step(`Activate coin ${symbol}`, async () => {
-                await settingsPage.changeNetworks({ enableNetworks: [symbol] });
-            });
+        const tagOptions = symbol === 'ada' ? { tag: ['@nightlyOnly'] } : { tag: [] };
+        test(
+            `Check ${symbol} XPUB`,
+            tagOptions,
+            async ({ settingsPage, walletPage, devicePrompt }) => {
+                await test.step(`Activate coin ${symbol}`, async () => {
+                    await settingsPage.changeNetworks({ enableNetworks: [symbol] });
+                });
 
-            await test.step('Verify Public key preview', async () => {
-                await walletPage.openAccount({ symbol });
-                await walletPage.accountDetailsTabButton.click();
-                await walletPage.showPublicKeyButton.click();
-                await expect(async () => {
+                await test.step('Verify Public key preview', async () => {
+                    await walletPage.openAccount({ symbol });
+                    await walletPage.accountDetailsTabButton.click();
+                    await walletPage.showPublicKeyButton.click();
+                    await expect(async () => {
+                        const value = await devicePrompt.outputValue.textContent();
+
+                        expect(value?.replace(/\s+/g, '')).toBe(xpub);
+                    }).toPass({ timeout: 25000 });
+                });
+
+                await test.step('Display and Verify Public key again', async () => {
+                    await devicePrompt.waitForPromptAndConfirm();
+
                     const value = await devicePrompt.outputValue.textContent();
 
                     expect(value?.replace(/\s+/g, '')).toBe(xpub);
-                }).toPass({ timeout: 25000 });
-            });
-
-            await test.step('Display and Verify Public key again', async () => {
-                await devicePrompt.waitForPromptAndConfirm();
-
-                const value = await devicePrompt.outputValue.textContent();
-
-                expect(value?.replace(/\s+/g, '')).toBe(xpub);
-            });
-        });
+                });
+            },
+        );
     });
 });


### PR DESCRIPTION
some tests needed just adding tag.
some needed test code to be extracted to function so we can have one cardano test that runs nightly and rest that run on pr

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All 5 changed files are E2E test files themselves, not application source code. The changes are confined to test definitions, so the risk is limited to test correctness rather than application regressions. Each changed test should be run at high priority to confirm it still passes. No application source files were modified, so no additional tests need to be inferred for indirect coverage.

<details><summary><b>Changed files (5)</b></summary>

- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts`
- `suite/e2e/tests/wallet/add-account-types.test.ts`
- `suite/e2e/tests/wallet/cardano.test.ts`
- `suite/e2e/tests/wallet/export-transactions.test.ts`
- `suite/e2e/tests/wallet/public-keys.test.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts` — This test file was directly changed. It must be run to verify that the modifications to the Cardano passphrase test itself are correct and the test passes.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — This test file was directly changed. It must be run to verify that modifications to the add-account-types test are correct and the test passes.
- `suite/e2e/tests/wallet/cardano.test.ts` — This test file was directly changed. It must be run to verify that modifications to the Cardano wallet test are correct and the test passes.
- `suite/e2e/tests/wallet/export-transactions.test.ts` — This test file was directly changed. It must be run to verify that modifications to the export-transactions test are correct and the test passes.
- `suite/e2e/tests/wallet/public-keys.test.ts` — This test file was directly changed. It must be run to verify that modifications to the public-keys test are correct and the test passes.

</details>

_Updated: 2026-06-02T12:14:24.070Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=cardano-tests-to-nightly&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=cardano-tests-to-nightly&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-03T16:08:17.825Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-03T16:05:41.637Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/cardano-tests-to-nightly/web/](https://dev.suite.sldev.cz/suite-web/cardano-tests-to-nightly/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->