### PR TITLE
fix(suite): Hide filter when its empty

### DIFF
--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenuHeader.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenuHeader.tsx
@@ -96,7 +96,7 @@ export const AccountsMenuHeader = () => {
                             </>
                         )}
                     </Row>
-                    {isCoinsFilterVisible && showCoinFilter && <CoinsFilter />}
+                    {isCoinsFilterVisible && showCoinFilter && !isEmpty && <CoinsFilter />}
                 </ExpandedSidebarOnly>
                 <CollapsedSidebarOnly>
                     <Column alignItems="center" margin={{ bottom: 12 }}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

hides opened filter if there is no account (no network activated).

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to AccountsMenuHeader.tsx, the header component of the wallet's AccountsMenu sidebar. This component likely renders account search/filter input, add account button, and possibly global wallet action buttons. Since the file maps to 121 tests (essentially every test that renders the wallet layout), only tests that specifically exercise the header's interactive features — account search, account addition, and account filtering — are recommended. The risk is moderate: a regression would affect wallet sidebar navigation, but the blast radius is well-scoped to the accounts menu header UI.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenuHeader.tsx`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/wallet/account-search.test.ts` — AccountsMenuHeader.tsx is the header component of the AccountsMenu, which directly contains the account search functionality. This test exercises typing into the account search field, filtering accounts, and clearing the search — all behaviors that directly depend on the AccountsMenuHeader component.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — The AccountsMenuHeader likely contains the 'add account' button and account type filtering UI. This test directly exercises adding accounts via the add account button, expanding account groups in the menu, and counting accounts in type groups — all interactions rooted in the accounts menu header area.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/metadata/legacy/account-metadata.test.ts` — This test searches/filters accounts by metadata label text through the account search functionality, which is likely rendered in AccountsMenuHeader. The search filtering behavior directly depends on this component's search input.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test uses the global receive/send buttons from the wallet menu (@wallet/menu/wallet-global-receive, @wallet/menu/wallet-global-send) and account filtering/search in the asset picker. The AccountsMenuHeader may render these global action buttons as part of the accounts menu header.
- `suite/e2e/tests/wallet/transactions.test.ts` — This test opens a BTC account via the wallet page and searches transactions by address. The account navigation through the accounts menu depends on AccountsMenuHeader rendering correctly to access accounts.

</details>

_Updated: 2026-06-02T15:28:41.063Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=hide-filter-when-empty&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=hide-filter-when-empty&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-02T15:34:00.394Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-02T15:31:48.467Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/hide-filter-when-empty/web/](https://dev.suite.sldev.cz/suite-web/hide-filter-when-empty/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->