### PR TITLE
fix(suite): Fix guide modal zIndex

### DIFF
--- a/packages/suite/src/components/guide/GuideImage.tsx
+++ b/packages/suite/src/components/guide/GuideImage.tsx
@@ -57,7 +57,7 @@ export const GuideImage = ({ src, alt }: GuideImageProps) => {
             <ThumbnailImage src={resolvedSrc} alt={alt} onClick={() => setIsOpen(true)} />
             {isOpen &&
                 createPortal(
-                    <Modal.Backdrop onClick={close} zIndex={zIndices.guide}>
+                    <Modal.Backdrop onClick={close} zIndex={zIndices.modalGuide}>
                         <FullSizeImage src={resolvedSrc} alt={alt} onClick={close} />
                         <CloseButtonWrapper>
                             <Button

--- a/packages/theme/src/zIndices.ts
+++ b/packages/theme/src/zIndices.ts
@@ -5,6 +5,7 @@ export const zIndices = {
     windowControls: 100,
     toast: 70,
     tooltip: 60, // above all content to be always fully visible when toggled
+    modalGuide: 51, // above GUIDE to stay accessible when guide is open
     guide: 50, // above MODAL to stay accessible when modal is open
     guideButton: 49, // below GUIDE to get covered by the guide when it is opening
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

modal in guide was sometimes undef guide itself, this should fix it

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

before
<img width="1041" height="1096" alt="image" src="https://github.com/user-attachments/assets/edd21b84-b064-4e2b-acbd-f86ff14c4339" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set is low-to-moderate risk. It modifies a guide-specific image component (GuideImage.tsx) and the global z-index definitions (zIndices.ts). The GuideImage change has no static test coverage but is clearly exercised by guide-related E2E tests. The zIndices.ts change maps to 121 tests, indicating it's a broadly shared utility — however, z-index changes are most likely to cause visible regressions in overlay/modal/panel stacking, making the guide panel tests (which test opening the guide over modals) the most targeted validation. Most other tests are unlikely to be affected unless the z-index change breaks fundamental layering of modals or prompts, which would be caught by the guide-over-modal test case.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/components/guide/GuideImage.tsx`
- `packages/theme/src/zIndices.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/general/suite-guide.test.ts` — This test directly exercises the Guide panel UI, which includes opening the panel, viewing articles, and submitting bug reports. The GuideImage.tsx component is part of the guide feature and changes to it could affect how guide content renders. Additionally, guide panel z-index layering (from zIndices.ts) is critical for the panel to appear correctly over other content.
- `suite/e2e/tests/suite/guide.test.ts` — This test comprehensively exercises the guide panel — opening/closing, navigating content nodes, searching articles, submitting feedback, and opening the guide over a modal. GuideImage.tsx is a guide component that renders within guide content, and zIndices.ts changes could affect the guide panel's ability to layer over modals.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/suite/bug-report-form.test.ts` — This test opens the Guide panel and submits a bug report through it. Since GuideImage.tsx is part of the guide component tree, changes could affect guide panel rendering. The z-index change could also affect guide panel visibility.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/components/guide/GuideImage.tsx`

_Updated: 2026-06-04T14:45:33.009Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-guide-modal-zindex2&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-guide-modal-zindex2&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-04T14:51:15.553Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-04T14:49:11.977Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-guide-modal-zindex2/web/](https://dev.suite.sldev.cz/suite-web/fix-guide-modal-zindex2/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->