### PR TITLE
test(utils): isHex `prefix: 'required'` loses `0x${string}` narrowing (repro)

### DIFF
--- a/packages/utils/tests/isHex.type-test.ts
+++ b/packages/utils/tests/isHex.type-test.ts
@@ -1,0 +1,48 @@
+// Type-level regression test for the `isHex` overloads.
+//
+// `isHex(value, { prefix: 'required' })` must narrow `value` to `0x${string}`,
+// exactly like the no-argument `isHex(value)` form (whose default prefix is
+// already 'required'). It currently does NOT: `Extract<Options, { prefix:
+// 'required' }>` in the first overload resolves to `never` (because `Options`
+// is a single object type whose `prefix` is the wider union, not the literal
+// 'required'), so the call falls through to the second overload and the type
+// guard degrades to `value is string`.
+//
+// This file is part of `type-check` (tsc --build), so it fails to compile until
+// the overload is fixed — see the PR description for the proposed fix.
+
+import { isHex } from '../src/isHex';
+
+const expectHexString = (_value: `0x${string}`) => {};
+const expectString = (_value: string) => {};
+
+declare const value: unknown;
+
+// Default prefix is 'required' → narrows to `0x${string}`.
+if (isHex(value)) {
+    expectHexString(value);
+}
+
+// Explicit `{ prefix: 'required' }` is semantically identical and must narrow
+// to `0x${string}` as well.
+if (isHex(value, { prefix: 'required' })) {
+    expectHexString(value);
+}
+
+// `{ prefix: 'required', allowEmpty: false }` must also keep the `0x${string}` guard.
+if (isHex(value, { prefix: 'required', allowEmpty: false })) {
+    expectHexString(value);
+}
+
+// 'optional' / 'prohibited' do not guarantee a 0x prefix → plain `string`.
+if (isHex(value, { prefix: 'optional' })) {
+    expectString(value);
+    // @ts-expect-error 'optional' prefix must not narrow to `0x${string}`
+    expectHexString(value);
+}
+
+if (isHex(value, { prefix: 'prohibited' })) {
+    expectString(value);
+    // @ts-expect-error 'prohibited' prefix must not narrow to `0x${string}`
+    expectHexString(value);
+}


### PR DESCRIPTION
## What

Adds a type-level regression test (`packages/utils/tests/isHex.type-test.ts`) that pins the intended narrowing behaviour of the `isHex` overloads introduced in #28393.

> ⚠️ **This PR is expected to fail `type-check` on purpose.** Red CI here *is* the deliverable — it makes a latent typing bug in #28393 visible. Once the fix below is applied in #28393, this test goes green.

## The bug

In #28393 the first overload is:

```ts
export function isHex(
    value: unknown,
    options?: Extract<Options, { prefix: 'required' }>,
): value is `0x${string}`;
```

`Extract<T, U> = T extends U ? T : never`. `Options` is a single object type whose `prefix` is the wider union `'required' | 'optional' | 'prohibited' | undefined`, which is **not** assignable to the literal `'required'`. So `Extract<Options, { prefix: 'required' }>` collapses to **`never`**, the first overload's parameter becomes `never | undefined`, and any explicit `isHex(x, { prefix: 'required' })` call skips it and matches the *second* overload — degrading the guard from `value is \`0x${string}\`` to `value is string`.

Net effect: narrowing to `` `0x${string}` `` works for `isHex(x)` but is silently lost for the semantically identical `isHex(x, { prefix: 'required' })`. There is **no runtime impact** (the runtime default `prefix = 'required'` is correct, and no current call-site passes `{ prefix: 'required' }` explicitly), so a unit test cannot catch it — only `type-check` can.

## Expected CI failure

```
tests/isHex.type-test.ts(29,21): error TS2345: Argument of type 'string' is not assignable to parameter of type '`0x${string}`'.
tests/isHex.type-test.ts(34,21): error TS2345: Argument of type 'string' is not assignable to parameter of type '`0x${string}`'.
```

Both lines are the `{ prefix: 'required' }` / `{ prefix: 'required', allowEmpty: false }` blocks. The default-form and the `optional`/`prohibited` blocks compile fine.

## Proposed fix (apply in #28393, not here)

Replace the `Extract`/`Exclude` conditionals with concrete literals:

```ts
export function isHex(
    value: unknown,
    options?: { prefix?: 'required'; allowEmpty?: boolean },
): value is `0x${string}`;
export function isHex(
    value: unknown,
    options: { prefix: 'optional' | 'prohibited'; allowEmpty?: boolean },
): value is string;

export function isHex(value: unknown, { prefix = 'required', allowEmpty = true }: Options = {}) {
    /* body unchanged */
}
```

Verified locally with `tsc --strict`: with this fix every case narrows correctly — `isHex(x)`, `{ prefix: 'required' }`, `{ prefix: 'required', allowEmpty: false }` and `{ allowEmpty: false }` → `` `0x${string}` ``; `{ prefix: 'optional' }` / `{ prefix: 'prohibited' }` → `string` — and this type-test compiles clean (exit 0).

## Related

- Targets / based on #28393 (Extended `isHex` util)
