### PR TITLE
feat(trading): centralised inputs for txn recompose

### DIFF
--- a/suite-common/trading/src/thunks/common/__tests__/buildRecomposeInputsFromTrade.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/buildRecomposeInputsFromTrade.test.ts
@@ -1,0 +1,153 @@
+import { ETHEREUM_ADJUST_GAS_LIMIT } from '@suite-common/wallet-core';
+
+import { buildRecomposeInputsFromTrade } from '../buildRecomposeInputsFromTrade';
+
+const dexTx = {
+    from: '0xSender',
+    to: '0xSwapContract',
+    value: '1000000000000000000',
+    data: '0xdeadbeef',
+};
+
+describe('buildRecomposeInputsFromTrade', () => {
+    describe('sendAddress input', () => {
+        it('returns address, amount, destinationTag without sats conversion', () => {
+            const result = buildRecomposeInputsFromTrade({
+                sendAddress: '0xSendAddr',
+                sendStringAmount: '1.5',
+                partnerPaymentExtraId: 'memo-cex',
+                shouldSendInSats: false,
+                decimals: 8,
+            });
+
+            expect(result).toEqual({
+                address: '0xSendAddr',
+                amount: '1.5',
+                destinationTag: 'memo-cex',
+            });
+        });
+
+        it('converts amount to sats when shouldSendInSats is true', () => {
+            const result = buildRecomposeInputsFromTrade({
+                sendAddress: '0xSendAddr',
+                sendStringAmount: '1.5',
+                partnerPaymentExtraId: 'memo-cex',
+                shouldSendInSats: true,
+                decimals: 8,
+            });
+
+            expect(result.amount).toBe('150000000');
+        });
+
+        it('uses provided decimals when converting amount to subunits', () => {
+            const result = buildRecomposeInputsFromTrade({
+                sendAddress: '0xSendAddr',
+                sendStringAmount: '1.234567890123456789',
+                partnerPaymentExtraId: 'memo-cex',
+                shouldSendInSats: true,
+                decimals: 18,
+            });
+
+            expect(result.amount).toBe('1234567890123456789');
+        });
+
+        it('treats shouldSendInSats=undefined as false', () => {
+            const result = buildRecomposeInputsFromTrade({
+                sendAddress: '0xSendAddr',
+                sendStringAmount: '1.5',
+                partnerPaymentExtraId: 'memo-cex',
+                shouldSendInSats: undefined,
+                decimals: 8,
+            });
+
+            expect(result.amount).toBe('1.5');
+        });
+
+        it('does not set DEX-only fields', () => {
+            const result = buildRecomposeInputsFromTrade({
+                sendAddress: '0xSendAddr',
+                sendStringAmount: '1.5',
+                partnerPaymentExtraId: 'memo-cex',
+                shouldSendInSats: false,
+                decimals: 8,
+            });
+
+            expect(result.transactionData).toBeUndefined();
+            expect(result.ethereumAdjustGasLimit).toBeUndefined();
+            expect(result.recalculateCustomLimit).toBeUndefined();
+        });
+    });
+
+    describe('dexTx input', () => {
+        it('returns dexTx.to/value, destinationTag, DEX-only fields', () => {
+            const result = buildRecomposeInputsFromTrade({
+                dexTx,
+                partnerPaymentExtraId: 'memo-dex',
+                serializedTx: '0xabcd',
+            });
+
+            expect(result).toEqual({
+                address: '0xSwapContract',
+                amount: '1000000000000000000',
+                destinationTag: 'memo-dex',
+                transactionData: '0xabcd',
+                ethereumAdjustGasLimit: ETHEREUM_ADJUST_GAS_LIMIT,
+                recalculateCustomLimit: true,
+            });
+        });
+
+        it('forwards undefined serializedTx without synthesizing a default', () => {
+            const result = buildRecomposeInputsFromTrade({
+                dexTx,
+                partnerPaymentExtraId: 'memo-dex',
+                serializedTx: undefined,
+            });
+
+            expect(result.transactionData).toBeUndefined();
+        });
+    });
+
+    describe('destinationAddress input', () => {
+        it('returns destinationAddress, amount, destinationTag without sats conversion', () => {
+            const result = buildRecomposeInputsFromTrade({
+                destinationAddress: 'bc1qDest',
+                cryptoStringAmount: '0.25',
+                destinationPaymentExtraId: 'memo-sell',
+                shouldSendInSats: false,
+                decimals: 8,
+            });
+
+            expect(result).toEqual({
+                address: 'bc1qDest',
+                amount: '0.25',
+                destinationTag: 'memo-sell',
+            });
+        });
+
+        it('converts amount to sats when shouldSendInSats is true', () => {
+            const result = buildRecomposeInputsFromTrade({
+                destinationAddress: 'bc1qDest',
+                cryptoStringAmount: '0.25',
+                destinationPaymentExtraId: 'memo-sell',
+                shouldSendInSats: true,
+                decimals: 8,
+            });
+
+            expect(result.amount).toBe('25000000');
+        });
+
+        it('does not set DEX-only fields', () => {
+            const result = buildRecomposeInputsFromTrade({
+                destinationAddress: 'bc1qDest',
+                cryptoStringAmount: '0.25',
+                destinationPaymentExtraId: 'memo-sell',
+                shouldSendInSats: false,
+                decimals: 8,
+            });
+
+            expect(result.transactionData).toBeUndefined();
+            expect(result.ethereumAdjustGasLimit).toBeUndefined();
+            expect(result.recalculateCustomLimit).toBeUndefined();
+        });
+    });
+});

--- a/suite-common/trading/src/thunks/common/buildRecomposeInputsFromTrade.ts
+++ b/suite-common/trading/src/thunks/common/buildRecomposeInputsFromTrade.ts
@@ -1,0 +1,95 @@
+import { type ExchangeTrade } from 'invity-api';
+
+import { ETHEREUM_ADJUST_GAS_LIMIT } from '@suite-common/wallet-core';
+import { asAmountUnit, unitsToSubunits } from '@suite-common/wallet-utils';
+import { exhaustive } from '@trezor/type-utils';
+import { BigNumber } from '@trezor/utils';
+
+import { type RecomposeAndSignTxThunkProps } from './recomposeAndSignTxThunk';
+
+export type RecomposeInputs = Pick<
+    RecomposeAndSignTxThunkProps,
+    | 'address'
+    | 'amount'
+    | 'destinationTag'
+    | 'transactionData'
+    | 'ethereumAdjustGasLimit'
+    | 'recalculateCustomLimit'
+>;
+
+export type TradeRecomposeInput =
+    // Exchange CEX trade.
+    | {
+          sendAddress: string;
+          sendStringAmount: string;
+          partnerPaymentExtraId: string | undefined;
+          shouldSendInSats: boolean | undefined;
+          decimals: number;
+      }
+    // Exchange DEX trade.
+    | {
+          dexTx: NonNullable<ExchangeTrade['dexTx']>;
+          partnerPaymentExtraId: string | undefined;
+          serializedTx: string | undefined;
+      }
+    // Sell trade.
+    | {
+          destinationAddress: string;
+          cryptoStringAmount: string;
+          destinationPaymentExtraId: string | undefined;
+          shouldSendInSats: boolean | undefined;
+          decimals: number;
+      };
+
+type GetRecomposeAmountParams = {
+    value: string;
+    shouldSendInSats: boolean | undefined;
+    decimals: number;
+};
+
+const getRecomposeAmount = ({ value, shouldSendInSats, decimals }: GetRecomposeAmountParams) =>
+    shouldSendInSats
+        ? unitsToSubunits({ value: asAmountUnit(new BigNumber(value)), decimals }).toString()
+        : value;
+
+export const buildRecomposeInputsFromTrade = (trade: TradeRecomposeInput): RecomposeInputs => {
+    if ('sendAddress' in trade) {
+        return {
+            address: trade.sendAddress,
+            amount: getRecomposeAmount({
+                value: trade.sendStringAmount,
+                shouldSendInSats: trade.shouldSendInSats,
+                decimals: trade.decimals,
+            }),
+            destinationTag: trade.partnerPaymentExtraId,
+        };
+    }
+
+    if ('dexTx' in trade) {
+        // after discussion with 1inch, adjust the gas limit by the factor of 1.25:
+        // swap can use different swap paths when mining tx than when estimating tx,
+        // and the geth gas estimate may be too low.
+        return {
+            address: trade.dexTx.to,
+            amount: trade.dexTx.value,
+            destinationTag: trade.partnerPaymentExtraId,
+            transactionData: trade.serializedTx,
+            ethereumAdjustGasLimit: ETHEREUM_ADJUST_GAS_LIMIT,
+            recalculateCustomLimit: true,
+        };
+    }
+
+    if ('destinationAddress' in trade) {
+        return {
+            address: trade.destinationAddress,
+            amount: getRecomposeAmount({
+                value: trade.cryptoStringAmount,
+                shouldSendInSats: trade.shouldSendInSats,
+                decimals: trade.decimals,
+            }),
+            destinationTag: trade.destinationPaymentExtraId,
+        };
+    }
+
+    return exhaustive(trade);
+};

--- a/suite-common/trading/src/thunks/exchange/__tests__/sendDexTransactionThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/sendDexTransactionThunk.test.ts
@@ -195,12 +195,66 @@ describe('sendDexTransactionThunk', () => {
 
         expect(result.meta.requestStatus).toEqual('fulfilled');
         expect(tradingThunks.recomposeAndSignTxThunk).toHaveBeenCalledTimes(1);
+        expect(
+            (tradingThunks.recomposeAndSignTxThunk as unknown as jest.Mock).mock.calls[0][0],
+        ).toEqual(
+            expect.objectContaining({
+                address: 'to',
+                amount: 'value',
+                destinationTag: 'partnerPaymentExtraId',
+                transactionData: 'data',
+                ethereumAdjustGasLimit: expect.any(String),
+                recalculateCustomLimit: true,
+            }),
+        );
         expect(store.getState().wallet.trading.trades).toEqual([]);
         expect(confirmExchangeTradeThunkSpy).toHaveBeenCalledTimes(1);
         expect(confirmTradeThunkArgs.trade?.approvalSendTxHash).toEqual('txid');
         expect(confirmTradeThunkArgs.trade?.status).toEqual('APPROVAL_PENDING');
         expect(nextStep).not.toHaveBeenCalled();
         expect(confirmTradeThunkArgs.nextStep).toBe(nextStep);
+    });
+
+    it('should base64→hex convert dexTx.data when account.networkType is solana', async () => {
+        const base64Data = Buffer.from('hello', 'utf8').toString('base64');
+        const expectedHex = Buffer.from(base64Data, 'base64').toString('hex');
+
+        const quote = getQuote();
+        const { store, returnUrl } = getMocks({
+            selectedQuote: {
+                ...quote,
+                dexTx: { ...quote.dexTx, data: base64Data },
+            } as TradingExchangeState['selectedQuote'],
+        });
+
+        const solanaAccount = { ...accountBtc, networkType: 'solana' } as Account;
+
+        (tradingThunks.recomposeAndSignTxThunk as unknown as jest.Mock) = jest
+            .fn()
+            .mockImplementation(
+                createThunk('@trading/thunk/recomposeAndSignTx', (_, { fulfillWithValue }) =>
+                    fulfillWithValue({ success: true, payload: { txid: 'txid' } }),
+                ),
+            );
+        (confirmExchangeTradeThunk as unknown as jest.Mock).mockImplementation(
+            createThunk('@trading-exchange/thunk/confirmTrade', () => undefined),
+        );
+
+        await store.dispatch(
+            exchangeThunks.sendDexTransactionThunk({
+                account: solanaAccount,
+                returnUrl,
+                nextStep: jest.fn(),
+                triggerAnalyticsTradeConfirmation: jest.fn(),
+                processResponseData: jest.fn(),
+                signAndPushSendFormTransaction: jest.fn(),
+            }),
+        );
+
+        expect(
+            (tradingThunks.recomposeAndSignTxThunk as unknown as jest.Mock).mock.calls[0][0]
+                .transactionData,
+        ).toBe(expectedHex);
     });
 
     it('should successfully call confirmTradeThunk for making trade', async () => {
@@ -246,6 +300,18 @@ describe('sendDexTransactionThunk', () => {
 
         expect(result.meta.requestStatus).toEqual('fulfilled');
         expect(tradingThunks.recomposeAndSignTxThunk).toHaveBeenCalledTimes(1);
+        expect(
+            (tradingThunks.recomposeAndSignTxThunk as unknown as jest.Mock).mock.calls[0][0],
+        ).toEqual(
+            expect.objectContaining({
+                address: 'to',
+                amount: 'value',
+                destinationTag: 'partnerPaymentExtraId',
+                transactionData: 'data',
+                ethereumAdjustGasLimit: expect.any(String),
+                recalculateCustomLimit: true,
+            }),
+        );
         expect(store.getState().wallet.trading.trades).toEqual([
             {
                 tradeType: 'exchange',

--- a/suite-common/trading/src/thunks/exchange/__tests__/sendTransactionThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/sendTransactionThunk.test.ts
@@ -320,6 +320,18 @@ describe('sendTransactionThunk', () => {
         expect(store.getState().wallet.trading.modalAccountKey).toBe(account.key);
         expect(sendDexTransactionThunkSpy).toHaveBeenCalledTimes(0);
         expect(tradingThunks.recomposeAndSignTxThunk).toHaveBeenCalledTimes(1);
+        const recomposeCallArg = (tradingThunks.recomposeAndSignTxThunk as unknown as jest.Mock)
+            .mock.calls[0][0];
+        expect(recomposeCallArg).toEqual(
+            expect.objectContaining({
+                address: '1',
+                amount: '1200000000',
+                destinationTag: undefined,
+            }),
+        );
+        expect(recomposeCallArg.transactionData).toBeUndefined();
+        expect(recomposeCallArg.ethereumAdjustGasLimit).toBeUndefined();
+        expect(recomposeCallArg.recalculateCustomLimit).toBeUndefined();
         expect(store.getState().wallet.trading.trades).toEqual([
             {
                 tradeType: 'exchange',

--- a/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts
@@ -2,7 +2,6 @@ import { isRejectedWithValue } from '@reduxjs/toolkit';
 import { type ExchangeTrade } from 'invity-api';
 
 import { createThunk } from '@suite-common/redux-utils';
-import { ETHEREUM_ADJUST_GAS_LIMIT } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 
 import { confirmExchangeTradeThunk } from './confirmExchangeTradeThunk';
@@ -18,6 +17,7 @@ import {
 import { type TradingSendRejectedProps } from '../../types';
 import { getTradingFormState } from '../../utils';
 import { tradingThunks } from '../common';
+import { buildRecomposeInputsFromTrade } from '../common/buildRecomposeInputsFromTrade';
 import { type RecomposeAndSignTxThunkProps } from '../common/recomposeAndSignTxThunk';
 
 export type SendDexTransactionThunkProps = {
@@ -96,21 +96,18 @@ export const sendDexTransactionThunk = createThunk<
             }
         }
 
-        // after discussion with 1inch, adjust the gas limit by the factor of 1.25
-        // swap can use different swap paths when mining tx than when estimating tx
-        // the geth gas estimate may be too low
+        const recomposeInputs = buildRecomposeInputsFromTrade({
+            dexTx: selectedQuote.dexTx,
+            partnerPaymentExtraId: selectedQuote.partnerPaymentExtraId,
+            serializedTx,
+        });
         const recomposeAndSignTx = await dispatch(
             tradingThunks.recomposeAndSignTxThunk({
                 account,
-                address: selectedQuote.dexTx.to,
-                amount: selectedQuote.dexTx.value,
-                destinationTag: selectedQuote.partnerPaymentExtraId,
-                recalculateCustomLimit: true,
-                ethereumAdjustGasLimit: ETHEREUM_ADJUST_GAS_LIMIT,
+                ...recomposeInputs,
                 setMaxOutputId,
                 signAndPushSendFormTransaction,
                 tradingFormState,
-                transactionData: serializedTx,
             }),
         );
 

--- a/suite-common/trading/src/thunks/exchange/sendTransactionThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/sendTransactionThunk.ts
@@ -2,7 +2,6 @@ import { isRejectedWithValue } from '@reduxjs/toolkit';
 import { type ExchangeTrade } from 'invity-api';
 
 import { createThunk } from '@suite-common/redux-utils';
-import { convertAmountUnitsToSubunits } from '@suite-common/wallet-utils';
 
 import { tradingThunks } from '../common';
 import {
@@ -20,6 +19,7 @@ import {
 } from '../../selectors/tradingSelectors';
 import { type TradingSendRejectedProps } from '../../types';
 import { getTradingFormState } from '../../utils';
+import { buildRecomposeInputsFromTrade } from '../common/buildRecomposeInputsFromTrade';
 
 export type SendTransactionThunkProps = {
     trade: ExchangeTrade | undefined;
@@ -99,17 +99,18 @@ export const sendTransactionThunk = createThunk<
             receiveAccountKey,
         });
 
-        const sendStringAmount = shouldSendInSats
-            ? convertAmountUnitsToSubunits(selectedTrade.sendStringAmount, decimals)
-            : selectedTrade.sendStringAmount;
-        const sendPaymentExtraId =
-            selectedTrade.partnerPaymentExtraId || trade?.partnerPaymentExtraId;
+        const recomposeInputs = buildRecomposeInputsFromTrade({
+            sendAddress,
+            sendStringAmount: selectedTrade.sendStringAmount,
+            partnerPaymentExtraId:
+                selectedTrade.partnerPaymentExtraId || trade?.partnerPaymentExtraId,
+            shouldSendInSats,
+            decimals,
+        });
         const recomposeAndSignTx = await dispatch(
             tradingThunks.recomposeAndSignTxThunk({
                 account,
-                address: sendAddress,
-                amount: sendStringAmount,
-                destinationTag: sendPaymentExtraId,
+                ...recomposeInputs,
                 signAndPushSendFormTransaction,
                 setMaxOutputId,
                 isSlip24Active,

--- a/suite-common/trading/src/thunks/sell/sendSellTransactionThunk.ts
+++ b/suite-common/trading/src/thunks/sell/sendSellTransactionThunk.ts
@@ -3,7 +3,6 @@ import { type SellFiatTrade } from 'invity-api';
 
 import { createThunk } from '@suite-common/redux-utils';
 import { type Account } from '@suite-common/wallet-types';
-import { convertAmountUnitsToSubunits } from '@suite-common/wallet-utils';
 
 import { TRADING_SELL_THUNK_PREFIX } from '../../constants';
 import { invityAPI } from '../../invityAPI';
@@ -17,6 +16,7 @@ import {
 import { type TradingSellFormProps } from '../../types';
 import { getTradingFormState } from '../../utils';
 import { tradingThunks } from '../common';
+import { buildRecomposeInputsFromTrade } from '../common/buildRecomposeInputsFromTrade';
 import { type RecomposeAndSignTxThunkProps } from '../common/recomposeAndSignTxThunk';
 
 export type SendSellTransactionThunkProps = {
@@ -70,17 +70,19 @@ export const sendSellTransactionThunk = createThunk(
             isSlip24Active,
             sendAccountKey: account.key,
         });
-        const cryptoStringAmount = shouldSendInSats
-            ? convertAmountUnitsToSubunits(selectedTrade.cryptoStringAmount, decimals)
-            : selectedTrade.cryptoStringAmount;
         const { destinationPaymentExtraId } = selectedTrade;
+        const recomposeInputs = buildRecomposeInputsFromTrade({
+            destinationAddress,
+            cryptoStringAmount: selectedTrade.cryptoStringAmount,
+            destinationPaymentExtraId,
+            shouldSendInSats,
+            decimals,
+        });
 
         const recomposeAndSignTx = await dispatch(
             tradingThunks.recomposeAndSignTxThunk({
                 account,
-                address: destinationAddress,
-                amount: cryptoStringAmount,
-                destinationTag: destinationPaymentExtraId,
+                ...recomposeInputs,
                 isSlip24Active,
                 signAndPushSendFormTransaction,
                 // when lockSendAmount is true, the amount should not be recomputed based on the maximum balance.


### PR DESCRIPTION
centralise txn recomposing 

## Notes for QA

Everything should work as before


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are focused on trading/exchange transaction thunks (sendDexTransactionThunk, sendTransactionThunk, sendSellTransactionThunk) and a shared utility (buildRecomposeInputsFromTrade). Although these files statically map to 121 tests each (indicating broad transitive imports), the actual behavioral impact is confined to swap and sell trading flows. The unit test files in the changeset cover the logic directly, but E2E tests for swap and sell flows should be prioritized to verify end-to-end transaction sending, device confirmation, and status tracking work correctly after these changes.

<details><summary><b>Changed files (7)</b></summary>

- `suite-common/trading/src/thunks/common/__tests__/buildRecomposeInputsFromTrade.test.ts`
- `suite-common/trading/src/thunks/common/buildRecomposeInputsFromTrade.ts`
- `suite-common/trading/src/thunks/exchange/__tests__/sendDexTransactionThunk.test.ts`
- `suite-common/trading/src/thunks/exchange/__tests__/sendTransactionThunk.test.ts`
- `suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts`
- `suite-common/trading/src/thunks/exchange/sendTransactionThunk.ts`
- `suite-common/trading/src/thunks/sell/sendSellTransactionThunk.ts`

</details>

**Recommended tests (14)**

<details><summary>🔴 <b>High priority (8)</b></summary>

- `suite/e2e/tests/trading/swap-coins.test.ts` — This test exercises the full swap flow including sending crypto to the swap provider, which directly invokes sendDexTransactionThunk and sendTransactionThunk. Changes to these thunks could break the swap confirmation, device prompt, and transaction sending logic.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — This test performs a SOL-to-USDC swap including sending the transaction and verifying toast notifications, directly exercising the exchange sendTransactionThunk and potentially buildRecomposeInputsFromTrade for transaction composition.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Tests swapping USDT token to BTC, which sends crypto through the exchange transaction thunks. This directly exercises sendTransactionThunk/sendDexTransactionThunk code paths.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Tests SPL token-to-token swap (USDT to USDC) including transaction sending and confirmation on device, directly exercising the exchange send transaction thunks.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — This test completes the full sell BTC flow including initiating the send transaction and verifying device prompt details. It directly exercises sendSellTransactionThunk and buildRecomposeInputsFromTrade.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Tests the full sell SOL flow including sending the transaction to the provider and verifying device confirmation, directly exercising sendSellTransactionThunk.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Tests selling ETH with custom gas fees through the full sell flow including device prompt confirmation, directly exercising sendSellTransactionThunk.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Tests selling an ERC-20 token (USDC) through the sell flow including send confirmation on device, directly exercising sendSellTransactionThunk.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Tests BTC-to-ETH swap with custom fee settings, verifying fee calculations and device display. Changes to buildRecomposeInputsFromTrade could affect how transaction inputs are composed with custom fees.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests ETH-to-BTC swap with custom Ethereum fee parameters (gas limit, max fee). Changes to buildRecomposeInputsFromTrade could affect how fee parameters flow through the swap transaction composition.
- `suite/e2e/tests/trading-live/live-swap-coin-to-token.test.ts` — Live swap test that exercises the real swap flow including transaction sending. While it uses live endpoints, the transaction sending logic goes through the same exchange thunks being modified.
- `suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts` — Live swap test for SPL token to native coin via CEX, exercising sendTransactionThunk code path with real exchange providers.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — Tests swap quote display for a disabled network asset. While it doesn't send a transaction, it exercises the swap form infrastructure that shares code with the changed thunks.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Tests sell form input validation and percentage calculations. While it doesn't complete a send transaction, changes to buildRecomposeInputsFromTrade could affect how max/percentage amounts are calculated in the sell form.

</details>

⚠️ **Changes with no test coverage (3)**
- `suite-common/trading/src/thunks/common/__tests__/buildRecomposeInputsFromTrade.test.ts`
- `suite-common/trading/src/thunks/exchange/__tests__/sendDexTransactionThunk.test.ts`
- `suite-common/trading/src/thunks/exchange/__tests__/sendTransactionThunk.test.ts`

_Updated: 2026-06-02T22:18:00.814Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=24120-trading---amount-in-tx-review-modal-doesnt-match-the-amount-on-trezor&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=24120-trading---amount-in-tx-review-modal-doesnt-match-the-amount-on-trezor&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=24120-trading---amount-in-tx-review-modal-doesnt-match-the-amount-on-trezor&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-02T22:24:53.522Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-02T22:21:51.016Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/24120-trading---amount-in-tx-review-modal-doesnt-match-the-amount-on-trezor/web/](https://dev.suite.sldev.cz/suite-web/24120-trading---amount-in-tx-review-modal-doesnt-match-the-amount-on-trezor/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->