### PR TITLE
fix(trading): show zero network fee for gasless 1inch Fusion quotes

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchange.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchange.tsx
@@ -11,6 +11,7 @@ import { useServices } from '@suite-common/dependency-injection';
 import {
     type TradingExchangeType,
     selectTradingComposedTransactionInfo,
+    selectTradingDisplayComposedFee,
 } from '@suite-common/trading';
 import { selectAccounts } from '@suite-common/wallet-core';
 import { Box, BulletList, Card, Column, H3, Paragraph } from '@trezor/components';
@@ -69,12 +70,14 @@ export const TradingDetailExchange = () => {
     const exchange = trade?.data?.exchange;
     const provider = exchange ? info?.providerInfos?.[exchange] : undefined;
 
+    const networkFee = useSelector(state => selectTradingDisplayComposedFee(state, trade?.data));
+
     const quoteAmounts: TradingGetCryptoQuoteAmountProps = {
         sendAmount: trade?.data?.sendStringAmount ?? '',
         sendCurrency: trade?.data?.send,
         receiveAmount: trade?.data?.receiveStringAmount ?? '',
         receiveCurrency: trade?.data?.receive,
-        networkFee: composedTransaction?.composed?.fee,
+        networkFee,
     };
 
     useEffect(() => {

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
@@ -9,6 +9,7 @@ import {
     TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT,
     type TradingExchangeFormProps,
     type TradingExchangeType,
+    getDisplayComposedLevels,
     selectTradingExchangeBuyCryptoIds,
     selectTradingExchangeSellCryptoIds,
     selectTradingLoadingAndTimestamp,
@@ -56,8 +57,14 @@ export const TradingExchangeFormInputs = () => {
         shouldSendInSats,
         showReserveBanner,
         resetSelectedOffer,
+        selectedQuote,
         setAmountLimits,
     } = context;
+
+    const displayComposedLevels = useMemo(
+        () => getDisplayComposedLevels(selectedQuote, composedLevels),
+        [selectedQuote, composedLevels],
+    );
     const { getValues, setValue } = useFormContext<TradingExchangeFormProps>();
     const {
         [TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT]: sendCryptoSelect,
@@ -179,7 +186,7 @@ export const TradingExchangeFormInputs = () => {
                 <TradingFormFees
                     feeInfo={feeInfo}
                     account={account}
-                    composedLevels={composedLevels}
+                    composedLevels={displayComposedLevels}
                     changeFeeLevel={changeFeeLevel}
                 />
                 <TradingSelectedOfferProvider />

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeDetails.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeDetails.tsx
@@ -6,7 +6,7 @@ import {
     TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT,
     type TradingExchangeType,
     cryptoIdToNetwork,
-    selectTradingComposedTransactionInfo,
+    selectTradingDisplayComposedFee,
     selectTradingExchangeFormStep,
     useTradingUtils,
 } from '@suite-common/trading';
@@ -44,14 +44,12 @@ export const TradingOfferExchangeDetails = ({
     const formStep = useSelector(selectTradingExchangeFormStep);
     const isMevProtectionEnabled = useSelector(selectIsMevProtectionEnabled);
     const isMevProtectionFeatureEnabled = useSelector(selectIsMevProtectionFeatureEnabled);
-    const composedTransactionInfo = useSelector(selectTradingComposedTransactionInfo);
+    const networkFee = useSelector(state => selectTradingDisplayComposedFee(state, exchangeQuote));
     const { cryptoIdToSymbolAndContractAddress } = useTradingUtils();
 
     const context = useTradingFormContext<TradingExchangeType>();
     const { account, exchangeInfo, getValues } = context;
     const { symbol } = account;
-
-    const networkFee = composedTransactionInfo?.composed?.fee;
     const formattedNetworkFee = formatNetworkAmount(networkFee || '0', symbol);
 
     const sendCryptoSelect = getValues(TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT);

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -3,6 +3,7 @@ import {
     type BuyTrade,
     type Coins,
     type CryptoId,
+    type ExchangeTrade,
     type FiatCurrencyCode,
     type Platforms,
     type SellCryptoPaymentMethod,
@@ -46,6 +47,7 @@ import {
     isExchangeProvider,
     testnetToProdCryptoId,
 } from '../utils';
+import { getDisplayNetworkFee } from '../utils/exchange/exchangeUtils';
 import {
     getTradingCoinInfoByCryptoId,
     getTradingCoinSymbolByCryptoId,
@@ -630,6 +632,12 @@ export const selectTradingSellFormStep = (state: TradingRootState) =>
 
 export const selectTradingComposedTransactionInfo = (state: TradingRootState) =>
     state.wallet.trading.composedTransactionInfo;
+
+export const selectTradingDisplayComposedFee = (
+    state: TradingRootState,
+    quote: ExchangeTrade | undefined,
+): string | undefined =>
+    getDisplayNetworkFee(quote, state.wallet.trading.composedTransactionInfo.composed?.fee);
 
 export const selectTradingAccountAccordingActiveSection =
     createMemoizedSelectorWithDeviceAndAccounts(

--- a/suite-common/trading/src/utils/exchange/__tests__/exchangeUtils.test.ts
+++ b/suite-common/trading/src/utils/exchange/__tests__/exchangeUtils.test.ts
@@ -1,10 +1,14 @@
 import { type CryptoId } from 'invity-api';
 
+import { type PrecomposedLevels } from '@suite-common/wallet-types';
 import { buildApprovalTransactionData } from '@suite-common/wallet-utils';
 
 import {
     getApprovalStatus,
     getDexEstimationData,
+    getDisplayComposedLevels,
+    getDisplayNetworkFee,
+    hasEip712SignDataType,
     requiresTokenApproval,
     tokenSupportsIncreasingAllowance,
 } from '../exchangeUtils';
@@ -309,5 +313,110 @@ describe('getDexEstimationData', () => {
         };
 
         expect(getDexEstimationData(quote)).toBeUndefined();
+    });
+});
+
+describe('hasEip712SignDataType', () => {
+    it('should return false when no quote is provided', () => {
+        expect(hasEip712SignDataType(undefined)).toBe(false);
+    });
+
+    it('should return false for a CEX quote without signData', () => {
+        const quote = { orderId: 'test-order', isDex: false };
+        expect(hasEip712SignDataType(quote)).toBe(false);
+    });
+
+    it('should return false for a non-fusion DEX quote without signData', () => {
+        const quote = {
+            orderId: 'test-order',
+            isDex: true,
+            send: 'ethereum--0xdac17f958d2ee523a2206206994597c13d831ec7' as CryptoId,
+        };
+        expect(hasEip712SignDataType(quote)).toBe(false);
+    });
+
+    it('should return true for a quote with EIP-712 signData regardless of status', () => {
+        const quote = {
+            orderId: 'test-order',
+            exchange: '1inchfusion',
+            isDex: true,
+            signData: {
+                type: 'eip712-typed-data' as const,
+                data: { primaryType: 'Order' },
+            },
+        };
+        expect(hasEip712SignDataType(quote)).toBe(true);
+    });
+});
+
+describe('getDisplayNetworkFee', () => {
+    it('should return the original fee for a non-gasless quote', () => {
+        const quote = { orderId: 'test-order', isDex: false };
+        expect(getDisplayNetworkFee(quote, '12345')).toBe('12345');
+    });
+
+    it('should return "0" for an EIP-712-signed (gasless) quote', () => {
+        const quote = {
+            orderId: 'test-order',
+            exchange: '1inchfusion',
+            isDex: true,
+            signData: {
+                type: 'eip712-typed-data' as const,
+                data: { primaryType: 'Order' },
+            },
+        };
+        expect(getDisplayNetworkFee(quote, '12345')).toBe('0');
+    });
+});
+
+describe('getDisplayComposedLevels', () => {
+    const gaslessQuote = {
+        orderId: 'test-order',
+        exchange: '1inchfusion',
+        isDex: true,
+        signData: {
+            type: 'eip712-typed-data' as const,
+            data: { primaryType: 'Order' },
+        },
+    };
+
+    const composedLevels = {
+        normal: { type: 'final', fee: '12345' },
+        high: { type: 'nonfinal', fee: '67890' },
+        custom: { type: 'error', error: 'NOT_ENOUGH_FUNDS' },
+    } as unknown as PrecomposedLevels;
+
+    it('should return undefined when composedLevels is undefined', () => {
+        expect(getDisplayComposedLevels(gaslessQuote, undefined)).toBe(undefined);
+    });
+
+    it('should return undefined when both quote and composedLevels are undefined', () => {
+        expect(getDisplayComposedLevels(undefined, undefined)).toBe(undefined);
+    });
+
+    it('should return the original levels when quote is undefined', () => {
+        expect(getDisplayComposedLevels(undefined, composedLevels)).toBe(composedLevels);
+    });
+
+    it('should return the original levels for a non-gasless quote', () => {
+        const quote = { orderId: 'test-order', isDex: false };
+        expect(getDisplayComposedLevels(quote, composedLevels)).toBe(composedLevels);
+    });
+
+    it('should return the original levels for a non-gasless DEX quote', () => {
+        const quote = {
+            orderId: 'test-order',
+            isDex: true,
+            send: 'ethereum--0xdac17f958d2ee523a2206206994597c13d831ec7' as CryptoId,
+        };
+        expect(getDisplayComposedLevels(quote, composedLevels)).toBe(composedLevels);
+    });
+
+    it('should zero the fee on final and nonfinal levels, leaving error levels untouched', () => {
+        expect(getDisplayComposedLevels(gaslessQuote, composedLevels)).toEqual({
+            normal: { type: 'final', fee: '0' },
+            high: { type: 'nonfinal', fee: '0' },
+            custom: { type: 'error', error: 'NOT_ENOUGH_FUNDS' },
+        });
     });
 });

--- a/suite-common/trading/src/utils/exchange/exchangeUtils.ts
+++ b/suite-common/trading/src/utils/exchange/exchangeUtils.ts
@@ -1,6 +1,7 @@
 import type { CryptoId, ExchangeTrade, ExchangeTradeStatus } from 'invity-api';
 
 import { invariant } from '@suite-common/suite-utils';
+import { type GeneralPrecomposedLevels } from '@suite-common/wallet-types';
 import {
     buildApprovalTransactionData,
     getErc20ApproveSpender,
@@ -116,8 +117,11 @@ export type ApprovalStatus =
     | 'not_needed'
     | null;
 
+export const hasEip712SignDataType = (quote?: ExchangeTrade): boolean =>
+    quote?.signData?.type === 'eip712-typed-data';
+
 export const hasEip712SignData = (quote?: ExchangeTrade) =>
-    quote?.status === 'SIGN_DATA' && quote?.signData?.type === 'eip712-typed-data';
+    quote?.status === 'SIGN_DATA' && hasEip712SignDataType(quote);
 
 export const requiresTokenApproval = (quote?: ExchangeTrade): boolean =>
     !!quote &&
@@ -125,6 +129,27 @@ export const requiresTokenApproval = (quote?: ExchangeTrade): boolean =>
     !!quote.send &&
     !isSendingEvmNativeToken(quote.send) &&
     !hasEip712SignData(quote);
+
+export const getDisplayNetworkFee = (
+    quote: ExchangeTrade | undefined,
+    fee: string | undefined,
+): string | undefined => (hasEip712SignDataType(quote) ? '0' : fee);
+
+export const getDisplayComposedLevels = <T extends GeneralPrecomposedLevels>(
+    quote: ExchangeTrade | undefined,
+    composedLevels: T | undefined,
+): T | undefined => {
+    if (composedLevels && hasEip712SignDataType(quote)) {
+        return Object.fromEntries(
+            Object.entries(composedLevels).map(([label, level]) => [
+                label,
+                level.type === 'error' ? level : { ...level, fee: '0' },
+            ]),
+        ) as T;
+    }
+
+    return composedLevels;
+};
 
 export const getApprovalStatus = (candidateQuote?: ExchangeTrade): ApprovalStatus => {
     if (!candidateQuote) {
@@ -181,8 +206,11 @@ export const exchangeUtils = {
     getSuccessQuotesOrdered,
     getStatusMessage,
     tokenSupportsIncreasingAllowance,
+    hasEip712SignDataType,
     hasEip712SignData,
     requiresTokenApproval,
     getApprovalStatus,
     getDexEstimationData,
+    getDisplayNetworkFee,
+    getDisplayComposedLevels,
 };


### PR DESCRIPTION
## Description

- detect gasless exchange quotes via a shared trading helper based on EIP-712 sign data
- show zero network fee in the Exchange form Maximum fee row for 1inch Fusion offers
- show zero network fee in selected offer details and trade detail for gasless exchange quotes
- keep non-gasless exchange quotes on the existing composed transaction fee path
- add unit coverage for gasless quote detection and displayed network fee mapping

## Notes for QA

- Open Wallet > Trading > Exchange, select a 1inch Fusion offer, and verify the Maximum fee row shows 0 ETH and $0.
- Continue to selected offer details and trade detail for the same Fusion flow, and verify network fee stays 0; switch to a non-gasless quote and verify the regular network fee is still shown.
- I tested this manually, but please confirm that you can perform a swap on an account with 0 native tokens and that the form validation allows you to do so (you must have approval before, you know ;) ).

## Related Issue

Resolve #27911

## Screenshots:

<img width="708" height="655" alt="image" src="https://github.com/user-attachments/assets/a1b45a3b-d619-40cb-8493-d620f4863aa0" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/trading-27911-fusion-fee&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/trading-27911-fusion-fee&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/trading-27911-fusion-fee&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-16T07:42:25.167Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-16T07:41:41.254Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/trading-27911-fusion-fee/web/](https://dev.suite.sldev.cz/suite-web/feat/trading-27911-fusion-fee/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies swap/exchange-specific UI components (form inputs, offer details, detail view) along with shared exchange utility functions and trading selectors. The core risk is in the swap/exchange flow — form rendering, offer confirmation display, and transaction detail views. The two files mapping to 121 tests (tradingSelectors.ts, exchangeUtils.ts) are broad shared utilities, but the changes are exchange-specific, so only swap/exchange tests need to run. The recommended strategy prioritizes the mocked swap E2E tests that directly exercise all three view components, with medium priority for fee-specific and input-validation swap tests, and low priority for the slower live swap tests.

<details><summary><b>Changed files (6)</b></summary>

- `packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchange.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeDetails.tsx`
- `suite-common/trading/src/selectors/tradingSelectors.ts`
- `suite-common/trading/src/utils/exchange/__tests__/exchangeUtils.test.ts`
- `suite-common/trading/src/utils/exchange/exchangeUtils.ts`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Directly exercises the swap flow end-to-end including TradingDetailExchange (swap detail status/success), TradingExchangeFormInputs (swap form fill), and TradingOfferExchangeDetails (confirmation with exchange type, provider, amounts). All three view-layer changed files are exercised.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Full swap flow (SOL→BTC) that validates swap form inputs, offer confirmation details (exchange type, provider name), transaction status progression through multiple states, and the detail exchange view. Covers all three swap-specific changed view files plus exercises exchangeUtils through status/detail rendering.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Tests token-to-coin swap which exercises the exchange form inputs (asset selection with token), offer exchange details (confirmation amounts, exchange type, provider), and detail exchange (success status). Covers a different asset combination than swap-coins, increasing coverage breadth.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Tests token-to-token swap (USDT→USDC on Solana) exercising all three changed view files. Validates exchange form inputs with token assets on both sides, offer exchange details confirmation, and detail exchange success status.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Tests the swap form with custom Bitcoin fee settings, exercising TradingExchangeFormInputs (form filling) and TradingOfferExchangeDetails (confirmation modal with fee details). Validates fee calculation path that may be affected by exchangeUtils changes.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests swap form with custom Ethereum gas fees, exercising TradingExchangeFormInputs and TradingOfferExchangeDetails. Validates Ethereum-specific fee parameters that flow through the exchange utils and confirmation components.
- `suite/e2e/tests/trading/swap-history.test.ts` — Tests swap trade history display including transaction detail sidebar with send/receive amounts, provider, status, and order ID. The TradingDetailExchange component renders swap detail views, and tradingSelectors likely provides data for the history/detail views.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — Directly tests the swap form input interactions including asset selection, amount entry, fraction buttons, provider selection, and validation errors. TradingExchangeFormInputs is the primary component under test, and tradingSelectors feeds data to it.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — Tests swap form behavior when buy asset is on a disabled network, directly exercising TradingExchangeFormInputs for asset selection and quote display. Validates that the form correctly handles edge-case network configurations.
- `suite/e2e/tests/trading/navigation.test.ts` — Tests navigating to the Swap form from multiple entry points and verifying it opens with the correct pre-selected cryptocurrency. TradingExchangeFormInputs renders the swap form that is verified after navigation.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts` — Live swap test that exercises the full swap flow including form inputs, detail exchange, and offer exchange details. Lower priority because live tests are slower and the mocked swap tests already cover the changed components, but this validates against real exchange behavior.
- `suite/e2e/tests/trading-live/live-swap-coin-to-token.test.ts` — Live swap test covering SOL→USDC flow. All three view-layer changed files are exercised but this duplicates coverage already provided by the mocked swap tests at higher priority. Useful only for live environment validation.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/trading/src/utils/exchange/__tests__/exchangeUtils.test.ts`

_Updated: 2026-06-16T07:38:38.367Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->