### PR TITLE
Nightly agent fixer: schema enforced on agent output

### DIFF
--- a/.github/workflows/test-suite-nightly-fix-agent.yml
+++ b/.github/workflows/test-suite-nightly-fix-agent.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Validate report
         run: |
-          if ! jq -e 'all(.fix_tasks[]; (.id | type == "string" and test("^fix-[0-9]{3}$") and (test("[\\r\\n]") | not)) and (.branch | type == "string" and test("^fix/nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}-[a-z0-9-]{1,40}$") and (test("[\\r\\n]") | not)))' report-download/report.json >/dev/null; then
+          if ! jq -e 'all(.fixTasks[]; (.id | type == "string" and test("^fix-[0-9]{3}$") and (test("[\\r\\n]") | not)) and (.branch | type == "string" and test("^fix/nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}-[a-z0-9-]{1,40}$") and (test("[\\r\\n]") | not)))' report-download/report.json >/dev/null; then
             echo "INVALID task id or branch found"
             exit 1
           fi
@@ -97,8 +97,8 @@ jobs:
         id: set-matrix
         run: |
           REPORT_FILE=report-download/report.json
-          MATRIX=$(jq -c '[.fix_tasks[].id]' "$REPORT_FILE")
-          HAS_TASKS=$(jq -r 'if (.fix_tasks | length) > 0 then "true" else "false" end' "$REPORT_FILE")
+          MATRIX=$(jq -c '[.fixTasks[].id]' "$REPORT_FILE")
+          HAS_TASKS=$(jq -r 'if (.fixTasks | length) > 0 then "true" else "false" end' "$REPORT_FILE")
           echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
           echo "has-tasks=$HAS_TASKS" >> $GITHUB_OUTPUT
 
@@ -246,7 +246,7 @@ jobs:
           TASK_ID: ${{ matrix.task-id }}
         run: |
           BRANCH=$(jq -r --arg id "$TASK_ID" \
-            'first(.fix_tasks[] | select(.id == $id) | .branch) // empty' "report-download/report.json")
+            'first(.fixTasks[] | select(.id == $id) | .branch) // empty' "report-download/report.json")
           if [ -z "$BRANCH" ]; then echo "Branch not found for task id: $TASK_ID" && exit 1; fi
           git checkout -b "$BRANCH"
           echo "BRANCH=$BRANCH" >> "$GITHUB_ENV"

--- a/packages/e2e-utils/src/fixBot/ANALYSIS_AGENT.md
+++ b/packages/e2e-utils/src/fixBot/ANALYSIS_AGENT.md
@@ -158,10 +158,10 @@ For each fix task assign:
 - **`branch`** — `"fix/nightly-<YYYY-MM-DD>-<slug>"` where `<slug>` is a short kebab-case
   summary of the root cause (e.g. `send-button-locator`, `receive-address-timeout`).
   Use today's date. Keep the slug under 40 characters.
-- **`root_cause`** — one sentence describing the underlying problem
-- **`fix_scope`** — one of: `TEST_CODE`, `LOCATOR_ADD`, `PRODUCT_BUG`, `INFRA`
+- **`rootCause`** — one sentence describing the underlying problem
+- **`fixScope`** — one of: `TEST_CODE`, `LOCATOR_ADD`, `PRODUCT_BUG`, `INFRA`
 - **`confidence`** — `HIGH`, `MEDIUM`, or `LOW`
-- **`fix_description`** — concrete description of what needs to change and where
+- **`fixDescription`** — concrete description of what needs to change and where
 - **`diagnosis`** — the full MD prose from Step 6 for every test that belongs to this fix
   task: error messages, stack traces, visual evidence descriptions, and root cause reasoning.
   Copy it verbatim from the diagnosis report. This is the only context the fix agent
@@ -176,25 +176,24 @@ For each fix task assign:
     - If the test carries `@webOnly`, do **not** add a `platform: "desktop"` entry for the same reason.
     - Only include a platform in `validations` if that platform actually ran the test.
 
-Tasks with `fix_scope` of `PRODUCT_BUG` or `INFRA` go into `skipped` instead of `fix_tasks`.
+## Step 8 — Return the structured report
 
-## Step 8 — Write report.json
-
-Write the following JSON structure to `packages/e2e-utils/src/fixBot/reports/report.json`.
+Do **not** write `report.json` to disk — the harness captures your final answer and writes
+it. Return a JSON object (validated against a matching JSON Schema) with:
 
 ```json
 {
-    "run_date": "<YYYY-MM-DD>",
-    "web_run_id": "<runId or null>",
-    "desktop_run_id": "<runId or null>",
-    "fix_tasks": [
+    "runDate": "<YYYY-MM-DD>",
+    "webRunId": "<runId or null>",
+    "desktopRunId": "<runId or null>",
+    "fixTasks": [
         {
             "id": "fix-001",
             "branch": "fix/nightly-<YYYY-MM-DD>-<slug>",
-            "root_cause": "<one sentence>",
-            "fix_scope": "TEST_CODE | LOCATOR_ADD",
+            "rootCause": "<one sentence>",
+            "fixScope": "TEST_CODE | LOCATOR_ADD",
             "confidence": "HIGH | MEDIUM | LOW",
-            "fix_description": "<what to change and where>",
+            "fixDescription": "<what to change and where>",
             "validations": [
                 {
                     "platform": "web | desktop",
@@ -206,9 +205,9 @@ Write the following JSON structure to `packages/e2e-utils/src/fixBot/reports/rep
     ],
     "skipped": [
         {
-            "root_cause": "<one sentence>",
-            "reason": "<fix_scope> — <brief explanation>",
-            "affected_tests": ["suite/e2e/tests/..."]
+            "rootCause": "<one sentence>",
+            "reason": "<fixScope> — <brief explanation>",
+            "affectedTests": ["suite/e2e/tests/..."]
         }
     ]
 }

--- a/packages/e2e-utils/src/fixBot/FIX_AGENT.md
+++ b/packages/e2e-utils/src/fixBot/FIX_AGENT.md
@@ -79,7 +79,7 @@ touch /tmp/preflight-marker
 Exit code 0 = already passing in pre-flight.
 Non-zero = failing — read the trace before deciding anything further (see below).
 
-**If all validations already pass in pre-flight:** write the status block (Step 4) with `result: "not_duplicated"` and stop — do not enter the fix loop.
+**If all validations already pass in pre-flight:** return the status block (Step 4) with `result: "not_duplicated"` and stop — do not enter the fix loop.
 
 ### Reading traces after pre-flight and any test run
 
@@ -99,7 +99,7 @@ ls /tmp/trace-preflight/resources/page@*.jpeg | sort | tail -10
 After reading the trace: if the test fails due to an infrastructure or environment error
 (emulator crash, transport failure, bridge error, process startup issue) rather than the
 test assertion described in `diagnosis` — retry once. If the retry shows the same
-infrastructure or environment error, write the result files (Step 4) with `result: "fail"` and
+infrastructure or environment error, return the result (Step 4) with `result: "fail"` and
 `iterations: 0`, and stop. Do not enter the fix loop.
 
 ---
@@ -156,11 +156,15 @@ Then use `git commit --fixup $FIRST_SHA` for all subsequent iterations.
 
 ---
 
-## Step 4 — Write result files
+## Step 4 — Write the PR description and return the result
 
-Write two files to the repo root (current directory) using the Write tool.
+**`pr-description.md`** — write this file to the repo root (current directory) using the
+Write tool (see the section below for its contents).
 
-**`fix-result.json`** — machine-readable status for the caller:
+**Machine-readable status** — do **not** write `fix-result.json` to disk; the harness
+captures it for you. Your **final response** must be a single JSON object matching the
+structure below (the run is configured with a JSON Schema that validates this output).
+Emit only the JSON object as your final answer, with no surrounding prose or code fence:
 
 ```json
 {

--- a/packages/e2e-utils/src/fixBot/FIX_AGENT.md
+++ b/packages/e2e-utils/src/fixBot/FIX_AGENT.md
@@ -23,7 +23,7 @@ Your fix task is embedded at the bottom of this prompt. Read it before doing any
 
 ## Fix Constraints
 
-Allowed changes depend on the fix task's `fix_scope`:
+Allowed changes depend on the fix task's `fixScope`:
 
 - `TEST_CODE` — only files inside `suite/e2e/`
 - `LOCATOR_ADD` — files inside `suite/e2e/` AND `data-testid` attributes in product source files. No other product code changes.
@@ -112,7 +112,7 @@ Track your current iteration number starting at 1. Stop when budget is exhausted
 
 ### Per iteration
 
-**1. Make changes** according to `fix_scope`. For `LOCATOR_ADD`: only add or modify `data-testid`
+**1. Make changes** according to `fixScope`. For `LOCATOR_ADD`: only add or modify `data-testid`
 attributes — no logic changes in product code.
 
 **2. Run all validations that are still failing:**
@@ -164,16 +164,16 @@ Write two files to the repo root (current directory) using the Write tool.
 
 ```json
 {
-  "task_id": "<id from fix task>",
+  "taskId": "<id from fix task>",
   "result": "<pass | partial | fail | not_duplicated>",
   "iterations": <number of fix iterations performed, 0 if none needed>,
   "passed": ["<platform>/<group>/<spec>"],
   "failed": ["<platform>/<group>/<spec>"],
-  "pr_title": "<string up to 100 chars>"
+  "prTitle": "<string up to 100 chars>"
 }
 ```
 
-`pr_title` must be the full PR title including the `Nightly fix <YY-MM-DD> - ` prefix. Base it on the fix you just made.
+`prTitle` must be the full PR title including the `Nightly fix <YY-MM-DD> - ` prefix. Base it on the fix you just made.
 `pass` — all validations pass after fixes.
 `partial` — at least one passes, at least one fails.
 `fail` — zero validations pass after fixes.
@@ -186,8 +186,8 @@ Use `<platform>/<group>/<spec>` format with the `spec` value as-is (repo-root-re
 
 1. `## Nightly fix — <YYYY-MM-DD>`
 2. `**Task:**`, `**Scope:**`, `**Result:**` (✅ pass / ⚠️ partial / ❌ fail)
-3. `### Root cause` — `root_cause` from the fix task
-4. `### Fix` — `fix_description` from the fix task
+3. `### Root cause` — `rootCause` from the fix task
+4. `### Fix` — `fixDescription` from the fix task
 5. `### Validations` — markdown table with Status (✅/❌), Platform, Group, Spec for every validation
 6. `### Commits` — output of `git log --oneline origin/develop..HEAD`
 7. `### Prompt gaps` — one bullet per ambiguity or missing instruction you encountered,

--- a/packages/e2e-utils/src/fixBot/analyze.ts
+++ b/packages/e2e-utils/src/fixBot/analyze.ts
@@ -1,11 +1,11 @@
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { prettifyError } from 'zod';
 
 import { error, log } from '../logger';
 import { processAgentOutput, runClaude } from './common';
-import { ReportSchema } from './schemas';
+import { AnalysisReportJsonSchema, AnalysisReportSchema } from './schemas';
 
 function main(): void {
     const root = execFileSync('git', ['rev-parse', '--show-toplevel'], {
@@ -35,6 +35,8 @@ function main(): void {
             '--verbose',
             '--output-format',
             'json',
+            '--json-schema',
+            JSON.stringify(AnalysisReportJsonSchema),
             '--settings',
             join(botDir, 'settings.json'),
             '--mcp-config',
@@ -46,34 +48,43 @@ function main(): void {
     });
 
     const { model } = JSON.parse(readFileSync(join(botDir, 'settings.json'), 'utf-8'));
-    processAgentOutput(claudeOutput, 'nightlyAnalyzer', model);
+    const agentResult = processAgentOutput(claudeOutput, 'nightlyAnalyzer', model);
 
     if (spawnError) {
         error(`Failed to run claude: ${spawnError.message}`);
         process.exit(1);
     }
 
-    const reportMd = join(reportDir, 'report.md');
-    const reportJson = join(reportDir, 'report.json');
-
-    const missing = [reportMd, reportJson].filter(f => !existsSync(f));
-
-    if (missing.length > 0) {
-        missing.forEach(f => error(`Expected output not found: ${f}`));
+    if (!agentResult) {
+        error('Could not parse Claude result envelope from analysis agent output.');
         process.exit(1);
     }
 
-    const unsafeParse = JSON.parse(readFileSync(reportJson, 'utf-8'));
-    const report = ReportSchema.safeParse(unsafeParse);
+    if (agentResult.subtype === 'error_max_structured_output_retries') {
+        // Persist the raw CLI envelope for troubleshooting
+        const envelopePath = join(reportDir, 'analyze-envelope.json');
+        writeFileSync(envelopePath, claudeOutput);
+        error(
+            `Analysis agent could not produce schema-conformant output after retries. Raw envelope saved to ${envelopePath}.`,
+        );
+        process.exit(1);
+    }
+
+    const reportJsonPath = join(reportDir, 'report.json');
+    const report = AnalysisReportSchema.safeParse(agentResult.structured_output);
     if (!report.success) {
-        error(`report.json failed schema validation: ${prettifyError(report.error)}`);
+        // Persist the raw structured output anyway for troubleshooting
+        writeFileSync(
+            reportJsonPath,
+            `${JSON.stringify(agentResult.structured_output, null, 2)}\n`,
+        );
+        error(`structured output failed schema validation: ${prettifyError(report.error)}`);
         process.exit(1);
     }
 
-    log('');
-    log(`Report saved to ${reportMd}`);
-    log(`Fix tasks saved to ${reportJson}`);
-    log('');
+    writeFileSync(reportJsonPath, `${JSON.stringify(report.data, null, 2)}\n`);
+
+    log('Agent done.');
 
     process.exit(status);
 }

--- a/packages/e2e-utils/src/fixBot/common.ts
+++ b/packages/e2e-utils/src/fixBot/common.ts
@@ -59,14 +59,14 @@ export function processAgentOutput(
     rawOutput: string,
     agent: 'nightlyAnalyzer' | 'nightlyFixer',
     model: string,
-): void {
+): ClaudeResult | null {
     let result: ClaudeResult;
     try {
         result = parseClaudeOutput(rawOutput);
     } catch {
         process.stderr.write(`[${agent}] agent output unparsable (${rawOutput.length} bytes)\n`);
 
-        return;
+        return null;
     }
 
     const subtype = result.subtype ?? '?';
@@ -88,4 +88,6 @@ export function processAgentOutput(
         output_tokens: result.usage?.output_tokens ?? null,
         total_cost_usd: result.total_cost_usd,
     });
+
+    return result;
 }

--- a/packages/e2e-utils/src/fixBot/docs.md
+++ b/packages/e2e-utils/src/fixBot/docs.md
@@ -35,12 +35,12 @@ After completing its work, the fix agent writes two files to the **worktree root
 - **`fix-result.json`** — machine-readable result for the caller:
     ```json
     {
-        "task_id": "fix-001",
+        "taskId": "fix-001",
         "result": "pass | partial | fail | not_duplicated",
         "iterations": 2,
         "passed": ["web/T3W1/suite/e2e/tests/wallet/send.ts"],
         "failed": [],
-        "pr_title": "Nightly fix 26-05-19 - send-button locator"
+        "prTitle": "Nightly fix 26-05-19 - send-button locator"
     }
     ```
 - **`pr-description.md`** — ready-to-post PR body, passed directly to `gh pr create --body-file`
@@ -80,17 +80,17 @@ The only allowed product change is adding or modifying `data-testid` attributes.
 | `PRODUCT_BUG` / `INFRA` | 0 — not attempted |
 
 `{
-  "run_date": "2026-04-23",
-  "web_run_id": "...",
-  "desktop_run_id": "...",
-  "fix_tasks": [
+  "runDate": "2026-04-23",
+  "webRunId": "...",
+  "desktopRunId": "...",
+  "fixTasks": [
     {
       "id": "fix-001",
       "branch": "fix/nightly-2026-04-23-send-button-locator",
-      "root_cause": "send-button data-testid renamed in SendForm component",
-      "fix_scope": "LOCATOR_ADD",
+      "rootCause": "send-button data-testid renamed in SendForm component",
+      "fixScope": "LOCATOR_ADD",
       "confidence": "HIGH",
-      "fix_description": "Add data-testid='send-button' to submit button in SendForm.tsx, update page object",
+      "fixDescription": "Add data-testid='send-button' to submit button in SendForm.tsx, update page object",
       "diagnosis": "<MD prose for the tests in this fix task — error messages, stack traces, visual evidence, root cause reasoning>",
       "validations": [
         { "platform": "web",     "group": "T3W1", "spec": "suite/e2e/tests/wallet/send.ts" },
@@ -103,9 +103,9 @@ The only allowed product change is adding or modifying `data-testid` attributes.
   ],
   "skipped": [
     {
-      "root_cause": "...",
+      "rootCause": "...",
       "reason": "PRODUCT_BUG — requires human review",
-      "affected_tests": ["suite/e2e/tests/firmware/update.ts"]
+      "affectedTests": ["suite/e2e/tests/firmware/update.ts"]
     }
   ]
 }`

--- a/packages/e2e-utils/src/fixBot/fix.ts
+++ b/packages/e2e-utils/src/fixBot/fix.ts
@@ -1,10 +1,11 @@
 import { execFileSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { prettifyError } from 'zod';
 
 import { error, log } from '../logger';
 import { processAgentOutput, runClaude } from './common';
-import { AnalysisReportSchema } from './schemas';
+import { AnalysisReportSchema, FixResultJsonSchema, FixResultSchema } from './schemas';
 
 function main(): void {
     const reportPath = process.env.REPORT_PATH;
@@ -50,6 +51,8 @@ function main(): void {
             '--verbose',
             '--output-format',
             'json',
+            '--json-schema',
+            JSON.stringify(FixResultJsonSchema),
             '--settings',
             join(fixAgentDir, 'settings.json'),
         ],
@@ -58,12 +61,34 @@ function main(): void {
     });
 
     const { model } = JSON.parse(readFileSync(join(fixAgentDir, 'settings.json'), 'utf-8'));
-    processAgentOutput(output, 'nightlyFixer', model);
+    const agentResult = processAgentOutput(output, 'nightlyFixer', model);
 
     if (spawnError) {
         error(`Failed to run claude: ${spawnError.message}`);
         process.exit(1);
     }
+
+    if (!agentResult) {
+        error('Could not parse Claude result envelope from fix agent output.');
+        process.exit(1);
+    }
+
+    if (agentResult.subtype === 'error_max_structured_output_retries') {
+        error(
+            `Fix agent could not produce schema-conformant output after retries. Raw envelope:\n${output}`,
+        );
+        process.exit(1);
+    }
+
+    const fixResult = FixResultSchema.safeParse(agentResult.structured_output);
+    if (!fixResult.success) {
+        error(
+            `structured output failed schema validation: ${prettifyError(fixResult.error)} \nRaw structured output:\n${JSON.stringify(agentResult.structured_output, null, 2)}`,
+        );
+        process.exit(1);
+    }
+
+    writeFileSync(join(root, 'fix-result.json'), `${JSON.stringify(fixResult.data, null, 2)}\n`);
 
     log('Agent done.');
     process.exit(status);

--- a/packages/e2e-utils/src/fixBot/fix.ts
+++ b/packages/e2e-utils/src/fixBot/fix.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 
 import { error, log } from '../logger';
 import { processAgentOutput, runClaude } from './common';
-import { ReportSchema } from './schemas';
+import { AnalysisReportSchema } from './schemas';
 
 function main(): void {
     const reportPath = process.env.REPORT_PATH;
@@ -25,8 +25,8 @@ function main(): void {
     }).trim();
     const fixAgentDir = join(root, 'packages/e2e-utils/src/fixBot');
 
-    const report = ReportSchema.parse(JSON.parse(readFileSync(reportPath, 'utf-8')));
-    const task = report.fix_tasks.find(t => t.id === taskId);
+    const report = AnalysisReportSchema.parse(JSON.parse(readFileSync(reportPath, 'utf-8')));
+    const task = report.fixTasks.find(t => t.id === taskId);
 
     if (!task) {
         error(`Task '${taskId}' not found in ${reportPath}`);
@@ -37,7 +37,7 @@ function main(): void {
     const desktopCount = task.validations.filter(v => v.platform === 'desktop').length;
 
     log(`━━━ Task ${task.id} ━━━`);
-    log(`Scope:   ${task.fix_scope}`);
+    log(`Scope:   ${task.fixScope}`);
     log(`Branch:  ${task.branch}`);
     log(`Web:     ${webCount}  Desktop: ${desktopCount}`);
 

--- a/packages/e2e-utils/src/fixBot/publish.ts
+++ b/packages/e2e-utils/src/fixBot/publish.ts
@@ -36,7 +36,7 @@ function publishPR(): void {
         return;
     }
 
-    const { result, passed, failed, iterations, pr_title } = FixResultSchema.parse(
+    const { result, passed, failed, iterations, prTitle } = FixResultSchema.parse(
         JSON.parse(readFileSync(resultFile, 'utf-8')),
     );
 
@@ -44,14 +44,12 @@ function publishPR(): void {
         `Result: ${ICONS[result] ?? '?'} ${result}  passed=${passed.length}  failed=${failed.length}  iterations=${iterations}`,
     );
 
-    if (result === 'fail') {
-        log('  → No branch pushed (zero validations pass).');
-
-        return;
-    }
-
-    if (result === 'not_duplicated') {
-        log('  → No branch pushed (failure not reproduced in pre-flight).');
+    if (result === 'fail' || result === 'not_duplicated') {
+        log(
+            result === 'fail'
+                ? '  → No branch pushed (zero validations pass).'
+                : '  → No branch pushed (failure not reproduced in pre-flight).',
+        );
 
         return;
     }
@@ -61,7 +59,7 @@ function publishPR(): void {
     execFileSync('git', ['push', '--', GIT_REMOTE, branch], { stdio: 'inherit' });
 
     const prDescriptionFile = join(root, 'pr-description.md');
-    const prArgs = ['pr', 'create', '--title', pr_title, '--head', branch, '--base', BASE_BRANCH];
+    const prArgs = ['pr', 'create', '--title', prTitle, '--head', branch, '--base', BASE_BRANCH];
 
     if (existsSync(prDescriptionFile)) prArgs.push('--body-file', prDescriptionFile);
 
@@ -70,12 +68,16 @@ function publishPR(): void {
     const prUrl = execFileSync('gh', prArgs, { encoding: 'utf-8' }).trim();
     log(`PR: ${prUrl}`);
 
-    execFileSync(
-        'gh',
-        ['project', 'item-add', String(QA_PROJECT_NUMBER), '--owner', 'trezor', '--url', prUrl],
-        { stdio: 'inherit' },
-    );
-    log(`Assigned PR to QA and Test Automation project (#${QA_PROJECT_NUMBER})`);
+    try {
+        execFileSync(
+            'gh',
+            ['project', 'item-add', String(QA_PROJECT_NUMBER), '--owner', 'trezor', '--url', prUrl],
+            { stdio: 'inherit' },
+        );
+        log(`Assigned PR to QA and Test Automation project (#${QA_PROJECT_NUMBER})`);
+    } catch (err) {
+        error(`Failed to assign PR to QA and Test Automation project: ${err}`);
+    }
 }
 
 publishPR();

--- a/packages/e2e-utils/src/fixBot/schemas.ts
+++ b/packages/e2e-utils/src/fixBot/schemas.ts
@@ -65,5 +65,7 @@ export const ClaudeResultSchema = z.object({
 });
 
 export type FixResult = z.infer<typeof FixResultSchema>;
+export type ClaudeResult = z.infer<typeof ClaudeResultSchema>;
 
 export const AnalysisReportJsonSchema = z.toJSONSchema(AnalysisReportSchema);
+export const FixResultJsonSchema = z.toJSONSchema(FixResultSchema);

--- a/packages/e2e-utils/src/fixBot/schemas.ts
+++ b/packages/e2e-utils/src/fixBot/schemas.ts
@@ -15,35 +15,35 @@ export const FixTaskSchema = z.object({
         .string()
         .regex(/^fix\/nightly-\d{4}-\d{2}-\d{2}-[a-z0-9-]{1,40}$/)
         .refine(v => !/[\r\n]/.test(v), 'branch must not contain newlines'),
-    root_cause: z.string(),
-    fix_scope: z.enum(['TEST_CODE', 'LOCATOR_ADD']),
+    rootCause: z.string(),
+    fixScope: z.enum(['TEST_CODE', 'LOCATOR_ADD']),
     confidence: z.enum(['HIGH', 'MEDIUM', 'LOW']),
-    fix_description: z.string(),
+    fixDescription: z.string(),
     diagnosis: z.string(),
     validations: z.array(TestToValidateSchema),
 });
 
 export const SkippedTaskSchema = z.object({
-    root_cause: z.string(),
+    rootCause: z.string(),
     reason: z.string(),
-    affected_tests: z.array(z.string()),
+    affectedTests: z.array(z.string()),
 });
 
-export const ReportSchema = z.object({
-    run_date: z.string(),
-    web_run_id: z.string().nullable(),
-    desktop_run_id: z.string().nullable(),
-    fix_tasks: z.array(FixTaskSchema),
+export const AnalysisReportSchema = z.object({
+    runDate: z.string(),
+    webRunId: z.string().nullable(),
+    desktopRunId: z.string().nullable(),
+    fixTasks: z.array(FixTaskSchema),
     skipped: z.array(SkippedTaskSchema),
 });
 
 export const FixResultSchema = z.object({
-    task_id: z.string(),
+    taskId: z.string(),
     result: z.enum(['pass', 'partial', 'fail', 'not_duplicated']),
     passed: z.array(z.string()),
     failed: z.array(z.string()),
     iterations: z.number().int().nonnegative(),
-    pr_title: z.string(),
+    prTitle: z.string(),
 });
 
 export const ClaudeUsageSchema = z.object({
@@ -57,14 +57,13 @@ export const ClaudeResultSchema = z.object({
     type: z.string().optional(),
     subtype: z.string().optional(),
     result: z.string().optional(),
+    structured_output: z.unknown().optional(),
     num_turns: z.number().optional(),
     usage: ClaudeUsageSchema.optional(),
     total_cost_usd: z.number().optional(),
     duration_ms: z.number().optional(),
 });
 
-export type FixTask = z.infer<typeof FixTaskSchema>;
-export type SkippedTask = z.infer<typeof SkippedTaskSchema>;
-export type Report = z.infer<typeof ReportSchema>;
 export type FixResult = z.infer<typeof FixResultSchema>;
-export type ClaudeResult = z.infer<typeof ClaudeResultSchema>;
+
+export const AnalysisReportJsonSchema = z.toJSONSchema(AnalysisReportSchema);


### PR DESCRIPTION
I have encounter few situations where the agent did not follow json schema given to him. Very probably because the schema had leftover relic from bash version - snake_case. Anyway, keys changed to camelCase and call of agents reworked to demand JSON schema output.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=nightly-agent-fixer-schema&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=nightly-agent-fixer-schema&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-03T08:33:13.238Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-03T08:29:33.514Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/nightly-agent-fixer-schema/web/](https://dev.suite.sldev.cz/suite-web/nightly-agent-fixer-schema/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->