### PR TITLE
fix(transport): UdpApi read messages only if device is opened

### DIFF
--- a/packages/transport/src/api/udp.ts
+++ b/packages/transport/src/api/udp.ts
@@ -29,6 +29,7 @@ export class UdpApi extends AbstractApi {
     });
     private debugLink?: boolean;
     private readBuffer: ReturnType<typeof readMessageBuffer>;
+    private openedDevices = new Set<string>();
 
     constructor({
         logger,
@@ -44,7 +45,9 @@ export class UdpApi extends AbstractApi {
             }
 
             const id = `${info.address}:${info.port}`;
-            this.readBuffer.onMessage(id, message);
+            if (this.openedDevices.has(id)) {
+                this.readBuffer.onMessage(id, message);
+            }
             this.logger?.debug('udp: globalOnMessage log:', message.toString('hex'));
         };
         this.interface.addListener('message', onMessage);
@@ -200,7 +203,10 @@ export class UdpApi extends AbstractApi {
             this.devices,
             device => !devices.some(d => d.path === device.path),
         );
-        disconnected.forEach(d => this.readBuffer.cancelRead(d.path));
+        disconnected.forEach(({ path }) => {
+            this.openedDevices.delete(path);
+            this.readBuffer.cancelRead(path);
+        });
 
         if (known.length !== this.devices.length || unknown.length > 0) {
             this.devices = devices;
@@ -210,12 +216,15 @@ export class UdpApi extends AbstractApi {
         }
     }
 
-    public openDevice(...[_path]: AbstractApiArgs<'openDevice'>) {
+    public openDevice(...[path]: AbstractApiArgs<'openDevice'>) {
         // todo: maybe ping?
+        this.openedDevices.add(path);
+
         return Promise.resolve(success(undefined));
     }
 
     public closeDevice(...[path]: AbstractApiArgs<'closeDevice'>) {
+        this.openedDevices.delete(path);
         this.readBuffer.cancelRead(path);
 
         return Promise.resolve(success(undefined));

--- a/packages/transport/src/api/udp.ts
+++ b/packages/transport/src/api/udp.ts
@@ -17,6 +17,7 @@ import { arrayPartition, isNotUndefined, resolveAfter } from '@trezor/utils';
 
 const PING = Buffer.from('PINGPING');
 const PONG = Buffer.from('PONGPONG');
+const PING_TIMEOUT = 1000;
 
 export class UdpApi extends AbstractApi {
     chunkSize = 64;
@@ -30,6 +31,7 @@ export class UdpApi extends AbstractApi {
     private debugLink?: boolean;
     private readBuffer: ReturnType<typeof readMessageBuffer>;
     private openedDevices = new Set<string>();
+    private lastPongTimestamp = 0;
 
     constructor({
         logger,
@@ -40,6 +42,8 @@ export class UdpApi extends AbstractApi {
         this.readBuffer = readMessageBuffer();
 
         const onMessage = (message: Buffer, info: UDP.RemoteInfo) => {
+            this.lastPongTimestamp = Date.now();
+
             if (message.compare(PONG) === 0) {
                 return;
             }
@@ -123,6 +127,11 @@ export class UdpApi extends AbstractApi {
     }
 
     private async ping(path: PathInternal, signal?: AbortSignal) {
+        const diff = Date.now() - this.lastPongTimestamp;
+        if (diff < PING_TIMEOUT) {
+            return true;
+        }
+
         await this.write(path, PING, { signal });
         if (signal?.aborted) {
             throw new Error(ERRORS.ABORTED_BY_SIGNAL);
@@ -152,8 +161,7 @@ export class UdpApi extends AbstractApi {
             this.interface.addListener('error', onError);
             this.interface.addListener('message', onMessage);
 
-            // TODO temporarily increased from 1s to 4s until success screen is solved on fw side
-            const timeout = setTimeout(onError, 4000);
+            const timeout = setTimeout(onError, PING_TIMEOUT);
         });
 
         return pinged;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

addresses: https://github.com/trezor/trezor-suite/issues/27604

- `readBuffer.onMessage` is called only if device is opened. ignore messages when they are not expected.
- `PING` is sent through `debug` channel, probably related to https://github.com/trezor/trezor-suite/pull/21777 should fix the issue when main (wire) channel is busy and not responding.


<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/transport-udp-read/web/](https://dev.suite.sldev.cz/suite-web/fix/transport-udp-read/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/transport-udp-read&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/transport-udp-read&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/transport-udp-read&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T12:57:48.323Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T12:57:06.749Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are concentrated in the transport layer: bridge core, transport-common abstractions (API, THP protocol, USB), Bluetooth APIs, and the trezor-user-env-link test helper. The highest risk is to bridge lifecycle management and THP device communication. Tests exercising bridge spawning/restart and THP pairing flows should be prioritized. Most E2E tests use the transport layer implicitly but only a few directly test transport-specific behaviors (bridge lifecycle, session management, device reconnection, THP pairing). The majority of changed files (unit tests, native Bluetooth, CI scripts) have no direct E2E coverage.

<details><summary><b>Changed files (16)</b></summary>

- `packages/transport-bluetooth/src/client/bluetooth-api.ts`
- `packages/transport-bridge/src/core.ts`
- `packages/transport-common/src/api/abstract.ts`
- `packages/transport-common/src/api/usb.ts`
- `packages/transport-common/src/index.ts`
- `packages/transport-common/src/thp/loop.ts`
- `packages/transport-common/src/thp/receiveExpectedMessage.ts`
- `packages/transport-common/src/transports/abstractApi.ts`
- `packages/transport-common/tests/apiUsb.test.ts`
- `packages/transport-common/tests/thp.test.ts`
- `packages/transport-native-bluetooth/src/api/BluetoothApi.ts`
- `packages/transport-test/e2e/api/api.test.ts`
- `packages/transport/src/api/udp.ts`
- `packages/transport/tests/apiUdp.test.ts`
- `packages/trezor-user-env-link/src/api.ts`
- `scripts/ci/connect-test-matrix-generator.js`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — This test directly exercises the bridge spawning, lifecycle, and reconnection logic. Changes to packages/transport-bridge/src/core.ts (bridge core) and packages/transport-common (transport abstractions) could break bridge startup, health checks, and device reconnection after bridge restart.
- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — This test validates bridge daemon mode — spawning, detecting running state, and stopping. Changes to transport-bridge/core.ts and transport-common abstractions directly affect the bridge process lifecycle that this test verifies.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/suite/initial-run.test.ts` — This test covers THP (Trezor Host Protocol) pairing during initial onboarding. Changes to packages/transport-common/src/thp/loop.ts and thp/receiveExpectedMessage.ts directly affect THP communication, which this test exercises via device connection and THP pairing code entry.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test validates Bridge session management (stealing, reclaiming, multi-tab behavior). Changes to transport-bridge/core.ts and transport-common transport abstractions could affect session acquire/enumerate behavior that this test directly verifies.
- `suite/e2e/tests/recovery/dry-run.test.ts` — This test simulates bridge stop/restart (device disconnect/reconnect) during a recovery dry run. Changes to transport-bridge core and transport-common abstractions could affect how the app handles bridge interruption and reinitializes the transport connection.
- `suite/e2e/tests/recovery/t2t1-dry-run.test.ts` — Similar to dry-run.test.ts, this test exercises bridge stop/restart cycles during recovery. Transport layer changes could affect the reconnection and reinitialization behavior tested here.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts` — T3T1 onboarding involves THP protocol communication for device setup. Changes to transport-common THP loop and message handling could affect the device communication during wallet creation on newer device models.
- `suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts` — T3W1 onboarding explicitly exercises THP pairing code entry and device connection. Changes to THP loop/message handling in transport-common could affect this flow.
- `suite/e2e/tests/settings/forget-device.test.ts` — This test covers Bluetooth unpairing for TS7 devices and device disconnection handling. Changes to transport-bluetooth API and transport-common abstractions could affect the Bluetooth forget/unpair flow tested here.

</details>

⚠️ **Changes with no test coverage (8)**
- `packages/transport-common/src/api/usb.ts`
- `packages/transport-common/tests/apiUsb.test.ts`
- `packages/transport-common/tests/thp.test.ts`
- `packages/transport-native-bluetooth/src/api/BluetoothApi.ts`
- `packages/transport-test/e2e/api/api.test.ts`
- `packages/transport/src/api/udp.ts`
- `packages/transport/tests/apiUdp.test.ts`
- `scripts/ci/connect-test-matrix-generator.js`

_Updated: 2026-06-09T11:08:05.690Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->