### PR TITLE
WIP: fix(analytics): move accounts/new-account event to AddAccountModal logic

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddAccountButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddAccountButton.tsx
@@ -1,8 +1,6 @@
 import { useCallback } from 'react';
 
-import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
-import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
 import { type Network, type NetworkAccount } from '@suite-common/wallet-config';
 import { type UnavailableCapability } from '@trezor/connect';
@@ -71,7 +69,6 @@ const AddDefaultAccountButton = ({
 }: AddAccountButtonProps) => {
     const defaultAccount = scopedAccounts.at(-1);
     const device = useSelector(selectSelectedDevice);
-    const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     const { setCoinFilter, setSearchString, coinFilter } = useAccountSearch();
 
@@ -84,15 +81,6 @@ const AddDefaultAccountButton = ({
                 // if coinFilter is active then reset it only if added account doesn't belong to selected/filtered coin
                 setCoinFilter([]);
             }
-
-            analytics.report({
-                type: events.accountsNewAccountEvent.name,
-                payload: {
-                    type: defaultAccount.accountType,
-                    path: defaultAccount.path,
-                    symbol: defaultAccount.symbol,
-                },
-            });
         } else {
             onAddNewAccount();
         }
@@ -101,7 +89,6 @@ const AddDefaultAccountButton = ({
         onEnableAccount,
         setSearchString,
         coinFilter,
-        analytics,
         setCoinFilter,
         onAddNewAccount,
     ]);

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -1,8 +1,10 @@
 import { useState } from 'react';
 
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { goto, selectRouterApp } from '@suite/router';
 import { selectHasExperimentalFeature, selectIsDebugModeActive } from '@suite/settings';
+import { useServices } from '@suite-common/dependency-injection';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import {
     type Network,
@@ -63,6 +65,7 @@ export const AddAccountModal = ({
     const enabledNetworkSymbols = useSelector(selectEnabledNetworks);
     const useTestnetNetworks = useSelector(selectHasExperimentalFeature('testnet-networks'));
     const dispatch = useDispatch();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     const { showUnsupportedCoins, supportedMainnets, unsupportedMainnets, supportedTestnets } =
         useNetworkSupport();
@@ -226,6 +229,16 @@ export const AddAccountModal = ({
         onConfirm?.();
 
         onAddAccount?.(account);
+
+        analytics.report({
+            type: events.accountsNewAccountEvent.name,
+            payload: {
+                type: account.accountType,
+                symbol: account.symbol,
+                path: account.path,
+            },
+        });
+
         if (app === 'wallet' && !noRedirect) {
             // redirect to account only if added from "wallet" app
             dispatch(
@@ -273,6 +286,16 @@ export const AddAccountModal = ({
 
         onCancel();
         dispatch(accountsActions.createAccount(newAccount));
+
+        analytics.report({
+            type: events.accountsNewAccountEvent.name,
+            payload: {
+                type: newAccount.accountType,
+                symbol: newAccount.symbol,
+                path: newAccount.path,
+            },
+        });
+
         dispatch(reportWalletBalanceThunk());
         onConfirm?.();
     }


### PR DESCRIPTION
## Description

This ensures the event is reliably captured in two scenarios where it was previously missed:
1. Single-type bypass: Coins with only one account type (e.g. ADA, ETH, Base) skip the selection screen and the AddAccountButton entirely.
2. Slow discovery: A race condition where discovery is slower than the user's click, hitting a code path in the button that lacked reporting.

## Related Issue

https://app.currents.dev/projects/Og0NOQ/insights/tests/dc1ff3efb4dd01431a249e75822c630d?s=wallet%2Fadd-account-types.test.ts&test_history_test_state=failed&testId=31d0e44192686900c0a0-898fa4731bd63da10140&instanceId=51518f3b0c9b13b6&testExplorerTab=attempts

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are scoped to the AddAccountModal and its AddAccountButton component, which are used when users add new cryptocurrency accounts. Although these files map to 121 tests via static analysis (indicating they are bundled as part of a broad modal system), only a handful of tests actually exercise the add-account flow directly. The highest risk is in tests that explicitly open the add-account modal, select account types, and confirm creation. The recommended strategy focuses on these 6 tests that directly interact with account creation modals and buttons.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddAccountButton.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/wallet/add-account-types.test.ts` — This test directly exercises the AddAccountModal and AddAccountButton components by adding different account types (normal, taproot, segwit, legacy) for multiple coins. It verifies the add-account modal visibility, account type selection, and confirm button — all of which are rendered by the changed files.
- `suite/e2e/tests/dashboard/assets.test.ts` — This test enables new assets via the 'Activate Assets' modal which internally uses the AddAccountModal flow to add network accounts. It directly exercises enabling a new network (ETH) through the modal and verifying the asset appears correctly.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/wallet/global-receive-send.test.ts` — The global receive flow adds a new ETH account via the asset picker which triggers the AddAccountModal (tradingPage.receiveAccount.addAccount). Changes to the modal or button could break this account creation path.
- `suite/e2e/tests/settings/coins.test.ts` — This test activates mainnet assets via the 'Activate Assets' modal from the dashboard empty state, which involves the AddAccountModal flow for enabling networks. Changes to the modal could affect the activation workflow.
- `suite/e2e/tests/metadata/legacy/account-metadata.test.ts` — This test adds a new BTC account via the add account button (walletPage.addAccountButton, settingsPage.coinsTab.networkAddButton) and labels it. The AddAccountModal and AddAccountButton are directly exercised when creating the new account.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — This test adds a new Suite receive account for ETH during the buy flow, which triggers the AddAccountModal to create a new ETH account. Changes to the modal could break the account addition during trading.

</details>

_Updated: 2026-06-03T13:55:14.032Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/analytics-accounts-new-account&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/analytics-accounts-new-account&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-03T14:01:48.518Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-03T13:57:04.379Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/analytics-accounts-new-account/web/](https://dev.suite.sldev.cz/suite-web/fix/analytics-accounts-new-account/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->