### PR TITLE
feat(suite-native): add yield withdraw flow

### DIFF
--- a/packages/suite/src/actions/wallet/stablecoin-yield/composeYieldWithdrawTransaction.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/composeYieldWithdrawTransaction.ts
@@ -1,6 +1,4 @@
-import { numberToHex, toWei } from 'web3-utils';
-
-import { Calldata, asEvmAddress } from '@suite-common/calldata';
+import { asEvmAddress } from '@suite-common/calldata';
 import { getYieldVault } from '@suite-common/earn-stablecoin-api';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { getNetwork } from '@suite-common/wallet-config';
@@ -8,18 +6,14 @@ import { ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT } from '@suite-common/wallet-constan
 import {
     type YieldFlowResolvedData,
     type YieldWithdrawInputUnit,
+    buildYieldWithdrawCalldata,
+    buildYieldWithdrawUnsignedTransaction,
     selectRawNetworkFeeInfo,
 } from '@suite-common/wallet-core';
 import { ethereumGetCurrentNonceThunk } from '@suite-common/wallet-core/src/send/sendFormEthereumThunks';
 import { type Account } from '@suite-common/wallet-types';
-import {
-    asAmountUnit,
-    getAccountIdentity,
-    getConvertedOrDefaultFeeInfo,
-    unitsToSubunits,
-} from '@suite-common/wallet-utils';
+import { getAccountIdentity, getConvertedOrDefaultFeeInfo } from '@suite-common/wallet-utils';
 import TrezorConnect from '@trezor/connect';
-import { BigNumber } from '@trezor/utils';
 
 import type { AppState, Dispatch } from 'src/types/suite';
 
@@ -40,7 +34,7 @@ export const composeYieldWithdrawTransaction = async ({
     dispatch,
     getState,
 }: ComposeYieldWithdrawTransactionParams): Promise<string> => {
-    const { vault, token, receiptToken } = flowData;
+    const { vault } = flowData;
 
     const { address: vaultAddress } = await getYieldVault({
         routeParams: {
@@ -60,37 +54,14 @@ export const composeYieldWithdrawTransaction = async ({
         );
     }
 
-    const isSharesInput = withdrawInputUnit === 'shares';
-    const decimals = isSharesInput ? receiptToken.decimals : token.decimals;
     const ownerAddress = asEvmAddress(account.descriptor);
-    const amountSubunits = unitsToSubunits({
-        value: asAmountUnit(new BigNumber(amount)),
-        decimals,
+    const calldata = buildYieldWithdrawCalldata({
+        amount,
+        flowData,
+        ownerAddress,
+        receiverAddress: ownerAddress,
+        withdrawInputUnit,
     });
-
-    const builderResult = isSharesInput
-        ? Calldata.evm.erc4626.redeem.encode(
-              {
-                  shares: amountSubunits,
-                  receiver: account.descriptor,
-                  owner: account.descriptor,
-              },
-              { sender: ownerAddress },
-          )
-        : Calldata.evm.erc4626.withdraw.encode(
-              {
-                  assets: amountSubunits,
-                  receiver: account.descriptor,
-                  owner: account.descriptor,
-              },
-              { sender: ownerAddress },
-          );
-
-    if (!builderResult.isValid || !builderResult.data) {
-        const issues = builderResult.errors.map(issue => issue.code).join(', ');
-
-        throw new Error(`Failed to encode withdraw calldata${issues ? `: ${issues}` : '.'}`);
-    }
 
     const nonceTask = dispatch(ethereumGetCurrentNonceThunk({ selectedAccount: account })).unwrap();
 
@@ -102,7 +73,7 @@ export const composeYieldWithdrawTransaction = async ({
             specific: {
                 from: account.descriptor,
                 to: vaultAddress,
-                data: builderResult.data,
+                data: calldata,
                 value: '0x0',
             },
         },
@@ -130,30 +101,15 @@ export const composeYieldWithdrawTransaction = async ({
         throw new Error(`Fee info is not available.`);
     }
 
-    const commonFields = {
-        from: account.descriptor,
-        to: vaultAddress,
-        data: builderResult.data,
-        value: '0x0',
-        nonce: Number(nonce),
+    const unsignedTx = buildYieldWithdrawUnsignedTransaction({
         chainId: network.chainId,
-        gasLimit: numberToHex(gasLimit),
-    };
-
-    const unsignedTx =
-        normalLevel?.maxFeePerGas && normalLevel.maxPriorityFeePerGas
-            ? {
-                  ...commonFields,
-                  type: 2,
-                  maxFeePerGas: numberToHex(toWei(normalLevel.maxFeePerGas, 'gwei')),
-                  maxPriorityFeePerGas: numberToHex(
-                      toWei(normalLevel.maxPriorityFeePerGas, 'gwei'),
-                  ),
-              }
-            : {
-                  ...commonFields,
-                  gasPrice: numberToHex(toWei(normalLevel.feePerUnit, 'gwei')),
-              };
+        data: calldata,
+        feeLevel: normalLevel,
+        from: account.descriptor,
+        gasLimit,
+        nonce: Number(nonce),
+        to: vaultAddress,
+    });
 
     return JSON.stringify(unsignedTx);
 };

--- a/suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldUtils.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldUtils.test.ts
@@ -1,0 +1,161 @@
+import { Calldata, asEvmAddress } from '@suite-common/calldata';
+
+import {
+    buildEvmSelectedFee,
+    buildYieldWithdrawCalldata,
+    buildYieldWithdrawUnsignedTransaction,
+} from '../stablecoinYieldUtils';
+
+const ACCOUNT_DESCRIPTOR = asEvmAddress('0x9ea3721b5bf3b64b4418c38b603154d2d597fae3');
+const VAULT_ADDRESS = '0x58d97b57bb95320f9a05dc918aef65434969c2b2';
+
+const account = {
+    descriptor: ACCOUNT_DESCRIPTOR,
+    networkType: 'ethereum',
+};
+
+const flowData = {
+    account,
+    vault: {
+        chainId: 1,
+        id: 'ethereum:1:0x58d97b57bb95320f9a05dc918aef65434969c2b2',
+    },
+    token: {
+        balance: '0',
+        contractAddress: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+        decimals: 6,
+        networkSymbol: 'eth',
+        symbol: 'USDC',
+    },
+    receiptToken: {
+        contractAddress: VAULT_ADDRESS,
+        decimals: 18,
+        networkSymbol: 'eth',
+        symbol: 'trUSDC',
+    },
+} as unknown as Parameters<typeof buildYieldWithdrawCalldata>[0]['flowData'];
+
+describe('stablecoinYieldUtils', () => {
+    describe('buildYieldWithdrawCalldata', () => {
+        it('builds ERC4626 withdraw calldata for asset input', () => {
+            const calldata = buildYieldWithdrawCalldata({
+                amount: '10',
+                flowData,
+                ownerAddress: ACCOUNT_DESCRIPTOR,
+                receiverAddress: ACCOUNT_DESCRIPTOR,
+                withdrawInputUnit: 'asset',
+            });
+
+            expect(Calldata.evm.erc4626.withdraw.decode(calldata)).toEqual({
+                assets: 10_000_000n,
+                owner: ACCOUNT_DESCRIPTOR.toLowerCase(),
+                receiver: ACCOUNT_DESCRIPTOR.toLowerCase(),
+            });
+        });
+
+        it('builds ERC4626 redeem calldata for shares input', () => {
+            const calldata = buildYieldWithdrawCalldata({
+                amount: '10',
+                flowData,
+                ownerAddress: ACCOUNT_DESCRIPTOR,
+                receiverAddress: ACCOUNT_DESCRIPTOR,
+                withdrawInputUnit: 'shares',
+            });
+
+            expect(Calldata.evm.erc4626.redeem.decode(calldata)).toEqual({
+                shares: 10_000_000_000_000_000_000n,
+                owner: ACCOUNT_DESCRIPTOR.toLowerCase(),
+                receiver: ACCOUNT_DESCRIPTOR.toLowerCase(),
+            });
+        });
+
+        it('throws when calldata cannot be encoded', () => {
+            expect(() =>
+                buildYieldWithdrawCalldata({
+                    amount: '10',
+                    flowData,
+                    ownerAddress: 'not-an-address' as unknown as Parameters<
+                        typeof buildYieldWithdrawCalldata
+                    >[0]['ownerAddress'],
+                    receiverAddress: ACCOUNT_DESCRIPTOR,
+                    withdrawInputUnit: 'asset',
+                }),
+            ).toThrow('Failed to encode withdraw calldata');
+        });
+    });
+
+    describe('buildYieldWithdrawUnsignedTransaction', () => {
+        const commonParams = {
+            chainId: 1,
+            data: '0x1234',
+            gasLimit: '21000',
+            from: ACCOUNT_DESCRIPTOR,
+            nonce: 7,
+            to: VAULT_ADDRESS,
+        };
+
+        it('builds legacy fee fields', () => {
+            expect(
+                buildYieldWithdrawUnsignedTransaction({
+                    ...commonParams,
+                    feeLevel: {
+                        feePerUnit: '5',
+                    },
+                }),
+            ).toEqual({
+                chainId: 1,
+                data: '0x1234',
+                from: ACCOUNT_DESCRIPTOR,
+                gasLimit: '0x5208',
+                gasPrice: '0x12a05f200',
+                nonce: 7,
+                to: VAULT_ADDRESS,
+                value: '0x0',
+            });
+        });
+
+        it('builds EIP1559 fee fields', () => {
+            expect(
+                buildYieldWithdrawUnsignedTransaction({
+                    ...commonParams,
+                    feeLevel: {
+                        feePerUnit: '5',
+                        maxFeePerGas: '6',
+                        maxPriorityFeePerGas: '1',
+                    },
+                }),
+            ).toEqual({
+                chainId: 1,
+                data: '0x1234',
+                from: ACCOUNT_DESCRIPTOR,
+                gasLimit: '0x5208',
+                maxFeePerGas: '0x165a0bc00',
+                maxPriorityFeePerGas: '0x3b9aca00',
+                nonce: 7,
+                to: VAULT_ADDRESS,
+                type: 2,
+                value: '0x0',
+            });
+        });
+    });
+
+    it('builds EVM selected fee with base fee', () => {
+        expect(
+            buildEvmSelectedFee({
+                feeLevel: {
+                    baseFeePerGas: '4',
+                    feePerUnit: '5',
+                    maxFeePerGas: '6',
+                    maxPriorityFeePerGas: '1',
+                },
+                gasLimit: '21000',
+            }),
+        ).toEqual({
+            baseFeePerGas: '0xee6b2800',
+            gasLimit: '0x5208',
+            maxFeePerGas: '0x165a0bc00',
+            maxPriorityFeePerGas: '0x3b9aca00',
+            type: 'eip1559',
+        });
+    });
+});

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
@@ -1,4 +1,6 @@
-import { Calldata } from '@suite-common/calldata';
+import { numberToHex, toWei } from 'web3-utils';
+
+import { Calldata, type EvmAddress } from '@suite-common/calldata';
 import {
     type TransactionDto,
     TransactionDtoStatus,
@@ -7,14 +9,20 @@ import {
     parseUnsignedEvmTransaction,
 } from '@suite-common/earn-stablecoin-api';
 import type { NetworkSymbol } from '@suite-common/wallet-config';
-import { type AccountKey } from '@suite-common/wallet-types';
-import { getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils';
+import { type AccountKey, type EvmSelectedFee } from '@suite-common/wallet-types';
+import {
+    asAmountUnit,
+    getContractAddressForNetworkSymbol,
+    unitsToSubunits,
+} from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
 
 import type {
+    YieldFlowDisplayToken,
     YieldFlowResolvedData,
     YieldFlowType,
     YieldPendingTransactionState,
+    YieldWithdrawInputUnit,
 } from './stablecoinYieldTypes';
 
 type TokenLike = {
@@ -60,12 +68,166 @@ type GetStablecoinYieldFlowKeyParams = {
     yieldId: string;
 };
 
+type EvmFeeLevel = {
+    baseFeePerGas?: string;
+    feePerUnit: string;
+    maxFeePerGas?: string;
+    maxPriorityFeePerGas?: string;
+};
+
+type BuildYieldWithdrawCalldataParams = {
+    amount: string;
+    flowData: YieldFlowResolvedData;
+    ownerAddress: EvmAddress;
+    receiverAddress: EvmAddress;
+    withdrawInputUnit: YieldWithdrawInputUnit;
+};
+
+type BuildYieldWithdrawUnsignedTransactionParams = {
+    chainId: number;
+    data: string;
+    feeLevel: EvmFeeLevel;
+    from: string;
+    gasLimit: string;
+    nonce: number;
+    to: string;
+};
+
+type BuildEvmFeeFieldsParams = {
+    feeLevel: EvmFeeLevel;
+    gasLimit: string;
+};
+
 export const getStablecoinYieldFlowKey = ({
     accountKey,
     tokenContract,
     yieldId,
 }: GetStablecoinYieldFlowKeyParams) =>
     `${accountKey}:${yieldId}:${tokenContract?.toLowerCase() ?? ''}`;
+
+export const getYieldWithdrawInputToken = ({
+    flowData,
+    withdrawInputUnit,
+}: {
+    flowData: YieldFlowResolvedData;
+    withdrawInputUnit: YieldWithdrawInputUnit;
+}): YieldFlowDisplayToken =>
+    withdrawInputUnit === 'shares' ? flowData.receiptToken : flowData.token;
+
+export const buildYieldWithdrawCalldata = ({
+    amount,
+    flowData,
+    ownerAddress,
+    receiverAddress,
+    withdrawInputUnit,
+}: BuildYieldWithdrawCalldataParams) => {
+    const isSharesInput = withdrawInputUnit === 'shares';
+    const inputToken = getYieldWithdrawInputToken({ flowData, withdrawInputUnit });
+    const amountSubunits = unitsToSubunits({
+        value: asAmountUnit(new BigNumber(amount)),
+        decimals: inputToken.decimals,
+    });
+
+    const builderResult = isSharesInput
+        ? Calldata.evm.erc4626.redeem.encode(
+              {
+                  shares: amountSubunits,
+                  receiver: receiverAddress,
+                  owner: ownerAddress,
+              },
+              { sender: ownerAddress },
+          )
+        : Calldata.evm.erc4626.withdraw.encode(
+              {
+                  assets: amountSubunits,
+                  receiver: receiverAddress,
+                  owner: ownerAddress,
+              },
+              { sender: ownerAddress },
+          );
+
+    if (!builderResult.isValid || !builderResult.data) {
+        const issues = builderResult.errors.map(issue => issue.code).join(', ');
+
+        throw new Error(`Failed to encode withdraw calldata${issues ? `: ${issues}` : '.'}`);
+    }
+
+    return builderResult.data;
+};
+
+export const buildEvmFeeFields = ({ feeLevel, gasLimit }: BuildEvmFeeFieldsParams) => {
+    const commonFields = {
+        gasLimit: numberToHex(gasLimit),
+    };
+
+    if (feeLevel.maxFeePerGas && feeLevel.maxPriorityFeePerGas) {
+        return {
+            ...commonFields,
+            maxFeePerGas: numberToHex(toWei(feeLevel.maxFeePerGas, 'gwei')),
+            maxPriorityFeePerGas: numberToHex(toWei(feeLevel.maxPriorityFeePerGas, 'gwei')),
+        };
+    }
+
+    return {
+        ...commonFields,
+        gasPrice: numberToHex(toWei(feeLevel.feePerUnit, 'gwei')),
+    };
+};
+
+export const buildEvmSelectedFee = ({
+    feeLevel,
+    gasLimit,
+}: BuildEvmFeeFieldsParams): EvmSelectedFee => {
+    const feeFields = buildEvmFeeFields({ feeLevel, gasLimit });
+
+    if ('maxFeePerGas' in feeFields && 'maxPriorityFeePerGas' in feeFields) {
+        return {
+            type: 'eip1559',
+            ...feeFields,
+            baseFeePerGas: numberToHex(toWei(feeLevel.baseFeePerGas ?? '0', 'gwei')),
+        };
+    }
+
+    return {
+        type: 'legacy',
+        ...feeFields,
+    };
+};
+
+export const buildYieldWithdrawUnsignedTransaction = ({
+    chainId,
+    data,
+    feeLevel,
+    from,
+    gasLimit,
+    nonce,
+    to,
+}: BuildYieldWithdrawUnsignedTransactionParams) => {
+    const feeFields = buildEvmFeeFields({ feeLevel, gasLimit });
+    const commonFields = {
+        from,
+        to,
+        data,
+        value: '0x0',
+        nonce,
+        chainId,
+        gasLimit: feeFields.gasLimit,
+    };
+
+    if ('maxFeePerGas' in feeFields && 'maxPriorityFeePerGas' in feeFields) {
+        return {
+            ...commonFields,
+            type: 2,
+            maxFeePerGas: feeFields.maxFeePerGas,
+            maxPriorityFeePerGas: feeFields.maxPriorityFeePerGas,
+        };
+    }
+
+    return {
+        ...commonFields,
+        gasPrice: feeFields.gasPrice,
+    };
+};
 
 export const splitYieldPendingTransaction = (
     pendingTransaction: YieldPendingTransactionState | null,

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2777,6 +2777,19 @@ export const messages = {
             limit: 'Limit',
             pendingTitle: 'Confirming revoke',
         },
+        yieldWithdrawFlowScreen: {
+            title: 'Withdraw',
+            withdrawalAmount: 'Withdrawal amount',
+            withdrawMax: 'Withdraw max',
+            supplied: 'Supplied:',
+            withdrawPendingTitle: 'Confirming withdrawal',
+            amountToWithdraw: 'Amount to withdraw',
+            maximumFee: 'Maximum fee',
+            feeToBeCalculated: 'To be calculated',
+            amountExceedsSupplied: 'The amount exceeds your supplied balance.',
+            networkFeeWarning:
+                'Network fees may exceed this amount. Your balance may decrease. Enter higher amount.',
+        },
         yieldDepositApprovalReviewScreen: {
             title: 'Review with Trezor',
             successMessage: "You're all set.",
@@ -2790,9 +2803,18 @@ export const messages = {
             successMessage: "You're all set.",
             submitButton: 'Deposit now',
         },
+        yieldWithdrawReviewScreen: {
+            title: 'Review with Trezor',
+            successMessage: "You're all set.",
+            submitButton: 'Withdraw now',
+        },
         yieldDepositCompleteScreen: {
             title: 'Deposit complete',
             subtitle: 'Your deposit is now earning yield in the vault.',
+        },
+        yieldWithdrawCompleteScreen: {
+            title: 'Withdrawal complete',
+            subtitle: 'Your funds have been withdrawn from the vault.',
         },
         yieldCompleteScreen: {
             status: 'Status',
@@ -2800,11 +2822,15 @@ export const messages = {
             apy: 'APY',
             received: 'Received',
             sent: 'Sent',
+            withdrawalAmount: 'Withdrawal amount',
             backToOverview: 'Back to overview',
         },
         yieldReview: {
             depositCard: {
                 title: 'Deposit',
+            },
+            withdrawCard: {
+                title: 'Withdraw',
             },
             receiveCard: {
                 title: 'Receive',
@@ -2850,6 +2876,22 @@ export const messages = {
                     },
                     pendingTransactionConflict: {
                         title: 'Deposit was not submitted',
+                        description:
+                            'There is already a pending transaction for this account. Wait for it to finish before trying again.',
+                    },
+                },
+                withdraw: {
+                    signTransactionFailed: {
+                        title: 'Transaction was not signed',
+                        description: 'Review the transaction and sign it again.',
+                    },
+                    pushTransactionFailed: {
+                        title: 'Withdraw was not submitted',
+                        description:
+                            'The withdraw transaction was signed but could not be submitted to the network.',
+                    },
+                    pendingTransactionConflict: {
+                        title: 'Withdraw was not submitted',
                         description:
                             'There is already a pending transaction for this account. Wait for it to finish before trying again.',
                     },

--- a/suite-native/module-accounts-management/src/components/StablecoinYieldTokenOverview.tsx
+++ b/suite-native/module-accounts-management/src/components/StablecoinYieldTokenOverview.tsx
@@ -24,7 +24,7 @@ import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
 import { TokenAmountFormatter } from '@suite-native/formatters';
 import { CryptoIconWithNetwork, Icon } from '@suite-native/icons';
 import { Translation, useTranslate } from '@suite-native/intl';
-import { useResolvedYieldFlowData, useWorkInProgressAlert } from '@suite-native/module-earn';
+import { useResolvedYieldFlowData } from '@suite-native/module-earn';
 import {
     type RootStackParamList,
     RootStackRoutes,
@@ -45,16 +45,16 @@ export const StablecoinYieldTokenOverview = ({
     accountKey,
     tokenContract,
 }: StablecoinYieldTokenOverviewProps) => {
-    const handleShowWithdrawWorkInProgressAlert = useWorkInProgressAlert();
     const navigation = useNavigation<NavigationProps>();
     const { showAlert } = useAlert();
     const { translate } = useTranslate();
     const isEnabled = useFeatureFlag(FeatureFlag.IsStablecoinYieldEnabled);
-    const { account, apy, resolutionStatus, token, vault } = useResolvedYieldFlowData({
-        accountKey,
-        tokenContract,
-        displayError: false,
-    });
+    const { account, apy, resolutionStatus, suppliedSharesAmount, vault } =
+        useResolvedYieldFlowData({
+            accountKey,
+            tokenContract,
+            displayError: false,
+        });
     const apyValueText = apy !== null ? `~${apy.toFixed(2)}%` : null;
 
     const handleOpenApyAlert = useCallback(() => {
@@ -100,18 +100,28 @@ export const StablecoinYieldTokenOverview = ({
         });
     }, [accountKey, navigation, vault]);
 
+    const handleWithdrawPress = useCallback(() => {
+        navigation.navigate(RootStackRoutes.YieldNavigator, {
+            screen: YieldStackRoutes.YieldWithdraw,
+            params: {
+                accountKey,
+                tokenContract,
+            },
+        });
+    }, [accountKey, navigation, tokenContract]);
+
     if (resolutionStatus !== 'resolved' || !vault?.token.address) return null;
 
     const apyColor = apyValueText === null ? 'contentSecondary' : 'contentPrimary';
     const apyValue = apyValueText ?? <Translation id="earn.notAvailable" />;
     const depositedPosition =
-        account && token?.balance !== undefined
+        account && suppliedSharesAmount !== null
             ? {
                   balance: getConvertedOutputTokenBalanceToInputTokenAmount({
                       networkSymbol: account.symbol,
                       token: vault.token,
                       outputToken: vault.outputToken,
-                      outputTokenBalance: token.balance,
+                      outputTokenBalance: suppliedSharesAmount,
                       pricePerShareState: vault.state?.pricePerShareState,
                   }),
                   contractAddress: toTokenAddress(vault.token.address),
@@ -192,8 +202,7 @@ export const StablecoinYieldTokenOverview = ({
                             </Box>
                             <Box flex={1}>
                                 <Button
-                                    // TODO: Remove once the stablecoin yield withdraw flow is implemented.
-                                    onPress={handleShowWithdrawWorkInProgressAlert}
+                                    onPress={handleWithdrawPress}
                                     intent="brand"
                                     priority="secondary"
                                     size="medium"

--- a/suite-native/module-earn/package.json
+++ b/suite-native/module-earn/package.json
@@ -17,6 +17,7 @@
         "@react-navigation/native-stack": "7.12.0",
         "@reduxjs/toolkit": "2.11.2",
         "@shopify/flash-list": "2.3.0",
+        "@suite-common/calldata": "workspace:*",
         "@suite-common/dependency-injection": "workspace:*",
         "@suite-common/device": "workspace:*",
         "@suite-common/earn-stablecoin": "workspace:*",

--- a/suite-native/module-earn/src/components/YieldCompleteScreenPresets.tsx
+++ b/suite-native/module-earn/src/components/YieldCompleteScreenPresets.tsx
@@ -78,3 +78,79 @@ export const getYieldDepositCompleteRows = ({
         ),
     },
 ];
+
+type GetYieldWithdrawCompleteRowsParams = {
+    accountSymbol: NetworkSymbol;
+    apyValue: ReactNode;
+    receivedAmount: string;
+    receivedTokenContract?: string;
+    withdrawalAmount?: string;
+    withdrawalTokenContract?: string;
+};
+
+export const getYieldWithdrawCompleteRows = ({
+    accountSymbol,
+    apyValue,
+    receivedAmount,
+    receivedTokenContract,
+    withdrawalAmount,
+    withdrawalTokenContract,
+}: GetYieldWithdrawCompleteRowsParams): YieldCompleteSummaryRow[] => [
+    {
+        key: 'status',
+        label: <Translation id="earn.yieldCompleteScreen.status" />,
+        value: (
+            <HStack spacing="sp4" alignItems="center">
+                <Icon name="checkCircle" size="mediumLarge" color="contentBrand" />
+                <Text variant="body-md" color="contentBrand">
+                    <Translation id="earn.yieldCompleteScreen.completed" />
+                </Text>
+            </HStack>
+        ),
+    },
+    {
+        key: 'apy',
+        label: <Translation id="earn.yieldCompleteScreen.apy" />,
+        value: (
+            <Text variant="body-md" color="contentPrimary">
+                {apyValue}
+            </Text>
+        ),
+    },
+    ...(withdrawalAmount
+        ? [
+              {
+                  key: 'withdrawal-amount',
+                  label: <Translation id="earn.yieldCompleteScreen.withdrawalAmount" />,
+                  value: (
+                      <HStack spacing="sp4" alignItems="center" flexShrink={1}>
+                          <CryptoIcon
+                              symbol={accountSymbol}
+                              contractAddress={withdrawalTokenContract}
+                              size="extraSmall"
+                          />
+                          <Text variant="body-md-strong" color="contentPrimary" numberOfLines={1}>
+                              {withdrawalAmount}
+                          </Text>
+                      </HStack>
+                  ),
+              },
+          ]
+        : []),
+    {
+        key: 'received',
+        label: <Translation id="earn.yieldCompleteScreen.received" />,
+        value: (
+            <HStack spacing="sp4" alignItems="center" flexShrink={1}>
+                <CryptoIcon
+                    symbol={accountSymbol}
+                    contractAddress={receivedTokenContract}
+                    size="extraSmall"
+                />
+                <Text variant="body-md-strong" color="contentPrimary" numberOfLines={1}>
+                    {receivedAmount}
+                </Text>
+            </HStack>
+        ),
+    },
+];

--- a/suite-native/module-earn/src/components/YieldReviewList.tsx
+++ b/suite-native/module-earn/src/components/YieldReviewList.tsx
@@ -1,0 +1,112 @@
+import { type LayoutChangeEvent, View } from 'react-native';
+import { useSelector } from 'react-redux';
+
+import { type DeviceRootState } from '@suite-common/device';
+import { selectSendFormReviewButtonRequestsCount } from '@suite-common/wallet-core';
+import { type ReviewOutputState } from '@suite-common/wallet-types';
+import { Button, VStack } from '@suite-native/atoms';
+import { Translation, useTranslate } from '@suite-native/intl';
+import {
+    LIST_VERTICAL_SPACING,
+    ReviewOutputCard,
+    SlidingFooterOverlay,
+    useActiveStepOffset,
+} from '@suite-native/transaction-management';
+
+import {
+    type YieldReviewCard,
+    type YieldReviewListProps,
+    getYieldReviewCards,
+} from './YieldReviewListPresets';
+
+type YieldReviewCardProps = {
+    card: YieldReviewCard;
+    onLayout: (event: LayoutChangeEvent) => void;
+    outputState: ReviewOutputState;
+};
+
+const YieldReviewCard = ({ card, onLayout, outputState }: YieldReviewCardProps) => (
+    <View onLayout={onLayout}>
+        <ReviewOutputCard title={card.title} outputState={outputState}>
+            {card.content}
+        </ReviewOutputCard>
+    </View>
+);
+
+export const YieldReviewList = ({
+    accountKey,
+    amount,
+    fee,
+    isFooterVisible = true,
+    isSubmitDisabled,
+    isSubmitLoading,
+    networkSymbol,
+    onSubmit,
+    receiveAmount,
+    receiveTokenSymbol,
+    tokenSymbol,
+    variant,
+}: YieldReviewListProps) => {
+    const { translate } = useTranslate();
+    const buttonRequestsCount = useSelector((state: DeviceRootState) =>
+        selectSendFormReviewButtonRequestsCount(state, networkSymbol),
+    );
+    const cards = getYieldReviewCards(
+        {
+            accountKey,
+            amount,
+            fee,
+            networkSymbol,
+            receiveAmount,
+            receiveTokenSymbol,
+            tokenSymbol,
+            variant,
+        },
+        translate,
+    );
+    const activeCardIndex = Math.min(buttonRequestsCount - 1, cards.length - 1);
+    const activeStep = Math.max(activeCardIndex, 0);
+    const { activeStepBottomOffset, handleReadListItemHeight } = useActiveStepOffset(activeStep);
+
+    const getOutputState = (index: number): ReviewOutputState => {
+        if (activeCardIndex < 0) {
+            return undefined;
+        }
+
+        if (index < activeCardIndex) {
+            return 'success';
+        }
+
+        if (index === activeCardIndex) {
+            return 'active';
+        }
+
+        return undefined;
+    };
+
+    return (
+        <>
+            <VStack spacing={LIST_VERTICAL_SPACING}>
+                {cards.map((card, index) => (
+                    <YieldReviewCard
+                        key={card.key}
+                        card={card}
+                        onLayout={event => handleReadListItemHeight(event, index)}
+                        outputState={getOutputState(index)}
+                    />
+                ))}
+            </VStack>
+            {isFooterVisible && (
+                <SlidingFooterOverlay activeStepOffset={activeStepBottomOffset}>
+                    <Button
+                        isDisabled={isSubmitDisabled}
+                        isLoading={isSubmitLoading}
+                        onPress={onSubmit}
+                    >
+                        <Translation id="generic.buttons.continue" />
+                    </Button>
+                </SlidingFooterOverlay>
+            )}
+        </>
+    );
+};

--- a/suite-native/module-earn/src/components/YieldReviewListPresets.tsx
+++ b/suite-native/module-earn/src/components/YieldReviewListPresets.tsx
@@ -1,0 +1,122 @@
+import { type ReactNode } from 'react';
+
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { type AccountKey, toTokenSymbol } from '@suite-common/wallet-types';
+import { HStack, Text, VStack } from '@suite-native/atoms';
+import { CryptoAmountFormatter } from '@suite-native/formatters';
+import { type TxKeyPath } from '@suite-native/intl';
+import { ReviewOutputItemValues } from '@suite-native/transaction-management';
+
+export type YieldReviewListVariant = 'deposit' | 'withdraw';
+
+type YieldReviewListCommonProps = {
+    accountKey: AccountKey;
+    amount: string;
+    fee: string;
+    networkSymbol: NetworkSymbol;
+    tokenSymbol: string;
+};
+
+type YieldActionReviewListProps = YieldReviewListCommonProps & {
+    receiveAmount?: string;
+    receiveTokenSymbol?: string;
+    variant: 'deposit' | 'withdraw';
+};
+
+type YieldReviewListActionProps = {
+    isFooterVisible?: boolean;
+    isSubmitDisabled?: boolean;
+    isSubmitLoading?: boolean;
+    onSubmit: () => void | Promise<void>;
+};
+
+export type YieldReviewListProps = YieldActionReviewListProps & YieldReviewListActionProps;
+
+export type YieldReviewCard = {
+    content: ReactNode;
+    key: string;
+    title: string;
+};
+
+type DetailRowProps = {
+    label: string;
+    value: ReactNode;
+};
+
+type CreateYieldReviewCardsParams = YieldActionReviewListProps;
+
+type Translate = (id: TxKeyPath) => string;
+
+const cardTitleTranslationIds = {
+    deposit: 'earn.yieldReview.depositCard.title',
+    withdraw: 'earn.yieldReview.withdrawCard.title',
+} satisfies Record<YieldReviewListVariant, TxKeyPath>;
+
+const detailsTitleTranslationIds = {
+    deposit: 'earn.yieldReview.transactionDetailsCard.title',
+    withdraw: 'earn.yieldReview.transactionDetailsCard.title',
+} satisfies Record<YieldReviewListVariant, TxKeyPath>;
+
+const DetailRow = ({ label, value }: DetailRowProps) => (
+    <HStack justifyContent="space-between" alignItems="center">
+        <Text variant="body-sm">{label}</Text>
+        {value}
+    </HStack>
+);
+
+export const getYieldReviewCards = (
+    { accountKey, amount, fee, tokenSymbol, ...variantProps }: CreateYieldReviewCardsParams,
+    translate: Translate,
+): YieldReviewCard[] => [
+    {
+        content: (
+            <CryptoAmountFormatter
+                value={amount}
+                symbol={toTokenSymbol(tokenSymbol)}
+                isDiscreetText={false}
+            />
+        ),
+        key: 'amount',
+        title: translate(cardTitleTranslationIds[variantProps.variant]),
+    },
+    ...(variantProps.variant === 'deposit' &&
+    variantProps.receiveAmount &&
+    variantProps.receiveTokenSymbol
+        ? [
+              {
+                  content: (
+                      <CryptoAmountFormatter
+                          value={variantProps.receiveAmount}
+                          symbol={toTokenSymbol(variantProps.receiveTokenSymbol)}
+                          isDiscreetText={false}
+                      />
+                  ),
+                  key: 'receive-amount',
+                  title: translate('earn.yieldReview.receiveCard.title'),
+              },
+          ]
+        : []),
+    {
+        content: (
+            <VStack spacing="sp16">
+                <DetailRow
+                    label={translate('transactionManagement.review.outputs.summary.amount')}
+                    value={
+                        <CryptoAmountFormatter
+                            value={amount}
+                            symbol={toTokenSymbol(tokenSymbol)}
+                            isDiscreetText={false}
+                        />
+                    }
+                />
+                <ReviewOutputItemValues
+                    accountKey={accountKey}
+                    value={fee}
+                    translationKey="transactionManagement.review.outputs.summary.maxFee"
+                />
+            </VStack>
+        ),
+        key: 'details',
+        title: translate(detailsTitleTranslationIds[variantProps.variant]),
+    },
+];

--- a/suite-native/module-earn/src/components/YieldWithdrawWarning.tsx
+++ b/suite-native/module-earn/src/components/YieldWithdrawWarning.tsx
@@ -1,0 +1,32 @@
+import { InlineAlertBox } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+
+type YieldWithdrawWarningProps = {
+    isAmountTooHigh: boolean;
+    shouldShowNetworkFeeWarning: boolean;
+};
+
+export const YieldWithdrawWarning = ({
+    isAmountTooHigh,
+    shouldShowNetworkFeeWarning,
+}: YieldWithdrawWarningProps) => {
+    if (isAmountTooHigh) {
+        return (
+            <InlineAlertBox
+                variant="warning"
+                title={<Translation id="earn.yieldWithdrawFlowScreen.amountExceedsSupplied" />}
+            />
+        );
+    }
+
+    if (shouldShowNetworkFeeWarning) {
+        return (
+            <InlineAlertBox
+                variant="warning"
+                title={<Translation id="earn.yieldWithdrawFlowScreen.networkFeeWarning" />}
+            />
+        );
+    }
+
+    return null;
+};

--- a/suite-native/module-earn/src/hooks/__tests__/useResolvedYieldFlowData.test.ts
+++ b/suite-native/module-earn/src/hooks/__tests__/useResolvedYieldFlowData.test.ts
@@ -104,6 +104,7 @@ describe('resolveYieldFlowData', () => {
         expect(result.receiptToken.symbol).toBe('trSHUSDCp');
         expect(result.receiptToken.contractAddress).toBe(receiptTokenAddress);
         expect(result.flowData.token.symbol).toBe('USDC');
+        expect(result.suppliedSharesAmount).toBe('1.5');
     });
 
     it('keeps receipt token data for the existing output-token overview entry', () => {
@@ -117,9 +118,11 @@ describe('resolveYieldFlowData', () => {
             throw new Error('Expected resolved yield flow data.');
         }
 
-        expect(result.token.symbol).toBe('trSHUSDCp');
-        expect(result.token.decimals).toBe(18);
-        expect(result.token.balance).toBe('1.5');
+        expect(result.token.symbol).toBe('USDC');
+        expect(result.token.decimals).toBe(6);
+        expect(result.token.balance).toBe('25');
+        expect(result.receiptToken.symbol).toBe('trSHUSDCp');
+        expect(result.suppliedSharesAmount).toBe('1.5');
         expect(result.flowKey).toContain(receiptTokenAddress);
     });
 });

--- a/suite-native/module-earn/src/hooks/useResolvedYieldFlowData.ts
+++ b/suite-native/module-earn/src/hooks/useResolvedYieldFlowData.ts
@@ -35,6 +35,7 @@ type UnresolvedYieldFlowData = {
     receiptToken: YieldFlowDisplayToken | null;
     resolutionStatus: Exclude<YieldFlowResolutionStatus, 'resolved'>;
     flowData: YieldFlowResolvedData | null;
+    suppliedSharesAmount: string | null;
     token: YieldFlowToken | null;
     tokenSymbol: TokenSymbol | null;
     vault: YieldDto | null;
@@ -49,6 +50,7 @@ type YieldFlowDataResolved = {
     receiptToken: YieldFlowDisplayToken;
     flowData: YieldFlowResolvedData;
     resolutionStatus: 'resolved';
+    suppliedSharesAmount: string;
     token: YieldFlowToken;
     tokenSymbol: TokenSymbol;
     vault: YieldDto;
@@ -78,6 +80,7 @@ const defaultFlowData: ResolvedYieldFlowData = {
     providerName: null,
     receiptToken: null,
     resolutionStatus: 'missing-vault',
+    suppliedSharesAmount: null,
     token: null,
     flowData: null,
     tokenSymbol: null,
@@ -121,7 +124,7 @@ export const resolveYieldFlowData = ({
                   ) === normalizedContract,
           );
 
-    if (!vault?.outputToken) {
+    if (!vault?.outputToken?.address) {
         return defaultFlowData;
     }
 
@@ -144,16 +147,23 @@ export const resolveYieldFlowData = ({
             resolutionStatus: 'missing-network',
         };
     }
-    const flowTokenContract =
-        yieldId && vault.token.address
-            ? getContractAddressForNetworkSymbol(account.symbol, vault.token.address)
-            : normalizedContract;
+    const underlyingTokenContract = vault.token.address
+        ? getContractAddressForNetworkSymbol(account.symbol, vault.token.address)
+        : normalizedContract;
+    const outputTokenContract = getContractAddressForNetworkSymbol(
+        account.symbol,
+        vault.outputToken.address,
+    );
     const token = getMatchingToken({
         account,
-        tokenContract: flowTokenContract,
+        tokenContract: underlyingTokenContract,
+    });
+    const outputToken = getMatchingToken({
+        account,
+        tokenContract: outputTokenContract,
     });
 
-    if (!token && !yieldId) {
+    if (!outputToken && !yieldId) {
         return {
             ...defaultFlowData,
             account,
@@ -163,14 +173,15 @@ export const resolveYieldFlowData = ({
     }
 
     const receiptToken = {
-        symbol: vault.outputToken.symbol,
-        decimals: vault.outputToken.decimals,
-        contractAddress: vault.outputToken.address,
+        symbol: outputToken?.symbol ?? vault.outputToken.symbol,
+        decimals: outputToken?.decimals ?? vault.outputToken.decimals,
+        contractAddress: outputToken?.contract ?? vault.outputToken.address,
         coingeckoId: vault.outputToken.coinGeckoId ?? vault.token.coinGeckoId,
     };
+
     const tokenSymbol = toTokenSymbol((token?.symbol ?? vault.token.symbol).toUpperCase());
     const flowKey = getStablecoinYieldFlowKey({
-        tokenContract: flowTokenContract,
+        tokenContract: yieldId ? underlyingTokenContract : normalizedContract,
         accountKey: account.key,
         yieldId: vault.id,
     });
@@ -180,7 +191,7 @@ export const resolveYieldFlowData = ({
         account,
         token: {
             balance: token?.balance ?? '0',
-            contractAddress: token?.contract ?? flowTokenContract,
+            contractAddress: token?.contract ?? underlyingTokenContract,
             decimals: token?.decimals ?? vault.token.decimals,
             networkSymbol: account.symbol,
             symbol: token?.symbol ?? tokenSymbol,
@@ -199,6 +210,7 @@ export const resolveYieldFlowData = ({
         flowData,
         flowKey,
         resolutionStatus: 'resolved',
+        suppliedSharesAmount: outputToken?.balance ?? '0',
         tokenSymbol,
     };
 };

--- a/suite-native/module-earn/src/hooks/useShowPushTransactionFailedDuringReviewAlert.tsx
+++ b/suite-native/module-earn/src/hooks/useShowPushTransactionFailedDuringReviewAlert.tsx
@@ -19,7 +19,8 @@ type ReviewFormType =
     | 'claim'
     | 'yield-approval'
     | 'yield-deposit'
-    | 'yield-revoke';
+    | 'yield-revoke'
+    | 'yield-withdraw';
 
 type NavigationProps = StackToStackCompositeNavigationProps<
     AppTabsParamList,
@@ -126,6 +127,23 @@ const translationKeys = {
         pendingConflict: {
             title: 'earn.yieldReview.alerts.revoke.pendingTransactionConflict.title',
             description: 'earn.yieldReview.alerts.revoke.pendingTransactionConflict.description',
+            primaryButton: 'earn.yieldReview.alerts.primaryButton',
+        },
+    },
+    'yield-withdraw': {
+        signFailed: {
+            title: 'earn.yieldReview.alerts.withdraw.signTransactionFailed.title',
+            description: 'earn.yieldReview.alerts.withdraw.signTransactionFailed.description',
+            primaryButton: 'earn.yieldReview.alerts.primaryButton',
+        },
+        pushFailed: {
+            title: 'earn.yieldReview.alerts.withdraw.pushTransactionFailed.title',
+            description: 'earn.yieldReview.alerts.withdraw.pushTransactionFailed.description',
+            primaryButton: 'earn.yieldReview.alerts.primaryButton',
+        },
+        pendingConflict: {
+            title: 'earn.yieldReview.alerts.withdraw.pendingTransactionConflict.title',
+            description: 'earn.yieldReview.alerts.withdraw.pendingTransactionConflict.description',
             primaryButton: 'earn.yieldReview.alerts.primaryButton',
         },
     },

--- a/suite-native/module-earn/src/hooks/useYieldActionReviewBackNavigation.ts
+++ b/suite-native/module-earn/src/hooks/useYieldActionReviewBackNavigation.ts
@@ -7,33 +7,33 @@ import { stablecoinYieldActions } from '@suite-common/wallet-core';
 import TrezorConnect from '@trezor/connect';
 
 import { useShowYieldReviewCancellationAlert } from './useShowYieldReviewCancellationAlert';
-import { type YieldDepositReviewStatus } from '../types';
+import { type YieldReviewStatus } from '../types';
 
-type UseYieldDepositReviewBackNavigationParams = {
-    depositStatus: YieldDepositReviewStatus;
+type UseYieldActionReviewBackNavigationParams = {
     onReviewLeave?: () => void;
+    reviewStatus: YieldReviewStatus;
 };
 
-export const useYieldDepositReviewBackNavigation = ({
-    depositStatus,
+export const useYieldActionReviewBackNavigation = ({
     onReviewLeave,
-}: UseYieldDepositReviewBackNavigationParams) => {
+    reviewStatus,
+}: UseYieldActionReviewBackNavigationParams) => {
     const dispatch = useDispatch();
     const navigation = useNavigation();
     const showReviewCancellationAlert = useShowYieldReviewCancellationAlert();
     const isCleanupHandledRef = useRef(false);
 
-    const discardDepositReview = useCallback(() => {
+    const discardActionReview = useCallback(() => {
         dispatch(stablecoinYieldActions.discardTransaction());
     }, [dispatch]);
 
-    const cleanupCanceledDepositReview = useCallback(() => {
-        if (depositStatus === 'signing') {
+    const cleanupCanceledActionReview = useCallback(() => {
+        if (reviewStatus === 'signing') {
             TrezorConnect.cancel({ reason: 'tx-cancelled' });
         }
 
-        discardDepositReview();
-    }, [depositStatus, discardDepositReview]);
+        discardActionReview();
+    }, [discardActionReview, reviewStatus]);
 
     const markReviewNavigationSuccess = useCallback(() => {
         isCleanupHandledRef.current = true;
@@ -41,16 +41,14 @@ export const useYieldDepositReviewBackNavigation = ({
 
     const leaveReviewFromDeviceCancel = useCallback(() => {
         onReviewLeave?.();
-        cleanupCanceledDepositReview();
+        cleanupCanceledActionReview();
         isCleanupHandledRef.current = true;
         navigation.goBack();
-    }, [cleanupCanceledDepositReview, navigation, onReviewLeave]);
+    }, [cleanupCanceledActionReview, navigation, onReviewLeave]);
 
     useEffect(() => {
         const shouldConfirmCancellation =
-            depositStatus === 'signing' ||
-            depositStatus === 'signed' ||
-            depositStatus === 'sending';
+            reviewStatus === 'signing' || reviewStatus === 'signed' || reviewStatus === 'sending';
 
         const unsubscribe = navigation.addListener('beforeRemove', event => {
             if (isCleanupHandledRef.current) {
@@ -62,7 +60,7 @@ export const useYieldDepositReviewBackNavigation = ({
                 showReviewCancellationAlert().then(({ wasReviewCanceled }) => {
                     if (wasReviewCanceled) {
                         onReviewLeave?.();
-                        cleanupCanceledDepositReview();
+                        cleanupCanceledActionReview();
                         isCleanupHandledRef.current = true;
                         unsubscribe();
                         navigation.dispatch(event.data.action);
@@ -74,22 +72,22 @@ export const useYieldDepositReviewBackNavigation = ({
 
             if (event.data.action.type === 'GO_BACK') {
                 onReviewLeave?.();
-                discardDepositReview();
+                discardActionReview();
 
                 return;
             }
 
             onReviewLeave?.();
-            discardDepositReview();
+            discardActionReview();
         });
 
         return unsubscribe;
     }, [
-        cleanupCanceledDepositReview,
-        depositStatus,
-        discardDepositReview,
+        cleanupCanceledActionReview,
+        discardActionReview,
         navigation,
         onReviewLeave,
+        reviewStatus,
         showReviewCancellationAlert,
     ]);
 

--- a/suite-native/module-earn/src/hooks/useYieldDepositReview.ts
+++ b/suite-native/module-earn/src/hooks/useYieldDepositReview.ts
@@ -16,11 +16,15 @@ import type {
     YieldStackRoutes,
 } from '@suite-native/navigation';
 
-import { useShowPushTransactionFailedDuringReviewAlert } from './useShowPushTransactionFailedDuringReviewAlert';
-import { useYieldDepositReviewBackNavigation } from './useYieldDepositReviewBackNavigation';
-import { type YieldDepositReviewStatus, type YieldReviewSigningResult } from '../types';
+import {
+    type YieldReviewActionStatus,
+    type YieldReviewSigningResult,
+    type YieldReviewStatus,
+} from '../types';
 import { isUserCancelledSignError } from '../utils';
 import { pushYieldActionReviewThunk, signYieldActionReviewThunk } from '../yieldTransactionThunks';
+import { useShowPushTransactionFailedDuringReviewAlert } from './useShowPushTransactionFailedDuringReviewAlert';
+import { useYieldActionReviewBackNavigation } from './useYieldActionReviewBackNavigation';
 
 type UseYieldDepositReviewParams = {
     flowData: YieldFlowResolvedData;
@@ -28,10 +32,8 @@ type UseYieldDepositReviewParams = {
     onReviewLeave?: () => void;
 };
 
-type YieldDepositReviewActionStatus = 'idle' | 'signing' | 'sending';
-
 type UseYieldDepositReviewResult = {
-    depositStatus: YieldDepositReviewStatus;
+    depositStatus: YieldReviewStatus;
     handleDepositSubmitted: () => Promise<void>;
     leaveReviewFromDeviceCancel: () => void;
     startDepositReview: () => Promise<YieldReviewSigningResult>;
@@ -54,18 +56,17 @@ export const useYieldDepositReview = ({
         showPushTransactionFailedAlert,
         showSignTransactionFailedAlert,
     } = useShowPushTransactionFailedDuringReviewAlert('yield-deposit');
-    const [depositActionStatus, setDepositActionStatus] =
-        useState<YieldDepositReviewActionStatus>('idle');
+    const [depositActionStatus, setDepositActionStatus] = useState<YieldReviewActionStatus>('idle');
     const txReview = useSelector((state: StablecoinYieldRootState) =>
         selectStablecoinYieldTxReview(state),
     );
     const isDepositSigned = txReview.accountKey === flowData.account.key && !!txReview.serializedTx;
-    const depositStatus: YieldDepositReviewStatus =
+    const depositStatus: YieldReviewStatus =
         depositActionStatus === 'idle' && isDepositSigned ? 'signed' : depositActionStatus;
     const { leaveReviewFromDeviceCancel, markReviewNavigationSuccess } =
-        useYieldDepositReviewBackNavigation({
-            depositStatus,
+        useYieldActionReviewBackNavigation({
             onReviewLeave,
+            reviewStatus: depositStatus,
         });
 
     const startDepositReview = useCallback(async (): Promise<YieldReviewSigningResult> => {

--- a/suite-native/module-earn/src/hooks/useYieldSession.ts
+++ b/suite-native/module-earn/src/hooks/useYieldSession.ts
@@ -27,7 +27,8 @@ export const useYieldSession = ({
         selectStablecoinYieldSessionByFlowKey(state, flowType, flowKey),
     );
     const hasSession = !!session;
-    const isApprovalPending = session?.approval.isPending;
+    const hasPendingTransaction =
+        session?.approval.isPending || !!session?.action.pendingTransaction;
 
     useEffect(() => {
         if (flowKey && !hasSession) {
@@ -36,7 +37,7 @@ export const useYieldSession = ({
     }, [dispatch, flowKey, flowType, hasSession]);
 
     useEffect(() => {
-        if (!shouldDisposeOnGoBack || !flowKey || isApprovalPending) {
+        if (!shouldDisposeOnGoBack || !flowKey || hasPendingTransaction) {
             return;
         }
 
@@ -47,7 +48,7 @@ export const useYieldSession = ({
                 dispatch(stablecoinYieldActions.disposeSession(sessionParams));
             }
         });
-    }, [dispatch, flowKey, flowType, isApprovalPending, navigation, shouldDisposeOnGoBack]);
+    }, [dispatch, flowKey, flowType, hasPendingTransaction, navigation, shouldDisposeOnGoBack]);
 
     return session;
 };

--- a/suite-native/module-earn/src/hooks/useYieldWithdrawFees.ts
+++ b/suite-native/module-earn/src/hooks/useYieldWithdrawFees.ts
@@ -1,0 +1,450 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { asEvmAddress } from '@suite-common/calldata';
+import { buildStablecoinYieldTransactionReview } from '@suite-common/earn-stablecoin/src/signing';
+import { getNetwork } from '@suite-common/wallet-config';
+import { ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT } from '@suite-common/wallet-constants';
+import {
+    type FeesRootState,
+    type FormDraftRootState,
+    type YieldWithdrawInputUnit,
+    buildEvmSelectedFee,
+    buildYieldWithdrawCalldata,
+    buildYieldWithdrawUnsignedTransaction,
+    ethereumGetCurrentNonceThunk,
+    formDraftActions,
+    selectConvertedNetworkFeeInfo,
+    selectFormDraft,
+} from '@suite-common/wallet-core';
+import {
+    type FeeInfo,
+    type FeeLevelLabel,
+    type FormState,
+    type PrecomposedLevels,
+    isFinalPrecomposedTransaction,
+} from '@suite-common/wallet-types';
+import { getAccountIdentity } from '@suite-common/wallet-utils';
+import {
+    type NativeSendRootState,
+    getFeeAvailability,
+    selectFeeLevels,
+    transactionManagementActions,
+} from '@suite-native/transaction-management';
+import TrezorConnect from '@trezor/connect';
+import { useDebounce } from '@trezor/react-utils';
+
+import { updateEarnSelectedFeeLevelThunk } from './useComposeEarnFees';
+import { type ResolvedYieldFlowData } from './useResolvedYieldFlowData';
+import {
+    getYieldWithdrawFormDraftKey,
+    getYieldWithdrawInputToken,
+} from '../utils/yieldWithdrawUtils';
+
+type UseYieldWithdrawFeesParams = Pick<ResolvedYieldFlowData, 'flowData' | 'flowKey'> & {
+    amount: string;
+    isEnabled: boolean;
+    withdrawInputUnit: YieldWithdrawInputUnit;
+};
+
+type PreparedYieldWithdrawAction = {
+    amount: string;
+    unsignedTransaction: string;
+    withdrawInputUnit: YieldWithdrawInputUnit;
+};
+
+type WithdrawFlowData = NonNullable<ResolvedYieldFlowData['flowData']>;
+
+type UseYieldWithdrawFeesResult = {
+    fee: string | null;
+    formDraft: FormState | undefined;
+    formDraftKey: string;
+    isComposingWithdrawFee: boolean;
+    isFeeUnavailable: boolean;
+    preparedAction: PreparedYieldWithdrawAction | null;
+    selectedFee: FeeLevelLabel;
+    updateFeeLevelThunk: typeof updateEarnSelectedFeeLevelThunk;
+};
+
+// Only the inputs that should trigger a fresh (network) fee composition. The fee context
+// (feeInfo, selected/custom fee, flowData) is read from refs at compose time instead, so it can't
+// re-trigger the effect — most importantly the fee draft that the compose itself writes.
+type ComposeWithdrawFeeParams = {
+    amount: string;
+    formDraftKey: string;
+    withdrawInputUnit: YieldWithdrawInputUnit;
+};
+
+type ComposeYieldWithdrawTransactionParams = {
+    amount: string;
+    dispatch: ReturnType<typeof useDispatch>;
+    feeInfo: FeeInfo;
+    flowData: WithdrawFlowData;
+    withdrawInputUnit: YieldWithdrawInputUnit;
+};
+
+type BuildYieldWithdrawFeeLevelsParams = {
+    amount: string;
+    feeInfo: FeeInfo;
+    gasLimit: string;
+    reviewToken: WithdrawFlowData['receiptToken'];
+    symbol: WithdrawFlowData['account']['symbol'];
+    unsignedTransaction: string;
+};
+
+const FEE_LEVEL_LABELS_BY_PRICE: FeeLevelLabel[] = ['economy', 'low', 'normal', 'high'];
+
+const getFeeLevelForUnsignedTransaction = (feeInfo: FeeInfo) =>
+    FEE_LEVEL_LABELS_BY_PRICE.map(label =>
+        feeInfo.levels.find(level => level.label === label),
+    ).find(level => level !== undefined) ?? feeInfo.levels[0];
+
+const getYieldWithdrawFeeState = (formDraft: FormState | null | undefined) => {
+    const selectedFee: FeeLevelLabel =
+        formDraft?.selectedFee === 'custom' && (!formDraft.feeLimit || !formDraft.feePerUnit)
+            ? 'normal'
+            : (formDraft?.selectedFee ?? 'normal');
+
+    if (selectedFee !== 'custom' || !formDraft?.feeLimit || !formDraft.feePerUnit) {
+        return {
+            customFee: undefined,
+            selectedFee,
+        };
+    }
+
+    return {
+        customFee: {
+            feeLimit: formDraft.feeLimit,
+            feePerUnit: formDraft.feePerUnit,
+            maxFeePerGas: formDraft.maxFeePerGas,
+            maxPriorityFeePerGas: formDraft.maxPriorityFeePerGas,
+        },
+        selectedFee,
+    };
+};
+
+const getWithdrawFeeInfoRevision = (feeInfo: FeeInfo | null | undefined) =>
+    feeInfo?.levels
+        .map(({ baseFeePerGas, blocks, feePerUnit, label, maxFeePerGas, maxPriorityFeePerGas }) =>
+            [label, feePerUnit, blocks, maxFeePerGas, maxPriorityFeePerGas, baseFeePerGas].join(
+                ':',
+            ),
+        )
+        .join('|') ?? '';
+
+const isWithdrawFeeInfoReady = (feeInfo: FeeInfo | null | undefined) =>
+    !!feeInfo?.levels.some(
+        feeLevel => feeLevel.label !== 'normal' || feeLevel.maxFeePerGas || feeLevel.blocks !== -1,
+    );
+
+const composeYieldWithdrawTransaction = async ({
+    amount,
+    dispatch,
+    feeInfo,
+    flowData,
+    withdrawInputUnit,
+}: ComposeYieldWithdrawTransactionParams) => {
+    const { account, receiptToken, vault } = flowData;
+
+    if (account.networkType !== 'ethereum') {
+        throw new Error('Yield withdraw supports only EVM accounts.');
+    }
+
+    const vaultAddress = receiptToken.contractAddress ?? vault.outputToken?.address;
+    const network = getNetwork(account.symbol);
+
+    if (!vaultAddress || !network.chainId || vault.chainId !== network.chainId) {
+        throw new Error('Yield withdraw cannot be composed for this vault.');
+    }
+
+    const ownerAddress = asEvmAddress(account.descriptor);
+    const calldata = buildYieldWithdrawCalldata({
+        amount,
+        flowData,
+        ownerAddress,
+        receiverAddress: ownerAddress,
+        withdrawInputUnit,
+    });
+
+    const [{ nonce }, estimatedFee] = await Promise.all([
+        dispatch(ethereumGetCurrentNonceThunk({ selectedAccount: account })).unwrap(),
+        TrezorConnect.blockchainEstimateFee({
+            coin: account.symbol,
+            identity: getAccountIdentity(account),
+            request: {
+                blocks: [2],
+                specific: {
+                    from: account.descriptor,
+                    to: vaultAddress,
+                    data: calldata,
+                    value: '0x0',
+                },
+            },
+        }),
+    ]);
+    const estimatedGasLimit = estimatedFee.success
+        ? estimatedFee.payload.levels[0]?.feeLimit
+        : undefined;
+    const feeLevel = getFeeLevelForUnsignedTransaction(feeInfo);
+
+    if (!feeLevel) {
+        throw new Error('Fee info is not available.');
+    }
+
+    const unsignedTransaction = buildYieldWithdrawUnsignedTransaction({
+        chainId: network.chainId,
+        data: calldata,
+        feeLevel,
+        from: account.descriptor,
+        gasLimit: estimatedGasLimit ?? ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT,
+        nonce: Number(nonce),
+        to: vaultAddress,
+    });
+
+    return JSON.stringify(unsignedTransaction);
+};
+
+const buildYieldWithdrawFeeLevels = ({
+    amount,
+    feeInfo,
+    gasLimit,
+    reviewToken,
+    symbol,
+    unsignedTransaction,
+}: BuildYieldWithdrawFeeLevelsParams): PrecomposedLevels =>
+    Object.fromEntries(
+        feeInfo.levels
+            .filter(feeLevel => feeLevel.label !== 'custom')
+            .map(feeLevel => {
+                const { precomposedTransaction } = buildStablecoinYieldTransactionReview({
+                    amount,
+                    selectedFee: buildEvmSelectedFee({ feeLevel, gasLimit }),
+                    symbol,
+                    token: reviewToken,
+                    unsignedTransaction,
+                });
+
+                return [feeLevel.label, precomposedTransaction];
+            }),
+    );
+
+export const useYieldWithdrawFees = ({
+    amount,
+    flowData,
+    flowKey,
+    isEnabled,
+    withdrawInputUnit,
+}: UseYieldWithdrawFeesParams): UseYieldWithdrawFeesResult => {
+    const dispatch = useDispatch();
+    const debounce = useDebounce();
+    const requestIdRef = useRef(0);
+    const [preparedAction, setPreparedAction] = useState<PreparedYieldWithdrawAction | null>(null);
+    const [isComposingWithdrawFee, setIsComposingWithdrawFee] = useState(false);
+
+    const formDraftKey = useMemo(
+        () => (flowKey ? getYieldWithdrawFormDraftKey(flowKey) : ''),
+        [flowKey],
+    );
+    const feeInfo = useSelector((state: FeesRootState) =>
+        selectConvertedNetworkFeeInfo(state, flowData?.account.symbol),
+    );
+    const formDraft = useSelector((state: FormDraftRootState) =>
+        formDraftKey ? selectFormDraft<FormState>(state, formDraftKey) : undefined,
+    );
+    const feeLevels = useSelector((state: NativeSendRootState) => selectFeeLevels(state));
+
+    const feeState = useMemo(() => getYieldWithdrawFeeState(formDraft), [formDraft]);
+    const { selectedFee } = feeState;
+
+    // Latest fee context kept in refs so the compose effect can read it without re-running when it
+    // changes (which would otherwise loop: compose -> stores draft -> draft change -> compose ...).
+    const flowDataRef = useRef(flowData);
+    flowDataRef.current = flowData;
+    const feeInfoRef = useRef(feeInfo);
+    feeInfoRef.current = feeInfo;
+    const feeStateRef = useRef(feeState);
+    feeStateRef.current = feeState;
+    const selectedFeeLevel = feeLevels[selectedFee];
+    const fee = isFinalPrecomposedTransaction(selectedFeeLevel) ? selectedFeeLevel.fee : null;
+    const { isFeeUnavailable } = getFeeAvailability({
+        fee,
+        feeLevels,
+        selectedFee,
+        isLoading: isComposingWithdrawFee,
+    });
+
+    // `formDraftKey` is truthy only once the flow is resolved (so flowData is available), and
+    // `hasFeeInfo` flips compose back on when fee info finishes loading without re-triggering on
+    // every fee-info identity change.
+    const feeInfoRevision = useMemo(() => getWithdrawFeeInfoRevision(feeInfo), [feeInfo]);
+    const hasFeeInfo = isWithdrawFeeInfoReady(feeInfo);
+    const composeWithdrawFee = useCallback(
+        async (params: ComposeWithdrawFeeParams, requestId: number) => {
+            const { amount: withdrawAmount, formDraftKey: withdrawFormDraftKey } = params;
+            const withdrawFlowData = flowDataRef.current;
+            const withdrawFeeInfo = feeInfoRef.current;
+            const currentWithdrawInputUnit = params.withdrawInputUnit;
+            const { customFee: withdrawCustomFee, selectedFee: withdrawSelectedFee } =
+                feeStateRef.current;
+
+            if (!withdrawFlowData || !withdrawFeeInfo) {
+                if (requestId === requestIdRef.current) {
+                    dispatch(formDraftActions.removeDraft({ key: withdrawFormDraftKey }));
+                    setPreparedAction(null);
+                    setIsComposingWithdrawFee(false);
+                }
+
+                return;
+            }
+
+            try {
+                if (requestId !== requestIdRef.current) {
+                    return;
+                }
+
+                const unsignedTransaction = await composeYieldWithdrawTransaction({
+                    amount: withdrawAmount,
+                    dispatch,
+                    feeInfo: withdrawFeeInfo,
+                    flowData: withdrawFlowData,
+                    withdrawInputUnit: currentWithdrawInputUnit,
+                });
+
+                if (requestId !== requestIdRef.current) {
+                    return;
+                }
+
+                const reviewToken = getYieldWithdrawInputToken({
+                    flowData: withdrawFlowData,
+                    withdrawInputUnit: currentWithdrawInputUnit,
+                });
+                const { formState: baseFormState } = buildStablecoinYieldTransactionReview({
+                    amount: withdrawAmount,
+                    selectedFee: null,
+                    symbol: withdrawFlowData.account.symbol,
+                    token: reviewToken,
+                    unsignedTransaction,
+                });
+                const withdrawFeeLevels = buildYieldWithdrawFeeLevels({
+                    amount: withdrawAmount,
+                    feeInfo: withdrawFeeInfo,
+                    gasLimit: baseFormState.feeLimit,
+                    reviewToken,
+                    symbol: withdrawFlowData.account.symbol,
+                    unsignedTransaction,
+                });
+                const mergedFormState = {
+                    ...baseFormState,
+                    selectedFee: withdrawSelectedFee,
+                    feePerUnit: withdrawCustomFee?.feePerUnit ?? baseFormState.feePerUnit,
+                    feeLimit: withdrawCustomFee?.feeLimit ?? baseFormState.feeLimit,
+                    maxFeePerGas: withdrawCustomFee?.maxFeePerGas ?? baseFormState.maxFeePerGas,
+                    maxPriorityFeePerGas:
+                        withdrawCustomFee?.maxPriorityFeePerGas ??
+                        baseFormState.maxPriorityFeePerGas,
+                };
+
+                dispatch(
+                    transactionManagementActions.storeFeeLevels({ feeLevels: withdrawFeeLevels }),
+                );
+
+                const resolvedSelectedFee = isFinalPrecomposedTransaction(
+                    withdrawFeeLevels[mergedFormState.selectedFee],
+                )
+                    ? mergedFormState.selectedFee
+                    : FEE_LEVEL_LABELS_BY_PRICE.find(label =>
+                          isFinalPrecomposedTransaction(withdrawFeeLevels[label]),
+                      );
+                const selectedFeeTransaction = resolvedSelectedFee
+                    ? withdrawFeeLevels[resolvedSelectedFee]
+                    : undefined;
+
+                if (!isFinalPrecomposedTransaction(selectedFeeTransaction)) {
+                    dispatch(formDraftActions.removeDraft({ key: withdrawFormDraftKey }));
+                    setPreparedAction(null);
+
+                    return;
+                }
+
+                dispatch(
+                    formDraftActions.storeDraft({
+                        key: withdrawFormDraftKey,
+                        formDraft: {
+                            ...mergedFormState,
+                            selectedFee: resolvedSelectedFee,
+                            feePerUnit: selectedFeeTransaction.feePerByte,
+                            feeLimit: selectedFeeTransaction.feeLimit,
+                            maxFeePerGas: selectedFeeTransaction.maxFeePerGas,
+                            maxPriorityFeePerGas: selectedFeeTransaction.maxPriorityFeePerGas,
+                        },
+                    }),
+                );
+                setPreparedAction({
+                    amount: withdrawAmount,
+                    unsignedTransaction,
+                    withdrawInputUnit: currentWithdrawInputUnit,
+                });
+            } catch {
+                if (requestId === requestIdRef.current) {
+                    dispatch(formDraftActions.removeDraft({ key: withdrawFormDraftKey }));
+                    setPreparedAction(null);
+                }
+            } finally {
+                if (requestId === requestIdRef.current) {
+                    setIsComposingWithdrawFee(false);
+                }
+            }
+        },
+        [dispatch],
+    );
+
+    useEffect(() => {
+        const requestId = requestIdRef.current + 1;
+        requestIdRef.current = requestId;
+
+        if (!isEnabled || !amount || !formDraftKey || !hasFeeInfo) {
+            setIsComposingWithdrawFee(false);
+            setPreparedAction(null);
+
+            if (!amount && formDraftKey) {
+                dispatch(formDraftActions.removeDraft({ key: formDraftKey }));
+            }
+
+            return;
+        }
+
+        setIsComposingWithdrawFee(true);
+        debounce(
+            () =>
+                void composeWithdrawFee(
+                    {
+                        amount,
+                        formDraftKey,
+                        withdrawInputUnit,
+                    },
+                    requestId,
+                ),
+        );
+    }, [
+        amount,
+        composeWithdrawFee,
+        debounce,
+        dispatch,
+        feeInfoRevision,
+        formDraftKey,
+        hasFeeInfo,
+        isEnabled,
+        withdrawInputUnit,
+    ]);
+
+    return {
+        fee,
+        formDraft,
+        formDraftKey,
+        isComposingWithdrawFee,
+        isFeeUnavailable,
+        preparedAction,
+        selectedFee,
+        updateFeeLevelThunk: updateEarnSelectedFeeLevelThunk,
+    };
+};

--- a/suite-native/module-earn/src/hooks/useYieldWithdrawReview.ts
+++ b/suite-native/module-earn/src/hooks/useYieldWithdrawReview.ts
@@ -1,0 +1,223 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { useNavigation } from '@react-navigation/native';
+import { isRejected } from '@reduxjs/toolkit';
+
+import {
+    type FormDraftRootState,
+    type StablecoinYieldRootState,
+    type YieldFlowResolvedData,
+    type YieldWithdrawInputUnit,
+    buildEvmSelectedFee,
+    selectFormDraft,
+    selectStablecoinYieldTxReview,
+} from '@suite-common/wallet-core';
+import {
+    type EvmSelectedFee,
+    type FormState,
+    type PrecomposedTransactionFinal,
+    isFinalPrecomposedTransaction,
+} from '@suite-common/wallet-types';
+import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
+import type {
+    StackNavigationProps,
+    YieldStackParamList,
+    YieldStackRoutes,
+} from '@suite-native/navigation';
+import { type NativeSendRootState, selectFeeLevels } from '@suite-native/transaction-management';
+
+import { type YieldReviewActionStatus, type YieldReviewStatus } from '../types';
+import { isUserCancelledSignError } from '../utils';
+import { useShowPushTransactionFailedDuringReviewAlert } from './useShowPushTransactionFailedDuringReviewAlert';
+import { useYieldActionReviewBackNavigation } from './useYieldActionReviewBackNavigation';
+import {
+    getYieldWithdrawFormDraftKey,
+    getYieldWithdrawInputToken,
+} from '../utils/yieldWithdrawUtils';
+import { pushYieldActionReviewThunk, signYieldActionReviewThunk } from '../yieldTransactionThunks';
+
+type UseYieldWithdrawReviewParams = {
+    flowData: YieldFlowResolvedData;
+    flowKey: string;
+    onReviewLeave?: () => void;
+    withdrawInputUnit: YieldWithdrawInputUnit;
+};
+
+type UseYieldWithdrawReviewResult = {
+    handleSubmitWithdrawReview: () => Promise<void>;
+    handleWithdrawSubmitted: () => Promise<void>;
+    withdrawStatus: YieldReviewStatus;
+};
+
+type NavigationProps = StackNavigationProps<
+    YieldStackParamList,
+    YieldStackRoutes.YieldWithdrawReview
+>;
+
+const getSelectedEvmFee = (
+    precomposedTransaction: PrecomposedTransactionFinal | undefined,
+): EvmSelectedFee | null => {
+    if (!precomposedTransaction?.feeLimit) {
+        return null;
+    }
+
+    if (precomposedTransaction.maxFeePerGas && precomposedTransaction.maxPriorityFeePerGas) {
+        return buildEvmSelectedFee({
+            feeLevel: {
+                feePerUnit: precomposedTransaction.feePerByte,
+                maxFeePerGas: precomposedTransaction.maxFeePerGas,
+                maxPriorityFeePerGas: precomposedTransaction.maxPriorityFeePerGas,
+                baseFeePerGas: '0',
+            },
+            gasLimit: precomposedTransaction.feeLimit,
+        });
+    }
+
+    if (precomposedTransaction.feePerByte) {
+        return buildEvmSelectedFee({
+            feeLevel: { feePerUnit: precomposedTransaction.feePerByte },
+            gasLimit: precomposedTransaction.feeLimit,
+        });
+    }
+
+    return null;
+};
+
+export const useYieldWithdrawReview = ({
+    flowData,
+    flowKey,
+    onReviewLeave,
+    withdrawInputUnit,
+}: UseYieldWithdrawReviewParams): UseYieldWithdrawReviewResult => {
+    const dispatch = useDispatch();
+    const navigation = useNavigation<NavigationProps>();
+    const {
+        showPendingTransactionConflictAlert,
+        showPushTransactionFailedAlert,
+        showSignTransactionFailedAlert,
+    } = useShowPushTransactionFailedDuringReviewAlert('yield-withdraw');
+    const [withdrawActionStatus, setWithdrawActionStatus] =
+        useState<YieldReviewActionStatus>('idle');
+    const txReview = useSelector((state: StablecoinYieldRootState) =>
+        selectStablecoinYieldTxReview(state),
+    );
+    const formDraftKey = getYieldWithdrawFormDraftKey(flowKey);
+    const formDraft = useSelector((state: FormDraftRootState) =>
+        selectFormDraft<FormState>(state, formDraftKey),
+    );
+    const feeLevels = useSelector((state: NativeSendRootState) => selectFeeLevels(state));
+    const selectedFeeTransaction = formDraft?.selectedFee
+        ? feeLevels[formDraft.selectedFee]
+        : undefined;
+    const selectedFee = useMemo(
+        () =>
+            getSelectedEvmFee(
+                isFinalPrecomposedTransaction(selectedFeeTransaction)
+                    ? selectedFeeTransaction
+                    : undefined,
+            ),
+        [selectedFeeTransaction],
+    );
+    const isWithdrawSigned =
+        txReview.accountKey === flowData.account.key && !!txReview.serializedTx;
+    const withdrawStatus: YieldReviewStatus =
+        withdrawActionStatus === 'idle' && isWithdrawSigned ? 'signed' : withdrawActionStatus;
+    const reviewToken = getYieldWithdrawInputToken({ flowData, withdrawInputUnit });
+    const { markReviewNavigationSuccess } = useYieldActionReviewBackNavigation({
+        onReviewLeave,
+        reviewStatus: withdrawStatus,
+    });
+
+    const handleSubmitWithdrawReview = useCallback(async () => {
+        if (withdrawStatus !== 'idle') {
+            return;
+        }
+
+        setWithdrawActionStatus('signing');
+
+        const deviceAccessResponse = await requestPrioritizedDeviceAccess(() =>
+            dispatch(
+                signYieldActionReviewThunk({
+                    flowData,
+                    flowKey,
+                    flowType: 'withdraw',
+                    reviewToken,
+                    selectedFee,
+                }),
+            ),
+        );
+
+        setWithdrawActionStatus('idle');
+
+        if (!deviceAccessResponse.success) {
+            showSignTransactionFailedAlert();
+
+            return;
+        }
+
+        const signResponse = deviceAccessResponse.payload;
+        const isSignRejected = isRejected(signResponse);
+
+        if (isSignRejected && !isUserCancelledSignError(signResponse.payload)) {
+            showSignTransactionFailedAlert();
+        }
+    }, [
+        dispatch,
+        flowData,
+        flowKey,
+        reviewToken,
+        selectedFee,
+        showSignTransactionFailedAlert,
+        withdrawStatus,
+    ]);
+
+    const handleWithdrawSubmitted = useCallback(async () => {
+        if (withdrawStatus !== 'signed') {
+            return;
+        }
+
+        setWithdrawActionStatus('sending');
+
+        const pushResponse = await dispatch(
+            pushYieldActionReviewThunk({
+                flowData,
+                flowKey,
+                flowType: 'withdraw',
+            }),
+        );
+
+        setWithdrawActionStatus('idle');
+        const isPushRejected = isRejected(pushResponse);
+
+        if (isPushRejected) {
+            if (pushResponse.payload?.error === 'push-transaction-pending-conflict') {
+                showPendingTransactionConflictAlert();
+
+                return;
+            }
+
+            showPushTransactionFailedAlert();
+
+            return;
+        }
+
+        markReviewNavigationSuccess();
+        navigation.goBack();
+    }, [
+        dispatch,
+        flowData,
+        flowKey,
+        markReviewNavigationSuccess,
+        navigation,
+        showPendingTransactionConflictAlert,
+        showPushTransactionFailedAlert,
+        withdrawStatus,
+    ]);
+
+    return {
+        handleSubmitWithdrawReview,
+        handleWithdrawSubmitted,
+        withdrawStatus,
+    };
+};

--- a/suite-native/module-earn/src/navigation/YieldStackNavigator.tsx
+++ b/suite-native/module-earn/src/navigation/YieldStackNavigator.tsx
@@ -15,6 +15,9 @@ import { YieldDepositCompleteScreen } from '../screens/YieldDepositCompleteScree
 import { YieldDepositReviewScreen } from '../screens/YieldDepositReviewScreen';
 import { YieldDepositRevokeScreen } from '../screens/YieldDepositRevokeScreen';
 import { YieldDepositScreen } from '../screens/YieldDepositScreen';
+import { YieldWithdrawCompleteScreen } from '../screens/YieldWithdrawCompleteScreen';
+import { YieldWithdrawReviewScreen } from '../screens/YieldWithdrawReviewScreen';
+import { YieldWithdrawScreen } from '../screens/YieldWithdrawScreen';
 
 const YieldStack = createNativeStackNavigator<YieldStackParamList>();
 
@@ -52,6 +55,11 @@ export const YieldStackNavigator = () => {
                 component={YieldDepositRevokeScreen}
             />
             <YieldStack.Screen
+                options={{ title: YieldStackRoutes.YieldWithdraw }}
+                name={YieldStackRoutes.YieldWithdraw}
+                component={YieldWithdrawScreen}
+            />
+            <YieldStack.Screen
                 options={{ title: YieldStackRoutes.YieldDepositApprovalReview }}
                 name={YieldStackRoutes.YieldDepositApprovalReview}
                 component={YieldDepositApprovalTransactionDataReviewScreen}
@@ -67,9 +75,19 @@ export const YieldStackNavigator = () => {
                 component={YieldDepositReviewScreen}
             />
             <YieldStack.Screen
+                options={{ title: YieldStackRoutes.YieldWithdrawReview }}
+                name={YieldStackRoutes.YieldWithdrawReview}
+                component={YieldWithdrawReviewScreen}
+            />
+            <YieldStack.Screen
                 options={{ title: YieldStackRoutes.YieldDepositComplete }}
                 name={YieldStackRoutes.YieldDepositComplete}
                 component={YieldDepositCompleteScreen}
+            />
+            <YieldStack.Screen
+                options={{ title: YieldStackRoutes.YieldWithdrawComplete }}
+                name={YieldStackRoutes.YieldWithdrawComplete}
+                component={YieldWithdrawCompleteScreen}
             />
         </YieldStack.Navigator>
     );

--- a/suite-native/module-earn/src/screens/YieldDepositCompleteScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldDepositCompleteScreen.tsx
@@ -19,6 +19,7 @@ import {
     useOverrideBackNavigation,
 } from '@suite-native/navigation';
 
+import { ApyValue } from '../components/ApyValue';
 import { YieldCompleteScreenContent } from '../components/YieldCompleteScreenContent';
 import { getYieldDepositCompleteRows } from '../components/YieldCompleteScreenPresets';
 import { useResolvedYieldFlowData } from '../hooks/useResolvedYieldFlowData';
@@ -86,12 +87,10 @@ export const YieldDepositCompleteScreen = () => {
             isEllipsisAppended: false,
             maxDisplayedDecimals: 8,
         });
-        const apyValue =
-            apy === null ? <Translation id="earn.notAvailableShort" /> : `${apy.toFixed(2)}%`;
 
         return getYieldDepositCompleteRows({
             accountSymbol: account.symbol,
-            apyValue,
+            apyValue: <ApyValue apy={apy} />,
             receivedAmount,
             receivedTokenContract: flowData.receiptToken.contractAddress ?? undefined,
             sentAmount,

--- a/suite-native/module-earn/src/screens/YieldWithdrawCompleteScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldWithdrawCompleteScreen.tsx
@@ -1,0 +1,130 @@
+import { useCallback, useEffect, useMemo } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { type RouteProp, useNavigation, useRoute } from '@react-navigation/native';
+
+import { useFormatters } from '@suite-common/formatters';
+import {
+    type StablecoinYieldRootState,
+    getConvertedOutputTokenBalanceToInputTokenAmount,
+    selectStablecoinYieldSessionByFlowKey,
+    stablecoinYieldActions,
+} from '@suite-common/wallet-core';
+import { toTokenSymbol } from '@suite-common/wallet-types';
+import { Translation } from '@suite-native/intl';
+import {
+    type StackNavigationProps,
+    type YieldStackParamList,
+    YieldStackRoutes,
+    useNavigateToInitialScreen,
+} from '@suite-native/navigation';
+
+import { ApyValue } from '../components/ApyValue';
+import { YieldCompleteScreenContent } from '../components/YieldCompleteScreenContent';
+import { getYieldWithdrawCompleteRows } from '../components/YieldCompleteScreenPresets';
+import { useResolvedYieldFlowData } from '../hooks/useResolvedYieldFlowData';
+
+type RouteProps = RouteProp<YieldStackParamList, YieldStackRoutes.YieldWithdrawComplete>;
+type NavigationProps = StackNavigationProps<
+    YieldStackParamList,
+    YieldStackRoutes.YieldWithdrawComplete
+>;
+
+export const YieldWithdrawCompleteScreen = () => {
+    const route = useRoute<RouteProps>();
+    const navigation = useNavigation<NavigationProps>();
+    const dispatch = useDispatch();
+    const navigateToInitialScreen = useNavigateToInitialScreen();
+    const { CryptoAmountFormatter } = useFormatters();
+    const { account, apy, flowKey, resolutionStatus, vault } = useResolvedYieldFlowData(
+        route.params,
+    );
+    const session = useSelector((state: StablecoinYieldRootState) =>
+        selectStablecoinYieldSessionByFlowKey(state, 'withdraw', flowKey),
+    );
+    const isSharesInput = route.params.withdrawInputUnit === 'shares';
+
+    const handleExit = useCallback(() => {
+        if (flowKey) {
+            dispatch(stablecoinYieldActions.disposeSession({ flowType: 'withdraw', flowKey }));
+        }
+
+        navigateToInitialScreen();
+    }, [dispatch, flowKey, navigateToInitialScreen]);
+
+    useEffect(() => {
+        if (resolutionStatus !== 'resolved') {
+            return;
+        }
+
+        if (!session) {
+            navigateToInitialScreen();
+
+            return;
+        }
+
+        if (session.step !== 'complete') {
+            navigation.replace(YieldStackRoutes.YieldWithdraw, route.params);
+        }
+    }, [navigation, navigateToInitialScreen, resolutionStatus, route.params, session]);
+
+    const rows = useMemo(() => {
+        if (resolutionStatus !== 'resolved' || !session || !vault.outputToken) {
+            return [];
+        }
+
+        const { completedAmount } = session.result;
+        const underlyingSymbol = toTokenSymbol(vault.token.symbol.toUpperCase());
+        const vaultTokenSymbol = toTokenSymbol(vault.outputToken.symbol.toUpperCase());
+        const receivedUnderlyingAmount = isSharesInput
+            ? getConvertedOutputTokenBalanceToInputTokenAmount({
+                  networkSymbol: account.symbol,
+                  token: vault.token,
+                  outputToken: vault.outputToken,
+                  outputTokenBalance: completedAmount,
+                  pricePerShareState: vault.state?.pricePerShareState,
+              })
+            : completedAmount;
+
+        const receivedAmount = CryptoAmountFormatter.format(receivedUnderlyingAmount, {
+            symbol: underlyingSymbol,
+            isBalance: true,
+            withSymbol: true,
+            isEllipsisAppended: false,
+            maxDisplayedDecimals: 8,
+        });
+
+        const withdrawalAmount = isSharesInput
+            ? CryptoAmountFormatter.format(completedAmount, {
+                  symbol: vaultTokenSymbol,
+                  isBalance: true,
+                  withSymbol: true,
+                  isEllipsisAppended: false,
+                  maxDisplayedDecimals: 8,
+              })
+            : undefined;
+
+        return getYieldWithdrawCompleteRows({
+            accountSymbol: account.symbol,
+            apyValue: <ApyValue apy={apy} />,
+            receivedAmount,
+            receivedTokenContract: vault.token.address ?? undefined,
+            withdrawalAmount,
+            withdrawalTokenContract: vault.outputToken.address ?? undefined,
+        });
+    }, [CryptoAmountFormatter, account, apy, isSharesInput, resolutionStatus, session, vault]);
+
+    if (resolutionStatus !== 'resolved' || session?.step !== 'complete') {
+        return null;
+    }
+
+    return (
+        <YieldCompleteScreenContent
+            buttonTranslationId="earn.yieldCompleteScreen.backToOverview"
+            onButtonPress={handleExit}
+            rows={rows}
+            title={<Translation id="earn.yieldWithdrawCompleteScreen.title" />}
+            subtitle={<Translation id="earn.yieldWithdrawCompleteScreen.subtitle" />}
+        />
+    );
+};

--- a/suite-native/module-earn/src/screens/YieldWithdrawReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldWithdrawReviewScreen.tsx
@@ -1,0 +1,184 @@
+import { useEffect, useMemo } from 'react';
+import { useSelector } from 'react-redux';
+
+import { type RouteProp, useNavigation, useRoute } from '@react-navigation/native';
+
+import {
+    type FormDraftRootState,
+    type StablecoinYieldRootState,
+    type YieldFlowResolvedData,
+    type YieldWithdrawInputUnit,
+    selectFormDraft,
+    selectStablecoinYieldSessionByFlowKey,
+} from '@suite-common/wallet-core';
+import {
+    type FormState,
+    isFinalPrecomposedTransaction,
+    toTokenSymbol,
+} from '@suite-common/wallet-types';
+import { Text, VStack } from '@suite-native/atoms';
+import {
+    ConfirmOnTrezorWrapper,
+    useConfirmOnTrezorController,
+} from '@suite-native/confirm-on-trezor';
+import { Translation } from '@suite-native/intl';
+import {
+    ScreenHeader,
+    type StackNavigationProps,
+    type YieldStackParamList,
+    YieldStackRoutes,
+} from '@suite-native/navigation';
+import { type NativeSendRootState, selectFeeLevels } from '@suite-native/transaction-management';
+
+import { EarnReviewSubmittedCard } from '../components/EarnReviewSubmittedCard';
+import { YieldReviewList } from '../components/YieldReviewList';
+import { useResolvedYieldFlowData } from '../hooks/useResolvedYieldFlowData';
+import { useYieldWithdrawReview } from '../hooks/useYieldWithdrawReview';
+import {
+    getYieldWithdrawFormDraftKey,
+    getYieldWithdrawInputToken,
+} from '../utils/yieldWithdrawUtils';
+import { buildYieldDepositFeePreview } from '../yieldDepositFeeUtils';
+
+type RouteProps = RouteProp<YieldStackParamList, YieldStackRoutes.YieldWithdrawReview>;
+type NavigationProps = StackNavigationProps<
+    YieldStackParamList,
+    YieldStackRoutes.YieldWithdrawReview
+>;
+
+type WithdrawReviewContentProps = {
+    fee: string;
+    flowData: YieldFlowResolvedData;
+    flowKey: string;
+    review: {
+        amount: string;
+    };
+    withdrawInputUnit: YieldWithdrawInputUnit;
+};
+
+const WithdrawReviewContent = ({
+    fee,
+    flowData,
+    flowKey,
+    review,
+    withdrawInputUnit,
+}: WithdrawReviewContentProps) => {
+    const { confirmOnTrezorRef, revealConfirmOnTrezorSheet, closeSheet } =
+        useConfirmOnTrezorController();
+    const { withdrawStatus, handleSubmitWithdrawReview, handleWithdrawSubmitted } =
+        useYieldWithdrawReview({
+            flowData,
+            flowKey,
+            withdrawInputUnit,
+        });
+    const isSigningWithdraw = withdrawStatus === 'signing';
+    const isWithdrawSigned = withdrawStatus === 'signed' || withdrawStatus === 'sending';
+    const isSendingWithdraw = withdrawStatus === 'sending';
+    const isSubmitDisabled = withdrawStatus !== 'idle';
+
+    const reviewToken = getYieldWithdrawInputToken({ flowData, withdrawInputUnit });
+
+    useEffect(() => {
+        if (isSigningWithdraw) {
+            revealConfirmOnTrezorSheet();
+        } else {
+            closeSheet();
+        }
+    }, [closeSheet, isSigningWithdraw, revealConfirmOnTrezorSheet]);
+
+    return (
+        <ConfirmOnTrezorWrapper
+            isManualControlEnabled
+            controlRef={confirmOnTrezorRef}
+            closeActionType="back"
+            defaultHeader={
+                <ScreenHeader
+                    closeActionType="back"
+                    customContent={
+                        <Text variant="body-md-strong">
+                            <Translation id="earn.yieldWithdrawReviewScreen.title" />
+                        </Text>
+                    }
+                />
+            }
+        >
+            <VStack flex={1} justifyContent="space-between">
+                <YieldReviewList
+                    accountKey={flowData.account.key}
+                    amount={review.amount}
+                    fee={fee}
+                    isFooterVisible={!isSigningWithdraw && !isWithdrawSigned}
+                    isSubmitDisabled={isSubmitDisabled}
+                    isSubmitLoading={isSigningWithdraw}
+                    networkSymbol={flowData.account.symbol}
+                    onSubmit={handleSubmitWithdrawReview}
+                    tokenSymbol={toTokenSymbol(reviewToken.symbol.toUpperCase())}
+                    variant="withdraw"
+                />
+                {isWithdrawSigned && (
+                    <EarnReviewSubmittedCard
+                        buttonTranslationId="earn.yieldWithdrawReviewScreen.submitButton"
+                        isButtonLoading={isSendingWithdraw}
+                        messageTranslationId="earn.yieldWithdrawReviewScreen.successMessage"
+                        onButtonPress={handleWithdrawSubmitted}
+                    />
+                )}
+            </VStack>
+        </ConfirmOnTrezorWrapper>
+    );
+};
+
+export const YieldWithdrawReviewScreen = () => {
+    const route = useRoute<RouteProps>();
+    const navigation = useNavigation<NavigationProps>();
+    const { flowData, flowKey, resolutionStatus } = useResolvedYieldFlowData(route.params);
+    const session = useSelector((state: StablecoinYieldRootState) =>
+        selectStablecoinYieldSessionByFlowKey(state, 'withdraw', flowKey),
+    );
+    const formDraftKey = flowKey ? getYieldWithdrawFormDraftKey(flowKey) : '';
+    const formDraft = useSelector((state: FormDraftRootState) =>
+        formDraftKey ? selectFormDraft<FormState>(state, formDraftKey) : undefined,
+    );
+    const feeLevels = useSelector((state: NativeSendRootState) => selectFeeLevels(state));
+    const review = session?.action.review;
+    const feePreview = useMemo(
+        () => (review ? buildYieldDepositFeePreview(review.unsignedTransaction) : null),
+        [review],
+    );
+    const selectedFeePreview = formDraft?.selectedFee
+        ? feeLevels[formDraft.selectedFee]
+        : undefined;
+    const reviewFee = isFinalPrecomposedTransaction(selectedFeePreview)
+        ? selectedFeePreview.fee
+        : feePreview?.fee;
+
+    useEffect(() => {
+        if (resolutionStatus !== 'resolved') {
+            return;
+        }
+
+        if (session?.step === 'complete') {
+            navigation.replace(YieldStackRoutes.YieldWithdrawComplete, route.params);
+
+            return;
+        }
+
+        if (!review || session?.step !== 'action') {
+            navigation.navigate(YieldStackRoutes.YieldWithdraw, route.params);
+        }
+    }, [navigation, resolutionStatus, review, route.params, session?.step]);
+
+    if (resolutionStatus !== 'resolved' || !review || !feePreview || !reviewFee) {
+        return null;
+    }
+
+    return (
+        <WithdrawReviewContent
+            fee={reviewFee}
+            flowData={flowData}
+            flowKey={flowKey}
+            review={review}
+            withdrawInputUnit={route.params.withdrawInputUnit ?? 'asset'}
+        />
+    );
+};

--- a/suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx
@@ -1,0 +1,564 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useDispatch } from 'react-redux';
+
+import { type RouteProp, useIsFocused, useNavigation, useRoute } from '@react-navigation/native';
+
+import { useFormatters } from '@suite-common/formatters';
+import { getNetwork } from '@suite-common/wallet-config';
+import {
+    type YieldWithdrawInputUnit,
+    getConvertedOutputTokenBalanceToInputTokenAmount,
+    getWithdrawRequestAmount,
+    splitYieldPendingTransaction,
+    stablecoinYieldActions,
+} from '@suite-common/wallet-core';
+import { toTokenAddress, toTokenSymbol } from '@suite-common/wallet-types';
+import { asAmountSubunit, subunitsToUnits } from '@suite-common/wallet-utils';
+import {
+    AnimatedDoubleInput,
+    Box,
+    Button,
+    Card,
+    HStack,
+    Input,
+    ScreenFooterGradient,
+    Switch,
+    Text,
+    VStack,
+    useBottomSheetModal,
+} from '@suite-native/atoms';
+import { useCryptoFiatConverters } from '@suite-native/formatters';
+import { decimalTransformer } from '@suite-native/helpers';
+import { Translation, useTranslate } from '@suite-native/intl';
+import {
+    Screen,
+    type StackNavigationProps,
+    type YieldStackParamList,
+    YieldStackRoutes,
+} from '@suite-native/navigation';
+import { FeeSelector, useTransactionDetails } from '@suite-native/transaction-management';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+import { BigNumber } from '@trezor/utils';
+
+import { YieldDepositFlowScreenHeader } from '../components/YieldDepositFlowScreenHeader';
+import { YieldDepositInfoBottomSheet } from '../components/YieldDepositInfoBottomSheet';
+import { YieldPendingTransactionModal } from '../components/YieldPendingTransactionModal';
+import { YieldWithdrawWarning } from '../components/YieldWithdrawWarning';
+import { useResolvedYieldFlowData } from '../hooks/useResolvedYieldFlowData';
+import { useShowYieldTransactionFailureAlert } from '../hooks/useShowYieldTransactionFailureAlert';
+import { useYieldPendingTransactionTracking } from '../hooks/useYieldPendingTransactionTracking';
+import { useYieldSession } from '../hooks/useYieldSession';
+import { useYieldWithdrawFees } from '../hooks/useYieldWithdrawFees';
+import { getYieldWithdrawInputToken } from '../utils/yieldWithdrawUtils';
+
+type RouteProps = RouteProp<YieldStackParamList, YieldStackRoutes.YieldWithdraw>;
+type NavigationProps = StackNavigationProps<YieldStackParamList, YieldStackRoutes.YieldWithdraw>;
+
+const withdrawFormCardStyle = prepareNativeStyle(utils => ({
+    borderColor: utils.colors.borderNeutral,
+    borderWidth: utils.borders.widths.small,
+}));
+
+const screenFooterStyle = prepareNativeStyle(utils => ({
+    backgroundColor: utils.colors.surfaceFillPage,
+    paddingBottom: utils.spacings.sp16,
+    paddingHorizontal: utils.spacings.sp16,
+}));
+
+export const YieldWithdrawScreen = () => {
+    const route = useRoute<RouteProps>();
+    const navigation = useNavigation<NavigationProps>();
+    const dispatch = useDispatch();
+    const isFocused = useIsFocused();
+    const { applyStyle } = useNativeStyles();
+    const { CryptoAmountFormatter } = useFormatters();
+    const { translate } = useTranslate();
+
+    const [assetAmount, setAssetAmount] = useState('');
+    const [sharesAmount, setSharesAmount] = useState('');
+    const [isMaxSelected, setIsMaxSelected] = useState(false);
+    const [withdrawInputUnit, setWithdrawInputUnit] = useState<YieldWithdrawInputUnit>('asset');
+    const isSharesInput = withdrawInputUnit === 'shares';
+    const amount = isSharesInput ? sharesAmount : assetAmount;
+    const {
+        bottomSheetRef: infoBottomSheetRef,
+        closeModal: closeInfoBottomSheet,
+        openModal: openInfoBottomSheet,
+    } = useBottomSheetModal();
+    const {
+        bottomSheetRef: pendingBottomSheetRef,
+        closeModal: closePendingBottomSheet,
+        openModal: openPendingBottomSheet,
+    } = useBottomSheetModal();
+
+    const {
+        account,
+        apy,
+        flowData,
+        flowKey,
+        resolutionStatus,
+        suppliedSharesAmount: resolvedSuppliedSharesAmount,
+        vault,
+        vaultTokenName,
+    } = useResolvedYieldFlowData(route.params);
+
+    const suppliedAmount = useMemo(() => {
+        if (resolutionStatus !== 'resolved') {
+            return null;
+        }
+
+        return getConvertedOutputTokenBalanceToInputTokenAmount({
+            networkSymbol: account.symbol,
+            token: vault.token,
+            outputToken: vault.outputToken,
+            outputTokenBalance: resolvedSuppliedSharesAmount,
+            pricePerShareState: vault.state?.pricePerShareState,
+        });
+    }, [account, resolutionStatus, resolvedSuppliedSharesAmount, vault]);
+
+    const suppliedSharesAmount = useMemo(() => {
+        if (resolutionStatus !== 'resolved') {
+            return null;
+        }
+
+        return resolvedSuppliedSharesAmount;
+    }, [resolutionStatus, resolvedSuppliedSharesAmount]);
+    const maxAmount = isSharesInput ? suppliedSharesAmount : suppliedAmount;
+    const isAmountTooHigh = useMemo(
+        () => !!amount && !!maxAmount && new BigNumber(amount).gt(maxAmount),
+        [amount, maxAmount],
+    );
+    const {
+        fee: withdrawFee,
+        formDraft: withdrawFeeFormDraft,
+        formDraftKey: withdrawFeeFormDraftKey,
+        isComposingWithdrawFee,
+        isFeeUnavailable,
+        preparedAction,
+        selectedFee: selectedWithdrawFee,
+        updateFeeLevelThunk: updateWithdrawFeeLevelThunk,
+    } = useYieldWithdrawFees({
+        amount,
+        flowData,
+        flowKey,
+        isEnabled: resolutionStatus === 'resolved' && !!amount && !isAmountTooHigh,
+        withdrawInputUnit,
+    });
+    const feeFiatConverters = useCryptoFiatConverters({
+        symbol: account?.symbol ?? null,
+    });
+    const amountFiatTokenContract = useMemo(() => {
+        if (!flowData) {
+            return undefined;
+        }
+
+        const inputToken = getYieldWithdrawInputToken({ flowData, withdrawInputUnit });
+
+        return inputToken.contractAddress ? toTokenAddress(inputToken.contractAddress) : undefined;
+    }, [flowData, withdrawInputUnit]);
+
+    const amountFiatConverters = useCryptoFiatConverters({
+        symbol: account?.symbol ?? null,
+        tokenContract: amountFiatTokenContract,
+    });
+
+    const shouldShowNetworkFeeWarning = useMemo(() => {
+        if (
+            !amount ||
+            !withdrawFee ||
+            resolutionStatus !== 'resolved' ||
+            preparedAction?.amount !== amount ||
+            preparedAction.withdrawInputUnit !== withdrawInputUnit
+        ) {
+            return false;
+        }
+
+        const amountFiat = amountFiatConverters?.convertCryptoToFiat(new BigNumber(amount));
+        const feeUnits = subunitsToUnits({
+            value: asAmountSubunit(new BigNumber(withdrawFee)),
+            symbol: account.symbol,
+        });
+        const feeFiat = feeFiatConverters?.convertCryptoToFiat(new BigNumber(feeUnits));
+
+        return !!amountFiat && !!feeFiat && feeFiat.gt(amountFiat);
+    }, [
+        account,
+        amount,
+        amountFiatConverters,
+        feeFiatConverters,
+        preparedAction,
+        resolutionStatus,
+        withdrawFee,
+        withdrawInputUnit,
+    ]);
+
+    const isWithdrawReviewReady =
+        !!amount &&
+        preparedAction?.amount === amount &&
+        preparedAction.withdrawInputUnit === withdrawInputUnit &&
+        !!withdrawFeeFormDraft;
+
+    const session = useYieldSession({
+        flowKey,
+        flowType: 'withdraw',
+        shouldDisposeOnGoBack: true,
+    });
+    const pendingTransaction = session?.action.pendingTransaction ?? null;
+    const { actionPendingTransaction } = splitYieldPendingTransaction(
+        pendingTransaction,
+        'withdraw',
+    );
+    const isWithdrawPending = !!actionPendingTransaction;
+    const { explorerUrl, openInBlockchain } = useTransactionDetails({
+        accountKey: account?.key ?? null,
+        txid: actionPendingTransaction?.txid ?? null,
+    });
+    const isSubmitDisabled =
+        !amount ||
+        isWithdrawPending ||
+        isAmountTooHigh ||
+        !isWithdrawReviewReady ||
+        isComposingWithdrawFee ||
+        isFeeUnavailable;
+
+    useShowYieldTransactionFailureAlert({
+        error: session?.error,
+        flowKey,
+        flowType: 'withdraw',
+        isEnabled: isFocused,
+    });
+
+    useYieldPendingTransactionTracking({
+        account,
+        flowKey,
+        flowType: 'withdraw',
+        pendingTransaction: actionPendingTransaction,
+    });
+
+    useEffect(() => {
+        if (!isFocused || !isWithdrawPending) {
+            closePendingBottomSheet();
+
+            return;
+        }
+
+        openPendingBottomSheet();
+    }, [closePendingBottomSheet, isFocused, isWithdrawPending, openPendingBottomSheet]);
+
+    useEffect(() => {
+        if (resolutionStatus !== 'resolved' || !flowKey || session?.step !== 'approve') {
+            return;
+        }
+
+        dispatch(stablecoinYieldActions.skipApprovalStep({ flowType: 'withdraw', flowKey }));
+    }, [dispatch, flowKey, resolutionStatus, session?.step]);
+
+    useEffect(() => {
+        if (session?.step === 'complete') {
+            navigation.replace(YieldStackRoutes.YieldWithdrawComplete, {
+                ...route.params,
+                withdrawInputUnit,
+            });
+        }
+    }, [navigation, route.params, session?.step, withdrawInputUnit]);
+
+    const getSharesAmountFromAssetAmount = useCallback(
+        (value: string) => {
+            if (resolutionStatus !== 'resolved') {
+                return '';
+            }
+
+            return (
+                getWithdrawRequestAmount({
+                    networkSymbol: account.symbol,
+                    amount: value,
+                    token: vault.token,
+                    receiptToken: flowData.receiptToken,
+                    pricePerShare: vault.state?.pricePerShareState?.price,
+                }) ?? ''
+            );
+        },
+        [account, flowData, resolutionStatus, vault],
+    );
+
+    const getAssetAmountFromSharesAmount = useCallback(
+        (value: string) => {
+            if (resolutionStatus !== 'resolved') {
+                return '';
+            }
+
+            return getConvertedOutputTokenBalanceToInputTokenAmount({
+                networkSymbol: account.symbol,
+                token: vault.token,
+                outputToken: vault.outputToken,
+                outputTokenBalance: value,
+                pricePerShareState: vault.state?.pricePerShareState,
+            });
+        },
+        [account, resolutionStatus, vault],
+    );
+
+    const handleMaxChange = (value: boolean) => {
+        setIsMaxSelected(value);
+
+        if (!value || !suppliedAmount || !suppliedSharesAmount) {
+            return;
+        }
+
+        setAssetAmount(suppliedAmount);
+        setSharesAmount(suppliedSharesAmount);
+    };
+
+    const handleAmountChange = (value: string) => {
+        const transformedValue = decimalTransformer(value);
+
+        if (!transformedValue) {
+            setAssetAmount('');
+            setSharesAmount('');
+
+            return;
+        }
+
+        if (isSharesInput) {
+            setSharesAmount(transformedValue);
+            setAssetAmount(getAssetAmountFromSharesAmount(transformedValue));
+
+            return;
+        }
+
+        setAssetAmount(transformedValue);
+        setSharesAmount(getSharesAmountFromAssetAmount(transformedValue));
+    };
+
+    const handleClose = useCallback(() => {
+        if (isWithdrawPending) {
+            openPendingBottomSheet();
+
+            return;
+        }
+
+        navigation.goBack();
+    }, [isWithdrawPending, navigation, openPendingBottomSheet]);
+
+    const handleCloseInfoBottomSheet = useCallback(() => {
+        closeInfoBottomSheet();
+
+        if (isWithdrawPending) {
+            requestAnimationFrame(openPendingBottomSheet);
+        }
+    }, [closeInfoBottomSheet, isWithdrawPending, openPendingBottomSheet]);
+
+    const handleInputSwitch = useCallback((activeView: 'primary' | 'secondary') => {
+        setWithdrawInputUnit(activeView === 'secondary' ? 'shares' : 'asset');
+    }, []);
+
+    const handleContinue = useCallback(() => {
+        if (!flowKey || !isWithdrawReviewReady || !preparedAction) {
+            return;
+        }
+
+        dispatch(stablecoinYieldActions.discardTransaction());
+        dispatch(
+            stablecoinYieldActions.storeActionReviewData({
+                amount: preparedAction.amount,
+                flowKey,
+                flowType: 'withdraw',
+                receiptAmount: preparedAction.amount,
+                unsignedTransaction: preparedAction.unsignedTransaction,
+            }),
+        );
+        navigation.navigate(YieldStackRoutes.YieldWithdrawReview, {
+            ...route.params,
+            withdrawInputUnit,
+        });
+    }, [
+        dispatch,
+        flowKey,
+        isWithdrawReviewReady,
+        navigation,
+        preparedAction,
+        route.params,
+        withdrawInputUnit,
+    ]);
+
+    if (resolutionStatus !== 'resolved') {
+        return null;
+    }
+
+    const underlyingTokenSymbol = toTokenSymbol(flowData.token.symbol.toUpperCase());
+    const vaultTokenSymbol = toTokenSymbol(flowData.receiptToken.symbol.toUpperCase());
+
+    const activeInputToken = getYieldWithdrawInputToken({ flowData, withdrawInputUnit });
+    const activeUnitSymbol = toTokenSymbol(activeInputToken.symbol.toUpperCase());
+    const activeUnitTokenContract = activeInputToken.contractAddress
+        ? toTokenAddress(activeInputToken.contractAddress)
+        : undefined;
+
+    const vaultTokenContract = vault.outputToken?.address
+        ? toTokenAddress(vault.outputToken.address)
+        : undefined;
+    const headerTokenContract = vault.token.address
+        ? toTokenAddress(vault.token.address)
+        : route.params.tokenContract;
+    const accountLabel = account.accountLabel ?? getNetwork(account.symbol).name;
+    const suppliedAmountLabel = maxAmount
+        ? CryptoAmountFormatter.format(maxAmount, {
+              symbol: activeUnitSymbol,
+              isBalance: true,
+              withSymbol: true,
+              isEllipsisAppended: false,
+              maxDisplayedDecimals: 8,
+          })
+        : null;
+
+    return (
+        <Screen
+            noHorizontalPadding
+            header={
+                <YieldDepositFlowScreenHeader
+                    account={account}
+                    closeAction={handleClose}
+                    onInfoPress={openInfoBottomSheet}
+                    tokenContract={headerTokenContract}
+                    vaultName={vault.metadata.name}
+                />
+            }
+            footer={
+                <>
+                    <ScreenFooterGradient />
+                    <Box style={applyStyle(screenFooterStyle)}>
+                        <Button isDisabled={isSubmitDisabled} onPress={handleContinue}>
+                            <Translation id="generic.buttons.continue" />
+                        </Button>
+                    </Box>
+                </>
+            }
+        >
+            <VStack
+                spacing="sp16"
+                paddingHorizontal="sp16"
+                pointerEvents={isWithdrawPending ? 'none' : 'auto'}
+            >
+                <Card style={applyStyle(withdrawFormCardStyle)}>
+                    <VStack spacing="sp12">
+                        <HStack justifyContent="space-between" alignItems="center">
+                            <Text variant="body-sm">
+                                <Translation id="earn.yieldWithdrawFlowScreen.withdrawalAmount" />
+                            </Text>
+                            <HStack spacing="sp8" alignItems="center">
+                                <Text variant="body-sm">
+                                    <Translation id="earn.yieldWithdrawFlowScreen.withdrawMax" />
+                                </Text>
+                                <Switch isChecked={isMaxSelected} onChange={handleMaxChange} />
+                            </HStack>
+                        </HStack>
+
+                        <AnimatedDoubleInput
+                            onInputSwitch={handleInputSwitch}
+                            renderPrimary={({ inputRef, isDisabled, onPress }) => (
+                                <Input
+                                    ref={inputRef}
+                                    value={assetAmount}
+                                    placeholder="0"
+                                    keyboardType="numeric"
+                                    editable={!isMaxSelected && !isDisabled}
+                                    onChangeText={handleAmountChange}
+                                    onPress={onPress}
+                                    accessibilityLabel={translate(
+                                        'earn.yieldWithdrawFlowScreen.amountToWithdraw',
+                                    )}
+                                    rightIcon={
+                                        <Text
+                                            color={
+                                                isDisabled ? 'contentSecondary' : 'contentPrimary'
+                                            }
+                                        >
+                                            {underlyingTokenSymbol}
+                                        </Text>
+                                    }
+                                />
+                            )}
+                            renderSecondary={({ inputRef, isDisabled, onPress }) => (
+                                <Input
+                                    ref={inputRef}
+                                    value={sharesAmount}
+                                    placeholder="0"
+                                    keyboardType="numeric"
+                                    editable={!isMaxSelected && !isDisabled}
+                                    onChangeText={handleAmountChange}
+                                    onPress={onPress}
+                                    accessibilityLabel={translate(
+                                        'earn.yieldWithdrawFlowScreen.amountToWithdraw',
+                                    )}
+                                    rightIcon={
+                                        <Text
+                                            color={
+                                                isDisabled ? 'contentSecondary' : 'contentPrimary'
+                                            }
+                                        >
+                                            {vaultTokenSymbol}
+                                        </Text>
+                                    }
+                                />
+                            )}
+                        />
+
+                        {suppliedAmountLabel && (
+                            <HStack spacing="sp4" alignItems="center">
+                                <Text variant="body-sm" color="contentSecondary">
+                                    <Translation id="earn.yieldWithdrawFlowScreen.supplied" />
+                                </Text>
+                                <Text variant="body-sm" color="contentSecondary">
+                                    {suppliedAmountLabel}
+                                </Text>
+                            </HStack>
+                        )}
+                    </VStack>
+                </Card>
+
+                {isWithdrawReviewReady && (
+                    <FeeSelector
+                        accountKey={account.key}
+                        tokenContract={route.params.tokenContract}
+                        updateThunk={updateWithdrawFeeLevelThunk}
+                        selectedFee={selectedWithdrawFee}
+                        selectedFeePerUnit={withdrawFeeFormDraft.feePerUnit}
+                        formDraft={withdrawFeeFormDraft}
+                        formDraftKey={withdrawFeeFormDraftKey}
+                    />
+                )}
+
+                <YieldWithdrawWarning
+                    isAmountTooHigh={isAmountTooHigh}
+                    shouldShowNetworkFeeWarning={shouldShowNetworkFeeWarning}
+                />
+            </VStack>
+            {actionPendingTransaction && (
+                <YieldPendingTransactionModal
+                    ref={pendingBottomSheetRef}
+                    accountLabel={accountLabel}
+                    accountSymbol={account.symbol}
+                    amount={actionPendingTransaction.amount}
+                    amountLabel={<Translation id="earn.yieldWithdrawFlowScreen.amountToWithdraw" />}
+                    amountTokenContract={activeUnitTokenContract}
+                    amountTokenSymbol={activeUnitSymbol}
+                    fee={actionPendingTransaction.fee}
+                    isExploreDisabled={!explorerUrl}
+                    onExplorePress={openInBlockchain}
+                    submittedAt={new Date(actionPendingTransaction.submittedAt ?? 0)}
+                    title={<Translation id="earn.yieldWithdrawFlowScreen.withdrawPendingTitle" />}
+                    vaultName={vault.metadata.name}
+                    vaultTokenContract={vaultTokenContract}
+                />
+            )}
+
+            <YieldDepositInfoBottomSheet
+                ref={infoBottomSheetRef}
+                apy={apy}
+                onClose={handleCloseInfoBottomSheet}
+                tokenSymbol={underlyingTokenSymbol}
+                vaultTokenName={vaultTokenName}
+            />
+        </Screen>
+    );
+};

--- a/suite-native/module-earn/src/types.ts
+++ b/suite-native/module-earn/src/types.ts
@@ -13,7 +13,11 @@ export type YieldApprovalLimitType = 'per-deposit' | 'unlimited';
 
 export type YieldAllowanceFormDraftTransactionType = 'approve' | 'revoke';
 
-export type YieldDepositReviewStatus = 'idle' | 'signing' | 'sending' | 'signed';
+export type YieldReviewActionStatus = 'idle' | 'signing' | 'sending';
+
+export type YieldReviewStatus = YieldReviewActionStatus | 'signed';
+
+export type YieldDepositReviewStatus = YieldReviewStatus;
 
 export type YieldReviewSigningResult =
     | 'signed'

--- a/suite-native/module-earn/src/utils.ts
+++ b/suite-native/module-earn/src/utils.ts
@@ -50,6 +50,12 @@ export const buildEarnComposeFormState = (
     feeLimit: '',
 });
 
+export const isUserCancelledSignError = (
+    payload: { errorCode?: string; message?: string } | undefined,
+) =>
+    payload?.message === 'tx-cancelled' ||
+    (!!payload?.errorCode && USER_CANCELLED_ERROR_CODES.some(code => code === payload.errorCode));
+
 type HandleEarnReviewErrorProps = {
     payload: { error?: string; errorCode?: string; message?: string } | undefined;
     navigation: { pop: () => void };
@@ -57,12 +63,6 @@ type HandleEarnReviewErrorProps = {
     showPendingTransactionConflictAlert: () => void;
     showDeviceDisconnectedAlert: () => void;
 };
-
-export const isUserCancelledSignError = (
-    payload: { errorCode?: string; message?: string } | undefined,
-) =>
-    payload?.message === 'tx-cancelled' ||
-    (!!payload?.errorCode && USER_CANCELLED_ERROR_CODES.some(code => code === payload.errorCode));
 
 export const handleEarnReviewError = ({
     payload,

--- a/suite-native/module-earn/src/utils/yieldWithdrawUtils.ts
+++ b/suite-native/module-earn/src/utils/yieldWithdrawUtils.ts
@@ -1,0 +1,6 @@
+export { getYieldWithdrawInputToken } from '@suite-common/wallet-core';
+
+import { EARN_MODULE_PREFIX } from '../constants';
+
+export const getYieldWithdrawFormDraftKey = (flowKey: string) =>
+    `${EARN_MODULE_PREFIX}/yield-withdraw/${flowKey}`;

--- a/suite-native/module-earn/src/yieldTransactionThunks.ts
+++ b/suite-native/module-earn/src/yieldTransactionThunks.ts
@@ -2,6 +2,7 @@ import { selectSelectedDevice } from '@suite-common/device';
 import { buildStablecoinYieldTransactionReview } from '@suite-common/earn-stablecoin/src/signing';
 import { createThunk } from '@suite-common/redux-utils';
 import {
+    type YieldFlowDisplayToken,
     type YieldFlowResolvedData,
     type YieldFlowType,
     selectAddressDisplayType,
@@ -10,7 +11,7 @@ import {
     stablecoinYieldActions,
     synchronizeSentTransactionThunk,
 } from '@suite-common/wallet-core';
-import { AddressDisplayOptions } from '@suite-common/wallet-types';
+import { AddressDisplayOptions, type EvmSelectedFee } from '@suite-common/wallet-types';
 import { getAccountIdentity } from '@suite-common/wallet-utils';
 import TrezorConnect from '@trezor/connect';
 
@@ -22,6 +23,8 @@ type YieldActionReviewThunkPayload = {
     flowData: YieldFlowResolvedData;
     flowKey: string;
     flowType: Extract<YieldFlowType, 'deposit' | 'withdraw'>;
+    reviewToken?: YieldFlowDisplayToken;
+    selectedFee?: EvmSelectedFee | null;
 };
 
 type YieldSignTransactionError = {
@@ -46,7 +49,10 @@ export const signYieldActionReviewThunk = createThunk<
     { rejectValue: YieldSignTransactionError }
 >(
     `${YIELD_TRANSACTION_THUNK_PREFIX}/signActionReview`,
-    async ({ flowData, flowKey, flowType }, { dispatch, getState, rejectWithValue }) => {
+    async (
+        { flowData, flowKey, flowType, reviewToken, selectedFee },
+        { dispatch, getState, rejectWithValue },
+    ) => {
         const session = selectStablecoinYieldSession(getState(), flowType, flowKey);
         const {
             action: { review },
@@ -65,9 +71,9 @@ export const signYieldActionReviewThunk = createThunk<
         try {
             transactionReview = buildStablecoinYieldTransactionReview({
                 amount: review.amount,
-                selectedFee: null,
+                selectedFee: selectedFee ?? null,
                 symbol: flowData.account.symbol,
-                token: flowData.token,
+                token: reviewToken ?? flowData.token,
                 unsignedTransaction: review.unsignedTransaction,
             });
         } catch (error) {

--- a/suite-native/module-earn/tsconfig.json
+++ b/suite-native/module-earn/tsconfig.json
@@ -3,6 +3,7 @@
     "compilerOptions": { "outDir": "libDev" },
     "include": [".", "**/*.json"],
     "references": [
+        { "path": "../../suite-common/calldata" },
         {
             "path": "../../suite-common/dependency-injection"
         },

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -112,16 +112,23 @@ export type YieldDepositRevokeReviewParams = YieldFlowParams & {
     isAmountUnlimited: boolean;
 };
 
+export type YieldWithdrawParams = YieldFlowParams & {
+    withdrawInputUnit?: 'asset' | 'shares';
+};
+
 export type YieldStackParamList = {
     [YieldStackRoutes.HowYieldWorks]: YieldFlowParams;
     [YieldStackRoutes.YieldConsents]: YieldFlowParams;
     [YieldStackRoutes.YieldDepositApproval]: YieldFlowParams;
     [YieldStackRoutes.YieldDeposit]: YieldFlowParams;
     [YieldStackRoutes.YieldDepositRevoke]: YieldDepositRevokeParams;
+    [YieldStackRoutes.YieldWithdraw]: YieldWithdrawParams;
     [YieldStackRoutes.YieldDepositApprovalReview]: YieldDepositApprovalReviewParams;
     [YieldStackRoutes.YieldDepositRevokeReview]: YieldDepositRevokeReviewParams;
     [YieldStackRoutes.YieldDepositReview]: YieldFlowParams;
+    [YieldStackRoutes.YieldWithdrawReview]: YieldWithdrawParams;
     [YieldStackRoutes.YieldDepositComplete]: YieldFlowParams;
+    [YieldStackRoutes.YieldWithdrawComplete]: YieldWithdrawParams;
 };
 
 export type HomeStackParamList = {

--- a/suite-native/navigation/src/routes.ts
+++ b/suite-native/navigation/src/routes.ts
@@ -245,10 +245,13 @@ export enum YieldStackRoutes {
     YieldDepositApproval = 'YieldDepositApproval',
     YieldDeposit = 'YieldDeposit',
     YieldDepositRevoke = 'YieldDepositRevoke',
+    YieldWithdraw = 'YieldWithdraw',
     YieldDepositApprovalReview = 'YieldDepositApprovalReview',
     YieldDepositRevokeReview = 'YieldDepositRevokeReview',
     YieldDepositReview = 'YieldDepositReview',
+    YieldWithdrawReview = 'YieldWithdrawReview',
     YieldDepositComplete = 'YieldDepositComplete',
+    YieldWithdrawComplete = 'YieldWithdrawComplete',
 }
 
 export enum ReceiveStackRoutes {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12881,6 +12881,7 @@ __metadata:
     "@react-navigation/native-stack": "npm:7.12.0"
     "@reduxjs/toolkit": "npm:2.11.2"
     "@shopify/flash-list": "npm:2.3.0"
+    "@suite-common/calldata": "workspace:*"
     "@suite-common/dependency-injection": "workspace:*"
     "@suite-common/device": "workspace:*"
     "@suite-common/earn-stablecoin": "workspace:*"


### PR DESCRIPTION
## Description

Adds the stablecoin yield withdraw flow, including amount entry with asset/share unit switching, fee selection, transaction review, pending transaction handling, and completion screen.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27924

## Screenshots:

https://github.com/user-attachments/assets/33d53d94-cb44-4c8f-a8b8-762835e7a699

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/yield-withdraw-flow&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/yield-withdraw-flow&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/yield-withdraw-flow&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-08T16:45:18.324Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add account types ada | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-08T16:41:56.081Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/native/yield-withdraw-flow/web/](https://dev.suite.sldev.cz/suite-web/feat/native/yield-withdraw-flow/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->