### PR TITLE
fix(ci): block PR merge when unit tests fail

### DIFF
--- a/.github/workflows/check-code-validation.yml
+++ b/.github/workflows/check-code-validation.yml
@@ -120,8 +120,8 @@ jobs:
     needs: setup-and-cache
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
         test-task: [suite, native, "native:trading"]
     steps:


### PR DESCRIPTION
## Problem

Per-PR unit tests do **not** block merges. A PR can land on `develop` with a visibly red `Unit Tests (...)` check.

**Proof:** [#28016](https://github.com/trezor/trezor-suite/pull/28016) changed a `@suite-common/formatters` function. `nx affected` correctly pulled in the downstream `@suite-native/module-trading` consumer and **did run** its tests — the `Unit Tests (native:trading)` leg **failed** on #28016's own CI ([run 27007109333](https://github.com/trezor/trezor-suite/actions/runs/27007109333)):

```
FAIL src/hooks/history/__tests__/useChangeStringsExtractor.test.ts
  ● useChangeStringsExtractor › should extract strings for exchange trade
    - "formattedRate": "21.883930771791622 JTO / 1 SOL"
    + "formattedRate": "21.8839307717916236 JTO / 1 SOL"
  Tests: 1 failed, 1495 passed, 1496 total
```

Despite that red check, #28016 merged, breaking the test on `develop` (fixed separately in [#28417](https://github.com/trezor/trezor-suite/pull/28417)).

## Root cause — wrong knob

The `unit-tests-suite` job in `check-code-validation.yml` carried `continue-on-error: true`, added in 218ab1cdad5 *"unit tests should not cancel whole matrix on error"*. That intent — don't let one failing matrix leg cancel its siblings — is the job of **`strategy.fail-fast: false`**.

`continue-on-error: true` does something different (and stronger): it makes the **job non-blocking**, so its failure no longer fails the `[Check] Validation` workflow run. So a real unit-test regression goes red on the individual leg but the overall validation still passes.

## Fix

```diff
-    continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
         test-task: [suite, native, "native:trading"]
```

- Preserves the original intent: all three legs (`suite`, `native`, `native:trading`) still run to completion, no sibling cancellation.
- Removes the side effect: a failing leg now fails the job **and** the workflow run, so unit-test regressions surface as red CI on the PR.

## ⚠️ Note for a repo admin

Branch protection for `develop` is **not** versioned in this repo, so this PR can only fix the workflow side. For a red run to actually **block** the merge, the three `Unit Tests (suite | native | native:trading)` checks must be in `develop`'s **required status checks**. Please confirm/add them in repo settings — I can't read the protection config to verify it.

The full-suite safety net today is the nightly `test-misc.yml` (`nx run-many`), which runs after merge; this change moves enforcement to pre-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
