### PR TITLE
chore(suite-native): change CryptoIcon size for extraLarge as per DS

### DIFF
--- a/suite-native/icons/src/CryptoIcon.tsx
+++ b/suite-native/icons/src/CryptoIcon.tsx
@@ -27,7 +27,7 @@ export const cryptoIconSizes = {
     extraSmall: 24,
     small: 32,
     large: 48,
-    extraLarge: 68,
+    extraLarge: 64,
 } as const;
 
 const iconStyle = prepareNativeStyle<{ width: number; height: number }>(


### PR DESCRIPTION
💀 

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/crypto-icon-sizes&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->