### PR TITLE
fix(suite-native): isDebugOnlyAccountType for legacy tsep & thod

### DIFF
--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -618,6 +618,7 @@ export const networks = {
             legacy: {
                 accountType: 'legacy',
                 bip43Path: "m/44'/1'/0'/0/i",
+                isDebugOnlyAccountType: true,
             },
         },
         coingeckoId: 'sepolia-test-ethereum', // fake, coingecko does not have testnets
@@ -640,6 +641,7 @@ export const networks = {
             legacy: {
                 accountType: 'legacy',
                 bip43Path: "m/44'/1'/0'/0/i",
+                isDebugOnlyAccountType: true,
             },
         },
         coingeckoId: 'hoodi-test-ethereum', // fake, coingecko does not have testnets

--- a/suite-common/wallet-utils/src/__tests__/filterReceiveAccounts.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/filterReceiveAccounts.test.ts
@@ -68,6 +68,8 @@ describe('filter receive accounts', () => {
         expect(isDebugOnlyAccountType('ledger', 'eth')).toBe(true);
         expect(isDebugOnlyAccountType('ledger', 'trx')).toBe(true);
         expect(isDebugOnlyAccountType('normal', 'regtest')).toBe(false);
+        expect(isDebugOnlyAccountType('legacy', 'tsep')).toBe(true);
+        expect(isDebugOnlyAccountType('legacy', 'thod')).toBe(true);
     });
 
     it('returns no results when given an empty accounts array', () => {

--- a/suite-common/wallet-utils/src/filterReceiveAccounts.ts
+++ b/suite-common/wallet-utils/src/filterReceiveAccounts.ts
@@ -36,7 +36,7 @@ export const filterReceiveAccounts = ({
     const shouldDisplayDebugOnly = (account: Account) =>
         isDebug ||
         !isDebugOnlyAccountType(account.accountType, account.symbol) ||
-        isNotEmptyAccount;
+        isNotEmptyAccount(account);
     const isVisibleAccount = (account: Account) => account.visible;
     const isFirstNormalAccount = (account: Account) =>
         account.accountType === 'normal' && account.index === 0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds missing configuration for ethereum accounts and resolves https://github.com/trezor/trezor-suite/pull/28223/changes#r3362112029 

<!--- Describe your changes in detail -->

## Notes for QA

After adding an eth account we need to make sure that warning about segwit is not displayed on evm testnets

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/28410

## Screenshots:

https://github.com/user-attachments/assets/973f9464-5d6e-43a7-ad3b-dcfea48f830d



<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes touch two broadly-shared modules: networksConfig.ts (network definitions) and filterReceiveAccounts.ts (account filtering for receive flows), plus the unit test for the latter. Since both files map to 121+ E2E tests, we apply strict filtering. The highest risk is in trading/buy/swap flows that use filterReceiveAccounts to select receive accounts and in the global receive/send flow. Network config changes could affect discovery and coin activation but are lower risk unless network definitions were structurally altered. The unit test file has no E2E coverage (appropriately — it's a unit test).

<details><summary><b>Changed files (3)</b></summary>

- `suite-common/wallet-config/src/networksConfig.ts`
- `suite-common/wallet-utils/src/__tests__/filterReceiveAccounts.test.ts`
- `suite-common/wallet-utils/src/filterReceiveAccounts.ts`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — This test exercises navigating to Buy/Sell/Swap forms for specific coins and tokens, which directly uses filterReceiveAccounts to determine which accounts to show in receive account selectors and asset pickers. Changes to filtering logic or network config could cause wrong accounts to appear or be missing.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test opens a global receive form, adds a new ETH account via an asset picker, filters and selects it, then reveals the address. The filterReceiveAccounts function is directly used when filtering/selecting receive accounts in the global receive flow.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — Buy flow includes selecting a Suite receive account (selectSuiteReceiveAccount), which relies on filterReceiveAccounts to determine eligible accounts. Changes could affect which accounts appear in the receive account selector.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — This test adds a new Suite receive account for ETH during the buy flow, which exercises filterReceiveAccounts logic for account selection and network filtering.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — This test selects a Solana token (JUP) via the asset picker with network filters and selects a Suite receive account, directly exercising filterReceiveAccounts for token-level account filtering.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Swap flow includes selecting a receive address/account, which uses filterReceiveAccounts to determine valid receive accounts across networks (SOL to ETH USDC).
- `suite/e2e/tests/trading/swap-coins.test.ts` — Cross-network swap (SOL to BTC) requires selecting a receive address on a different network, which exercises filterReceiveAccounts for cross-network account selection.
- `suite/e2e/tests/wallet/discovery.test.ts` — This test activates multiple cryptocurrency networks and verifies discovery completes. Changes to networksConfig.ts could affect which networks are available, their symbols, or discovery behavior.
- `suite/e2e/tests/settings/coins.test.ts` — This test verifies enabling/disabling mainnet and testnet networks from the coins settings page, directly using network symbols and configuration from networksConfig.ts to validate which networks appear.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — Activating assets via the Activate Assets modal uses network configuration to determine available networks. The test also verifies newly enabled assets appear correctly, which depends on networksConfig.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — This test specifically verifies swapping a token to an asset on a disabled network, which exercises network configuration and account filtering logic for disabled networks.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/wallet-utils/src/__tests__/filterReceiveAccounts.test.ts`

_Updated: 2026-06-05T14:38:14.160Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/acounts-segwit-tsep&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/acounts-segwit-tsep&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/acounts-segwit-tsep&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-05T14:42:51.381Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-05T14:41:09.066Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/acounts-segwit-tsep/web/](https://dev.suite.sldev.cz/suite-web/fix/acounts-segwit-tsep/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->