### PR TITLE
feat(trading): update payment method quote

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputPaymentMethod/PaymentMethodModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputPaymentMethod/PaymentMethodModal.tsx
@@ -8,18 +8,54 @@ import {
     TRADING_FORM_PROVIDER_SELECT,
     type TradingPaymentMethodListProps,
 } from '@suite-common/trading';
-import { Modal, Row, Text } from '@trezor/components';
+import { Column, Modal, Row, Text } from '@trezor/components';
 import { CardList } from '@trezor/product-components';
 
-import { FormattedCryptoAmount } from 'src/components/suite';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { type TradingTradeBuySellType } from 'src/types/trading/trading';
 import { type TradingBuySellFormProps } from 'src/types/trading/tradingForm';
+
+import { useTradingRateFromOperationData } from '../../../TradingOffers/useTradingOfferRate';
 
 interface PaymentMethodModalProps {
     onClose: () => void;
     heading?: TranslationKey;
 }
+
+interface PaymentMethodModalItemProps {
+    item: TradingPaymentMethodListProps;
+    onSelect: (paymentMethod: TradingPaymentMethodListProps) => void;
+}
+
+const PaymentMethodModalItem = ({ item, onSelect }: PaymentMethodModalItemProps) => {
+    const formattedRate = useTradingRateFromOperationData(item.tradeOperationData);
+
+    return (
+        <CardList.Item
+            onClick={() => onSelect(item)}
+            data-testid={`@trading/form/payment-method-select/option/${item.value}`}
+        >
+            <Row gap={4} width="100%" justifyContent="space-between">
+                <Row gap={12} alignItems="start">
+                    <PaymentMethodIcon paymentMethod={item.value} />
+                    <Column>
+                        <Text typographyStyle="body-md">{item.label}</Text>
+                        <Text typographyStyle="body-sm" color="contentSecondary">
+                            <Translation id="TR_TRADING_RATE" />
+                        </Text>
+                    </Column>
+                </Row>
+                {formattedRate && (
+                    <Row gap={4} justifyContent="space-between">
+                        <Text typographyStyle="body-sm" color="contentSecondary">
+                            {formattedRate}
+                        </Text>
+                    </Row>
+                )}
+            </Row>
+        </CardList.Item>
+    );
+};
 
 export const PaymentMethodModal = ({ onClose, heading }: PaymentMethodModalProps) => {
     const { paymentMethods, setValue } = useTradingFormContext<TradingTradeBuySellType>();
@@ -43,27 +79,11 @@ export const PaymentMethodModal = ({ onClose, heading }: PaymentMethodModalProps
         >
             <CardList>
                 {paymentMethods.map(item => (
-                    <CardList.Item
+                    <PaymentMethodModalItem
                         key={item.value}
-                        onClick={() => selectPaymentMethod(item)}
-                        data-testid={`@trading/form/payment-method-select/option/${item.value}`}
-                    >
-                        <Row gap={12} alignItems="center">
-                            <PaymentMethodIcon paymentMethod={item.value} />
-                            {item.label}
-                        </Row>
-                        {item.receiveAmount && item.symbol && (
-                            <Row>
-                                <Text typographyStyle="body-sm">
-                                    {'≈ '}
-                                    <FormattedCryptoAmount
-                                        value={item.receiveAmount}
-                                        symbol={item.symbol}
-                                    />
-                                </Text>
-                            </Row>
-                        )}
-                    </CardList.Item>
+                        item={item}
+                        onSelect={selectPaymentMethod}
+                    />
                 ))}
             </CardList>
         </Modal>

--- a/packages/suite/src/views/wallet/trading/common/TradingOffers/useTradingOfferRate.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingOffers/useTradingOfferRate.ts
@@ -2,6 +2,7 @@ import type { CryptoId } from 'invity-api';
 
 import { useFormatters } from '@suite-common/formatters';
 import {
+    type TradeOperationData,
     type TradingTradeType,
     formatExchangeRate,
     getTradeOperationData,
@@ -13,12 +14,9 @@ import { BigNumber } from '@trezor/utils';
 
 const DEFAULT_TOKEN_DECIMALS_LENGTH = 18;
 
-export const useTradingOfferRate = (trade: TradingTradeType | undefined): string | undefined => {
+const useRateFormatters = () => {
     const { CryptoAmountFormatter, BaseCurrencyAmountFormatter } = useFormatters();
     const { cryptoIdToCoinSymbol } = useTradingUtils();
-
-    const { fromValue, fromCurrency, toValue, toCurrency, isFromCrypto, isToCrypto } =
-        getTradeOperationData(trade);
 
     const formatCryptoValue = (
         value: string | undefined,
@@ -53,6 +51,58 @@ export const useTradingOfferRate = (trade: TradingTradeType | undefined): string
             }) ?? undefined
         );
     };
+
+    return { cryptoIdToCoinSymbol, formatCryptoValue, formatFiatValue };
+};
+
+export const useTradingRateFromOperationData = (
+    operationData: TradeOperationData | undefined,
+): string | undefined => {
+    const { cryptoIdToCoinSymbol, formatCryptoValue } = useRateFormatters();
+
+    if (!operationData) return undefined;
+    const { fromValue, fromCurrency, toValue, toCurrency, isFromCrypto, isToCrypto } =
+        operationData;
+
+    if (!fromValue || !toValue || !fromCurrency || !toCurrency) return undefined;
+
+    const fromBigNumber = new BigNumber(fromValue);
+    const toBigNumber = new BigNumber(toValue);
+
+    if (fromBigNumber.isNaN() || toBigNumber.isNaN()) return undefined;
+
+    // Buy/sell: always orient as <crypto> / 1 <fiat>. Exchange (crypto-to-crypto):
+    // orient as <sendCoin> / 1 <receiveCoin> (keep the from/to direction).
+    const isBuySell = isFromCrypto !== isToCrypto;
+    const cryptoValue = isBuySell && !isFromCrypto ? toValue : fromValue;
+    const cryptoCurrency = isBuySell && !isFromCrypto ? toCurrency : fromCurrency;
+    const counterValue = isBuySell && !isFromCrypto ? fromValue : toValue;
+    const counterCurrency = isBuySell && !isFromCrypto ? fromCurrency : toCurrency;
+    const isCounterCrypto = isBuySell ? false : isToCrypto;
+
+    const counterBigNumber = new BigNumber(counterValue);
+    if (counterBigNumber.isZero()) return undefined;
+    const rate = new BigNumber(cryptoValue).div(counterBigNumber);
+
+    const cryptoSymbol = (
+        cryptoIdToCoinSymbol(cryptoCurrency as CryptoId) ?? cryptoCurrency
+    ).toUpperCase();
+    const rateFormatted = `${formatExchangeRate(rate)} ${cryptoSymbol}`;
+
+    const targetCurrencyFormatted = isCounterCrypto
+        ? formatCryptoValue('1', counterCurrency as CryptoId, false)
+        : `1 ${counterCurrency.toUpperCase()}`;
+
+    if (!targetCurrencyFormatted) return undefined;
+
+    return `${rateFormatted} / ${targetCurrencyFormatted}`;
+};
+
+export const useTradingOfferRate = (trade: TradingTradeType | undefined): string | undefined => {
+    const { cryptoIdToCoinSymbol, formatCryptoValue, formatFiatValue } = useRateFormatters();
+
+    const { fromValue, fromCurrency, toValue, toCurrency, isFromCrypto, isToCrypto } =
+        getTradeOperationData(trade);
 
     if (!fromValue || !toValue || !fromCurrency || !toCurrency) return undefined;
 

--- a/suite-common/trading/src/__tests__/utils.test.ts
+++ b/suite-common/trading/src/__tests__/utils.test.ts
@@ -165,7 +165,9 @@ describe('getTradingPaymentMethods', () => {
     });
 
     it('should sort payment methods by receive amount in descending order', () => {
-        const amounts = paymentMethods.map(method => new BigNumber(method.receiveAmount || '0'));
+        const amounts = paymentMethods.map(
+            method => new BigNumber(method.tradeOperationData?.toValue || '0'),
+        );
         const sortedAmounts = [...amounts].sort((a, b) => b.minus(a).toNumber());
 
         expect(amounts.map(amount => amount.toString())).toEqual(
@@ -179,7 +181,7 @@ describe('getTradingPaymentMethods', () => {
         // @ts-expect-error: indexing with noUncheckedIndexedAccess
         const minMaxQuote: (typeof MIN_MAX_QUOTES_OK)[number] = MIN_MAX_QUOTES_OK[1];
 
-        expect(applePayMethod?.receiveAmount).toBe(minMaxQuote.receiveStringAmount);
+        expect(applePayMethod?.tradeOperationData?.toValue).toBe(minMaxQuote.receiveStringAmount);
     });
 });
 

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -42,7 +42,6 @@ import {
 import {
     cryptoIdToNetwork,
     getTradingQuotesByPaymentMethod,
-    isBuyTrade,
     isExchangeProvider,
     testnetToProdCryptoId,
 } from '../utils';
@@ -53,6 +52,7 @@ import {
     getTradingPlatformsInfoByCryptoId,
     getTradingSymbolAndContractAddressByCryptoId,
 } from '../utils/infoUtils';
+import { isBuyTrade } from '../utils/typeGuards';
 
 export { EMPTY_GROUPED_TRADING_EXCHANGE_QUOTES, type GroupedTradingExchangeQuotes };
 

--- a/suite-common/trading/src/types.ts
+++ b/suite-common/trading/src/types.ts
@@ -111,11 +111,52 @@ export type TradingFiatCurrenciesProps = Map<FiatCurrencyCode, string>;
 export type TradingBuyPaymentMethodProps = BuyCryptoPaymentMethod | '';
 export type TradingSellPaymentMethodProps = SellCryptoPaymentMethod | '';
 export type TradingPaymentMethodProps = TradingPaymentMethodType | '';
+type UndefinedTradeOperation = {
+    fromValue: undefined;
+    fromCurrency: undefined;
+    toValue: undefined;
+    toCurrency: undefined;
+    isFromCrypto: undefined;
+    isToCrypto: undefined;
+};
+
+type FiatToCryptoOperation = {
+    fromValue: string | undefined;
+    fromCurrency: string | undefined;
+    toValue: string | undefined;
+    toCurrency: CryptoId | undefined;
+    isFromCrypto: false;
+    isToCrypto: true;
+};
+
+type CryptoToFiatOperation = {
+    fromValue: string | undefined;
+    fromCurrency: CryptoId | undefined;
+    toValue: string | undefined;
+    toCurrency: string | undefined;
+    isFromCrypto: true;
+    isToCrypto: false;
+};
+
+type CryptoToCryptoOperation = {
+    fromValue: string | undefined;
+    fromCurrency: CryptoId | undefined;
+    toValue: string | undefined;
+    toCurrency: CryptoId | undefined;
+    isFromCrypto: true;
+    isToCrypto: true;
+};
+
+export type TradeOperationData =
+    | UndefinedTradeOperation
+    | FiatToCryptoOperation
+    | CryptoToFiatOperation
+    | CryptoToCryptoOperation;
+
 export type TradingPaymentMethodListProps = {
     value: TradingPaymentMethodProps;
     label: string;
-    receiveAmount?: string;
-    symbol?: string;
+    tradeOperationData?: TradeOperationData;
 };
 
 type TradingCommonTransaction = {

--- a/suite-common/trading/src/utils.ts
+++ b/suite-common/trading/src/utils.ts
@@ -49,6 +49,7 @@ import {
     type TradingType,
 } from './types';
 import { getCountrySubdivisionByCode } from './utils/countryUtils';
+import { getTradeOperationData } from './utils/tradeOperationUtils';
 
 type NetworkAndContractAddress = {
     network: Network | undefined;
@@ -82,15 +83,6 @@ export const isFinalStatus = (
     tradingType: TradingType,
     tradeStatus: TradingTradeStatusType | undefined,
 ) => (tradeStatus ? tradeFinalStatuses[tradingType].includes(tradeStatus) : false);
-
-export const isBuyTrade = (quote: TradingTradeType): quote is BuyTrade =>
-    'fiatStringAmount' in quote && 'receiveStringAmount' in quote;
-
-export const isSellFiatTrade = (quote: TradingTradeType): quote is SellFiatTrade =>
-    'cryptoStringAmount' in quote && 'fiatStringAmount' in quote;
-
-export const isExchangeTrade = (quote: TradingTradeType): quote is ExchangeTrade =>
-    'sendStringAmount' in quote && 'receiveStringAmount' in quote;
 
 export const isExchangeProvider = (provider: TradingProviderInfo) =>
     provider && 'kycPolicyType' in provider;
@@ -280,20 +272,16 @@ export const getTradingPaymentMethods = (
     quotes.forEach(quote => {
         if (!quote.paymentMethod) return;
         if (uniqueMethods.has(quote.paymentMethod)) return;
-        const amount = isBuyTrade(quote) ? quote.receiveStringAmount : quote.fiatStringAmount;
         uniqueMethods.set(quote.paymentMethod, {
             value: quote.paymentMethod,
             label: quote.paymentMethodName ?? quote.paymentMethod,
-            receiveAmount: amount,
-            symbol: isBuyTrade(quote)
-                ? cryptoIdToSymbol(quote.receiveCurrency)
-                : (quote as SellFiatTrade).fiatCurrency,
+            tradeOperationData: getTradeOperationData(quote),
         });
     });
 
     const sortedMethods = Array.from(uniqueMethods.values()).sort((a, b) => {
-        const aAmount = new BigNumber(a.receiveAmount || '0');
-        const bAmount = new BigNumber(b.receiveAmount || '0');
+        const aAmount = new BigNumber(a.tradeOperationData?.toValue || '0');
+        const bAmount = new BigNumber(b.tradeOperationData?.toValue || '0');
 
         return bAmount.minus(aAmount).toNumber();
     });

--- a/suite-common/trading/src/utils/__tests__/typeGuards.test.ts
+++ b/suite-common/trading/src/utils/__tests__/typeGuards.test.ts
@@ -1,6 +1,59 @@
-import { isSendRejectedError } from '../typeGuards';
+import { type TradingTradeType } from '../../types';
+import { isBuyTrade, isExchangeTrade, isSellFiatTrade, isSendRejectedError } from '../typeGuards';
 
 describe('typeGuards', () => {
+    describe('trade type guards', () => {
+        const buyQuote = {
+            fiatStringAmount: '10',
+            fiatCurrency: 'EUR',
+            receiveCurrency: 'bitcoin',
+            receiveStringAmount: '0.0005',
+        } as TradingTradeType;
+
+        const sellQuote = {
+            fiatStringAmount: '10',
+            fiatCurrency: 'EUR',
+            cryptoCurrency: 'bitcoin',
+            cryptoStringAmount: '0.0005',
+        } as TradingTradeType;
+
+        const sellQuoteWithoutCryptoAmount = {
+            fiatStringAmount: '10',
+            fiatCurrency: 'EUR',
+        } as TradingTradeType;
+
+        const exchangeQuote = {
+            send: 'bitcoin',
+            sendStringAmount: '0.01',
+            receive: 'litecoin',
+            receiveStringAmount: '0.5',
+        } as TradingTradeType;
+
+        it('classifies a buy quote', () => {
+            expect(isBuyTrade(buyQuote)).toBe(true);
+            expect(isSellFiatTrade(buyQuote)).toBe(false);
+            expect(isExchangeTrade(buyQuote)).toBe(false);
+        });
+
+        it('classifies a sell quote', () => {
+            expect(isSellFiatTrade(sellQuote)).toBe(true);
+            expect(isBuyTrade(sellQuote)).toBe(false);
+            expect(isExchangeTrade(sellQuote)).toBe(false);
+        });
+
+        it('classifies a sell quote that has no crypto amount yet', () => {
+            expect(isSellFiatTrade(sellQuoteWithoutCryptoAmount)).toBe(true);
+            expect(isBuyTrade(sellQuoteWithoutCryptoAmount)).toBe(false);
+            expect(isExchangeTrade(sellQuoteWithoutCryptoAmount)).toBe(false);
+        });
+
+        it('classifies an exchange quote', () => {
+            expect(isExchangeTrade(exchangeQuote)).toBe(true);
+            expect(isBuyTrade(exchangeQuote)).toBe(false);
+            expect(isSellFiatTrade(exchangeQuote)).toBe(false);
+        });
+    });
+
     describe('isSendRejectedError', () => {
         it('returns true for valid trading send rejected error', () => {
             expect(

--- a/suite-common/trading/src/utils/tradeOperationUtils.ts
+++ b/suite-common/trading/src/utils/tradeOperationUtils.ts
@@ -1,51 +1,7 @@
-import type { CryptoId } from 'invity-api';
-
 import { exhaustive } from '@trezor/type-utils';
 
-import type { TradingTradeType } from '../types';
-import { isBuyTrade, isExchangeTrade, isSellFiatTrade } from '../utils';
-
-type UndefinedTradeOperation = {
-    fromValue: undefined;
-    fromCurrency: undefined;
-    toValue: undefined;
-    toCurrency: undefined;
-    isFromCrypto: undefined;
-    isToCrypto: undefined;
-};
-
-type FiatToCryptoOperation = {
-    fromValue: string | undefined;
-    fromCurrency: string | undefined;
-    toValue: string | undefined;
-    toCurrency: CryptoId | undefined;
-    isFromCrypto: false;
-    isToCrypto: true;
-};
-
-type CryptoToFiatOperation = {
-    fromValue: string | undefined;
-    fromCurrency: CryptoId | undefined;
-    toValue: string | undefined;
-    toCurrency: string | undefined;
-    isFromCrypto: true;
-    isToCrypto: false;
-};
-
-type CryptoToCryptoOperation = {
-    fromValue: string | undefined;
-    fromCurrency: CryptoId | undefined;
-    toValue: string | undefined;
-    toCurrency: CryptoId | undefined;
-    isFromCrypto: true;
-    isToCrypto: true;
-};
-
-export type TradeOperationData =
-    | UndefinedTradeOperation
-    | FiatToCryptoOperation
-    | CryptoToFiatOperation
-    | CryptoToCryptoOperation;
+import type { TradeOperationData, TradingTradeType } from '../types';
+import { isBuyTrade, isExchangeTrade, isSellFiatTrade } from './typeGuards';
 
 export const getTradeOperationData = (trade: TradingTradeType | undefined): TradeOperationData => {
     if (!trade) {

--- a/suite-common/trading/src/utils/typeGuards.ts
+++ b/suite-common/trading/src/utils/typeGuards.ts
@@ -1,6 +1,17 @@
+import { type BuyTrade, type ExchangeTrade, type SellFiatTrade } from 'invity-api';
+
 import { isArrayMember } from '@trezor/utils';
 
-import { type TradingSendRejectedProps } from '../types';
+import { type TradingSendRejectedProps, type TradingTradeType } from '../types';
+
+export const isBuyTrade = (quote: TradingTradeType): quote is BuyTrade =>
+    'fiatStringAmount' in quote && 'receiveStringAmount' in quote;
+
+export const isSellFiatTrade = (quote: TradingTradeType): quote is SellFiatTrade =>
+    'fiatStringAmount' in quote && !('receiveStringAmount' in quote);
+
+export const isExchangeTrade = (quote: TradingTradeType): quote is ExchangeTrade =>
+    'sendStringAmount' in quote && 'receiveStringAmount' in quote;
 
 const TRADING_SEND_REJECTED_TYPES = ['error', 'sign-tx-error', 'sign-transaction-timeout'] as const;
 

--- a/suite-native/module-trading/src/hooks/history/useChangeStringsExtractor.ts
+++ b/suite-native/module-trading/src/hooks/history/useChangeStringsExtractor.ts
@@ -1,12 +1,15 @@
 import type { CryptoId } from 'invity-api';
 
 import { useFormatters } from '@suite-common/formatters';
-import { type TradingTradeType, useTradingUtils } from '@suite-common/trading';
+import {
+    type TradeOperationData,
+    type TradingTradeType,
+    getTradeOperationData,
+    useTradingUtils,
+} from '@suite-common/trading';
 import { type NetworkSymbol, getNetworkDecimals } from '@suite-common/wallet-config';
 import { type BaseCurrencyAmount, asBaseCurrencyAmount } from '@suite-common/wallet-types';
 import { BigNumber } from '@trezor/utils';
-
-import { type TradeOperationData, getTradeOperationData } from '../../utils/general/utils';
 
 const TOKEN_DECIMALS_LENGTH = 16;
 

--- a/suite-native/module-trading/src/utils/general/__tests__/utils.test.ts
+++ b/suite-native/module-trading/src/utils/general/__tests__/utils.test.ts
@@ -10,67 +10,11 @@ import {
     getErrorStrFromThunkRejectedValue,
     getFormDraftKeyPrefixFromTradingType,
     getRandomAccountDescriptor,
-    getTradeOperationData,
     getTradeStatusStep,
     getTradeTitle,
 } from '../utils';
 
 describe('utils', () => {
-    describe('getTradeOperationData', () => {
-        it('should return correct data for buy trade', () => {
-            const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
-            const result = getTradeOperationData(buyTrade.data);
-
-            expect(result).toEqual({
-                fromValue: '1234',
-                fromCurrency: 'USD',
-                toValue: '0.462586',
-                toCurrency: 'ethereum',
-                isFromCrypto: false,
-                isToCrypto: true,
-            });
-        });
-
-        it('should return correct data for exchange trade', () => {
-            const exchangeTrade = getExchangeTrade({ status: 'CONVERTING' });
-            const result = getTradeOperationData(exchangeTrade.data);
-
-            expect(result).toEqual({
-                fromValue: '10.1232',
-                fromCurrency: 'solana--jtojtomepa8beP8AuQc6eXt5FriJwfFMwQx2v2f9mCL',
-                toValue: '0.462586',
-                toCurrency: 'solana',
-                isFromCrypto: true,
-                isToCrypto: true,
-            });
-        });
-
-        it('should return correct data for sell trade', () => {
-            const sellTrade = getSellTrade({ status: 'SEND_CRYPTO' });
-            const result = getTradeOperationData(sellTrade.data);
-
-            expect(result).toEqual({
-                fromValue: '1.22',
-                fromCurrency: 'bitcoin',
-                toValue: '100',
-                toCurrency: 'USD',
-                isFromCrypto: true,
-                isToCrypto: false,
-            });
-        });
-
-        it('should return undefined values for undefined transaction', () => {
-            const result = getTradeOperationData(undefined);
-
-            expect(result).toEqual({
-                fromValue: undefined,
-                fromCurrency: undefined,
-                toValue: undefined,
-                toCurrency: undefined,
-            });
-        });
-    });
-
     describe('getTradeStatusStep', () => {
         it.each([
             ['SUBMITTED', 'waiting'],

--- a/suite-native/module-trading/src/utils/general/utils.ts
+++ b/suite-native/module-trading/src/utils/general/utils.ts
@@ -1,108 +1,14 @@
-import type { BuyTradeStatus, CryptoId, ExchangeTradeStatus, SellTradeStatus } from 'invity-api';
+import type { BuyTradeStatus, ExchangeTradeStatus, SellTradeStatus } from 'invity-api';
 
 import {
-    type TradingTradeType,
     type TradingTransaction,
     type TradingType,
-    isBuyTrade,
-    isExchangeTrade,
-    isSellFiatTrade,
     tradeFinalStatuses,
 } from '@suite-common/trading';
 import type { FormDraftKeyPrefix } from '@suite-common/wallet-types';
 import type { Translate } from '@suite-native/intl';
 import { exhaustive } from '@trezor/type-utils';
 import { getWeakRandomId } from '@trezor/utils';
-
-type UndefinedTradeOperation = {
-    fromValue: undefined;
-    fromCurrency: undefined;
-    toValue: undefined;
-    toCurrency: undefined;
-    isFromCrypto: undefined;
-    isToCrypto: undefined;
-};
-
-type FiatToCryptoOperation = {
-    fromValue: string | undefined;
-    fromCurrency: string | undefined;
-    toValue: string | undefined;
-    toCurrency: CryptoId | undefined;
-    isFromCrypto: false;
-    isToCrypto: true;
-};
-
-type CryptoToFiatOperation = {
-    fromValue: string | undefined;
-    fromCurrency: CryptoId | undefined;
-    toValue: string | undefined;
-    toCurrency: string | undefined;
-    isFromCrypto: true;
-    isToCrypto: false;
-};
-
-type CryptoToCryptoOperation = {
-    fromValue: string | undefined;
-    fromCurrency: CryptoId | undefined;
-    toValue: string | undefined;
-    toCurrency: CryptoId | undefined;
-    isFromCrypto: true;
-    isToCrypto: true;
-};
-
-export type TradeOperationData =
-    | UndefinedTradeOperation
-    | FiatToCryptoOperation
-    | CryptoToFiatOperation
-    | CryptoToCryptoOperation;
-
-export const getTradeOperationData = (trade: TradingTradeType | undefined): TradeOperationData => {
-    if (!trade) {
-        return {
-            fromValue: undefined,
-            fromCurrency: undefined,
-            toValue: undefined,
-            toCurrency: undefined,
-            isFromCrypto: undefined,
-            isToCrypto: undefined,
-        };
-    }
-
-    if (isBuyTrade(trade)) {
-        return {
-            fromValue: trade.fiatStringAmount,
-            fromCurrency: trade.fiatCurrency,
-            toValue: trade.receiveStringAmount,
-            toCurrency: trade.receiveCurrency,
-            isFromCrypto: false,
-            isToCrypto: true,
-        };
-    }
-
-    if (isSellFiatTrade(trade)) {
-        return {
-            fromValue: trade.cryptoStringAmount,
-            fromCurrency: trade.cryptoCurrency,
-            toValue: trade.fiatStringAmount,
-            toCurrency: trade.fiatCurrency,
-            isFromCrypto: true,
-            isToCrypto: false,
-        };
-    }
-
-    if (isExchangeTrade(trade)) {
-        return {
-            fromValue: trade.sendStringAmount,
-            fromCurrency: trade.send,
-            toValue: trade.receiveStringAmount,
-            toCurrency: trade.receive,
-            isFromCrypto: true,
-            isToCrypto: true,
-        };
-    }
-
-    return exhaustive(trade);
-};
 
 export const getBuyTradeStatusStep = (tradeStatus: BuyTradeStatus | undefined) => {
     if (!tradeStatus) {


### PR DESCRIPTION
## Description

- update the buy/sell payment method selector to show the formatted rate instead of the crypto/fiat amount
- move shared trade operation data typing and extraction to `@suite-common/trading` so desktop and native use the same rate formatting inputs
- keep payment methods sorted by the quoted receive value while using the new shared data shape

## Notes for QA

Check buy and sell payment method selectors on desktop and confirm each option shows a rate, not the amount. Verify the shown rate keeps stable decimal formatting and the payment method order still matches the best quote first.

## Related Issue

Resolve #25973

## Screenshots:

<img width="516" height="484" alt="image" src="https://github.com/user-attachments/assets/00e347b8-f73b-46a3-b379-7a26bd7cd4b0" />

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/trading-payment-method-quote-25973/web/](https://dev.suite.sldev.cz/suite-web/feat/trading-payment-method-quote-25973/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/trading-payment-method-quote-25973&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/trading-payment-method-quote-25973&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/trading-payment-method-quote-25973&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-04T16:22:56.792Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-04T16:20:39.551Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->