### PR TITLE
fix(suite-desktop): prevent infinite reload loop on did-fail-load

### DIFF
--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -414,9 +414,16 @@ const init = async () => {
         // load and wait for handshake message from renderer
 
         // Refresh if it failed to load
-        mainWindow.webContents.on('did-fail-load', () => {
-            loadIndex(mainWindow);
-        });
+        mainWindow.webContents.on(
+            'did-fail-load',
+            (_event, errorCode, _desc, _url, isMainFrame) => {
+                // ERR_ABORTED (-3) fires when a new load cancels an in-progress one — ignore it to avoid an infinite loop.
+                // https://source.chromium.org/chromium/chromium/src/+/main:net/base/net_error_list.h
+                if (!isMainFrame || errorCode === -3) return;
+                // Delay retry to avoid a busy loop if the failure persists.
+                setTimeout(() => loadIndex(mainWindow), 1000);
+            },
+        );
 
         const { handshake, cleanup } = handshakeAndHangDetect({ mainWindow, statePatch });
         mainWindowProxy.once('destroy', cleanup);


### PR DESCRIPTION
## Description

The `did-fail-load` handler in the Electron main process was calling `loadIndex` unconditionally on every failure. Electron fires `did-fail-load` with `ERR_ABORTED` (-3) whenever a new load call cancels an in-progress one, so each retry immediately triggered another `did-fail-load`, creating an infinite loop where `index.html` would never actually load.

The fix filters out `ERR_ABORTED` and sub-frame failures, and adds a 1-second delay before retrying to avoid busy-looping on persistent failures.

However I'm not sure what the original problem that triggers the failure is. 

## Notes for QA

Verify the Electron app loads normally on startup in the scenario that originally triggered the problem

## Related Issue

Resolves #28380

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is to packages/suite-desktop-core/src/app.ts, which is the main entry point for the Electron desktop application. This file orchestrates app lifecycle (startup, shutdown), bridge process spawning, window management, IPC channel setup, and TrezorConnect WebSocket exposure. The highest risk areas are bridge spawning/daemon tests and all desktop-only TrezorConnect tests that rely on the exposeConnectWs and suite-desktop coreMode infrastructure. No static test mapping was available, so all recommendations are inferred from the LLM analysis of test behaviors and source hints.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite-desktop-core/src/app.ts`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — This test directly exercises the Electron app lifecycle including bridge spawning, window management, and app initialization — all of which are orchestrated by the desktop core app.ts. Changes to app.ts could affect bridge process spawning, renderer window creation, and app shutdown behavior that this test validates.
- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — This test validates the daemon mode of the Electron app (bridgeDaemon flag handling in app.ts), bridge lifecycle management across multiple app instances, and app close behavior. The app.ts file is the entry point that handles daemon mode logic and bridge process management.

</details>

<details><summary>🟡 <b>Medium priority (9)</b></summary>

- `suite/e2e/tests/trezor-connect/error.test.ts` — This test launches the desktop Electron app with suite-desktop core mode and tests TrezorConnect initialization through the app shell. Changes to app.ts could affect how the connect WebSocket is exposed (exposeConnectWs) and how the app initializes the connect infrastructure.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — This test exercises the app/focus IPC event handler in the Electron main process and the exposeConnectWs functionality, both of which are likely managed or configured in app.ts. Silent mode behavior depends on correct IPC channel setup in the desktop core.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — This test uses TrezorConnect with coreMode 'suite-desktop' and exposeConnectWs, exercising the Electron app's WebSocket bridge setup for connect communication which is configured in the desktop core app entry point.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — This test initializes TrezorConnect in suite-desktop core mode via exposeConnectWs, exercising the Electron app's connect integration layer that app.ts configures. Permission persistence also depends on correct app initialization.
- `suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts` — Desktop-only test that relies on suite-desktop coreMode and exposeConnectWs Electron IPC configuration, which is set up in the desktop core app.ts module.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Desktop-only test using suite-desktop core mode with exposeConnectWs. The Electron app initialization in app.ts is responsible for setting up the WebSocket bridge that this test depends on.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — Desktop-only test using suite-desktop coreMode and exposeConnectWs for BTC transaction signing. Depends on correct Electron main process initialization handled by app.ts.
- `suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — Desktop-only test using suite-desktop coreMode with exposeConnectWs, relying on the Electron app's connect WebSocket bridge setup managed in app.ts.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts` — This test runs the Desktop Electron app in offline mode, which is a specific app configuration likely handled in app.ts. Changes to the app entry point could affect how offline mode is initialized and how the no-connection banner is managed.

</details>

_Updated: 2026-06-05T08:45:02.219Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=electron-continuous-index-reload&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=electron-continuous-index-reload&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-05T08:50:55.019Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-05T08:48:10.208Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/electron-continuous-index-reload/web/](https://dev.suite.sldev.cz/suite-web/electron-continuous-index-reload/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->