### PR TITLE
feat(tests): add comprehensive swap inputs validation test

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAccountModal/TradingReceiveAccountSuiteOption.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAccountModal/TradingReceiveAccountSuiteOption.tsx
@@ -65,7 +65,11 @@ export const TradingReceiveAccountSuiteOption = ({
                 <CoinLogo size={24} symbol={account.symbol} />
 
                 <Column>
-                    <Text maxWidth={200} as="div">
+                    <Text
+                        maxWidth={200}
+                        as="div"
+                        data-testid="@trading/receive-account-modal/option/suite/name"
+                    >
                         <AccountLabeling
                             account={account}
                             accountTypeBadgeSize="small"

--- a/suite/e2e/support/pageObjects/trading/formInputs.ts
+++ b/suite/e2e/support/pageObjects/trading/formInputs.ts
@@ -2,6 +2,7 @@ import { Locator, Page } from '@playwright/test';
 
 import type { TradingCountryCode } from '@suite-common/trading';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
+import { BigNumber } from '@trezor/utils';
 
 import { calculatePercentageOfBalance, step } from '../../common';
 import { expect } from '../../testExtends/customMatchers';
@@ -25,6 +26,7 @@ export class TradingFormInputs {
     readonly fiatCryptoSwitchButton: Locator;
     readonly fractionButtons: Locator;
     readonly bottomText: Locator;
+    readonly fiatBottomText: Locator;
     readonly countrySelect: Locator;
     readonly countryValue: Locator;
     readonly countryOption = (countryCode: TradingCountryCode) =>
@@ -42,6 +44,7 @@ export class TradingFormInputs {
         this.fiatCryptoSwitchButton = this.page.getByTestId('@trading/form/switch-crypto-fiat');
         this.fractionButtons = this.page.getByTestId('@trading/form/fraction-buttons');
         this.bottomText = this.page.getByTestId('@trading/form/crypto-input/bottom-text');
+        this.fiatBottomText = this.page.getByTestId('@trading/form/fiat-input/bottom-text');
         this.countrySelect = this.page.getByTestId('@trading/form/country-select');
         this.countryValue = this.page.getByTestId('@trading/form/country-select/value');
         this.paymentMethodSelect = this.page.getByTestId('@trading/form/payment-method-select');
@@ -112,5 +115,41 @@ export class TradingFormInputs {
     async expectInputToBe(params: PercentageOfBalanceParams) {
         const expectedValue = calculatePercentageOfBalance(params);
         await expect.soft(this.cryptoAmount).toHaveValue(expectedValue);
+    }
+
+    @step()
+    async verifyFractionButtons(balance: string, decimals: number) {
+        for (const percentage of [10, 25, 50]) {
+            await this.fractionButtons.getByRole('button', { name: `${percentage}%` }).click();
+            const expectedValue = new BigNumber(balance)
+                .times(percentage / 100)
+                .decimalPlaces(decimals)
+                .toString();
+            await expect(this.cryptoAmount).toHaveValue(expectedValue);
+        }
+    }
+
+    @step()
+    async verifyCryptoAmountExceedsBalance(amount: string) {
+        await this.cryptoAmount.fill(amount);
+        await expect(this.bottomText).toHaveTranslation('AMOUNT_IS_NOT_ENOUGH', {
+            timeout: 15_000,
+        });
+        await this.cryptoAmount.clear();
+        await expect(this.bottomText).toBeHidden();
+    }
+
+    @step()
+    async verifyFiatAmountExceedsBalance(amount: string) {
+        await this.fiatCryptoSwitchButton.click();
+        await expect(this.fractionButtons).toBeHidden();
+        await this.fiatAmount.fill(amount);
+        await expect(this.fiatBottomText).toHaveTranslation('AMOUNT_IS_NOT_ENOUGH', {
+            timeout: 15_000,
+        });
+        await this.fiatAmount.clear();
+        await expect(this.fiatBottomText).toBeHidden();
+        await this.fiatCryptoSwitchButton.click();
+        await expect(this.fractionButtons).toBeVisible();
     }
 }

--- a/suite/e2e/support/pageObjects/trading/quotesSection.ts
+++ b/suite/e2e/support/pageObjects/trading/quotesSection.ts
@@ -9,6 +9,7 @@ export class TradingQuotesSection {
     readonly providerOfQuote = (provider: string) =>
         this.page.getByTestId(`@trading/offers/quote-${provider}`);
     readonly selectedProvider: Locator;
+    readonly selectedProviderName: Locator;
     readonly loadingSpinner: Locator;
     readonly bestOfferAmount: Locator;
 
@@ -16,6 +17,9 @@ export class TradingQuotesSection {
         this.list = this.page.getByTestId('@trading/offers/quote');
         this.provider = this.page.getByTestId('@trading/offers/quote/provider');
         this.selectedProvider = this.page.getByTestId('@trading/selected-offer-provider');
+        this.selectedProviderName = this.selectedProvider.getByTestId(
+            '@trading/offers/quote/provider',
+        );
         this.loadingSpinner = this.page.getByTestId('@trading/offers/loading-spinner');
         this.bestOfferAmount = this.page.getByTestId('@trading/best-offer/amount');
     }
@@ -30,5 +34,44 @@ export class TradingQuotesSection {
     @step()
     async selectQuoteByProvider(provider: string) {
         await this.provider.filter({ hasText: provider }).click();
+    }
+
+    //  When `provider` is given, that specific provider is selected(must be
+    //  present in the list) Otherwise a random provider different from the currently
+    //  selected one is picked. When only a single provider is available it re-selects it
+
+    @step()
+    async chooseDifferentOfferIfAvailable(provider?: string): Promise<void> {
+        const initialProvider = (await this.selectedProviderName.textContent())?.trim();
+        if (!initialProvider) {
+            throw new Error('Cannot get text content from the initial provider.');
+        }
+
+        await this.selectedProvider.click();
+        await expect(this.list.first()).toBeVisible();
+
+        const offerProviderNames = (
+            await this.list.getByTestId('@trading/offers/quote/provider').allTextContents()
+        ).map(name => name.trim());
+
+        let differentProvider: string | undefined;
+        if (provider) {
+            differentProvider = offerProviderNames.find(name => name === provider);
+            if (!differentProvider) {
+                throw new Error(
+                    `Provider "${provider}" not found in offers. Available: ${offerProviderNames.join(', ')}`,
+                );
+            }
+        } else {
+            const candidates = offerProviderNames.filter(name => name && name !== initialProvider);
+            differentProvider = candidates[Math.floor(Math.random() * candidates.length)];
+        }
+
+        const providerToSelect = differentProvider ?? initialProvider;
+        await this.list
+            .filter({ has: this.provider.filter({ hasText: providerToSelect }) })
+            .first()
+            .click();
+        await expect(this.selectedProviderName).toHaveText(providerToSelect);
     }
 }

--- a/suite/e2e/support/pageObjects/trading/receiveAccount.ts
+++ b/suite/e2e/support/pageObjects/trading/receiveAccount.ts
@@ -73,7 +73,15 @@ export class TradingReceiveAccount {
         await this.receiveAddressPicker.click();
         await expect(this.receiveAccountModal).toBeVisible();
 
-        await this.receiveAccountModalSuiteOption.nth(index).click();
+        const selectedOption = this.receiveAccountModalSuiteOption.nth(index);
+        // Capture the option's account name (not the balance/address)
+        const selectedAccountName =
+            (
+                await selectedOption
+                    .getByTestId('@trading/receive-account-modal/option/suite/name')
+                    .textContent()
+            )?.trim() ?? '';
+        await selectedOption.click();
 
         if (symbol === 'btc') {
             await expect(this.bitcoinReceiveAddressModal).toBeVisible();
@@ -82,6 +90,10 @@ export class TradingReceiveAccount {
         }
 
         await expect(this.receiveAccountModal).toBeHidden();
+
+        // Verify the picker now reflects the account we just selected
+        await expect(this.selectedReceiveAccount).not.toBeEmpty();
+        await expect(this.selectedReceiveAccount).toContainText(selectedAccountName);
     }
 
     @step()

--- a/suite/e2e/tests/trading/swap-inputs.test.ts
+++ b/suite/e2e/tests/trading/swap-inputs.test.ts
@@ -1,0 +1,170 @@
+import { getCryptoId } from '@suite-common/trading';
+import type { NetworkSymbol } from '@suite-common/wallet-config';
+
+import dump from '../../fixtures/remembered-wallet-db-lite.json';
+import { expect, test } from '../../support/fixtures';
+import type { IndexedDbDump } from '../../support/indexedDb';
+import type { TradingPage } from '../../support/pageObjects/trading/tradingPage';
+
+const fundedSymbol = 'eth' as const;
+const insufficientCryptoAmount = '1000';
+const insufficientFiatAmount = '1000000';
+
+const sellBalance = '58.72333';
+const sellDecimals = 6;
+const amount = '37.12345';
+
+// Each "To" asset and the Suite receive network expected for it.
+const buyAssets: {
+    label: string;
+    buy: Parameters<TradingPage['assetPicker']['selectBuyAsset']>[0];
+    receiveNetwork: NetworkSymbol;
+    accountIndex: number;
+}[] = [
+    {
+        label: 'ETH@ETH',
+        buy: { searchFilter: 'Ethereum', assetCryptoId: getCryptoId('eth') },
+        receiveNetwork: 'eth',
+        accountIndex: 0,
+    },
+    {
+        label: 'USDC@SOL',
+        buy: {
+            searchFilter: 'USDC',
+            networkFilter: 'sol',
+            assetCryptoId: getCryptoId('sol', 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'),
+        },
+        receiveNetwork: 'sol',
+        accountIndex: 1,
+    },
+    {
+        label: 'USDT@ETH',
+        buy: {
+            searchFilter: 'USDT',
+            networkFilter: 'eth',
+            assetCryptoId: getCryptoId('eth', '0xdac17f958d2ee523a2206206994597c13d831ec7'),
+        },
+        receiveNetwork: 'eth',
+        accountIndex: 0,
+    },
+    {
+        label: 'ETH@ETH',
+        buy: {
+            searchFilter: 'ETH',
+            networkFilter: 'eth',
+            assetCryptoId: getCryptoId('eth'),
+        },
+        receiveNetwork: 'eth',
+        accountIndex: 0,
+    },
+];
+
+test.describe('Trading - Swap inputs', { tag: ['@webOnly', '@noDevice'] }, () => {
+    test.use({
+        startEmulator: false,
+        setupEmulator: false,
+    });
+
+    test.describe.configure({ timeout: 3 * 60 * 1000 });
+
+    test.beforeEach(async ({ page, indexedDb, walletPage }) => {
+        await test.step('Wait for Suite to initialize IndexedDB schema', async () => {
+            await indexedDb.waitForInit();
+        });
+
+        await test.step('Seed remembered wallet from real DB dump', async () => {
+            await indexedDb.seedFromDump(dump as IndexedDbDump);
+        });
+
+        await test.step('Reload Suite with remembered state', async () => {
+            await expect(page.getByTestId('@suite/loading')).toBeHidden({
+                timeout: 20_000,
+            });
+            await expect(page.getByTestId('@suite/bundle-loader')).toBeHidden({
+                timeout: 20_000,
+            });
+            await expect(walletPage.deviceDisconnectedStatus).toBeVisible({
+                timeout: 20_000,
+            });
+        });
+    });
+
+    test('Swap form inputs validation', async ({ walletPage, tradingPage }) => {
+        await test.step('Open the funded account and open the Swap form', async () => {
+            await walletPage.openAccount({ symbol: fundedSymbol });
+            await walletPage.swapButton.click();
+            await tradingPage.verifySwapFormOpened(/Ethereum/);
+        });
+
+        await test.step('Select sell asset USDC@ETH)', async () => {
+            await tradingPage.assetPicker.selectSellAsset({
+                searchFilter: 'USDC',
+                networkSymbol: 'eth',
+                tokenSymbol: 'USDC',
+            });
+        });
+
+        for (const [index, asset] of buyAssets.entries()) {
+            await test.step(`[${asset.label}] Select buy asset and fill amount`, async () => {
+                await tradingPage.assetPicker.selectBuyAsset(asset.buy);
+                await tradingPage.inputs.cryptoAmount.fill(amount);
+                await tradingPage.quotes.waitForSync();
+            });
+            // The form is now fully filled, so the read-only assertions about its
+            // resulting state (ticker, amount, offer, provider, fees) all run together.
+            await test.step(`[${asset.label}] Verify filled form state`, async () => {
+                await expect(tradingPage.inputs.swapAmountCurrencyTicker).toHaveText('USDC', {
+                    ignoreCase: true,
+                });
+                await expect(tradingPage.inputs.cryptoAmount).toHaveValue(amount);
+                await expect(
+                    tradingPage.inputs.bottomText,
+                    `[${asset.label}] amount ${amount} is outside the live swap limits; adjust the test amount.`,
+                ).toBeHidden();
+
+                await expect(tradingPage.quotes.bestOfferAmount).not.toHaveText(/^0( \w+)?$/, {
+                    timeout: 15_000,
+                });
+                await expect(tradingPage.quotes.selectedProvider).toBeVisible();
+                await expect(tradingPage.quotes.selectedProviderName).not.toBeEmpty();
+
+                await expect(tradingPage.fees.maximumFeeAmountToBeCalculated).toBeHidden();
+                await expect(tradingPage.fees.maxFee).toBeVisible();
+                await expect(tradingPage.fees.maxFee).not.toBeEmpty();
+            });
+
+            await test.step(`[${asset.label}] Change provider`, async () => {
+                await tradingPage.quotes.chooseDifferentOfferIfAvailable();
+            });
+
+            await test.step(`[${asset.label}] Select receive account`, async () => {
+                await tradingPage.receiveAccount.selectSuiteReceiveAccount(
+                    asset.accountIndex,
+                    asset.receiveNetwork,
+                );
+            });
+
+            // We want to run the "the fraction / Max / amount limits" asserts only once in this loop.
+            // No value in testing it multiple times with different "Swap to Asset network"
+            if (index > 0) {
+                continue;
+            }
+
+            await test.step('Verify fraction buttons', async () => {
+                await tradingPage.inputs.verifyFractionButtons(sellBalance, sellDecimals);
+            });
+
+            await test.step('Verify Max amount (full token balance)', async () => {
+                await tradingPage.inputs.fractionButtons
+                    .getByRole('button', { name: 'Max' })
+                    .click();
+                await expect(tradingPage.inputs.cryptoAmount).toHaveValue(sellBalance);
+            });
+
+            await test.step('Verify amount limits and fiat input', async () => {
+                await tradingPage.inputs.verifyCryptoAmountExceedsBalance(insufficientCryptoAmount);
+                await tradingPage.inputs.verifyFiatAmountExceedsBalance(insufficientFiatAmount);
+            });
+        }
+    });
+});


### PR DESCRIPTION
Add E2E test suite for swap form input validation. Introduces `swap-inputs.test.ts` plus new `formInputs` and `quotesSection` page objects, extends `receiveAccount`, and adds a test id to the receive account option for reliable targeting.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies a trading receive account modal component (TradingReceiveAccountSuiteOption) and three key trading E2E page objects (formInputs, quotesSection, receiveAccount), plus a swap-inputs test file itself. The risk is concentrated in the trading/coinmarket flows — buy, sell, and swap — that rely on form inputs, quote display, and receive account selection. The recommended strategy prioritizes running the changed test file and buy flow tests that directly exercise the receive account modal, followed by swap and sell tests that use the modified page objects. Non-trading tests should be skipped as the changes are scoped entirely to trading functionality.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAccountModal/TradingReceiveAccountSuiteOption.tsx`
- `suite/e2e/support/pageObjects/trading/formInputs.ts`
- `suite/e2e/support/pageObjects/trading/quotesSection.ts`
- `suite/e2e/support/pageObjects/trading/receiveAccount.ts`
- `suite/e2e/tests/trading/swap-inputs.test.ts`

</details>

**Recommended tests (15)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/trading/swap-inputs.test.ts` — This test file itself is one of the changed files, so it must be run to validate its own modifications. It likely exercises the swap form inputs including the changed formInputs.ts and quotesSection.ts page objects.
- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — The buy-bitcoin test explicitly exercises the receive account selection flow (selectSuiteReceiveAccount) and quotes display, directly touching the changed TradingReceiveAccountSuiteOption component and the receiveAccount/quotesSection page objects.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — This test adds a new Suite receive account for ETH during the buy flow, directly exercising the TradingReceiveAccountSuiteOption component and the receiveAccount page object's add-account functionality.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — This test selects a Suite receive account and verifies quotes for a Solana token buy, directly using the receiveAccount page object and quotesSection page object which are both changed.

</details>

<details><summary>🟡 <b>Medium priority (8)</b></summary>

- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — This swap test fills a swap form with receive address selection and verifies the best quote offer, exercising formInputs, receiveAccount, and quotesSection page objects that were all changed.
- `suite/e2e/tests/trading/swap-coins.test.ts` — This swap test selects a receive address and verifies the best swap offer quote, exercising the receiveAccount and quotesSection page objects which were changed.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — This test swaps SPL tokens (USDT to USDC) using the swap form with receive address selection and quote verification, exercising the changed formInputs, receiveAccount, and quotesSection page objects.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — This test swaps a Solana USDT token to BTC, filling the swap form and selecting a receive address, directly using the changed formInputs and receiveAccount page objects.
- `suite/e2e/tests/trading/sell-solana.test.ts` — This test exercises the sell flow quotes section including best offer display and offer comparison, directly using the quotesSection page object which was changed.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — This test validates sell form input behaviors (amounts, percentages, currency switching) which directly use the formInputs page object that was changed.
- `suite/e2e/tests/trading/buy-negative.test.ts` — This test validates buy form input validation (min/max limits, empty quotes) using the formInputs page object (fiatAmount input, selectFiatCurrency) and quotesSection (selectedProvider, bestOfferButton) which were both changed.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — This test fills a swap form targeting a disabled network and checks the selected provider in quotes, using the formInputs and quotesSection page objects that were changed.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — This test exercises swap form fee customization and best offer selection which could be affected by changes to the formInputs and quotesSection page objects, though its primary focus is on fee display rather than receive account selection.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Similar to swap-fees-bitcoin, this test uses the swap form and quotes flow but primarily focuses on Ethereum custom fee parameters. Changes to formInputs and quotesSection page objects could indirectly affect it.
- `suite/e2e/tests/trading/navigation.test.ts` — This test verifies navigation to buy/sell/swap forms and checks that forms open with correct assets. Changes to the TradingReceiveAccountSuiteOption component could affect the buy form's account selection flow tested here.

</details>

_Updated: 2026-06-08T13:10:25.995Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=swap-form-inputs-test&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=swap-form-inputs-test&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-08T13:16:09.714Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add account types ada | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-08T13:13:15.667Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/swap-form-inputs-test/web/](https://dev.suite.sldev.cz/suite-web/swap-form-inputs-test/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->