### PR TITLE
fix(trading): reorder inputs in TradingBuyForm

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingBuyFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingBuyFormInputs.tsx
@@ -75,6 +75,13 @@ export const TradingBuyFormInputs = () => {
             <TradingFormCard>
                 <TradingFormSection>
                     <Column gap={8}>
+                        <TradingFormInputBuyAsset
+                            inputLabel="TR_TRADING_YOU_BUY"
+                            inputName={TRADING_FORM_CRYPTO_CURRENCY_SELECT}
+                            inputDisabled={hasBitcoinOnlyFirmware(device)}
+                            onAssetSelect={handleCryptoSelect}
+                            includedCryptoIds={buySupportedCryptoIds}
+                        />
                         <TradingFormInputFiatCrypto
                             cryptoInputName={TRADING_FORM_CRYPTO_INPUT}
                             fiatInputName={TRADING_FORM_FIAT_INPUT}
@@ -98,14 +105,6 @@ export const TradingBuyFormInputs = () => {
                             </Row>
                         )}
                     </Column>
-
-                    <TradingFormInputBuyAsset
-                        inputLabel="TR_TRADING_YOU_BUY"
-                        inputName={TRADING_FORM_CRYPTO_CURRENCY_SELECT}
-                        inputDisabled={hasBitcoinOnlyFirmware(device)}
-                        onAssetSelect={handleCryptoSelect}
-                        includedCryptoIds={buySupportedCryptoIds}
-                    />
                 </TradingFormSection>
                 {cryptoSelect && !isLoading && <TradingReceiveAddress />}
             </TradingFormCard>


### PR DESCRIPTION
## Description

- Move the BUY asset selector above the fiat and crypto amount inputs.
- Keep the entered amount filled when the asset is selected after entering the amount.
- Limit the change to the desktop BUY form layout order.

## Notes for QA
- Small thing, no need QA

## Related Issue

Resolve #27802

## Screenshots:

<img width="737" height="604" alt="image" src="https://github.com/user-attachments/assets/f257ffcc-aa41-4ec0-bf2d-e858ce9a9017" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to TradingBuyFormInputs.tsx, the buy form input component for the trading/coinmarket feature. This is a moderately scoped change that directly impacts all buy-related trading flows. The highest risk is in buy form input validation and interaction (buy-negative, buy-bitcoin, buy-ethereum tests). Sell-related tests and the dashboard assets test are omitted because they don't meaningfully exercise the buy form inputs component despite static mapping.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingBuyFormInputs.tsx`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — This test directly exercises the buy form inputs for Bitcoin (filling fiat amount, selecting receive address, viewing quotes). Changes to TradingBuyFormInputs.tsx directly affect the buy form's input rendering, validation, and interaction logic tested here.
- `suite/e2e/tests/trading/buy-negative.test.ts` — This test validates buy form input validation behavior — decimal limits, min/max errors, disabled states, and empty quote handling. These are direct behaviors of TradingBuyFormInputs.tsx, making it the most sensitive test to input component changes.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — This test fills in the buy form with a fiat amount and selects a receive address for ETH, directly exercising TradingBuyFormInputs.tsx with a different asset than BTC, covering asset picker and input interactions.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/trading/buy-solana-token.test.ts` — This test exercises the buy form inputs for a Solana token (JUP), including switching between fiat/crypto input modes and selecting a receive account — behaviors that rely on TradingBuyFormInputs.tsx. It covers a distinct code path (token + crypto input mode toggle).
- `suite/e2e/tests/trading/navigation.test.ts` — This test verifies that buy forms open correctly with the right cryptocurrency pre-filled from various navigation entry points. The buy form rendering depends on TradingBuyFormInputs.tsx, and a rendering failure would break the form-opened verification assertions.

</details>

_Updated: 2026-06-05T12:46:33.966Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trading-buy-asset-change-clears-you-get-27802&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trading-buy-asset-change-clears-you-get-27802&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-05T12:53:13.886Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-05T12:49:27.039Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/trading-buy-asset-change-clears-you-get-27802/web/](https://dev.suite.sldev.cz/suite-web/fix/trading-buy-asset-change-clears-you-get-27802/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->