### PR TITLE
docs(nix): fixing broken nix documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ It's recommended to enable `git config --global submodule.recurse true` so you d
 
 > You don't need a Trezor device to get into the app, you can use emulator. There is a [Trezor User Env](https://github.com/trezor/trezor-user-env) to help you set it up and run emulator for any Trezor model 🎉
 
-> You can use Nix to set up the repository — see [Nix Documentation](docs/nix.md).
+> You can use Nix to set up the repository — see [Nix Documentation](docs/misc/development-on-nix.md).
 
 ## **Connect** @trezor/connect
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The file with documentation for nix in the project was moved and renamed, but the link was not updated.

## Notes for QA

Nothing to test, just documentation.
