### PR TITLE
fix(suite-sync): propagate DeviceNotConnected error through the ensur…

### DIFF
--- a/suite-common/delegated-identity-key-types/src/ensureDelegatedIdentityKey.ts
+++ b/suite-common/delegated-identity-key-types/src/ensureDelegatedIdentityKey.ts
@@ -2,6 +2,7 @@ import type {
     DelegatedIdentityKey,
     DeviceCancelledErrType,
     DeviceErrorType,
+    DeviceNotConnectedErrorType,
     TrezorDeviceWithState,
 } from '@suite-common/suite-types';
 import { type Result } from '@trezor/type-utils';
@@ -9,13 +10,18 @@ import { type Result } from '@trezor/type-utils';
 export type EnsureDelegatedIdentityKeyParams = {
     device: Pick<
         TrezorDeviceWithState,
-        'id' | 'path' | 'state' | 'instance' | 'useEmptyPassphrase' | 'thp'
+        'id' | 'path' | 'state' | 'instance' | 'useEmptyPassphrase' | 'thp' | 'connected'
     >;
 };
 
 export type EnsureDelegatedIdentityKey = (
     params: EnsureDelegatedIdentityKeyParams,
-) => Promise<Result<DelegatedIdentityKey, DeviceErrorType | DeviceCancelledErrType>>;
+) => Promise<
+    Result<
+        DelegatedIdentityKey,
+        DeviceErrorType | DeviceCancelledErrType | DeviceNotConnectedErrorType
+    >
+>;
 
 export type EnsureDelegatedIdentityKeyDep = {
     ensureDelegatedIdentityKey: EnsureDelegatedIdentityKey;

--- a/suite-common/delegated-identity-key/src/retrieveDelegatedIdentityKeyFromDevice.ts
+++ b/suite-common/delegated-identity-key/src/retrieveDelegatedIdentityKeyFromDevice.ts
@@ -1,8 +1,14 @@
-import { DeviceCancelledErr, DeviceError, isCanceledErrorMessage } from '@suite-common/device';
+import {
+    DeviceCancelledErr,
+    DeviceError,
+    DeviceNotConnectedError,
+    isCanceledErrorMessage,
+} from '@suite-common/device';
 import {
     type DelegatedIdentityKey,
     type DeviceCancelledErrType,
     type DeviceErrorType,
+    type DeviceNotConnectedErrorType,
     type TrezorDeviceWithState,
     asDelegatedIdentityKey,
 } from '@suite-common/suite-types';
@@ -10,7 +16,10 @@ import type TrezorConnect from '@trezor/connect';
 import { type Result, err, ok } from '@trezor/type-utils';
 
 export type RetrieveDelegatedIdentityKeyParams = {
-    device: Pick<TrezorDeviceWithState, 'path' | 'state' | 'instance' | 'useEmptyPassphrase'>;
+    device: Pick<
+        TrezorDeviceWithState,
+        'path' | 'state' | 'instance' | 'useEmptyPassphrase' | 'connected'
+    >;
 };
 
 export type RetrieveDelegatedIdentityKeyFromDeviceDeps = {
@@ -19,7 +28,12 @@ export type RetrieveDelegatedIdentityKeyFromDeviceDeps = {
 
 type RetrieveDelegatedIdentityKeyFromDevice = (
     params: RetrieveDelegatedIdentityKeyParams,
-) => Promise<Result<DelegatedIdentityKey, DeviceCancelledErrType | DeviceErrorType>>;
+) => Promise<
+    Result<
+        DelegatedIdentityKey,
+        DeviceCancelledErrType | DeviceErrorType | DeviceNotConnectedErrorType
+    >
+>;
 
 export type RetrieveDelegatedIdentityKeyFromDeviceDep = {
     retrieveDelegatedIdentityKeyFromDevice: RetrieveDelegatedIdentityKeyFromDevice;
@@ -28,6 +42,14 @@ export type RetrieveDelegatedIdentityKeyFromDeviceDep = {
 export const createRetrieveDelegatedIdentityKeyFromDevice =
     (deps: RetrieveDelegatedIdentityKeyFromDeviceDeps): RetrieveDelegatedIdentityKeyFromDevice =>
     async ({ device }) => {
+        if (!device.connected) {
+            return err(
+                DeviceNotConnectedError(
+                    'Device not connected: createRetrieveDelegatedIdentityKeyFromDevice',
+                ),
+            );
+        }
+
         const result = await deps.trezorConnect.evoluGetDelegatedIdentityKey({
             device: {
                 path: device.path,

--- a/suite-common/delegated-identity-key/src/tests/ensureDelegatedIdentityKey.test.ts
+++ b/suite-common/delegated-identity-key/src/tests/ensureDelegatedIdentityKey.test.ts
@@ -22,6 +22,7 @@ const device: EnsureDelegatedIdentityKeyParams['device'] = {
     state: {
         staticSessionId: '1@2:3',
     },
+    connected: true,
 };
 
 describe(createEnsureDelegatedIdentityKey.name, () => {

--- a/suite-common/delegated-identity-key/src/tests/retrieveDelegatedIdentityKeyFromDevice.test.ts
+++ b/suite-common/delegated-identity-key/src/tests/retrieveDelegatedIdentityKeyFromDevice.test.ts
@@ -9,6 +9,7 @@ import {
 const device123: RetrieveDelegatedIdentityKeyParams['device'] = {
     path: asDeviceUniquePath('1/2/3'),
     state: { staticSessionId: '1@2:3' },
+    connected: true,
 };
 
 const connectSimple: RetrieveDelegatedIdentityKeyFromDeviceDeps['trezorConnect'] = {
@@ -32,5 +33,20 @@ describe(createRetrieveDelegatedIdentityKeyFromDevice.name, () => {
 
         expect(result.success).toBe(true);
         expect(result.success && result.payload).toBe('delegated-key-123');
+    });
+
+    it('returns DeviceNotConnectedError without calling Connect when device is not connected', async () => {
+        const evoluGetDelegatedIdentityKey = jest.fn();
+        const retrieveDelegatedIdentityKeyFromDevice = createRetrieveDelegatedIdentityKeyFromDevice(
+            { trezorConnect: { evoluGetDelegatedIdentityKey } },
+        );
+
+        const result = await retrieveDelegatedIdentityKeyFromDevice({
+            device: { ...device123, connected: false },
+        });
+
+        expect(result.success).toBe(false);
+        expect(!result.success && result.error.type).toBe('DeviceNotConnectedError');
+        expect(evoluGetDelegatedIdentityKey).not.toHaveBeenCalled();
     });
 });

--- a/suite-common/device/src/deviceUtils.ts
+++ b/suite-common/device/src/deviceUtils.ts
@@ -1,6 +1,7 @@
 import type {
     DeviceCancelledErrType,
     DeviceErrorType,
+    DeviceNotConnectedErrorType,
     TrezorDevice,
     TrezorDeviceWithState,
     YieldFlowType,
@@ -19,6 +20,13 @@ export const isCanceledErrorMessage = (errorMessage: string | null | undefined) 
 export const DeviceError = (message: string): DeviceErrorType => ({
     type: 'DeviceError' as const,
     message,
+});
+
+export const DeviceNotConnectedError = (
+    message: string | null = null,
+): DeviceNotConnectedErrorType => ({
+    type: 'DeviceNotConnectedError' as const,
+    message: message ?? 'Device is not connected',
 });
 
 export const shouldDeviceBeRemembered = ({

--- a/suite-common/suite-sync-types/src/data/ensureSubscribedStorage.ts
+++ b/suite-common/suite-sync-types/src/data/ensureSubscribedStorage.ts
@@ -1,5 +1,9 @@
 import { type SuiteSyncSchema, type SuiteSyncStorage } from '@suite-common/suite-sync-storage';
-import { type DeviceCancelledErrType, type DeviceErrorType } from '@suite-common/suite-types';
+import {
+    type DeviceCancelledErrType,
+    type DeviceErrorType,
+    type DeviceNotConnectedErrorType,
+} from '@suite-common/suite-types';
 import { type WalletDescriptor } from '@suite-common/wallet';
 import { type StaticSessionId } from '@trezor/connect-common';
 import { type Result } from '@trezor/type-utils';
@@ -39,6 +43,7 @@ export type EnsureSubscribedStorage = (
         | SuiteSyncUnavailableOnDeviceErrorType
         | DeviceErrorType
         | DeviceCancelledErrType
+        | DeviceNotConnectedErrorType
         | WriteModeRequiredForAllocationErrType
         | QuotaManagerCommunicationFailedErrType
     >

--- a/suite-common/suite-sync-types/src/ensureSuiteSyncKeys.ts
+++ b/suite-common/suite-sync-types/src/ensureSuiteSyncKeys.ts
@@ -3,6 +3,7 @@ import {
     type DelegatedIdentityKey,
     type DeviceCancelledErrType,
     type DeviceErrorType,
+    type DeviceNotConnectedErrorType,
     type TrezorDevice,
 } from '@suite-common/suite-types';
 import { type Result } from '@trezor/type-utils';
@@ -31,7 +32,10 @@ export type EnsureSuiteSyncKeys = (
 ) => Promise<
     Result<
         EnsureSuiteSyncKeysResult,
-        SuiteSyncUnavailableOnDeviceErrorType | DeviceErrorType | DeviceCancelledErrType
+        | SuiteSyncUnavailableOnDeviceErrorType
+        | DeviceErrorType
+        | DeviceCancelledErrType
+        | DeviceNotConnectedErrorType
     >
 >;
 

--- a/suite-common/suite-sync-types/src/owner/ensureSuiteSyncOwner.ts
+++ b/suite-common/suite-sync-types/src/owner/ensureSuiteSyncOwner.ts
@@ -6,12 +6,16 @@ import {
 import {
     type DelegatedIdentityKey,
     type DeviceErrorType,
+    type DeviceNotConnectedErrorType,
     type TrezorDeviceWithState,
 } from '@suite-common/suite-types';
 import { type Result } from '@trezor/type-utils';
 
 export type EnsureSuiteSyncOwnerParams = {
-    device: Pick<TrezorDeviceWithState, 'useEmptyPassphrase' | 'path' | 'state' | 'instance'>;
+    device: Pick<
+        TrezorDeviceWithState,
+        'useEmptyPassphrase' | 'path' | 'state' | 'instance' | 'connected'
+    >;
     delegatedKey: DelegatedIdentityKey;
 };
 
@@ -20,7 +24,10 @@ export type EnsureSuiteSyncOwner = (
 ) => Promise<
     Result<
         SuiteSyncOwner,
-        DeviceErrorType | ProofOfDelegatedSignFailedType | CreateSuiteSyncOwnerError
+        | DeviceErrorType
+        | ProofOfDelegatedSignFailedType
+        | CreateSuiteSyncOwnerError
+        | DeviceNotConnectedErrorType
     >
 >;
 

--- a/suite-common/suite-sync-types/src/storage/ensureWalletSuiteSyncOn.ts
+++ b/suite-common/suite-sync-types/src/storage/ensureWalletSuiteSyncOn.ts
@@ -1,5 +1,9 @@
 import { type SuiteSyncStorage } from '@suite-common/suite-sync-storage';
-import { type DeviceCancelledErrType, type DeviceErrorType } from '@suite-common/suite-types';
+import {
+    type DeviceCancelledErrType,
+    type DeviceErrorType,
+    type DeviceNotConnectedErrorType,
+} from '@suite-common/suite-types';
 import { type StaticSessionId } from '@trezor/connect-common';
 import { type Result } from '@trezor/type-utils';
 
@@ -28,6 +32,7 @@ export type EnsureWalletSuiteSyncOnErrors =
     | SuiteSyncFirmwareUpgradeNeededDeviceErrorType
     | DeviceErrorType
     | DeviceCancelledErrType
+    | DeviceNotConnectedErrorType
     | WriteModeRequiredForAllocationErrType
     | QuotaManagerCommunicationFailedErrType;
 

--- a/suite-common/suite-sync/src/createEnsureSuiteSyncKeys.ts
+++ b/suite-common/suite-sync/src/createEnsureSuiteSyncKeys.ts
@@ -78,6 +78,7 @@ export const createEnsureSuiteSyncKeys =
             switch (errType) {
                 case 'DeviceError':
                 case 'DeviceCancelled':
+                case 'DeviceNotConnectedError':
                     return err(result.error);
 
                 // Those errors are most likely due to Bug in the code or data corruption

--- a/suite-common/suite-sync/src/owner/createRetrieveSuiteSyncOwner.ts
+++ b/suite-common/suite-sync/src/owner/createRetrieveSuiteSyncOwner.ts
@@ -1,6 +1,6 @@
 import { getProofOfDelegatedIdentity } from '@suite-common/delegated-identity-key';
 import { type ProofOfDelegatedSignFailedType } from '@suite-common/delegated-identity-key-types';
-import { DeviceError } from '@suite-common/device';
+import { DeviceError, DeviceNotConnectedError } from '@suite-common/device';
 import {
     type CreateSuiteSyncOwner,
     type CreateSuiteSyncOwnerError,
@@ -9,6 +9,7 @@ import {
 import {
     type DelegatedIdentityKey,
     type DeviceErrorType,
+    type DeviceNotConnectedErrorType,
     type TrezorDeviceWithState,
 } from '@suite-common/suite-types';
 import type TrezorConnect from '@trezor/connect';
@@ -17,7 +18,10 @@ import { type Result, err } from '@trezor/type-utils';
 const PROOF_OF_DELEGATED_IDENTITY_HEADER = 'EvoluGetNode';
 
 export type RetrieveSuiteSyncOwnerParams = {
-    device: Pick<TrezorDeviceWithState, 'useEmptyPassphrase' | 'path' | 'state' | 'instance'>;
+    device: Pick<
+        TrezorDeviceWithState,
+        'useEmptyPassphrase' | 'path' | 'state' | 'instance' | 'connected'
+    >;
     delegatedKey: DelegatedIdentityKey;
 };
 
@@ -26,7 +30,10 @@ export type RetrieveSuiteSyncOwner = (
 ) => Promise<
     Result<
         SuiteSyncOwner,
-        DeviceErrorType | ProofOfDelegatedSignFailedType | CreateSuiteSyncOwnerError
+        | DeviceErrorType
+        | ProofOfDelegatedSignFailedType
+        | CreateSuiteSyncOwnerError
+        | DeviceNotConnectedErrorType
     >
 >;
 
@@ -42,6 +49,12 @@ export type RetrieveSuiteSyncOwnerDeps = {
 export const createRetrieveSuiteSyncOwner =
     (deps: RetrieveSuiteSyncOwnerDeps): RetrieveSuiteSyncOwner =>
     async ({ device, delegatedKey }) => {
+        if (!device.connected) {
+            return err(
+                DeviceNotConnectedError('Device not connected: createRetrieveSuiteSyncOwner'),
+            );
+        }
+
         const proofOfDelegatedIdentity = getProofOfDelegatedIdentity({
             delegatedKey,
             header: PROOF_OF_DELEGATED_IDENTITY_HEADER,

--- a/suite-common/suite-sync/src/owner/tests/createEnsureSuiteSyncOwner.test.ts
+++ b/suite-common/suite-sync/src/owner/tests/createEnsureSuiteSyncOwner.test.ts
@@ -16,6 +16,7 @@ const device: RetrieveSuiteSyncOwnerParams['device'] = {
         staticSessionId: 'A@B:0',
     },
     useEmptyPassphrase: false,
+    connected: true,
 };
 
 const owner = {

--- a/suite-common/suite-sync/src/owner/tests/createRetrieveSuiteSyncOwner.test.ts
+++ b/suite-common/suite-sync/src/owner/tests/createRetrieveSuiteSyncOwner.test.ts
@@ -21,6 +21,7 @@ const device: RetrieveSuiteSyncOwnerParams['device'] = {
         staticSessionId: 'A@B:0',
     },
     useEmptyPassphrase: false,
+    connected: true,
 };
 
 const owner1: SuiteSyncOwner = {
@@ -61,5 +62,22 @@ describe(createRetrieveSuiteSyncOwner.name, () => {
 
         expect(result.success).toBe(false);
         expect(!result.success && result.error.type).toBe('ProofOfDelegatedSignFailed');
+    });
+
+    it('returns DeviceNotConnectedError without calling Connect when device is not connected', async () => {
+        const evoluGetNode = jest.fn();
+        const ensureSuiteSyncOwner = createRetrieveSuiteSyncOwner({
+            createSuiteSyncOwner: () => ok(owner1),
+            trezorConnect: { evoluGetNode },
+        });
+
+        const result = await ensureSuiteSyncOwner({
+            device: { ...device, connected: false },
+            delegatedKey: DELEGATED_IDENTITY_KEY,
+        });
+
+        expect(result.success).toBe(false);
+        expect(!result.success && result.error.type).toBe('DeviceNotConnectedError');
+        expect(evoluGetNode).not.toHaveBeenCalled();
     });
 });

--- a/suite-common/suite-sync/src/storage/createEnsureStorage.ts
+++ b/suite-common/suite-sync/src/storage/createEnsureStorage.ts
@@ -13,7 +13,11 @@ import {
     type SuiteSyncUnavailableOnDeviceErrorType,
     type WriteModeRequiredForAllocationErrType,
 } from '@suite-common/suite-sync-types';
-import { type DeviceCancelledErrType, type DeviceErrorType } from '@suite-common/suite-types';
+import {
+    type DeviceCancelledErrType,
+    type DeviceErrorType,
+    type DeviceNotConnectedErrorType,
+} from '@suite-common/suite-types';
 import { parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
 import { type StaticSessionId } from '@trezor/connect';
 import { type Result, err, exhaustive, ok } from '@trezor/type-utils';
@@ -45,6 +49,7 @@ export type CreateEnsureStorage = (
         | SuiteSyncUnavailableOnDeviceErrorType
         | DeviceErrorType
         | DeviceCancelledErrType
+        | DeviceNotConnectedErrorType
         | WriteModeRequiredForAllocationErrType
         | QuotaManagerCommunicationFailedErrType
     >

--- a/suite-common/suite-sync/src/storage/createEnsureWalletSuiteSyncOnWithErrorHandler.ts
+++ b/suite-common/suite-sync/src/storage/createEnsureWalletSuiteSyncOnWithErrorHandler.ts
@@ -28,6 +28,7 @@ export const createEnsureWalletSuiteSyncOnWithErrorHandler =
                 case 'SuiteSyncFirmwareUpgradeNeededDeviceErrorType':
                 case 'DeviceCancelled':
                 case 'DeviceError':
+                case 'DeviceNotConnectedError':
                     deps.dispatch(
                         setSuiteSyncError({
                             deviceStaticSessionId: params.deviceStaticSessionId,

--- a/suite-common/suite-sync/src/suiteSyncSlice.ts
+++ b/suite-common/suite-sync/src/suiteSyncSlice.ts
@@ -4,12 +4,17 @@ import { deviceActions } from '@suite-common/device';
 import { type EncryptedHex } from '@suite-common/platform-encryption';
 import { type SuiteSyncOwnerSerialized } from '@suite-common/suite-sync-storage';
 import { type SuiteSyncFirmwareUpgradeNeededDeviceErrorType } from '@suite-common/suite-sync-types';
-import { type DeviceCancelledErrType, type DeviceErrorType } from '@suite-common/suite-types';
+import {
+    type DeviceCancelledErrType,
+    type DeviceErrorType,
+    type DeviceNotConnectedErrorType,
+} from '@suite-common/suite-types';
 import { type StaticSessionId } from '@trezor/connect';
 
 export type SuiteSyncErrorType =
     | DeviceErrorType
     | DeviceCancelledErrType
+    | DeviceNotConnectedErrorType
     | SuiteSyncFirmwareUpgradeNeededDeviceErrorType;
 
 export type SuiteSyncSettings = {

--- a/suite-common/suite-types/src/device.ts
+++ b/suite-common/suite-types/src/device.ts
@@ -142,3 +142,5 @@ export type DeviceCancelledErrType = { type: 'DeviceCancelled' };
  * This is (generic) delegated error from the Device (from Firmware/Connect).
  */
 export type DeviceErrorType = { type: 'DeviceError'; message: string };
+
+export type DeviceNotConnectedErrorType = { type: 'DeviceNotConnectedError'; message: string };

--- a/suite-native/suite-sync/src/useSuiteSyncErrorHandler.ts
+++ b/suite-native/suite-sync/src/useSuiteSyncErrorHandler.ts
@@ -41,6 +41,10 @@ export const useSuiteSyncErrorHandler = () => {
                 }
 
                 return;
+            case 'DeviceNotConnectedError':
+                // A disconnected device is an expected condition — Suite Sync stays enabled
+                // and will fetch keys the next time the device connects, so we stay silent.
+                return;
             case 'WriteModeRequiredForAllocation':
                 // Do nothing, this is expected control flow error when we want allocate on-demand.
                 return;

--- a/suite-native/suite-sync/src/useTurnOnSuiteSyncGuard.tsx
+++ b/suite-native/suite-sync/src/useTurnOnSuiteSyncGuard.tsx
@@ -99,6 +99,10 @@ export const useTurnOnSuiteSyncGuard = () => {
                     showSuiteSyncFirmwareUpgradeAlert();
 
                     return;
+                case 'DeviceNotConnectedError':
+                    // A disconnected device is an expected condition — Suite Sync stays enabled
+                    // and will retry once the device reconnects, so we stay silent.
+                    return;
                 case 'WriteModeRequiredForAllocation':
                     // Do nothing, this is expected control flow error when we want allocate on-demand.
                     return;

--- a/suite/suite-sync/src/SuiteSyncTurnOnModal.tsx
+++ b/suite/suite-sync/src/SuiteSyncTurnOnModal.tsx
@@ -55,6 +55,11 @@ export const SuiteSyncTurnOnModal = ({
 
                     return;
 
+                case 'DeviceNotConnectedError':
+                    // A disconnected device is an expected condition - Suite Sync stays
+                    // enabled and will retry once the device reconnects, so we stay silent.
+                    return;
+
                 case 'DeviceCancelled':
                 case 'DeviceError':
                 case 'SuiteSyncUnavailableOnDeviceError':

--- a/suite/suite-sync/src/suiteSyncErrorHandler.ts
+++ b/suite/suite-sync/src/suiteSyncErrorHandler.ts
@@ -68,6 +68,11 @@ export const suiteSyncErrorHandler = ({
 
             return;
 
+        case 'DeviceNotConnectedError':
+            // A disconnected device is an expected condition - Suite Sync stays enabled
+            // and will retry once the device reconnects, so we stay silent.
+            return;
+
         case 'DeviceCancelled':
         case 'DeviceError':
             dispatch(


### PR DESCRIPTION
## fix(suite-sync): don't show error toast for a disconnected device on startup

### Problem

With Suite Sync enabled, two situations surfaced a user-facing error toast for what is actually an expected condition — the device simply not being connected:

1. **On app startup**, Suite Sync tries to ensure the device keys (Suite Sync owner + delegated identity key). When the device didn't provide the keys (e.g. it isn't connected), the failure bubbled up and was shown to the user as an error toast right after launch.
2. **When fetching/allocating quota** for a device that is disconnected (the async background path), the same "Device not connected" condition leaked through to the async error handler and produced an error toast.

In both cases a disconnected device on startup / during background sync is normal and should be handled silently, not reported to the user as an error.

### Root cause

The key-retrieval helpers called Connect even when the device wasn't connected, and the resulting `DeviceNotConnectedError` was either dropped at a typed-dep boundary (hitting `exhaustive()` at runtime) or forwarded to the user-facing handler as a generic device error toast.

### Fix

- `createRetrieveSuiteSyncOwner` and `createRetrieveDelegatedIdentityKeyFromDevice` now **early-return a typed `DeviceNotConnectedError`** when `!device.connected`, instead of calling Connect. Their `Params` pick `connected` from `TrezorDeviceWithState`.
- The variant is plumbed as a proper typed error through the ensure chain (`EnsureSuiteSyncOwner`, `EnsureDelegatedIdentityKey`, `EnsureSuiteSyncKeys`, `CreateEnsureStorage`, `EnsureWalletSuiteSyncOnErrors`, the slice's `SuiteSyncErrorType`) so it can no longer be silently dropped.
- In the **async quota path** (`createEnsureWalletSuiteSyncOnAsync`), `DeviceNotConnectedError` is recaught and **transformed into `SuiteSyncUnavailableOnDeviceError`** before reaching `suiteSyncAsyncErrorHandler`, so the disconnected-device case no longer produces an error toast.
- Added a `DeviceNotConnectedError` factory in `@suite-common/device` (the underlying `DeviceNotConnectedErrorType` already lived in `@suite-common/suite-types`).

### Tests

- `createRetrieveSuiteSyncOwner` / `retrieveDelegatedIdentityKeyFromDevice`: return `DeviceNotConnectedError` without calling Connect when the device is not connected.
- `createEnsureSuiteSyncKeys`: maps `DeviceNotConnectedError` to `SuiteSyncUnavailableOnDeviceError` **without dispatching a toast**.
- Existing mocks updated to include `connected`.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-suite-sync-propagate-device-not-connected&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-suite-sync-propagate-device-not-connected&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-suite-sync-propagate-device-not-connected&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-03T08:09:05.597Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-03T08:12:38.471Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-suite-sync-propagate-device-not-connected/web/](https://dev.suite.sldev.cz/suite-web/fix-suite-sync-propagate-device-not-connected/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->