### PR TITLE
fix(suite): Fix trade page

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingContainer.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingContainer.tsx
@@ -8,7 +8,6 @@ import { spacings } from '@trezor/theme';
 import { useSelector } from 'src/hooks/suite';
 import { DiscoveryWarning } from 'src/views/wallet/staking/components/StakingDashboard/components/DiscoveryWarning';
 import { TradingFooter } from 'src/views/wallet/trading/common/TradingFooter/TradingFooter';
-import { TradingLayoutHeader } from 'src/views/wallet/trading/common/TradingLayout/TradingLayoutHeader';
 
 export interface TradingContainerProps {
     SectionComponent: ElementType;
@@ -19,7 +18,7 @@ export const TradingContainer = ({ SectionComponent, provider }: TradingContaine
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
 
     return (
-        <TradingLayoutHeader>
+        <>
             {isDiscoveryRunning && (
                 <Column margin={{ bottom: spacings.md }}>
                     <DiscoveryWarning />
@@ -27,6 +26,6 @@ export const TradingContainer = ({ SectionComponent, provider }: TradingContaine
             )}
             <SectionComponent />
             <TradingFooter provider={provider} />
-        </TradingLayoutHeader>
+        </>
     );
 };

--- a/packages/suite/src/views/wallet/trading/common/TradingLayout/TradingLayout.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingLayout/TradingLayout.tsx
@@ -8,6 +8,7 @@ import { Column } from '@trezor/components';
 import { DiscoveryEmpty } from 'src/components/wallet/WalletLayout/AccountException/DiscoveryEmpty';
 import { useSelector } from 'src/hooks/suite';
 import { ConnectDeviceGenericPromo } from 'src/views/wallet/receive/components/ConnectDevicePromo';
+import { TradingLayoutHeader } from 'src/views/wallet/trading/common/TradingLayout/TradingLayoutHeader';
 import { TradingLayoutNavigation } from 'src/views/wallet/trading/common/TradingLayout/TradingLayoutNavigation';
 
 export const TradingLayout = ({ children }: PropsWithChildren) => {
@@ -26,7 +27,9 @@ export const TradingLayout = ({ children }: PropsWithChildren) => {
     return (
         <Column data-testid="@trading" gap={24}>
             <TradingLayoutNavigation route={routeName} />
-            {hasVisibleAccounts ? children : noVisibleAccountsContent}
+            <TradingLayoutHeader>
+                {hasVisibleAccounts ? children : noVisibleAccountsContent}
+            </TradingLayoutHeader>
         </Column>
     );
 };

--- a/packages/suite/src/views/wallet/trading/common/TradingLayout/__tests__/TradingLayout.test.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingLayout/__tests__/TradingLayout.test.tsx
@@ -26,6 +26,10 @@ jest.mock('../TradingLayoutNavigation', () => ({
     ),
 }));
 
+jest.mock('../TradingLayoutHeader', () => ({
+    TradingLayoutHeader: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
 jest.mock('src/components/wallet/WalletLayout/AccountException/DiscoveryEmpty', () => ({
     DiscoveryEmpty: () => <div data-testid="discovery-empty" />,
 }));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect TradingContainer and TradingLayout, which are shared wrapper/layout components for all trading (buy/sell/swap) views. Since these are high-level container components, a rendering or layout regression would affect all trading flows. The recommended strategy is to run one representative test from each trading type (buy, sell, swap) at high/medium priority, plus the navigation test that validates all entry points. The unit test file has no E2E coverage but is a co-located unit test that should run in the unit test suite.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/views/wallet/trading/common/TradingContainer.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingLayout/TradingLayout.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingLayout/__tests__/TradingLayout.test.tsx`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — This test exercises navigation to Buy/Sell/Swap trading forms from multiple entry points, directly testing that the TradingContainer and TradingLayout render correctly when the trading UI is opened. Changes to the layout/container wrapper could break form rendering or navigation detection.
- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — This is the core buy flow test that exercises the full trading UI lifecycle (form → quotes → confirmation → transaction detail). TradingContainer and TradingLayout are the wrapper components for all these views, so layout/container changes could break rendering at any step.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/trading/buy-negative.test.ts` — Tests error states and validation within the buy form, which renders inside TradingLayout/TradingContainer. If the layout changes affect form element positioning or visibility, validation error display could break.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Tests sell form input validation, percentage buttons, and fee calculations within the trading layout. These form interactions rely on TradingLayout for proper rendering of inputs, error messages, and fraction buttons.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Comprehensive swap flow test covering form filling, quotes, device confirmation, toast notifications, and status polling — all rendered within TradingContainer/TradingLayout. Covers the swap variant of the trading UI distinct from buy/sell.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Tests the full sell flow including offer comparison modal and transaction status updates, exercised within TradingLayout. Covers a different network (Solana) than the BTC buy test, providing cross-network coverage of the trading container.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests custom Ethereum fee settings within the swap flow, verifying fee display in the confirmation modal. The confirmation modal renders inside TradingLayout, so layout changes could affect fee information display.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/views/wallet/trading/common/TradingLayout/__tests__/TradingLayout.test.tsx`

_Updated: 2026-06-02T15:11:02.947Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-trade-page&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-trade-page&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-02T15:16:55.007Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-02T15:14:04.931Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-trade-page/web/](https://dev.suite.sldev.cz/suite-web/fix-trade-page/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->