### PR TITLE
fix(suite-native): correct stale formattedRate assertion in useChangeStringsExtractor test

### DIFF
--- a/suite-native/module-trading/src/hooks/history/__tests__/useChangeStringsExtractor.test.ts
+++ b/suite-native/module-trading/src/hooks/history/__tests__/useChangeStringsExtractor.test.ts
@@ -64,7 +64,7 @@ describe('useChangeStringsExtractor', () => {
             toValue: '0.462586',
             isFromCrypto: true,
             isToCrypto: true,
-            formattedRate: '21.883930771791622 JTO / 1 SOL',
+            formattedRate: '21.8839307717916236 JTO / 1 SOL',
         });
     });
 


### PR DESCRIPTION
## Problem

`useChangeStringsExtractor.test.ts › should extract strings for exchange trade` started failing on `develop`:

```
- Expected: "21.883930771791622 JTO / 1 SOL"
+ Received: "21.8839307717916236 JTO / 1 SOL"
```

## Root cause (git history) — two interacting PRs

The exchange rate is computed in `useChangeStringsExtractor.ts` as `BigNumber.div`, yielding the full-precision string `21.88393077179162361161`, then rendered through the shared `CryptoAmountFormatter` (`@suite-common/.../prepareCryptoAmountFormatter`).

**1. [#25798](https://github.com/trezor/trezor-suite/pull/25798)** *"24612 price quote for each payment mobile"* (@jbazant, merged 2026‑03‑20) migrated the hook's rate calc from `parseFloat` to `BigNumber.div`, and set the assertion to `21.883930771791622`. That was **correct at the time**, because the formatter then coerced the value via `Number(value)`:

```js
Number('21.88393077179162361161') === 21.883930771791622   // ← the asserted value
```

The full BigNumber precision was therefore **masked** by the formatter's `Number()` truncation, and the test stayed green for ~2.5 months.

**2. [#28016](https://github.com/trezor/trezor-suite/pull/28016)** *"Format crypto amounts with localizeNumber for precision"* (@myasiura-stack, merged 2026‑06‑05, current `develop` HEAD) replaced that coercion:

```diff
- const formattedValue = intl.formatNumber(Number(value), { maximumFractionDigits });
+ const formattedValue = localizeNumber(value, safeLocale, 0, maxDisplayedDecimals);
```

`localizeNumber(value, …)` formats the string directly and keeps full precision → `21.8839307717916236`, removing the mask and breaking the (older) assertion.

It is **not a concurrent merge race** — the two PRs merged 2.5 months apart, and #25798's assertion was genuinely correct against the truncating formatter, so the test was green on `develop` right up until #28016 changed the formatter.

It is also **not an `nx affected` blind spot**. `nx affected` correctly identified `@suite-native/module-trading` as a downstream consumer of `@suite-common/formatters` and **did run this test during #28016's own CI — where it failed** ([run 27007109333](https://github.com/trezor/trezor-suite/actions/runs/27007109333), check `Unit Tests (native:trading)` → `failure`):

```
FAIL src/hooks/history/__tests__/useChangeStringsExtractor.test.ts
  ● useChangeStringsExtractor › should extract strings for exchange trade
    - "formattedRate": "21.883930771791622 JTO / 1 SOL"
    + "formattedRate": "21.8839307717916236 JTO / 1 SOL"
  Tests: 1 failed, 1495 passed, 1496 total
```

The red check did **not** gate the merge: the `unit-tests-suite` job in `.github/workflows/check-code-validation.yml` is declared `continue-on-error: true`, i.e. per-PR unit tests are **advisory / non-blocking**. #28016 therefore merged into `develop` with this failure visible but un-gated. The only blocking full-suite safety net is the nightly `test-misc.yml` (`nx run-many` over everything), which is why this surfaced as a `develop`-level red rather than being stopped pre-merge.

## Fix

Update the assertion to what the precision-preserving formatter now produces: `21.8839307717916236`. No production change — the rate is mathematically correct (`10.1232 / 0.462586 = 21.88393077179162361161`). Fixture inputs unchanged since 2025‑05‑20.

## Notes

- Reproduced on a clean `develop` checkout (not introduced by any in‑flight PR).
- The displayed crypto rate now carries 16 fraction digits; trimming that for display would be a separate UX decision and is intentionally out of scope.
- cc @jbazant @myasiura-stack (authors of the two interacting PRs).
- **Prevention:** [#28421](https://github.com/trezor/trezor-suite/pull/28421) fixes the CI gap that let this land — per-PR unit tests were non-blocking (`continue-on-error: true`), so #28016's red `Unit Tests (native:trading)` leg did not block its merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/trading-history-formatted-rate-test&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->