### PR TITLE
Small cleanup

### DIFF
--- a/packages/suite/src/actions/wallet/selectedAccountActions.ts
+++ b/packages/suite/src/actions/wallet/selectedAccountActions.ts
@@ -173,7 +173,6 @@ const actions = new Set<Action['type']>([
     blockchainActions.synced.type,
     blockchainActions.connected.type,
     discoveryActions.updateDiscovery.type,
-    feesActions.updateFee.type,
     feesActions.updateMultipleFees.type,
 ]);
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/SelectFeeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/SelectFeeModal.tsx
@@ -89,17 +89,17 @@ export const SelectFeeModal = ({ data }: SelectAccountModalProps) => {
         tokens: [],
     };
     const feeInfo = {
-        levels: sortLevels(
-            fees
-                .filter(level => level.fee != '0')
-                .filter(level => level.name !== 'low') // this option is hidden in Suite
-                .map(level => ({
-                    // level.name is just a string instead of enum
-                    label: level.name as any,
-                    feePerUnit: level.feePerByte!,
-                    blocks: level.blocks!,
-                })),
-        ),
+        levels: fees
+            .filter(level => level.fee != '0')
+            .filter(level => level.name !== 'low') // this option is hidden in Suite
+            .map(level => ({
+                // level.name is just a string instead of enum
+                label: level.name as any,
+                feePerUnit: level.feePerByte!,
+                blocks: level.blocks!,
+            }))
+            .sort(sortLevels),
+
         minFee,
         maxFee,
         minPriorityFee: -1,

--- a/suite-common/wallet-core/src/fees/feesActions.ts
+++ b/suite-common/wallet-core/src/fees/feesActions.ts
@@ -1,17 +1,8 @@
 import { createAction } from '@reduxjs/toolkit';
 
-import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { type FeeInfo, type FeesState, type FeesStatus } from '@suite-common/wallet-types';
+import { type FeesState } from '@suite-common/wallet-types';
 
 export const FEES_MODULE_PREFIX = '@common/wallet-core/fees';
-
-const updateFee = createAction(
-    `${FEES_MODULE_PREFIX}/updateFee`,
-    // note: status is handled automatically by reducer cases for `updateFeeInfoThunk`
-    (payload: { symbol: NetworkSymbol; data: FeeInfo; status?: FeesStatus }) => ({
-        payload,
-    }),
-);
 
 const updateMultipleFees = createAction(
     `${FEES_MODULE_PREFIX}/updateMultipleFees`,
@@ -20,7 +11,4 @@ const updateMultipleFees = createAction(
     }),
 );
 
-export const feesActions = {
-    updateFee,
-    updateMultipleFees,
-};
+export const feesActions = { updateMultipleFees };

--- a/suite-common/wallet-core/src/fees/feesReducer.ts
+++ b/suite-common/wallet-core/src/fees/feesReducer.ts
@@ -33,10 +33,6 @@ export const DEFAULT_FEE_INFO: FeeInfo = {
 export const feesInitialState: FeesState = {};
 
 export const feesReducer = createReducer<FeesState>(feesInitialState, builder => {
-    builder.addCase(feesActions.updateFee, (state, { payload: { symbol, data } }) => {
-        const defaultStatus = 'loaded'; // in case the object doesn't exist yet (shouldn't happen)
-        state[symbol] = { status: defaultStatus, ...state[symbol], data };
-    });
     builder.addCase(feesActions.updateMultipleFees, (state, { payload }) => ({
         ...state,
         ...payload,

--- a/suite-common/wallet-core/src/fees/feesReducer.ts
+++ b/suite-common/wallet-core/src/fees/feesReducer.ts
@@ -15,11 +15,7 @@ import { type FeeLevel } from '@trezor/connect';
 import { feesActions } from './feesActions';
 import { updateFeeInfoThunk } from './feesThunks';
 
-export type FeesRootState = {
-    wallet: {
-        fees: FeesState;
-    };
-};
+export type FeesRootState = { wallet: { fees: FeesState } };
 
 export const DEFAULT_FEE_INFO: FeeInfo = {
     blockHeight: 0,

--- a/suite-common/wallet-core/src/fees/feesThunks.ts
+++ b/suite-common/wallet-core/src/fees/feesThunks.ts
@@ -1,9 +1,9 @@
 import { selectSelectedDevice } from '@suite-common/device';
 import { createThunk } from '@suite-common/redux-utils';
 import { type NetworkSymbol, getNetwork, networksCollection } from '@suite-common/wallet-config';
-import { type FeeInfo, type FeesState } from '@suite-common/wallet-types';
+import { type FeeInfo } from '@suite-common/wallet-types';
 import TrezorConnect from '@trezor/connect';
-import { resolveAfter } from '@trezor/utils';
+import { isNotUndefined, resolveAfter, typedObjectFromEntries } from '@trezor/utils';
 
 import { FEES_MODULE_PREFIX, feesActions } from './feesActions';
 import { getNewFeeInfo, sortLevels } from './feesUtils';
@@ -24,22 +24,20 @@ export const preloadFeeInfoThunk = createThunk(
         const networks = networksCollection.filter(
             n => !n.isHidden && enabledNetworks?.includes(n.symbol),
         );
-        const promises = networks.map(network =>
-            TrezorConnect.blockchainEstimateFee({
-                coin: network.symbol,
-                request: {
-                    feeLevels: 'preloaded',
-                },
+
+        const levels = await Promise.all(
+            networks.map(async network => {
+                const result = await TrezorConnect.blockchainEstimateFee({
+                    coin: network.symbol,
+                    request: { feeLevels: 'preloaded' },
+                });
+
+                return result.success ? ([network, result] as const) : undefined;
             }),
         );
-        const levels = await Promise.all(promises);
 
-        const partial: Partial<FeesState> = {};
-        networks.forEach((network, index) => {
-            // @ts-expect-error: indexing with noUncheckedIndexedAccess
-            const result: (typeof levels)[number] = levels[index];
-
-            if (result.success) {
+        const partial = typedObjectFromEntries(
+            levels.filter(isNotUndefined).map(([network, result]) => {
                 const { payload } = result;
                 const feeInfo: FeeInfo = {
                     blockHeight: 0,
@@ -54,12 +52,10 @@ export const preloadFeeInfoThunk = createThunk(
                             label: level.label || 'normal',
                         })),
                 };
-                partial[network.symbol] = {
-                    status: 'preloaded',
-                    data: feeInfo,
-                };
-            }
-        });
+
+                return [network.symbol, { status: 'preloaded' as const, data: feeInfo }];
+            }),
+        );
 
         dispatch(feesActions.updateMultipleFees(partial));
     },
@@ -69,9 +65,6 @@ type UpdateFeeInfoThunkProps = {
     networkSymbol: NetworkSymbol;
     artificialDelay?: number;
 };
-
-const getArtificialDelayPromise = (artificialDelay?: number): Promise<void> =>
-    artificialDelay === undefined ? Promise.resolve() : resolveAfter(artificialDelay);
 
 /**
  * Fetches feeInfo for a given network from backend.
@@ -92,7 +85,7 @@ export const updateFeeInfoThunk = createThunk<
 
         const [newFeeInfo] = await Promise.all([
             getNewFeeInfo({ network, device }),
-            getArtificialDelayPromise(artificialDelay),
+            resolveAfter(artificialDelay ?? 0),
         ]);
 
         if (newFeeInfo === undefined) {

--- a/suite-common/wallet-core/src/fees/feesThunks.ts
+++ b/suite-common/wallet-core/src/fees/feesThunks.ts
@@ -44,15 +44,15 @@ export const preloadFeeInfoThunk = createThunk(
                 const feeInfo: FeeInfo = {
                     blockHeight: 0,
                     ...payload,
-                    levels: sortLevels(
-                        payload.levels
-                            // hack to hide "low" fee option
-                            // (we do not want to change the connect API as it is a potentially breaking change)
-                            .filter(level => level.label !== 'low'),
-                    ).map(level => ({
-                        ...level,
-                        label: level.label || 'normal',
-                    })),
+                    levels: payload.levels
+                        // hack to hide "low" fee option
+                        // (we do not want to change the connect API as it is a potentially breaking change)
+                        .filter(level => level.label !== 'low')
+                        .sort(sortLevels)
+                        .map(level => ({
+                            ...level,
+                            label: level.label || 'normal',
+                        })),
                 };
                 partial[network.symbol] = {
                     status: 'preloaded',

--- a/suite-common/wallet-core/src/fees/feesUtils.ts
+++ b/suite-common/wallet-core/src/fees/feesUtils.ts
@@ -31,7 +31,7 @@ type GetEip1559AvailabilityProps = {
     feeLevel: FeeLevel;
     device?: TrezorDevice;
 };
-export const getEip1559Availability = ({ symbol, feeLevel, device }: GetEip1559AvailabilityProps) =>
+const getEip1559Availability = ({ symbol, feeLevel, device }: GetEip1559AvailabilityProps) =>
     getNetwork(symbol).features.includes('eip1559') &&
     isEip1559(feeLevel) &&
     !device?.unavailableCapabilities?.['eip1559'];

--- a/suite-common/wallet-core/src/fees/feesUtils.ts
+++ b/suite-common/wallet-core/src/fees/feesUtils.ts
@@ -23,8 +23,8 @@ export const ETHEREUM_ADJUST_GAS_LIMIT = '1.25';
 // TODO: consider to use same order in @trezor/connect to avoid double sorting
 const order: FeeLevel['label'][] = ['low', 'economy', 'normal', 'high'];
 
-export const sortLevels = (levels: FeeLevel[]) =>
-    levels.sort((levelA, levelB) => order.indexOf(levelA.label) - order.indexOf(levelB.label));
+export const sortLevels = (levelA: FeeLevel, levelB: FeeLevel) =>
+    order.indexOf(levelA.label) - order.indexOf(levelB.label);
 
 type GetEip1559AvailabilityProps = {
     symbol: NetworkSymbol;
@@ -111,11 +111,10 @@ export const getNewFeeInfo = async ({
 
     return {
         ...result.payload,
-        levels: sortLevels(
-            result.payload.levels
-                // hack to hide "low" fee option
-                // (we do not want to change the connect API as it is a potentially breaking change)
-                .filter(level => level.label !== 'low'),
-        ),
+        levels: result.payload.levels
+            // hack to hide "low" fee option
+            // (we do not want to change the connect API as it is a potentially breaking change)
+            .filter(level => level.label !== 'low')
+            .sort(sortLevels),
     };
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Random refactoring done during ehtereum libraries cleanup:

- `updateFee` action removed as it was unused
- fee levels sorter improved so it can be passed to `.sort()` function (which is better readable imo)
- `preloadFeeInfoThunk` improved (so there is no unchecked index access and mapping instead of assigning)
- other meaningless changes

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes target the fees infrastructure (feesActions, feesReducer, feesThunks, feesUtils), the SelectFeeModal component, and selectedAccountActions. These are foundational to any transaction-sending flow in Trezor Suite. The highest risk is in tests that directly exercise custom fee settings and verify fee amounts on the device prompt (swap-fees-bitcoin, swap-fees-ethereum, send-eth, send-form-regtest, send-sol). Medium risk extends to all sell/swap/staking flows that display fee information. Since all 6 changed files map to 121 tests each (global dependencies), only tests with concrete fee-related assertions or send-form interactions are recommended.

<details><summary><b>Changed files (6)</b></summary>

- `packages/suite/src/actions/wallet/selectedAccountActions.ts`
- `packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/SelectFeeModal.tsx`
- `suite-common/wallet-core/src/fees/feesActions.ts`
- `suite-common/wallet-core/src/fees/feesReducer.ts`
- `suite-common/wallet-core/src/fees/feesThunks.ts`
- `suite-common/wallet-core/src/fees/feesUtils.ts`

</details>

**Recommended tests (19)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — This test directly exercises custom fee settings for Bitcoin swap transactions, including fee rate display in the confirmation modal and on the device emulator. Changes to SelectFeeModal.tsx, feesReducer, feesThunks, feesUtils, and feesActions directly affect the fee selection and calculation logic exercised here.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — This test directly exercises custom Ethereum fee parameters (gas limit, max fee per gas, max priority fee per gas) through the swap flow and verifies fee display on the device. Changes to the fees module and SelectFeeModal directly impact the custom fee setting and calculation logic tested here.
- `suite/e2e/tests/wallet/send-eth.test.ts` — This test fills in the ETH send form with custom gas fee parameters and verifies fee calculations (gasLimit * maxFeePerGas) on both the UI and device display. The fees module changes (feesUtils, feesThunks, feesReducer) and SelectFeeModal directly govern the fee logic exercised here.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test exercises BTC send form functionality including filling amounts, adding/removing outputs, locktime, and confirming transactions — all of which depend on fee estimation and the fees Redux state. Changes to feesReducer/feesThunks affect how fees are fetched and stored for the send form.
- `suite/e2e/tests/wallet/send-sol.test.ts` — This test exercises sending SOL with max amount calculation that deducts fees and network reserve, then verifies fee display on the device prompt. The fee calculation relies on feesUtils/feesThunks and the fee state managed by feesReducer.

</details>

<details><summary>🟡 <b>Medium priority (11)</b></summary>

- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — This test confirms a sell BTC transaction including device prompt verification of fee amounts. The fee calculation for the Bitcoin send transaction depends on the fees module. Changes to fee fetching/calculation could cause fee display mismatches.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — This test exercises selling ETH with custom gas fee settings and verifies fee display on the device prompt. The custom Ethereum fee parameters flow through the fees module and SelectFeeModal.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — This test validates sell form input behavior including custom fee rate settings and the Max button calculation that subtracts fees from balance. Fee calculation changes in feesUtils/feesThunks could affect the max amount computation.
- `suite/e2e/tests/trading/sell-solana.test.ts` — This test verifies Solana sell flow including fee resolution (max fee visibility) and device prompt fee display. Fee state changes could affect whether fees resolve correctly and the amounts shown.
- `suite/e2e/tests/wallet/send-doge.test.ts` — This test sends DOGE and verifies fee display on the device prompt. The fee calculation depends on the fees module, and changes to feesReducer/feesThunks could affect the fee amount shown for DOGE transactions.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — This test exercises sending LTC with a MimbleWimble peg-out UTXO through the send form. Fee estimation for LTC depends on the fees module, and changes to fee fetching could affect whether the transaction composes successfully.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test verifies ETH staking including fee display on the device prompt ('0.000290278609719 ETH'). The fee calculation for the staking transaction flows through the fees module, and changes could affect displayed fee amounts.
- `suite/e2e/tests/staking/staking-form.test.ts` — This test validates the ETH staking form including Max button behavior that subtracts a withdrawal buffer, and validates amounts against balances. Fee state from feesReducer affects form validation and available balance calculations.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — This test sells an ERC-20 token (USDC) and verifies fee display on the device prompt. Ethereum fee calculation changes in the fees module could affect the fee amount shown during token sell confirmation.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — This test swaps SOL to USDC and verifies the fee amount is greater than 0 on the device prompt. Fee fetching changes in feesThunks could affect whether fees are properly retrieved for Solana swap transactions.
- `suite/e2e/tests/trading/swap-coins.test.ts` — This test swaps SOL to BTC and verifies fee display on the hardware device. Fee state from the fees module is used to compose the swap transaction and display fee information.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/staking/ada/stake.test.ts` — This test stakes ADA and verifies fee display on device. While Cardano fee calculation may differ from BTC/ETH, the fee state is still managed by the shared fees module, so changes to feesReducer could affect fee display.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — This test performs SOL staking and verifies fee display. The fee for Solana transactions is fetched via the fees module, so changes to fee fetching logic could affect displayed fee values.
- `suite/e2e/tests/wallet/import-btc-csv.test.ts` — This test imports a CSV into the BTC send form and populates outputs. The send form depends on fee state from the fees module to be functional, so fee fetching changes could prevent the form from loading correctly.

</details>

_Updated: 2026-06-05T08:49:30.963Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/eth-general-cleanup&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/eth-general-cleanup&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/eth-general-cleanup&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-05T08:54:07.558Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-05T08:52:16.967Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/eth-general-cleanup/web/](https://dev.suite.sldev.cz/suite-web/chore/eth-general-cleanup/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->