### PR TITLE
fix(suite-native): fix minor passphrase form issues

### DIFF
--- a/suite-common/validators/src/schemas/passphraseSchema.ts
+++ b/suite-common/validators/src/schemas/passphraseSchema.ts
@@ -2,7 +2,10 @@ import { yup } from '../config';
 import { formInputsMaxLength } from '../inputsLengthConfig';
 
 export const passphraseFormSchema = yup.object({
-    passphrase: yup.string().required('Empty passphrase.').max(formInputsMaxLength.passphrase),
+    passphrase: yup
+        .string()
+        .required('Enter your passphrase to continue.')
+        .max(formInputsMaxLength.passphrase),
 });
 
 export type PassphraseFormValues = yup.InferType<typeof passphraseFormSchema>;

--- a/suite-native/forms/src/fields/TextInputField.tsx
+++ b/suite-native/forms/src/fields/TextInputField.tsx
@@ -41,8 +41,6 @@ export const TextInputField = forwardRef<InputType, FieldProps>(
             name,
             defaultValue,
             valueTransformer,
-            // Accessing `label` from destructured props does break the `RequireOneOrNone` validation of `Input` props.
-            label: otherProps.label,
         });
         const { errorMessage, onBlur: hookFormOnBlur, onChange, value, hasError } = field;
 

--- a/suite-native/forms/src/hooks/useField.ts
+++ b/suite-native/forms/src/hooks/useField.ts
@@ -8,14 +8,12 @@ import { type FieldName } from '../types';
 
 interface UseFieldArgs {
     name: FieldName;
-    label?: string;
     defaultValue?: unknown;
     valueTransformer?: (value: string) => string;
 }
 
 export const useField = ({
     name,
-    label,
     defaultValue,
     valueTransformer = value => value,
 }: UseFieldArgs) => {
@@ -39,8 +37,7 @@ export const useField = ({
     // Allows to parse/transform the value before it's set to the input.
     const transformedValue = G.isString(value) ? valueTransformer(value) : '';
 
-    // TODO: proper error message resolution using intl
-    const errorMessage = label ? error?.message?.replace(name, label) : error?.message;
+    const errorMessage = error?.message;
     const hasError = !!error;
 
     return {

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2100,8 +2100,8 @@ export const messages = {
         },
         form: {
             enterWallet: 'Enter passphrase',
-            createWalletInputLabel: 'Enter your passphrase',
-            verifyPassphraseInputLabel: 'Re-enter your passphrase',
+            createWalletInputLabel: 'Enter passphrase',
+            verifyPassphraseInputLabel: 'Re-enter passphrase',
         },
         enterPassphraseOnTrezor: {
             button: 'Enter passphrase on Trezor',

--- a/suite-native/intl/translations/en-US.json
+++ b/suite-native/intl/translations/en-US.json
@@ -1090,7 +1090,7 @@
     "modulePassphrase.alertCard.paragraphWarning3": "No one can recover it, not even Trezor support.",
     "modulePassphrase.alertCard.button": "How passphrase works",
     "modulePassphrase.form.enterWallet": "Enter passphrase",
-    "modulePassphrase.form.createWalletInputLabel": "Enter your passphrase",
+    "modulePassphrase.form.createWalletInputLabel": "Enter passphrase",
     "modulePassphrase.form.verifyPassphraseInputLabel": "Re-enter your passphrase",
     "modulePassphrase.enterPassphraseOnTrezor.button": "Enter passphrase on Trezor",
     "modulePassphrase.enterPassphraseOnTrezor.title": "Continue on Trezor",

--- a/suite-native/passphrase/src/components/PassphraseForm.tsx
+++ b/suite-native/passphrase/src/components/PassphraseForm.tsx
@@ -59,7 +59,7 @@ export const PassphraseForm = ({
 
     const form = useForm<PassphraseFormValues>({
         validation: passphraseFormSchema,
-        reValidateMode: 'onSubmit',
+        mode: 'onSubmit',
         defaultValues: {
             passphrase: '',
         },
@@ -101,7 +101,7 @@ export const PassphraseForm = ({
                             onBlur={() => setIsInputFocused(false)}
                             testID="@passphrase/passphraseInput"
                         />
-                        {isDirty && (
+                        {isInputFocused && (
                             <Animated.View entering={FadeIn} exiting={FadeOut}>
                                 <Button
                                     accessibilityRole="button"
@@ -109,7 +109,7 @@ export const PassphraseForm = ({
                                     onPress={handleCreateHiddenWallet}
                                     testID="@passphrase/confirmButton"
                                 >
-                                    <Translation id="modulePassphrase.form.enterWallet" />
+                                    <Translation id="generic.buttons.confirm" />
                                 </Button>
                             </Animated.View>
                         )}


### PR DESCRIPTION
## Description

- `useField` was replacing the field `name` (`"passphrase"`) with the input `label` string inside the yup error message text, producing nonsense like _"Enter your Enter your passphrase to continue."_
- Show the confirm button when the input is focused (was: when dirty) so it appears immediately on focus
- Switch confirm button to the generic `generic.buttons.confirm` translation key

## Notes for QA

- Open the passphrase entry screen and tap the input without typing anything; the confirm button should be visible right away.  Then tap Confirm — the error _"Enter your passphrase to continue."_ should appear exactly once, with no duplicate or mangled text

## Related Issue

Resolve #28289

## Screenshots:

https://github.com/user-attachments/assets/acaf44dd-d521-4846-9f78-f21e80acbb14



<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are primarily in suite-native/ (mobile app) components — PassphraseForm, TextInputField, useField hook, and intl messages/translations — plus a shared passphrase validation schema in suite-common/validators. The suite-native/ files are not exercised by the Playwright E2E tests, which target suite-web and suite-desktop. The only file with potential cross-platform impact is passphraseSchema.ts in suite-common/validators, which may be consumed by the desktop/web passphrase flows. Risk is low for regressions detectable by these E2E tests; the bulk of the changes require mobile-specific testing not covered here.

<details><summary><b>Changed files (6)</b></summary>

- `suite-common/validators/src/schemas/passphraseSchema.ts`
- `suite-native/forms/src/fields/TextInputField.tsx`
- `suite-native/forms/src/hooks/useField.ts`
- `suite-native/intl/src/messages.ts`
- `suite-native/intl/translations/en-US.json`
- `suite-native/passphrase/src/components/PassphraseForm.tsx`

</details>

**Recommended tests (4)**

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/passphrase/passphrase.test.ts` — This test exercises passphrase entry, validation, mismatch detection, and visibility toggling — all behaviors that could be affected by changes to passphraseSchema.ts (validation rules) and PassphraseForm.tsx (form component). While the changed files are in suite-native/ (mobile), the shared passphraseSchema in suite-common/validators could affect desktop passphrase validation too.
- `suite/e2e/tests/passphrase/passphrase-duplicate.test.ts` — This test validates passphrase duplicate detection when adding hidden wallets. Changes to passphraseSchema.ts could alter validation behavior that gates passphrase submission, potentially affecting whether duplicate detection is reached.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/passphrase/passphrase-cancel.test.ts` — This test covers passphrase entry and cancellation flow. The shared passphraseSchema validation changes could theoretically affect the form submission step that precedes the cancel action.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — This test involves passphrase re-entry after device reconnection. If passphraseSchema.ts validation logic changed, it could affect the re-confirmation passphrase input flow tested here.

</details>

⚠️ **Changes with no test coverage (5)**
- `suite-native/forms/src/fields/TextInputField.tsx`
- `suite-native/forms/src/hooks/useField.ts`
- `suite-native/intl/src/messages.ts`
- `suite-native/intl/translations/en-US.json`
- `suite-native/passphrase/src/components/PassphraseForm.tsx`

_Updated: 2026-06-04T11:31:49.289Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/passphrase-doubled-error-message&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/passphrase-doubled-error-message&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/passphrase-doubled-error-message&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-04T11:36:57.052Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-04T11:34:24.185Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/passphrase-doubled-error-message/web/](https://dev.suite.sldev.cz/suite-web/fix/passphrase-doubled-error-message/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->