### PR TITLE
fix(address-validator): guard malformed Cardano CBOR

### DIFF
--- a/packages/address-validator/src/ada_validator.ts
+++ b/packages/address-validator/src/ada_validator.ts
@@ -20,17 +20,22 @@ function getDecoded(address: string): any {
 
 function isValidLegacyAddress(address: string): boolean {
     const decoded = getDecoded(address);
-    if (!decoded || (!Array.isArray(decoded) && decoded.length !== 2)) {
+    if (!decoded || !Array.isArray(decoded) || decoded.length !== 2) {
         return false;
     }
 
     const tagged = decoded[0];
+    const taggedValue = tagged?.value;
     const validCrc = decoded[1];
-    if (typeof validCrc !== 'number') {
+    if (
+        taggedValue === null ||
+        typeof taggedValue === 'undefined' ||
+        typeof validCrc !== 'number'
+    ) {
         return false;
     }
-    // crc/calculators/crc32 returns a signed 32-bit int; coerce to unsigned to match the CBOR-decoded checksum
-    const crc = crc32(tagged.value) >>> 0;
+    // Coerce signed crc32 output to unsigned to match the CBOR-decoded checksum.
+    const crc = crc32(taggedValue) >>> 0;
 
     return crc === validCrc;
 }

--- a/packages/address-validator/tests/wallet_address_validator.test.ts
+++ b/packages/address-validator/tests/wallet_address_validator.test.ts
@@ -556,6 +556,8 @@ describe('WAValidator.validate()', function () {
                 'addr1qxnv5u3vrx2t37h3u27qd5ukgcjmrl4f8mu9f5sza3h20cxsfjh80un9kvlggfcdw8fp5kqp9tztqnee9msd0qsafhdsyqclvl',
                 'cardano',
             );
+            invalid('5yWKF5vph3', 'cardano');
+            invalid('kzKq', 'cardano');
         });
 
         it('should return true for correct tron addresses', function () {

--- a/packages/address-validator/tests/wallet_address_validator.test.ts
+++ b/packages/address-validator/tests/wallet_address_validator.test.ts
@@ -368,6 +368,22 @@ describe('WAValidator.validate()', function () {
             );
         });
 
+        it('should return true for a correct Cardano stake address when network type is stake', function () {
+            valid(
+                'stake1uya87zwnmax0v6nnn8ptqkl6ydx4522kpsc3l3wmf3yswygwx45el',
+                'cardano',
+                'stake',
+            );
+        });
+
+        it('should return false for a mainnet bech32 Cardano address when network type is testnet', function () {
+            invalid(
+                'addr1qxnv5u3vrx2t37h3u27qd5ukgcjmrl4f8mu9f5sza3h20cxsfjh80un9kvlggfcdw8fp5kqp9tztqnee9msd0qsafhdsyqclvk',
+                'cardano',
+                'testnet',
+            );
+        });
+
         it('should match the expected Cardano address type - mainnet', function () {
             isValidAddressType(
                 'Ae2tdPwUPEYxYNJw1He1esdZYvjmr4NtPzUsGTiqL9zd8ohjZYQcwu6kom7',
@@ -556,8 +572,26 @@ describe('WAValidator.validate()', function () {
                 'addr1qxnv5u3vrx2t37h3u27qd5ukgcjmrl4f8mu9f5sza3h20cxsfjh80un9kvlggfcdw8fp5kqp9tztqnee9msd0qsafhdsyqclvl',
                 'cardano',
             );
+        });
+
+        it('should return false for a Cardano address that decodes to a CBOR non-array primitive', function () {
+            invalid('2', 'cardano');
+        });
+
+        it('should return false for a Cardano address whose CBOR-decoded second element is not a number', function () {
+            invalid('kkVd', 'cardano');
+        });
+
+        it('should return false for a Cardano address whose CBOR-decoded array has an unexpected length', function () {
             invalid('5yWKF5vph3', 'cardano');
+        });
+
+        it('should return false for a Cardano address whose CBOR-decoded tag is missing a value', function () {
             invalid('kzKq', 'cardano');
+        });
+
+        it('should return undefined as the Cardano address type for a string that fails both legacy and bech32 decoding', function () {
+            isValidAddressType('notacardanoaddress', 'cardano', 'prod', undefined);
         });
 
         it('should return true for correct tron addresses', function () {


### PR DESCRIPTION
## Description

Fixes the malformed CBOR shape guard in Cardano legacy address validation.

The previous condition used `!Array.isArray(decoded) && decoded.length !== 2`, so decoded arrays with a length other than 2 were not rejected before CRC validation. This PR changes the guard to reject non-arrays and arrays with an unexpected length, and adds a defensive check for a missing decoded tagged value before calling `CRC.crc32`.

Regression coverage was added for malformed base58 CBOR payloads that previously reached the legacy Cardano CRC path.

## Notes for QA

No manual QA expected. This is limited to address validation for malformed legacy Cardano inputs; valid Cardano fixtures remain covered by the existing unit test file.

## Related Issue

Related review comment: https://github.com/trezor/trezor-suite/pull/28230#discussion_r3333962550

## Screenshots:

N/A

## Test plan

- [x] `git diff --check HEAD~1 HEAD`
- [x] `yarn workspace @trezor/address-validator test:unit --coverage=0 wallet_address_validator.test.ts`

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are confined to the Cardano (ADA) address validator and its unit tests. The primary risk is that ADA address validation could break in send, receive, and staking flows for Cardano accounts. No static coverage mapping exists for these files, so all recommendations are inferred from the LLM test analysis. The recommended strategy focuses on Cardano-specific E2E tests: the cardano wallet test and passphrase-cardano test are highest priority as they directly exercise ADA address handling, followed by the three ADA staking tests which also involve ADA transaction and address flows.

<details><summary><b>Changed files (2)</b></summary>

- `packages/address-validator/src/ada_validator.ts`
- `packages/address-validator/tests/wallet_address_validator.test.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/wallet/cardano.test.ts` — This test exercises Cardano (ADA) account functionality including receiving addresses, send form, and account details. The changed file `ada_validator.ts` is the Cardano address validator, which is directly used when validating ADA addresses in send/receive flows. A regression in ADA address validation could cause failures in this test's receive address confirmation flow.
- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts` — This test verifies Cardano receive address flows behind a passphrase-protected wallet, including address display, confirmation, and error handling for wrong passphrases. ADA address validation changes could directly affect how Cardano addresses are validated and displayed in this flow.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/staking/ada/stake.test.ts` — This test covers Cardano staking which involves ADA transactions and address handling. Changes to the ADA address validator could affect transaction construction or address validation during the staking flow.
- `suite/e2e/tests/staking/ada/claim.test.ts` — This test exercises Cardano reward claiming which involves withdrawal addresses and transaction signing. ADA address validation changes could impact how withdrawal addresses are validated during the claim flow.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — This test covers Cardano unstaking with stake key deregistration transactions. ADA address validation logic could be involved in validating addresses during the unstaking transaction construction.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/wallet/export-transactions.test.ts` — This test exports transactions for ADA accounts among others. While address validation changes are unlikely to affect export directly, exported data includes ADA addresses that might go through validation.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/address-validator/tests/wallet_address_validator.test.ts`

_Updated: 2026-06-15T10:38:35.984Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/fix-pr-28230-comment&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/fix-pr-28230-comment&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-15T10:43:27.810Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-15T10:42:29.246Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/fix-pr-28230-comment/web/](https://dev.suite.sldev.cz/suite-web/mroz22/fix-pr-28230-comment/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->