### PR TITLE
fix(suite-native): display internal transactions summary in tx list

### DIFF
--- a/suite-native/formatters/src/components/CryptoAmountFormatter.tsx
+++ b/suite-native/formatters/src/components/CryptoAmountFormatter.tsx
@@ -20,6 +20,7 @@ type CryptoToFiatAmountFormatterProps = FormatterProps<string | null | number> &
         decimals?: number;
         isForcedDiscreetMode?: boolean;
         isLoading?: boolean;
+        sign?: '+' | '-' | null;
     };
 
 export const CryptoAmountFormatter = React.memo(
@@ -31,6 +32,7 @@ export const CryptoAmountFormatter = React.memo(
         variant = 'body-sm',
         color = 'contentSecondary',
         isLoading = false,
+        sign = null,
         decimals,
         ...otherProps
     }: CryptoToFiatAmountFormatterProps) => {
@@ -52,9 +54,11 @@ export const CryptoAmountFormatter = React.memo(
             isEllipsisAppended: false,
         });
 
+        const valueWithSign = !sign ? formattedValue : `${sign}${formattedValue}`;
+
         return (
             <AmountText
-                value={formattedValue}
+                value={valueWithSign}
                 isDiscreetText={isDiscreetText}
                 variant={variant}
                 color={color}

--- a/suite-native/transactions/src/components/TransactionListItem.tsx
+++ b/suite-native/transactions/src/components/TransactionListItem.tsx
@@ -7,6 +7,8 @@ import {
     type PhishingRootState,
     type TransactionsRootState,
     type WalletSettingsRootState,
+    createTargets,
+    selectAccountByKey,
     selectIsPhishingTransaction,
     selectIsTestnetAccount,
 } from '@suite-common/wallet-core';
@@ -26,6 +28,7 @@ import { selectTransactionFiatRate } from '../selectors';
 import { getTransactionValueSign } from '../utils';
 import { TokenTransferListItem } from './TokenTransferListItem';
 import { TransactionListItemContainer } from './TransactionListItemContainer';
+import { TransactionTarget } from './TransactionTarget';
 
 type TransactionListItemProps = {
     transaction: WalletAccountTransaction;
@@ -111,10 +114,24 @@ export const TransactionListItem = ({
     isFirst = false,
     isLast = false,
 }: TransactionListItemProps) => {
+    const account = useSelector((state: AccountsRootState) =>
+        selectAccountByKey(state, accountKey),
+    );
+    const { isPhishing: isPhishingTransaction } = useSelector(
+        (
+            state: TokenDefinitionsRootState &
+                TransactionsRootState &
+                FiatRatesRootState &
+                PhishingRootState,
+        ) => selectIsPhishingTransaction(state, transaction.txid, accountKey),
+    );
+
     const includedCoinsCount = transaction.tokens.length;
 
     const firstToken = transaction.tokens[0];
     const isTokenOnlyTransaction = transaction.amount === '0' && firstToken !== undefined;
+
+    const allOutputs = account !== null ? createTargets({ transaction, account }) : [];
 
     if (isTokenOnlyTransaction)
         return (
@@ -140,7 +157,15 @@ export const TransactionListItem = ({
             isFirst={isFirst}
             isLast={isLast}
         >
-            <TransactionListItemValues accountKey={accountKey} transaction={transaction} />
+            {allOutputs.map((target, i) => (
+                <TransactionTarget
+                    key={i}
+                    accountKey={accountKey}
+                    isPhishingTransaction={isPhishingTransaction}
+                    transaction={transaction}
+                    {...target}
+                />
+            ))}
         </TransactionListItemContainer>
     );
 };

--- a/suite-native/transactions/src/components/TransactionTarget.tsx
+++ b/suite-native/transactions/src/components/TransactionTarget.tsx
@@ -1,0 +1,151 @@
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+
+import { type SignOperator } from '@suite-common/suite-types';
+import {
+    type AccountsRootState,
+    type FiatRatesRootState,
+    type Target,
+    type WalletSettingsRootState,
+    selectIsTestnetAccount,
+} from '@suite-common/wallet-core';
+import { type AccountKey } from '@suite-common/wallet-types';
+import { getTxOperation } from '@suite-common/wallet-utils';
+import { Box, VStack } from '@suite-native/atoms';
+import {
+    CryptoAmountFormatter,
+    CryptoToFiatAmountFormatter,
+    EmptyAmountText,
+    SignValueFormatter,
+} from '@suite-native/formatters';
+import { type WalletAccountTransaction } from '@suite-native/tokens';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+import { exhaustive } from '@trezor/type-utils';
+import { BigNumber } from '@trezor/utils';
+
+import { selectTransactionFiatRate } from '../selectors';
+
+type TransactionListItemValuesProps = {
+    accountKey: AccountKey;
+    transaction: WalletAccountTransaction;
+    isPhishingTransaction: boolean;
+    amount: string;
+    operation: SignOperator | null;
+};
+
+const failedTxStyle = prepareNativeStyle<{ isFailedTx: boolean }>((_, { isFailedTx }) => ({
+    extend: {
+        condition: isFailedTx,
+        style: {
+            textDecorationLine: 'line-through',
+        },
+    },
+}));
+
+const TransactionListItemValues = ({
+    accountKey,
+    transaction,
+    isPhishingTransaction,
+    amount,
+    operation,
+}: TransactionListItemValuesProps) => {
+    const isTestnetAccount = useSelector((state: AccountsRootState) =>
+        selectIsTestnetAccount(state, accountKey),
+    );
+
+    const { applyStyle } = useNativeStyles();
+
+    const historicRate = useSelector((state: WalletSettingsRootState & FiatRatesRootState) =>
+        selectTransactionFiatRate(state, transaction),
+    );
+    const isFailedTx = transaction.type === 'failed';
+
+    return (
+        <VStack spacing="sp4" alignItems="flex-end">
+            {isTestnetAccount ? (
+                <EmptyAmountText />
+            ) : (
+                <Box flexDirection="row">
+                    {!isFailedTx && !isPhishingTransaction && (
+                        <SignValueFormatter value={operation} />
+                    )}
+                    <CryptoToFiatAmountFormatter
+                        value={amount || transaction.amount}
+                        symbol={transaction.symbol}
+                        historicRate={historicRate}
+                        useHistoricRate
+                        isForcedDiscreetMode={isPhishingTransaction}
+                        style={applyStyle(failedTxStyle, { isFailedTx })}
+                    />
+                </Box>
+            )}
+
+            <CryptoAmountFormatter
+                value={amount || transaction.amount}
+                symbol={transaction.symbol}
+                isBalance={false}
+                numberOfLines={1}
+                sign={operation === 'positive' ? '+' : '-'}
+                adjustsFontSizeToFit
+                isForcedDiscreetMode={isPhishingTransaction}
+                variant="body-sm"
+                color="contentSecondary"
+            />
+        </VStack>
+    );
+};
+
+type TransactionTargetProps = Target & {
+    transaction: WalletAccountTransaction;
+    accountKey: AccountKey;
+    isActionDisabled?: boolean;
+    isPhishingTransaction?: boolean;
+};
+
+export const TransactionTarget = ({
+    transaction,
+    type,
+    payload,
+    accountKey,
+    isPhishingTransaction,
+}: TransactionTargetProps) => {
+    const isSolanaUnstakeTx = transaction?.solanaSpecific?.stakeOperation?.type === 'unstake';
+
+    // formatting is handled in a child component
+    const amount = useMemo(() => {
+        if (isSolanaUnstakeTx) return null;
+        switch (type) {
+            case 'target':
+                return transaction.amount;
+            case 'internal':
+            case 'token':
+                return payload.amount;
+            default:
+                return exhaustive(type);
+        }
+    }, [type, payload, transaction, isSolanaUnstakeTx]);
+
+    const operation = useMemo(() => {
+        switch (type) {
+            case 'target':
+                return getTxOperation(transaction.type);
+            case 'internal':
+            case 'token':
+                return getTxOperation(payload.type);
+            default:
+                return exhaustive(type);
+        }
+    }, [transaction.type, payload, type]);
+
+    if (new BigNumber(amount ?? '0').lte(0)) return null;
+
+    return (
+        <TransactionListItemValues
+            transaction={transaction}
+            amount={amount!}
+            operation={operation}
+            accountKey={accountKey}
+            isPhishingTransaction={!!isPhishingTransaction}
+        />
+    );
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR attempts to unify logic of displaying transaction outputs in the transactions list screen on mobile. The main issue is incorrect values displayed for unstaking/claiming and other transactions like approve. 

With these changes I've attempted to reproduce the way how outcomes are displayed on mobile without introducing a lot of changes and basically mapping the transaction amount in the new `suite-native/../TransactionTarget` and rendering the same element that was there. The zero value outcomes are currently ignored and not displayed 

The sign is now determined using `getTxOperation` and not `getTransactionValueSign`.

## Notes for QA

This PR touches the broad scope of transactions outcomes, so it would make sense to make it doesn't affect anything outside of EVM and for Ethereum transaction would be displayed according to the scope of issue

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26852

## Screenshots:

<img width="3278" height="1668" alt="image" src="https://github.com/user-attachments/assets/9b3f6681-5d98-4ebb-9383-044646823af4" />

`+` plus sign to the crypto amount added later
<img width="390" height="316" alt="Screenshot 2026-06-04 at 14 25 38" src="https://github.com/user-attachments/assets/785993c4-b6ad-4dc1-bcb4-5264d8744508" />




<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/tsm-evm-internal-tx&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->