### PR TITLE
fix(suite-native): update fees before calculating max amount

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -3072,6 +3072,7 @@ export const messages = {
             max: 'Maximum is {max}',
             noQuotes: 'No offers available for your request. Change amount or currency.',
             insufficientBalance: 'Insufficient balance',
+            dustLimit: 'The value is lower than dust limit',
             networkReserve: 'Not enough {displaySymbol} after network fees',
         },
         tradingExchangePreviewScreen: {

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -3072,7 +3072,7 @@ export const messages = {
             max: 'Maximum is {max}',
             noQuotes: 'No offers available for your request. Change amount or currency.',
             insufficientBalance: 'Insufficient balance',
-            dustLimit: 'The value is lower than dust limit',
+            dustLimit: 'The value is lower than the dust limit',
             networkReserve: 'Not enough {displaySymbol} after network fees',
         },
         tradingExchangePreviewScreen: {

--- a/suite-native/module-send/src/components/AmountInputs.tsx
+++ b/suite-native/module-send/src/components/AmountInputs.tsx
@@ -25,11 +25,12 @@ import { SendMaxSwitch } from './SendMaxSwitch';
 
 type AmountInputProps = {
     index: number;
+    maxSpendableAmount?: string;
 };
 
 type RouteProps = StackProps<SendStackParamList, SendStackRoutes.SendOutputs>['route'];
 
-export const AmountInputs = ({ index }: AmountInputProps) => {
+export const AmountInputs = ({ index, maxSpendableAmount }: AmountInputProps) => {
     const { analytics } = useServices(selectNativeAnalyticsDep);
     const route = useRoute<RouteProps>();
     const { accountKey, tokenContract } = route.params;
@@ -61,6 +62,7 @@ export const AmountInputs = ({ index }: AmountInputProps) => {
                     outputIndex={index}
                     accountKey={accountKey}
                     tokenContract={tokenContract}
+                    maxSpendableAmount={maxSpendableAmount}
                 />
             </HStack>
             {shallDisplayBaseCurrency ? (

--- a/suite-native/module-send/src/components/RecipientInputs.tsx
+++ b/suite-native/module-send/src/components/RecipientInputs.tsx
@@ -13,8 +13,13 @@ import { DestinationTagInput } from './DestinationTagInput';
 type RecipientInputsProps = {
     index: number;
     accountKey: AccountKey;
+    maxSpendableAmount?: string;
 };
-export const RecipientInputs = ({ index, accountKey }: RecipientInputsProps) => {
+export const RecipientInputs = ({
+    index,
+    accountKey,
+    maxSpendableAmount,
+}: RecipientInputsProps) => {
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
     );
@@ -27,7 +32,7 @@ export const RecipientInputs = ({ index, accountKey }: RecipientInputsProps) => 
         <VStack spacing="sp16">
             <AddressInput index={index} accountKey={accountKey} />
             <CardDivider />
-            <AmountInputs index={index} />
+            <AmountInputs index={index} maxSpendableAmount={maxSpendableAmount} />
             {hasDestinationTag && (
                 <Animated.View layout={LinearTransition}>
                     <VStack spacing="sp16">

--- a/suite-native/module-send/src/components/SendMaxSwitch.tsx
+++ b/suite-native/module-send/src/components/SendMaxSwitch.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react';
 import { Keyboard } from 'react-native';
 import Animated, { FadeIn } from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
@@ -16,22 +15,24 @@ import { HStack, Switch, Text } from '@suite-native/atoms';
 import { useCryptoFiatConverters } from '@suite-native/formatters';
 import { useFormContext } from '@suite-native/forms';
 import { Translation } from '@suite-native/intl';
-import { useMaxSpendableAmount } from '@suite-native/transaction-management';
 import { BigNumber } from '@trezor/utils';
 
-import { useUtxoSelection } from '../hooks/useUtxoSelection';
 import { type SendOutputsFormValues } from '../sendOutputsFormSchema';
-import { constructFormDraft, getOutputFieldName } from '../utils';
+import { getOutputFieldName } from '../utils';
 
 type SendMaxSwitchProps = {
     outputIndex: number;
     accountKey: AccountKey;
     tokenContract?: TokenAddress;
+    maxSpendableAmount?: string;
 };
 
-export const SendMaxSwitch = ({ outputIndex, accountKey, tokenContract }: SendMaxSwitchProps) => {
-    const { selectedUtxos } = useUtxoSelection(accountKey);
-
+export const SendMaxSwitch = ({
+    outputIndex,
+    accountKey,
+    tokenContract,
+    maxSpendableAmount,
+}: SendMaxSwitchProps) => {
     const symbol = useSelector((state: AccountsRootState) =>
         selectAccountNetworkSymbol(state, accountKey),
     );
@@ -49,42 +50,24 @@ export const SendMaxSwitch = ({ outputIndex, accountKey, tokenContract }: SendMa
 
     const [outputs, setMaxOutputId] = watch(['outputs', 'setMaxOutputId']);
 
-    const formState = useMemo(
-        () =>
-            constructFormDraft({
-                formValues: {
-                    outputs,
-                    setMaxOutputId,
-                },
-                selectedUtxos,
-            }),
-        [selectedUtxos, outputs, setMaxOutputId],
-    );
-
     const isMainnetSendMaxAvailable = !tokenContract && outputs.length === 1;
     const isSendMaxAvailable = tokenContract || isMainnetSendMaxAvailable;
 
     const isSendMaxEnabled = setMaxOutputId === outputIndex;
 
-    const { maxSpendableAmount: maxAmountValue } = useMaxSpendableAmount({
-        accountKey,
-        tokenContract,
-        formState,
-        enabled: !!isSendMaxAvailable,
-    });
-    const isSendMaxVisible = isSendMaxAvailable && !!maxAmountValue;
+    const isSendMaxVisible = isSendMaxAvailable && !!maxSpendableAmount;
 
     const enableSendMax = () => {
-        if (!maxAmountValue) return;
+        if (!maxSpendableAmount) return;
 
         setValue('setMaxOutputId', outputIndex);
 
-        setValue(getOutputFieldName(outputIndex, 'amount'), maxAmountValue, {
+        setValue(getOutputFieldName(outputIndex, 'amount'), maxSpendableAmount, {
             shouldValidate: true,
             shouldTouch: true,
         });
 
-        const fiatValue = converters?.convertCryptoToFiat(new BigNumber(maxAmountValue));
+        const fiatValue = converters?.convertCryptoToFiat(new BigNumber(maxSpendableAmount));
         if (fiatValue && decimals !== null) {
             setValue(
                 getOutputFieldName(outputIndex, 'fiat'),

--- a/suite-native/module-send/src/components/SendOutputFields.tsx
+++ b/suite-native/module-send/src/components/SendOutputFields.tsx
@@ -69,7 +69,12 @@ export const SendOutputFields = ({
             <Card style={applyStyle(cardStyle)}>
                 <VStack spacing="sp12">
                     {outputsFieldArray.fields.map((output, index) => (
-                        <RecipientInputs key={output.id} index={index} accountKey={accountKey} />
+                        <RecipientInputs
+                            key={output.id}
+                            index={index}
+                            accountKey={accountKey}
+                            maxSpendableAmount={maxAmount}
+                        />
                     ))}
                     {/*
                     TODO: add output (outputs.append({...})) button

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeForm.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeForm.test.ts
@@ -41,6 +41,30 @@ const services: NativeAnalyticsDep = {
 };
 type PrefetchDexQuoteApprovalThunk = typeof exchangeThunks.prefetchDexQuoteApprovalThunk;
 
+jest.mock('@suite-native/transaction-management', () => ({
+    ...jest.requireActual('@suite-native/transaction-management'),
+    useMaxSpendableAmount: jest.fn(({ accountKey, symbol, tokenContract }) => {
+        if (!accountKey || !symbol) {
+            return { maxSpendableAmount: undefined };
+        }
+
+        if (tokenContract) {
+            const maxSpendableAmountByTokenContract: Record<string, string | undefined> = {
+                '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48': '1',
+                '0xdac17f958d2ee523a2206206994597c13d831ec7': '1',
+            };
+
+            return { maxSpendableAmount: maxSpendableAmountByTokenContract[tokenContract] };
+        }
+
+        if (symbol === 'btc') {
+            return { maxSpendableAmount: '0.01' };
+        }
+
+        return { maxSpendableAmount: undefined };
+    }),
+}));
+
 const createPrefetchDexQuoteApprovalThunkMock = (
     arg: Parameters<PrefetchDexQuoteApprovalThunk>[0],
 ): ReturnType<PrefetchDexQuoteApprovalThunk> => {

--- a/suite-native/module-trading/src/hooks/general/form/useContextForTradingForm.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useContextForTradingForm.ts
@@ -34,6 +34,7 @@ export const useContextForTradingForm = (limits: TradingAmountLimitProps | undef
     const { maxSpendableAmount } = useMaxSpendableAmount({
         accountKey,
         tokenContract: contractAddress,
+        symbol: sendSymbol as NetworkSymbol,
     });
 
     const networkReserve = sendSymbol

--- a/suite-native/module-trading/src/utils/general/__tests__/validationSchemes.test.ts
+++ b/suite-native/module-trading/src/utils/general/__tests__/validationSchemes.test.ts
@@ -243,16 +243,16 @@ describe('validationSchemes', () => {
                 );
             });
 
-            it('falls back to balance when maxSpendableAmount is undefined', async () => {
+            it('shows lower than dust limit when maxSpendableAmount is undefined', async () => {
                 const context = createContext({
                     sendSymbol: 'btc',
-                    balance: '100',
+                    balance: '0.00000001',
                     maxSpendableAmount: undefined,
                 });
 
                 await expect(
-                    validate(sendCryptoAmountValidationSchema, 100, context),
-                ).resolves.toBe(100);
+                    validate(sendCryptoAmountValidationSchema, 0.00000001, context),
+                ).rejects.toThrow(getTranslation('moduleTrading.validators.dustLimit'));
             });
         });
     });

--- a/suite-native/module-trading/src/utils/general/validationSchemes.ts
+++ b/suite-native/module-trading/src/utils/general/validationSchemes.ts
@@ -128,7 +128,7 @@ export const sendCryptoAmountValidationSchema = yup
 
         const convertedValue = convertNumberToBaseUnit(value, sendSymbol.toLowerCase());
 
-        if (convertedValue === undefined || balance === undefined) {
+        if (convertedValue === undefined || convertedValue === 0 || balance === undefined) {
             return true;
         }
 
@@ -146,7 +146,7 @@ export const sendCryptoAmountValidationSchema = yup
             });
         }
 
-        if (convertedValue > parseFloat(maxSpendableAmount)) {
+        if (maxSpendableAmount && convertedValue > parseFloat(maxSpendableAmount)) {
             return testContext.createError({
                 type: 'network-reserve',
                 message: translate('moduleTrading.validators.networkReserve', {

--- a/suite-native/module-trading/src/utils/general/validationSchemes.ts
+++ b/suite-native/module-trading/src/utils/general/validationSchemes.ts
@@ -132,8 +132,6 @@ export const sendCryptoAmountValidationSchema = yup
             return true;
         }
 
-        const maxAvailableAmount = maxSpendableAmount ?? balance;
-
         if (convertedValue > parseFloat(balance)) {
             return testContext.createError({
                 type: 'insufficient-balance',
@@ -141,7 +139,14 @@ export const sendCryptoAmountValidationSchema = yup
             });
         }
 
-        if (convertedValue > parseFloat(maxAvailableAmount)) {
+        if (maxSpendableAmount === undefined) {
+            return testContext.createError({
+                type: 'dust-limit',
+                message: translate('moduleTrading.validators.dustLimit'),
+            });
+        }
+
+        if (convertedValue > parseFloat(maxSpendableAmount)) {
             return testContext.createError({
                 type: 'network-reserve',
                 message: translate('moduleTrading.validators.networkReserve', {

--- a/suite-native/transaction-management/src/hooks/__tests__/useMaxSpendableAmount.test.ts
+++ b/suite-native/transaction-management/src/hooks/__tests__/useMaxSpendableAmount.test.ts
@@ -12,6 +12,15 @@ jest.mock('../../thunks', () => ({
         mockCalculateFeeLevelsMaxAmountThunk(...args),
 }));
 
+jest.mock('@suite-common/wallet-core', () => ({
+    ...jest.requireActual('@suite-common/wallet-core'),
+    updateFeeInfoThunk: (payload: unknown) => ({
+        type: 'updateFeeInfoThunkMock',
+        payload,
+        unwrap: () => Promise.resolve(undefined),
+    }),
+}));
+
 describe('useMaxSpendableAmount', () => {
     const btcAccountKey = 'btc-account-1' as AccountKey;
     const ethAccountKey = 'eth-account-1' as AccountKey;
@@ -116,7 +125,7 @@ describe('useMaxSpendableAmount', () => {
     it('should calculate max spendable amount with provided form state', async () => {
         mockMaxAmountThunkResult({ normal: '0.009', economy: '0.008' });
 
-        renderUseMaxSpendableAmount({
+        const { result } = renderUseMaxSpendableAmount({
             accountKey: btcAccountKey,
             formState: customFormState,
             symbol: 'btc',
@@ -130,6 +139,7 @@ describe('useMaxSpendableAmount', () => {
                 },
                 expect.objectContaining({ signal: expect.any(AbortSignal) }),
             );
+            expect(result.current.maxSpendableAmount).toBe('0.009');
         });
     });
 

--- a/suite-native/transaction-management/src/hooks/__tests__/useMaxSpendableAmount.test.ts
+++ b/suite-native/transaction-management/src/hooks/__tests__/useMaxSpendableAmount.test.ts
@@ -42,6 +42,7 @@ describe('useMaxSpendableAmount', () => {
         accountKey,
         tokenContract,
         formState,
+        symbol,
     }: Parameters<typeof useMaxSpendableAmount>[0]) =>
         renderHookWithStoreProvider(
             () =>
@@ -49,6 +50,7 @@ describe('useMaxSpendableAmount', () => {
                     accountKey,
                     tokenContract,
                     formState,
+                    symbol,
                 }),
             {
                 preloadedState: {
@@ -79,7 +81,7 @@ describe('useMaxSpendableAmount', () => {
     });
 
     it('should keep max spendable amount undefined without account key', () => {
-        const { result } = renderUseMaxSpendableAmount({});
+        const { result } = renderUseMaxSpendableAmount({ symbol: null });
 
         expect(result.current.maxSpendableAmount).toBeUndefined();
         expect(mockCalculateFeeLevelsMaxAmountThunk).not.toHaveBeenCalled();
@@ -89,6 +91,7 @@ describe('useMaxSpendableAmount', () => {
         const { result } = renderUseMaxSpendableAmount({
             accountKey: ethAccountKey,
             tokenContract: usdcTokenContract,
+            symbol: 'etc',
         });
 
         await waitFor(() => {
@@ -102,6 +105,7 @@ describe('useMaxSpendableAmount', () => {
         mockMaxAmountThunkResult({ normal: '0.009', economy: '0.008' });
         const { result } = renderUseMaxSpendableAmount({
             accountKey: btcAccountKey,
+            symbol: 'btc',
         });
 
         await waitFor(() => {
@@ -115,6 +119,7 @@ describe('useMaxSpendableAmount', () => {
         renderUseMaxSpendableAmount({
             accountKey: btcAccountKey,
             formState: customFormState,
+            symbol: 'btc',
         });
 
         await waitFor(() => {
@@ -133,6 +138,7 @@ describe('useMaxSpendableAmount', () => {
 
         const { result } = renderUseMaxSpendableAmount({
             accountKey: btcAccountKey,
+            symbol: 'btc',
         });
 
         await waitFor(() => {
@@ -143,6 +149,7 @@ describe('useMaxSpendableAmount', () => {
     it('should skip native asset calculation when calculation is disabled', () => {
         const { result } = renderUseMaxSpendableAmount({
             accountKey: btcAccountKey,
+            symbol: 'btc',
             enabled: false,
         });
 

--- a/suite-native/transaction-management/src/hooks/useMaxSpendableAmount.ts
+++ b/suite-native/transaction-management/src/hooks/useMaxSpendableAmount.ts
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { updateFeeInfoThunk } from '@suite-common/wallet-core';
 import { type AccountKey, type FormState, type TokenAddress } from '@suite-common/wallet-types';
 import { type TokensRootState, selectAccountTokenBalance } from '@suite-native/tokens';
 import { useDebounce } from '@trezor/react-utils';
@@ -12,6 +14,7 @@ type UseMaxSpendableAmountProps = {
     tokenContract?: TokenAddress;
     formState?: FormState;
     enabled?: boolean;
+    symbol: NetworkSymbol | null;
 };
 
 const buildDefaultFormState = ({ tokenContract }: { tokenContract?: TokenAddress }): FormState => ({
@@ -40,6 +43,7 @@ export const useMaxSpendableAmount = ({
     tokenContract,
     formState,
     enabled = true,
+    symbol,
 }: UseMaxSpendableAmountProps) => {
     const dispatch = useDispatch();
     const debounce = useDebounce();
@@ -51,7 +55,7 @@ export const useMaxSpendableAmount = ({
     );
 
     useEffect(() => {
-        if (!accountKey || !enabled) {
+        if (!accountKey || !enabled || !symbol) {
             setMaxSpendableAmount(undefined);
 
             return;
@@ -67,19 +71,17 @@ export const useMaxSpendableAmount = ({
 
         const calculateMaxAmount = async () => {
             try {
-                const { normal, economy, low, high } = await debounce(
-                    async () =>
-                        await dispatch(
-                            calculateFeeLevelsMaxAmountThunk(
-                                {
-                                    formState:
-                                        formState ?? buildDefaultFormState({ tokenContract }),
-                                    accountKey,
-                                },
-                                { signal: controller.signal },
-                            ),
-                        ).unwrap(),
-                );
+                await dispatch(updateFeeInfoThunk({ networkSymbol: symbol }));
+
+                const { normal, economy, low, high } = await dispatch(
+                    calculateFeeLevelsMaxAmountThunk(
+                        {
+                            formState: formState ?? buildDefaultFormState({ tokenContract }),
+                            accountKey,
+                        },
+                        { signal: controller.signal },
+                    ),
+                ).unwrap();
 
                 if (!controller.signal.aborted) {
                     setMaxSpendableAmount(high ?? normal ?? low ?? economy);
@@ -95,7 +97,7 @@ export const useMaxSpendableAmount = ({
         return () => {
             controller.abort();
         };
-    }, [dispatch, accountKey, tokenContract, formState, tokenBalance, debounce, enabled]);
+    }, [dispatch, accountKey, tokenContract, formState, tokenBalance, debounce, enabled, symbol]);
 
     return { maxSpendableAmount };
 };

--- a/suite-native/transaction-management/src/hooks/useMaxSpendableAmount.ts
+++ b/suite-native/transaction-management/src/hooks/useMaxSpendableAmount.ts
@@ -5,7 +5,6 @@ import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { updateFeeInfoThunk } from '@suite-common/wallet-core';
 import { type AccountKey, type FormState, type TokenAddress } from '@suite-common/wallet-types';
 import { type TokensRootState, selectAccountTokenBalance } from '@suite-native/tokens';
-import { useDebounce } from '@trezor/react-utils';
 
 import { calculateFeeLevelsMaxAmountThunk } from '../thunks';
 
@@ -46,7 +45,6 @@ export const useMaxSpendableAmount = ({
     symbol,
 }: UseMaxSpendableAmountProps) => {
     const dispatch = useDispatch();
-    const debounce = useDebounce();
 
     const [maxSpendableAmount, setMaxSpendableAmount] = useState<string | undefined>(undefined);
 
@@ -71,7 +69,7 @@ export const useMaxSpendableAmount = ({
 
         const calculateMaxAmount = async () => {
             try {
-                await dispatch(updateFeeInfoThunk({ networkSymbol: symbol }));
+                await dispatch(updateFeeInfoThunk({ networkSymbol: symbol })).unwrap();
 
                 const { normal, economy, low, high } = await dispatch(
                     calculateFeeLevelsMaxAmountThunk(
@@ -97,7 +95,7 @@ export const useMaxSpendableAmount = ({
         return () => {
             controller.abort();
         };
-    }, [dispatch, accountKey, tokenContract, formState, tokenBalance, debounce, enabled, symbol]);
+    }, [dispatch, accountKey, tokenContract, formState, tokenBalance, enabled, symbol]);
 
     return { maxSpendableAmount };
 };


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
* update fees before calculating max spendable value 
* handle case when amount is lower than dust limit 
* drill max spendable value to SendMax so its matched with the one used for validation

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/22035

## Screens
<img width="320" alt="Simulator Screenshot - iPhone 16e - 2026-06-04 at 12 57 38" src="https://github.com/user-attachments/assets/70f7eba2-7c4d-467e-a9e1-081861355b06" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-native-22035-validate-max-amount&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->