### PR TITLE
Eth conversion utils

### DIFF
--- a/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
@@ -1,5 +1,3 @@
-import { fromWei, hexToNumberString, numberToHex } from 'web3-utils';
-
 import { asTypedDesktopAnalytics, events } from '@suite/analytics';
 import { closeModal, openDeferredModal, preserveModal } from '@suite/modal';
 import { Calldata, asEvmAddress } from '@suite-common/calldata';
@@ -31,7 +29,13 @@ import {
     type PrecomposedTransactionFinal,
     type YieldClaimReward,
 } from '@suite-common/wallet-types';
-import { getAccountIdentity, getMevProtectedTxData, sanitizeHex } from '@suite-common/wallet-utils';
+import {
+    fromHex,
+    fromIntegerString,
+    getAccountIdentity,
+    getMevProtectedTxData,
+    sanitizeHex,
+} from '@suite-common/wallet-utils';
 import TrezorConnect, { type StaticSessionId } from '@trezor/connect';
 import { BigNumber } from '@trezor/utils';
 
@@ -56,13 +60,12 @@ const buildClaimReviewState = ({
     fee,
     rewards,
 }: BuildClaimReviewStateParams): BuildClaimReviewStateResult => {
-    const feePriceWei = new BigNumber(
-        hexToNumberString(fee.type === 'eip1559' ? fee.maxFeePerGas : fee.gasPrice),
-    );
-    const feeLimitWei = hexToNumberString(fee.gasLimit);
-    const feeWei = new BigNumber(feeLimitWei).multipliedBy(feePriceWei).toFixed(0);
+    const feePrice = fromHex(fee.type === 'eip1559' ? fee.maxFeePerGas : fee.gasPrice);
+    const feeLimit = fromHex(fee.gasLimit);
+    const feeLimitWei = feeLimit.toIntegerString();
+    const feeWei = feeLimit.toBigNumber().multipliedBy(feePrice.toBigNumber()).toFixed(0);
 
-    const feePerUnitGwei = fromWei(feePriceWei.toFixed(0), 'gwei');
+    const feePerUnitGwei = feePrice.asWei().toGwei();
     const eip1559Fields: {
         maxFeePerGasGwei?: PrecomposedTransactionFinal['maxFeePerGas'];
         maxPriorityFeePerGasGwei?: PrecomposedTransactionFinal['maxPriorityFeePerGas'];
@@ -71,9 +74,9 @@ const buildClaimReviewState = ({
 
     if (fee.type === 'eip1559') {
         Object.assign(eip1559Fields, {
-            maxFeePerGasGwei: fromWei(hexToNumberString(fee.maxFeePerGas), 'gwei'),
-            maxPriorityFeePerGasGwei: fromWei(hexToNumberString(fee.maxPriorityFeePerGas), 'gwei'),
-            baseFeePerGasGwei: fromWei(hexToNumberString(fee.baseFeePerGas), 'gwei'),
+            maxFeePerGasGwei: fromHex(fee.maxFeePerGas).asWei().toGwei(),
+            maxPriorityFeePerGasGwei: fromHex(fee.maxPriorityFeePerGas).asWei().toGwei(),
+            baseFeePerGasGwei: fromHex(fee.baseFeePerGas).asWei().toGwei(),
         });
     }
 
@@ -324,7 +327,7 @@ export const claimMerklRewardsThunk = createThunk(
                         to: unsignedClaimTx.to,
                         chainId: unsignedClaimTx.chainId,
                         value: '0x0',
-                        nonce: numberToHex(unsignedClaimTx.nonce),
+                        nonce: fromIntegerString(unsignedClaimTx.nonce).toHex(),
                         data: sanitizeHex(unsignedClaimTx.data),
                         gasLimit: parsedSelectedFee.gasLimit,
                         ...(parsedSelectedFee.type === 'eip1559'

--- a/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
@@ -1,5 +1,3 @@
-import { toWei } from 'web3-utils';
-
 import { asTypedDesktopAnalytics, events } from '@suite/analytics';
 import { selectSelectedDevice } from '@suite-common/device';
 import { type ExtraDependencies } from '@suite-common/redux-utils';
@@ -31,7 +29,12 @@ import {
     type PrecomposedTransactionFinal,
     type StakeFormState,
 } from '@suite-common/wallet-types';
-import { calculateTotalGasCost, getAccountIdentity } from '@suite-common/wallet-utils';
+import {
+    calculateTotalGasCost,
+    fromEther,
+    fromGwei,
+    getAccountIdentity,
+} from '@suite-common/wallet-utils';
 import TrezorConnect, { type FeeLevel } from '@trezor/connect';
 
 import { type Dispatch, type GetState } from 'src/types/suite';
@@ -44,15 +47,15 @@ const calculateStakingTransaction = (
     symbol: NetworkSymbol,
 ): PrecomposedTransaction => {
     const totalGasCostInWei = calculateTotalGasCost(
-        toWei(feeLevel.maxFeePerGas || feeLevel.feePerUnit, 'gwei'),
+        fromGwei(feeLevel.maxFeePerGas || feeLevel.feePerUnit).toWei(),
         feeLevel.feeLimit,
     );
 
     const stakingParams = {
         feeInBaseUnits: totalGasCostInWei,
-        minBalanceForStakingInBaseUnits: toWei(MIN_ETH_BALANCE_FOR_STAKING.toString(), 'ether'),
-        minAmountForStakingInBaseUnits: toWei(MIN_ETH_AMOUNT_FOR_STAKING.toString(), 'ether'),
-        minAmountForWithdrawalInBaseUnits: toWei(MIN_ETH_FOR_WITHDRAWALS.toString(), 'ether'),
+        minBalanceForStakingInBaseUnits: fromEther(MIN_ETH_BALANCE_FOR_STAKING.toString()).toWei(),
+        minAmountForStakingInBaseUnits: fromEther(MIN_ETH_AMOUNT_FOR_STAKING.toString()).toWei(),
+        minAmountForWithdrawalInBaseUnits: fromEther(MIN_ETH_FOR_WITHDRAWALS.toString()).toWei(),
     };
 
     return calculate(availableBalance, output, feeLevel, compareWithAmount, symbol, stakingParams);

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
@@ -1,10 +1,9 @@
 import styled from 'styled-components';
-import { fromWei } from 'web3-utils';
 
 import { useExternalLink } from '@suite/external-links';
 import { Translation } from '@suite/intl';
 import { type Network } from '@suite-common/wallet-config';
-import { getFeeRate, getTxIcon, isEip1559, isPending } from '@suite-common/wallet-utils';
+import { fromWei, getFeeRate, getTxIcon, isEip1559, isPending } from '@suite-common/wallet-utils';
 import {
     Card,
     Divider,
@@ -203,7 +202,7 @@ export const BasicTxDetails = ({
                         <Item label={<Translation id="TR_GAS_PRICE" />} iconName="gasPump">
                             {isConfirmed || !isEip1559(tx.ethereumSpecific) ? (
                                 <FeeRate
-                                    feeRate={fromWei(tx.ethereumSpecific?.gasPrice || 0, 'gwei')}
+                                    feeRate={fromWei(tx.ethereumSpecific?.gasPrice || '0').toGwei()}
                                     networkType="ethereum"
                                     preserveDecimals
                                 />
@@ -221,8 +220,7 @@ export const BasicTxDetails = ({
                                     <FeeRate
                                         feeRate={fromWei(
                                             tx.ethereumSpecific?.maxFeePerGas ?? '0',
-                                            'gwei',
-                                        )}
+                                        ).toGwei()}
                                         networkType="ethereum"
                                         preserveDecimals
                                     />
@@ -236,8 +234,7 @@ export const BasicTxDetails = ({
                                         <FeeRate
                                             feeRate={fromWei(
                                                 tx.ethereumSpecific.baseFeePerGas || '0',
-                                                'gwei',
-                                            )}
+                                            ).toGwei()}
                                             networkType="ethereum"
                                             preserveDecimals
                                         />
@@ -253,8 +250,7 @@ export const BasicTxDetails = ({
                                     <FeeRate
                                         feeRate={fromWei(
                                             tx.ethereumSpecific?.maxPriorityFeePerGas ?? '0',
-                                            'gwei',
-                                        )}
+                                        ).toGwei()}
                                         networkType="ethereum"
                                         preserveDecimals
                                     />

--- a/packages/suite/src/components/tx-simulation/common/hooks/useEvmTxSimulationFeesForm.ts
+++ b/packages/suite/src/components/tx-simulation/common/hooks/useEvmTxSimulationFeesForm.ts
@@ -1,8 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { useForm } from 'react-hook-form';
 
-import { numberToHex, toWei } from 'web3-utils';
-
 import { type TxSimulationEVMResult } from '@suite-common/tx-simulation';
 import {
     type NetworkSymbol,
@@ -12,7 +10,11 @@ import {
 import { ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT } from '@suite-common/wallet-constants';
 import { selectRawNetworkFeeInfo } from '@suite-common/wallet-core';
 import { type EvmSelectedFee } from '@suite-common/wallet-types';
-import { getConvertedOrDefaultFeeInfo } from '@suite-common/wallet-utils';
+import {
+    fromGwei,
+    fromIntegerString,
+    getConvertedOrDefaultFeeInfo,
+} from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
 
 import { useSelector } from 'src/hooks/suite';
@@ -119,12 +121,10 @@ export function useEvmTxSimulationFeesForm({
         ) {
             return {
                 type: 'eip1559',
-                gasLimit: numberToHex(values.feeLimit),
-                maxFeePerGas: numberToHex(toWei(eip1559payload.maxFeePerGas, 'gwei')),
-                maxPriorityFeePerGas: numberToHex(
-                    toWei(eip1559payload.maxPriorityFeePerGas, 'gwei'),
-                ),
-                baseFeePerGas: numberToHex(toWei(eip1559payload.baseFeePerGas, 'gwei')),
+                gasLimit: fromIntegerString(values.feeLimit).toHex(),
+                maxFeePerGas: fromGwei(eip1559payload.maxFeePerGas).toWei('hex'),
+                maxPriorityFeePerGas: fromGwei(eip1559payload.maxPriorityFeePerGas).toWei('hex'),
+                baseFeePerGas: fromGwei(eip1559payload.baseFeePerGas).toWei('hex'),
             };
         }
 
@@ -133,8 +133,8 @@ export function useEvmTxSimulationFeesForm({
         if (gasPrice) {
             return {
                 type: 'legacy',
-                gasLimit: numberToHex(values.feeLimit),
-                gasPrice: numberToHex(toWei(gasPrice, 'gwei')),
+                gasLimit: fromIntegerString(values.feeLimit).toHex(),
+                gasPrice: fromGwei(gasPrice).toWei('hex'),
             };
         }
 

--- a/packages/suite/src/hooks/earn/useSupplyForm.ts
+++ b/packages/suite/src/hooks/earn/useSupplyForm.ts
@@ -2,7 +2,6 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useState } 
 import { useForm, useWatch } from 'react-hook-form';
 
 import useDebounce from 'react-use/lib/useDebounce';
-import { fromWei } from 'web3-utils';
 
 import { getStakeFormsDefaultValues, getStakingContractAddress } from '@suite-common/staking';
 import { getNetwork } from '@suite-common/wallet-config';
@@ -19,6 +18,7 @@ import {
 } from '@suite-common/wallet-types';
 import {
     fromBaseCurrencyToCryptoUnit,
+    fromWei,
     getConvertedOrDefaultFeeInfo,
     getFiatRateKey,
     getStakingLimitsByNetworkSymbol,
@@ -173,7 +173,7 @@ export const useSupplyForm = ({ account }: UseSupplyFormProps): SupplyContextVal
         const transactionInfo = composedLevels?.[selectedFee];
 
         return transactionInfo !== undefined && transactionInfo.type !== 'error'
-            ? new BigNumber(fromWei(transactionInfo.fee, 'ether'))
+            ? fromWei(transactionInfo.fee).toEther('bignumber')
             : new BigNumber('0');
     }, [composedLevels, selectedFee]);
 

--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -1,5 +1,3 @@
-import { toWei } from 'web3-utils';
-
 import {
     type NetworkSymbol,
     getNetwork,
@@ -15,6 +13,7 @@ import {
 import {
     convertAmountUnitsToSubunits,
     formatNetworkAmount,
+    fromGwei,
     networkAmountToSmallestUnit,
 } from '@suite-common/wallet-utils';
 import { parseAsset } from '@trezor/blockchain-link-utils/src/blockfrost';
@@ -429,7 +428,7 @@ export const runLegacyMigrations: OnUpgradeFunc<SuiteDBSchema> = async (
                     ethereumSpecific: origTx.ethereumSpecific
                         ? {
                               ...origTx.ethereumSpecific,
-                              gasPrice: toWei(origTx.ethereumSpecific?.gasPrice ?? '0', 'gwei'),
+                              gasPrice: fromGwei(origTx.ethereumSpecific?.gasPrice ?? '0').toWei(),
                           }
                         : undefined,
                     cardanoSpecific: origTx.cardanoSpecific

--- a/packages/suite/src/utils/wallet/exportTransactionsUtils.ts
+++ b/packages/suite/src/utils/wallet/exportTransactionsUtils.ts
@@ -1,7 +1,6 @@
 import { format } from 'date-fns';
 import type PdfMake from 'pdfmake/build/pdfmake';
 import type { TDocumentDefinitions } from 'pdfmake/interfaces';
-import { fromWei } from 'web3-utils';
 
 import { trezorLogo } from '@suite-common/suite-constants';
 import { type TokenDefinitions, isPhishingTransaction } from '@suite-common/token-definitions';
@@ -16,6 +15,7 @@ import {
 import {
     convertAmountSubunitsToUnits,
     formatNetworkAmount,
+    fromWei,
     getFiatRateKey,
     getNftTokenId,
     isNftTokenTransfer,
@@ -113,7 +113,7 @@ const formatAmounts =
         ethereumSpecific: tx.ethereumSpecific
             ? {
                   ...tx.ethereumSpecific,
-                  gasPrice: fromWei(tx.ethereumSpecific?.gasPrice ?? '0', 'gwei'),
+                  gasPrice: fromWei(tx.ethereumSpecific?.gasPrice ?? '0').toGwei(),
               }
             : undefined,
         cardanoSpecific: tx.cardanoSpecific

--- a/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/InstantStakeBanner.tsx
+++ b/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/InstantStakeBanner.tsx
@@ -1,12 +1,11 @@
 import { useEffect, useRef, useState } from 'react';
 
-import { fromWei } from 'web3-utils';
-
 import { selectSelectedAccount } from '@suite/account';
 import { Translation } from '@suite/intl';
 import { getChangedInternalTx, getInstantStakeType } from '@suite-common/staking';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { type StakeType, type WalletAccountTransaction } from '@suite-common/wallet-types';
+import { fromWei } from '@suite-common/wallet-utils';
 import { Banner } from '@trezor/components';
 import { type InternalTransfer } from '@trezor/connect';
 
@@ -60,7 +59,7 @@ export const InstantStakeBanner = ({
         setIsBannerShown(false);
     };
 
-    const amount = fromWei(instantStakeTransfer?.amount ?? '0', 'ether');
+    const amount = fromWei(instantStakeTransfer?.amount ?? '0').toEther();
     const stakeType = getInstantStakeType(instantStakeTransfer, address, symbol);
 
     if (!stakeType || stakeType === 'claim') return null; // claim is not supported

--- a/suite-common/earn-stablecoin/src/signing/stablecoinYieldSigningUtils.ts
+++ b/suite-common/earn-stablecoin/src/signing/stablecoinYieldSigningUtils.ts
@@ -8,8 +8,7 @@ import {
 } from '@suite-common/wallet-types';
 import {
     asAmountUnit,
-    evmHexToBigNumber,
-    evmHexWeiToGwei,
+    fromHex,
     getContractAddressForNetworkSymbol,
     unitsToSubunits,
 } from '@suite-common/wallet-utils';
@@ -126,10 +125,10 @@ export const buildStablecoinYieldReviewState = ({
     symbol,
 }: BuildStablecoinYieldReviewStateParams): BuildStablecoinYieldReviewStateResult => {
     const gasPriceHex = tx.maxFeePerGas ?? tx.gasPrice ?? ('0x0' as `0x${string}`);
-    const gasLimit = evmHexToBigNumber(tx.gasLimit);
-    const gasPrice = evmHexToBigNumber(gasPriceHex);
-    const feePerUnit = evmHexWeiToGwei(gasPriceHex);
-    const fee = gasLimit.multipliedBy(gasPrice);
+    const gasLimit = fromHex(tx.gasLimit);
+    const gasPrice = fromHex(gasPriceHex);
+    const feePerUnit = fromHex(gasPriceHex).asWei().toGwei();
+    const fee = gasLimit.toBigNumber().multipliedBy(gasPrice.toBigNumber());
     const reviewToken = buildStablecoinYieldReviewToken({ token, symbol });
     const amountSubunits = unitsToSubunits({
         value: asAmountUnit(new BigNumber(amount)),
@@ -141,8 +140,8 @@ export const buildStablecoinYieldReviewState = ({
     > =
         tx.maxFeePerGas && tx.maxPriorityFeePerGas
             ? {
-                  maxFeePerGas: evmHexWeiToGwei(tx.maxFeePerGas),
-                  maxPriorityFeePerGas: evmHexWeiToGwei(tx.maxPriorityFeePerGas),
+                  maxFeePerGas: fromHex(tx.maxFeePerGas).asWei().toGwei(),
+                  maxPriorityFeePerGas: fromHex(tx.maxPriorityFeePerGas).asWei().toGwei(),
               }
             : {};
 
@@ -160,7 +159,7 @@ export const buildStablecoinYieldReviewState = ({
         ],
         selectedFee: 'custom',
         feePerUnit,
-        feeLimit: gasLimit.toFixed(0),
+        feeLimit: gasLimit.toIntegerString(),
         ...eip1559ReviewFields,
         options: ['broadcast', 'transactionData'],
         transactionData: tx.data,
@@ -173,7 +172,7 @@ export const buildStablecoinYieldReviewState = ({
         type: 'final',
         fee: fee.toFixed(0),
         feePerByte: feePerUnit,
-        feeLimit: gasLimit.toFixed(0),
+        feeLimit: gasLimit.toIntegerString(),
         totalSpent: reviewToken ? amountSubunits.toFixed(0) : amountSubunits.plus(fee).toFixed(0),
         bytes: 0,
         inputs: [],

--- a/suite-common/staking/package.json
+++ b/suite-common/staking/package.json
@@ -23,7 +23,6 @@
         "@trezor/connect-common": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
-        "viem": "^2.48.1",
-        "web3-utils": "^4.3.3"
+        "viem": "^2.48.1"
     }
 }

--- a/suite-common/staking/src/utils/ethereumStaking.ts
+++ b/suite-common/staking/src/utils/ethereumStaking.ts
@@ -1,5 +1,4 @@
 import { decodeFunctionResult } from 'viem';
-import { fromWei, numberToHex, toWei } from 'web3-utils';
 
 import { Calldata, EVM_ABI, Verifier, type VerifyIssue } from '@suite-common/calldata';
 import { type EthValidatorsQueue } from '@suite-common/earn-staking-api';
@@ -18,6 +17,10 @@ import {
     type WalletAccountTransaction,
 } from '@suite-common/wallet-types';
 import {
+    fromEther,
+    fromGwei,
+    fromIntegerString,
+    fromWei,
     getEthereumEstimateFeeParams,
     isPending,
     isSupportedEthStakingNetworkSymbol,
@@ -167,7 +170,7 @@ export const stake = async ({
 }: StakeTxBaseArgs & {
     amount: string;
 }) => {
-    const amountWei = toWei(amount, 'ether');
+    const amountWei = fromEther(amount).toWei();
 
     if (new BigNumber(amount).lt(MIN_ETH_AMOUNT_FOR_STAKING)) {
         throw new Error(
@@ -239,7 +242,7 @@ export const unstake = async ({
             throw new Error('Failed to get the autocompound balance');
         }
 
-        const balance = new BigNumber(fromWei(autocompoundBalance, 'ether'));
+        const balance = fromWei(autocompoundBalance).toEther('bignumber');
         if (balance.lt(amount)) {
             throw new Error(`Max Amount For Unstake ${balance}`);
         }
@@ -249,7 +252,7 @@ export const unstake = async ({
             interchanges = UINT16_MAX;
         }
 
-        const amountWei = toWei(amount, 'ether');
+        const amountWei = fromEther(amount).toWei();
         const { addressContractPool } =
             getEthNetworkAddresses(symbol) ??
             throwError(`Unsupported staking network symbol: ${symbol}`);
@@ -308,8 +311,8 @@ export const claimWithdrawRequest = async ({
             throw new Error('Failed to get the claimable or withdraw total amount');
         }
 
-        const requested = new BigNumber(fromWei(withdrawTotalAmount, 'ether'));
-        const readyForClaim = new BigNumber(fromWei(claimableAmount, 'ether'));
+        const requested = fromWei(withdrawTotalAmount).toEther('bignumber');
+        const readyForClaim = fromWei(claimableAmount).toEther('bignumber');
         if (requested.isZero()) {
             throw new Error('No amount requested for unstake');
         }
@@ -397,10 +400,10 @@ export const transformTx = (
     const commonTxData = {
         to: tx.to,
         // in send form, the amount is in ether, here in wei because it is converted earlier in stake, unstake, claimToWithdraw methods
-        value: numberToHex(tx.value),
+        value: fromWei(tx.value).toWei('hex'),
         chainId,
-        nonce: numberToHex(nonce),
-        gasLimit: numberToHex(tx.gasLimit),
+        nonce: fromIntegerString(nonce).toHex(),
+        gasLimit: fromIntegerString(tx.gasLimit).toHex(),
         data: sanitizeHex(tx.data),
     };
 
@@ -408,13 +411,13 @@ export const transformTx = (
         result = {
             ...commonTxData,
             gasPrice: undefined,
-            maxFeePerGas: numberToHex(toWei(maxFeePerGas, 'gwei')),
-            maxPriorityFeePerGas: numberToHex(toWei(maxPriorityFeePerGas || '0', 'gwei')),
+            maxFeePerGas: fromGwei(maxFeePerGas).toWei('hex'),
+            maxPriorityFeePerGas: fromGwei(maxPriorityFeePerGas || '0').toWei('hex'),
         } as EthereumTransactionEIP1559;
     } else if (gasPrice) {
         result = {
             ...commonTxData,
-            gasPrice: numberToHex(toWei(gasPrice, 'gwei')),
+            gasPrice: fromGwei(gasPrice).toWei('hex'),
             maxFeePerGas: undefined,
             maxPriorityFeePerGas: undefined,
         } as EthereumTransaction;
@@ -742,7 +745,7 @@ export const simulateUnstake = async ({
     if (!ethAddresses) return null;
     const { addressContractPool } = ethAddresses;
 
-    const amountWei = toWei(amount, 'ether');
+    const amountWei = fromEther(amount).toWei();
     const data = buildUnstakeData(amountWei, UNSTAKE_INTERCHANGES);
 
     const transactionData = await TrezorConnect.blockchainEvmRpcCall({
@@ -762,7 +765,7 @@ export const simulateUnstake = async ({
         data: transactionData.payload.data as `0x${string}`,
     });
 
-    return fromWei(unstakeFromPendingValue.toString(), 'ether');
+    return fromWei(unstakeFromPendingValue.toString()).toEther();
 };
 
 export const getEthereumStakingAddressByType = (

--- a/suite-common/wallet-core/package.json
+++ b/suite-common/wallet-core/package.json
@@ -51,7 +51,6 @@
         "lodash": "^4.18.1",
         "react": "19.2.4",
         "react-hook-form": "^7.71.2",
-        "react-redux": "9.2.0",
-        "web3-utils": "^4.3.3"
+        "react-redux": "9.2.0"
     }
 }

--- a/suite-common/wallet-core/src/allowance/buildAllowanceTransaction.ts
+++ b/suite-common/wallet-core/src/allowance/buildAllowanceTransaction.ts
@@ -1,7 +1,5 @@
-import { fromWei, toWei } from 'web3-utils';
-
 import { type PrecomposedTransaction } from '@suite-common/wallet-types';
-import { calculateTotalGasCost } from '@suite-common/wallet-utils';
+import { calculateTotalGasCost, fromGwei, fromWei } from '@suite-common/wallet-utils';
 import { type FeeLevel, type TokenInfo } from '@trezor/connect';
 import { BigNumber } from '@trezor/utils';
 
@@ -15,7 +13,7 @@ export const buildAllowanceTransaction = (
 ): PrecomposedTransaction => {
     const gasPrice = feeLevel.maxFeePerGas || feeLevel.feePerUnit;
 
-    const fee = calculateTotalGasCost(toWei(gasPrice, 'gwei'), feeLevel.feeLimit);
+    const fee = calculateTotalGasCost(fromGwei(gasPrice).toWei(), feeLevel.feeLimit);
 
     if (new BigNumber(fee).gt(balance)) {
         return {
@@ -24,7 +22,7 @@ export const buildAllowanceTransaction = (
             errorMessage: {
                 id: 'AMOUNT_NOT_ENOUGH_CURRENCY_FEE_WITH_ETH_AMOUNT',
                 values: {
-                    feeAmount: fromWei(fee, 'ether'),
+                    feeAmount: fromWei(fee).toEther(),
                     networkDisplaySymbol,
                 },
             },

--- a/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
@@ -1,5 +1,3 @@
-import { fromWei, toWei } from 'web3-utils';
-
 import { isApprovalFlowSupported, selectSelectedDevice } from '@suite-common/device';
 import { createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
@@ -26,6 +24,8 @@ import {
     calculateTotalGasCost,
     convertAmountSubunitsToUnits,
     convertAmountUnitsToSubunits,
+    fromGwei,
+    fromWei,
     getAccountIdentity,
     getApprovalComposeOutput,
     getCryptoMaxAmountWithReserve,
@@ -64,7 +64,7 @@ export const calculate = (
     let max: string | undefined;
 
     const totalGasCostInWei = calculateTotalGasCost(
-        toWei(feeLevel.maxFeePerGas || feeLevel.feePerUnit, 'gwei'),
+        fromGwei(feeLevel.maxFeePerGas || feeLevel.feePerUnit).toWei(),
         feeLevel.feeLimit,
     );
 
@@ -122,7 +122,7 @@ export const calculate = (
                 errorMessage: {
                     id: 'AMOUNT_NOT_ENOUGH_CURRENCY_FEE_WITH_ETH_AMOUNT',
                     values: {
-                        feeAmount: fromWei(totalGasCostInWei, 'ether').toString(),
+                        feeAmount: fromWei(totalGasCostInWei).toEther(),
                     },
                 },
             } as const;

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
@@ -1,11 +1,11 @@
-import { numberToHex, toWei } from 'web3-utils';
-
 import { Calldata, type EvmAddress } from '@suite-common/calldata';
 import { type YieldDto } from '@suite-common/earn-stablecoin-api';
 import type { NetworkSymbol } from '@suite-common/wallet-config';
 import { type AccountKey, type EvmSelectedFee } from '@suite-common/wallet-types';
 import {
     asAmountUnit,
+    fromGwei,
+    fromIntegerString,
     getContractAddressForNetworkSymbol,
     unitsToSubunits,
 } from '@suite-common/wallet-utils';
@@ -184,22 +184,22 @@ export const buildYieldDepositCalldata = ({
     return builderResult.data;
 };
 
-export const buildEvmFeeFields = ({ feeLevel, gasLimit }: BuildEvmFeeFieldsParams) => {
+const buildEvmFeeFields = ({ feeLevel, gasLimit }: BuildEvmFeeFieldsParams) => {
     const commonFields = {
-        gasLimit: numberToHex(gasLimit),
+        gasLimit: fromIntegerString(gasLimit).toHex(),
     };
 
     if (feeLevel.maxFeePerGas && feeLevel.maxPriorityFeePerGas) {
         return {
             ...commonFields,
-            maxFeePerGas: numberToHex(toWei(feeLevel.maxFeePerGas, 'gwei')),
-            maxPriorityFeePerGas: numberToHex(toWei(feeLevel.maxPriorityFeePerGas, 'gwei')),
+            maxFeePerGas: fromGwei(feeLevel.maxFeePerGas).toWei('hex'),
+            maxPriorityFeePerGas: fromGwei(feeLevel.maxPriorityFeePerGas).toWei('hex'),
         };
     }
 
     return {
         ...commonFields,
-        gasPrice: numberToHex(toWei(feeLevel.feePerUnit, 'gwei')),
+        gasPrice: fromGwei(feeLevel.feePerUnit).toWei('hex'),
     };
 };
 
@@ -213,7 +213,7 @@ export const buildEvmSelectedFee = ({
         return {
             type: 'eip1559',
             ...feeFields,
-            baseFeePerGas: numberToHex(toWei(feeLevel.baseFeePerGas ?? '0', 'gwei')),
+            baseFeePerGas: fromGwei(feeLevel.baseFeePerGas ?? '0').toWei('hex'),
         };
     }
 

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -1,5 +1,3 @@
-import { toWei } from 'web3-utils';
-
 import { createSingleInstanceThunk, createThunk } from '@suite-common/redux-utils';
 import { getTxsPerPage } from '@suite-common/suite-utils';
 import {
@@ -17,6 +15,7 @@ import {
     ensureHexPrefix,
     findAccountsByAddress,
     findTransactions,
+    fromGwei,
     getEvmTransactionTextSignature,
     getPendingAccount,
     getRbfParams,
@@ -281,13 +280,13 @@ const buildFakePendingEvmTx = ({
             status: -1,
             nonce: parseInt(nonce),
             gasLimit: parseInt(precomposedTransaction.feeLimit ?? '0'),
-            gasPrice: isLegacyTx ? toWei(precomposedTransaction.feePerByte, 'gwei') : undefined,
+            gasPrice: isLegacyTx ? fromGwei(precomposedTransaction.feePerByte).toWei() : undefined,
             maxFeePerGas: isLegacyTx
                 ? undefined
-                : toWei(precomposedTransaction.maxFeePerGas ?? '0', 'gwei'),
+                : fromGwei(precomposedTransaction.maxFeePerGas ?? '0').toWei(),
             maxPriorityFeePerGas: isLegacyTx
                 ? undefined
-                : toWei(precomposedTransaction.maxPriorityFeePerGas ?? '0', 'gwei'),
+                : fromGwei(precomposedTransaction.maxPriorityFeePerGas ?? '0').toWei(),
             data: ensureHexPrefix(precomposedForm?.transactionData),
         },
         details: {

--- a/suite-common/wallet-types/src/ethereumUnits.ts
+++ b/suite-common/wallet-types/src/ethereumUnits.ts
@@ -1,0 +1,9 @@
+import type { Branded } from '@trezor/type-utils';
+
+export type HexString = `0x${string}`;
+export type IntegerString = `${bigint}`;
+export type DecimalString = `${bigint}` | `${bigint}.${bigint}`;
+
+export type Wei = Branded<'wei'>;
+export type Gwei = Branded<'gwei'>;
+export type Ether = Branded<'ether'>;

--- a/suite-common/wallet-types/src/index.ts
+++ b/suite-common/wallet-types/src/index.ts
@@ -11,6 +11,7 @@ export type * from './selectedAccount';
 export * from './transaction';
 export type * from './transactionReviewOutput';
 export * from './ethereumStaking';
+export type * from './ethereumUnits';
 export type * from './stakeForm';
 export type * from './stablecoinYield';
 export type * from './send';

--- a/suite-common/wallet-utils/src/__tests__/ethConverter.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/ethConverter.test.ts
@@ -1,0 +1,123 @@
+import { BigNumber } from '@trezor/utils';
+
+import {
+    fromBigInt,
+    fromEther,
+    fromGwei,
+    fromHex,
+    fromIntegerString,
+    fromWei,
+} from '../ethConverter';
+
+// [wei, gwei, ether, hex]
+const rows = [
+    ['0', '0', '0', '0x0'],
+    ['8191', '0.000008191', '0.000000000000008191', '0x1fff'],
+    ['2147483647', '2.147483647', '0.000000002147483647', '0x7fffffff'],
+    [
+        '618970019642690137449562111',
+        '618970019642690137.449562111',
+        '618970019.642690137449562111',
+        '0x1ffffffffffffffffffffff',
+    ],
+] as const;
+
+type Row = (typeof rows)[number];
+
+describe('eth converter', () => {
+    describe('units', () => {
+        it.each([
+            ['fromWei', ([wei]: Row) => fromWei(wei)],
+            ['fromGwei', ([, gwei]: Row) => fromGwei(gwei)],
+            ['fromEther', ([, , ether]: Row) => fromEther(ether)],
+        ])('%s', (_label, func) => {
+            for (const row of rows) {
+                const [wei, gwei, ether, hex] = row;
+                expect(func(row).toWei()).toBe(wei);
+                expect(func(row).toWei('string')).toBe(wei);
+                expect(func(row).toWei('hex')).toBe(hex);
+                expect(func(row).toWei('bignumber')).toStrictEqual(new BigNumber(wei));
+                expect(func(row).toGwei()).toBe(gwei);
+                expect(func(row).toGwei('string')).toBe(gwei);
+                expect(func(row).toGwei('bignumber')).toStrictEqual(new BigNumber(gwei));
+                expect(func(row).toEther()).toBe(ether);
+                expect(func(row).toEther('string')).toBe(ether);
+                expect(func(row).toEther('bignumber')).toStrictEqual(new BigNumber(ether));
+            }
+        });
+
+        it('compatibility', () => {
+            // @ts-expect-error Old fromWei supported number as well
+            expect(fromWei(43981).toWei()).toBe('43981');
+            // @ts-expect-error Old fromWei supported bigint as well
+            expect(fromWei(BigInt(43981)).toWei()).toBe('43981');
+            // Old fromWei supported hex string as well (technically still does, but it's meant to take decimal string)
+            expect(fromWei('0xabcd').toWei()).toBe('43981');
+
+            // @ts-expect-error Old toWei supported number as well
+            expect(fromGwei(43981).toGwei()).toBe('43981');
+            // @ts-expect-error Old toWei supported bigint as well
+            expect(fromGwei(BigInt(43981)).toGwei()).toBe('43981');
+            // Old toWei supported hex string as well (technically still does, but it's meant to take decimal string)
+            expect(fromGwei('0xabcd').toGwei()).toBe('43981');
+
+            // @ts-expect-error Old toWei supported number as well
+            expect(fromEther(43981).toEther()).toBe('43981');
+            // @ts-expect-error Old toWei supported bigint as well
+            expect(fromEther(BigInt(43981)).toEther()).toBe('43981');
+            // Old toWei supported hex string as well (technically still does, but it's meant to take decimal string)
+            expect(fromEther('0xabcd').toEther()).toBe('43981');
+        });
+
+        it('errors', () => {
+            Object.entries({
+                '1ab2': 'not a number',
+                '0xy': 'not a number',
+                '-43': 'negative',
+                Infinity: 'infinity',
+            }).forEach(([value, reason]) => {
+                expect(() => fromWei(value)).toThrow(`Value '${value}' is invalid (${reason})`);
+                expect(() => fromGwei(value)).toThrow(`Value '${value}' is invalid (${reason})`);
+                expect(() => fromEther(value)).toThrow(`Value '${value}' is invalid (${reason})`);
+            });
+
+            expect(() => fromWei('0.3')).toThrow(`Value '0.3' is invalid (decimal)`);
+            expect(() => fromGwei('0.3')).not.toThrow();
+            expect(() => fromEther('0.3')).not.toThrow();
+        });
+    });
+
+    describe('formats', () => {
+        it.each([
+            ['fromHex', ([, , , hex]: Row) => fromHex(hex)],
+            ['fromBigInt', ([wei]: Row) => fromBigInt(BigInt(wei))],
+            ['fromIntegerString', ([wei]: Row) => fromIntegerString(wei)],
+        ])('%s', (_label, func) => {
+            for (const row of rows) {
+                const [wei, gwei, ether, hex] = row;
+                expect(func(row).toHex()).toBe(hex);
+                expect(func(row).toBigNumber()).toStrictEqual(new BigNumber(wei));
+                expect(func(row).toIntegerString()).toBe(wei);
+                expect(func(row).asWei().toWei()).toBe(wei);
+                expect(func(row).asWei().toGwei()).toBe(gwei);
+                expect(func(row).asWei().toEther()).toBe(ether);
+            }
+        });
+
+        it('errors', () => {
+            Object.entries({
+                '1ab2': 'not a number',
+                '0xy': 'not a number',
+                '-43': 'negative',
+                Infinity: 'infinity',
+                '0.3': 'decimal',
+            }).forEach(([value, reason]: [any, string]) => {
+                expect(() => fromHex(value)).toThrow(`Value '${value}' is invalid (${reason})`);
+                expect(() => fromBigInt(value)).toThrow(`Value '${value}' is invalid (${reason})`);
+                expect(() => fromIntegerString(value)).toThrow(
+                    `Value '${value}' is invalid (${reason})`,
+                );
+            });
+        });
+    });
+});

--- a/suite-common/wallet-utils/src/__tests__/ethConverter.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/ethConverter.test.ts
@@ -24,6 +24,8 @@ const rows = [
 
 type Row = (typeof rows)[number];
 
+const err = (value: string, reason: string) => `Value '${value}' is invalid (${reason})`;
+
 describe('eth converter', () => {
     describe('units', () => {
         it.each([
@@ -76,14 +78,25 @@ describe('eth converter', () => {
                 '-43': 'negative',
                 Infinity: 'infinity',
             }).forEach(([value, reason]) => {
-                expect(() => fromWei(value)).toThrow(`Value '${value}' is invalid (${reason})`);
-                expect(() => fromGwei(value)).toThrow(`Value '${value}' is invalid (${reason})`);
-                expect(() => fromEther(value)).toThrow(`Value '${value}' is invalid (${reason})`);
+                expect(() => fromWei(value)).toThrow(err(value, reason));
+                expect(() => fromGwei(value)).toThrow(err(value, reason));
+                expect(() => fromEther(value)).toThrow(err(value, reason));
             });
 
-            expect(() => fromWei('0.3')).toThrow(`Value '0.3' is invalid (decimal)`);
+            const errDecimals = (dec: number, max: number) =>
+                err(`0.${'0'.repeat(dec)}3`, `more than ${max} decimal places`);
+
+            expect(() => fromWei('0.3')).toThrow(errDecimals(0, 0));
             expect(() => fromGwei('0.3')).not.toThrow();
             expect(() => fromEther('0.3')).not.toThrow();
+
+            expect(() => fromWei('0.0000000003')).toThrow(errDecimals(9, 0));
+            expect(() => fromGwei('0.0000000003')).toThrow(errDecimals(9, 9));
+            expect(() => fromEther('0.0000000003')).not.toThrow();
+
+            expect(() => fromWei('0.0000000000000000003')).toThrow(errDecimals(18, 0));
+            expect(() => fromGwei('0.0000000000000000003')).toThrow(errDecimals(18, 9));
+            expect(() => fromEther('0.0000000000000000003')).toThrow(errDecimals(18, 18));
         });
     });
 
@@ -110,13 +123,11 @@ describe('eth converter', () => {
                 '0xy': 'not a number',
                 '-43': 'negative',
                 Infinity: 'infinity',
-                '0.3': 'decimal',
+                '0.3': 'more than 0 decimal places',
             }).forEach(([value, reason]: [any, string]) => {
-                expect(() => fromHex(value)).toThrow(`Value '${value}' is invalid (${reason})`);
-                expect(() => fromBigInt(value)).toThrow(`Value '${value}' is invalid (${reason})`);
-                expect(() => fromIntegerString(value)).toThrow(
-                    `Value '${value}' is invalid (${reason})`,
-                );
+                expect(() => fromHex(value)).toThrow(err(value, reason));
+                expect(() => fromBigInt(value)).toThrow(err(value, reason));
+                expect(() => fromIntegerString(value)).toThrow(err(value, reason));
             });
         });
     });

--- a/suite-common/wallet-utils/src/__tests__/ethUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/ethUtils.test.ts
@@ -4,8 +4,6 @@ import { BigNumber } from '@trezor/utils';
 
 import {
     buildApprovalTransactionData,
-    evmHexToBigNumber,
-    evmHexWeiToGwei,
     getEvmTransactionTextSignature,
     padLeftEven,
     sanitizeHex,
@@ -33,11 +31,6 @@ describe('eth utils', () => {
         expect(strip('0x')).toBe('');
         expect(strip('0x2540be3ff')).toBe('02540be3ff');
         expect(strip('2540be3ff')).toBe('02540be3ff');
-    });
-
-    it('converts EVM fee units', () => {
-        expect(evmHexToBigNumber('0x5208').toFixed()).toBe('21000');
-        expect(evmHexWeiToGwei('0x3b9aca00')).toBe('1');
     });
 
     describe('getEvmTransactionTextSignature', () => {

--- a/suite-common/wallet-utils/src/ethConverter.ts
+++ b/suite-common/wallet-utils/src/ethConverter.ts
@@ -18,23 +18,26 @@ interface EthValue {
     toEther(format?: 'string'): Ether & DecimalString;
 }
 
-const GWEI = new BigNumber('1e9');
-const ETHER = new BigNumber('1e18');
+const GWEI_DECIMALS = 9;
+const ETHER_DECIMALS = 18;
 
 const error = (value: unknown, reason: string) =>
     new Error(`Value '${value}' is invalid (${reason})`);
 
 const toHex = (value: BigNumber): HexString => `0x${value.toString(16)}`;
 
-const toBN = (value: string | bigint, assertInteger?: boolean) => {
+const toBN = (value: string | bigint, shift = 0) => {
     const bn = new BigNumber(value);
 
     if (bn.isNaN()) throw error(value, 'not a number');
     if (bn.isNegative()) throw error(value, 'negative');
     if (!bn.isFinite()) throw error(value, 'infinity');
-    if (!bn.isInteger() && assertInteger) throw error(value, 'decimal');
 
-    return bn;
+    const shifted = bn.shiftedBy(shift);
+
+    if (!shifted.isInteger()) throw error(value, `more than ${shift} decimal places`);
+
+    return shifted;
 };
 
 const convertUnit = (wei: BigNumber) =>
@@ -50,7 +53,7 @@ const convertUnit = (wei: BigNumber) =>
             }
         }) as EthValue['toWei'],
         toGwei: (format = 'string') => {
-            const gwei = wei.div(GWEI);
+            const gwei = wei.shiftedBy(-GWEI_DECIMALS);
             switch (format) {
                 case 'bignumber':
                     return gwei;
@@ -59,7 +62,7 @@ const convertUnit = (wei: BigNumber) =>
             }
         },
         toEther: (format = 'string') => {
-            const ether = wei.div(ETHER);
+            const ether = wei.shiftedBy(-ETHER_DECIMALS);
             switch (format) {
                 case 'bignumber':
                     return ether;
@@ -78,14 +81,14 @@ const convertFormat = (value: BigNumber) => ({
 
 // TODO input amounts should be branded as well, but it requires broad changes over the whole monorepo
 
-export const fromWei = (wei: string) => convertUnit(toBN(wei, true));
+export const fromWei = (wei: string) => convertUnit(toBN(wei));
 
-export const fromGwei = (gwei: string) => convertUnit(toBN(gwei).times(GWEI).integerValue());
+export const fromGwei = (gwei: string) => convertUnit(toBN(gwei, GWEI_DECIMALS));
 
-export const fromEther = (ether: string) => convertUnit(toBN(ether).times(ETHER).integerValue());
+export const fromEther = (ether: string) => convertUnit(toBN(ether, ETHER_DECIMALS));
 
-export const fromHex = (hex: HexString) => convertFormat(toBN(hex, true));
+export const fromHex = (hex: HexString) => convertFormat(toBN(hex));
 
-export const fromBigInt = (value: bigint) => convertFormat(toBN(value, true));
+export const fromBigInt = (value: bigint) => convertFormat(toBN(value));
 
-export const fromIntegerString = (value: string) => convertFormat(toBN(value, true));
+export const fromIntegerString = (value: string) => convertFormat(toBN(value));

--- a/suite-common/wallet-utils/src/ethConverter.ts
+++ b/suite-common/wallet-utils/src/ethConverter.ts
@@ -1,0 +1,91 @@
+import type {
+    DecimalString,
+    Ether,
+    Gwei,
+    HexString,
+    IntegerString,
+    Wei,
+} from '@suite-common/wallet-types';
+import { BigNumber } from '@trezor/utils';
+
+interface EthValue {
+    toWei(format: 'hex'): Wei & HexString;
+    toWei(format: 'bignumber'): Wei & BigNumber;
+    toWei(format?: 'string'): Wei & IntegerString;
+    toGwei(format: 'bignumber'): Gwei & BigNumber;
+    toGwei(format?: 'string'): Gwei & DecimalString;
+    toEther(format: 'bignumber'): Ether & BigNumber;
+    toEther(format?: 'string'): Ether & DecimalString;
+}
+
+const GWEI = new BigNumber('1e9');
+const ETHER = new BigNumber('1e18');
+
+const error = (value: unknown, reason: string) =>
+    new Error(`Value '${value}' is invalid (${reason})`);
+
+const toHex = (value: BigNumber): HexString => `0x${value.toString(16)}`;
+
+const toBN = (value: string | bigint, assertInteger?: boolean) => {
+    const bn = new BigNumber(value);
+
+    if (bn.isNaN()) throw error(value, 'not a number');
+    if (bn.isNegative()) throw error(value, 'negative');
+    if (!bn.isFinite()) throw error(value, 'infinity');
+    if (!bn.isInteger() && assertInteger) throw error(value, 'decimal');
+
+    return bn;
+};
+
+const convertUnit = (wei: BigNumber) =>
+    ({
+        toWei: ((format = 'string') => {
+            switch (format) {
+                case 'hex':
+                    return toHex(wei);
+                case 'bignumber':
+                    return wei;
+                case 'string':
+                    return wei.toString();
+            }
+        }) as EthValue['toWei'],
+        toGwei: (format = 'string') => {
+            const gwei = wei.div(GWEI);
+            switch (format) {
+                case 'bignumber':
+                    return gwei;
+                case 'string':
+                    return gwei.toString();
+            }
+        },
+        toEther: (format = 'string') => {
+            const ether = wei.div(ETHER);
+            switch (format) {
+                case 'bignumber':
+                    return ether;
+                case 'string':
+                    return ether.toString();
+            }
+        },
+    }) as EthValue;
+
+const convertFormat = (value: BigNumber) => ({
+    toHex: () => toHex(value),
+    toBigNumber: () => value,
+    toIntegerString: () => value.toString(),
+    asWei: () => convertUnit(value),
+});
+
+// TODO input amounts should be branded as well, but it requires broad changes over the whole monorepo
+
+export const fromWei = (wei: string) => convertUnit(toBN(wei, true));
+
+export const fromGwei = (gwei: string) => convertUnit(toBN(gwei).times(GWEI).integerValue());
+
+export const fromEther = (ether: string) => convertUnit(toBN(ether).times(ETHER).integerValue());
+
+export const fromHex = (hex: HexString) => convertFormat(toBN(hex, true));
+
+export const fromBigInt = (value: bigint) => convertFormat(toBN(value, true));
+
+export const fromIntegerString = (value: string) => convertFormat(toBN(value, true));

--- a/suite-common/wallet-utils/src/ethUtils.ts
+++ b/suite-common/wallet-utils/src/ethUtils.ts
@@ -1,5 +1,3 @@
-import { fromWei } from 'web3-utils';
-
 import { Calldata } from '@suite-common/calldata';
 import { UINT256_MAX } from '@suite-common/suite-constants';
 import { type EvmTransactionPurpose } from '@suite-common/wallet-types';
@@ -34,11 +32,6 @@ export const strip = (str: string): string => {
 
     return padLeftEven(str);
 };
-
-export const evmHexToBigNumber = (hex: `0x${string}`) => new BigNumber(strip(hex) || '0', 16);
-
-export const evmHexWeiToGwei = (hex: `0x${string}`) =>
-    fromWei(evmHexToBigNumber(hex).toFixed(0), 'gwei');
 
 export const getEvmTransactionTextSignature = (data?: string): EvmTransactionPurpose => {
     if (!data) return '';

--- a/suite-common/wallet-utils/src/ethereumStakingUtils.ts
+++ b/suite-common/wallet-utils/src/ethereumStakingUtils.ts
@@ -1,5 +1,3 @@
-import { fromWei, hexToNumberString } from 'web3-utils';
-
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import {
     type Account,
@@ -12,6 +10,8 @@ import {
     supportedNetworkSymbols,
 } from '@suite-common/wallet-types';
 import { BigNumber, isArrayMember } from '@trezor/utils';
+
+import { fromHex, fromWei } from './ethConverter';
 
 export const getEverstakePool = (account?: Account) => {
     if (account?.networkType !== 'ethereum') {
@@ -30,17 +30,16 @@ export const getAccountEverstakeStakingPool = (
 
     return {
         ...pool,
-        autocompoundBalance: fromWei(pool.autocompoundBalance, 'ether'),
-        claimableAmount: fromWei(pool.claimableAmount, 'ether'),
-        depositedBalance: fromWei(pool.depositedBalance, 'ether'),
-        pendingBalance: fromWei(pool.pendingBalance, 'ether'),
-        pendingDepositedBalance: fromWei(pool.pendingDepositedBalance, 'ether'),
-        restakedReward: fromWei(pool.restakedReward, 'ether'),
-        withdrawTotalAmount: fromWei(pool.withdrawTotalAmount, 'ether'),
+        autocompoundBalance: fromWei(pool.autocompoundBalance).toEther(),
+        claimableAmount: fromWei(pool.claimableAmount).toEther(),
+        depositedBalance: fromWei(pool.depositedBalance).toEther(),
+        pendingBalance: fromWei(pool.pendingBalance).toEther(),
+        pendingDepositedBalance: fromWei(pool.pendingDepositedBalance).toEther(),
+        restakedReward: fromWei(pool.restakedReward).toEther(),
+        withdrawTotalAmount: fromWei(pool.withdrawTotalAmount).toEther(),
         totalPendingStakeBalance: fromWei(
             new BigNumber(pool.pendingBalance).plus(pool.pendingDepositedBalance).toString(),
-            'ether',
-        ),
+        ).toEther(),
         canClaim:
             new BigNumber(pool.claimableAmount).gt(0) &&
             new BigNumber(pool.withdrawTotalAmount).eq(pool.claimableAmount),
@@ -125,7 +124,7 @@ export const getUnstakeAmountByEthereumDataHex = (dataHex?: string) => {
 
     const dataBuffer = Buffer.from(data, 'hex');
 
-    return hexToNumberString(`0x${dataBuffer.subarray(4, 36).toString('hex')}`);
+    return fromHex(`0x${dataBuffer.subarray(4, 36).toString('hex')}`).toIntegerString();
 };
 
 export const isStakeForm = (form: FormState | StakeFormState): form is StakeFormState =>

--- a/suite-common/wallet-utils/src/index.ts
+++ b/suite-common/wallet-utils/src/index.ts
@@ -8,6 +8,7 @@ export * from './calculateChainedTransactionsFeeForRbf';
 export * from './cardanoUtils';
 export * from './csvParserUtils';
 export * from './deviceUtils';
+export * from './ethConverter';
 export * from './ethUtils';
 export * from './ethereumStakingUtils';
 export * from './fiatConverterUtils';

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.ts
@@ -1,5 +1,3 @@
-import { fromWei, toWei } from 'web3-utils';
-
 import { Calldata, isEvmClearSigningTx } from '@suite-common/calldata';
 import { EVM_SPENDER_LABELS } from '@suite-common/suite-constants';
 import { type TrezorDevice } from '@suite-common/suite-types';
@@ -24,6 +22,7 @@ import {
     isApprovalFlowSupported as isApprovalSupported,
     isEvmClearSigningSupported as isEvmClearSigningSupportedByDevice,
 } from './deviceUtils';
+import { fromGwei, fromWei } from './ethConverter';
 import {
     getEvmTransactionTextSignature,
     isEvmApprovalTx,
@@ -604,8 +603,8 @@ const constructNewFlow = ({
 
     if (networkType === 'ethereum' && !isUpdatedEthereumSendFlow) {
         // device shows ether, precomposedTx.feePerByte is in gwei
-        const wei = toWei(precomposedTx.feePerByte, 'gwei'); // from gwei to wei
-        const ether = fromWei(wei, 'ether'); // from wei to ether
+        const wei = fromGwei(precomposedTx.feePerByte).toWei(); // from gwei to wei
+        const ether = fromWei(wei).toEther(); // from wei to ether
 
         outputs.push({
             type: 'gas',

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -7,7 +7,7 @@ import {
     type Merge,
 } from 'react-hook-form';
 
-import { fromWei, numberToHex, padLeft, toWei } from 'web3-utils';
+import { padLeft } from 'web3-utils';
 
 import {
     type Network,
@@ -58,6 +58,7 @@ import {
     networkAmountToSmallestUnit,
 } from './amountUtils';
 import { isBaseCurrencyWithSats } from './baseCurrency';
+import { fromEther, fromGwei, fromIntegerString, fromWei } from './ethConverter';
 import { isEip1559, isEvmApprovalTx, sanitizeHex } from './ethUtils';
 
 export const calculateTotal = (amount: string, fee: string): string => {
@@ -124,8 +125,7 @@ export const calculateTotalGasCost = (gasPriceInWei?: string, gasLimit?: string)
     return fee.toFixed();
 };
 
-const getSerializedAmount = (amount?: string) =>
-    amount ? numberToHex(toWei(amount, 'ether')) : '0x00';
+const getSerializedAmount = (amount?: string) => (amount ? fromEther(amount).toWei('hex') : '0x00');
 
 const getSerializedErc20Transfer = (token: TokenInfo, to: string, amount: string) => {
     // 32 bytes address parameter, remove '0x' prefix
@@ -133,7 +133,7 @@ const getSerializedErc20Transfer = (token: TokenInfo, to: string, amount: string
     // convert amount to satoshi
     const tokenAmount = convertAmountUnitsToSubunits(amount, token.decimals);
     // 32 bytes amount paramter, remove '0x' prefix
-    const erc20amount = padLeft(numberToHex(tokenAmount), 64).substring(2);
+    const erc20amount = padLeft(fromIntegerString(tokenAmount).toHex(), 64).substring(2);
 
     // join data
     return `0x${ERC20_TRANSFER}${erc20recipient}${erc20amount}`;
@@ -180,8 +180,8 @@ export const prepareEthereumTransaction = (
         to: txInfo.to,
         value: getSerializedAmount(txInfo.amount),
         chainId: txInfo.chainId,
-        nonce: numberToHex(txInfo.nonce),
-        gasLimit: numberToHex(txInfo.gasLimit),
+        nonce: fromIntegerString(txInfo.nonce).toHex(),
+        gasLimit: fromIntegerString(txInfo.gasLimit).toHex(),
         payment_req: txInfo.payment_req,
     };
 
@@ -189,13 +189,13 @@ export const prepareEthereumTransaction = (
         result = {
             ...commonTxData,
             gasPrice: undefined,
-            maxFeePerGas: numberToHex(toWei(txInfo.maxFeePerGas, 'gwei')),
-            maxPriorityFeePerGas: numberToHex(toWei(txInfo.maxPriorityFeePerGas || '0', 'gwei')),
+            maxFeePerGas: fromGwei(txInfo.maxFeePerGas).toWei('hex'),
+            maxPriorityFeePerGas: fromGwei(txInfo.maxPriorityFeePerGas || '0').toWei('hex'),
         } satisfies EthereumTransactionEIP1559;
     } else if (txInfo.gasPrice) {
         result = {
             ...commonTxData,
-            gasPrice: numberToHex(toWei(txInfo.gasPrice, 'gwei')),
+            gasPrice: fromGwei(txInfo.gasPrice).toWei('hex'),
             maxFeePerGas: undefined,
             maxPriorityFeePerGas: undefined,
         } satisfies EthereumTransaction;
@@ -245,12 +245,12 @@ const getConvertedOrDefaultFeeLevels = ({
         return levels.map(level => {
             const { feePerUnit, maxFeePerGas, maxPriorityFeePerGas, baseFeePerGas } = level;
 
-            const feePerUnitInGwei = fromWei(feePerUnit, 'gwei');
-            const maxFeePerGasInGwei = maxFeePerGas ? fromWei(maxFeePerGas, 'gwei') : undefined;
+            const feePerUnitInGwei = fromWei(feePerUnit).toGwei();
+            const maxFeePerGasInGwei = maxFeePerGas ? fromWei(maxFeePerGas).toGwei() : undefined;
             const maxPriorityFeePerGasInGwei = maxPriorityFeePerGas
-                ? fromWei(maxPriorityFeePerGas, 'gwei')
+                ? fromWei(maxPriorityFeePerGas).toGwei()
                 : undefined;
-            const baseFeePerGasInGwei = baseFeePerGas ? fromWei(baseFeePerGas, 'gwei') : undefined;
+            const baseFeePerGasInGwei = baseFeePerGas ? fromWei(baseFeePerGas).toGwei() : undefined;
 
             return {
                 ...level,

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -1,5 +1,4 @@
 import { addDays, startOfMonth } from 'date-fns';
-import { fromWei, toWei } from 'web3-utils';
 
 import { Calldata } from '@suite-common/calldata';
 import { type SignOperator } from '@suite-common/suite-types';
@@ -33,6 +32,7 @@ import { BigNumber, arrayPartition, isNotNullOrUndefined, typedObjectKeys } from
 
 import { convertAmountSubunitsToUnits, formatNetworkAmount } from './amountUtils';
 import { isCardanoStakingTx } from './cardanoStakingUtils';
+import { fromGwei, fromWei } from './ethConverter';
 import { getEvmTransactionTextSignature } from './ethUtils';
 import { isStakeTypeTx } from './ethereumStakingUtils';
 import { toFiatCurrency } from './fiatConverterUtils';
@@ -704,7 +704,7 @@ export const replaceEthereumSpecific = (
     return {
         ...tx.ethereumSpecific,
         gasLimit: Number(precomposedTx.feeLimit),
-        gasPrice: toWei(precomposedTx.feePerByte, 'gwei'),
+        gasPrice: fromGwei(precomposedTx.feePerByte).toWei(),
     };
 };
 
@@ -801,9 +801,9 @@ const getEthereumRbfParams = (
         ],
         ethereumNonce: nonce,
         transactionData: txSignature === 'transfer' ? '' : transactionData,
-        gasPrice: gasPrice ? fromWei(gasPrice, 'gwei') : '',
-        maxFeePerGas: maxFeePerGas ? fromWei(maxFeePerGas, 'gwei') : '',
-        maxPriorityFeePerGas: maxPriorityFeePerGas ? fromWei(maxPriorityFeePerGas, 'gwei') : '',
+        gasPrice: gasPrice ? fromWei(gasPrice).toGwei() : '',
+        maxFeePerGas: maxFeePerGas ? fromWei(maxFeePerGas).toGwei() : '',
+        maxPriorityFeePerGas: maxPriorityFeePerGas ? fromWei(maxPriorityFeePerGas).toGwei() : '',
     };
 };
 

--- a/suite-native/formatters/package.json
+++ b/suite-native/formatters/package.json
@@ -31,8 +31,7 @@
         "expo-localization": "~55.0.8",
         "react": "19.2.4",
         "react-native": "0.83.2",
-        "react-redux": "9.2.0",
-        "web3-utils": "^4.3.3"
+        "react-redux": "9.2.0"
     },
     "devDependencies": {
         "@suite-native/test-utils-store": "workspace:*"

--- a/suite-native/formatters/src/components/FeeFormatter.tsx
+++ b/suite-native/formatters/src/components/FeeFormatter.tsx
@@ -1,10 +1,8 @@
 import { useMemo } from 'react';
 
-import { fromWei } from 'web3-utils';
-
 import { networks } from '@suite-common/wallet-config';
 import { type WalletAccountTransaction } from '@suite-common/wallet-types';
-import { getFeeRate, getFeeUnits } from '@suite-common/wallet-utils';
+import { fromWei, getFeeRate, getFeeUnits } from '@suite-common/wallet-utils';
 import { Text } from '@suite-native/atoms';
 
 type FeeFormatterProps = {
@@ -17,7 +15,7 @@ export const FeeFormatter = ({ transaction }: FeeFormatterProps) => {
     const formattedValue = useMemo(
         () =>
             networkType === 'ethereum'
-                ? fromWei(transaction.ethereumSpecific?.gasPrice ?? '0', 'gwei')
+                ? fromWei(transaction.ethereumSpecific?.gasPrice ?? '0').toGwei()
                 : transaction.feeRate || getFeeRate(transaction),
         [networkType, transaction],
     );

--- a/suite-native/module-earn/src/hooks/useUnstakeForm.ts
+++ b/suite-native/module-earn/src/hooks/useUnstakeForm.ts
@@ -6,12 +6,15 @@ import { getNetwork } from '@suite-common/wallet-config';
 import { UNSTAKE_INTERCHANGES } from '@suite-common/wallet-constants';
 import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
-import { getStakingLimitsByNetworkSymbol, isPositiveBalance } from '@suite-common/wallet-utils';
+import {
+    fromEther,
+    getStakingLimitsByNetworkSymbol,
+    isPositiveBalance,
+} from '@suite-common/wallet-utils';
 import { useForm, useWatch } from '@suite-native/forms';
 import { useTranslate } from '@suite-native/intl';
 import {
     type NativeStakingRootState,
-    ethToWei,
     selectStakedBalanceByAccountKey,
 } from '@suite-native/staking';
 import { BigNumber } from '@trezor/utils';
@@ -59,7 +62,7 @@ export const useUnstakeForm = (accountKey: AccountKey) => {
             return buildEarnComposeFormState(account.descriptor, amountValue, '');
         }
 
-        const amountWei = ethToWei(amountValue);
+        const amountWei = fromEther(amountValue).toWei();
         if (!isPositiveBalance(amountWei)) return undefined;
 
         return buildEarnComposeFormState(

--- a/suite-native/module-earn/src/yieldDepositFeeUtils.ts
+++ b/suite-native/module-earn/src/yieldDepositFeeUtils.ts
@@ -1,10 +1,6 @@
 import { parseUnsignedEvmTransactionForSigning } from '@suite-common/earn-stablecoin-api';
 import { type PrecomposedTransactionFinal } from '@suite-common/wallet-types';
-import {
-    calculateTotalGasCost,
-    evmHexToBigNumber,
-    evmHexWeiToGwei,
-} from '@suite-common/wallet-utils';
+import { calculateTotalGasCost, fromHex } from '@suite-common/wallet-utils';
 
 type ParsedUnsignedEvmTransaction = NonNullable<
     ReturnType<typeof parseUnsignedEvmTransactionForSigning>
@@ -19,17 +15,17 @@ const buildPrecomposedTransaction = (
         return null;
     }
 
-    const gasLimit = evmHexToBigNumber(tx.gasLimit).toFixed(0);
-    const gasPrice = evmHexToBigNumber(gasPriceHex).toFixed(0);
-    const feePerByte = evmHexWeiToGwei(gasPriceHex);
+    const gasLimit = fromHex(tx.gasLimit).toBigNumber().toFixed(0);
+    const gasPrice = fromHex(gasPriceHex).toBigNumber().toFixed(0);
+    const feePerByte = fromHex(gasPriceHex).asWei().toGwei();
     const fee = calculateTotalGasCost(gasPrice, gasLimit);
     const eip1559Fields: Partial<
         Pick<PrecomposedTransactionFinal, 'maxFeePerGas' | 'maxPriorityFeePerGas'>
     > =
         tx.maxFeePerGas && tx.maxPriorityFeePerGas
             ? {
-                  maxFeePerGas: evmHexWeiToGwei(tx.maxFeePerGas),
-                  maxPriorityFeePerGas: evmHexWeiToGwei(tx.maxPriorityFeePerGas),
+                  maxFeePerGas: fromHex(tx.maxFeePerGas).asWei().toGwei(),
+                  maxPriorityFeePerGas: fromHex(tx.maxPriorityFeePerGas).asWei().toGwei(),
               }
             : {};
 

--- a/suite-native/staking/package.json
+++ b/suite-native/staking/package.json
@@ -31,8 +31,7 @@
         "@trezor/env-utils": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
-        "react-redux": "9.2.0",
-        "web3-utils": "^4.3.3"
+        "react-redux": "9.2.0"
     },
     "devDependencies": {
         "@suite-common/message-system": "workspace:*",

--- a/suite-native/staking/src/stakeFormEthereumNativeThunks.ts
+++ b/suite-native/staking/src/stakeFormEthereumNativeThunks.ts
@@ -14,7 +14,7 @@ import {
     type PrecomposedTransactionFinal,
     type StakeFormState,
 } from '@suite-common/wallet-types';
-import { getFormDraftKey } from '@suite-common/wallet-utils';
+import { fromEther, getFormDraftKey } from '@suite-common/wallet-utils';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
 import TrezorConnect, { type FeeLevel } from '@trezor/connect';
 import { BigNumber } from '@trezor/utils';
@@ -27,7 +27,6 @@ import {
     type PreparedEthereumStakingContext,
 } from './stakeFormEthereumNativeTypes';
 import { type SignStakeNativeRejectValue, type StakeNativeType } from './stakeNativeTypes';
-import { ethToWei } from './utils';
 
 const LOG_PREFIX = 'signEthereumStakingTransactionNativeThunk';
 
@@ -82,7 +81,7 @@ const readVariantFromComposeDraft = (
         stakeType,
         calldata,
         contractAddress,
-        value: stakeType === 'stake' ? ethToWei(composeAmount) : '0',
+        value: stakeType === 'stake' ? fromEther(composeAmount).toWei() : '0',
     };
 };
 

--- a/suite-native/staking/src/utils.ts
+++ b/suite-native/staking/src/utils.ts
@@ -1,7 +1,3 @@
-import { toWei } from 'web3-utils';
-
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 
 export const AUTO_STAKED_SYMBOLS: NetworkSymbol[] = ['ada'] as const;
-
-export const ethToWei = (amount: string): string => toWei(amount, 'ether');

--- a/suite-native/tx-simulation/package.json
+++ b/suite-native/tx-simulation/package.json
@@ -23,7 +23,6 @@
         "@trezor/utils": "workspace:*",
         "react": "19.2.4",
         "react-native": "0.83.2",
-        "react-native-reanimated": "~4.2.1",
-        "web3-utils": "^4.3.3"
+        "react-native-reanimated": "~4.2.1"
     }
 }

--- a/suite-native/tx-simulation/src/components/EvmTxSimulationInfoPresets.tsx
+++ b/suite-native/tx-simulation/src/components/EvmTxSimulationInfoPresets.tsx
@@ -1,12 +1,10 @@
 import { type ReactNode } from 'react';
 
-import { fromWei } from 'web3-utils';
-
 import { type Formatters } from '@suite-common/formatters';
 import { type TransactionSimulation } from '@suite-common/tx-simulation';
 import { type Network } from '@suite-common/wallet-config';
 import { type TxSimulationMethod } from '@suite-common/wallet-types';
-import { getFeeUnits } from '@suite-common/wallet-utils';
+import { fromBigInt, fromWei, getFeeUnits } from '@suite-common/wallet-utils';
 import { PressableOpacity, Text } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 
@@ -74,7 +72,9 @@ export const getEvmTxSimulationFeeInfoItems = ({
             key: 'total',
             label: <Translation id="moduleSend.fees.custom.bottomSheet.total" />,
             value: formatCryptoAmount(
-                fromWei(Number(gasLimit) * Number(maxFeePerGas ?? gasPrice ?? '0'), 'ether'),
+                fromBigInt(BigInt(gasLimit) * BigInt(maxFeePerGas ?? gasPrice ?? '0'))
+                    .asWei()
+                    .toEther(),
                 {
                     symbol: network.symbol,
                     isBalance: true,
@@ -87,7 +87,7 @@ export const getEvmTxSimulationFeeInfoItems = ({
             label: (
                 <Translation id="transactionManagement.fees.custom.bottomSheet.label.maxFeePerGas" />
             ),
-            value: maxFeePerGas && `${fromWei(maxFeePerGas, 'gwei').toLocaleString()} ${feeUnits}`,
+            value: maxFeePerGas && `${fromWei(maxFeePerGas).toGwei().toLocaleString()} ${feeUnits}`,
         },
         {
             key: 'max-priority-fee-per-gas',
@@ -96,14 +96,14 @@ export const getEvmTxSimulationFeeInfoItems = ({
             ),
             value:
                 maxPriorityFeePerGas &&
-                `${fromWei(maxPriorityFeePerGas, 'gwei').toLocaleString()} ${feeUnits}`,
+                `${fromWei(maxPriorityFeePerGas).toGwei().toLocaleString()} ${feeUnits}`,
         },
         {
             key: 'gas-price',
             label: (
                 <Translation id="transactionManagement.fees.custom.bottomSheet.label.gasPrice" />
             ),
-            value: gasPrice && `${fromWei(Number(gasPrice), 'gwei').toLocaleString()} ${feeUnits}`,
+            value: gasPrice && `${fromWei(gasPrice).toGwei().toLocaleString()} ${feeUnits}`,
         },
         {
             key: 'gas-limit',

--- a/yarn.lock
+++ b/yarn.lock
@@ -10793,7 +10793,6 @@ __metadata:
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
     viem: "npm:^2.48.1"
-    web3-utils: "npm:^4.3.3"
   languageName: unknown
   linkType: soft
 
@@ -11223,7 +11222,6 @@ __metadata:
     react: "npm:19.2.4"
     react-hook-form: "npm:^7.71.2"
     react-redux: "npm:9.2.0"
-    web3-utils: "npm:^4.3.3"
   languageName: unknown
   linkType: soft
 
@@ -12235,7 +12233,6 @@ __metadata:
     react: "npm:19.2.4"
     react-native: "npm:0.83.2"
     react-redux: "npm:9.2.0"
-    web3-utils: "npm:^4.3.3"
   languageName: unknown
   linkType: soft
 
@@ -13644,7 +13641,6 @@ __metadata:
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
     react-redux: "npm:9.2.0"
-    web3-utils: "npm:^4.3.3"
   languageName: unknown
   linkType: soft
 
@@ -14363,7 +14359,6 @@ __metadata:
     react: "npm:19.2.4"
     react-native: "npm:0.83.2"
     react-native-reanimated: "npm:~4.2.1"
-    web3-utils: "npm:^4.3.3"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Description

As part of an effort to isolate coin-specific 3rd party dependencies, custom utilities for converting Ethereum amounts and formats were implemented and used in place of outdated web3-utils.

The new utilities use branded types for `Wei`/`Gwei`/`Ether` units and `hex`/`string`/`BigNumber` formats. For now, branded units are used only on output as it requires a lot of changes to use them for inputs as well, but it should be a long term goal.

BigNumber is used for parsing, internal calculations and for some outputs. It is required not to be negative, infinite or NaN. Wei values can't be decimal.

`fromGwei` and `fromEther` throw an error (`"too many decimal places"`) when the input has more fractional digits than the unit supports (>9 for gwei, >18 for ether). This is intentionally stricter than `web3-utils` v4, which silently truncates excess decimals and returns an empty string when the result would be below 1 wei — both of which are unsafe behaviors for financial amounts. _(note: this was clanker's idea and we must make sure that it doesn't break anything as it's backwards incompatible!)_

## Call diagram

```
fromHex() ───────────┐ ┌─ toHex(): Hex
fromBigInt() ────────┼─┼─ toBigNumber(): BigNumber
fromIntegerString() ─┘ ├─ toIntegerString(): Integer
                       └─ asWei() ─────┐
                          fromWei() ───┤ ┌─ toWei('hex' | 'string' | 'bignumber'): Hex | Integer | BigNumber
                          fromGwei() ──┼─┼─ toGwei('string' | 'bignumber'): Decimal | BigNumber
                          fromEther() ─┘ └─ toEther('string' | 'bignumber'): Decimal | BigNumber

_________________________
type Hex = `0x${string}`;
type Integer = `${bigint}`;
type Decimal = `${bigint}` | `${bigint}.${bigint}`;
```

## Notes for QA

Please test everything Eth related.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/eth-conversion-utils&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/eth-conversion-utils&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/eth-conversion-utils&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-15T11:14:22.552Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-15T11:15:35.906Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/eth-conversion-utils/web/](https://dev.suite.sldev.cz/suite-web/chore/eth-conversion-utils/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->