### PR TITLE
Add Solana claim flow

### DIFF
--- a/suite-native/module-earn/src/components/ClaimTransactionDataReviewStepList.tsx
+++ b/suite-native/module-earn/src/components/ClaimTransactionDataReviewStepList.tsx
@@ -6,6 +6,7 @@ import { type RouteProp, useRoute } from '@react-navigation/native';
 
 import { getNetworkDecimals } from '@suite-common/wallet-config';
 import { type AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
+import { isSupportedSolStakingNetworkSymbol } from '@suite-common/wallet-utils';
 import { Button, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { type RootStackParamList, type RootStackRoutes } from '@suite-native/navigation';
@@ -25,6 +26,7 @@ import { BigNumber } from '@trezor/utils';
 
 import { ClaimOutputItem } from './ClaimOutputItem';
 import { ClaimSummaryOutputItem } from './ClaimSummaryOutputItem';
+import { useEarnSelectedPrecomposedTransaction } from '../hooks/useEarnSelectedPrecomposedTransaction';
 import { useHandleOnClaimTransactionReview } from '../hooks/useHandleOnClaimTransactionReview';
 
 const NUMBER_OF_STEPS = 2;
@@ -57,6 +59,8 @@ export const ClaimTransactionDataReviewStepList = ({
         selectClaimableAmountByAccountKey(state, accountKey),
     );
 
+    const precomposedTransaction = useEarnSelectedPrecomposedTransaction('claim', accountKey);
+
     const [stepIndex, setStepIndex] = useState(0);
 
     const { activeStepBottomOffset, handleReadListItemHeight } = useActiveStepOffset(stepIndex);
@@ -77,9 +81,18 @@ export const ClaimTransactionDataReviewStepList = ({
     };
 
     const networkDecimals = accountSymbol ? (getNetworkDecimals(accountSymbol) ?? 18) : 18;
-    const claimableAmountInWei = new BigNumber(claimableAmount || '0')
-        .times(new BigNumber(10).pow(networkDecimals))
-        .toFixed(0);
+    const isSolanaClaim = !!accountSymbol && isSupportedSolStakingNetworkSymbol(accountSymbol);
+
+    // Solana: show composed lamports (totalSpent − fee)
+    // Ethereum: show claimable amount (calldata-only)
+    const claimableAmountInWei =
+        isSolanaClaim && precomposedTransaction
+            ? new BigNumber(precomposedTransaction.totalSpent)
+                  .minus(precomposedTransaction.fee)
+                  .toFixed(0)
+            : new BigNumber(claimableAmount || '0')
+                  .times(new BigNumber(10).pow(networkDecimals))
+                  .toFixed(0);
 
     return (
         <View>

--- a/suite-native/module-earn/src/components/EarnAccountCard.tsx
+++ b/suite-native/module-earn/src/components/EarnAccountCard.tsx
@@ -2,7 +2,7 @@ import { useSelector } from 'react-redux';
 
 import { selectIsPortfolioTrackerDevice } from '@suite-common/device';
 import { getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
-import { isSupportedEthStakingNetworkSymbol } from '@suite-common/wallet-utils';
+import { isSupportedStakingNetworkSymbol } from '@suite-common/wallet-utils';
 import { AccountTypeBadge } from '@suite-native/accounts';
 import { Box, Card, PressableOpacity, Text, VStack } from '@suite-native/atoms';
 import { CryptoIconWithNetwork, Icon } from '@suite-native/icons';
@@ -65,7 +65,7 @@ export const EarnAccountCard = ({ item, onPress, onClaimPress }: EarnAccountCard
     const { applyStyle } = useNativeStyles();
     const isStakingItem = item.type === 'staking';
     const isStablecoinYieldItem = item.type === 'stablecoin-yield';
-    const isSupportedStaking = isStakingItem && isSupportedEthStakingNetworkSymbol(item.symbol);
+    const isSupportedStaking = isStakingItem && isSupportedStakingNetworkSymbol(item.symbol);
     const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
 
     const apy = useStakingSelector(state =>

--- a/suite-native/module-earn/src/components/EarnActiveItemsBottomSheet.tsx
+++ b/suite-native/module-earn/src/components/EarnActiveItemsBottomSheet.tsx
@@ -5,6 +5,7 @@ import { useNavigation } from '@react-navigation/native';
 import { FlashList } from '@shopify/flash-list';
 
 import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
+import { isSupportedSolStakingNetworkSymbol } from '@suite-common/wallet-utils';
 import { BottomSheetModal, type BottomSheetModalRef, Box } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
@@ -25,6 +26,7 @@ type EarnActiveItemsBottomSheetProps = {
     type: EarnDepositsCardActiveItem['type'];
     items: EarnDepositsCardActiveItem[];
     onClose: () => void;
+    onSolanaClaimPress?: () => void;
 };
 
 export const EarnActiveItemsBottomSheet = ({
@@ -32,6 +34,7 @@ export const EarnActiveItemsBottomSheet = ({
     type,
     items,
     onClose,
+    onSolanaClaimPress,
 }: EarnActiveItemsBottomSheetProps) => {
     const navigation = useNavigation<NavigationProp>();
     const { navigateToStakingDetail } = useStakingDetailNavigation();
@@ -80,13 +83,22 @@ export const EarnActiveItemsBottomSheet = ({
         (item: EarnDepositsCardActiveItem) => {
             if (item.type !== 'staking') return;
 
+            // Temporary: claiming Solana rewards is not yet available in the mobile app,
+            // so we point users to Trezor Suite desktop instead of opening the claim flow.
+            if (isSupportedSolStakingNetworkSymbol(item.symbol)) {
+                onClose();
+                onSolanaClaimPress?.();
+
+                return;
+            }
+
             onClose();
             navigation.navigate(RootStackRoutes.ClaimReview, {
                 accountKey: item.accountKey,
                 symbol: item.symbol,
             });
         },
-        [navigation, onClose],
+        [navigation, onClose, onSolanaClaimPress],
     );
 
     const renderItem = useCallback(

--- a/suite-native/module-earn/src/components/EarnDepositsCard.tsx
+++ b/suite-native/module-earn/src/components/EarnDepositsCard.tsx
@@ -14,6 +14,7 @@ import { useEarnDepositsCardData } from '../hooks/useEarnDepositsCardData';
 import { type StablecoinYieldEarnItem, type StakingEarnItem } from '../types';
 import { EarnActiveItemsBottomSheet } from './EarnActiveItemsBottomSheet';
 import { EarnDepositsCardRow } from './EarnDepositsCardRow';
+import { EarnItemInfoModal } from './EarnItemInfoModal';
 
 const cardHeaderStyle = prepareNativeStyle(utils => ({
     padding: utils.spacings.sp16,
@@ -46,6 +47,9 @@ export const EarnDepositsCard = ({
         closeModal: closeStablecoinYieldSheet,
         openModal: openStablecoinYieldSheet,
     } = useBottomSheetModal();
+
+    const { bottomSheetRef: stakingInfoSheetRef, openModal: openStakingInfoModal } =
+        useBottomSheetModal();
 
     return (
         <>
@@ -88,6 +92,7 @@ export const EarnDepositsCard = ({
                 type="staking"
                 items={stakingRow?.activeItems ?? []}
                 onClose={closeStakingSheet}
+                onSolanaClaimPress={openStakingInfoModal}
             />
             <EarnActiveItemsBottomSheet
                 ref={stablecoinYieldSheetRef}
@@ -95,6 +100,8 @@ export const EarnDepositsCard = ({
                 items={stablecoinYieldRow?.activeItems ?? []}
                 onClose={closeStablecoinYieldSheet}
             />
+
+            <EarnItemInfoModal ref={stakingInfoSheetRef} type="staking" />
         </>
     );
 };

--- a/suite-native/module-earn/src/components/StakeClaimableCard.tsx
+++ b/suite-native/module-earn/src/components/StakeClaimableCard.tsx
@@ -5,8 +5,19 @@ import { useNavigation } from '@react-navigation/native';
 import { BASE_CRYPTO_MAX_DISPLAYED_DECIMALS } from '@suite-common/formatters';
 import { selectAccountNetworkSymbol, useAccountsSelector } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
-import { isPositiveBalance, isSupportedEthStakingNetworkSymbol } from '@suite-common/wallet-utils';
-import { Box, Card, InlineAlertBox, PressableOpacity, Text } from '@suite-native/atoms';
+import {
+    isPositiveBalance,
+    isSupportedSolStakingNetworkSymbol,
+    isSupportedStakingNetworkSymbol,
+} from '@suite-common/wallet-utils';
+import {
+    Box,
+    Card,
+    InlineAlertBox,
+    PressableOpacity,
+    Text,
+    useBottomSheetModal,
+} from '@suite-native/atoms';
 import { CryptoAmountFormatter, CryptoToFiatAmountFormatter } from '@suite-native/formatters';
 import { Translation } from '@suite-native/intl';
 import {
@@ -20,6 +31,7 @@ import {
 } from '@suite-native/staking';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
+import { EarnItemInfoModal } from './EarnItemInfoModal';
 import { useMessageSystemStaking } from '../hooks/useMessageSystemStaking';
 
 type StakeClaimableCardProps = {
@@ -52,53 +64,66 @@ export const StakeClaimableCard = ({ accountKey }: StakeClaimableCardProps) => {
 
     const { isClaimingDisabled, claimingMessageContent } = useMessageSystemStaking(symbol);
 
+    const { bottomSheetRef: infoSheetRef, openModal: openInfoModal } = useBottomSheetModal();
+
     const handlePress = useCallback(() => {
         if (!symbol || isClaimingDisabled) {
             return;
         }
+
+        // Temporary: claiming Solana rewards is not yet available in the mobile app
+        if (isSupportedSolStakingNetworkSymbol(symbol)) {
+            openInfoModal();
+
+            return;
+        }
+
         navigation.navigate(RootStackRoutes.ClaimReview, { accountKey, symbol });
-    }, [accountKey, navigation, symbol, isClaimingDisabled]);
+    }, [accountKey, navigation, symbol, isClaimingDisabled, openInfoModal]);
 
     if (
         !symbol ||
         !isPositiveBalance(claimableAmount) ||
-        !isSupportedEthStakingNetworkSymbol(symbol)
+        !isSupportedStakingNetworkSymbol(symbol)
     ) {
         return null;
     }
 
     return (
-        <PressableOpacity onPress={handlePress} disabled={isClaimingDisabled}>
-            <Card>
-                <Box style={applyStyle(stakingItemStyle)}>
-                    <Box flex={1}>
-                        <Text>
-                            <Translation id="earn.claimableCard.claimable" />
-                        </Text>
-                    </Box>
-                    <Box style={applyStyle(valuesContainerStyle)}>
-                        <CryptoAmountFormatter
-                            value={claimableAmount}
-                            symbol={symbol}
-                            decimals={BASE_CRYPTO_MAX_DISPLAYED_DECIMALS}
-                            color="contentPrimary"
-                            variant="body-md-strong"
-                        />
-                        <Box flexDirection="row">
-                            <Text color="contentSecondary">≈</Text>
-                            <CryptoToFiatAmountFormatter
+        <>
+            <PressableOpacity onPress={handlePress} disabled={isClaimingDisabled}>
+                <Card>
+                    <Box style={applyStyle(stakingItemStyle)}>
+                        <Box flex={1}>
+                            <Text>
+                                <Translation id="earn.claimableCard.claimable" />
+                            </Text>
+                        </Box>
+                        <Box style={applyStyle(valuesContainerStyle)}>
+                            <CryptoAmountFormatter
                                 value={claimableAmount}
                                 symbol={symbol}
-                                color="contentSecondary"
-                                isBalance
+                                decimals={BASE_CRYPTO_MAX_DISPLAYED_DECIMALS}
+                                color="contentPrimary"
+                                variant="body-md-strong"
                             />
+                            <Box flexDirection="row">
+                                <Text color="contentSecondary">≈</Text>
+                                <CryptoToFiatAmountFormatter
+                                    value={claimableAmount}
+                                    symbol={symbol}
+                                    color="contentSecondary"
+                                    isBalance
+                                />
+                            </Box>
                         </Box>
                     </Box>
-                </Box>
-                {isClaimingDisabled && claimingMessageContent && (
-                    <InlineAlertBox variant="warning" title={claimingMessageContent} />
-                )}
-            </Card>
-        </PressableOpacity>
+                    {isClaimingDisabled && claimingMessageContent && (
+                        <InlineAlertBox variant="warning" title={claimingMessageContent} />
+                    )}
+                </Card>
+            </PressableOpacity>
+            <EarnItemInfoModal ref={infoSheetRef} type="staking" />
+        </>
     );
 };

--- a/suite-native/module-earn/src/screens/ClaimReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/ClaimReviewScreen.tsx
@@ -4,16 +4,14 @@ import { useSelector } from 'react-redux';
 import { type RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 
 import { useServices } from '@suite-common/dependency-injection';
-import {
-    buildClaimWithdrawRequestData,
-    getEthereumStakingAddressByType,
-} from '@suite-common/staking';
+import { buildClaimWithdrawRequestData, getStakingContractAddress } from '@suite-common/staking';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
 import {
     asAmountSubunit,
     getStakingLimitsByNetworkSymbol,
     isSupportedEthStakingNetworkSymbol,
+    isSupportedSolStakingNetworkSymbol,
     subunitsToUnits,
 } from '@suite-common/wallet-utils';
 import { AccountDetailsCard } from '@suite-native/accounts';
@@ -52,10 +50,10 @@ export const ClaimReviewScreen = () => {
     const claimableAmount = useSelector((state: NativeStakingRootState) =>
         selectClaimableAmountByAccountKey(state, accountKey),
     );
-    const availableBalance = useSelector(
-        (state: AccountsRootState) =>
-            selectAccountByKey(state, accountKey)?.availableBalance ?? '0',
+    const account = useSelector((state: AccountsRootState) =>
+        selectAccountByKey(state, accountKey),
     );
+    const availableBalance = account?.availableBalance ?? '0';
 
     const feeBuffer = getStakingLimitsByNetworkSymbol(symbol)?.MIN_BALANCE_FOR_FEE_BUFFER;
     const availableBalanceInUnits = subunitsToUnits({
@@ -65,15 +63,22 @@ export const ClaimReviewScreen = () => {
     const isInsufficientFeeBalance = !!feeBuffer && availableBalanceInUnits.lt(feeBuffer);
     const formattedAvailableBalance = `${availableBalanceInUnits.toString()} ${displaySymbol}`;
 
-    const claimFormState = useMemo(
-        () =>
-            buildEarnComposeFormState(
-                getEthereumStakingAddressByType(symbol, 'claim'),
-                '0',
-                buildClaimWithdrawRequestData(),
-            ),
-        [symbol],
-    );
+    const claimFormState = useMemo(() => {
+        if (!account) return undefined;
+
+        const contractAddress = getStakingContractAddress(account, 'claim');
+
+        // Ethereum claims via calldata, Solana via the claimable amount.
+        if (account.networkType === 'ethereum') {
+            return buildEarnComposeFormState(contractAddress, '0', buildClaimWithdrawRequestData());
+        }
+
+        if (account.networkType === 'solana') {
+            return buildEarnComposeFormState(contractAddress, claimableAmount ?? '0', '');
+        }
+
+        return buildEarnComposeFormState(contractAddress, '0', '');
+    }, [account, claimableAmount]);
 
     const { formDraft, formDraftKey, isFeeUnavailable, isPrecomposeError, updateFeeLevelThunk } =
         useComposeEarnFees({
@@ -125,10 +130,14 @@ export const ClaimReviewScreen = () => {
                     <Button
                         onPress={handleReviewAndSign}
                         isDisabled={
+                            !claimFormState ||
                             isInsufficientFeeBalance ||
                             isFeeUnavailable ||
                             isPrecomposeError ||
-                            !isSupportedEthStakingNetworkSymbol(symbol)
+                            !(
+                                isSupportedEthStakingNetworkSymbol(symbol) ||
+                                isSupportedSolStakingNetworkSymbol(symbol)
+                            )
                         }
                     >
                         <Translation id="earn.claimReviewScreen.reviewAndSignButton" />

--- a/suite-native/staking/src/__tests__/stakeFormSolanaNativeThunks.test.ts
+++ b/suite-native/staking/src/__tests__/stakeFormSolanaNativeThunks.test.ts
@@ -38,32 +38,26 @@ const solanaTxShim = {
     addSignature: jest.fn(),
 };
 
+const solanaTxMetaMock = {
+    deviceAmountLamports: '1000000000',
+    feeLamports: '5000',
+    rentLamports: '2282880',
+    feeIncludingRentLamports: '2287880',
+};
+
+const prepareStakeSolTxMock = jest.fn();
+const prepareUnstakeSolTxMock = jest.fn();
+const prepareClaimSolTxMock = jest.fn();
+
 jest.mock('@trezor/coins-solana/runtime', () => ({
     __esModule: true,
     default: () =>
         Promise.resolve({
             selectSolanaConnection: jest.fn().mockReturnValue({}),
             selectSolanaValidator: jest.fn().mockReturnValue('validatorAddress'),
-            prepareStakeSolTx: jest.fn().mockResolvedValue({
-                success: true,
-                txShim: solanaTxShim,
-                solanaTxMeta: {
-                    deviceAmountLamports: '1000000000',
-                    feeLamports: '5000',
-                    rentLamports: '2282880',
-                    feeIncludingRentLamports: '2287880',
-                },
-            }),
-            prepareUnstakeSolTx: jest.fn().mockResolvedValue({
-                success: true,
-                txShim: solanaTxShim,
-                solanaTxMeta: {
-                    deviceAmountLamports: '1000000000',
-                    feeLamports: '5000',
-                    rentLamports: '2282880',
-                    feeIncludingRentLamports: '2287880',
-                },
-            }),
+            prepareStakeSolTx: prepareStakeSolTxMock,
+            prepareUnstakeSolTx: prepareUnstakeSolTxMock,
+            prepareClaimSolTx: prepareClaimSolTxMock,
             address: (value: string) => value,
         }),
 }));
@@ -180,6 +174,25 @@ beforeEach(() => {
         payload: { signature: 'ed25519signature' },
     });
     solanaTxShim.addSignature.mockClear();
+
+    prepareStakeSolTxMock.mockReset();
+    prepareStakeSolTxMock.mockResolvedValue({
+        success: true,
+        txShim: solanaTxShim,
+        solanaTxMeta: solanaTxMetaMock,
+    });
+    prepareUnstakeSolTxMock.mockReset();
+    prepareUnstakeSolTxMock.mockResolvedValue({
+        success: true,
+        txShim: solanaTxShim,
+        solanaTxMeta: solanaTxMetaMock,
+    });
+    prepareClaimSolTxMock.mockReset();
+    prepareClaimSolTxMock.mockResolvedValue({
+        success: true,
+        txShim: solanaTxShim,
+        solanaTxMeta: solanaTxMetaMock,
+    });
 });
 
 describe('composeSolanaStakingTransactionFeeLevelsNativeThunk', () => {
@@ -225,7 +238,7 @@ describe('composeSolanaStakingTransactionFeeLevelsNativeThunk', () => {
         expect(levels.normal.solanaTxMeta.feeIncludingRentLamports).toBe('2287880');
     });
 
-    it('rejects claim (out of scope on mobile)', async () => {
+    it('composes a claim through prepareClaimSolTx (not the stake builder)', async () => {
         const store = buildStore();
 
         const result = await dispatchCompose(store, {
@@ -234,13 +247,11 @@ describe('composeSolanaStakingTransactionFeeLevelsNativeThunk', () => {
             amount: '1',
         });
 
-        expect(result).toEqual({
-            ok: false,
-            error: {
-                error: 'not-implemented',
-                message: 'Solana claim is not supported on mobile.',
-            },
-        });
+        expect(result.ok).toBe(true);
+        const levels = (result as { payload: Record<string, any> }).payload;
+        expect(levels.normal.type).toBe('final');
+        expect(prepareClaimSolTxMock).toHaveBeenCalled();
+        expect(prepareStakeSolTxMock).not.toHaveBeenCalled();
     });
 
     it('returns precomposed fee levels with the solana tx meta applied', async () => {
@@ -311,5 +322,86 @@ describe('signSolanaStakingTransactionNativeThunk', () => {
 
         expect(result.ok).toBe(false);
         expect((result as { error: { message: string } }).error.message).toBe('tx-cancelled');
+    });
+
+    it('signs and pushes a solana unstake, forwarding the composed amount', async () => {
+        const store = buildStore();
+
+        const result = await dispatchSign(store, {
+            accountKey: SOL_ACCOUNT_KEY,
+            stakeType: 'unstake',
+            precomposedTransaction: buildSolanaPrecomposedTransaction(),
+        });
+
+        expect(result).toEqual({ ok: true, txid: 'solanaTxId' });
+        // Unstake must route through prepareUnstakeSolTx with a non-zero amount.
+        expect(prepareUnstakeSolTxMock).toHaveBeenCalledTimes(1);
+        expect(prepareUnstakeSolTxMock.mock.calls[0][0].amount).not.toBe('0');
+        expect(prepareStakeSolTxMock).not.toHaveBeenCalled();
+        expect(prepareClaimSolTxMock).not.toHaveBeenCalled();
+    });
+
+    it('signs, serializes and pushes a solana claim transaction', async () => {
+        const store = buildStore();
+
+        const result = await dispatchSign(store, {
+            accountKey: SOL_ACCOUNT_KEY,
+            stakeType: 'claim',
+            precomposedTransaction: buildSolanaPrecomposedTransaction(),
+        });
+
+        expect(result).toEqual({ ok: true, txid: 'solanaTxId' });
+        // Claim must route through prepareClaimSolTx, never the stake builder.
+        expect(prepareClaimSolTxMock).toHaveBeenCalledTimes(1);
+        expect(prepareStakeSolTxMock).not.toHaveBeenCalled();
+        expect(solanaSignTransactionMock).toHaveBeenCalledTimes(1);
+        expect(solanaTxShim.addSignature).toHaveBeenCalledWith(
+            solAccount.descriptor,
+            'ed25519signature',
+        );
+    });
+
+    it('rejects a stake whose composed amount is zero', async () => {
+        // A zero amount would sign a stake that moves nothing, so it must be rejected upfront
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const store = buildStore();
+        const precomposedTransaction = {
+            ...buildSolanaPrecomposedTransaction(),
+            outputs: [{ address: solAccount.descriptor, amount: '0', script_type: 'PAYTOADDRESS' }],
+        } as unknown as PrecomposedTransactionFinal;
+
+        const result = await dispatchSign(store, {
+            accountKey: SOL_ACCOUNT_KEY,
+            stakeType: 'stake',
+            precomposedTransaction,
+        });
+
+        expect(result).toEqual({
+            ok: false,
+            error: {
+                error: 'sign-transaction-failed',
+                message: 'Compose result for stake is missing the amount.',
+            },
+        });
+        expect(prepareStakeSolTxMock).not.toHaveBeenCalled();
+        errorSpy.mockRestore();
+    });
+
+    it('signs a claim and ignores the composed amount', async () => {
+        const store = buildStore();
+        const precomposedTransaction = {
+            ...buildSolanaPrecomposedTransaction(),
+            outputs: [{ address: solAccount.descriptor, amount: '0', script_type: 'PAYTOADDRESS' }],
+        } as unknown as PrecomposedTransactionFinal;
+
+        const result = await dispatchSign(store, {
+            accountKey: SOL_ACCOUNT_KEY,
+            stakeType: 'claim',
+            precomposedTransaction,
+        });
+
+        expect(result).toEqual({ ok: true, txid: 'solanaTxId' });
+        expect(prepareClaimSolTxMock).toHaveBeenCalledTimes(1);
+        expect(prepareClaimSolTxMock.mock.calls[0][0]).not.toHaveProperty('amount');
     });
 });

--- a/suite-native/staking/src/stakeFormSolanaNativeThunks.ts
+++ b/suite-native/staking/src/stakeFormSolanaNativeThunks.ts
@@ -67,13 +67,10 @@ const buildSolanaStakeFormState = (
     stakeType,
 });
 
-// Resolves the Solana staking account (mainnet + devnet) and the backend URL needed to  build the transaction.
-// Solana stake and unstake are supported on mobile
 const resolveSolanaStakingContext = (
     state: Parameters<typeof selectAccountByKey>[0] &
         Parameters<typeof selectNetworkBlockchainInfo>[0],
     accountKey: AccountKey,
-    stakeType: StakeNativeType,
 ):
     | { success: true; account: SolanaAccount; blockchainUrl: string }
     | { success: false; error: string; message?: string } => {
@@ -92,14 +89,6 @@ const resolveSolanaStakingContext = (
             success: false,
             error: 'sign-transaction-failed',
             message: `Staking is not supported for Solana network: ${account.symbol}`,
-        };
-    }
-
-    if (stakeType === 'claim') {
-        return {
-            success: false,
-            error: 'not-implemented',
-            message: `Solana ${stakeType} is not supported on mobile.`,
         };
     }
 
@@ -124,7 +113,7 @@ export const composeSolanaStakingTransactionFeeLevelsNativeThunk = createThunk<
     async ({ accountKey, stakeType, amount }, { getState, rejectWithValue }) => {
         if (!amount || amount === '0') return undefined;
 
-        const resolved = resolveSolanaStakingContext(getState(), accountKey, stakeType);
+        const resolved = resolveSolanaStakingContext(getState(), accountKey);
         if (!resolved.success) {
             return rejectWithValue({ error: resolved.error, message: resolved.message });
         }
@@ -162,7 +151,7 @@ export const signSolanaStakingTransactionNativeThunk = createThunk<
         { dispatch, getState, rejectWithValue },
     ) => {
         try {
-            const resolved = resolveSolanaStakingContext(getState(), accountKey, stakeType);
+            const resolved = resolveSolanaStakingContext(getState(), accountKey);
             if (!resolved.success) {
                 console.error(`${SIGN_LOG_PREFIX}: ${resolved.message}`);
 
@@ -174,18 +163,19 @@ export const signSolanaStakingTransactionNativeThunk = createThunk<
 
             const { account, blockchainUrl } = resolved;
 
-            const composedAmount = precomposedTransaction.outputs?.[0]?.amount;
-            if (!composedAmount || new BigNumber(composedAmount).isLessThanOrEqualTo(0)) {
-                const message = 'Compose result for stake is missing the amount.';
-                console.error(`${SIGN_LOG_PREFIX}: ${message}`);
+            let amount = '0';
 
-                return rejectWithValue({ error: 'sign-transaction-failed', message });
+            if (stakeType !== 'claim') {
+                const composedAmount = precomposedTransaction.outputs?.[0]?.amount;
+                if (!composedAmount || new BigNumber(composedAmount).isLessThanOrEqualTo(0)) {
+                    const message = `Compose result for ${stakeType} is missing the amount.`;
+                    console.error(`${SIGN_LOG_PREFIX}: ${message}`);
+
+                    return rejectWithValue({ error: 'sign-transaction-failed', message });
+                }
+
+                amount = formatNetworkAmount(String(composedAmount), account.symbol);
             }
-            // precomposedTransaction.outputs[0].amount is in lamports (compose runs the form
-            // amount through getExternalComposeOutput → convertAmountUnitsToSubunits). The
-            // staking runtime expects decimal SOL because prepareStakeSolTx calls toLamports
-            // internally, so convert back here to avoid a 10^9× device amount.
-            const amount = formatNetworkAmount(String(composedAmount), account.symbol);
 
             const estimatedFee: Fee = {
                 feePerTx:


### PR DESCRIPTION
## Description

Adds the Solana staking claim flow to the native (mobile) app, reusing the existing network-agnostic claim screens with Solana-specific transaction composition, signing, and amount handling. For now, the two Solana claim entry points — the "Your stakes" sheet on the Earn dashboard and the staking dashboard's claimable card — open the "Manage staking in Trezor Suite for desktop" info modal instead of starting the flow, so users are directed to desktop until claiming is enabled on mobile. Ethereum claiming is unaffected.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/28030

## Screenshots:
<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 16 Plus - 2026-06-05 at 11 22 34" src="https://github.com/user-attachments/assets/41978fe3-6f70-42b8-ac07-53a42470e45d" />
