### PR TITLE
fix(connect): reject odd-length cardano signMessage payload

### DIFF
--- a/packages/connect/src/api/cardano/api/cardanoSignMessage.ts
+++ b/packages/connect/src/api/cardano/api/cardanoSignMessage.ts
@@ -40,10 +40,14 @@ export default class CardanoSignMessage extends AbstractMethod<
 
         Assert(CardanoSignMessageSchema, payload);
 
-        if (!isHexString(payload.payload) || hasHexPrefix(payload.payload)) {
+        if (
+            !isHexString(payload.payload) ||
+            hasHexPrefix(payload.payload) ||
+            payload.payload.length % 2 !== 0
+        ) {
             throw ERRORS.TypedError(
                 'Method_InvalidParameter',
-                'Message payload must be a hexadecimal string without a "0x" prefix.',
+                'Message payload must be a byte-aligned hexadecimal string (even number of characters) without a "0x" prefix.',
             );
         }
 


### PR DESCRIPTION
## What

`cardanoSignMessage` validates its `payload` with `isHexString` + `hasHexPrefix`, then derives the device-side `payload_size` via `hexStringByteLength(payload) = payload.length / 2`.

`isHexString` only guarantees the character set (`^(0x|0X)?[0-9A-Fa-f]*$`) — it deliberately does **not** enforce byte alignment (it is a faithful port of `ethjs-util`, and the other caller, `messageToBuffer`, pads odd-length input itself). So an **odd-length** payload passes validation and then produces a **non-integer** `payload_size`, which misaligns:

- the byte count sent to the device in `CardanoSignMessageInit`, and
- the `slice(offset * 2, (offset + length) * 2)` hex chunking that streams the payload.

## Fix

Reject odd-length payloads at the **validation boundary** (the constructor), where caller input is already checked, rather than changing the generic `isHexString` / `hexStringByteLength` helpers — those are intentionally dumb and shared by other callers (`cardanoOutputs` uses `hexStringByteLength` for `inlineDatum` / `referenceScript`). Throwing or rounding inside them would either surface a confusing error far from the input boundary or silently mask malformed input.

## Notes

- Caught by Copilot on #28107; out of scope there (that PR is test/refactor only), so split out here.
- Behaviour change is limited to malformed input that should never have been accepted; well-formed (even-length) payloads are unaffected.

## Cardano e2e (manual run)

The connect core e2e cardano group only runs in the `node` env on a regular PR push (`PR-check / node-methods-cardano`). Full coverage (web env, all firmwares/models) only runs nightly or via manual dispatch, so it was triggered manually on this branch to confirm cardano passes:

- 🃏 **Cardano e2e (manual dispatch):** https://github.com/trezor/trezor-suite/actions/runs/26909152866

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/cardano-signmessage-odd-payload&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/cardano-signmessage-odd-payload&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/cardano-signmessage-odd-payload&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-03T13:15:00.275Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-03T13:11:35.929Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/cardano-signmessage-odd-payload/web/](https://dev.suite.sldev.cz/suite-web/mroz22/cardano-signmessage-odd-payload/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->
