### PR TITLE
Coin enabling rendering optimization

### DIFF
--- a/suite-native/coin-enabling/src/coinEnablingFormUtils.ts
+++ b/suite-native/coin-enabling/src/coinEnablingFormUtils.ts
@@ -1,0 +1,24 @@
+import { type NetworkSymbol, networkSymbolCollection } from '@suite-common/wallet-config';
+
+export type EnabledCoins = Partial<Record<NetworkSymbol, boolean>>;
+
+export type EnabledCoinFieldName = `enabledCoins.${NetworkSymbol}`;
+
+export type CoinEnablingFormValues = {
+    enabledCoins: EnabledCoins;
+};
+
+export const getEnabledCoinsFromNetworkSymbols = (symbols: NetworkSymbol[]): EnabledCoins =>
+    symbols.reduce<EnabledCoins>(
+        (enabledCoins, symbol) => ({
+            ...enabledCoins,
+            [symbol]: true,
+        }),
+        {},
+    );
+
+export const getEnabledCoinFieldName = (symbol: NetworkSymbol): EnabledCoinFieldName =>
+    `enabledCoins.${symbol}`;
+
+export const getNetworkSymbolsFromEnabledCoins = (enabledCoins: EnabledCoins): NetworkSymbol[] =>
+    networkSymbolCollection.filter(symbol => enabledCoins[symbol]);

--- a/suite-native/coin-enabling/src/coinEnablingSchema.ts
+++ b/suite-native/coin-enabling/src/coinEnablingSchema.ts
@@ -1,13 +1,6 @@
 import { yup } from '@suite-common/validators';
-import { type NetworkSymbol, networkSymbolCollection } from '@suite-common/wallet-config';
 
-export type EnabledCoins = Partial<Record<NetworkSymbol, boolean>>;
-
-export type EnabledCoinFieldName = `enabledCoins.${NetworkSymbol}`;
-
-export type CoinEnablingFormValues = {
-    enabledCoins: EnabledCoins;
-};
+import { type EnabledCoins } from './coinEnablingFormUtils';
 
 export const coinEnablingFormValidationSchema = yup.object({
     enabledCoins: yup
@@ -16,18 +9,3 @@ export const coinEnablingFormValidationSchema = yup.object({
             Object.values(value ?? {}).some(Boolean),
         ),
 });
-
-export const getEnabledCoinsFromNetworkSymbols = (symbols: NetworkSymbol[]): EnabledCoins =>
-    symbols.reduce<EnabledCoins>(
-        (enabledCoins, symbol) => ({
-            ...enabledCoins,
-            [symbol]: true,
-        }),
-        {},
-    );
-
-export const getEnabledCoinFieldName = (symbol: NetworkSymbol): EnabledCoinFieldName =>
-    `enabledCoins.${symbol}`;
-
-export const getNetworkSymbolsFromEnabledCoins = (enabledCoins: EnabledCoins): NetworkSymbol[] =>
-    networkSymbolCollection.filter(symbol => enabledCoins[symbol]);

--- a/suite-native/coin-enabling/src/coinEnablingSchema.ts
+++ b/suite-native/coin-enabling/src/coinEnablingSchema.ts
@@ -1,10 +1,33 @@
 import { yup } from '@suite-common/validators';
-import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { type NetworkSymbol, networkSymbolCollection } from '@suite-common/wallet-config';
+
+export type EnabledCoins = Partial<Record<NetworkSymbol, boolean>>;
+
+export type EnabledCoinFieldName = `enabledCoins.${NetworkSymbol}`;
 
 export type CoinEnablingFormValues = {
-    enabledCoins: NetworkSymbol[];
+    enabledCoins: EnabledCoins;
 };
 
 export const coinEnablingFormValidationSchema = yup.object({
-    enabledCoins: yup.array().of(yup.string().required()).min(1),
+    enabledCoins: yup
+        .object()
+        .test('has-enabled-network', (value: EnabledCoins | undefined) =>
+            Object.values(value ?? {}).some(Boolean),
+        ),
 });
+
+export const getEnabledCoinsFromNetworkSymbols = (symbols: NetworkSymbol[]): EnabledCoins =>
+    symbols.reduce<EnabledCoins>(
+        (enabledCoins, symbol) => ({
+            ...enabledCoins,
+            [symbol]: true,
+        }),
+        {},
+    );
+
+export const getEnabledCoinFieldName = (symbol: NetworkSymbol): EnabledCoinFieldName =>
+    `enabledCoins.${symbol}`;
+
+export const getNetworkSymbolsFromEnabledCoins = (enabledCoins: EnabledCoins): NetworkSymbol[] =>
+    networkSymbolCollection.filter(symbol => enabledCoins[symbol]);

--- a/suite-native/coin-enabling/src/components/CoinEnablingForm.tsx
+++ b/suite-native/coin-enabling/src/components/CoinEnablingForm.tsx
@@ -14,10 +14,10 @@ import { Translation } from '@suite-native/intl';
 
 import {
     type CoinEnablingFormValues,
-    coinEnablingFormValidationSchema,
     getEnabledCoinsFromNetworkSymbols,
     getNetworkSymbolsFromEnabledCoins,
-} from '../coinEnablingSchema';
+} from '../coinEnablingFormUtils';
+import { coinEnablingFormValidationSchema } from '../coinEnablingSchema';
 import { DiscoveryCoinsFilter } from './DiscoveryCoinsFilter';
 
 export const CoinEnablingForm = () => {

--- a/suite-native/coin-enabling/src/components/CoinEnablingForm.tsx
+++ b/suite-native/coin-enabling/src/components/CoinEnablingForm.tsx
@@ -15,6 +15,8 @@ import { Translation } from '@suite-native/intl';
 import {
     type CoinEnablingFormValues,
     coinEnablingFormValidationSchema,
+    getEnabledCoinsFromNetworkSymbols,
+    getNetworkSymbolsFromEnabledCoins,
 } from '../coinEnablingSchema';
 import { DiscoveryCoinsFilter } from './DiscoveryCoinsFilter';
 
@@ -41,21 +43,21 @@ export const CoinEnablingForm = () => {
 
     const form = useForm<CoinEnablingFormValues>({
         defaultValues: {
-            enabledCoins: enabledNetworkSymbols,
+            enabledCoins: getEnabledCoinsFromNetworkSymbols(enabledNetworkSymbols),
         },
         validation: coinEnablingFormValidationSchema,
     });
 
-    const handleSubmit = form.handleSubmit(values => {
+    const handleSubmit = form.handleSubmit((values: CoinEnablingFormValues) => {
+        const enabledCoins = getNetworkSymbolsFromEnabledCoins(values.enabledCoins);
         const changedCoins = networkSymbolCollection.filter(
-            symbol =>
-                enabledNetworkSymbols.includes(symbol) !== values.enabledCoins.includes(symbol),
+            symbol => enabledNetworkSymbols.includes(symbol) !== enabledCoins.includes(symbol),
         );
 
         if (changedCoins.length === 0) return;
 
         changedCoins.forEach(symbol => {
-            const isEnabled = values.enabledCoins.includes(symbol);
+            const isEnabled = enabledCoins.includes(symbol);
             dispatch(changeCoinVisibility({ symbol, shouldBeVisible: isEnabled }));
 
             analytics.report({

--- a/suite-native/coin-enabling/src/components/CoinEnablingInitFooter.tsx
+++ b/suite-native/coin-enabling/src/components/CoinEnablingInitFooter.tsx
@@ -1,0 +1,19 @@
+import Animated, { SlideInDown, SlideOutDown } from 'react-native-reanimated';
+
+import { Box, Button, ScreenFooterGradient } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+
+type CoinEnablingInitFooterProps = {
+    onSubmit: () => void;
+};
+
+export const CoinEnablingInitFooter = ({ onSubmit }: CoinEnablingInitFooterProps) => (
+    <Animated.View entering={SlideInDown} exiting={SlideOutDown}>
+        <ScreenFooterGradient />
+        <Box marginHorizontal="sp16" marginBottom="sp16">
+            <Button onPress={onSubmit} testID="@coin-enabling/button-save">
+                <Translation id="generic.buttons.confirm" />
+            </Button>
+        </Box>
+    </Animated.View>
+);

--- a/suite-native/coin-enabling/src/components/DiscoveryCoinsFilter.tsx
+++ b/suite-native/coin-enabling/src/components/DiscoveryCoinsFilter.tsx
@@ -1,19 +1,43 @@
+import { memo, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 
 import { selectIsDeviceConnected } from '@suite-common/device';
 import { type Network, type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import { Switch, Text, VStack } from '@suite-native/atoms';
 import { selectDiscoveryNetworkGroups } from '@suite-native/discovery';
-import { useFormContext } from '@suite-native/forms';
+import { useFormContext, useWatch } from '@suite-native/forms';
 import { Translation } from '@suite-native/intl';
 import { useToast } from '@suite-native/toasts';
 
+import {
+    type CoinEnablingFormValues,
+    getEnabledCoinFieldName,
+    getNetworkSymbolsFromEnabledCoins,
+} from '../coinEnablingSchema';
 import { NetworkListItem } from './NetworkListItem';
+
+type NetworkSymbolSwitchProps = {
+    symbol: NetworkSymbol;
+    onToggle: (symbol: NetworkSymbol, isEnabled: boolean) => void;
+};
+
+const NetworkSymbolSwitch = memo(({ symbol, onToggle }: NetworkSymbolSwitchProps) => {
+    const { control } = useFormContext<CoinEnablingFormValues>();
+    const isEnabled = !!useWatch({
+        control,
+        name: getEnabledCoinFieldName(symbol),
+    });
+    const handleToggle = useCallback(
+        (nextIsEnabled: boolean) => onToggle(symbol, nextIsEnabled),
+        [onToggle, symbol],
+    );
+
+    return <Switch onChange={handleToggle} isChecked={isEnabled} />;
+});
 
 type NetworkGroupProps = {
     networks: Network[];
-    enabledSymbols: NetworkSymbol[];
-    handleToggle: (symbol: NetworkSymbol) => void;
+    handleToggle: (symbol: NetworkSymbol, isEnabled?: boolean) => void;
     showTestnetsLabel?: boolean;
 };
 
@@ -21,12 +45,7 @@ type DiscoveryCoinsFilterProps = {
     onDisablingLastCoin?: () => void;
 };
 
-const NetworkGroup = ({
-    networks,
-    enabledSymbols,
-    handleToggle,
-    showTestnetsLabel,
-}: NetworkGroupProps) => (
+const NetworkGroup = ({ networks, handleToggle, showTestnetsLabel }: NetworkGroupProps) => (
     <VStack spacing="sp12">
         {showTestnetsLabel && (
             <Text variant="body-sm">
@@ -37,12 +56,7 @@ const NetworkGroup = ({
             <NetworkListItem
                 key={symbol}
                 symbol={symbol}
-                accessory={
-                    <Switch
-                        isChecked={enabledSymbols.includes(symbol)}
-                        onChange={() => handleToggle(symbol)}
-                    />
-                }
+                accessory={<NetworkSymbolSwitch symbol={symbol} onToggle={handleToggle} />}
                 onPress={() => handleToggle(symbol)}
                 accessibilityRole="togglebutton"
                 testID={`@coin-enabling/toggle-${symbol}`}
@@ -51,61 +65,66 @@ const NetworkGroup = ({
     </VStack>
 );
 
+const MemoizedNetworkGroup = memo(NetworkGroup);
+
 export const DiscoveryCoinsFilter = ({ onDisablingLastCoin }: DiscoveryCoinsFilterProps) => {
     const { supportedMainnets, supportedTestnets, unsupportedMainnets, unsupportedTestnets } =
         useSelector(selectDiscoveryNetworkGroups);
     const isDeviceConnected = useSelector(selectIsDeviceConnected);
     const { showToast } = useToast();
 
-    const { setValue, watch } = useFormContext();
-    const enabledSymbols: NetworkSymbol[] = watch('enabledCoins');
+    const { getValues, setValue } = useFormContext<CoinEnablingFormValues>();
 
-    const handleToggle = (symbol: NetworkSymbol) => {
-        const isEnabled = !enabledSymbols.includes(symbol);
+    const handleToggle = useCallback(
+        (symbol: NetworkSymbol, isEnabled?: boolean) => {
+            const enabledCoins = getValues('enabledCoins') ?? {};
+            const isSymbolEnabled = !!enabledCoins[symbol];
+            // Row press does not subscribe to form state, so it toggles from current form value.
+            // Switch press already knows the next value and passes it directly.
+            const nextIsEnabled = isEnabled ?? !isSymbolEnabled;
 
-        if (
-            !isEnabled &&
-            onDisablingLastCoin &&
-            enabledSymbols.length === 1 &&
-            enabledSymbols.includes(symbol)
-        ) {
-            onDisablingLastCoin();
+            if (nextIsEnabled === isSymbolEnabled) {
+                return;
+            }
 
-            return;
-        }
+            const enabledSymbols = getNetworkSymbolsFromEnabledCoins(enabledCoins);
 
-        if (!isDeviceConnected && isEnabled) {
-            const { name } = getNetwork(symbol);
-            showToast({
-                intent: 'neutral',
-                message: (
-                    <Translation
-                        id="moduleSettings.coinEnabling.toasts.coinEnabled"
-                        values={{ coin: name }}
-                    />
-                ),
-            });
-        }
+            if (
+                !nextIsEnabled &&
+                onDisablingLastCoin &&
+                enabledSymbols.length === 1 &&
+                isSymbolEnabled
+            ) {
+                onDisablingLastCoin();
 
-        const newEnabledSymbols = isEnabled
-            ? [...enabledSymbols, symbol]
-            : enabledSymbols.filter(s => s !== symbol);
+                return;
+            }
 
-        setValue('enabledCoins', newEnabledSymbols, { shouldDirty: true, shouldValidate: true });
-    };
+            if (!isDeviceConnected && nextIsEnabled) {
+                const { name } = getNetwork(symbol);
+                showToast({
+                    intent: 'neutral',
+                    message: (
+                        <Translation
+                            id="moduleSettings.coinEnabling.toasts.coinEnabled"
+                            values={{ coin: name }}
+                        />
+                    ),
+                });
+            }
+
+            setValue(getEnabledCoinFieldName(symbol), nextIsEnabled);
+        },
+        [getValues, isDeviceConnected, onDisablingLastCoin, setValue, showToast],
+    );
 
     return (
         <VStack spacing="sp32">
             <VStack spacing="sp24">
-                <NetworkGroup
-                    networks={supportedMainnets}
-                    enabledSymbols={enabledSymbols}
-                    handleToggle={handleToggle}
-                />
+                <MemoizedNetworkGroup networks={supportedMainnets} handleToggle={handleToggle} />
                 {supportedTestnets.length > 0 && (
-                    <NetworkGroup
+                    <MemoizedNetworkGroup
                         networks={supportedTestnets}
-                        enabledSymbols={enabledSymbols}
                         handleToggle={handleToggle}
                         showTestnetsLabel
                     />
@@ -117,15 +136,13 @@ export const DiscoveryCoinsFilter = ({ onDisablingLastCoin }: DiscoveryCoinsFilt
                         <Translation id="moduleSettings.coinEnabling.unsupportedSubtitle" />
                     </Text>
                     <VStack spacing="sp24">
-                        <NetworkGroup
+                        <MemoizedNetworkGroup
                             networks={unsupportedMainnets}
-                            enabledSymbols={enabledSymbols}
                             handleToggle={handleToggle}
                         />
                         {unsupportedTestnets.length > 0 && (
-                            <NetworkGroup
+                            <MemoizedNetworkGroup
                                 networks={unsupportedTestnets}
-                                enabledSymbols={enabledSymbols}
                                 handleToggle={handleToggle}
                                 showTestnetsLabel
                             />

--- a/suite-native/coin-enabling/src/components/DiscoveryCoinsFilter.tsx
+++ b/suite-native/coin-enabling/src/components/DiscoveryCoinsFilter.tsx
@@ -3,9 +3,9 @@ import { useSelector } from 'react-redux';
 
 import { selectIsDeviceConnected } from '@suite-common/device';
 import { type Network, type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
-import { Switch, Text, VStack } from '@suite-native/atoms';
+import { Text, VStack } from '@suite-native/atoms';
 import { selectDiscoveryNetworkGroups } from '@suite-native/discovery';
-import { useFormContext, useWatch } from '@suite-native/forms';
+import { useFormContext } from '@suite-native/forms';
 import { Translation } from '@suite-native/intl';
 import { useToast } from '@suite-native/toasts';
 
@@ -13,27 +13,9 @@ import {
     type CoinEnablingFormValues,
     getEnabledCoinFieldName,
     getNetworkSymbolsFromEnabledCoins,
-} from '../coinEnablingSchema';
+} from '../coinEnablingFormUtils';
 import { NetworkListItem } from './NetworkListItem';
-
-type NetworkSymbolSwitchProps = {
-    symbol: NetworkSymbol;
-    onToggle: (symbol: NetworkSymbol, isEnabled: boolean) => void;
-};
-
-const NetworkSymbolSwitch = memo(({ symbol, onToggle }: NetworkSymbolSwitchProps) => {
-    const { control } = useFormContext<CoinEnablingFormValues>();
-    const isEnabled = !!useWatch({
-        control,
-        name: getEnabledCoinFieldName(symbol),
-    });
-    const handleToggle = useCallback(
-        (nextIsEnabled: boolean) => onToggle(symbol, nextIsEnabled),
-        [onToggle, symbol],
-    );
-
-    return <Switch onChange={handleToggle} isChecked={isEnabled} />;
-});
+import { NetworkSymbolSwitch } from './NetworkSymbolSwitch';
 
 type NetworkGroupProps = {
     networks: Network[];

--- a/suite-native/coin-enabling/src/components/NetworkSymbolSwitch.tsx
+++ b/suite-native/coin-enabling/src/components/NetworkSymbolSwitch.tsx
@@ -1,0 +1,26 @@
+import { memo, useCallback } from 'react';
+
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { Switch } from '@suite-native/atoms';
+import { useFormContext, useWatch } from '@suite-native/forms';
+
+import { type CoinEnablingFormValues, getEnabledCoinFieldName } from '../coinEnablingFormUtils';
+
+type NetworkSymbolSwitchProps = {
+    symbol: NetworkSymbol;
+    onToggle: (symbol: NetworkSymbol, isEnabled: boolean) => void;
+};
+
+export const NetworkSymbolSwitch = memo(({ symbol, onToggle }: NetworkSymbolSwitchProps) => {
+    const { control } = useFormContext<CoinEnablingFormValues>();
+    const isEnabled = !!useWatch({
+        control,
+        name: getEnabledCoinFieldName(symbol),
+    });
+    const handleToggle = useCallback(
+        (nextIsEnabled: boolean) => onToggle(symbol, nextIsEnabled),
+        [onToggle, symbol],
+    );
+
+    return <Switch onChange={handleToggle} isChecked={isEnabled} />;
+});

--- a/suite-native/coin-enabling/src/hooks/useHasEnabledCoin.ts
+++ b/suite-native/coin-enabling/src/hooks/useHasEnabledCoin.ts
@@ -1,0 +1,12 @@
+import { type UseFormReturn, useWatch } from '@suite-native/forms';
+
+import { type CoinEnablingFormValues } from '../coinEnablingFormUtils';
+
+export const useHasEnabledCoin = (control: UseFormReturn<CoinEnablingFormValues>['control']) =>
+    useWatch({
+        control,
+        name: 'enabledCoins',
+        defaultValue: {},
+        compute: (enabledCoins: CoinEnablingFormValues['enabledCoins']) =>
+            Object.values(enabledCoins ?? {}).some(Boolean),
+    });

--- a/suite-native/coin-enabling/src/screens/CoinEnablingInitScreen.tsx
+++ b/suite-native/coin-enabling/src/screens/CoinEnablingInitScreen.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import Animated, { LinearTransition, SlideInDown, SlideOutDown } from 'react-native-reanimated';
+import { LinearTransition } from 'react-native-reanimated';
 import { useDispatch } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
@@ -7,15 +7,8 @@ import { useNavigation } from '@react-navigation/native';
 import { useServices } from '@suite-common/dependency-injection';
 import { changeCoinVisibility } from '@suite-common/wallet-core';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
-import {
-    AnimatedBox,
-    AnimatedInlineAlertBox,
-    Box,
-    Button,
-    ScreenFooterGradient,
-    VStack,
-} from '@suite-native/atoms';
-import { Form, type UseFormReturn, useForm, useWatch } from '@suite-native/forms';
+import { AnimatedBox, AnimatedInlineAlertBox, VStack } from '@suite-native/atoms';
+import { Form, useForm } from '@suite-native/forms';
 import { Translation } from '@suite-native/intl';
 import {
     type AuthorizeDeviceStackParamList,
@@ -30,40 +23,18 @@ import {
 
 import {
     type CoinEnablingFormValues,
-    coinEnablingFormValidationSchema,
     getNetworkSymbolsFromEnabledCoins,
-} from '../coinEnablingSchema';
+} from '../coinEnablingFormUtils';
+import { coinEnablingFormValidationSchema } from '../coinEnablingSchema';
+import { CoinEnablingInitFooter } from '../components/CoinEnablingInitFooter';
 import { DiscoveryCoinsFilter } from '../components/DiscoveryCoinsFilter';
+import { useHasEnabledCoin } from '../hooks/useHasEnabledCoin';
 
 type NavigationProps = StackToStackCompositeNavigationProps<
     AuthorizeDeviceStackParamList,
     AuthorizeDeviceStackRoutes.CoinEnablingInit,
     RootStackParamList
 >;
-
-type CoinEnablingInitFooterProps = {
-    onSubmit: () => void;
-};
-
-const useHasEnabledCoin = (control: UseFormReturn<CoinEnablingFormValues>['control']) =>
-    useWatch({
-        control,
-        name: 'enabledCoins',
-        defaultValue: {},
-        compute: (enabledCoins: CoinEnablingFormValues['enabledCoins']) =>
-            Object.values(enabledCoins ?? {}).some(Boolean),
-    });
-
-const CoinEnablingInitFooter = ({ onSubmit }: CoinEnablingInitFooterProps) => (
-    <Animated.View entering={SlideInDown} exiting={SlideOutDown}>
-        <ScreenFooterGradient />
-        <Box marginHorizontal="sp16" marginBottom="sp16">
-            <Button onPress={onSubmit} testID="@coin-enabling/button-save">
-                <Translation id="generic.buttons.confirm" />
-            </Button>
-        </Box>
-    </Animated.View>
-);
 
 export const CoinEnablingInitScreen = () => {
     const dispatch = useDispatch();

--- a/suite-native/coin-enabling/src/screens/CoinEnablingInitScreen.tsx
+++ b/suite-native/coin-enabling/src/screens/CoinEnablingInitScreen.tsx
@@ -15,7 +15,7 @@ import {
     ScreenFooterGradient,
     VStack,
 } from '@suite-native/atoms';
-import { Form, useForm } from '@suite-native/forms';
+import { Form, type UseFormReturn, useForm, useWatch } from '@suite-native/forms';
 import { Translation } from '@suite-native/intl';
 import {
     type AuthorizeDeviceStackParamList,
@@ -31,6 +31,7 @@ import {
 import {
     type CoinEnablingFormValues,
     coinEnablingFormValidationSchema,
+    getNetworkSymbolsFromEnabledCoins,
 } from '../coinEnablingSchema';
 import { DiscoveryCoinsFilter } from '../components/DiscoveryCoinsFilter';
 
@@ -39,6 +40,30 @@ type NavigationProps = StackToStackCompositeNavigationProps<
     AuthorizeDeviceStackRoutes.CoinEnablingInit,
     RootStackParamList
 >;
+
+type CoinEnablingInitFooterProps = {
+    onSubmit: () => void;
+};
+
+const useHasEnabledCoin = (control: UseFormReturn<CoinEnablingFormValues>['control']) =>
+    useWatch({
+        control,
+        name: 'enabledCoins',
+        defaultValue: {},
+        compute: (enabledCoins: CoinEnablingFormValues['enabledCoins']) =>
+            Object.values(enabledCoins ?? {}).some(Boolean),
+    });
+
+const CoinEnablingInitFooter = ({ onSubmit }: CoinEnablingInitFooterProps) => (
+    <Animated.View entering={SlideInDown} exiting={SlideOutDown}>
+        <ScreenFooterGradient />
+        <Box marginHorizontal="sp16" marginBottom="sp16">
+            <Button onPress={onSubmit} testID="@coin-enabling/button-save">
+                <Translation id="generic.buttons.confirm" />
+            </Button>
+        </Box>
+    </Animated.View>
+);
 
 export const CoinEnablingInitScreen = () => {
     const dispatch = useDispatch();
@@ -50,22 +75,22 @@ export const CoinEnablingInitScreen = () => {
 
     const form = useForm<CoinEnablingFormValues>({
         defaultValues: {
-            enabledCoins: [],
+            enabledCoins: {},
         },
         validation: coinEnablingFormValidationSchema,
     });
-    const {
-        formState: { isValid },
-    } = form;
+    const hasEnabledCoin = useHasEnabledCoin(form.control);
 
-    const handleSubmit = form.handleSubmit(values => {
-        values.enabledCoins.forEach(symbol => {
+    const handleSubmit = form.handleSubmit((values: CoinEnablingFormValues) => {
+        const enabledCoins = getNetworkSymbolsFromEnabledCoins(values.enabledCoins);
+
+        enabledCoins.forEach(symbol => {
             dispatch(changeCoinVisibility({ symbol, shouldBeVisible: true }));
         });
 
         analytics.report({
             type: events.coinEnablingInitStateEvent.name,
-            payload: { enabledNetworks: values.enabledCoins },
+            payload: { enabledNetworks: enabledCoins },
         });
 
         navigation.popTo(RootStackRoutes.AuthorizeDeviceStack, {
@@ -82,18 +107,7 @@ export const CoinEnablingInitScreen = () => {
                     closeActionType="close"
                 />
             }
-            footer={
-                isValid && (
-                    <Animated.View entering={SlideInDown} exiting={SlideOutDown}>
-                        <ScreenFooterGradient />
-                        <Box marginHorizontal="sp16" marginBottom="sp16">
-                            <Button onPress={handleSubmit} testID="@coin-enabling/button-save">
-                                <Translation id="generic.buttons.confirm" />
-                            </Button>
-                        </Box>
-                    </Animated.View>
-                )
-            }
+            footer={hasEnabledCoin && <CoinEnablingInitFooter onSubmit={handleSubmit} />}
         >
             <VStack spacing="sp16">
                 {!isAlertDismissed && (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Tweaked form data structure and controllers to minimize re-renders on the coin enabling form. Now when you toggle coin, rerendering is kept only to things that actually need to update.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #28362 

## Screenshots:

https://github.com/user-attachments/assets/8157a158-5595-471e-8611-2661473da694


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=juriczech/issue-28362&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->