### PR TITLE
refactor(transport): unify AbstractApi options access style

### DIFF
--- a/packages/transport-bluetooth/src/client/bluetooth-api.ts
+++ b/packages/transport-bluetooth/src/client/bluetooth-api.ts
@@ -100,8 +100,8 @@ export class BluetoothApi extends AbstractApi {
         return this.api.disconnect();
     }
 
-    read(...[path, options = {}]: AbstractApiArgs<'read'>) {
-        return this.readBuffer.read(path, options.signal);
+    read(...[path, options]: AbstractApiArgs<'read'>) {
+        return this.readBuffer.read(path, options?.signal);
     }
 
     write(...[path, buffer]: AbstractApiArgs<'write'>) {


### PR DESCRIPTION
## Description

Follow-up to #28275 (stacked on top of `feat/transport-with-options`).

Addresses a minor style inconsistency introduced in #28275: `BluetoothApi.read`
used a destructuring default (`...[path, options = {}]` + `options.signal`) while
all other `AbstractApi` implementations (`UsbApi`, `UdpApi`, native `BluetoothApi`)
use optional chaining (`...[path, options]` + `options?.signal`).

This PR aligns `BluetoothApi.read` with the rest. Purely cosmetic — no behavior change.

Kept separate so it doesn't hold up the merge of #28275; we can evaluate it
independently later.
