### PR TITLE
Extended `isHex` util

### DIFF
--- a/packages/blockchain-link/src/workers/evm-rpc/handlers/getBlock.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/handlers/getBlock.ts
@@ -1,7 +1,6 @@
-import { isHex } from 'viem';
-
 import { CustomError } from '@trezor/blockchain-link-types';
 import type { MessageTypes, ResponseTypes as Responses } from '@trezor/blockchain-link-types';
+import { isHex } from '@trezor/utils';
 
 import { mapGetBlockResponse } from '../mappers/block';
 import type { Request } from '../types';

--- a/packages/blockchain-link/src/workers/evm-rpc/utils/hex.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/utils/hex.ts
@@ -1,9 +1,3 @@
-import { isHex } from 'viem';
+import { isHex } from '@trezor/utils';
 
-export const toHex = (value: string): `0x${string}` => {
-    if (isHex(value)) {
-        return value;
-    }
-
-    return `0x${value}` as `0x${string}`;
-};
+export const toHex = (value: string): `0x${string}` => (isHex(value) ? value : `0x${value}`);

--- a/packages/transport/src/utils/bridgeProtocolMessage.ts
+++ b/packages/transport/src/utils/bridgeProtocolMessage.ts
@@ -1,4 +1,5 @@
 import type { ThpChannelState, TransportProtocol } from '@trezor/protocol';
+import { isHex } from '@trezor/utils';
 
 export type BridgeProtocolMessage = {
     data: string;
@@ -10,7 +11,6 @@ export type BridgeProtocolMessage = {
 // - json string (protocol message)
 // - parsed json string (parsed protocol message)
 export function validateProtocolMessage(body: unknown, withData = true): BridgeProtocolMessage {
-    const isHex = (s: string) => /^[0-9A-Fa-f]+$/g.test(s); // TODO: trezor/utils accepts 0x prefix (eth)
     const isValidProtocol = (s: any): s is BridgeProtocolMessage['protocol'] =>
         s === 'v1' || s === 'v2' || s === 'bridge';
 
@@ -34,7 +34,11 @@ export function validateProtocolMessage(body: unknown, withData = true): BridgeP
         throw new Error('Invalid BridgeProtocolMessage protocol');
     }
     // optionally validate BridgeProtocolMessage['data]
-    if (withData && (typeof json.data !== 'string' || !isHex(json.data))) {
+    if (
+        withData &&
+        (typeof json.data !== 'string' ||
+            !isHex(json.data, { prefix: 'prohibited', allowEmpty: false }))
+    ) {
         throw new Error('Invalid BridgeProtocolMessage data');
     }
 

--- a/packages/utils/src/isHex.ts
+++ b/packages/utils/src/isHex.ts
@@ -1,5 +1,19 @@
-export const isHex = (str: string): boolean => {
-    const regExp = /^(0x|0X)?[0-9A-Fa-f]+$/g;
+type Options = { prefix?: 'required' | 'optional' | 'prohibited'; allowEmpty?: boolean };
 
-    return regExp.test(str);
-};
+export function isHex(
+    value: unknown,
+    options?: Options & { prefix?: 'required' },
+): value is `0x${string}`;
+export function isHex(
+    value: unknown,
+    options: Options & { prefix: 'optional' | 'prohibited' },
+): value is string;
+
+export function isHex(value: unknown, { prefix = 'required', allowEmpty = true }: Options = {}) {
+    const p = prefix === 'prohibited' ? '' : '(0x)';
+    const o = prefix === 'optional' ? '?' : '';
+    const e = allowEmpty ? '*' : '+';
+    const regex = `^${p}${o}[0-9a-fA-F]${e}$`;
+
+    return typeof value === 'string' && new RegExp(regex).test(value);
+}

--- a/packages/utils/tests/isHex.test.ts
+++ b/packages/utils/tests/isHex.test.ts
@@ -1,10 +1,38 @@
 import { isHex } from '../src/isHex';
 
 describe('isHex', () => {
-    it('isHex', () => {
+    it('default', () => {
         expect(isHex('0x2540be3ff')).toBe(true);
-        expect(isHex('0x89205A3A3b2A69De6Dbf7f01ED13B2108B2c43e6')).toBe(true);
-        expect(isHex('89205A3A3b2A69De6Dbf7f01ED13B2108B2c43e6')).toBe(true);
+        expect(isHex('0x89205A3A3b2A69De6Dbf7f01')).toBe(true);
+        expect(isHex('89205A3A3b2A69De6Dbf7f01')).toBe(false);
         expect(isHex('bla')).toBe(false);
+    });
+
+    it('prefix required', () => {
+        expect(isHex('0x2540be3ff', { prefix: 'required' })).toBe(true);
+        expect(isHex('0x89205A3A3b2A69De6Dbf7f01', { prefix: 'required' })).toBe(true);
+        expect(isHex('89205A3A3b2A69De6Dbf7f01', { prefix: 'required' })).toBe(false);
+        expect(isHex('bla', { prefix: 'required' })).toBe(false);
+    });
+
+    it('prefix optional', () => {
+        expect(isHex('0x2540be3ff', { prefix: 'optional' })).toBe(true);
+        expect(isHex('0x89205A3A3b2A69De6Dbf7f01', { prefix: 'optional' })).toBe(true);
+        expect(isHex('89205A3A3b2A69De6Dbf7f01', { prefix: 'optional' })).toBe(true);
+        expect(isHex('bla', { prefix: 'optional' })).toBe(false);
+    });
+
+    it('prefix prohibited', () => {
+        expect(isHex('0x2540be3ff', { prefix: 'prohibited' })).toBe(false);
+        expect(isHex('0x89205A3A3b2A69De6Dbf7f01', { prefix: 'prohibited' })).toBe(false);
+        expect(isHex('89205A3A3b2A69De6Dbf7f01', { prefix: 'prohibited' })).toBe(true);
+        expect(isHex('bla', { prefix: 'prohibited' })).toBe(false);
+    });
+
+    it('allow empty', () => {
+        expect(isHex('0x', { allowEmpty: true })).toBe(true);
+        expect(isHex('0x', { allowEmpty: false })).toBe(false);
+        expect(isHex('', { prefix: 'optional', allowEmpty: true })).toBe(true);
+        expect(isHex('', { prefix: 'optional', allowEmpty: false })).toBe(false);
     });
 });

--- a/packages/utils/tests/isHex.type-test.ts
+++ b/packages/utils/tests/isHex.type-test.ts
@@ -1,0 +1,48 @@
+// Type-level regression test for the `isHex` overloads.
+//
+// `isHex(value, { prefix: 'required' })` must narrow `value` to `0x${string}`,
+// exactly like the no-argument `isHex(value)` form (whose default prefix is
+// already 'required'). It currently does NOT: `Extract<Options, { prefix:
+// 'required' }>` in the first overload resolves to `never` (because `Options`
+// is a single object type whose `prefix` is the wider union, not the literal
+// 'required'), so the call falls through to the second overload and the type
+// guard degrades to `value is string`.
+//
+// This file is part of `type-check` (tsc --build), so it fails to compile until
+// the overload is fixed — see the PR description for the proposed fix.
+
+import { isHex } from '../src/isHex';
+
+const expectHexString = (_value: `0x${string}`) => {};
+const expectString = (_value: string) => {};
+
+declare const value: unknown;
+
+// Default prefix is 'required' → narrows to `0x${string}`.
+if (isHex(value)) {
+    expectHexString(value);
+}
+
+// Explicit `{ prefix: 'required' }` is semantically identical and must narrow
+// to `0x${string}` as well.
+if (isHex(value, { prefix: 'required' })) {
+    expectHexString(value);
+}
+
+// `{ prefix: 'required', allowEmpty: false }` must also keep the `0x${string}` guard.
+if (isHex(value, { prefix: 'required', allowEmpty: false })) {
+    expectHexString(value);
+}
+
+// 'optional' / 'prohibited' do not guarantee a 0x prefix → plain `string`.
+if (isHex(value, { prefix: 'optional' })) {
+    expectString(value);
+    // @ts-expect-error 'optional' prefix must not narrow to `0x${string}`
+    expectHexString(value);
+}
+
+if (isHex(value, { prefix: 'prohibited' })) {
+    expectString(value);
+    // @ts-expect-error 'prohibited' prefix must not narrow to `0x${string}`
+    expectHexString(value);
+}

--- a/suite-common/validators/src/config.ts
+++ b/suite-common/validators/src/config.ts
@@ -16,7 +16,9 @@ yup.addMethod<yup.StringSchema>(yup.string, 'isAscii', function () {
 });
 
 yup.addMethod<yup.StringSchema>(yup.string, 'isHex', function () {
-    return this.test('isHex', 'DATA_NOT_VALID_HEX', value => isHex(value as string));
+    return this.test('isHex', 'DATA_NOT_VALID_HEX', value =>
+        isHex(value, { prefix: 'optional', allowEmpty: false }),
+    );
 });
 
 export { yup };

--- a/suite-common/walletconnect/src/adapters/ethereum.ts
+++ b/suite-common/walletconnect/src/adapters/ethereum.ts
@@ -75,7 +75,7 @@ const ethereumRequestThunk = createThunk<
             const messageDecoded = message.startsWith('0x')
                 ? Buffer.from(message.slice(2), 'hex').toString('utf8')
                 : message;
-            const messageHex = isHex(message)
+            const messageHex = isHex(message, { prefix: 'optional', allowEmpty: false })
                 ? sanitizeHex(message)
                 : Buffer.from(message, 'utf8').toString('hex');
             const isReadable = isAscii(messageDecoded);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

As part of an effort to isolate coin-specific 3rd party dependencies, `isHex` util was extended so we can use it everywhere instead of inlined utils or `viem`/`web3-utils` imports.

Supported options:

- `prefix` - `0x` prefix may be required (then the util works as `0x${string}` typeguard), optional or prohibited.
- `allowEmpty` - whether `''` and `'0x'` are considered valid hex values

Unit tests were extended to cover these cases.

Every `isHex` instance (our or 3rd party) was (hopefully) replaced by the same behaving `isHex` call (previous implementation is equivalent to `{ prefix: 'optional', allowEmpty: false }` and viem implementation is `{ prefix: 'required', allowEmpty: true }` which is current default).

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set touches low-level utilities (isHex, hex conversion in EVM RPC, bridge protocol messaging), a validators config, and the WalletConnect Ethereum adapter. The highest risk is in the WalletConnect Ethereum adapter change (directly tested) and EVM RPC changes (affecting ETH/Base transaction flows). The `isHex.ts`, `bridgeProtocolMessage.ts`, and `validators/config.ts` changes map to 100+ tests each, indicating they are broad shared utilities — most tests should NOT be run just because they transitively import these. Focus testing on WalletConnect, EVM send/staking flows, and Ethereum-specific functionality.

<details><summary><b>Changed files (7)</b></summary>

- `packages/blockchain-link/src/workers/evm-rpc/handlers/getBlock.ts`
- `packages/blockchain-link/src/workers/evm-rpc/utils/hex.ts`
- `packages/transport/src/utils/bridgeProtocolMessage.ts`
- `packages/utils/src/isHex.ts`
- `packages/utils/tests/isHex.test.ts`
- `suite-common/validators/src/config.ts`
- `suite-common/walletconnect/src/adapters/ethereum.ts`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/analytics/wallet-connect-events.test.ts` — This test directly exercises WalletConnect functionality including proposal approval/rejection. The changed file `suite-common/walletconnect/src/adapters/ethereum.ts` is the Ethereum adapter for WalletConnect, which is directly invoked during WalletConnect pairing and proposal flows tested here.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/wallet/send-eth.test.ts` — This test sends ETH with custom gas parameters and verifies fee calculations. Changes to `packages/blockchain-link/src/workers/evm-rpc/handlers/getBlock.ts` and `evm-rpc/utils/hex.ts` affect EVM RPC block fetching and hex utilities, which are part of the ETH transaction infrastructure. The validators config change could also affect address validation in the send form.
- `suite/e2e/tests/wallet/send-base.test.ts` — This test performs a full send transaction on the Base (EVM) network with custom Ethereum fees and verifies confirmed status. EVM RPC changes in `getBlock.ts` and `hex.ts` directly affect how blocks are fetched for EVM chains like Base, and the validators config may affect address validation.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — ETH staking uses the EVM RPC layer for transaction submission and confirmation tracking. Changes to `evm-rpc/handlers/getBlock.ts` and `evm-rpc/utils/hex.ts` affect how block data is fetched, which is critical for detecting transaction confirmation state transitions tested here.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — This test verifies Ethereum fee parameters (gas limit, max fee per gas, priority fee) during a swap. The EVM RPC hex utility changes could affect how fee-related hex values are parsed, and the validators config may affect address/amount validation in the swap form.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test configures custom blockbook backends for ETH and tests discovery. The EVM RPC changes in `getBlock.ts` affect how blocks are fetched from custom backends, and `isHex.ts` changes could affect hex validation used in backend communication.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/wallet/sign-and-verify-eth.test.ts` — ETH signing produces hex signatures and verification checks hex values. Changes to `isHex.ts` could affect hex validation of signatures, and the WalletConnect Ethereum adapter changes touch Ethereum signing infrastructure.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — The validators config change could affect validation of addresses or amounts in the swap form. The `bridgeProtocolMessage.ts` change affects transport layer communication which this test relies on for device prompt confirmation.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/blockchain-link/src/workers/evm-rpc/handlers/getBlock.ts`
- `packages/blockchain-link/src/workers/evm-rpc/utils/hex.ts`
- `packages/utils/tests/isHex.test.ts`

_Updated: 2026-06-05T08:45:53.497Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/use-hex-util&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/use-hex-util&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/use-hex-util&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-05T12:53:50.474Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-05T12:51:46.815Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/use-hex-util/web/](https://dev.suite.sldev.cz/suite-web/chore/use-hex-util/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->