### PR TITLE
Fix/native/graph rerendering

### DIFF
--- a/suite-common/wallet-core/src/discovery/discoverySelectors.ts
+++ b/suite-common/wallet-core/src/discovery/discoverySelectors.ts
@@ -13,6 +13,10 @@ export const selectDiscoveryForSelectedDevice = (state: DiscoveryRootState & Dev
     return selectDiscoveryByDevicePath(state, selectedDevice?.path);
 };
 
+export const selectDiscoveryStartTimestampForSelectedDevice = (
+    state: DiscoveryRootState & DeviceRootState,
+) => selectDiscoveryForSelectedDevice(state)?.startTimestamp;
+
 export function isDiscoveryInProgress(
     discovery?: DiscoveryStatus,
 ): discovery is Exclude<

--- a/suite-native/discovery/src/useIsDiscoveryDurationTooLong.tsx
+++ b/suite-native/discovery/src/useIsDiscoveryDurationTooLong.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import {
-    selectDiscoveryForSelectedDevice,
+    selectDiscoveryStartTimestampForSelectedDevice,
     selectHasRunningDiscovery,
 } from '@suite-common/wallet-core';
 import { type IntervalId } from '@trezor/type-utils';
@@ -11,17 +11,16 @@ const DISCOVERY_LENGTH_CHECK_INTERVAL = 1_000;
 const DISCOVERY_DURATION_THRESHOLD = 50_000;
 
 export const useIsDiscoveryDurationTooLong = () => {
-    const discovery = useSelector(selectDiscoveryForSelectedDevice);
+    const discoveryStartTimestamp = useSelector(selectDiscoveryStartTimestampForSelectedDevice);
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
 
     const [loadingTakesLongerThanExpected, setLoadingTakesLongerThanExpected] = useState(false);
 
     useEffect(() => {
         let interval: IntervalId;
-        const startTimestamp = discovery?.startTimestamp;
-        if (isDiscoveryRunning && startTimestamp !== undefined) {
+        if (isDiscoveryRunning && discoveryStartTimestamp !== undefined) {
             interval = setInterval(() => {
-                if (Date.now() - startTimestamp > DISCOVERY_DURATION_THRESHOLD) {
+                if (Date.now() - discoveryStartTimestamp > DISCOVERY_DURATION_THRESHOLD) {
                     setLoadingTakesLongerThanExpected(true);
                     clearInterval(interval);
                 }
@@ -35,7 +34,7 @@ export const useIsDiscoveryDurationTooLong = () => {
                 clearInterval(interval);
             }
         };
-    }, [discovery, isDiscoveryRunning]);
+    }, [discoveryStartTimestamp, isDiscoveryRunning]);
 
     return loadingTakesLongerThanExpected;
 };

--- a/suite-native/graph/src/hooks.ts
+++ b/suite-native/graph/src/hooks.ts
@@ -32,7 +32,6 @@ import {
     selectAccountGraphTimeframe,
     selectPortfolioGraphTimeframe,
     setAccountGraphTimeframe,
-    setPortfolioGraphTimeframe,
 } from './slice';
 import { type TimeframeHoursValue } from './types';
 import { omitErrorMessageSensitiveData } from './utils';
@@ -156,7 +155,6 @@ export const useGraphForSingleAccount = ({
 };
 
 export const useGraphForAllDeviceAccounts = ({ baseCurrencyCode }: CommonUseGraphParams) => {
-    const dispatch = useDispatch();
     // Use deep comparison because account items are rebuilt from account data.
     const accountItems = useSelectorDeepComparison(
         selectPortfolioGraphAccountItemsIfDiscoveryIsNotRunning,
@@ -168,15 +166,6 @@ export const useGraphForAllDeviceAccounts = ({ baseCurrencyCode }: CommonUseGrap
 
     const { startOfTimeFrameDate, endOfTimeFrameDate } =
         useGetTimeFrameForHistoryHours(portfolioGraphTimeframe);
-
-    const handleSelectPortfolioTimeframe = useCallback(
-        (timeframeHours: TimeframeHoursValue) => {
-            if (portfolioGraphTimeframe !== timeframeHours) {
-                dispatch(setPortfolioGraphTimeframe({ timeframeHours }));
-            }
-        },
-        [dispatch, portfolioGraphTimeframe],
-    );
 
     useWatchTimeframeChangeForAnalytics(portfolioGraphTimeframe);
 
@@ -195,7 +184,6 @@ export const useGraphForAllDeviceAccounts = ({ baseCurrencyCode }: CommonUseGrap
         ...graphForAccounts,
         isAnyMainnetAccountPresent: A.isNotEmpty(accountItems),
         timeframe: portfolioGraphTimeframe,
-        onSelectTimeFrame: handleSelectPortfolioTimeframe,
     };
 };
 

--- a/suite-native/graph/src/hooks.ts
+++ b/suite-native/graph/src/hooks.ts
@@ -26,7 +26,7 @@ import { tryGetAccountIdentity } from '@suite-common/wallet-utils';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 
 import { timeSwitchItems } from './components/TimeSwitch';
-import { selectPortfolioGraphAccountItems } from './selectors';
+import { selectPortfolioGraphAccountItemsIfDiscoveryIsNotRunning } from './selectors';
 import {
     type GraphSliceRootState,
     selectAccountGraphTimeframe,
@@ -157,8 +157,10 @@ export const useGraphForSingleAccount = ({
 
 export const useGraphForAllDeviceAccounts = ({ baseCurrencyCode }: CommonUseGraphParams) => {
     const dispatch = useDispatch();
-    // if we memoize selectPortfolioGraphAccountItems, it will randomly break so we need to use deep comparison instead to prevent unnecessary rerenders
-    const accountItems = useSelectorDeepComparison(selectPortfolioGraphAccountItems);
+    // Use deep comparison because account items are rebuilt from account data.
+    const accountItems = useSelectorDeepComparison(
+        selectPortfolioGraphAccountItemsIfDiscoveryIsNotRunning,
+    );
     const portfolioGraphTimeframe = useSelector(selectPortfolioGraphTimeframe);
     const isElectrumBackend = useSelector((state: BlockchainRootState) =>
         selectIsElectrumBackendSelected(state, 'btc'),

--- a/suite-native/graph/src/index.ts
+++ b/suite-native/graph/src/index.ts
@@ -5,3 +5,4 @@ export * from './hooks';
 export * from './slice';
 export * from './selectors';
 export * from './components/GraphBaseCurrencyBalance';
+export { type TimeframeHoursValue } from './types';

--- a/suite-native/graph/src/selectors.ts
+++ b/suite-native/graph/src/selectors.ts
@@ -2,7 +2,7 @@ import { A } from '@mobily/ts-belt';
 
 import type { DeviceRootState } from '@suite-common/device';
 import { type AccountItem, isIgnoredBalanceHistoryCoin } from '@suite-common/graph';
-import { createWeakMapSelector } from '@suite-common/redux-utils';
+import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import {
     type TokenDefinitionsRootState,
     selectFilterKnownTokens,
@@ -10,13 +10,16 @@ import {
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
+    type DiscoveryRootState,
     selectAccountByKey,
     selectDeviceMainnetAccounts,
+    selectHasRunningDiscovery,
 } from '@suite-common/wallet-core';
 import { type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
 import { tryGetAccountIdentity } from '@suite-common/wallet-utils';
 
 type GraphCommonRootState = DeviceRootState & AccountsRootState & TokenDefinitionsRootState;
+type PortfolioGraphRootState = GraphCommonRootState & DiscoveryRootState;
 
 const createMemoizedSelector = createWeakMapSelector.withTypes<GraphCommonRootState>();
 
@@ -37,6 +40,16 @@ export const selectPortfolioGraphAccountItems = (state: GraphCommonRootState): A
             tokensFilter,
         };
     });
+};
+
+export const selectPortfolioGraphAccountItemsIfDiscoveryIsNotRunning = (
+    state: PortfolioGraphRootState,
+): AccountItem[] => {
+    if (selectHasRunningDiscovery(state)) {
+        return returnStableArrayIfEmpty<AccountItem>();
+    }
+
+    return selectPortfolioGraphAccountItems(state);
 };
 
 export const selectHasDeviceHistoryEnabledAccounts = createMemoizedSelector(

--- a/suite-native/graph/src/tests/selectors.test.ts
+++ b/suite-native/graph/src/tests/selectors.test.ts
@@ -148,7 +148,7 @@ describe('selectPortfolioGraphAccountItemsIfDiscoveryIsNotRunning', () => {
     it('should return portfolio graph account items when discovery is not running', () => {
         const account = mockWalletAccount({
             symbol: 'btc',
-            descriptor: asAccountDescriptor('descriptor-1'),
+            descriptor: asAccountDescriptor('descriptor1'),
         });
 
         mockSelectDeviceMainnetAccounts.mockReturnValue([account]);
@@ -158,7 +158,7 @@ describe('selectPortfolioGraphAccountItemsIfDiscoveryIsNotRunning', () => {
         expect(result).toEqual([
             {
                 symbol: 'btc',
-                descriptor: 'descriptor-1',
+                descriptor: 'descriptor1',
                 identity: undefined,
                 accountKey: account.key,
                 tokensFilter: [],

--- a/suite-native/graph/src/tests/selectors.test.ts
+++ b/suite-native/graph/src/tests/selectors.test.ts
@@ -1,15 +1,25 @@
 import type { DeviceRootState } from '@suite-common/device';
 import { type TokenDefinitionsRootState } from '@suite-common/token-definitions';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { type AccountsRootState, selectDeviceMainnetAccounts } from '@suite-common/wallet-core';
-import { type Account } from '@suite-common/wallet-types';
+import {
+    type AccountsRootState,
+    type DiscoveryRootState,
+    selectDeviceMainnetAccounts,
+    selectHasRunningDiscovery,
+} from '@suite-common/wallet-core';
+import { type Account, asAccountDescriptor } from '@suite-common/wallet-types';
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
-import { selectDeviceHistoryIgnoredNetworkSymbols } from '../selectors';
+import {
+    selectDeviceHistoryIgnoredNetworkSymbols,
+    selectPortfolioGraphAccountItemsIfDiscoveryIsNotRunning,
+} from '../selectors';
 
 // Mock the dependencies
 jest.mock('@suite-common/wallet-core', () => ({
     ...jest.requireActual('@suite-common/wallet-core'),
     selectDeviceMainnetAccounts: jest.fn(),
+    selectHasRunningDiscovery: jest.fn(),
 }));
 
 jest.mock('@suite-common/graph/src/constants', () => ({
@@ -19,7 +29,13 @@ jest.mock('@suite-common/graph/src/constants', () => ({
 const mockSelectDeviceMainnetAccounts = selectDeviceMainnetAccounts as jest.MockedFunction<
     typeof selectDeviceMainnetAccounts
 >;
-type TestState = DeviceRootState & AccountsRootState & TokenDefinitionsRootState;
+const mockSelectHasRunningDiscovery = selectHasRunningDiscovery as jest.MockedFunction<
+    typeof selectHasRunningDiscovery
+>;
+type TestState = DeviceRootState &
+    AccountsRootState &
+    DiscoveryRootState &
+    TokenDefinitionsRootState;
 
 describe('selectDeviceHistoryIgnoredNetworkSymbols', () => {
     let mockState: TestState;
@@ -29,9 +45,11 @@ describe('selectDeviceHistoryIgnoredNetworkSymbols', () => {
 
         mockState = {
             device: {} as DeviceRootState['device'],
-            wallet: {} as AccountsRootState['wallet'],
+            wallet: {} as TestState['wallet'],
             tokenDefinitions: {} as TokenDefinitionsRootState['tokenDefinitions'],
         } as TestState;
+
+        mockSelectHasRunningDiscovery.mockReturnValue(false);
     });
 
     it('should return empty array when no accounts are present', () => {
@@ -98,5 +116,53 @@ describe('selectDeviceHistoryIgnoredNetworkSymbols', () => {
         const result2 = selectDeviceHistoryIgnoredNetworkSymbols(mockState);
 
         expect(result1).toBe(result2);
+    });
+});
+
+describe('selectPortfolioGraphAccountItemsIfDiscoveryIsNotRunning', () => {
+    let mockState: TestState;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        mockState = {
+            device: {} as DeviceRootState['device'],
+            wallet: {} as TestState['wallet'],
+            tokenDefinitions: {} as TokenDefinitionsRootState['tokenDefinitions'],
+        } as TestState;
+
+        mockSelectHasRunningDiscovery.mockReturnValue(false);
+    });
+
+    it('should return stable empty account items while discovery is running', () => {
+        mockSelectHasRunningDiscovery.mockReturnValue(true);
+
+        const result1 = selectPortfolioGraphAccountItemsIfDiscoveryIsNotRunning(mockState);
+        const result2 = selectPortfolioGraphAccountItemsIfDiscoveryIsNotRunning(mockState);
+
+        expect(result1).toEqual([]);
+        expect(result1).toBe(result2);
+        expect(mockSelectDeviceMainnetAccounts).not.toHaveBeenCalled();
+    });
+
+    it('should return portfolio graph account items when discovery is not running', () => {
+        const account = mockWalletAccount({
+            symbol: 'btc',
+            descriptor: asAccountDescriptor('descriptor-1'),
+        });
+
+        mockSelectDeviceMainnetAccounts.mockReturnValue([account]);
+
+        const result = selectPortfolioGraphAccountItemsIfDiscoveryIsNotRunning(mockState);
+
+        expect(result).toEqual([
+            {
+                symbol: 'btc',
+                descriptor: 'descriptor-1',
+                identity: undefined,
+                accountKey: account.key,
+                tokensFilter: [],
+            },
+        ]);
     });
 });

--- a/suite-native/module-home/src/screens/HomeScreen/components/PortfolioGraph.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/PortfolioGraph.tsx
@@ -8,7 +8,6 @@ import { selectSelectedDeviceTotalFiatBalance } from '@suite-native/device';
 import { useIsDiscoveryDurationTooLong } from '@suite-native/discovery';
 import {
     Graph,
-    TimeSwitch,
     selectDeviceHistoryIgnoredNetworkSymbols,
     selectHasDeviceHistoryEnabledAccounts,
     useGraphAtoms,
@@ -17,6 +16,7 @@ import {
 import { Translation } from '@suite-native/intl';
 
 import { referencePointAtom, selectedPointAtom } from '../portfolioGraphAtoms';
+import { PortfolioGraphTimeSwitch } from './PortfolioGraphTimeSwitch';
 import { PortfolioHeader } from './PortfolioHeader';
 
 export type PortfolioGraphRef = {
@@ -50,17 +50,10 @@ export const PortfolioGraph = forwardRef<PortfolioGraphRef>((_props, ref) => {
     const loadingTakesLongerThanExpected = useIsDiscoveryDurationTooLong();
     const totalFiatBalance = useSelector(selectSelectedDeviceTotalFiatBalance);
 
-    const {
-        graphPoints,
-        error,
-        isLoading,
-        isAnyMainnetAccountPresent,
-        refetch,
-        onSelectTimeFrame,
-        timeframe,
-    } = useGraphForAllDeviceAccounts({
-        baseCurrencyCode,
-    });
+    const { graphPoints, error, isLoading, isAnyMainnetAccountPresent, refetch } =
+        useGraphForAllDeviceAccounts({
+            baseCurrencyCode,
+        });
 
     const { handleGestureStart, setInitialSelectedPoints, setSelectedPoint } = useGraphAtoms({
         referencePointAtom,
@@ -99,9 +92,7 @@ export const PortfolioGraph = forwardRef<PortfolioGraphRef>((_props, ref) => {
                 />
             )}
             <IgnoredNetworksBanner />
-            {showGraph && (
-                <TimeSwitch selectedTimeFrame={timeframe} onSelectTimeFrame={onSelectTimeFrame} />
-            )}
+            {showGraph && <PortfolioGraphTimeSwitch />}
         </VStack>
     );
 });

--- a/suite-native/module-home/src/screens/HomeScreen/components/PortfolioGraphTimeSwitch.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/PortfolioGraphTimeSwitch.tsx
@@ -1,0 +1,30 @@
+import { useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import {
+    TimeSwitch,
+    type TimeframeHoursValue,
+    selectPortfolioGraphTimeframe,
+    setPortfolioGraphTimeframe,
+} from '@suite-native/graph';
+
+export const PortfolioGraphTimeSwitch = () => {
+    const dispatch = useDispatch();
+    const timeframe = useSelector(selectPortfolioGraphTimeframe);
+
+    const handleSelectPortfolioTimeframe = useCallback(
+        (timeframeHours: TimeframeHoursValue) => {
+            if (timeframe !== timeframeHours) {
+                dispatch(setPortfolioGraphTimeframe({ timeframeHours }));
+            }
+        },
+        [dispatch, timeframe],
+    );
+
+    return (
+        <TimeSwitch
+            selectedTimeFrame={timeframe}
+            onSelectTimeFrame={handleSelectPortfolioTimeframe}
+        />
+    );
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Minimize Graph rerenders when discovery is in progress. In the graph, we were selecting the whole discovery object just to pick one property, which was not needed as well as not returning stable empty array when discovery was in progress, resulting in a lot of rerenders.

Recommend reviewing by commits.

## Notes for QA
Rerenders should be minimized for improved performance, but no change in functionality should occur.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/28363

## Screenshots:

https://github.com/user-attachments/assets/92e77b56-5340-4318-bb74-d257dff78764


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/graph-rerendering&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/graph-rerendering&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/graph-rerendering&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy BTC > Buy Bitcoin from best offer | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-19T09:41:40.999Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-19T09:40:00.876Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/native/graph-rerendering/web/](https://dev.suite.sldev.cz/suite-web/fix/native/graph-rerendering/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is split between two areas: (1) a shared discovery selector file (discoverySelectors.ts) used broadly across Suite web, and (2) several suite-native files (graph components, discovery hooks, home screen) that are mobile-only and have no E2E test coverage in the Playwright suite. The discovery selector change poses the highest risk since it's imported by 121 tests, but most of those tests only use discovery incidentally. The recommended strategy focuses on tests that directly exercise discovery lifecycle (status transitions, completion detection, UI gating on discovery state). The native mobile changes are completely uncovered by these E2E tests.

<details><summary><b>Changed files (8)</b></summary>

- `suite-common/wallet-core/src/discovery/discoverySelectors.ts`
- `suite-native/discovery/src/useIsDiscoveryDurationTooLong.tsx`
- `suite-native/graph/src/hooks.ts`
- `suite-native/graph/src/index.ts`
- `suite-native/graph/src/selectors.ts`
- `suite-native/graph/src/tests/selectors.test.ts`
- `suite-native/module-home/src/screens/HomeScreen/components/PortfolioGraph.tsx`
- `suite-native/module-home/src/screens/HomeScreen/components/PortfolioGraphTimeSwitch.tsx`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/discovery.test.ts` — This test directly exercises wallet discovery status checks (Redux state 'wallet.discovery' status transitions from 'starting' to 'complete'), which is the core functionality touched by discoverySelectors.ts. Changes to discovery selectors could affect how discovery status is read and propagated.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/general/wallet-discovery.test.ts` — This test exercises wallet discovery flow (ejecting wallet, adding standard wallet, verifying account balance after discovery). Discovery selectors changes could affect how discovery completion is detected and account data becomes available.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test verifies discovery completes successfully after configuring custom backends, using page.discoveryShouldFinish() which likely depends on discovery selectors to determine completion state.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/settings/coins.test.ts` — This test activates networks and verifies discovery finishes (page.discoveryShouldFinish), plus checks dashboard empty state when no coins are activated — both flows that read discovery state via selectors.
- `suite/e2e/tests/settings/forget-device.test.ts` — This test explicitly checks that the Forget button is disabled during active discovery and enabled after discovery finishes, directly testing UI behavior that depends on discovery selector state.

</details>

⚠️ **Changes with no test coverage (7)**
- `suite-native/discovery/src/useIsDiscoveryDurationTooLong.tsx`
- `suite-native/graph/src/hooks.ts`
- `suite-native/graph/src/index.ts`
- `suite-native/graph/src/selectors.ts`
- `suite-native/graph/src/tests/selectors.test.ts`
- `suite-native/module-home/src/screens/HomeScreen/components/PortfolioGraph.tsx`
- `suite-native/module-home/src/screens/HomeScreen/components/PortfolioGraphTimeSwitch.tsx`

_Updated: 2026-06-19T09:36:26.762Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->