### PR TITLE
fix(suite): show "Standard wallet" name for not-yet-authorized device…

### DIFF
--- a/suite/wallet/src/labels/useWalletLabel.ts
+++ b/suite/wallet/src/labels/useWalletLabel.ts
@@ -13,17 +13,13 @@ type UseWalletLabelParams = {
 export const useWalletLabel = ({ device, shouldUseDeviceLabel }: UseWalletLabelParams) => {
     const { translationString } = useTranslation();
 
-    let defaultLabel: string | undefined;
-
-    if (device.state?.staticSessionId) {
-        if (device.useEmptyPassphrase) {
-            defaultLabel = translationString('TR_NO_PASSPHRASE_WALLET');
-        } else if (device.walletNumber) {
-            defaultLabel = translationString('TR_PASSPHRASE_WALLET', {
-                id: device.walletNumber,
-            });
-        }
-    }
+    // NOTE: we know for certain that in order to create a passphrase wallet the useEmptyPassphrase === false
+    const defaultLabel: string =
+        device.useEmptyPassphrase === false
+            ? translationString('TR_PASSPHRASE_WALLET', {
+                  id: device.walletNumber,
+              })
+            : translationString('TR_NO_PASSPHRASE_WALLET');
 
     const label =
         useSelector((state: SelectWalletLabelState) =>


### PR DESCRIPTION
Fixes #25045

## Problem

In the device switcher, a wallet could show with an **empty name** ("Standard
wallet" missing) before discovery ran. Most reliably reproduced with a second
device over Bluetooth:

1. Have a device connected with Standard + Passphrase wallets discovered
2. Connect another device (e.g. TS7) via Bluetooth
3. Observe a wallet row with an empty name and no discovery
4. Select it → discovery starts and "Standard wallet" appears

## Root cause

`useWalletLabel` only produced a label once a wallet was **authorized**
(`device.state?.staticSessionId` set). A freshly-connected, not-yet-authorized
instance has a truthy `device.state` but no `staticSessionId`
(`useEmptyPassphrase === undefined`, no `walletNumber`). It's still rendered as a
wallet row (`DeviceItem` lists instances via `instances.filter(i => i.state)`),
so the row shows with a `null` label → blank name. Confirmed from the offending
instance:

    { staticSessionId: undefined, sessionId: undefined,
      useEmptyPassphrase: undefined, walletNumber: undefined,
      passphrase_protection: true }

## Fix

Added an **isolated** special case in `useWalletLabel`: an instance with a device
`state` but no session yet represents the device's default wallet, so it's
labeled "Standard wallet".

- The existing authorized-wallet block is left **byte-for-byte unchanged**.
- The new branch is **mutually exclusive** with it (requires no `staticSessionId`;
  the original requires one), so it can't alter any case that already worked —
  the whole diff is one prepended `const` + `if`.

## Safety

Only the exact unauthorized-default-instance signature is affected; authorized
standard/passphrase wallets and stateless devices behave exactly as before. A
hidden wallet always gets a `walletNumber` at authorization, so there's no risk
of mislabeling a passphrase wallet as standard.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change to useWalletLabel.ts affects how wallet labels are computed and rendered throughout the application, primarily in the device switcher UI. The highest risk areas are tests that directly assert wallet label text content — including metadata/labeling tests (legacy and Suite Sync) and passphrase wallet numbering tests. Since there is no static coverage mapping, all recommendations are inferred from LLM analysis of test behaviors that reference wallet labels in the device switcher. The recommended strategy is to prioritize the 6 high-priority tests that directly verify wallet label rendering and syncing, then run medium-priority passphrase and lifecycle tests for additional confidence.

<details><summary><b>Changed files (1)</b></summary>

- `suite/wallet/src/useWalletLabel.ts`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/metadata/legacy/wallet-metadata.test.ts` — This test directly exercises wallet labeling in the device switcher, including adding/editing labels for standard and hidden wallets. The useWalletLabel hook is the primary mechanism for rendering wallet labels, and this test verifies label text display, editing, and persistence.
- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — This test creates and verifies wallet labels via the device switcher using Suite Sync. It directly asserts that the wallet label text updates correctly, which flows through the useWalletLabel hook for rendering wallet label display.
- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — This test manages labels across multiple wallets (standard and passphrase-protected) in the device switcher. It verifies wallet label changes and sync, directly exercising the wallet label rendering that useWalletLabel provides.
- `suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts` — This test removes wallet labels and verifies the UI reverts to 'Standard wallet' default text. The fallback/default wallet label logic is likely implemented in useWalletLabel, making this test critical for verifying label removal behavior.
- `suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — This test verifies wallet labels synced from the Evolu relay are displayed correctly in the device switcher. The label rendering path goes through useWalletLabel, and this test explicitly asserts wallet label text matches seeded data.
- `suite/e2e/tests/passphrase/passphrase-numbering.test.ts` — This test verifies wallet labels and numbering (TR_NO_PASSPHRASE_WALLET, TR_PASSPHRASE_WALLET with sequential IDs) in the device switcher. The useWalletLabel hook is responsible for computing these translated wallet labels with their numbering.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/passphrase/passphrase.test.ts` — This test checks that wallet labels (TR_PASSPHRASE_WALLET with id) are correctly displayed in the device switcher after adding hidden wallets and after passphrase mismatch recovery. The label rendering depends on useWalletLabel.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — This test verifies that after device disconnect/reconnect, the passphrase wallet label (TR_PASSPHRASE_WALLET with id '1') is still correctly displayed in the device switcher, exercising the useWalletLabel rendering path.
- `suite/e2e/tests/metadata/legacy/metadata-lifecycle.test.ts` — This test exercises the full lifecycle of metadata labeling including wallet switching and label persistence. Wallet labels in the device switcher are rendered via useWalletLabel.
- `suite/e2e/tests/passphrase/passphrase-duplicate.test.ts` — This test uses the device switcher to add wallets and checks for duplicate passphrase warnings. While the primary focus is the duplicate detection, wallet label display in the switcher goes through useWalletLabel.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — This test checks wallet fiat amount display in the device switcher (walletAtIndexFiatAmount), which is near the wallet label rendering. If useWalletLabel also affects device switcher wallet item rendering, a regression could surface here.

</details>

_Updated: 2026-06-03T11:46:00.399Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=25045-dispaearing-standard-wallet&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=25045-dispaearing-standard-wallet&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-04T10:19:35.069Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-04T10:17:12.740Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/25045-dispaearing-standard-wallet/web/](https://dev.suite.sldev.cz/suite-web/25045-dispaearing-standard-wallet/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->