### PR TITLE
fix(suite): polish trading clear signing asset outputs

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputAssets.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputAssets.tsx
@@ -4,7 +4,6 @@ import { type CryptoId } from 'invity-api';
 
 import { Address } from '@suite/address';
 import { Translation } from '@suite/intl';
-import { selectLanguage } from '@suite/settings';
 import { selectTradingCoinSymbolByCryptoId, toTokenCryptoId } from '@suite-common/trading';
 import { getCoingeckoId, getNetwork } from '@suite-common/wallet-config';
 import {
@@ -44,10 +43,9 @@ const TransactionReviewOutputAssetsCryptoCurrency = ({
     type,
 }: TransactionReviewOutputAssetsCryptoCurrencyProps) => {
     const { symbol, contractAddress, amount } = cryptoCurrency;
-    const locale = useSelector(selectLanguage);
     const network = getNetwork(symbol);
     const isTokenAmount = !!cryptoCurrency.contractAddress;
-    const formattedAmount = localizeNumber(amount, locale);
+    const formattedAmount = localizeNumber(amount, 'en-US');
 
     const cryptoId = contractAddress
         ? toTokenCryptoId(symbol, contractAddress)
@@ -58,25 +56,30 @@ const TransactionReviewOutputAssetsCryptoCurrency = ({
             : network.displaySymbol,
     );
 
-    const getCoinLogo = () =>
-        isCoinSymbol(symbol) ? (
-            <CoinLogo size={20} symbol={symbol} type="tokenWithNetwork" />
-        ) : null;
+    const renderAssetLogo = () => {
+        if (contractAddress) {
+            return (
+                <AssetLogo
+                    size={20}
+                    symbol={symbol}
+                    contractAddress={contractAddress}
+                    placeholder={displaySymbol ?? ''}
+                />
+            );
+        }
+
+        if (isCoinSymbol(symbol)) {
+            return <CoinLogo size={20} symbol={symbol} type="tokenWithNetwork" />;
+        }
+
+        return null;
+    };
 
     return (
         <InfoItem
             label={
                 <Row alignItems="center" gap={12} margin={{ left: 32 }}>
-                    {network.coingeckoId ? (
-                        <AssetLogo
-                            size={20}
-                            symbol={symbol}
-                            contractAddress={contractAddress}
-                            placeholder={displaySymbol ?? ''}
-                        />
-                    ) : (
-                        getCoinLogo()
-                    )}
+                    {renderAssetLogo()}
                     <Text
                         intent={type === 'receive' ? 'brand' : 'critical'}
                         data-testid={`@modal/assets/${type}/crypto`}
@@ -118,7 +121,7 @@ const TransactionReviewOutputAssetsTo = ({ receive }: TransactionReviewOutputAss
                         intent="brand"
                         data-testid="@modal/assets/receive/label"
                     >
-                        + {receive.amount} {receive.fiatCurrency}
+                        + {localizeNumber(receive.amount, 'en-US')} {receive.fiatCurrency}
                     </Text>
                 }
                 data-testid="@modal/assets/receive"


### PR DESCRIPTION
## Description

- format send, receive, and fiat amounts in the transaction review asset list with en-US grouping
- render native coin logos in the transaction review asset list when no token contract is present
- keep the follow-up scoped to amount formatting and asset logos only

## Notes for QA
In Trading review, open a swap with a:
- large crypto amount and verify send and receive values use grouped digits.
- fiat receive amount and verify the fiat value also uses grouped digits.
- native asset such as BNB and verify the asset logo is shown.

## Related Issue

Resolve #28309

## Screenshots:

<img width="634" height="745" alt="image" src="https://github.com/user-attachments/assets/f9681471-5872-4856-b905-91b482e5cebe" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file is TransactionReviewOutputAssets.tsx, a component within the transaction review modal that renders output asset details (amounts, addresses, fees) during send/swap/sell transaction confirmations. Despite mapping to 121 tests via static analysis (indicating it's bundled broadly), only tests that actually trigger transaction review flows with device confirmation prompts are meaningfully affected. High-priority tests cover the core send and swap flows across different networks (BTC, ETH, SOL) where the component is directly visible. Medium-priority tests cover additional trading flows and fee customization scenarios. Most of the 121 mapped tests (analytics, onboarding, settings, metadata, etc.) never reach the transaction review modal and should be skipped.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputAssets.tsx`

</details>

**Recommended tests (18)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — This test exercises the full sell BTC flow including the device prompt confirmation modal where TransactionReviewOutputAssets is rendered. It verifies address, crypto amount, and fee display in the transaction review — directly exercising the changed component.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — This test confirms a sell ETH transaction and verifies the device prompt displays correct address, crypto amount, and fee — all rendered through the TransactionReviewOutputList which includes TransactionReviewOutputAssets.
- `suite/e2e/tests/trading/sell-solana.test.ts` — This test sends crypto to the swap provider and verifies device prompt details (address, total crypto amount, fee) which flow through the transaction review modal containing TransactionReviewOutputAssets.
- `suite/e2e/tests/trading/swap-coins.test.ts` — This test performs a SOL-to-BTC swap and explicitly verifies the device prompt modal showing total amount, fee, and recipient address. The transaction review output assets component is directly exercised during the confirmation flow.
- `suite/e2e/tests/wallet/send-eth.test.ts` — This test fills in the ETH send form and verifies the device prompt displays correct recipient address, gas limit, fee rates, crypto amount, and maximum fee — all part of the transaction review output that includes TransactionReviewOutputAssets.
- `suite/e2e/tests/wallet/send-sol.test.ts` — This test sends max SOL and verifies the Review & Send modal displays correct recipient address, amount, and fee. The TransactionReviewOutputAssets component is directly rendered in this review modal.

</details>

<details><summary>🟡 <b>Medium priority (9)</b></summary>

- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — This test sells an ERC-20 token (USDC) and verifies device prompt details including address, crypto amount, and fee during the transaction review flow where TransactionReviewOutputAssets renders token-specific output information.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — This test swaps SOL to USDC and verifies the device prompt output address, total crypto amount with symbol, and fee — rendered through the transaction review modal containing TransactionReviewOutputAssets.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — This test verifies custom BTC fee settings are displayed correctly in the confirmation modal and on the device, directly testing the transaction review output rendering including fee and total amount.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — This test verifies custom Ethereum fee parameters (gas limit, max fee, priority fee) are shown in the confirmation modal, exercising the transaction review output rendering path.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — This test swaps USDT to BTC and verifies device prompt output values and amounts during the transaction review, exercising the TransactionReviewOutputAssets component for token-to-coin flows.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — This test swaps SPL tokens (USDT to USDC) and verifies device prompt crypto amounts and addresses during the transaction review confirmation flow.
- `suite/e2e/tests/wallet/send-doge.test.ts` — This test verifies the device prompt modal displays correct DOGE send amount, total, fee, and address during transaction review — directly rendering TransactionReviewOutputAssets content.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — This test sends LTC via broadcast mode and confirms on device, exercising the transaction review modal where TransactionReviewOutputAssets renders the output details.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test sends regtest BTC transactions including OP_RETURN outputs and confirms on device, exercising the transaction review output rendering including special output types.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — This test confirms a Cardano claim rewards transaction on the device, which passes through the transaction review modal. The component change could affect how claim transaction outputs are displayed.
- `suite/e2e/tests/staking/ada/stake.test.ts` — This test confirms a Cardano staking transaction on the device, where the transaction review modal renders output details via TransactionReviewOutputAssets.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test confirms an ETH staking transaction on device where the device prompt shows stake amount and fee, potentially rendered through the transaction review output assets component.

</details>

_Updated: 2026-06-03T10:44:44.866Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trading-clear-signing-follow-up-28309&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trading-clear-signing-follow-up-28309&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-03T10:50:23.990Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-03T10:47:24.004Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/trading-clear-signing-follow-up-28309/web/](https://dev.suite.sldev.cz/suite-web/fix/trading-clear-signing-follow-up-28309/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->