### PR TITLE
fix(e2e): Fixed label migration test

### DIFF
--- a/suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts
+++ b/suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts
@@ -25,15 +25,7 @@ test.describe('Labeling migration', { tag: ['@T3W1', '@T3T1', '@desktopOnly'] },
         await metadataPage.enableLegacyLabeling(MetadataProvider.LOCAL);
     });
 
-    test('Migration from local file', async ({
-        page,
-        walletPage,
-        metadataPage,
-        device,
-        devicePrompt,
-        evoluClient,
-        settingsPage,
-    }) => {
+    test('Migration from local file', async ({ page, walletPage, metadataPage, evoluClient }) => {
         await test.step('Set up local file labeling', async () => {
             await walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }).click();
             await expect(
@@ -83,11 +75,6 @@ test.describe('Labeling migration', { tag: ['@T3W1', '@T3T1', '@desktopOnly'] },
 
         await test.step('Switch to Suite Sync labeling and confirm legacy label is migrated', async () => {
             await metadataPage.enableSuiteSync();
-            await settingsPage.navigateTo('application');
-            await metadataPage.migrateLabelsButton.click();
-            await metadataPage.migrateFromLocalFileButton.click();
-            await devicePrompt.confirmOnDevicePromptIsShown({ timeout: 30_000 });
-            await device.pressYes();
             await expect(
                 page.getByTestId('@toast/legacy-labeling-migration-success'),
             ).toHaveTranslation('TR_LABELING_MIGRATION_SUCCESS', {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is limited to a single E2E test file (legacy-to-suiteSync-migration.test.ts), so the primary risk is that the test itself is broken or no longer asserts correctly. The most critical action is running the changed test directly. Secondary risk is that shared page objects, fixtures, or helpers (metadataPage, evoluClient, enableSuiteSync, enableLegacyLabeling) may have been modified in ways that affect sibling Suite Sync and legacy migration tests. The recommended strategy is to run the changed test at high priority and a small set of closely related metadata/Suite Sync tests at medium/low priority.

<details><summary><b>Changed files (1)</b></summary>

- `suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts` — This is the exact test file that was changed. It must be run to verify the modifications are correct and the test itself passes.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts` — This test covers a closely related migration path — migrating legacy Dropbox labels to Suite Sync. It shares the same migration infrastructure (metadataPage, evoluClient, legacy labeling → Suite Sync flow) and could be affected if the change altered shared migration utilities or page object methods.
- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — This test exercises Suite Sync label creation and Evolu relay sync for accounts, wallets, addresses, and outputs — the same label types and sync infrastructure that the migration test validates post-migration. Changes to migration flow or shared metadataPage/evoluClient fixtures could surface here.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts` — This test uses the same Suite Sync and Evolu relay infrastructure (enableSuiteSync, evoluClient.expectInTable) for account/address/output labels. If the changed test modified shared fixtures or page object helpers, this test could be indirectly affected.

</details>

_Updated: 2026-06-03T05:34:30.327Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-nightly&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-nightly&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-03T08:16:34.489Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-03T08:13:23.448Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-e2e-nightly/web/](https://dev.suite.sldev.cz/suite-web/fix-e2e-nightly/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->