### PR TITLE
fix(trading): show selected asset ticker in buy payment selector

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingBuyHandleChange.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingBuyHandleChange.ts
@@ -7,7 +7,6 @@ import {
     TRADING_FORM_PAYMENT_METHOD_SELECT,
     type TradingBuyFormProps,
     buyThunks,
-    getTradingPaymentMethods,
     isCountrySubdivisionEmpty,
     tradingActions,
     useTradingRefetchScheduler,
@@ -82,10 +81,9 @@ export const useTradingBuyHandleChange = ({
                 const bestQuotePaymentMethodName =
                     bestQuote?.paymentMethodName ?? bestQuotePaymentMethod;
                 const paymentMethodSelected = formValues.paymentMethod?.value;
-                const paymentMethodsFromQuotes = getTradingPaymentMethods(quotes);
-                const isSelectedPaymentMethodAvailable =
-                    paymentMethodsFromQuotes.find(item => item.value === paymentMethodSelected) !==
-                    undefined;
+                const isSelectedPaymentMethodAvailable = quotes.some(
+                    quote => quote.paymentMethod === paymentMethodSelected,
+                );
                 if (!paymentMethodSelected || !isSelectedPaymentMethodAvailable) {
                     setValue(TRADING_FORM_PAYMENT_METHOD_SELECT, {
                         value: bestQuotePaymentMethod ?? '',

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingSellHandleChange.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingSellHandleChange.ts
@@ -6,7 +6,6 @@ import { useServices } from '@suite-common/dependency-injection';
 import {
     TRADING_FORM_PAYMENT_METHOD_SELECT,
     type TradingSellFormProps,
-    getTradingPaymentMethods,
     isCountrySubdivisionEmpty,
     sellThunks,
     tradingActions,
@@ -85,10 +84,9 @@ export const useTradingSellHandleChange = ({
                 const bestQuotePaymentMethodName =
                     bestQuote?.paymentMethodName ?? bestQuotePaymentMethod;
                 const paymentMethodSelected = formValues.paymentMethod?.value;
-                const paymentMethodsFromQuotes = getTradingPaymentMethods(quotes);
-                const isSelectedPaymentMethodAvailable =
-                    paymentMethodsFromQuotes.find(item => item.value === paymentMethodSelected) !==
-                    undefined;
+                const isSelectedPaymentMethodAvailable = quotes.some(
+                    quote => quote.paymentMethod === paymentMethodSelected,
+                );
                 if (!paymentMethodSelected || !isSelectedPaymentMethodAvailable) {
                     setValue(TRADING_FORM_PAYMENT_METHOD_SELECT, {
                         value: bestQuotePaymentMethod ?? '',

--- a/suite-common/trading/src/__tests__/utils.test.ts
+++ b/suite-common/trading/src/__tests__/utils.test.ts
@@ -7,7 +7,6 @@ import {
 
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import type { Account, AccountKey } from '@suite-common/wallet-types';
-import { BigNumber } from '@trezor/utils';
 
 import * as BUY_FIXTURE from '../__fixtures__/buyUtils';
 import * as EXCHANGE_FIXTURE from '../__fixtures__/exchangeUtils';
@@ -23,7 +22,6 @@ import {
     getDefaultCountry,
     getDefaultCountrySubdivision,
     getTradingFormState,
-    getTradingPaymentMethods,
     getTradingQuotesByPaymentMethod,
     getUnusedAddressFromAccount,
     isCryptoIdForNativeToken,
@@ -141,45 +139,6 @@ describe('isCryptoIdForNativeToken', () => {
                 'base--0x0000000000000000000000000000000000000000' as CryptoId,
             ),
         ).toEqual(true);
-    });
-});
-
-describe('getTradingPaymentMethods', () => {
-    const duplicateApplePayQuoteWithWorseAmount = {
-        ...BUY_FIXTURE.MIN_MAX_QUOTES_OK[1],
-        receiveStringAmount: '0.00000001',
-    };
-    const paymentMethods = getTradingPaymentMethods([
-        ...BUY_FIXTURE.MIN_MAX_QUOTES_OK,
-        duplicateApplePayQuoteWithWorseAmount, // duplicate applePay
-    ]);
-
-    it('should get payment methods from quotes', () => {
-        const findApplePay = paymentMethods.find(
-            paymentMethod =>
-                paymentMethod.value === 'applePay' && paymentMethod.label === 'Apple Pay',
-        );
-
-        expect(paymentMethods.length).toBe(2);
-        expect(findApplePay).toBeDefined();
-    });
-
-    it('should sort payment methods by receive amount in descending order', () => {
-        const amounts = paymentMethods.map(method => new BigNumber(method.receiveAmount || '0'));
-        const sortedAmounts = [...amounts].sort((a, b) => b.minus(a).toNumber());
-
-        expect(amounts.map(amount => amount.toString())).toEqual(
-            sortedAmounts.map(amount => amount.toString()),
-        );
-    });
-
-    it('should keep first quote amount for duplicate payment method', () => {
-        const applePayMethod = paymentMethods.find(method => method.value === 'applePay');
-        const { MIN_MAX_QUOTES_OK } = BUY_FIXTURE;
-        // @ts-expect-error: indexing with noUncheckedIndexedAccess
-        const minMaxQuote: (typeof MIN_MAX_QUOTES_OK)[number] = MIN_MAX_QUOTES_OK[1];
-
-        expect(applePayMethod?.receiveAmount).toBe(minMaxQuote.receiveStringAmount);
     });
 });
 

--- a/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
+++ b/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
@@ -39,6 +39,7 @@ import {
     selectTradingBuyIsLoading,
     selectTradingBuyLastErrorMessage,
     selectTradingBuyLoadingTimestampAndStatus,
+    selectTradingBuyPaymentMethods,
     selectTradingBuyProviders,
     selectTradingBuyQuoteByOrderId,
     selectTradingBuyQuotes,
@@ -83,6 +84,7 @@ import {
     selectTradingSellIsFromRedirect,
     selectTradingSellLastErrorMessage,
     selectTradingSellLoadingTimestampAndStatus,
+    selectTradingSellPaymentMethods,
     selectTradingSellProviders,
     selectTradingSellQuotes,
     selectTradingSellQuotesByPaymentMethod,
@@ -1355,6 +1357,111 @@ describe('tradingSelectors', () => {
 
         it('should be stable', () => {
             expect(selectValidTradingSellQuotes(state)).toBe(selectValidTradingSellQuotes(state));
+        });
+    });
+
+    describe(selectTradingBuyPaymentMethods.name, () => {
+        const usdcCryptoId = 'ethereum--0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as CryptoId;
+        const buildBuyQuote = (overrides: Partial<BuyTrade>): BuyTrade => ({
+            fiatStringAmount: '10',
+            fiatCurrency: 'EUR',
+            receiveCurrency: 'bitcoin' as CryptoId,
+            receiveStringAmount: '5',
+            rate: 2,
+            paymentMethod: 'creditCard',
+            paymentMethodName: 'Credit Card',
+            quoteId: 'quoteId1',
+            ...overrides,
+        });
+
+        it('should resolve token symbol from coin info for ERC-20 quotes', () => {
+            state.wallet.trading.buy.quotes = [buildBuyQuote({ receiveCurrency: usdcCryptoId })];
+
+            expect(selectTradingBuyPaymentMethods(state)).toEqual([
+                expect.objectContaining({ value: 'creditCard', symbol: 'USDC' }),
+            ]);
+        });
+
+        it('should return undefined symbol when coin info is missing', () => {
+            state.wallet.trading.buy.quotes = [
+                buildBuyQuote({ receiveCurrency: 'ethereum--0xunknown' as CryptoId }),
+            ];
+
+            expect(selectTradingBuyPaymentMethods(state)).toEqual([
+                expect.objectContaining({ value: 'creditCard', symbol: undefined }),
+            ]);
+        });
+
+        it('should dedupe by paymentMethod and keep first quote', () => {
+            state.wallet.trading.buy.quotes = [
+                buildBuyQuote({ quoteId: 'first', receiveStringAmount: '5' }),
+                buildBuyQuote({ quoteId: 'second', receiveStringAmount: '0.0001' }),
+            ];
+
+            const result = selectTradingBuyPaymentMethods(state);
+
+            expect(result).toHaveLength(1);
+            expect(result[0]?.receiveAmount).toBe('5');
+        });
+
+        it('should sort by receiveAmount descending', () => {
+            state.wallet.trading.buy.quotes = [
+                buildBuyQuote({
+                    paymentMethod: 'bankTransfer',
+                    paymentMethodName: 'Bank Transfer',
+                    receiveStringAmount: '1',
+                }),
+                buildBuyQuote({
+                    paymentMethod: 'creditCard',
+                    receiveStringAmount: '10',
+                }),
+            ];
+
+            expect(selectTradingBuyPaymentMethods(state).map(m => m.value)).toEqual([
+                'creditCard',
+                'bankTransfer',
+            ]);
+        });
+
+        it('should skip quotes without paymentMethod', () => {
+            state.wallet.trading.buy.quotes = [
+                buildBuyQuote({ paymentMethod: '' as BuyTrade['paymentMethod'] }),
+            ];
+
+            expect(selectTradingBuyPaymentMethods(state)).toEqual([]);
+        });
+
+        it('should be stable', () => {
+            state.wallet.trading.buy.quotes = [buildBuyQuote({ receiveCurrency: usdcCryptoId })];
+
+            expect(selectTradingBuyPaymentMethods(state)).toBe(
+                selectTradingBuyPaymentMethods(state),
+            );
+        });
+    });
+
+    describe(selectTradingSellPaymentMethods.name, () => {
+        it('should set fiat currency as symbol', () => {
+            const quoteDraft = state.wallet.trading.sell.quotes[0];
+            state.wallet.trading.sell.quotes = [
+                {
+                    ...quoteDraft,
+                    rate: 20000,
+                    orderId: 'orderId1',
+                    fiatCurrency: 'EUR',
+                    paymentMethod: 'creditCard',
+                    paymentMethodName: 'Credit Card',
+                    fiatStringAmount: '100',
+                },
+            ];
+
+            expect(selectTradingSellPaymentMethods(state)).toEqual([
+                expect.objectContaining({
+                    value: 'creditCard',
+                    symbol: 'EUR',
+                    receiveAmount: '100',
+                }),
+            ]);
         });
     });
 

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -27,6 +27,7 @@ import {
     type GroupedTradingExchangeQuotes,
     groupTradingExchangeQuotesProjection,
 } from './utils/groupTradingExchangeQuotesProjection';
+import { paymentMethodsFromQuotesProjection } from './utils/paymentMethodsFromQuotesProjection';
 import { bestQuotePerPaymentMethodProjection } from './utils/quotePerPaymentMethodProjection';
 import { type BuyInfo, type TradingBuyState } from '../reducers/buyReducer';
 import { type ExchangeInfo, type TradingExchangeState } from '../reducers/exchangeReducer';
@@ -151,6 +152,9 @@ export const selectTradingBuyLoadingTimestampAndStatus = createMemoizedSelector(
 );
 
 export const selectTradingInfo = (state: TradingRootState) => state.wallet?.trading?.info;
+
+export const selectTradingCoins = (state: TradingRootState): Coins | undefined =>
+    state.wallet.trading.info.coins;
 
 export const selectTradingBuyInfo = createMemoizedSelector(
     [state => state.wallet.trading.buy.buyInfo],
@@ -404,29 +408,27 @@ export const selectDeviceHasTradingTrades = (state: TradingRootStateWithDeviceAn
 export const selectTradingTradeByOrderId = (state: TradingRootState, orderId: string | undefined) =>
     selectTradingTrades(state).find(t => orderId && t.data.orderId === orderId);
 
-export const selectTradingCoinInfoByCryptoId = (
-    state: TradingRootState,
-    cryptoId: CryptoId | undefined,
-) => {
-    if (!cryptoId) {
-        return undefined;
-    }
-    const { coins = {} } = state.wallet.trading.info;
+export const selectTradingCoinInfoByCryptoId = createMemoizedSelector(
+    [selectTradingCoins, (_: TradingRootState, cryptoId: CryptoId | undefined) => cryptoId],
+    (coins, cryptoId) => {
+        if (!cryptoId) {
+            return undefined;
+        }
 
-    return getTradingCoinInfoByCryptoId(coins, cryptoId);
-};
+        return getTradingCoinInfoByCryptoId(coins ?? {}, cryptoId);
+    },
+);
 
-export const selectTradingCoinSymbolByCryptoId = (
-    state: TradingRootState,
-    cryptoId: CryptoId | undefined,
-) => {
-    if (cryptoId === undefined) {
-        return undefined;
-    }
-    const { coins = {} } = state.wallet.trading.info;
+export const selectTradingCoinSymbolByCryptoId = createMemoizedSelector(
+    [selectTradingCoins, (_: TradingRootState, cryptoId: CryptoId | undefined) => cryptoId],
+    (coins, cryptoId) => {
+        if (cryptoId === undefined) {
+            return undefined;
+        }
 
-    return getTradingCoinSymbolByCryptoId(coins, cryptoId);
-};
+        return getTradingCoinSymbolByCryptoId(coins ?? {}, cryptoId);
+    },
+);
 
 export const selectTradingPlatformByCryptoId = (
     state: TradingRootState,
@@ -440,14 +442,18 @@ export const selectTradingPlatformByCryptoId = (
     return getTradingPlatformsInfoByCryptoId(platforms, cryptoId);
 };
 
-export const selectTradingNativeCoinSymbolByCryptoId = (
+export const selectTradingNativeCoinSymbolByCryptoId: (
     state: TradingRootState,
     cryptoId: CryptoId,
-) => {
-    const { coins = {}, platforms = {} } = state.wallet.trading.info;
-
-    return getTradingNativeCoinSymbolByCryptoId(platforms, coins, cryptoId);
-};
+) => string | undefined = createMemoizedSelector(
+    [
+        selectTradingCoins,
+        ({ wallet }: TradingRootState) => wallet.trading.info.platforms,
+        (_: TradingRootState, cryptoId: CryptoId) => cryptoId,
+    ],
+    (coins, platforms, cryptoId) =>
+        getTradingNativeCoinSymbolByCryptoId(platforms ?? {}, coins ?? {}, cryptoId),
+);
 
 export const selectTradingSymbolAndContractAddressByCryptoId: (
     state: TradingRootState,
@@ -456,10 +462,7 @@ export const selectTradingSymbolAndContractAddressByCryptoId: (
     coinSymbol: NetworkSymbolExtended | undefined;
     contractAddress: string | undefined;
 } = createMemoizedSelector(
-    [
-        ({ wallet }: TradingRootState, _: CryptoId): Coins | undefined => wallet.trading.info.coins,
-        (_: TradingRootState, cryptoId: CryptoId): CryptoId => cryptoId,
-    ],
+    [selectTradingCoins, (_: TradingRootState, cryptoId: CryptoId): CryptoId => cryptoId],
     getTradingSymbolAndContractAddressByCryptoId,
 );
 
@@ -491,7 +494,7 @@ const getFilteredCryptoIds = (
 
 export const selectTradingBuySupportedCryptoIds = createMemoizedSelector(
     [
-        ({ wallet }) => wallet.trading.info.coins,
+        selectTradingCoins,
         ({ wallet }) => wallet.trading.info.platforms,
         ({ wallet }) =>
             returnStableArrayIfEmpty<CryptoId>(
@@ -504,7 +507,7 @@ export const selectTradingBuySupportedCryptoIds = createMemoizedSelector(
 
 export const selectTradingSellSupportedCryptoIds = createMemoizedSelector(
     [
-        ({ wallet }) => wallet.trading.info.coins,
+        selectTradingCoins,
         ({ wallet }) => wallet.trading.info.platforms,
         ({ wallet }) =>
             returnStableArrayIfEmpty<CryptoId>(
@@ -518,7 +521,7 @@ export const selectTradingSellSupportedCryptoIds = createMemoizedSelector(
 const createExchangeCryptoIdsSelector = (key: 'buyCryptoIds' | 'sellCryptoIds') =>
     createMemoizedSelector(
         [
-            ({ wallet }) => wallet.trading.info.coins,
+            selectTradingCoins,
             ({ wallet }) => wallet.trading.info.platforms,
             ({ wallet }) =>
                 returnStableArrayIfEmpty<CryptoId>(wallet.trading.exchange.exchangeInfo?.[key]),
@@ -531,7 +534,7 @@ export const selectTradingExchangeBuyCryptoIds = createExchangeCryptoIdsSelector
 
 export const selectTradingSellSellCryptoIds = createMemoizedSelector(
     [
-        ({ wallet }) => wallet.trading.info.coins,
+        selectTradingCoins,
         ({ wallet }) => wallet.trading.info.platforms,
         ({ wallet }) => wallet.trading.sell.sellInfo?.supportedCryptoCurrencies,
     ],
@@ -673,6 +676,26 @@ export const selectValidTradingSellQuotes = createMemoizedSelector(
 
         return quotes.filter(item => item.rate && item.rate !== 0);
     },
+);
+
+export const selectTradingBuyPaymentMethods = createMemoizedSelector(
+    [selectValidTradingBuyQuotes, selectTradingCoins],
+    (quotes, coins) =>
+        paymentMethodsFromQuotesProjection(quotes, quote => ({
+            receiveAmount: quote.receiveStringAmount,
+            symbol: quote.receiveCurrency
+                ? getTradingCoinSymbolByCryptoId(coins ?? {}, quote.receiveCurrency)
+                : undefined,
+        })),
+);
+
+export const selectTradingSellPaymentMethods = createMemoizedSelector(
+    [selectValidTradingSellQuotes],
+    quotes =>
+        paymentMethodsFromQuotesProjection(quotes, quote => ({
+            receiveAmount: quote.fiatStringAmount,
+            symbol: quote.fiatCurrency,
+        })),
 );
 
 export const selectTradingBuyAccountKey = (state: TradingRootState) =>

--- a/suite-common/trading/src/selectors/utils/__tests__/paymentMethodsFromQuotesProjection.test.ts
+++ b/suite-common/trading/src/selectors/utils/__tests__/paymentMethodsFromQuotesProjection.test.ts
@@ -1,0 +1,98 @@
+import { paymentMethodsFromQuotesProjection } from '../paymentMethodsFromQuotesProjection';
+
+type TestQuote = {
+    orderId: string;
+    paymentMethod?: string;
+    paymentMethodName?: string;
+    amount: string;
+    symbol?: string;
+};
+
+const extract = (quote: TestQuote) => ({ receiveAmount: quote.amount, symbol: quote.symbol });
+
+describe(paymentMethodsFromQuotesProjection.name, () => {
+    it('keeps the first quote for each payment method and sorts by receiveAmount descending', () => {
+        const quotes: TestQuote[] = [
+            {
+                orderId: 'bank-1',
+                paymentMethod: 'bankTransfer',
+                paymentMethodName: 'Bank Transfer',
+                amount: '1',
+                symbol: 'BTC',
+            },
+            {
+                orderId: 'card-best',
+                paymentMethod: 'creditCard',
+                paymentMethodName: 'Credit Card',
+                amount: '10',
+                symbol: 'BTC',
+            },
+            {
+                orderId: 'card-worse',
+                paymentMethod: 'creditCard',
+                paymentMethodName: 'Credit Card',
+                amount: '0.0001',
+                symbol: 'BTC',
+            },
+        ];
+
+        const result = paymentMethodsFromQuotesProjection(quotes, extract);
+
+        expect(result).toEqual([
+            {
+                value: 'creditCard',
+                label: 'Credit Card',
+                receiveAmount: '10',
+                symbol: 'BTC',
+            },
+            {
+                value: 'bankTransfer',
+                label: 'Bank Transfer',
+                receiveAmount: '1',
+                symbol: 'BTC',
+            },
+        ]);
+    });
+
+    it('falls back to paymentMethod when paymentMethodName is missing', () => {
+        const result = paymentMethodsFromQuotesProjection(
+            [
+                {
+                    orderId: 'q1',
+                    paymentMethod: 'creditCard',
+                    amount: '1',
+                    symbol: 'BTC',
+                },
+            ],
+            extract,
+        );
+
+        expect(result[0]?.label).toBe('creditCard');
+    });
+
+    it('skips quotes without a paymentMethod', () => {
+        const result = paymentMethodsFromQuotesProjection(
+            [{ orderId: 'q1', amount: '1', symbol: 'BTC' }],
+            extract,
+        );
+
+        expect(result).toEqual([]);
+    });
+
+    it('passes through undefined symbol from extract', () => {
+        const result = paymentMethodsFromQuotesProjection(
+            [
+                {
+                    orderId: 'q1',
+                    paymentMethod: 'creditCard',
+                    paymentMethodName: 'Credit Card',
+                    amount: '1',
+                    symbol: undefined,
+                },
+            ],
+            extract,
+        );
+
+        expect(result[0]?.symbol).toBeUndefined();
+    });
+});

--- a/suite-common/trading/src/selectors/utils/paymentMethodsFromQuotesProjection.ts
+++ b/suite-common/trading/src/selectors/utils/paymentMethodsFromQuotesProjection.ts
@@ -1,0 +1,32 @@
+import { BigNumber } from '@trezor/utils';
+
+import { type TradingPaymentMethodListProps } from '../../types';
+
+type QuoteForPaymentMethod = {
+    paymentMethod?: string;
+    paymentMethodName?: string;
+};
+
+export const paymentMethodsFromQuotesProjection = <TQuote extends QuoteForPaymentMethod>(
+    quotes: TQuote[],
+    extract: (quote: TQuote) => Pick<TradingPaymentMethodListProps, 'receiveAmount' | 'symbol'>,
+): TradingPaymentMethodListProps[] => {
+    const methods = new Map<string, TradingPaymentMethodListProps>();
+    quotes.forEach(quote => {
+        const { paymentMethod } = quote;
+        if (!paymentMethod || methods.has(paymentMethod)) {
+            return;
+        }
+        methods.set(paymentMethod, {
+            value: paymentMethod as TradingPaymentMethodListProps['value'],
+            label: quote.paymentMethodName ?? paymentMethod,
+            ...extract(quote),
+        });
+    });
+
+    return Array.from(methods.values()).sort((a, b) =>
+        new BigNumber(b.receiveAmount || '0')
+            .minus(new BigNumber(a.receiveAmount || '0'))
+            .toNumber(),
+    );
+};

--- a/suite-common/trading/src/thunks/buy/__tests__/handleBuyRequestThunk.test.ts
+++ b/suite-common/trading/src/thunks/buy/__tests__/handleBuyRequestThunk.test.ts
@@ -22,6 +22,7 @@ import { buyThunks } from '../index';
 const tradingReducer = prepareTradingReducer(extraDependenciesCommonMock);
 const createMockQuotes = () =>
     [...MIN_MAX_QUOTES_OK, ...ALTERNATIVE_QUOTES].map(quote => ({ ...quote }));
+const usdcCryptoId = 'ethereum--0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as CryptoId;
 
 describe('handleBuyRequestThunk', () => {
     afterEach(() => {
@@ -33,7 +34,10 @@ describe('handleBuyRequestThunk', () => {
     invityAPI.setInvityServersEnvironment = () => {};
     invityAPI.createInvityAPIKey = () => {};
 
-    const getMocks = (refetchQuotesOverride?: Partial<QuoteRefetchingState>) => {
+    const getMocks = (
+        refetchQuotesOverride?: Partial<QuoteRefetchingState>,
+        coinsOverride?: NonNullable<typeof initialState.info.coins>,
+    ) => {
         const store = configureMockStore({
             extra: {},
             reducer: combineReducers({
@@ -58,6 +62,7 @@ describe('handleBuyRequestThunk', () => {
                                         exchange: false,
                                     },
                                 },
+                                ...coinsOverride,
                             },
                         },
                         quoteRefetchingState: {
@@ -143,6 +148,57 @@ describe('handleBuyRequestThunk', () => {
             expect.objectContaining(mockQuotes[1]),
             expect.objectContaining(mockQuotes[6]),
         ]);
+    });
+
+    it('should resolve payment method symbol from trading coin info', async () => {
+        const { input, store } = getMocks();
+
+        invityAPI.getBuyQuotes = () => Promise.resolve(createMockQuotes());
+
+        await store.dispatch(buyThunks.handleRequestThunk(input)).unwrap();
+
+        expect(store.getState().wallet.trading.info.paymentMethods).toEqual(
+            expect.arrayContaining([expect.objectContaining({ symbol: 'BTC' })]),
+        );
+    });
+
+    it('should leave symbol undefined when coin info is missing for the receiveCurrency', async () => {
+        const { input, store } = getMocks();
+        const mockQuotes = createMockQuotes().map(quote => ({
+            ...quote,
+            receiveCurrency: usdcCryptoId,
+        }));
+
+        invityAPI.getBuyQuotes = () => Promise.resolve(mockQuotes);
+
+        await store.dispatch(buyThunks.handleRequestThunk(input)).unwrap();
+
+        expect(store.getState().wallet.trading.info.paymentMethods).toEqual(
+            expect.arrayContaining([expect.objectContaining({ symbol: undefined })]),
+        );
+    });
+
+    it('should use token symbol from coin info for ERC-20 receiveCurrency', async () => {
+        const { input, store } = getMocks(undefined, {
+            [usdcCryptoId]: {
+                symbol: 'usdc',
+                name: 'USD Coin',
+                coingeckoId: 'usd-coin',
+                services: { buy: true, sell: false, exchange: false },
+            },
+        });
+        const mockQuotes = createMockQuotes().map(quote => ({
+            ...quote,
+            receiveCurrency: usdcCryptoId,
+        }));
+
+        invityAPI.getBuyQuotes = () => Promise.resolve(mockQuotes);
+
+        await store.dispatch(buyThunks.handleRequestThunk(input)).unwrap();
+
+        expect(store.getState().wallet.trading.info.paymentMethods).toEqual(
+            expect.arrayContaining([expect.objectContaining({ symbol: 'USDC' })]),
+        );
     });
 
     it.each([

--- a/suite-common/trading/src/thunks/buy/handleBuyRequestThunk.ts
+++ b/suite-common/trading/src/thunks/buy/handleBuyRequestThunk.ts
@@ -9,6 +9,7 @@ import { invityAPI } from '../../invityAPI';
 import { tradingBuyActions } from '../../reducers/buyReducer';
 import { tradingActions } from '../../reducers/tradingCommonReducer';
 import {
+    selectTradingBuyPaymentMethods,
     selectTradingBuyQuotesRequest,
     selectTradingCoinSymbolByCryptoId,
 } from '../../selectors/tradingSelectors';
@@ -17,7 +18,6 @@ import {
     addIdsToQuotes,
     filterQuotesAccordingTags,
     getNetworkDecimalsWithFallback,
-    getTradingPaymentMethods,
     tradingGetSuccessQuotes,
 } from '../../utils';
 import { buyUtils } from '../../utils/buy/buyUtils';
@@ -141,7 +141,6 @@ export const handleBuyRequestThunk = createThunk<
         );
         // without errors
         const quotesSuccess = tradingGetSuccessQuotes<TradingBuyType>(quotesDefault);
-        const paymentMethodsFromQuotes = getTradingPaymentMethods(quotesSuccess);
 
         const symbol =
             selectTradingCoinSymbolByCryptoId(getState(), requestData.receiveCurrency) ??
@@ -152,10 +151,10 @@ export const handleBuyRequestThunk = createThunk<
             currency: symbol,
         }); // from all quotes except alternative
 
-        dispatch(tradingBuyActions.setAmountLimits(limits));
         dispatch(tradingBuyActions.saveQuotes(quotesSuccess));
+        dispatch(tradingBuyActions.setAmountLimits(limits));
         dispatch(tradingBuyActions.saveQuoteRequest(requestData));
-        dispatch(tradingActions.savePaymentMethods(paymentMethodsFromQuotes));
+        dispatch(tradingActions.savePaymentMethods(selectTradingBuyPaymentMethods(getState())));
         dispatch(tradingActions.setRefetchQuotesTimestamp(Date.now()));
 
         return fulfillWithValue(quotesSuccess);

--- a/suite-common/trading/src/thunks/sell/handleSellRequestThunk.ts
+++ b/suite-common/trading/src/thunks/sell/handleSellRequestThunk.ts
@@ -8,7 +8,10 @@ import { TRADING_DEFAULT_SELL_FLOWS, TRADING_SELL_THUNK_PREFIX } from '../../con
 import { invityAPI } from '../../invityAPI';
 import { tradingSellActions } from '../../reducers/sellReducer';
 import { tradingActions } from '../../reducers/tradingCommonReducer';
-import { selectTradingCoinSymbolByCryptoId } from '../../selectors/tradingSelectors';
+import {
+    selectTradingCoinSymbolByCryptoId,
+    selectTradingSellPaymentMethods,
+} from '../../selectors/tradingSelectors';
 import {
     type HandleSellRequestThunkProps,
     type MinimalSellFormProps,
@@ -18,7 +21,6 @@ import {
     addIdsToQuotes,
     filterQuotesAccordingTags,
     getNetworkDecimalsWithFallback,
-    getTradingPaymentMethods,
     tradingGetSuccessQuotes,
 } from '../../utils';
 import { isCountrySubdivisionEmpty } from '../../utils/countryUtils';
@@ -156,11 +158,9 @@ export const handleSellRequestThunk = createThunk<
         // without errors
         const successQuotes = tradingGetSuccessQuotes<TradingSellType>(quotesDefault);
 
-        const paymentMethodsFromQuotes = getTradingPaymentMethods(successQuotes);
-
         dispatch(tradingSellActions.saveQuotes(successQuotes));
         dispatch(tradingSellActions.saveQuoteRequest(requestData));
-        dispatch(tradingActions.savePaymentMethods(paymentMethodsFromQuotes));
+        dispatch(tradingActions.savePaymentMethods(selectTradingSellPaymentMethods(getState())));
         dispatch(tradingSellActions.setAmountLimits(limits));
 
         const { setMaxOutputId } = formValues;

--- a/suite-common/trading/src/utils.ts
+++ b/suite-common/trading/src/utils.ts
@@ -24,7 +24,6 @@ import type { Account, AccountKey, FormStateTrading } from '@suite-common/wallet
 import { getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils';
 import { type TokenInfo } from '@trezor/connect';
 import { exhaustive } from '@trezor/type-utils';
-import { BigNumber } from '@trezor/utils';
 
 import {
     CONTRACT_ADDRESS_FOR_NATIVE_TOKEN,
@@ -37,7 +36,6 @@ import {
     type TradingCountrySubdivisionOption,
     type TradingExchangeType,
     type TradingParsedCryptoIdProps,
-    type TradingPaymentMethodListProps,
     type TradingPaymentMethodProps,
     type TradingProviderInfo,
     type TradingSellType,
@@ -271,35 +269,6 @@ export const getNetworkDecimalsWithFallback = (
     symbol: NetworkSymbol | undefined,
     fallback = getNetwork('btc').decimals,
 ): number => (symbol ? (getNetwork(symbol).decimals ?? fallback) : fallback);
-
-export const getTradingPaymentMethods = (
-    quotes: BuyTrade[] | SellFiatTrade[],
-): TradingPaymentMethodListProps[] => {
-    const uniqueMethods = new Map<string, TradingPaymentMethodListProps>();
-
-    quotes.forEach(quote => {
-        if (!quote.paymentMethod) return;
-        if (uniqueMethods.has(quote.paymentMethod)) return;
-        const amount = isBuyTrade(quote) ? quote.receiveStringAmount : quote.fiatStringAmount;
-        uniqueMethods.set(quote.paymentMethod, {
-            value: quote.paymentMethod,
-            label: quote.paymentMethodName ?? quote.paymentMethod,
-            receiveAmount: amount,
-            symbol: isBuyTrade(quote)
-                ? cryptoIdToSymbol(quote.receiveCurrency)
-                : (quote as SellFiatTrade).fiatCurrency,
-        });
-    });
-
-    const sortedMethods = Array.from(uniqueMethods.values()).sort((a, b) => {
-        const aAmount = new BigNumber(a.receiveAmount || '0');
-        const bAmount = new BigNumber(b.receiveAmount || '0');
-
-        return bAmount.minus(aAmount).toNumber();
-    });
-
-    return sortedMethods;
-};
 
 export const getTradingQuotesByPaymentMethod = <T extends TradingTradeBuySellType>(
     quotes: TradingTradeMapProps[T][],


### PR DESCRIPTION
## Description

- use the selected buy asset display symbol for payment method entries in the payment selector
- avoid deriving the payment selector symbol from `quote.receiveCurrency` when buy quotes point to a token on a parent network
- keep the existing fallback chain for cases where the selected asset display symbol is not available
- add thunk coverage for selected-symbol, coin-info fallback, and quote fallback behavior

## Notes for QA

- In Trading > Buy, select a token such as USDC and open the payment selector; verify the amount ticker matches the selected asset instead of the parent network ticker.


## Related Issue

Resolve #28293

## Screenshots:

<img width="532" height="413" alt="image" src="https://github.com/user-attachments/assets/ffc8573b-0739-4a37-9434-81fbdf3e9c69" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are scoped to handleBuyRequestThunk.ts and its unit test — the thunk responsible for processing buy trade requests in the trading/coinmarket feature. The static mapping shows 121 tests referencing this file, but that's because it's bundled into the broad trading module imported transitively by nearly all E2E tests. Only the buy-related trading tests directly exercise this thunk's behavior. The unit test file has no E2E coverage (as expected for a unit test). The recommended strategy is to run the three buy flow E2E tests at high priority since they directly validate trade request submission, and include navigation and negative tests at medium priority for broader buy-flow confidence.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/trading/src/thunks/buy/__tests__/handleBuyRequestThunk.test.ts`
- `suite-common/trading/src/thunks/buy/handleBuyRequestThunk.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — This test directly exercises the buy BTC flow including confirming a buy trade, which is the primary user-facing behavior powered by handleBuyRequestThunk. Changes to how buy trade requests are handled would directly affect the trade confirmation, payload construction, and redirect behavior tested here.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — This test exercises the buy ETH flow including trade confirmation and success status verification. The handleBuyRequestThunk is responsible for processing buy trade requests, and this test validates the complete buy flow for Ethereum including payload submission and transaction detail display.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — This test exercises buying a Solana token (JUP) and explicitly validates the buy trade request payload sent to the Invity backend, which is constructed and dispatched by handleBuyRequestThunk. Any changes to payload structure or request handling would be caught here.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/trading/buy-negative.test.ts` — This test covers buy form error states including empty quotes and disabled best offer button. While it focuses on validation rather than trade submission, the buy flow infrastructure including quote handling touches handleBuyRequestThunk's domain.
- `suite/e2e/tests/trading/navigation.test.ts` — This test validates navigation to the Buy trading form from multiple entry points and verifies the buy form opens correctly for various cryptocurrencies. While it doesn't submit trades, it exercises the buy form initialization which may be affected by changes to the buy request thunk infrastructure.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/trading/src/thunks/buy/__tests__/handleBuyRequestThunk.test.ts`

_Updated: 2026-06-02T15:43:38.210Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trading-buy-payment-selector-ticker-28293&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trading-buy-payment-selector-ticker-28293&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/trading-buy-payment-selector-ticker-28293&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-03T07:37:19.090Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-03T07:19:56.000Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/trading-buy-payment-selector-ticker-28293/web/](https://dev.suite.sldev.cz/suite-web/fix/trading-buy-payment-selector-ticker-28293/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->