### PR TITLE
fix(suite): missing analytics in add account modal

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddAccountButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddAccountButton.tsx
@@ -1,58 +1,15 @@
 import { useCallback } from 'react';
 
-import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
-import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
 import { type Network, type NetworkAccount } from '@suite-common/wallet-config';
-import { type UnavailableCapability } from '@trezor/connect';
 
-import { useAccountSearch, useSelector } from 'src/hooks/suite';
+import { useSelector } from 'src/hooks/suite';
 import { type Account } from 'src/types/wallet';
 
 import { AddButton } from './AddButton';
 import { AddCoinjoinAccountButton } from './AddCoinjoinAccountButton';
-
-const verifyAvailability = ({
-    emptyAccounts,
-    account,
-    unavailableCapability,
-}: {
-    emptyAccounts: Account[];
-    account?: Account;
-    unavailableCapability?: UnavailableCapability;
-}) => {
-    if (unavailableCapability === 'no-support') {
-        return 'TR_ACCOUNT_TYPE_NO_SUPPORT';
-    }
-    if (unavailableCapability === 'update-required') {
-        return 'TR_ACCOUNT_TYPE_UPDATE_REQUIRED';
-    }
-    if (unavailableCapability === 'trezor-connect-outdated') {
-        return 'FW_CAPABILITY_CONNECT_OUTDATED';
-    }
-    if (unavailableCapability === 'no-capability') {
-        return 'TR_ACCOUNT_TYPE_NO_CAPABILITY';
-    }
-    if (!account) {
-        // discovery failed?
-        return 'MODAL_ADD_ACCOUNT_NO_ACCOUNT';
-    }
-
-    if (account.networkType !== 'ethereum') {
-        if (emptyAccounts.length === 0) {
-            return 'MODAL_ADD_ACCOUNT_NO_EMPTY_ACCOUNT';
-        }
-        if (emptyAccounts.length > 1) {
-            // prev account is empty, do not add another
-            return 'MODAL_ADD_ACCOUNT_PREVIOUS_EMPTY';
-        }
-        if (account.index === 0 && account.empty && account.accountType === 'normal') {
-            // current (first normal) account is empty, do not add another
-            return 'MODAL_ADD_ACCOUNT_PREVIOUS_EMPTY';
-        }
-    }
-};
+import { verifyAvailability } from '../verifyAvailability';
 
 interface AddAccountButtonProps {
     network: Network;
@@ -71,40 +28,14 @@ const AddDefaultAccountButton = ({
 }: AddAccountButtonProps) => {
     const defaultAccount = scopedAccounts.at(-1);
     const device = useSelector(selectSelectedDevice);
-    const { analytics } = useServices(selectDesktopAnalyticsDep);
-
-    const { setCoinFilter, setSearchString, coinFilter } = useAccountSearch();
 
     const handleClick = useCallback(() => {
         if (defaultAccount) {
             onEnableAccount(defaultAccount);
-            // reset search string in account search box
-            setSearchString(undefined);
-            if (coinFilter && !coinFilter.includes(defaultAccount.symbol)) {
-                // if coinFilter is active then reset it only if added account doesn't belong to selected/filtered coin
-                setCoinFilter([]);
-            }
-
-            analytics.report({
-                type: events.accountsNewAccountEvent.name,
-                payload: {
-                    type: defaultAccount.accountType,
-                    path: defaultAccount.path,
-                    symbol: defaultAccount.symbol,
-                },
-            });
         } else {
             onAddNewAccount();
         }
-    }, [
-        defaultAccount,
-        onEnableAccount,
-        setSearchString,
-        coinFilter,
-        analytics,
-        setCoinFilter,
-        onAddNewAccount,
-    ]);
+    }, [defaultAccount, onEnableAccount, onAddNewAccount]);
 
     const unavailableCapability = selectedAccount?.accountType
         ? device?.unavailableCapabilities?.[selectedAccount?.accountType]

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -1,8 +1,10 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { goto, selectRouterApp } from '@suite/router';
 import { selectHasExperimentalFeature, selectIsDebugModeActive } from '@suite/settings';
+import { useServices } from '@suite-common/dependency-injection';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import {
     type Network,
@@ -25,7 +27,7 @@ import { arrayPartition } from '@trezor/utils';
 
 import { useAvailableNetworkSymbols } from 'src/components/wallet/WalletLayout/AccountsMenu/useAvailableNetworkSymbols';
 import { useNetworkSupport } from 'src/hooks/settings/useNetworkSupport';
-import { useDispatch, useSelector } from 'src/hooks/suite';
+import { useAccountSearch, useDispatch, useSelector } from 'src/hooks/suite';
 import { selectIsPublic } from 'src/reducers/wallet/coinjoinReducer';
 import { type TrezorDevice } from 'src/types/suite';
 import { type Account } from 'src/types/wallet';
@@ -33,6 +35,7 @@ import { type Account } from 'src/types/wallet';
 import { AccountTypeSelect } from './AccountTypeSelect/AccountTypeSelect';
 import { AddAccountButton } from './AddAccountButton/AddAccountButton';
 import { SelectNetwork } from './SelectNetwork';
+import { verifyAvailability } from './verifyAvailability';
 import { AdvancedCoinSettingsModal } from '../AdvancedCoinSettingsModal/AdvancedCoinSettingsModal';
 
 type AddAccountProps = {
@@ -64,6 +67,31 @@ export const AddAccountModal = ({
     const useTestnetNetworks = useSelector(selectHasExperimentalFeature('testnet-networks'));
     const dispatch = useDispatch();
 
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
+    const { setCoinFilter, setSearchString, coinFilter } = useAccountSearch();
+
+    const resetAccountSearch = (symbol: NetworkSymbol) => {
+        // reset search string in account search box so the new account is visible in the list
+        setSearchString(undefined);
+        if (coinFilter && !coinFilter.includes(symbol)) {
+            // if coinFilter is active then reset it only if added account doesn't belong to selected/filtered coin
+            setCoinFilter([]);
+        }
+    };
+
+    const reportNewAccountAnalytics = (
+        account: Pick<Account, 'accountType' | 'path' | 'symbol'>,
+    ) => {
+        analytics.report({
+            type: events.accountsNewAccountEvent.name,
+            payload: {
+                type: account.accountType,
+                path: account.path,
+                symbol: account.symbol,
+            },
+        });
+    };
+
     const { showUnsupportedCoins, supportedMainnets, unsupportedMainnets, supportedTestnets } =
         useNetworkSupport();
 
@@ -84,16 +112,19 @@ export const AddAccountModal = ({
 
     const isCoinjoinVisible = (isCoinjoinPublic || isDebug) && !isCoinjoinDisabled;
 
-    const getAccountTypesForNetwork = (network?: Network) => {
-        if (!network || !enabledNetworkSymbols.includes(network.symbol)) {
-            return undefined;
-        }
+    const getAccountTypesForNetwork = useCallback(
+        (network?: Network) => {
+            if (!network || !enabledNetworkSymbols.includes(network.symbol)) {
+                return undefined;
+            }
 
-        return getAvailableAccountTypes(network.symbol, {
-            isCoinjoinVisible,
-            isDebug,
-        });
-    };
+            return getAvailableAccountTypes(network.symbol, {
+                isCoinjoinVisible,
+                isDebug,
+            });
+        },
+        [enabledNetworkSymbols, isCoinjoinVisible, isDebug],
+    );
 
     const defaultAccountTypeSelectionNetwork =
         preselectedNetwork || bitcoinOnlyDefaultNetworkSelection;
@@ -118,6 +149,10 @@ export const AddAccountModal = ({
     const enabledNetworks = availableNetworksSymbols.map(networkSymbol =>
         getNetwork(networkSymbol),
     );
+    const [enabledMainnetNetworks, enabledTestnetNetworks] = arrayPartition(
+        enabledNetworks,
+        network => !network?.testnet,
+    );
     const disabledNetworks = supportedNetworks.filter(
         network => !availableNetworksSymbols.includes(network.symbol),
     );
@@ -126,6 +161,7 @@ export const AddAccountModal = ({
         disabledNetworks,
         network => !network?.testnet,
     );
+    const testnetNetworks = [...enabledTestnetNetworks, ...disabledTestnetNetworks];
 
     // Collect all empty accounts related to selected device and selected accountType
     const currentType = selectedAccount?.accountType ?? 'normal';
@@ -164,6 +200,50 @@ export const AddAccountModal = ({
 
     const accountTypes = getAccountTypesForNetwork(accountTypeSelectionNetwork);
 
+    // Mirrors the validation of the account-type-selection "Add" button for the inline
+    // network-row buttons: disable + explain when an account can't be added (e.g. the
+    // previous account is still empty, or the device lacks the capability).
+    const getAddDisabledMessage = useCallback(
+        (network: Network) => {
+            // The inline button only adds an account directly for already-enabled networks
+            // with a single account type. Disabled networks just get enabled and multi-type
+            // networks open the account-type-selection step, so neither needs this guard.
+            if (!enabledNetworkSymbols.includes(network.symbol)) return undefined;
+
+            const networkAccountTypes = getAccountTypesForNetwork(network);
+            if (!networkAccountTypes || networkAccountTypes.length > 1) return undefined;
+
+            const defaultAccountTypeName = networkAccountTypes[0]?.accountType ?? 'normal';
+            const networkScopedAccounts = accounts.filter(
+                account =>
+                    account.deviceState === device.state?.staticSessionId &&
+                    account.symbol === network.symbol &&
+                    account.accountType === defaultAccountTypeName,
+            );
+            const defaultAccount = networkScopedAccounts
+                .toSorted((a, b) => a.index - b.index)
+                .at(-1);
+            const unavailableCapability = device?.unavailableCapabilities?.[defaultAccountTypeName];
+
+            const disabledMessage = verifyAvailability({
+                emptyAccounts: networkScopedAccounts.filter(
+                    account => account.empty && !account.visible,
+                ),
+                account: defaultAccount,
+                unavailableCapability,
+            });
+
+            return disabledMessage ? <Translation id={disabledMessage} /> : undefined;
+        },
+        [
+            accounts,
+            device.state?.staticSessionId,
+            device?.unavailableCapabilities,
+            enabledNetworkSymbols,
+            getAccountTypesForNetwork,
+        ],
+    );
+
     function enableNetwork(network: Network) {
         onCancel();
         dispatch(changeCoinVisibility({ symbol: network.symbol, shouldBeVisible: true }));
@@ -195,50 +275,59 @@ export const AddAccountModal = ({
         } = {},
     ) {
         onCancel();
-        if (account.visible) {
-            const newAccount = await prepareNewAccountPayload({
-                accountType: account.accountType,
-                networkSymbol: account.symbol,
-                index: account.index + 1,
-                backendType: account.backendType != 'coinjoin' ? account.backendType : undefined,
-                selectedAccount: nextSelectedAccount,
-                accountTypes: nextAccountTypes,
-                device,
-            });
 
-            if (newAccount instanceof Error) {
+        const finishEnableAccount = (addedAccount: Account) => {
+            resetAccountSearch(addedAccount.symbol);
+            reportNewAccountAnalytics(addedAccount);
+            dispatch(reportWalletBalanceThunk());
+            onConfirm?.();
+
+            onAddAccount?.(addedAccount);
+            if (app === 'wallet' && !noRedirect) {
                 dispatch(
-                    notificationsActions.addToast({
-                        type: 'discovery-error',
-                        error: newAccount.message,
+                    goto({
+                        routeName: 'wallet-index',
+                        params: {
+                            symbol: addedAccount.symbol,
+                            accountIndex: addedAccount.index,
+                            accountType: addedAccount.accountType,
+                        },
                     }),
                 );
-
-                return;
             }
+        };
 
-            dispatch(accountsActions.createAccount(newAccount));
-        } else {
+        if (!account.visible) {
             dispatch(accountsActions.changeAccountVisibility(account));
+            finishEnableAccount(account);
+
+            return;
         }
 
-        dispatch(reportWalletBalanceThunk());
-        onConfirm?.();
+        const newAccount = await prepareNewAccountPayload({
+            accountType: account.accountType,
+            networkSymbol: account.symbol,
+            index: account.index + 1,
+            backendType: account.backendType != 'coinjoin' ? account.backendType : undefined,
+            selectedAccount: nextSelectedAccount,
+            accountTypes: nextAccountTypes,
+            device,
+        });
 
-        onAddAccount?.(account);
-        if (app === 'wallet' && !noRedirect) {
-            // redirect to account only if added from "wallet" app
+        if (newAccount instanceof Error) {
             dispatch(
-                goto({
-                    routeName: 'wallet-index',
-                    params: {
-                        symbol: account.symbol,
-                        accountIndex: account.index,
-                        accountType: account.accountType,
-                    },
+                notificationsActions.addToast({
+                    type: 'discovery-error',
+                    error: newAccount.message,
                 }),
             );
+
+            return;
         }
+
+        const createAccountAction = accountsActions.createAccount(newAccount);
+        dispatch(createAccountAction);
+        finishEnableAccount(createAccountAction.payload);
     }
 
     async function addNewAccount({
@@ -273,6 +362,8 @@ export const AddAccountModal = ({
 
         onCancel();
         dispatch(accountsActions.createAccount(newAccount));
+        resetAccountSearch(newAccount.symbol);
+        reportNewAccountAnalytics(newAccount);
         dispatch(reportWalletBalanceThunk());
         onConfirm?.();
     }
@@ -399,9 +490,10 @@ export const AddAccountModal = ({
                           {!symbol && (
                               <SelectNetwork
                                   heading={<Translation id="TR_ACTIVATED_COINS" />}
-                                  networks={enabledNetworks}
+                                  networks={enabledMainnetNetworks}
                                   handleNetworkSelection={handleNetworkSelection}
                                   onSettings={setAdvancedSettingsSymbol}
+                                  getAddDisabledMessage={getAddDisabledMessage}
                               />
                           )}
                           <SelectNetwork
@@ -415,14 +507,16 @@ export const AddAccountModal = ({
                               networks={symbol ? visibleNetworks : disabledMainnetNetworks}
                               handleNetworkSelection={handleNetworkSelection}
                               onSettings={setAdvancedSettingsSymbol}
+                              getAddDisabledMessage={getAddDisabledMessage}
                           />
-                          {!symbol && !!disabledTestnetNetworks.length && useTestnetNetworks && (
+                          {!symbol && !!testnetNetworks.length && useTestnetNetworks && (
                               <SelectNetwork
                                   heading={<Translation id="TR_TESTNET_COINS" />}
                                   data-testid="@modal/account/activate_more_coins"
-                                  networks={disabledTestnetNetworks}
+                                  networks={testnetNetworks}
                                   handleNetworkSelection={handleNetworkSelection}
                                   onSettings={setAdvancedSettingsSymbol}
+                                  getAddDisabledMessage={getAddDisabledMessage}
                               />
                           )}
                           {!symbol && showUnsupportedCoins && (

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/SelectNetwork.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/SelectNetwork.tsx
@@ -1,6 +1,6 @@
 import { Translation } from '@suite/intl';
 import { type Network, type NetworkSymbol } from '@suite-common/wallet-config';
-import { Button, Column, H4 } from '@trezor/components';
+import { Button, Column, H4, Tooltip } from '@trezor/components';
 
 import { NetworkList } from 'src/components/suite/NetworkList/NetworkList';
 
@@ -9,6 +9,7 @@ type SelectNetworkProps = {
     networks: Network[];
     handleNetworkSelection?: (symbol?: NetworkSymbol) => void;
     onSettings?: (symbol: NetworkSymbol) => void;
+    getAddDisabledMessage?: (network: Network) => React.ReactNode;
     dataTestId?: string;
 };
 
@@ -17,6 +18,7 @@ export const SelectNetwork = ({
     networks,
     handleNetworkSelection,
     onSettings,
+    getAddDisabledMessage,
     dataTestId,
 }: SelectNetworkProps) => {
     if (!networks.length) {
@@ -35,16 +37,23 @@ export const SelectNetwork = ({
                 onSettings={onSettings}
                 renderRightContent={
                     handleNetworkSelection
-                        ? ({ network }) => (
-                              <Button
-                                  size="small"
-                                  intent="brand"
-                                  data-testid={`@settings/wallet/network/${network.symbol}/add-button`}
-                                  onClick={() => handleNetworkSelection(network.symbol)}
-                              >
-                                  <Translation id="TR_ADD" />
-                              </Button>
-                          )
+                        ? ({ network }) => {
+                              const disabledMessage = getAddDisabledMessage?.(network);
+
+                              return (
+                                  <Tooltip tooltipMaxWidth={285} content={disabledMessage}>
+                                      <Button
+                                          size="small"
+                                          intent="brand"
+                                          isDisabled={!!disabledMessage}
+                                          data-testid={`@settings/wallet/network/${network.symbol}/add-button`}
+                                          onClick={() => handleNetworkSelection(network.symbol)}
+                                      >
+                                          <Translation id="TR_ADD" />
+                                      </Button>
+                                  </Tooltip>
+                              );
+                          }
                         : undefined
                 }
             />

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/__tests__/verifyAvailability.test.ts
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/__tests__/verifyAvailability.test.ts
@@ -1,0 +1,102 @@
+import { type UnavailableCapability } from '@trezor/connect';
+
+import { type Account } from 'src/types/wallet';
+
+import { verifyAvailability } from '../verifyAvailability';
+
+const getMockAccount = (account: Partial<Account> = {}): Account =>
+    ({
+        networkType: 'bitcoin',
+        index: 0,
+        empty: false,
+        accountType: 'normal',
+        ...account,
+    }) as Account;
+
+describe('verifyAvailability', () => {
+    describe('unavailable capability', () => {
+        const cases: [UnavailableCapability, string][] = [
+            ['no-support', 'TR_ACCOUNT_TYPE_NO_SUPPORT'],
+            ['update-required', 'TR_ACCOUNT_TYPE_UPDATE_REQUIRED'],
+            ['trezor-connect-outdated', 'FW_CAPABILITY_CONNECT_OUTDATED'],
+            ['no-capability', 'TR_ACCOUNT_TYPE_NO_CAPABILITY'],
+        ];
+
+        it.each(cases)('returns the matching message for "%s"', (capability, expected) => {
+            expect(
+                verifyAvailability({
+                    emptyAccounts: [],
+                    account: getMockAccount(),
+                    unavailableCapability: capability,
+                }),
+            ).toBe(expected);
+        });
+
+        it('takes precedence over the account checks', () => {
+            expect(
+                verifyAvailability({
+                    emptyAccounts: [],
+                    account: undefined,
+                    unavailableCapability: 'no-support',
+                }),
+            ).toBe('TR_ACCOUNT_TYPE_NO_SUPPORT');
+        });
+    });
+
+    it('returns NO_ACCOUNT when no account is provided and the capability is available', () => {
+        expect(
+            verifyAvailability({
+                emptyAccounts: [],
+                account: undefined,
+                unavailableCapability: undefined,
+            }),
+        ).toBe('MODAL_ADD_ACCOUNT_NO_ACCOUNT');
+    });
+
+    describe('non-ethereum networks', () => {
+        it('returns NO_EMPTY_ACCOUNT when there are no empty accounts', () => {
+            expect(
+                verifyAvailability({
+                    emptyAccounts: [],
+                    account: getMockAccount({ index: 1 }),
+                }),
+            ).toBe('MODAL_ADD_ACCOUNT_NO_EMPTY_ACCOUNT');
+        });
+
+        it('returns PREVIOUS_EMPTY when more than one empty account exists', () => {
+            expect(
+                verifyAvailability({
+                    emptyAccounts: [getMockAccount(), getMockAccount()],
+                    account: getMockAccount({ index: 1 }),
+                }),
+            ).toBe('MODAL_ADD_ACCOUNT_PREVIOUS_EMPTY');
+        });
+
+        it('returns PREVIOUS_EMPTY when the first normal account is itself empty', () => {
+            expect(
+                verifyAvailability({
+                    emptyAccounts: [getMockAccount()],
+                    account: getMockAccount({ index: 0, empty: true, accountType: 'normal' }),
+                }),
+            ).toBe('MODAL_ADD_ACCOUNT_PREVIOUS_EMPTY');
+        });
+
+        it('returns undefined when exactly one empty account exists and the account can be added', () => {
+            expect(
+                verifyAvailability({
+                    emptyAccounts: [getMockAccount()],
+                    account: getMockAccount({ index: 1, empty: false }),
+                }),
+            ).toBeUndefined();
+        });
+    });
+
+    it('skips the empty-account checks for ethereum networks', () => {
+        expect(
+            verifyAvailability({
+                emptyAccounts: [],
+                account: getMockAccount({ networkType: 'ethereum' }),
+            }),
+        ).toBeUndefined();
+    });
+});

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/verifyAvailability.ts
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/verifyAvailability.ts
@@ -1,0 +1,44 @@
+import { type UnavailableCapability } from '@trezor/connect';
+
+import { type Account } from 'src/types/wallet';
+
+export const verifyAvailability = ({
+    emptyAccounts,
+    account,
+    unavailableCapability,
+}: {
+    emptyAccounts: Account[];
+    account?: Account;
+    unavailableCapability?: UnavailableCapability;
+}) => {
+    if (unavailableCapability === 'no-support') {
+        return 'TR_ACCOUNT_TYPE_NO_SUPPORT';
+    }
+    if (unavailableCapability === 'update-required') {
+        return 'TR_ACCOUNT_TYPE_UPDATE_REQUIRED';
+    }
+    if (unavailableCapability === 'trezor-connect-outdated') {
+        return 'FW_CAPABILITY_CONNECT_OUTDATED';
+    }
+    if (unavailableCapability === 'no-capability') {
+        return 'TR_ACCOUNT_TYPE_NO_CAPABILITY';
+    }
+    if (!account) {
+        // discovery failed?
+        return 'MODAL_ADD_ACCOUNT_NO_ACCOUNT';
+    }
+
+    if (account.networkType !== 'ethereum') {
+        if (emptyAccounts.length === 0) {
+            return 'MODAL_ADD_ACCOUNT_NO_EMPTY_ACCOUNT';
+        }
+        if (emptyAccounts.length > 1) {
+            // prev account is empty, do not add another
+            return 'MODAL_ADD_ACCOUNT_PREVIOUS_EMPTY';
+        }
+        if (account.index === 0 && account.empty && account.accountType === 'normal') {
+            // current (first normal) account is empty, do not add another
+            return 'MODAL_ADD_ACCOUNT_PREVIOUS_EMPTY';
+        }
+    }
+};


### PR DESCRIPTION
## Notes for QA
- fixes missing analytics when adding account on non BTC networks

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/add-account-modal&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/add-account-modal&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-05T12:50:42.621Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-05T19:05:40.718Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/add-account-modal/web/](https://dev.suite.sldev.cz/suite-web/fix/add-account-modal/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are focused on the AddAccountModal and its sub-components (AddAccountButton, SelectNetwork, verifyAvailability). These are broadly imported across 121+ tests due to being part of the modal tree, but only a handful of tests actually exercise the add-account flow directly. The highest risk is in tests that explicitly add new accounts or activate networks via modals. The verifyAvailability unit test covers the logic changes locally, but has no E2E coverage. Priority testing should focus on the add-account-types test (direct modal usage), dashboard assets activation, and coins settings activation flows.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddAccountButton.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/SelectNetwork.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/__tests__/verifyAvailability.test.ts`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/verifyAvailability.ts`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/wallet/add-account-types.test.ts` — This test directly exercises the AddAccountModal by adding different account types (normal, taproot, segwit, legacy) for multiple coins. It interacts with the AddAccountButton, account type select dropdown, and confirm button — all components within the changed AddAccountModal directory. Changes to AddAccountButton.tsx, AddAccountModal.tsx, SelectNetwork.tsx, or verifyAvailability.ts could break account creation flows.
- `suite/e2e/tests/dashboard/assets.test.ts` — This test enables new assets via the 'Activate Assets' modal which uses the AddAccountModal's network selection (SelectNetwork.tsx) and account addition flow. It verifies that newly enabled assets (ETH) appear correctly after activation, directly exercising the network enable/add-account path that the changed components implement.
- `suite/e2e/tests/settings/coins.test.ts` — This test activates mainnet assets via the 'Activate Assets' modal from the dashboard empty state, which directly uses the AddAccountModal's SelectNetwork component for network selection. It also verifies the full flow of enabling networks that weren't previously active, exercising verifyAvailability logic for network/account eligibility.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/wallet/global-receive-send.test.ts` — The global receive flow adds a new ETH account via the asset picker which triggers the AddAccountModal (tradingPage.receiveAccount.addAccountModal). This exercises the account creation path including network selection and the add account button, making it sensitive to changes in AddAccountModal.tsx and AddAccountButton.tsx.
- `suite/e2e/tests/trading/navigation.test.ts` — This test navigates to buy forms for various coins and tokens, and some paths involve opening accounts through trading UI which may trigger the AddAccountModal when the account doesn't exist yet. The buy flow for an empty account (LTC) and the asset picker flow for tokens exercise account addition paths.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — This test adds a new Suite receive account for ETH during the buy flow, which triggers the AddAccountModal to create a new ETH account. Changes to AddAccountButton or the modal's network selection could break this account creation step.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/metadata/legacy/account-metadata.test.ts` — This test adds a new BTC account via the add account button (settingsPage.coinsTab.networkAddButton / walletPage.addAccountButton) and labels it. While it doesn't primarily test the AddAccountModal, the account addition step exercises the modal flow and could be affected by changes to AddAccountButton.tsx.
- `suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — This test uses an account selection modal (@select-account-modal) which may share UI components or logic with the AddAccountModal, specifically the account type selection (p2wpkh subtab). Changes to SelectNetwork.tsx or the modal structure could potentially affect this flow.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/__tests__/verifyAvailability.test.ts`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/verifyAvailability.ts`

_Updated: 2026-06-05T19:02:48.633Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->