### PR TITLE
Remove `@ethereumjs`

### DIFF
--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -82,8 +82,6 @@
     },
     "dependencies": {
         "@bufbuild/protobuf": "^2.11.0",
-        "@ethereumjs/common": "^10.1.1",
-        "@ethereumjs/tx": "^10.1.1",
         "@noble/hashes": "^2.0.1",
         "@scure/base": "^2.0.0",
         "@scure/bip39": "^1.5.1",
@@ -128,7 +126,6 @@
         "vite-plugin-wasm": "^3.6.0",
         "vitest": "^4.1.4",
         "vm-browserify": "^1.1.2",
-        "web3-utils": "^4.3.3",
         "ws": "^8.20.0"
     },
     "peerDependencies": {

--- a/packages/connect/src/api/ethereum/__fixtures__/ethereumSignTx.ts
+++ b/packages/connect/src/api/ethereum/__fixtures__/ethereumSignTx.ts
@@ -19,6 +19,10 @@ interface EthereumTxFixture {
 export const serializeEthereumTx: EthereumTxFixture[] = [
     {
         // https://eth.trezor.io/tx/0xf6652a681b4474132b8b96512eb0bd5311f5ed8414af59e715c9738a3b3673f3
+        // NOTE: This is pre-EIP-155 transaction signed without chainId so it's decoded as -4;
+        // we replace it by exactly the same transaction including chainId = 1
+        // old hex: 0xf86a1285104c533c00825208944dc573d5db497c0bf0674599e81c7db91151d4e6863905f13a8f0e801ca04256ec5ddf73f12f781e9f646f56fd8843296cf3eb7e2fb8f0b67ea317be3e7ca07be26525b6d6d39ef8745801bbb463c35ede09746708316a011e6eee7a2d83cf
+        // new hex: 0xf86a1285104c533c00825208944dc573d5db497c0bf0674599e81c7db91151d4e6863905f13a8f0e8026a0f2de2fdef0488cc8e328d5996d916367bf87a1482a17d77184ebc0b240fdc48aa0363eb465246f7728ba4d945c43be68e04bb1efd3b0eb4d66298b8788245547e6
         description: 'Legacy tx - ETH regular',
         from: '0x73d0385f4d8e00c5e6504c6030f47bf6212736a8',
         tx: {
@@ -33,11 +37,11 @@ export const serializeEthereumTx: EthereumTxFixture[] = [
         },
         // data received from TrezorConnect.ethereumSignTransaction
         signature: {
-            v: '0x1c',
-            r: '0x4256ec5ddf73f12f781e9f646f56fd8843296cf3eb7e2fb8f0b67ea317be3e7c',
-            s: '0x7be26525b6d6d39ef8745801bbb463c35ede09746708316a011e6eee7a2d83cf',
+            v: '0x26',
+            r: '0xf2de2fdef0488cc8e328d5996d916367bf87a1482a17d77184ebc0b240fdc48a',
+            s: '0x363eb465246f7728ba4d945c43be68e04bb1efd3b0eb4d66298b8788245547e6',
         },
-        result: '0xf6652a681b4474132b8b96512eb0bd5311f5ed8414af59e715c9738a3b3673f3',
+        result: '0x6ebfac1bc517ff14453888c64d268353022178f42d8404215bda67afe2082104',
     },
     {
         // https://eth.trezor.io/tx/0xdcaf3eba690a3cdbad8c2926a8f5a95cd20003c5ba2aace91d8c5fe8048e395b

--- a/packages/connect/src/api/ethereum/__fixtures__/ethereumSignTx.ts
+++ b/packages/connect/src/api/ethereum/__fixtures__/ethereumSignTx.ts
@@ -1,5 +1,3 @@
-import { Hardfork } from '@ethereumjs/common';
-
 import type { EthereumTransaction, EthereumTransactionEIP1559 } from '@trezor/connect-common';
 
 interface EthereumTxFixture {
@@ -13,7 +11,6 @@ interface EthereumTxFixture {
     };
     from: string;
     result: string;
-    defaultHardfork?: Hardfork;
 }
 
 export const serializeEthereumTx: EthereumTxFixture[] = [
@@ -81,7 +78,6 @@ export const serializeEthereumTx: EthereumTxFixture[] = [
             r: '0x9d4599beedc587e0dc3d88578d79573c0138f9389810ffb036c37423ccd86375',
             s: '0x4a0eb870fbae9a11a02e3e0068830d141ee952bb4ab4d1e1b7542d75f7a24dc1',
         },
-        defaultHardfork: Hardfork.Petersburg,
         result: '0xebd7ef20c4358a6fdb09a951d6e77b8e88b37ac0f7a8d4e3b68f1666bf4c1d1a',
     },
     {

--- a/packages/connect/src/api/ethereum/__tests__/ethereumSignTx.test.ts
+++ b/packages/connect/src/api/ethereum/__tests__/ethereumSignTx.test.ts
@@ -1,6 +1,4 @@
-import { Mainnet, createCustomCommon } from '@ethereumjs/common';
-import { createTxFromRLP } from '@ethereumjs/tx';
-import { keccak256, toHex } from 'web3-utils';
+import { keccak256, recoverTransactionAddress } from 'viem';
 
 import * as fixtures from '../__fixtures__/ethereumSignTx';
 import { serializeEthereumTx } from '../ethereumSignTx';
@@ -8,28 +6,21 @@ import { serializeEthereumTx } from '../ethereumSignTx';
 describe('helpers/ethereumSignTx', () => {
     describe('serializeEthereumTx', () => {
         fixtures.serializeEthereumTx.forEach(f => {
-            it(f.description, () => {
+            it(f.description, async () => {
                 const isLegacy = f.type === undefined || f.type === 0;
                 const serialized = serializeEthereumTx(f.tx, f.signature, isLegacy);
 
                 // Verify signature hash
-                const hash = toHex(
-                    keccak256(Uint8Array.from(Buffer.from(serialized.slice(2), 'hex'))),
-                );
+                const hash = keccak256(serialized);
                 expect(hash).toEqual(f.result);
 
-                // Verify by parsing the serialized tx
-                const tx = createTxFromRLP(Buffer.from(serialized.slice(2), 'hex'), {
-                    common: createCustomCommon(
-                        { chainId: f.tx.chainId, defaultHardfork: f.defaultHardfork },
-                        Mainnet,
-                    ),
+                // Verify by parsing sender address from serialized transaction
+                const senderAddress = await recoverTransactionAddress({
+                    serializedTransaction: serialized,
                 });
-                const hash2 = Buffer.from(tx.hash()).toString('hex');
-                expect(`0x${hash2}`).toEqual(f.result);
 
                 // Compare sender address (based on signature)
-                expect(tx.getSenderAddress().toString()).toEqual(f.from);
+                expect(senderAddress.toLowerCase()).toEqual(f.from);
             });
         });
     });

--- a/packages/connect/src/api/ethereum/ethereumSignTx.ts
+++ b/packages/connect/src/api/ethereum/ethereumSignTx.ts
@@ -1,9 +1,6 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 
-import type { Common } from '@ethereumjs/common';
-import { Hardfork, Mainnet, createCustomCommon } from '@ethereumjs/common';
-import type { FeeMarketEIP1559TxData, LegacyTxData } from '@ethereumjs/tx';
-import { createTx } from '@ethereumjs/tx';
+import { serializeTransaction } from 'viem';
 
 import type {
     EthereumAccessList,
@@ -16,7 +13,7 @@ import type { MessagesSchema } from '@trezor/protobuf';
 
 import { getEthereumDefinitions } from './ethereumDefinitions';
 import type { TypedCall } from '../../device/DeviceCommands';
-import { addHexPrefix, deepTransform } from '../../utils/formatUtils';
+import { addHexPrefix } from '../../utils/formatUtils';
 
 const splitString = (str?: string, len?: number): [string, string] => {
     if (str == null) {
@@ -104,56 +101,43 @@ function handleTxFlowResponse(
     return processTxRequest(typedCall, response.message, data, chain_id);
 }
 
-const deepHexPrefix = deepTransform(addHexPrefix);
+const ifNotUndefined = <T, U>(value: T | undefined, convert: (value: T) => U): U | undefined =>
+    value === undefined ? undefined : convert(value);
 
-export const getCommonForChain = (chainId: number): Common => {
-    // @ethereumjs/tx doesn't support ETC (chain 61) by default
-    // see: https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/examples/custom-chain-id-tx.ts
-    if (chainId === 61) {
-        return createCustomCommon(
-            {
-                chainId: 61,
-                // last hardfork shared with Ethereum
-                defaultHardfork: Hardfork.Petersburg,
-            },
-            Mainnet,
-        );
-    }
-
-    return createCustomCommon({ chainId }, Mainnet);
-};
+const toBigInt = (value: string) => BigInt(addHexPrefix(value));
 
 export const serializeEthereumTx = (
     tx: EthereumTransactionEIP1559 | EthereumTransaction,
     signature: { v: `0x${string}`; r: `0x${string}`; s: `0x${string}` },
     isLegacy: boolean,
-) => {
-    const txData = deepHexPrefix({
-        ...tx,
-        ...signature,
-        to: tx.to || undefined,
-        type: isLegacy ? 0 : 2, // 0 for legacy, 2 for EIP-1559
-        ...(isLegacy
-            ? {
-                  gasPrice: tx.gasPrice,
-                  maxFeePerGas: undefined,
-                  maxPriorityFeePerGas: undefined,
-              }
-            : {
-                  gasPrice: undefined,
-                  maxFeePerGas: tx.maxFeePerGas,
-                  maxPriorityFeePerGas: tx.maxPriorityFeePerGas,
-              }),
-    }) satisfies LegacyTxData | FeeMarketEIP1559TxData;
-
-    const txOptions = {
-        common: getCommonForChain(tx.chainId),
-    };
-
-    const ethTx = createTx(txData, txOptions);
-
-    return `0x${Buffer.from(ethTx.serialize()).toString('hex')}`;
-};
+) =>
+    serializeTransaction(
+        {
+            value: toBigInt(tx.value),
+            nonce: Number(addHexPrefix(tx.nonce)),
+            data: ifNotUndefined(tx.data, addHexPrefix),
+            to: ifNotUndefined(tx.to || undefined, addHexPrefix), // empty ("") address must be omitted completely
+            gas: ifNotUndefined(tx.gasLimit, toBigInt),
+            chainId: tx.chainId,
+            ...(isLegacy
+                ? {
+                      type: 'legacy',
+                      gasPrice: ifNotUndefined(tx.gasPrice, toBigInt),
+                  }
+                : {
+                      type: 'eip1559',
+                      maxFeePerGas: ifNotUndefined(tx.maxFeePerGas, toBigInt),
+                      maxPriorityFeePerGas: ifNotUndefined(tx.maxPriorityFeePerGas, toBigInt),
+                      accessList: ('accessList' in tx ? tx.accessList : undefined)?.map(
+                          ({ address, storageKeys }) => ({
+                              address: addHexPrefix(address),
+                              storageKeys: storageKeys.map(addHexPrefix),
+                          }),
+                      ),
+                  }),
+        },
+        { ...signature, v: toBigInt(signature.v) },
+    );
 
 const stripLeadingZeroes = (str: string) => {
     while (/^00/.test(str)) {

--- a/scripts/list-outdated-dependencies/wallet-dependencies.txt
+++ b/scripts/list-outdated-dependencies/wallet-dependencies.txt
@@ -1,5 +1,3 @@
-@ethereumjs/common
-@ethereumjs/tx
 @exodus/patch-broken-hermes-typed-arrays
 @fivebinaries/coin-selection
 @hookform/resolvers

--- a/yarn.lock
+++ b/yarn.lock
@@ -3288,49 +3288,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethereumjs/common@npm:^10.1.1":
-  version: 10.1.1
-  resolution: "@ethereumjs/common@npm:10.1.1"
-  dependencies:
-    "@ethereumjs/util": "npm:^10.1.1"
-    eventemitter3: "npm:^5.0.1"
-  checksum: 10/c47aeed4e839fb7cd85944d570c31722bd20d8a0a1f4ddde2f2501e69f12ba563dda69e0d5c079590fe81e53889e34ccf46caa90956fa9563577f1359c7bc76b
-  languageName: node
-  linkType: hard
-
-"@ethereumjs/rlp@npm:^10.1.1":
-  version: 10.1.1
-  resolution: "@ethereumjs/rlp@npm:10.1.1"
-  bin:
-    rlp: bin/rlp.cjs
-  checksum: 10/6f713406e2cc32edb21096d03653e0391bab624cd3a1e518f15afc117d7aa9f5de56154b224b7c2628066289d72ac2d7c236f17aee4e28e6f5427cc32ab57b28
-  languageName: node
-  linkType: hard
-
-"@ethereumjs/tx@npm:^10.1.1":
-  version: 10.1.1
-  resolution: "@ethereumjs/tx@npm:10.1.1"
-  dependencies:
-    "@ethereumjs/common": "npm:^10.1.1"
-    "@ethereumjs/rlp": "npm:^10.1.1"
-    "@ethereumjs/util": "npm:^10.1.1"
-    "@noble/curves": "npm:^2.0.1"
-    "@noble/hashes": "npm:^2.0.1"
-  checksum: 10/f6ecb73068c6291844c66b33d0f3417f174839c32a40996a40454dd69b8676ae20df429f3d33cbce3b4f31eebdf6ef7b4e85836da4c085e87e32fa5e72a1a48c
-  languageName: node
-  linkType: hard
-
-"@ethereumjs/util@npm:^10.1.1":
-  version: 10.1.1
-  resolution: "@ethereumjs/util@npm:10.1.1"
-  dependencies:
-    "@ethereumjs/rlp": "npm:^10.1.1"
-    "@noble/curves": "npm:^2.0.1"
-    "@noble/hashes": "npm:^2.0.1"
-  checksum: 10/5ab48a85d52371126d1b29ec8304ae1fac8f61de9fc8becabbf2166fee9a2d168dfb85d7acd7190e02c5bef61f09afcd7552f1d38aea6bba33395fb49cf3f531
-  languageName: node
-  linkType: hard
-
 "@evolu/common@npm:8.0.0-next.5":
   version: 8.0.0-next.5
   resolution: "@evolu/common@npm:8.0.0-next.5"
@@ -15944,8 +15901,6 @@ __metadata:
   dependencies:
     "@babel/preset-typescript": "npm:^7.29.7"
     "@bufbuild/protobuf": "npm:^2.11.0"
-    "@ethereumjs/common": "npm:^10.1.1"
-    "@ethereumjs/tx": "npm:^10.1.1"
     "@noble/hashes": "npm:^2.0.1"
     "@scure/base": "npm:^2.0.0"
     "@scure/bip39": "npm:^1.5.1"
@@ -15987,7 +15942,6 @@ __metadata:
     vite-plugin-wasm: "npm:^3.6.0"
     vitest: "npm:^4.1.4"
     vm-browserify: "npm:^1.1.2"
-    web3-utils: "npm:^4.3.3"
     ws: "npm:^8.20.0"
   peerDependencies:
     tslib: ^2.6.2


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

As part of an effort to isolate coin-specific 3rd party dependencies, `@ethereumjs` packages were removed and their functionality replaced by `viem`.

The only place changed is the eth transaction serialization (`serializeEthereumTx` util used in `ethereumSignTransaction` method): previously, `createTx` from `@ethereumjs/tx` was used, now `serializeTransaction` from `viem` is used instead. 

There could be issues with input data formats, but I believe this is at least as safe as it was before (e.g. previously all the string parameters were first stripped from `0x` prefix and then prefixed again, meaning that some decimal string numbers may have been interpreted as hex instead).

## Notes for QA

Please test everything related to `ethereumSignTransaction` method.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are focused on the Ethereum transaction signing implementation in @trezor/connect (ethereumSignTx.ts), its unit test fixtures, and the package.json. The core risk is regression in Ethereum/EVM transaction signing — affecting ETH sends, ERC-20 transfers, staking contract calls, and swap confirmations. The recommended strategy prioritizes tests that directly exercise Ethereum transaction signing with device confirmation, then broadens to staking and trading flows that use the same code path. Tests like receive.test.ts and global-receive-send.test.ts are omitted since they don't invoke transaction signing despite being statically mapped.

<details><summary><b>Changed files (4)</b></summary>

- `packages/connect/package.json`
- `packages/connect/src/api/ethereum/__fixtures__/ethereumSignTx.ts`
- `packages/connect/src/api/ethereum/__tests__/ethereumSignTx.test.ts`
- `packages/connect/src/api/ethereum/ethereumSignTx.ts`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — This test directly exercises TrezorConnect.ethereumSignTransaction, which is the exact API method implemented by the changed ethereumSignTx.ts. Any regression in the signing logic would be caught here.
- `suite/e2e/tests/wallet/send-eth.test.ts` — This test fills in an Ethereum send form with custom gas parameters and verifies the transaction details on the device emulator, directly exercising the Ethereum transaction signing path through ethereumSignTx.ts including gas limit, max fee per gas, and priority fee handling.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — This test verifies custom Ethereum fee parameters (gas limit, max fee per gas, max priority fee per gas) are correctly passed through the swap flow and displayed on the device, exercising the EIP-1559 transaction signing path in ethereumSignTx.ts.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — This test confirms an Ethereum sell transaction with custom gas fees and verifies device prompt details (address, amount, fee), directly invoking Ethereum transaction signing through the changed code path.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — This test sends an ERC-20 token (USDC) sell transaction and verifies device prompt details including address, amount, and fee. ERC-20 token transfers use a different transaction data encoding path in ethereumSignTx.ts.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — ETH staking invokes a contract call to the Everstake staking pool, which goes through ethereumSignTx.ts for transaction signing. The test verifies amount and fee display on the device during the stake confirmation.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — ETH unstaking and claiming both involve contract interactions signed via ethereumSignTx.ts. The test verifies two separate transaction signing flows (unstake and claim) with device confirmation.
- `suite/e2e/tests/wallet/send-base.test.ts` — Base is an EVM L2 network that uses the same ethereumSignTx.ts code path for transaction signing. This test verifies gas parameters and transaction confirmation on Base, testing EVM signing on a non-mainnet chain.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/wallet/sign-and-verify-eth.test.ts` — While this test is for ethereumSignMessage/verifyMessage (not ethereumSignTransaction), changes to ethereumSignTx.ts package could have side effects on nearby Ethereum API methods if shared infrastructure was modified.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/connect/package.json`
- `packages/connect/src/api/ethereum/__fixtures__/ethereumSignTx.ts`
- `packages/connect/src/api/ethereum/__tests__/ethereumSignTx.test.ts`

_Updated: 2026-06-15T09:14:42.295Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/remove-ethereumjs&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/remove-ethereumjs&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/remove-ethereumjs&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-15T09:19:52.869Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-15T09:18:05.103Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/remove-ethereumjs/web/](https://dev.suite.sldev.cz/suite-web/chore/remove-ethereumjs/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->