### PR TITLE
Solana base fee fallback

### DIFF
--- a/coins/coins-solana/src/runtime/fees.ts
+++ b/coins/coins-solana/src/runtime/fees.ts
@@ -17,9 +17,9 @@ import {
 import { getTokenSize as _getTokenSize } from '@solana-program/token';
 import { getTokenSize as _getToken2022Size } from '@solana-program/token-2022';
 
-import { BigNumber, safeBigIntStringify, throwError } from '@trezor/utils';
+import { BigNumber, safeBigIntStringify } from '@trezor/utils';
 
-import { COMPUTE_BUDGET_PROGRAM_ID, STAKE_ACCOUNT_V2_SIZE } from '../constants';
+import { COMPUTE_BUDGET_PROGRAM_ID, SOL_BASE_FEE, STAKE_ACCOUNT_V2_SIZE } from '../constants';
 import type {
     Address,
     Base64EncodedWireTransaction,
@@ -81,7 +81,7 @@ const getBaseFee = async (api: Rpc<GetFeeForMessageApi>, message: CompiledTransa
 
     // The result can be null, for example if the transaction blockhash is invalid.
     // In this case, we should fall back to the default fee.
-    return result.value ?? throwError('Could not estimate fee for transaction.');
+    return result.value ?? SOL_BASE_FEE * BigInt(message.header.numSignerAccounts);
 };
 
 // More about Solana priority fees here:


### PR DESCRIPTION
## Description

`getBaseFee` (used by `blockchainEstimateFee`) calls `getFeeForMessage`, which returns `null` when the transaction blockhash is no longer queryable by the node — common for transactions built client-side by dApps (e.g. via WalletConnect, including memo transactions and Jupiter limit orders). It previously threw in that case, which broke the WalletConnect `solana_signTransaction` flow since the adapter relies on `blockchainEstimateFee` to resolve the `feePayer`. It now falls back to the deterministic Solana base fee (5000 lamports per required signature), matching the long-standing intent of the comment, so estimation succeeds and signing can proceed.

## Notes for QA

Try WalletConnect on https://jup.ag/limit - now it should work after clicking "Access vault", before the fix it would fail 

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change to `coins/coins-solana/src/runtime/fees.ts` is a targeted modification to Solana fee calculation logic. This is a critical path for any Solana transaction — staking, sending, swapping, and selling all depend on correct fee computation. The highest risk is in tests that explicitly assert on fee values displayed during device confirmation (send-sol, staking flows, swap-coins). Medium risk exists for Solana trading flows that verify fees are non-zero. No static coverage mapping was available, so all recommendations are inferred from the LLM analysis of test behaviors and source hints.

<details><summary><b>Changed files (1)</b></summary>

- `coins/coins-solana/src/runtime/fees.ts`

</details>

**Recommended tests (13)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — This test exercises the full Solana initial staking flow including fee display on the device prompt. The changed file `coins-solana/src/runtime/fees.ts` directly affects how Solana fees are calculated and formatted, which is verified in assertions about fee amounts and total crypto amounts during staking confirmation.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — This test validates staking additional SOL including fee calculation displayed on the device prompt (stake + rent, fee values). Changes to Solana fee logic directly impact the correctness of these displayed values and transaction confirmation.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — This test covers SOL unstaking and claiming flows, both of which display transaction fees on the device prompt. The fee calculation from `coins-solana/src/runtime/fees.ts` is directly exercised when the test verifies fee amounts during unstake and claim confirmations.
- `suite/e2e/tests/wallet/send-sol.test.ts` — This test sends max SOL from a wallet and explicitly asserts on fee values (maxFee), reserved amounts, and the net sendable amount after fee deduction. Solana fee calculation changes directly affect the send-max logic and displayed fee on the device prompt.
- `suite/e2e/tests/trading/sell-solana.test.ts` — This test sells SOL and asserts that the device prompt fee amount is greater than 0 and that fee section values (max fee, max fee fiat) are visible. Solana fee calculation changes could cause incorrect fee display or transaction failures in the sell flow.
- `suite/e2e/tests/trading/swap-coins.test.ts` — This test swaps SOL to BTC and verifies the Solana transaction fee displayed on the device matches the fee from the form. The fee is explicitly read and compared, making this directly sensitive to changes in Solana fee computation.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — This test swaps SOL to USDC and verifies the device prompt fee is greater than 0. While less precise than swap-coins, it still exercises Solana fee calculation during the swap send transaction.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — This test swaps a Solana SPL token (USDT) to BTC and asserts the device prompt fee amount is greater than 0. The Solana transaction fee calculation is exercised when sending the SPL token to the swap provider.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — This test swaps Solana SPL tokens (USDT to USDC) and verifies the fee amount is greater than 0. Solana fee calculation is involved in constructing and displaying the swap transaction fee.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — This test exercises sell form percentage buttons for SOL accounts and uses solanaStakingMock for balance mocking. Fee calculation could affect the max sellable amount computation for Solana, though the test focuses more on input validation than fee display.
- `suite/e2e/tests/staking/sol/rewards.test.ts` — This test displays Solana staking dashboard data and verifies staking account balances. While primarily focused on rewards display, it uses Solana staking infrastructure that may depend on fee-related calculations for account state.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trading/buy-solana-token.test.ts` — This test buys a Solana token (JUP) via the trading flow. While it involves the Solana network, the buy flow is primarily about quote display and trade confirmation with the Invity backend rather than on-chain fee calculation.
- `suite/e2e/tests/staking/staking-form.test.ts` — This test validates ETH staking form inputs, not SOL. However, the staking form validation infrastructure may share patterns. Including at low priority since the change is Solana-specific and this test is ETH-focused.

</details>

_Updated: 2026-06-03T13:45:39.806Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=solana-walletconnect-feepayer-fix&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=solana-walletconnect-feepayer-fix&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-04T08:21:15.191Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-04T08:19:34.713Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/solana-walletconnect-feepayer-fix/web/](https://dev.suite.sldev.cz/suite-web/solana-walletconnect-feepayer-fix/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->