### PR TITLE
chore(wallet): revert diagnostic logs for unknown BTC pending tx

### DIFF
--- a/packages/blockchain-link-utils/src/blockbook.ts
+++ b/packages/blockchain-link-utils/src/blockbook.ts
@@ -272,30 +272,6 @@ export const transformTransaction = (
         type = 'unknown';
         amount = tx.value;
         targets = [];
-        // [btc-unknown-tx-debug] 'unknown' is the catch-all the categorizer falls back to when it cannot
-        // tell whether the tx is recv/sent/self for this account — for an account's own tx that is never a
-        // desired outcome, it is a hole in our categorization (we show "something" rather than dropping it).
-        // We log every such case EXCEPT calls that pass no account context at all — transformTransaction(tx)
-        // by id (prev/ref-tx during signing, CoinControl UTXO detail): there is no account to compare
-        // against, so `type` is an unused placeholder that is never shown, not a categorization miss, and
-        // logging it would only flood Sentry. When account context WAS provided (an addresses object or a
-        // descriptor), an 'unknown' is a genuine gap worth capturing — including the anomalous case where
-        // the supplied addresses were empty (myAddressesCount === 0).
-        // Intentionally no txid / addresses / descriptor: these reach Sentry and could deanonymize the user.
-        if (addressesOrDescriptor !== undefined) {
-            console.error('[btc-unknown-tx-debug] transformTransaction → type=unknown', {
-                isPending: !tx.blockHeight || tx.blockHeight <= 0,
-                myAddressesCount: myAddresses.length,
-                vinCount: inputs.length,
-                voutCount: outputs.length,
-                vinWithAddressesCount: inputs.filter(
-                    v => Array.isArray(v.addresses) && v.addresses.length > 0,
-                ).length,
-                voutWithAddressesCount: outputs.filter(
-                    v => Array.isArray(v.addresses) && v.addresses.length > 0,
-                ).length,
-            });
-        }
     }
 
     type = isTxFailed(tx) ? 'failed' : type;

--- a/packages/blockchain-link-utils/src/tests/blockbook.test.ts
+++ b/packages/blockchain-link-utils/src/tests/blockbook.test.ts
@@ -13,15 +13,6 @@ describe('blockbook/utils', () => {
     });
 
     describe('transformTransaction', () => {
-        // [btc-unknown-tx-debug] transformTransaction emits a temporary console.error when it classifies
-        // a tx as 'unknown' with account context. Silence the JestCustomEnv console.error trap for these
-        // classification fixtures (the only console.error in transformTransaction is that diagnostic).
-        beforeEach(() => {
-            jest.spyOn(console, 'error').mockImplementation(() => {});
-        });
-        afterEach(() => {
-            jest.restoreAllMocks();
-        });
         fixtures.transformTransaction.forEach(f => {
             it(f.description, () => {
                 // @ts-expect-error incorrect params

--- a/packages/blockchain-link/tests/unit/getAccountInfo.test.ts
+++ b/packages/blockchain-link/tests/unit/getAccountInfo.test.ts
@@ -26,16 +26,6 @@ workers.forEach(instance => {
         beforeAll(setup);
         afterAll(teardown);
 
-        // [btc-unknown-tx-debug] getAccountInfo parses tx history through transformTransaction, which
-        // emits a temporary console.error for txs classified as 'unknown' with account context. Silence
-        // the JestCustomEnv console.error trap for these fixtures.
-        beforeEach(() => {
-            jest.spyOn(console, 'error').mockImplementation(() => {});
-        });
-        afterEach(() => {
-            jest.restoreAllMocks();
-        });
-
         fixtures[instance.name].forEach(f => {
             it(f.description, async () => {
                 server.setFixtures(f.serverFixtures);

--- a/packages/blockchain-link/tests/unit/notifications.test.ts
+++ b/packages/blockchain-link/tests/unit/notifications.test.ts
@@ -41,16 +41,6 @@ workers.forEach(instance => {
             beforeAll(setup);
             afterAll(teardown);
 
-            // [btc-unknown-tx-debug] notification txs are parsed through transformTransaction, which emits
-            // a temporary console.error for txs classified as 'unknown' with account context. Silence the
-            // JestCustomEnv console.error trap for these fixtures.
-            beforeEach(() => {
-                jest.spyOn(console, 'error').mockImplementation(() => {});
-            });
-            afterEach(() => {
-                jest.restoreAllMocks();
-            });
-
             // NOTE: do not skip any test because id's sequence must be continuous!
             fixtures[instance.name].notifyAddresses.forEach((f, id) => {
                 it(f.description, async () => {

--- a/packages/connect/src/api/bitcoin/createPendingTx.ts
+++ b/packages/connect/src/api/bitcoin/createPendingTx.ts
@@ -33,37 +33,6 @@ export const createPendingTransaction = (
             .map(address => address.address);
     };
 
-    const vin = inputs.map((ins, n) => {
-        const matched = findAddress(ins);
-        const hasAddressN = Array.isArray(ins.address_n) && ins.address_n.length > 0;
-
-        // [btc-unknown-tx-debug] address_n on this input did not match any address in
-        // account.addresses (unused/used/change). Downstream, blockbookUtils.transformTransaction
-        // will not recognize the input as ours, which can cascade to type='unknown' for the
-        // optimistic pending tx created right after signing. See addFakePendingTxThunk in
-        // suite-common/wallet-core/src/transactions/transactionsThunks.ts.
-        // Intentionally no txid / address_n / addresses: these reach Sentry and could deanonymize the user.
-        if (hasAddressN && matched.length === 0) {
-            console.error(
-                '[btc-unknown-tx-debug] createPendingTransaction → input has no matching address',
-                {
-                    inputIndex: n,
-                    knownAddressesCount: allAddresses.length,
-                },
-            );
-        }
-
-        return {
-            n,
-            txid: ins.prev_hash,
-            vout: ins.prev_index,
-            isAddress: true,
-            addresses: matched,
-            value: ins.amount.toString(),
-            sequence: ins.sequence,
-        };
-    });
-
     return {
         txid: tx.getId(),
         hex: tx.toHex(),
@@ -75,7 +44,15 @@ export const createPendingTransaction = (
         value: valueOut.toString(),
         valueIn: valueIn.toString(),
         fees: valueIn.minus(valueOut).toString(),
-        vin,
+        vin: inputs.map((ins, n) => ({
+            n,
+            txid: ins.prev_hash,
+            vout: ins.prev_index,
+            isAddress: true,
+            addresses: findAddress(ins),
+            value: ins.amount.toString(),
+            sequence: ins.sequence,
+        })),
         vout: outputs.map((out, n) => {
             let transformedAddresses: string[] = [];
 

--- a/suite-common/wallet-core/src/send/sendFormBitcoinThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormBitcoinThunks.ts
@@ -27,8 +27,6 @@ import TrezorConnect, {
     type SignTransaction,
     type SignedTransaction,
 } from '@trezor/connect';
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports -- temporary diagnostic; getSerializedPath is not re-exported from the @trezor/connect public barrel
-import { getSerializedPath } from '@trezor/connect/src/utils/pathUtils';
 import { BigNumber, isArrayMember } from '@trezor/utils';
 
 import { SEND_MODULE_PREFIX } from './sendFormConstants';
@@ -336,40 +334,6 @@ export const signBitcoinSendFormTransactionThunk = createThunk<
         if (isArrayMember(selectedAccount.symbol, BITCOIN_ONLY_SYMBOLS)) {
             // nVersion, use 2 as it enables BIP68 + seems to be the most commonly used (= harder to fingerprint the Trezor)
             signEnhancement.version = 2;
-        }
-
-        const accountAddressPaths = new Set(
-            selectedAccount.addresses
-                ? selectedAccount.addresses.change
-                      .concat(selectedAccount.addresses.used, selectedAccount.addresses.unused)
-                      .map(({ path }) => path)
-                : [],
-        );
-        const inputPaths = precomposedTransaction.inputs
-            .map(input =>
-                Array.isArray(input.address_n) && input.address_n.length > 0
-                    ? getSerializedPath(input.address_n)
-                    : undefined,
-            )
-            .filter((path): path is string => typeof path === 'string');
-        const unmatchedInputPathCount = inputPaths.filter(
-            path => !accountAddressPaths.has(path),
-        ).length;
-
-        if (unmatchedInputPathCount > 0) {
-            // [btc-unknown-tx-debug] the selected account does not contain paths used by the tx inputs.
-            // This can make Connect build a pending tx with wrong or empty vin addresses, which can then
-            // classify the optimistic pending tx incorrectly before the backend response arrives.
-            // Intentionally no paths / addresses / descriptor / txid: these reach Sentry and could
-            // deanonymize the user. accountType + symbol are low-cardinality, non-PII.
-            console.error('[btc-unknown-tx-debug] signBitcoin → input paths missing in account', {
-                accountType: selectedAccount.accountType,
-                symbol: selectedAccount.symbol,
-                inputCount: precomposedTransaction.inputs.length,
-                inputsWithAddressNCount: inputPaths.length,
-                knownAddressesCount: accountAddressPaths.size,
-                unmatchedInputPathCount,
-            });
         }
 
         const signPayload: Params<SignTransaction> = {

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -180,35 +180,6 @@ export const addFakePendingTxThunk = createThunk(
                     signedTransaction,
                     affectedAccount.addresses ?? affectedAccount.descriptor,
                 );
-                if (affectedAccountTransaction.type === 'unknown') {
-                    const unusedCount = affectedAccount.addresses?.unused.length ?? 0;
-                    const usedCount = affectedAccount.addresses?.used.length ?? 0;
-                    const changeCount = affectedAccount.addresses?.change.length ?? 0;
-                    // [btc-unknown-tx-debug] the just-signed BTC tx was classified as 'unknown' before
-                    // even reaching the backend. The user will see "Unknown transaction" in the list
-                    // until the backend response replaces this entry. This is the clean, send-path-only
-                    // smoking gun (see also the createPendingTx.ts and blockbook.ts logs for upstream
-                    // detail). The payload reaches Sentry as event.extra.arguments[1]; the bug is rare
-                    // enough to triage per-event, and mobile-vs-desktop frequency is already split by
-                    // Sentry project (native vs desktop/web DSN), so tags are not needed here.
-                    // emptyAddresses separates the two leading hypotheses at a glance:
-                    //   true  -> no addresses at classification time (account addresses absent)
-                    //   false -> addresses present but nothing matched (path mismatch: gap-limit / taproot)
-                    // Intentionally no txid / accountKey / descriptor / raw addresses: these reach Sentry
-                    // and could deanonymize the user. accountType + symbol are low-cardinality, non-PII.
-                    console.error(
-                        '[btc-unknown-tx-debug] addFakePendingTxThunk → prepending tx has type=unknown',
-                        {
-                            accountType: affectedAccount.accountType,
-                            symbol: affectedAccount.symbol,
-                            hasAddresses: Boolean(affectedAccount.addresses),
-                            emptyAddresses: unusedCount + usedCount + changeCount === 0,
-                            unusedCount,
-                            usedCount,
-                            changeCount,
-                        },
-                    );
-                }
                 const prependingTx = { ...affectedAccountTransaction, deadline: blockHeight + 2 };
                 dispatch(
                     transactionsActions.addTransaction({


### PR DESCRIPTION
## Description

Reverts commit f163bcfb3678261709f5ee2484e20dfd97b06140 (`chore(wallet): add diagnostic logs for unknown BTC pending tx`).

That commit shipped only temporary `console.error` diagnostics (tagged `[btc-unknown-tx-debug]`) to confirm the root cause of BTC txs showing up as **"Unknown transaction"** instead of **"Sending …"** in the tx list. It contained no fix.

We're reverting the instrumentation now to keep the temporary logs out of the codebase. In ~2 weeks we'll review the collected Sentry data and attempt a proper fix based on what the diagnostics revealed.

## Related

- Reverts #f163bcf

## Files touched (logs removed)

- `packages/blockchain-link-utils/src/blockbook.ts`
- `packages/connect/src/api/bitcoin/createPendingTx.ts`
- `suite-common/wallet-core/src/send/sendFormBitcoinThunks.ts`
- `suite-common/wallet-core/src/transactions/transactionsThunks.ts`
- plus the associated unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes touch Bitcoin transaction infrastructure at multiple layers: blockbook response parsing (blockchain-link-utils/blockbook.ts), pending transaction creation after signing (connect/createPendingTx.ts), Bitcoin send form composition (sendFormBitcoinThunks.ts), and transaction processing thunks (transactionsThunks.ts). While these files are imported broadly across the app (121 tests each), the actual risk is concentrated in Bitcoin-like send flows, pending transaction handling, account discovery via blockbook backends, and transaction list display. The recommended strategy focuses on tests that directly exercise BTC/DOGE/LTC send flows, pending transaction lifecycle, blockbook-backed discovery, and transaction export/display. Unit tests for the changed packages exist but are not E2E tests and fall outside coverage.

<details><summary><b>Changed files (7)</b></summary>

- `packages/blockchain-link-utils/src/blockbook.ts`
- `packages/blockchain-link-utils/src/tests/blockbook.test.ts`
- `packages/blockchain-link/tests/unit/getAccountInfo.test.ts`
- `packages/blockchain-link/tests/unit/notifications.test.ts`
- `packages/connect/src/api/bitcoin/createPendingTx.ts`
- `suite-common/wallet-core/src/send/sendFormBitcoinThunks.ts`
- `suite-common/wallet-core/src/transactions/transactionsThunks.ts`

</details>

**Recommended tests (13)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/wallet/pending-transactions.test.ts` — This test directly exercises Bitcoin pending transaction creation, display, and mining on regtest. Changes to createPendingTx.ts, sendFormBitcoinThunks.ts, and transactionsThunks.ts all directly affect the pending transaction lifecycle — from composing the BTC send, to creating the pending tx object, to processing transaction notifications from the backend (blockbook.ts).
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test sends BTC transactions on regtest with multiple outputs, locktime, OP_RETURN, and unit switching. It directly exercises sendFormBitcoinThunks.ts for composing Bitcoin transactions and createPendingTx.ts for the pending transaction after sending. Changes to these files could break the send flow or post-send state.
- `suite/e2e/tests/wallet/send-doge.test.ts` — This test validates sending DOGE (a Bitcoin-like coin) with an amount exceeding MAX_SAFE_INTEGER and verifies error handling in the signing flow. sendFormBitcoinThunks.ts handles BTC-like coin send composition, and createPendingTx.ts processes the result. Changes here could alter error handling or amount validation behavior.

</details>

<details><summary>🟡 <b>Medium priority (9)</b></summary>

- `suite/e2e/tests/wallet/coin-balance.test.ts` — This test verifies BTC regtest account balance discovery after receiving transactions. blockbook.ts parses blockbook API responses for account info and balance, and transactionsThunks.ts processes incoming transaction data. Changes to either could break balance display or account discovery.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — This test sends LTC (a Bitcoin-like coin) with a MimbleWimble peg-out output, using a custom blockbook backend. sendFormBitcoinThunks.ts handles LTC send composition, and blockbook.ts parses the backend responses. Changes could affect how MWEB outputs are handled.
- `suite/e2e/tests/wallet/transactions.test.ts` — This test exercises transaction list display, graph time ranges, and transaction search on a BTC account. transactionsThunks.ts handles fetching and processing transactions, and blockbook.ts parses the transaction data from the backend. Changes could affect transaction rendering or search.
- `suite/e2e/tests/wallet/discovery.test.ts` — This test activates multiple coins (btc, eth, ltc, etc, bch, doge, xrp, zec) and verifies discovery completes after a page reload interruption. blockbook.ts is used to parse account info from blockbook backends during discovery, and transactionsThunks.ts processes discovered transactions. Changes could cause discovery failures.
- `suite/e2e/tests/wallet/export-transactions.test.ts` — This test exports transaction history in PDF/CSV/JSON for BTC, LTC, ETH, and ADA. transactionsThunks.ts handles transaction fetching and blockbook.ts parses the transaction data. Changes to transaction parsing could produce malformed export data.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test configures custom Blockbook backends for BTC and LTC and verifies discovery completes. blockbook.ts directly parses the responses from these custom blockbook servers. Changes to blockbook parsing could break discovery with custom backends.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test configures custom blockbook backends for BTC and ETH and verifies discovery succeeds or fails based on correct/incorrect URLs. blockbook.ts parses the blockbook API responses, and changes could affect how backend connection errors are surfaced.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — This test performs a full BTC sell flow including initiating a send transaction with fee calculation. sendFormBitcoinThunks.ts composes the Bitcoin transaction for selling, and changes could affect fee computation or transaction composition in the sell flow.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — This test performs a BTC-to-ETH swap with custom fee settings, verifying fee rate and total amount on the device. sendFormBitcoinThunks.ts handles BTC transaction composition with custom fees, and changes could break fee calculation or display.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/wallet/import-btc-csv.test.ts` — This test imports a CSV file into the BTC send form to populate multiple outputs. While it primarily tests CSV parsing UI, the send form relies on sendFormBitcoinThunks.ts for transaction composition when multiple outputs are populated.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/blockchain-link-utils/src/tests/blockbook.test.ts`
- `packages/blockchain-link/tests/unit/getAccountInfo.test.ts`
- `packages/blockchain-link/tests/unit/notifications.test.ts`

_Updated: 2026-06-02T13:35:48.183Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/revert-commit-f163bcf&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/revert-commit-f163bcf&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/revert-commit-f163bcf&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-02T13:39:45.379Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-02T13:38:30.161Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/revert-commit-f163bcf/web/](https://dev.suite.sldev.cz/suite-web/mroz22/revert-commit-f163bcf/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->