### PR TITLE
chore(node-utils): drop deprecated fs.exists usages

### DIFF
--- a/packages/node-utils/src/ensureDirectoryExists.ts
+++ b/packages/node-utils/src/ensureDirectoryExists.ts
@@ -1,13 +1,9 @@
-import fs from 'fs';
-import { promisify } from 'util';
-
-const exists = promisify(fs.exists);
-const mkdir = promisify(fs.mkdir);
+import { promises as fs } from 'fs';
 
 export const ensureDirectoryExists = async (dir: string) => {
-    if (!(await exists(dir))) {
-        await mkdir(dir, { recursive: true });
-    }
+    // With `recursive: true`, mkdir creates missing directories and does not
+    // throw when the target already exists as a directory.
+    await fs.mkdir(dir, { recursive: true });
 
     return dir;
 };

--- a/packages/node-utils/src/tests/ensureDirectoryExists.test.ts
+++ b/packages/node-utils/src/tests/ensureDirectoryExists.test.ts
@@ -1,16 +1,44 @@
-import fs from 'fs';
-import { promisify } from 'util';
+import { existsSync, promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
 
 import { ensureDirectoryExists } from '../ensureDirectoryExists';
 
-const exists = promisify(fs.exists);
-
 describe('ensureDirectoryExists', () => {
-    it('if the files does not exist it creates it', async () => {
-        const directoryToCreate = './tmp/test';
-        const directory = await ensureDirectoryExists(directoryToCreate);
+    let baseDir: string;
 
-        expect(directory).toBeTruthy();
-        expect(await exists(directory)).toBeTruthy();
+    beforeEach(async () => {
+        baseDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ensure-dir-'));
+    });
+
+    afterEach(async () => {
+        await fs.rm(baseDir, { recursive: true, force: true });
+    });
+
+    it('creates the directory when it does not exist', async () => {
+        const target = path.join(baseDir, 'nested', 'dir');
+        expect(existsSync(target)).toBe(false);
+
+        const result = await ensureDirectoryExists(target);
+
+        expect(result).toBe(target);
+        expect(existsSync(target)).toBe(true);
+    });
+
+    it('is a no-op when the directory already exists', async () => {
+        const target = path.join(baseDir, 'existing');
+        await fs.mkdir(target);
+
+        const result = await ensureDirectoryExists(target);
+
+        expect(result).toBe(target);
+        expect(existsSync(target)).toBe(true);
+    });
+
+    it('throws when the target already exists as a file', async () => {
+        const target = path.join(baseDir, 'existing-file');
+        await fs.writeFile(target, '');
+
+        await expect(ensureDirectoryExists(target)).rejects.toThrow();
     });
 });

--- a/packages/request-manager/e2e/torControlPort.test.ts
+++ b/packages/request-manager/e2e/torControlPort.test.ts
@@ -7,7 +7,6 @@ import { TorControlPort, createHmacSignature, getCookieString } from '../src/tor
 import type { TorConnectionOptions } from '../src/types';
 
 const writeFile = util.promisify(fs.writeFile);
-const existsDirectory = util.promisify(fs.exists);
 const mkdir = util.promisify(fs.mkdir);
 const unlinkFile = util.promisify(fs.unlink);
 
@@ -22,7 +21,7 @@ const controlPort = 9999;
 // TODO: Skipping this for now, since I want to get the most critical tests to run in CI.
 describe.skip('TorControlPort', () => {
     beforeAll(async () => {
-        if (!(await existsDirectory(torDataDir))) {
+        if (!fs.existsSync(torDataDir)) {
             // Make sure there is `torDataDir` directory.
             mkdir(torDataDir);
         }

--- a/scripts/ci/connect-bump-versions.ts
+++ b/scripts/ci/connect-bump-versions.ts
@@ -12,7 +12,6 @@ import {
 } from './helpers';
 
 const readFile = promisify(fs.readFile);
-const existsDirectory = promisify(fs.exists);
 const writeFile = promisify(fs.writeFile);
 
 const args = process.argv.slice(2);
@@ -185,7 +184,7 @@ const bumpConnect = async () => {
             // We do that so we can generate the complete CHANGELOG automatically when doing stable release.
             if (newCommits.length && deploymentType === 'stable') {
                 const CHANGELOG_PATH = path.join(PACKAGE_PATH, 'CHANGELOG.md');
-                if (!(await existsDirectory(CHANGELOG_PATH))) {
+                if (!fs.existsSync(CHANGELOG_PATH)) {
                     await writeFile(CHANGELOG_PATH, '');
                 }
 

--- a/scripts/ci/pack-packages.ts
+++ b/scripts/ci/pack-packages.ts
@@ -7,7 +7,6 @@ import util from 'node:util';
 import { exec, getPackageDependencies, getTrezorPackageDir } from './helpers';
 
 const mkdir = util.promisify(fs.mkdir);
-const existsDirectory = util.promisify(fs.exists);
 const removeDir = util.promisify(fs.rm);
 const writeFile = util.promisify(fs.writeFile);
 
@@ -127,7 +126,7 @@ const buildAllPackages = async () => {
         ]),
     ];
 
-    if (await existsDirectory(OUTPUT_DIR)) {
+    if (fs.existsSync(OUTPUT_DIR)) {
         await removeDir(OUTPUT_DIR, { recursive: true });
     }
     await mkdir(OUTPUT_DIR, { recursive: true });
@@ -142,7 +141,7 @@ const buildAllPackages = async () => {
     for (const pkg of PACKAGES) {
         const pkgDir = getTrezorPackageDir(pkg);
 
-        if (!(await existsDirectory(pkgDir))) {
+        if (!fs.existsSync(pkgDir)) {
             console.error(`Package not found: ${pkg}`);
             results.failed.push({ pkg, error: 'Package directory not found' });
             continue;


### PR DESCRIPTION
## Summary

Removes the deprecated [`fs.exists`](https://nodejs.org/api/fs.html#fsexistspath-callback) API. `fs.exists` has been deprecated by Node for years (its callback breaks the `(err, …)` convention) and should not be used in new code. After this PR there are **no** `promisify(fs.exists)` usages left anywhere in the repo.

Four call sites across three areas:

- **`packages/node-utils/src/ensureDirectoryExists.ts`** — the `promisify(fs.exists)` guard was not only deprecated but redundant: `fs.mkdir(dir, { recursive: true })` already creates the directory (and missing parents) when absent and is a no-op when it already exists as a directory. The existence check is dropped entirely in favour of a direct, idempotent `mkdir`. The test is also hardened (see below).
- **`scripts/ci/pack-packages.ts`** and **`scripts/ci/connect-bump-versions.ts`** — the `existsDirectory = promisify(fs.exists)` helpers are replaced with a synchronous **`fs.existsSync`** check. These are sequential CI scripts where async indirection adds no value, and `fs.existsSync` is non-deprecated and already the idiomatic choice in this folder (see `scripts/ci/helpers.ts`). This keeps the diff to a one-liner per call site with no extra helper.
- **`packages/request-manager/e2e/torControlPort.test.ts`** — same `existsDirectory` → `fs.existsSync` swap in the (skipped) e2e setup path.

### Note on behavior

`ensureDirectoryExists` now **fails loudly** if the target path already exists as a regular *file*: previously `fs.exists` returned `true` and the `mkdir` was skipped, so the call silently returned the path; now the idempotent `mkdir` throws `EEXIST`. This is the more correct behavior (you asked to ensure a *directory* and there is a file in the way) and is covered by a new test.

### Test hardening

The existing `ensureDirectoryExists` test claimed to cover the "create when missing" path but never guaranteed the target was absent (no setup) and left `./tmp/test` on disk (no teardown), so on repeat runs it asserted nothing. It now:
- uses an isolated `mkdtemp` directory with proper `afterEach` teardown,
- asserts absence before / presence after (via non-deprecated `existsSync`),
- adds an idempotency case for an already-existing directory,
- adds a case asserting it throws when the target exists as a file.

## Context

Spun out of the dead-code-removal review around `@trezor/node-utils` (sibling PR #28348, staging #27551), where the deprecated `fs.exists` usage was spotted.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/node-utils-replace-deprecated-fs-exists&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/node-utils-replace-deprecated-fs-exists&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-06T10:47:21.044Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add account types ada | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-06T10:44:46.797Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/node-utils-replace-deprecated-fs-exists/web/](https://dev.suite.sldev.cz/suite-web/mroz22/node-utils-replace-deprecated-fs-exists/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files consist of: (1) a Node.js utility function `ensureDirectoryExists` and its unit test in `packages/node-utils`, (2) a Tor control port e2e test in `packages/request-manager`, and (3) two CI scripts for version bumping and package packing. None of these files are referenced by any of the 81 candidate Playwright E2E tests, and reviewing the LLM analysis of each test confirms no plausible connection — the tests cover Suite UI flows (onboarding, settings, trading, wallets, staking, analytics, metadata, etc.) which do not interact with low-level Node filesystem utilities, Tor control port logic, or CI packaging scripts. No E2E tests need to be run for this change set.

<details><summary><b>Changed files (5)</b></summary>

- `packages/node-utils/src/ensureDirectoryExists.ts`
- `packages/node-utils/src/tests/ensureDirectoryExists.test.ts`
- `packages/request-manager/e2e/torControlPort.test.ts`
- `scripts/ci/connect-bump-versions.ts`
- `scripts/ci/pack-packages.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (5)**
- `packages/node-utils/src/ensureDirectoryExists.ts`
- `packages/node-utils/src/tests/ensureDirectoryExists.test.ts`
- `packages/request-manager/e2e/torControlPort.test.ts`
- `scripts/ci/connect-bump-versions.ts`
- `scripts/ci/pack-packages.ts`

_Updated: 2026-06-06T10:41:37.832Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->