### PR TITLE
feat(suite-native): use network icons in device onboarding and settings

### DIFF
--- a/suite-native/coin-enabling/src/components/NetworkSymbolSwitchItem.tsx
+++ b/suite-native/coin-enabling/src/components/NetworkSymbolSwitchItem.tsx
@@ -2,7 +2,7 @@ import { View } from 'react-native';
 
 import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import { Card, HStack, PressableOpacity, Switch, Text, VStack } from '@suite-native/atoms';
-import { CryptoIcon } from '@suite-native/icons';
+import { NetworkIcon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 import { isNetworkWithTokens } from '@suite-native/tokens';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
@@ -45,7 +45,7 @@ export const NetworkSymbolSwitchItem = ({
             >
                 <HStack style={applyStyle(wrapperStyle)}>
                     <View style={applyStyle(iconWrapperStyle)}>
-                        <CryptoIcon symbol={symbol} />
+                        <NetworkIcon symbol={symbol} size={32} />
                     </View>
                     <HStack
                         flex={1}


### PR DESCRIPTION
`NetworkIcon` used in device onboarding and _Settings_.

## Related Issue

#28086

## Screenshots:

| Device onboarding | Settings |
| --- | --- |
| <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/437ec5e5-88d0-483f-8587-c62fc60887da" /> | <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/a52ddf96-3747-4991-b282-04983cc2e040" /> |
| <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/1cd99d8c-e07b-4a9a-9e5c-d7a7f4f308e5" /> | <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/dffab57d-f427-4511-b757-522ed735c72f" /> |

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/network-icons&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->