### PR TITLE
fix(react-native-usb): remove WebUSB event subscriptions on overwrite

### DIFF
--- a/packages/react-native-usb/jest.config.cjs
+++ b/packages/react-native-usb/jest.config.cjs
@@ -1,0 +1,9 @@
+const { ...baseConfig } = require('../../jest.config.base.swc');
+
+module.exports = {
+    ...baseConfig,
+    collectCoverage: true,
+    collectCoverageFrom: ['src/**/*.ts'],
+    watchPathIgnorePatterns: ['<rootDir>/libDev', '<rootDir>/lib'],
+    testEnvironment: '../../JestCustomEnv.js',
+};

--- a/packages/react-native-usb/package.json
+++ b/packages/react-native-usb/package.json
@@ -5,6 +5,7 @@
     "main": "src/index",
     "scripts": {
         "type-check": "yarn g:tsc --build tsconfig.json",
+        "test:unit": "yarn g:jest",
         "open:ios": "open -a \"Xcode\" example/ios",
         "open:android": "open -a \"Android Studio\" example/android",
         "depcheck": "yarn g:depcheck",

--- a/packages/react-native-usb/src/index.test.ts
+++ b/packages/react-native-usb/src/index.test.ts
@@ -1,0 +1,81 @@
+import { ReactNativeUsbModule } from './ReactNativeUsbModule';
+
+import { WebUSB } from './index';
+
+// `index.ts` imports `ReactNativeUsbModule`, which calls `requireNativeModule()` at module load
+// time and would throw outside a native runtime. Mock it so we can exercise the pure JS `WebUSB`
+// event-handler logic. `addListener` returns a subscription with a `remove` spy so tests can
+// assert which subscription gets removed.
+jest.mock('./ReactNativeUsbModule', () => ({
+    ReactNativeUsbModule: {
+        addListener: jest.fn(),
+    },
+}));
+
+const addListener = ReactNativeUsbModule.addListener as jest.Mock;
+
+const mockSubscription = () => ({ remove: jest.fn() });
+
+describe('WebUSB onconnect/ondisconnect event-handler setters', () => {
+    beforeEach(() => {
+        addListener.mockReset();
+        addListener.mockImplementation(mockSubscription);
+    });
+
+    it('registers a single native subscription when a handler is assigned', () => {
+        const usb = new WebUSB();
+
+        usb.onconnect = jest.fn();
+
+        expect(addListener).toHaveBeenCalledTimes(1);
+        expect(addListener).toHaveBeenCalledWith('onDeviceConnect', expect.any(Function));
+    });
+
+    it('removes the previous subscription when the handler is overwritten', () => {
+        const usb = new WebUSB();
+        const firstSubscription = mockSubscription();
+        addListener.mockReturnValueOnce(firstSubscription);
+
+        usb.onconnect = jest.fn();
+        usb.onconnect = jest.fn();
+
+        // the previous native listener is removed, then a new one is registered — never stacked
+        expect(firstSubscription.remove).toHaveBeenCalledTimes(1);
+        expect(addListener).toHaveBeenCalledTimes(2);
+    });
+
+    it('removes the subscription and registers nothing when set to null', () => {
+        const usb = new WebUSB();
+        const subscription = mockSubscription();
+        addListener.mockReturnValueOnce(subscription);
+
+        usb.onconnect = jest.fn();
+        usb.onconnect = null;
+
+        expect(subscription.remove).toHaveBeenCalledTimes(1);
+        // Regression guard: the pre-fix setter ignored null and called the native registration
+        // anyway, leaking a listener whose body later crashed on `null(event)`. A null assignment
+        // must detach only — no new subscription.
+        expect(addListener).toHaveBeenCalledTimes(1);
+    });
+
+    it('manages ondisconnect independently from onconnect', () => {
+        const usb = new WebUSB();
+        const connectSubscription = mockSubscription();
+        const disconnectSubscription = mockSubscription();
+        addListener
+            .mockReturnValueOnce(connectSubscription)
+            .mockReturnValueOnce(disconnectSubscription);
+
+        usb.onconnect = jest.fn();
+        usb.ondisconnect = jest.fn();
+
+        expect(addListener).toHaveBeenNthCalledWith(1, 'onDeviceConnect', expect.any(Function));
+        expect(addListener).toHaveBeenNthCalledWith(2, 'onDeviceDisconnect', expect.any(Function));
+
+        usb.ondisconnect = null;
+
+        expect(disconnectSubscription.remove).toHaveBeenCalledTimes(1);
+        expect(connectSubscription.remove).not.toHaveBeenCalled();
+    });
+});

--- a/packages/react-native-usb/src/index.ts
+++ b/packages/react-native-usb/src/index.ts
@@ -162,13 +162,30 @@ export async function getDevices(): Promise<any> {
 }
 
 export class WebUSB {
+    private _onConnectSubscription?: EventSubscription;
+    private _onDisconnectSubscription?: EventSubscription;
+
     public getDevices = getDevices;
 
-    set onconnect(listener: (event: OnConnectEvent) => void) {
-        onDeviceConnected(listener);
+    // `onconnect`/`ondisconnect` mirror the WebUSB `USB` event-handler IDL attributes
+    // (https://wicg.github.io/webusb/#dom-usb-onconnect). They are declared as `EventHandler`,
+    // which the HTML spec defines as a *nullable* attribute holding a single handler: assigning
+    // a new value replaces the previous handler, and assigning `null` detaches it
+    // (https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-attributes —
+    // "If the new value is null, then deactivate the event handler").
+    //
+    // `onDeviceConnected`/`onDeviceDisconnect` each register a fresh native subscription via
+    // `ReactNativeUsbModule.addListener`, so we must remove the previous one on every
+    // (re)assignment. Without this, repeated assignment leaks native listeners, and a `null`
+    // assignment (used by transport-common's `UsbApi.dispose()`) would otherwise register a
+    // handler that crashes when it fires.
+    set onconnect(listener: ((event: OnConnectEvent) => void) | null) {
+        this._onConnectSubscription?.remove();
+        this._onConnectSubscription = listener ? onDeviceConnected(listener) : undefined;
     }
-    set ondisconnect(listener: (event: OnConnectEvent) => void) {
-        onDeviceDisconnect(listener);
+    set ondisconnect(listener: ((event: OnConnectEvent) => void) | null) {
+        this._onDisconnectSubscription?.remove();
+        this._onDisconnectSubscription = listener ? onDeviceDisconnect(listener) : undefined;
     }
 
     // TODO: implement these commented out properties, because they are part of WebUSB specs, but very low priority we are not using them anywhere


### PR DESCRIPTION
## Description

Isolated single-file fix split out of the listener-leak audit (#27978): the `WebUSB` shim in `@trezor/react-native-usb` leaked native event subscriptions and could crash on teardown. Includes the unit tests (and the jest setup the package was missing).

## The bug

`@trezor/react-native-usb` exposes a `WebUSB` class that mirrors the browser `navigator.usb` shape, so the same `transport-common` `UsbApi` works across browser / node-`usb` / react-native. Its `onconnect`/`ondisconnect` setters are WebUSB `USB` event-handler IDL attributes:

- [WebUSB spec — `USB.onconnect` / `ondisconnect`](https://wicg.github.io/webusb/#dom-usb-onconnect): declared as `attribute EventHandler onconnect;`
- [HTML spec — event handler IDL attributes](https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-attributes): `EventHandler` is **nullable** and holds a **single** handler — assigning replaces the previous one, assigning `null` deactivates it ("If the new value is null, then deactivate the event handler").

The shim honored neither rule. Each setter called `onDeviceConnected()` / `onDeviceDisconnect()` (which register a fresh `ReactNativeUsbModule.addListener` subscription) and **discarded the returned subscription**. Two consequences:

1. **Listener leak** — every (re)assignment stacked another native listener; none were ever removed. `UsbApi.listen()` re-runs on transport setup, so the count grew across connect/disconnect cycles.
2. **Crash on teardown** — `UsbApi.dispose()` sets `onconnect = null` / `ondisconnect = null`. The old setter typed the parameter as non-nullable and passed `null` straight into `onDeviceConnected(null)`, registering a wrapper whose body ends in `listener(event)` → `null(event)` → `TypeError: null is not a function` the next time a device connected.

## The fix

Store the `EventSubscription` and `.remove()` it on every (re)assignment; `null` detaches only. Setter type widened to `… | null` to match the `UsbInterfaceApi` contract (and the spec).

## Tests

The package had no jest setup. Added a minimal `jest.config.cjs` (extends the repo base) + `test:unit`, and `src/index.test.ts` covering:
- single subscription on assign
- previous subscription removed on overwrite (leak guard)
- `null` detaches and registers nothing (crash regression guard)
- connect / disconnect managed independently

Verified the suite fails on the pre-fix setter (3/4 red) and passes on the fix.

## Why type-check didn't catch it

`UsbApi` consumes the structural `UsbInterfaceApi` interface (nullable handler), so the `= null` call site was always valid. The concrete `WebUSB` class assigned into that interface passed because TS checks mutable properties covariantly (unsound by design) and the callback parameter is `any`. The leak and crash are runtime bugs a type-checker cannot see regardless.

## Related PRs (listener-leak audit stream)

- #27978 — origin of this commit (`audit and patch event listener leaks across transport/connect/desktop packages`)
- #28241 — sibling desktop listener cleanup (merged)
- #28242 — sibling isolated single-file fixes (connect-common / connect-explorer); the react-native-usb fix it used to carry now lives here

## Test plan

- [x] `test:unit` green (4/4)
- [x] `lint:js` + `type-check` clean on changed files
- [ ] CI


