### PR TITLE
fix(suite-desktop): narrow phishing tooltip to zero value check

### DIFF
--- a/packages/suite/src/components/wallet/TransactionItem/TransactionHeading.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionHeading.tsx
@@ -12,14 +12,14 @@ import { BlurWrapper } from './TransactionItemBlurWrapper';
 type TransactionHeadingProps = {
     transaction: WalletAccountTransaction;
     isPending: boolean;
-    isPhishingTransaction: boolean;
+    isZeroPhishingTransaction: boolean;
     dataTestBase: string;
 };
 
 export const TransactionHeading = ({
     transaction,
     isPending,
-    isPhishingTransaction,
+    isZeroPhishingTransaction,
     dataTestBase,
 }: TransactionHeadingProps) => {
     const symbol = getTxHeaderSymbol(transaction);
@@ -47,7 +47,7 @@ export const TransactionHeading = ({
             isActive={isPhishingTransaction}
             hasIcon
         >
-            <BlurWrapper $isBlurred={isPhishingTransaction}>
+            <BlurWrapper $isBlurred={isZeroPhishingTransaction}>
                 <Row gap={4} data-testid={`${dataTestBase}/heading`}>
                     <TransactionHeader transaction={transaction} isPending={isPending} />
                     {isSupportedEthStakingNetworkSymbol(transaction.symbol) && (

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionHeading.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionHeading.tsx
@@ -1,4 +1,5 @@
 import { Translation } from '@suite/intl';
+import { type PhishingDetectorId } from '@suite-common/token-definitions';
 import { getTxHeaderSymbol, isSupportedEthStakingNetworkSymbol } from '@suite-common/wallet-utils';
 import { Row, TextButton, Tooltip } from '@trezor/components';
 import { HELP_CENTER_ZERO_VALUE_ATTACKS } from '@trezor/urls';
@@ -9,17 +10,36 @@ import { InstantStakeBadge } from './InstantStakeBadge';
 import { TransactionHeader } from './TransactionHeader';
 import { BlurWrapper } from './TransactionItemBlurWrapper';
 
+const getPhishingTooltipTranslationId = (detectorId?: PhishingDetectorId) => {
+    switch (detectorId) {
+        case 'FAKE_TOKEN':
+            return 'TR_PHISHING_TOOLTIP_FAKE_TOKEN';
+        case 'UNKNOWN_TX':
+            return 'TR_PHISHING_TOOLTIP_UNKNOWN_TX';
+        case 'DUST_AMOUNT':
+            return 'TR_PHISHING_TOOLTIP_DUST_AMOUNT';
+        case 'ZERO_AMOUNT':
+            return 'TR_PHISHING_TOOLTIP_ZERO_AMOUNT';
+        case 'TRC10_TRANSFER':
+            return 'TR_PHISHING_TOOLTIP_TRC10_TRANSFER';
+        default:
+            return 'TR_ZERO_PHISHING_TOOLTIP';
+    }
+};
+
 type TransactionHeadingProps = {
     transaction: WalletAccountTransaction;
     isPending: boolean;
-    isZeroPhishingTransaction: boolean;
+    isPhishingTransaction: boolean;
+    phishingDetectorId?: PhishingDetectorId;
     dataTestBase: string;
 };
 
 export const TransactionHeading = ({
     transaction,
     isPending,
-    isZeroPhishingTransaction,
+    isPhishingTransaction,
+    phishingDetectorId,
     dataTestBase,
 }: TransactionHeadingProps) => {
     const symbol = getTxHeaderSymbol(transaction);
@@ -28,7 +48,7 @@ export const TransactionHeading = ({
         <Tooltip
             content={
                 <Translation
-                    id="TR_ZERO_PHISHING_TOOLTIP"
+                    id={getPhishingTooltipTranslationId(phishingDetectorId)}
                     values={{
                         a: chunks => (
                             <TextButton
@@ -47,7 +67,7 @@ export const TransactionHeading = ({
             isActive={isPhishingTransaction}
             hasIcon
         >
-            <BlurWrapper $isBlurred={isZeroPhishingTransaction}>
+            <BlurWrapper $isBlurred={isPhishingTransaction}>
                 <Row gap={4} data-testid={`${dataTestBase}/heading`}>
                     <TransactionHeader transaction={transaction} isPending={isPending} />
                     {isSupportedEthStakingNetworkSymbol(transaction.symbol) && (

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
@@ -108,13 +108,16 @@ export const TransactionItem = memo(
                 }),
             );
         };
-        const { isPhishing: isPhishingTransaction } = useSelector(state =>
-            selectIsPhishingTransaction(state, transaction.txid, accountKey),
+        const { isPhishing: isPhishingTransaction, detectorId: phishingDetectorId } = useSelector(
+            state => selectIsPhishingTransaction(state, transaction.txid, accountKey),
         );
 
         const dataTestBase = `@transaction-item/${index}${
             transaction.deadline ? '/prepending' : ''
         }`;
+
+        const isZeroPhishingTransaction =
+            isPhishingTransaction && phishingDetectorId == 'DUST_AMOUNT';
 
         return (
             <Wrapper ref={anchorRef} data-testid="@wallet/transaction-item">
@@ -126,7 +129,7 @@ export const TransactionItem = memo(
                             <TransactionHeading
                                 transaction={transaction}
                                 isPending={isPending}
-                                isPhishingTransaction={isPhishingTransaction}
+                                isZeroPhishingTransaction={isZeroPhishingTransaction}
                                 dataTestBase={dataTestBase}
                             />
                         }

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
@@ -116,9 +116,6 @@ export const TransactionItem = memo(
             transaction.deadline ? '/prepending' : ''
         }`;
 
-        const isZeroPhishingTransaction =
-            isPhishingTransaction && phishingDetectorId == 'DUST_AMOUNT';
-
         return (
             <Wrapper ref={anchorRef} data-testid="@wallet/transaction-item">
                 <OutlineHighlight shouldHighlight={shouldHighlight}>
@@ -129,7 +126,8 @@ export const TransactionItem = memo(
                             <TransactionHeading
                                 transaction={transaction}
                                 isPending={isPending}
-                                isZeroPhishingTransaction={isZeroPhishingTransaction}
+                                isPhishingTransaction={isPhishingTransaction}
+                                phishingDetectorId={phishingDetectorId}
                                 dataTestBase={dataTestBase}
                             />
                         }

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -9224,11 +9224,12 @@ export const messages = defineMessages({
     TR_PHISHING_TOOLTIP_FAKE_TOKEN: {
         id: 'TR_PHISHING_TOOLTIP_FAKE_TOKEN',
         defaultMessage:
-            'This transaction includes tokens not found in any verified list and may be fake.',
+            'This transaction includes tokens not found in any verified list and may be fake. <a>Learn more</a>',
     },
     TR_PHISHING_TOOLTIP_UNKNOWN_TX: {
         id: 'TR_PHISHING_TOOLTIP_UNKNOWN_TX',
-        defaultMessage: 'This transaction type is unknown and could not be decoded.',
+        defaultMessage:
+            'This transaction type is unknown and could not be decoded. <a>Learn more</a>',
     },
     TR_PHISHING_TOOLTIP_DUST_AMOUNT: {
         id: 'TR_PHISHING_TOOLTIP_DUST_AMOUNT',
@@ -9242,7 +9243,7 @@ export const messages = defineMessages({
     },
     TR_PHISHING_TOOLTIP_TRC10_TRANSFER: {
         id: 'TR_PHISHING_TOOLTIP_TRC10_TRANSFER',
-        defaultMessage: 'This TRC10 token transfer may be a scam.',
+        defaultMessage: 'This TRC10 token transfer may be a scam. <a>Learn more</a>',
     },
     TR_ZERO_PHISHING_BANNER: {
         id: 'TR_ZERO_PHISHING_BANNER',

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -9221,6 +9221,29 @@ export const messages = defineMessages({
         defaultMessage:
             'Address poisoning alert. This transaction looks suspicious. <a>Learn more</a>',
     },
+    TR_PHISHING_TOOLTIP_FAKE_TOKEN: {
+        id: 'TR_PHISHING_TOOLTIP_FAKE_TOKEN',
+        defaultMessage:
+            'This transaction may include hidden or unrecognized tokens. <a>Learn more</a>',
+    },
+    TR_PHISHING_TOOLTIP_UNKNOWN_TX: {
+        id: 'TR_PHISHING_TOOLTIP_UNKNOWN_TX',
+        defaultMessage: "This transaction couldn't be fully verified.",
+    },
+    TR_PHISHING_TOOLTIP_DUST_AMOUNT: {
+        id: 'TR_PHISHING_TOOLTIP_DUST_AMOUNT',
+        defaultMessage:
+            'This transaction contains dust amounts, which can be used in scams. <a>Learn more</a>',
+    },
+    TR_PHISHING_TOOLTIP_ZERO_AMOUNT: {
+        id: 'TR_PHISHING_TOOLTIP_ZERO_AMOUNT',
+        defaultMessage: 'This transaction has a zero amount and may be suspicious.',
+    },
+    TR_PHISHING_TOOLTIP_TRC10_TRANSFER: {
+        id: 'TR_PHISHING_TOOLTIP_TRC10_TRANSFER',
+        defaultMessage:
+            'This transaction is a TRC10 transfer and may be suspicious.',
+    },
     TR_ZERO_PHISHING_BANNER: {
         id: 'TR_ZERO_PHISHING_BANNER',
         defaultMessage:

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -9224,25 +9224,25 @@ export const messages = defineMessages({
     TR_PHISHING_TOOLTIP_FAKE_TOKEN: {
         id: 'TR_PHISHING_TOOLTIP_FAKE_TOKEN',
         defaultMessage:
-            'This transaction may include hidden or unrecognized tokens. <a>Learn more</a>',
+            'This transaction includes tokens not found in any verified list and may be fake.',
     },
     TR_PHISHING_TOOLTIP_UNKNOWN_TX: {
         id: 'TR_PHISHING_TOOLTIP_UNKNOWN_TX',
-        defaultMessage: "This transaction couldn't be fully verified.",
+        defaultMessage: 'This transaction type is unknown and could not be decoded.',
     },
     TR_PHISHING_TOOLTIP_DUST_AMOUNT: {
         id: 'TR_PHISHING_TOOLTIP_DUST_AMOUNT',
         defaultMessage:
-            'This transaction contains dust amounts, which can be used in scams. <a>Learn more</a>',
+            'This transaction has a negligible value, which may indicate a dust attack. <a>Learn more</a>',
     },
     TR_PHISHING_TOOLTIP_ZERO_AMOUNT: {
         id: 'TR_PHISHING_TOOLTIP_ZERO_AMOUNT',
-        defaultMessage: 'This transaction has a zero amount and may be suspicious.',
+        defaultMessage:
+            'This zero-value token transfer may be an address poisoning attempt. <a>Learn more</a>',
     },
     TR_PHISHING_TOOLTIP_TRC10_TRANSFER: {
         id: 'TR_PHISHING_TOOLTIP_TRC10_TRANSFER',
-        defaultMessage:
-            'This transaction is a TRC10 transfer and may be suspicious.',
+        defaultMessage: 'This TRC10 token transfer may be a scam.',
     },
     TR_ZERO_PHISHING_BANNER: {
         id: 'TR_ZERO_PHISHING_BANNER',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

As reported in the linked issue the tooltip for phishing alert is displayed for different type of phishing transactions like fake tokens. As translations for tooltip only exist for address poisoning it would not be displayed for other marked transactions like fake tokens.

## Notes for QA

Tooltip is only displayed for dust attack warning

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26871

## Screenshots:

Before: 

<img width="878" height="330" alt="image" src="https://github.com/user-attachments/assets/f3463890-7ef1-466a-99b0-d8ec194f674c" />


After:

<img width="954" height="125" alt="Screenshot 2026-06-02 at 15 21 57" src="https://github.com/user-attachments/assets/495fcaf5-95a7-4f83-957c-86c25f03b15f" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes target TransactionItem and TransactionHeading components (core transaction list rendering) and the intl messages file. Since these components map to 121 tests via static analysis, they are clearly broad shared components. The highest-risk tests are those that directly assert on transaction list content, transaction addresses, transaction statuses, and output labels. The messages.ts file is a global translation file with no dedicated static coverage, but its changes could affect any test using translation keys — only tests asserting on transaction-specific translations are included. The recommended strategy is to prioritize tests that render and assert on transaction items directly.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/components/wallet/TransactionItem/TransactionHeading.tsx`
- `packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/wallet/transactions.test.ts` — This test directly exercises transaction display functionality — cycling through graph time ranges, finding the latest transaction by address, and searching transactions. TransactionItem and TransactionHeading are the core rendering components for each transaction row, so changes there directly affect what this test validates.
- `suite/e2e/tests/wallet/export-transactions.test.ts` — This test opens wallet accounts and interacts with transaction lists to export them in various formats. The TransactionItem component is rendered in the transaction list view that this test exercises, and changes to the heading or item could affect the export UI entry point or displayed content.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test explicitly asserts that a pending transaction list shows 'OP_RETURN (meow)' as a target address after sending — directly testing TransactionItem rendering of transaction targets. Changes to TransactionHeading or TransactionItem could break this assertion.
- `suite/e2e/tests/wallet/pagination.test.ts` — This test navigates paginated transaction lists and asserts on transaction addresses displayed in each page. TransactionItem is the component rendering each transaction row including the address, so changes directly affect these assertions.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — This test labels transaction outputs and verifies labels appear on transaction items, and also exports CSV containing output labels. TransactionItem renders output labels, so changes could affect label display or the metadata label integration within transaction rows.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test asserts on pending transaction text visibility and transaction status (TR_TX_CONFIRMING, TR_TX_CONFIRMED) which are rendered via TransactionItem components. Changes to TransactionItem or messages.ts translation keys could affect these status assertions.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Similar to initial-stake, this test asserts on pending transaction text, speed-up button, and transaction status translations (TR_TX_CONFIRMING, TR_TX_CONFIRMED) which are rendered within TransactionItem. Changes to these components or translation keys are directly relevant.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — This test checks pending unstaking transaction visibility and speed-up buttons, which are rendered through TransactionItem. Transaction status display changes could directly affect these assertions.
- `suite/e2e/tests/suite/db-migration.test.ts` — This test verifies transaction history and transaction addresses are preserved after database migration, including checking transaction items and metadata output labels. TransactionItem changes could affect how migrated transactions render.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — Discreet mode hides balance values across the dashboard. While TransactionItem could display amounts that get hidden in discreet mode, the test primarily focuses on dashboard-level balance elements rather than individual transaction items.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — This test verifies account balances after receiving BTC on regtest. While transaction items may be visible on the account page, the assertions focus on balance amounts rather than transaction rendering. Still, a broken TransactionItem could cause page rendering issues.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/intl/src/messages.ts`

_Updated: 2026-06-16T10:44:23.161Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/tx-flagging-reason&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/tx-flagging-reason&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-16T10:49:42.646Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-16T10:48:04.550Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/tx-flagging-reason/web/](https://dev.suite.sldev.cz/suite-web/fix/tx-flagging-reason/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->