### PR TITLE
refactor(suite): remove firmware barrel file and use direct imports

### DIFF
--- a/packages/suite/src/components/firmware/FirmwareInitial.tsx
+++ b/packages/suite/src/components/firmware/FirmwareInitial.tsx
@@ -10,7 +10,7 @@ import { Banner, Card, Column } from '@trezor/components';
 import { FirmwareType } from '@trezor/connect';
 import { getFirmwareVersion } from '@trezor/device-utils';
 
-import { FirmwareOffer } from 'src/components/firmware';
+import { FirmwareOffer } from 'src/components/firmware/FirmwareOffer';
 
 type GetDescriptionProps = {
     required: boolean;

--- a/packages/suite/src/components/firmware/FirmwareInstallation.tsx
+++ b/packages/suite/src/components/firmware/FirmwareInstallation.tsx
@@ -5,7 +5,9 @@ import TrezorConnect from '@trezor/connect';
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports -- TODO: expose the browser-specific TrezorConnect type via the @trezor/connect barrel and remove this exception (see #27376)
 import type TrezorConnectBrowser from '@trezor/connect/src/index.browser';
 
-import { FirmwareOffer, ReconnectDevicePrompt, RotatingPhrases } from 'src/components/firmware';
+import { FirmwareOffer } from 'src/components/firmware/FirmwareOffer';
+import { ReconnectDevicePrompt } from 'src/components/firmware/ReconnectDevicePrompt';
+import { RotatingPhrases } from 'src/components/firmware/RotatingPhrases';
 import { useSelector } from 'src/hooks/suite/useSelector';
 import { selectHasTransportOfType } from 'src/selectors/suite/suiteSelectors';
 

--- a/packages/suite/src/components/firmware/index.tsx
+++ b/packages/suite/src/components/firmware/index.tsx
@@ -1,7 +1,0 @@
-export { ReconnectDevicePrompt } from './ReconnectDevicePrompt';
-export { FirmwareOffer } from './FirmwareOffer';
-export { FirmwareInstallation } from './FirmwareInstallation';
-export { FirmwareInitial } from './FirmwareInitial';
-export { SelectCustomFirmware } from './SelectCustomFirmware';
-export { FirmwareInstallationProgressCheck } from './ProgressCheck/FirmwareInstallationProgressCheck';
-export { RotatingPhrases } from './RotatingPhrases';

--- a/packages/suite/src/views/firmware/FirmwareCustom.tsx
+++ b/packages/suite/src/views/firmware/FirmwareCustom.tsx
@@ -3,8 +3,8 @@ import { useState } from 'react';
 import { useFirmwareDesktopUpdate } from '@suite/firmware-upgrade';
 import { Translation } from '@suite/intl';
 
-import { SelectCustomFirmware } from 'src/components/firmware';
 import { FirmwareLowBatteryModal } from 'src/components/firmware/FirmwareLowBatteryModal';
+import { SelectCustomFirmware } from 'src/components/firmware/SelectCustomFirmware';
 
 import { FirmwareModal } from './FirmwareModal';
 

--- a/packages/suite/src/views/firmware/FirmwareModal.tsx
+++ b/packages/suite/src/views/firmware/FirmwareModal.tsx
@@ -12,7 +12,7 @@ import { acquireDevice } from '@suite-common/wallet-core';
 import { Modal } from '@trezor/components';
 import { exhaustive } from '@trezor/type-utils';
 
-import { FirmwareInstallationProgressCheck } from 'src/components/firmware';
+import { FirmwareInstallationProgressCheck } from 'src/components/firmware/ProgressCheck/FirmwareInstallationProgressCheck';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
 import { StepCheckSeed } from './Steps/StepCheckSeed';

--- a/packages/suite/src/views/firmware/FirmwareUpdate.tsx
+++ b/packages/suite/src/views/firmware/FirmwareUpdate.tsx
@@ -2,7 +2,7 @@ import { useFirmwareDesktopUpdate } from '@suite/firmware-upgrade';
 import { Translation } from '@suite/intl';
 import { FirmwareType } from '@trezor/connect';
 
-import { FirmwareInitial } from 'src/components/firmware';
+import { FirmwareInitial } from 'src/components/firmware/FirmwareInitial';
 import { FirmwareLowBatteryModal } from 'src/components/firmware/FirmwareLowBatteryModal';
 
 import { FirmwareModal } from './FirmwareModal';

--- a/packages/suite/src/views/firmware/Steps/StepDone.tsx
+++ b/packages/suite/src/views/firmware/Steps/StepDone.tsx
@@ -3,7 +3,7 @@ import { type ReactNode } from 'react';
 import { Translation } from '@suite/intl';
 import { Modal } from '@trezor/components';
 
-import { FirmwareInstallation } from 'src/components/firmware';
+import { FirmwareInstallation } from 'src/components/firmware/FirmwareInstallation';
 
 type StepDoneProps = {
     onClose: () => void;

--- a/packages/suite/src/views/firmware/Steps/StepStarted.tsx
+++ b/packages/suite/src/views/firmware/Steps/StepStarted.tsx
@@ -2,7 +2,7 @@ import { type ReactNode } from 'react';
 
 import { Modal } from '@trezor/components';
 
-import { FirmwareInstallation } from 'src/components/firmware';
+import { FirmwareInstallation } from 'src/components/firmware/FirmwareInstallation';
 
 type StepStartedProps = {
     onPromptClose: () => void;

--- a/packages/suite/src/views/onboarding/steps/FirmwareStep/FirmwareInitialStep.tsx
+++ b/packages/suite/src/views/onboarding/steps/FirmwareStep/FirmwareInitialStep.tsx
@@ -16,8 +16,8 @@ import { FirmwareType } from '@trezor/connect';
 import { DeviceModelInternal, isBitcoinOnlyDevice } from '@trezor/device-utils';
 import { unique } from '@trezor/utils';
 
-import { FirmwareOffer } from 'src/components/firmware';
 import { FirmwareLowBatteryModal } from 'src/components/firmware/FirmwareLowBatteryModal';
+import { FirmwareOffer } from 'src/components/firmware/FirmwareOffer';
 import { SkipStepConfirmation } from 'src/components/onboarding/SkipStepConfirmation';
 import { PrerequisitesGuide } from 'src/components/suite';
 import { useOnboarding, useSelector } from 'src/hooks/suite';

--- a/packages/suite/src/views/onboarding/steps/FirmwareStep/FirmwareInstallationStep.tsx
+++ b/packages/suite/src/views/onboarding/steps/FirmwareStep/FirmwareInstallationStep.tsx
@@ -3,7 +3,9 @@ import { Translation } from '@suite/intl';
 import { OnboardingCard } from '@suite/onboarding-components';
 import { Card, Column, Paragraph } from '@trezor/components';
 
-import { FirmwareOffer, ReconnectDevicePrompt, RotatingPhrases } from 'src/components/firmware';
+import { FirmwareOffer } from 'src/components/firmware/FirmwareOffer';
+import { ReconnectDevicePrompt } from 'src/components/firmware/ReconnectDevicePrompt';
+import { RotatingPhrases } from 'src/components/firmware/RotatingPhrases';
 import { WebUsbButton } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite/useSelector';
 import { selectHasTransportOfType } from 'src/selectors/suite/suiteSelectors';

--- a/packages/suite/src/views/onboarding/steps/FirmwareStep/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/FirmwareStep/index.tsx
@@ -14,7 +14,7 @@ import { Card } from '@trezor/components';
 import { getFirmwareVersion } from '@trezor/device-utils';
 import { exhaustive } from '@trezor/type-utils';
 
-import { FirmwareInstallationProgressCheck } from 'src/components/firmware';
+import { FirmwareInstallationProgressCheck } from 'src/components/firmware/ProgressCheck/FirmwareInstallationProgressCheck';
 import { ThpPairingStep } from 'src/components/onboarding/ThpPairingStep/ThpPairingStep';
 import { useOnboarding, useSelector } from 'src/hooks/suite';
 


### PR DESCRIPTION
Only random code improvement to test new Agent

## Testing
none, only moving files

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=destroy-barrel&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=destroy-barrel&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-07T21:03:48.062Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add account types ada | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-07T21:01:28.411Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/destroy-barrel/web/](https://dev.suite.sldev.cz/suite-web/destroy-barrel/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->