### PR TITLE
feat(suite-desktop): transaction card responsiveness 

### DIFF
--- a/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
@@ -194,7 +194,7 @@ export const TransactionItem = memo(
                                                 }}
                                                 isDisabled={disableBumpFee}
                                                 data-testid="@transaction-item/bump-fee-button"
-                                                size="small"
+                                                size="medium"
                                             >
                                                 <Translation id="TR_BUMP_FEE" />
                                             </Button>
@@ -211,7 +211,7 @@ export const TransactionItem = memo(
                                                 });
                                                 e.stopPropagation();
                                             }}
-                                            size="small"
+                                            size="medium"
                                         >
                                             <Translation id="TR_CANCEL_TX" />
                                         </Button>

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionLayout.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionLayout.tsx
@@ -21,7 +21,7 @@ export const TransactionLayout = ({
     icon,
     children,
 }: TransactionLayoutProps) => {
-    const { isBelowLaptop } = useLayoutSize();
+    const { isBelowLaptop, isBelowTablet } = useLayoutSize();
 
     return (
         <Card onClick={onClick} paddingType="none">
@@ -47,11 +47,11 @@ export const TransactionLayout = ({
 
                     <Grid
                         columns={
-                            isBelowLaptop
+                            isBelowTablet
                                 ? '1fr max-content'
                                 : '1fr max-content minmax(110px, max-content)'
                         }
-                        rowGap={isBelowLaptop ? 12 : 4}
+                        rowGap={isBelowTablet ? 12 : 4}
                         columnGap={24}
                         flex="1"
                     >

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionLayout.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionLayout.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode } from 'react';
 
-import { Card, Column, Grid, InfoSegments, Row, Text } from '@trezor/components';
+import { Card, Column, Flex, Grid, InfoSegments, Row, Text } from '@trezor/components';
 
 import { useLayoutSize } from 'src/hooks/suite';
 
@@ -21,13 +21,19 @@ export const TransactionLayout = ({
     icon,
     children,
 }: TransactionLayoutProps) => {
-    const { isBelowLaptop, isAboveMobile } = useLayoutSize();
+    const { isBelowLaptop } = useLayoutSize();
 
     return (
         <Card onClick={onClick} paddingType="none">
-            <Row gap={24} padding={{ vertical: 20, horizontal: 24 }}>
-                {isAboveMobile && icon}
-                <Column flex="1" gap={6}>
+            <Flex
+                gap={isBelowLaptop ? 12 : 24}
+                padding={{ vertical: 20, horizontal: 24 }}
+                alignItems="flex-start"
+                direction={isBelowLaptop ? 'column' : 'row'}
+                flexWrap="nowrap"
+            >
+                {icon}
+                <Column flex="1" gap={6} width="100%">
                     <Row justifyContent="space-between" gap={24}>
                         <InfoSegments intent="neutral" priority="secondary">
                             <Text typographyStyle="body-md-strong" intent="neutral" as="div">
@@ -37,7 +43,6 @@ export const TransactionLayout = ({
                                 {timestamp}
                             </Text>
                         </InfoSegments>
-                        {actions}
                     </Row>
 
                     <Grid
@@ -52,8 +57,9 @@ export const TransactionLayout = ({
                     >
                         {children}
                     </Grid>
+                    {actions}
                 </Column>
-            </Row>
+            </Flex>
         </Card>
     );
 };

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionRow.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionRow.tsx
@@ -46,7 +46,6 @@ export const CustomRow = ({
                     value={amount}
                     symbol={transaction.symbol}
                     signValue={sign}
-                    signGrayscale
                 />
             }
             fiatAmount={

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
@@ -114,7 +114,6 @@ export const TransactionTarget = ({
                         value={amount}
                         symbol={transaction.symbol}
                         signValue={operation}
-                        signGrayscale
                     />
                 ) : undefined;
             case 'token':
@@ -123,7 +122,6 @@ export const TransactionTarget = ({
                         transfer={payload}
                         withLink={false}
                         withSign
-                        signGrayscale
                         alignMultitoken="flex-end"
                     />
                 );

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTargetLayout.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTargetLayout.tsx
@@ -22,7 +22,7 @@ export const TransactionTargetLayout = ({
     useHiddenPlaceholder,
     isPhishingTransaction,
 }: TransactionTargetLayoutProps) => {
-    const { isBelowLaptop } = useLayoutSize();
+    const { isBelowTablet } = useLayoutSize();
 
     const commonProps = {
         typographyStyle: 'body-md',
@@ -59,7 +59,7 @@ export const TransactionTargetLayout = ({
                 )}
             </Text>
 
-            {isBelowLaptop ? <Column>{amounts}</Column> : amounts}
+            {isBelowTablet ? <Column>{amounts}</Column> : amounts}
         </>
     );
 };

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTargetLayout.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTargetLayout.tsx
@@ -31,9 +31,14 @@ export const TransactionTargetLayout = ({
         as: 'div',
     } as const;
 
+    const cryptoAmountProps = {
+        ...commonProps,
+        priority: 'primary',
+    } as const;
+
     const amounts = (
         <>
-            <Text {...commonProps} align="end">
+            <Text {...cryptoAmountProps} align="end">
                 {amount && (
                     <BlurWrapper $isBlurred={isPhishingTransaction ?? false}>{amount}</BlurWrapper>
                 )}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR implements changes for transaction item component for suite-desktop described in the related issue.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26853

## Screenshots:

Desktop:
<img width="971" height="372" alt="Screenshot 2026-06-02 at 18 43 19" src="https://github.com/user-attachments/assets/e7b0e833-4773-4d58-8aef-0c8aea7324f6" />


Tablet:
<img width="774" height="432" alt="Screenshot 2026-06-02 at 18 43 27" src="https://github.com/user-attachments/assets/f2a0e706-4636-485c-8a3a-fe1aacb03d9a" />


Mobile:
<img width="525" height="466" alt="Screenshot 2026-06-02 at 18 43 36" src="https://github.com/user-attachments/assets/b35d4427-5844-4650-823e-c22bbb9d7446" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are focused on the TransactionItem component family (TransactionItem, TransactionLayout, TransactionRow, TransactionTarget, TransactionTargetLayout), which renders individual transaction rows in wallet account views. While these files are statically imported by 121 tests due to broad bundling, only tests that actually interact with the transaction list UI, transaction addresses, transaction output labels, or transaction amounts are meaningfully affected. The highest-risk tests are those that assert on transaction addresses, OP_RETURN targets, pagination of transactions, and output labeling — these directly exercise the changed rendering components. Medium-priority tests cover related output label features and discreet mode hiding of transaction amounts.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx`
- `packages/suite/src/components/wallet/TransactionItem/TransactionLayout.tsx`
- `packages/suite/src/components/wallet/TransactionItem/TransactionRow.tsx`
- `packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx`
- `packages/suite/src/components/wallet/TransactionItem/TransactionTargetLayout.tsx`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/wallet/transactions.test.ts` — This test directly exercises the transaction list UI — cycling through graph time ranges, finding transaction addresses, and searching transactions. The changed files (TransactionItem, TransactionTarget, TransactionTargetLayout, TransactionRow, TransactionLayout) are the core components that render each transaction row and its target addresses in the transaction list.
- `suite/e2e/tests/wallet/export-transactions.test.ts` — This test opens account pages with transaction histories and exports them in multiple formats. The transaction list must render correctly (using TransactionItem and its sub-components) for the export to capture the right data. A rendering failure in TransactionItem could break the export flow.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test verifies that after sending a transaction with OP_RETURN, the pending transaction list shows 'OP_RETURN (meow)' as a target address. This directly exercises TransactionTarget and TransactionTargetLayout rendering of special transaction output types in the transaction list.
- `suite/e2e/tests/wallet/pagination.test.ts` — This test navigates through paginated transaction lists and asserts on transaction addresses displayed on each page. The transactionAddress assertions directly depend on TransactionTarget/TransactionTargetLayout rendering the address text correctly within each TransactionItem row.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — This test adds, edits, and verifies labels on transaction outputs, and exports CSV containing output labels. Transaction output labels are rendered within TransactionTarget components, so changes to TransactionTarget or TransactionTargetLayout could break the label display or edit button positioning.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — This test sends BTC to regtest and verifies account balance updates. While focused on balances, it navigates wallet account pages where TransactionItem components render, and a crash in these components could prevent the page from loading correctly.
- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — Discreet mode hides balance values across the dashboard including account balances. TransactionItem and TransactionTargetLayout may render amounts that need to be hidden in discreet mode; changes could break the discreet placeholder rendering within transaction rows.
- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — This test creates and verifies output labels via Suite Sync. Output labels are rendered within TransactionTarget components in the transaction list, so changes to TransactionTarget could affect label display or the edit label button.
- `suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts` — This test removes output labels and verifies the UI reverts to a truncated address format. The truncated address display for transaction outputs is rendered by TransactionTarget/TransactionTargetLayout, making it sensitive to changes in these components.
- `suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — This test verifies that output labels synced from the Evolu relay are correctly displayed in the transaction view. The output label rendering depends on TransactionTarget components.

</details>

_Updated: 2026-06-02T16:47:02.840Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/tx-card-resp&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/tx-card-resp&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-02T16:53:32.515Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-02T16:49:48.603Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/tx-card-resp/web/](https://dev.suite.sldev.cz/suite-web/feat/tx-card-resp/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->