### PR TITLE
Refactor/utxolib compose feepolicy

### DIFF
--- a/packages/connect-common/src/types/api/composeTransaction.ts
+++ b/packages/connect-common/src/types/api/composeTransaction.ts
@@ -31,7 +31,6 @@ export type ComposeParams = {
     push?: boolean;
     sequence?: number;
     baseFee?: number;
-    floorBaseFee?: boolean;
     sortingStrategy?: TransactionInputOutputSortingStrategy;
 };
 
@@ -56,7 +55,6 @@ export type PrecomposeParams = {
     feeLevels: { feePerUnit: string }[];
     push?: undefined;
     baseFee?: number;
-    floorBaseFee?: boolean;
     sequence?: number;
     sortingStrategy?: TransactionInputOutputSortingStrategy;
 };

--- a/packages/connect-explorer/src/pages/methods/bitcoin/composeTransaction.mdx
+++ b/packages/connect-explorer/src/pages/methods/bitcoin/composeTransaction.mdx
@@ -24,7 +24,6 @@ export const PrecomposeSchema = Type.Object({
     }),
     feeLevels: Type.Array(Type.Object({ feePerUnit: Type.String() })),
     baseFee: Type.Optional(Type.Number()),
-    floorBaseFee: Type.Optional(Type.Boolean()),
     sequence: Type.Optional(Type.Number()),
     sortingStrategy: Type.Optional(
         Type.Union([Type.Literal('bip69'), Type.Literal('none'), Type.Literal('random')]),
@@ -42,8 +41,6 @@ export const paramDescriptions = {
         'Array of objects. set of requested variants, partial result of `blockchainEstimateFee method`',
     baseFee:
         'base fee of transaction in satoshi. used in replacement transactions calculation (RBF) and DOGE',
-    floorBaseFee:
-        'decide whenever baseFee should be floored to the nearest baseFee unit, prevents from fee overpricing. used in DOGE',
     sortingStrategy: 'strategy for sorting inputs/outputs: bip69, none, random',
 };
 

--- a/packages/connect/src/api/bitcoin/TransactionComposer.ts
+++ b/packages/connect/src/api/bitcoin/TransactionComposer.ts
@@ -9,8 +9,12 @@ import type {
     SelectFeeLevel,
 } from '@trezor/connect-common';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
-import type { ComposeOutput, TransactionInputOutputSortingStrategy } from '@trezor/utxo-lib';
-import { composeTx } from '@trezor/utxo-lib';
+import type {
+    ComposeFeePolicy,
+    ComposeOutput,
+    TransactionInputOutputSortingStrategy,
+} from '@trezor/utxo-lib';
+import { composeTx, networks } from '@trezor/utxo-lib';
 
 import type { Blockchain } from '../../backend/BlockchainLink';
 import { getOrInitBitcoinFeeLevels } from '../../backend/fees';
@@ -168,6 +172,13 @@ export class TransactionComposer {
         const changeAddress = addresses.change.find(a => !a.transfers) || lastChange;
         // const inputAmounts = coinInfo.segwit || coinInfo.forkid !== null || coinInfo.network.consensusBranchId !== null;
 
+        let feePolicy: ComposeFeePolicy | undefined;
+        if (networks.isNetworkType('doge', coinInfo.network)) {
+            feePolicy = 'doge';
+        } else if (networks.isNetworkType('zcash', coinInfo.network)) {
+            feePolicy = 'zcash';
+        }
+
         return composeTx({
             txType: account.type,
             utxos: this.utxos,
@@ -179,6 +190,7 @@ export class TransactionComposer {
             changeAddress,
             dustThreshold: coinInfo.dustLimit,
             baseFee,
+            feePolicy,
         });
     }
 

--- a/packages/connect/src/api/composeTransaction.ts
+++ b/packages/connect/src/api/composeTransaction.ts
@@ -53,7 +53,6 @@ type Params = {
     account?: PrecomposeParams['account'];
     feeLevels?: PrecomposeParams['feeLevels'];
     baseFee?: PrecomposeParams['baseFee'];
-    floorBaseFee?: PrecomposeParams['floorBaseFee'];
     sequence?: PrecomposeParams['sequence'];
     total: BigNumber;
     sortingStrategy?: TransactionInputOutputSortingStrategy;
@@ -71,7 +70,6 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
             { name: 'account', type: 'object' },
             { name: 'feeLevels', type: 'array' },
             { name: 'baseFee', type: 'number' },
-            { name: 'floorBaseFee', type: 'boolean' },
             { name: 'sequence', type: 'number' },
             { name: 'sortingStrategy', type: 'string' },
         ]);
@@ -112,7 +110,6 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
             account: payload.account,
             feeLevels: payload.feeLevels,
             baseFee: payload.baseFee,
-            floorBaseFee: payload.floorBaseFee,
             sequence: payload.sequence,
             sortingStrategy: payload.sortingStrategy,
             push: typeof payload.push === 'boolean' ? payload.push : false,

--- a/packages/utxo-lib/src/coinselect/coinselectUtils.ts
+++ b/packages/utxo-lib/src/coinselect/coinselectUtils.ts
@@ -1,4 +1,3 @@
-import { type Network, isNetworkType } from '../networks';
 import {
     type CoinSelectAlgorithm,
     type CoinSelectInput,
@@ -163,13 +162,6 @@ export function sumOrNaN(range: { value?: bigint }[], forgiving = false) {
 
         return value + a;
     }, ZERO);
-}
-
-export function getFeePolicy(network?: Network) {
-    if (isNetworkType('doge', network)) return 'doge';
-    if (isNetworkType('zcash', network)) return 'zcash';
-
-    return 'bitcoin';
 }
 
 function getBitcoinFee(

--- a/packages/utxo-lib/src/coinselect/coinselectUtils.ts
+++ b/packages/utxo-lib/src/coinselect/coinselectUtils.ts
@@ -168,16 +168,12 @@ function getBitcoinFee(
     inputs: CoinSelectInput[],
     outputs: CoinSelectOutput[],
     feeRate: number,
-    { baseFee = 0, floorBaseFee }: Partial<CoinSelectOptions>,
+    { baseFee = 0 }: Partial<CoinSelectOptions>,
 ) {
     const bytes = transactionBytes(inputs, outputs);
     const defaultFee = getFeeForBytes(feeRate, bytes);
 
-    return baseFee && floorBaseFee
-        ? // increase baseFee for every started kilobyte (case only for DOGE)
-          baseFee * (1 + Math.floor(defaultFee / baseFee))
-        : // simple increase baseFee
-          baseFee + defaultFee;
+    return baseFee + defaultFee;
 }
 
 // DOGE fee policy https://github.com/dogecoin/dogecoin/blob/3a29ba6d497cd1d0a32ecb039da0d35ea43c9c85/doc/fee-recommendation.md

--- a/packages/utxo-lib/src/compose/request.ts
+++ b/packages/utxo-lib/src/compose/request.ts
@@ -239,7 +239,6 @@ export function validateAndParseRequest(request: Request): CoinSelectRequest | C
         longTermFeeRate,
         dustThreshold: request.dustThreshold,
         baseFee: request.baseFee,
-        floorBaseFee: request.floorBaseFee,
         sortingStrategy: request.sortingStrategy,
     };
 }

--- a/packages/utxo-lib/src/compose/request.ts
+++ b/packages/utxo-lib/src/compose/request.ts
@@ -4,7 +4,6 @@ import { toOutputScript } from '../address';
 import {
     INPUT_SCRIPT_LENGTH,
     OUTPUT_SCRIPT_LENGTH,
-    getFeePolicy,
     inputWeight,
     outputWeight,
     parseBigInt,
@@ -228,7 +227,7 @@ export function validateAndParseRequest(request: Request): CoinSelectRequest | C
         return changeOutput;
     }
 
-    const feePolicy = getFeePolicy(request.network);
+    const feePolicy = request.feePolicy ?? 'bitcoin';
 
     return {
         txType,

--- a/packages/utxo-lib/src/index.ts
+++ b/packages/utxo-lib/src/index.ts
@@ -44,7 +44,8 @@ export type {
     ComposeResultFinal,
     ComposedTransaction,
     CoinSelectPaymentType,
+    ComposeFeePolicy,
+    TransactionInputOutputSortingStrategy,
 } from './types';
 export type { Network } from './networks';
 export type { BIP32Interface } from './bip32';
-export type { TransactionInputOutputSortingStrategy } from './types/compose';

--- a/packages/utxo-lib/src/types/coinselect.ts
+++ b/packages/utxo-lib/src/types/coinselect.ts
@@ -1,4 +1,4 @@
-import { type TransactionInputOutputSortingStrategy } from './compose';
+import type { ComposeFeePolicy, TransactionInputOutputSortingStrategy } from './compose';
 
 export type CoinSelectPaymentType = 'p2pkh' | 'p2sh' | 'p2tr' | 'p2wpkh' | 'p2wsh';
 
@@ -24,7 +24,7 @@ export interface CoinSelectOptions {
      */
     floorBaseFee?: boolean;
     sortingStrategy: TransactionInputOutputSortingStrategy;
-    feePolicy?: 'bitcoin' | 'doge' | 'zcash';
+    feePolicy?: ComposeFeePolicy;
 }
 
 export interface CoinSelectInput {

--- a/packages/utxo-lib/src/types/coinselect.ts
+++ b/packages/utxo-lib/src/types/coinselect.ts
@@ -18,11 +18,6 @@ export interface CoinSelectOptions {
      * for the chained transaction, as well as for its own bandwidth (see BIP-125 rules).
      */
     baseFee?: number;
-
-    /**
-     * Only for DOGE
-     */
-    floorBaseFee?: boolean;
     sortingStrategy: TransactionInputOutputSortingStrategy;
     feePolicy?: ComposeFeePolicy;
 }

--- a/packages/utxo-lib/src/types/compose.ts
+++ b/packages/utxo-lib/src/types/compose.ts
@@ -80,6 +80,8 @@ export type TransactionInputOutputSortingStrategy =
     // This is useful for RBF transactions where the order of inputs and outputs must be preserved.
     | 'none';
 
+export type ComposeFeePolicy = 'bitcoin' | 'doge' | 'zcash';
+
 export type ComposeRequest<
     Input extends ComposeInput,
     Output extends ComposeOutput,
@@ -89,6 +91,7 @@ export type ComposeRequest<
     utxos: Input[]; // all inputs
     outputs: Output[]; // all outputs
     feeRate: string | number; // in sat/byte, virtual size
+    feePolicy?: ComposeFeePolicy; // explicit fee policy
     longTermFeeRate?: string | number; // dust output feeRate multiplier in sat/byte, virtual size
     network: Network;
     changeAddress: Change;

--- a/packages/utxo-lib/src/types/compose.ts
+++ b/packages/utxo-lib/src/types/compose.ts
@@ -97,7 +97,6 @@ export type ComposeRequest<
     changeAddress: Change;
     dustThreshold: number; // explicit dust threshold, in satoshi
     baseFee?: number; // DOGE or RBF base fee
-    floorBaseFee?: boolean; // DOGE floor base fee to the nearest integer
     skipUtxoSelection?: boolean; // use custom utxo selection, without algorithm
     sortingStrategy: TransactionInputOutputSortingStrategy;
 };

--- a/packages/utxo-lib/tests/__fixtures__/coinselect/accumulative.ts
+++ b/packages/utxo-lib/tests/__fixtures__/coinselect/accumulative.ts
@@ -822,12 +822,11 @@ export default [
         description: 'DOGE: 2 inputs, not enough to cover fee',
         feeRate: 100000,
         baseFee: 100000000,
-        floorBaseFee: true,
         feePolicy: 'doge',
         inputs: ['200000000', '20000000'],
         outputs: ['120000001'],
         expected: {
-            fee: 100000000,
+            fee: 134000000,
         },
         dustThreshold: 100000000,
     },
@@ -835,7 +834,6 @@ export default [
         description: 'DOGE: 2 inputs, not enough to cover fee (tx size)',
         feeRate: 100000,
         baseFee: 100000000,
-        floorBaseFee: true,
         feePolicy: 'doge',
         inputs: [
             '200000000',
@@ -848,7 +846,7 @@ export default [
         ],
         outputs: ['110000000'],
         expected: {
-            fee: 200000000,
+            fee: 223200000,
         },
         dustThreshold: 100000000,
     },
@@ -856,12 +854,11 @@ export default [
         description: 'DOGE: 1 input, not enough to cover fee (output-dust)',
         feeRate: 100000,
         baseFee: 100000000,
-        floorBaseFee: true,
         feePolicy: 'doge',
         inputs: ['200000000'],
         outputs: ['10000000'],
         expected: {
-            fee: 200000000,
+            fee: 219200000,
         },
         dustThreshold: 100000000,
     },
@@ -869,7 +866,6 @@ export default [
         description: 'DOGE: 1 input, 1 output, expect change',
         feeRate: 100000,
         baseFee: 100000000,
-        floorBaseFee: true,
         feePolicy: 'doge',
         inputs: ['500000111'],
         outputs: ['100000000'],
@@ -885,10 +881,10 @@ export default [
                     value: '100000000',
                 },
                 {
-                    value: '300000111',
+                    value: '277400111',
                 },
             ],
-            fee: 100000000,
+            fee: 122600000,
         },
         dustThreshold: 100000000,
     },
@@ -896,7 +892,6 @@ export default [
         description: 'DOGE: 2 outputs, no change (spend dust)',
         feeRate: 100000,
         baseFee: 100000000,
-        floorBaseFee: true,
         feePolicy: 'doge',
         inputs: ['400000000'],
         outputs: ['100000000', '5'],
@@ -923,14 +918,13 @@ export default [
         description: 'DOGE: 1 output, no change (tx size)',
         feeRate: 100000,
         baseFee: 100000000,
-        floorBaseFee: true,
         feePolicy: 'doge',
         inputs: [
             {
                 script: {
                     length: 1000,
                 },
-                value: '300000000',
+                value: '400000000',
             },
         ],
         outputs: ['100000000'],
@@ -941,7 +935,7 @@ export default [
                     script: {
                         length: 1000,
                     },
-                    value: '300000000',
+                    value: '400000000',
                 },
             ],
             outputs: [
@@ -949,7 +943,7 @@ export default [
                     value: '100000000',
                 },
             ],
-            fee: 200000000,
+            fee: 300000000,
         },
         dustThreshold: 100000000,
     },
@@ -957,7 +951,6 @@ export default [
         description: 'DOGE: 1 outputs, no change (increased fee rate)',
         feeRate: 150000,
         baseFee: 100000000,
-        floorBaseFee: true,
         feePolicy: 'doge',
         inputs: [
             {
@@ -965,7 +958,7 @@ export default [
                 script: {
                     length: 700,
                 },
-                value: '300000000',
+                value: '400000000',
             },
         ],
         outputs: ['100000000'],
@@ -976,7 +969,7 @@ export default [
                     script: {
                         length: 700,
                     },
-                    value: '300000000',
+                    value: '400000000',
                 },
             ],
             outputs: [
@@ -984,7 +977,7 @@ export default [
                     value: '100000000',
                 },
             ],
-            fee: 200000000,
+            fee: 300000000,
         },
         dustThreshold: 100000000,
     },

--- a/packages/utxo-lib/tests/__fixtures__/coinselect/split.ts
+++ b/packages/utxo-lib/tests/__fixtures__/coinselect/split.ts
@@ -263,23 +263,22 @@ export default [
         description: 'DOGE: 1 to 1',
         feeRate: 100000,
         baseFee: 100000000,
-        floorBaseFee: true,
         feePolicy: 'doge',
-        inputs: ['200000011'],
+        inputs: ['220000011'],
         outputs: [{}],
         expected: {
             inputs: [
                 {
                     i: 0,
-                    value: '200000011',
+                    value: '220000011',
                 },
             ],
             outputs: [
                 {
-                    value: '100000011',
+                    value: '100800011',
                 },
             ],
-            fee: 100000000,
+            fee: 119200000,
         },
         dustThreshold: 100000000,
     },
@@ -287,15 +286,14 @@ export default [
         description: 'DOGE: 1 to 3',
         feeRate: 100000,
         baseFee: 100000000,
-        floorBaseFee: true,
         feePolicy: 'doge',
-        inputs: ['400000000'],
+        inputs: ['426000002'],
         outputs: [{}, {}, {}],
         expected: {
             inputs: [
                 {
                     i: 0,
-                    value: '400000000',
+                    value: '426000002',
                 },
             ],
             outputs: [
@@ -309,7 +307,7 @@ export default [
                     value: '100000000',
                 },
             ],
-            fee: 100000000,
+            fee: 126000002,
         },
         dustThreshold: 100000000,
     },
@@ -317,7 +315,6 @@ export default [
         description: 'DOGE: 1 to 1 with tx size',
         feeRate: 100000,
         baseFee: 100000000,
-        floorBaseFee: true,
         feePolicy: 'doge',
         inputs: [
             {
@@ -341,10 +338,10 @@ export default [
             ],
             outputs: [
                 {
-                    value: '200000011',
+                    value: '191600011',
                 },
             ],
-            fee: 200000000,
+            fee: 208400000,
         },
         dustThreshold: 100000000,
     },
@@ -352,7 +349,6 @@ export default [
         description: 'DOGE: 1 to 1 with increased feeRate',
         feeRate: 150000,
         baseFee: 100000000,
-        floorBaseFee: true,
         feePolicy: 'doge',
         inputs: [
             {
@@ -376,10 +372,10 @@ export default [
             ],
             outputs: [
                 {
-                    value: '200000011',
+                    value: '182400011',
                 },
             ],
-            fee: 200000000,
+            fee: 217600000,
         },
         dustThreshold: 100000000,
     },
@@ -387,7 +383,6 @@ export default [
         description: 'DOGE: 1 to 2 with dust output',
         feeRate: 100000,
         baseFee: 100000000,
-        floorBaseFee: true,
         feePolicy: 'doge',
         inputs: [
             {
@@ -405,13 +400,13 @@ export default [
             ],
             outputs: [
                 {
-                    value: '200000010',
+                    value: '177400010',
                 },
                 {
                     value: '1',
                 },
             ],
-            fee: 200000000,
+            fee: 222600000,
         },
         dustThreshold: 100000000,
     },
@@ -419,7 +414,6 @@ export default [
         description: 'DOGE: 1 to 1, not enough funds (feeRate)',
         feeRate: 700000,
         baseFee: 100000000,
-        floorBaseFee: true,
         feePolicy: 'doge',
         inputs: [
             {
@@ -429,7 +423,7 @@ export default [
         ],
         outputs: [{}],
         expected: {
-            fee: 200000000,
+            fee: 234400000,
         },
         dustThreshold: 100000000,
     },
@@ -437,7 +431,6 @@ export default [
         description: 'DOGE: 1 to 1, not enough funds (dust output)',
         feeRate: 100000,
         baseFee: 100000000,
-        floorBaseFee: true,
         feePolicy: 'doge',
         inputs: [
             {
@@ -447,7 +440,7 @@ export default [
         ],
         outputs: [{}],
         expected: {
-            fee: 100000000,
+            fee: 119200000,
         },
         dustThreshold: 100000000,
     },
@@ -455,7 +448,6 @@ export default [
         description: 'DOGE: 1 to 2, not enough funds (dust defined output)',
         feeRate: 100000,
         baseFee: 100000000,
-        floorBaseFee: true,
         feePolicy: 'doge',
         inputs: [
             {
@@ -465,7 +457,7 @@ export default [
         ],
         outputs: [{}, { value: '1' }],
         expected: {
-            fee: 200000000,
+            fee: 222600000,
         },
         dustThreshold: 100000000,
     },

--- a/packages/utxo-lib/tests/__fixtures__/compose.ts
+++ b/packages/utxo-lib/tests/__fixtures__/compose.ts
@@ -1263,6 +1263,7 @@ export const composeTxFixture: Fixture[] = [
             feeRate: '1000',
             sortingStrategy: 'bip69',
             network: doge,
+            feePolicy: 'doge',
             outputs: [
                 {
                     address: 'DDn7UV1CrqVefzwrHyw7H2zEZZKqfzR2ZD',

--- a/packages/utxo-lib/tests/coinselect/accumulative.test.ts
+++ b/packages/utxo-lib/tests/coinselect/accumulative.test.ts
@@ -13,7 +13,6 @@ describe('coinselect: accumulative', () => {
                 txType: f.txType || 'p2pkh',
                 dustThreshold: f.dustThreshold,
                 baseFee: f.baseFee,
-                floorBaseFee: f.floorBaseFee,
                 feePolicy: f.feePolicy,
             } as CoinSelectOptions;
 

--- a/packages/utxo-lib/tests/coinselect/coinselectUtils.test.ts
+++ b/packages/utxo-lib/tests/coinselect/coinselectUtils.test.ts
@@ -30,12 +30,7 @@ describe('coinselectUtils', () => {
         expect(getFee([], [{ script: { length: 37 } }], 1.33)).toEqual(75);
         expect(getFee([], [{ script: { length: 81 } }], 1)).toEqual(100);
         expect(getFee([], [{ script: { length: 181 } }], 1)).toEqual(200);
-        // without floor
         expect(getFee([], [{ script: { length: 181 } }], 1, { baseFee: 1000 })).toEqual(1200);
-        // with floor
-        expect(
-            getFee([], [{ script: { length: 181 } }], 1, { baseFee: 1000, floorBaseFee: true }),
-        ).toEqual(1000);
     });
 
     it('sumOrNaN short-circuits subsequent items once accumulator becomes undefined', () => {
@@ -67,7 +62,7 @@ describe('coinselectUtils', () => {
                     { value: 7n, script: { length: 472 } },
                 ],
                 2,
-                { feePolicy: 'doge', baseFee: 1000, dustThreshold: 1000, floorBaseFee: true },
+                { feePolicy: 'doge', baseFee: 1000, dustThreshold: 1000 },
             ),
         ).toEqual(5000);
     });

--- a/packages/utxo-lib/tests/coinselect/coinselectUtils.test.ts
+++ b/packages/utxo-lib/tests/coinselect/coinselectUtils.test.ts
@@ -1,11 +1,4 @@
-import {
-    getDustAmount,
-    getFee,
-    getFeePolicy,
-    parseBigInt,
-    sumOrNaN,
-} from '../../src/coinselect/coinselectUtils';
-import { zcash as zcashNetwork } from '../../src/networks';
+import { getDustAmount, getFee, parseBigInt, sumOrNaN } from '../../src/coinselect/coinselectUtils';
 
 describe('coinselectUtils', () => {
     it('parseBigInt', () => {
@@ -43,10 +36,6 @@ describe('coinselectUtils', () => {
         expect(
             getFee([], [{ script: { length: 181 } }], 1, { baseFee: 1000, floorBaseFee: true }),
         ).toEqual(1000);
-    });
-
-    it('getFeePolicy returns "zcash" for the zcash network', () => {
-        expect(getFeePolicy(zcashNetwork)).toEqual('zcash');
     });
 
     it('sumOrNaN short-circuits subsequent items once accumulator becomes undefined', () => {

--- a/packages/utxo-lib/tests/coinselect/split.test.ts
+++ b/packages/utxo-lib/tests/coinselect/split.test.ts
@@ -14,7 +14,6 @@ describe('coinselect split', () => {
                 txType: f.txType || 'p2pkh',
                 dustThreshold: f.dustThreshold,
                 baseFee: f.baseFee,
-                floorBaseFee: f.floorBaseFee,
                 feePolicy: f.feePolicy,
             } as CoinSelectOptions;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Prerequisite for https://github.com/trezor/trezor-suite/pull/28285

I need to remove `network` params (utxo-lib/Network reference)  from the `composeTx` module.
To do that i need to add a new param: `feePolicy` so instead of inner `getFeePolicy` util (based on the Network) the value is passed from the consumer (trezor-connect TransactionComposer)

Additionally i'm removing unused `floorBaseFee` param. 
DOGE fee polices changed a couple of times since this param was added/needed and it has no purpose anymore.
DOGE test fixtures was updated to cover the lack of rounding.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/utxolib-compose-feepolicy&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/utxolib-compose-feepolicy&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/utxolib-compose-feepolicy&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-08T12:13:40.089Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add account types ada | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-08T12:10:52.436Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/utxolib-compose-feepolicy/web/](https://dev.suite.sldev.cz/suite-web/refactor/utxolib-compose-feepolicy/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->