### PR TITLE
Cardano APY fixes

### DIFF
--- a/packages/suite/src/components/earn/dashboard/staking/EarnStakingAccountRow.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/EarnStakingAccountRow.tsx
@@ -48,6 +48,10 @@ export const EarnStakingAccountRow = ({
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { isBelowMobile } = useLayoutSize();
     const apy = useSelector(state => selectPoolStatsApy(state, { account }));
+    // Promoted (best) pool APY, shown when suggesting a switch to a new provider.
+    const newProviderApy = useSelector(state =>
+        selectPoolStatsApy(state, { networkSymbol: account.symbol }),
+    );
     const displaySymbol = getDisplaySymbol(account.symbol);
     const isCardanoNetworkType = account.networkType === 'cardano';
     const isStakingActive = useSelector(state => selectAccountIsStakingActive(state, account.key));
@@ -251,7 +255,7 @@ export const EarnStakingAccountRow = ({
                     {stakingStatus === 'insufficient-funds' && minStakeParagraph}
 
                     {stakingStatus === 'staking-outdated-provider' && (
-                        <EarnStakingOutdatedProvider apy={apy} />
+                        <EarnStakingOutdatedProvider apy={newProviderApy} />
                     )}
 
                     {(stakingStatus === 'staking-active' || stakingStatus === 'staking-inactive') &&
@@ -405,7 +409,7 @@ export const EarnStakingAccountRow = ({
             {stakingStatus === 'staking-outdated-provider' && (
                 <>
                     <Table.Cell colSpan={2}>
-                        <EarnStakingOutdatedProvider apy={apy} />
+                        <EarnStakingOutdatedProvider apy={newProviderApy} />
                     </Table.Cell>
                     <Table.Cell align="end">
                         <EarnStakingActionButtons {...actionButtonsProps} />

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/components/EarnSupplyingInfo.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/components/EarnSupplyingInfo.tsx
@@ -165,7 +165,7 @@ const CardanoSupplyingRows = ({ flow, apy }: EarnSupplyingRowsProps) => (
 export const EarnSupplyingInfo = ({ account, flow }: EarnSupplyingInfoProps) => {
     const validatorsQueue = useSelector(selectEthValidatorsQueue);
 
-    const apy = useSelector(state => selectPoolStatsApy(state, { account }));
+    const apy = useSelector(state => selectPoolStatsApy(state, { networkSymbol: account.symbol }));
 
     const daysToAddToPoolInitial = getDaysToAddToPoolInitial(validatorsQueue);
     const displaySymbol = getNetworkDisplaySymbol(account.symbol);

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/hooks/useEarnInANutshell.ts
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/hooks/useEarnInANutshell.ts
@@ -32,7 +32,7 @@ export const useEarnInANutshell = ({
     yieldContext,
 }: UseEarnInANutshellProps) => {
     const validatorsQueueData = useSelector(selectEthValidatorsQueue);
-    const apy = useSelector(state => selectPoolStatsApy(state, { account }));
+    const apy = useSelector(state => selectPoolStatsApy(state, { networkSymbol: account.symbol }));
     const unstakingPeriod = getUnstakingPeriodInDays(account.networkType, validatorsQueueData);
 
     const dispatch = useDispatch();

--- a/packages/suite/src/components/earn/modals/StakeModal/StakeInfoCards/EstimatedGains.tsx
+++ b/packages/suite/src/components/earn/modals/StakeModal/StakeInfoCards/EstimatedGains.tsx
@@ -33,7 +33,7 @@ export const EstimatedGains = () => {
         return '0';
     }, [hasInvalidFormState, value, account]);
 
-    const apy = useSelector(state => selectPoolStatsApy(state, { account }));
+    const apy = useSelector(state => selectPoolStatsApy(state, { networkSymbol: account.symbol }));
 
     const gains = [
         {
@@ -72,16 +72,16 @@ export const EstimatedGains = () => {
                 <Image image="GAINS_GRAPH" width="100%" />
             </Column>
             <Column gap={12} hasDivider>
-                {gains.map(({ label, value }, index) => (
+                {gains.map(({ label, value: gainValue }, index) => (
                     <Grid key={index} columns={3}>
                         <Paragraph intent="neutral" priority="secondary">
                             {label}
                         </Paragraph>
                         <Text intent="brand">
-                            <FormattedCryptoAmount value={value} symbol={account.symbol} />
+                            <FormattedCryptoAmount value={gainValue} symbol={account.symbol} />
                         </Text>
                         <Paragraph align="end">
-                            <BaseCurrencyValue amount={value} symbol={account.symbol} />
+                            <BaseCurrencyValue amount={gainValue} symbol={account.symbol} />
                         </Paragraph>
                     </Grid>
                 ))}

--- a/packages/suite/src/components/earn/modals/StakeModal/StakeInfoCards/StakeInfoCards.tsx
+++ b/packages/suite/src/components/earn/modals/StakeModal/StakeInfoCards/StakeInfoCards.tsx
@@ -15,7 +15,7 @@ type StakeInfoCardsProps = {
 };
 
 export const StakeInfoCards = ({ account, flow }: StakeInfoCardsProps) => {
-    const apy = useSelector(state => selectPoolStatsApy(state, { account }));
+    const apy = useSelector(state => selectPoolStatsApy(state, { networkSymbol: account.symbol }));
 
     const cards = [
         {

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/NewProviderCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/NewProviderCard.tsx
@@ -20,7 +20,7 @@ export const NewProviderCard = ({ account }: NewProviderCardProps) => {
 
     const { isStakingDisabled, stakingMessageContent } = useMessageSystemStaking(account?.symbol);
 
-    const apy = useSelector(state => selectPoolStatsApy(state, { account }));
+    const apy = useSelector(state => selectPoolStatsApy(state, { networkSymbol: account.symbol }));
 
     const isStakedWithFiveBinaries = isCardanoStakedWithFiveBinaries(account);
 

--- a/suite-common/wallet-core/src/stake/stakeSelectors.ts
+++ b/suite-common/wallet-core/src/stake/stakeSelectors.ts
@@ -1,7 +1,11 @@
 import { returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
-import { secondsToDays, selectBestCardanoPool } from '@suite-common/wallet-utils';
+import {
+    getCardanoAccountPoolId,
+    secondsToDays,
+    selectBestCardanoPool,
+} from '@suite-common/wallet-utils';
 
 import type { VotingDelegationOption } from './stakeActions';
 import type { StakeRootState } from './stakeReducerTypes';
@@ -47,17 +51,17 @@ export const selectPoolStatsApy = (
 
         case 'ada': {
             const poolStats = data.ada?.pools ?? [];
+            const accountPoolId = getCardanoAccountPoolId(account);
 
-            if (account?.networkType === 'cardano') {
-                const poolFromAccount = poolStats.find(
-                    pool => pool.id === account.misc.staking.poolId,
-                );
+            if (accountPoolId) {
+                // The account's own APY, or null when staked outside Everstake (no pool stats).
+                // For the promoted APY, query by networkSymbol instead.
+                const poolFromAccount = poolStats.find(pool => pool.id === accountPoolId);
 
-                if (poolFromAccount) {
-                    return poolFromAccount.apy;
-                }
+                return poolFromAccount?.apy ?? null;
             }
 
+            // No active delegation (not staking yet, or queried by network) → promote best pool.
             const bestPoolId = selectBestCardanoPool(poolStats).bech32;
             const bestPool = bestPoolId
                 ? poolStats.find(pool => pool.id === bestPoolId)

--- a/suite-common/wallet-utils/src/cardanoStakingUtils.ts
+++ b/suite-common/wallet-utils/src/cardanoStakingUtils.ts
@@ -62,21 +62,20 @@ export const isCardanoStakedWithEverstake = (
     const accountPoolId = getCardanoAccountPoolId(account);
     if (!accountPoolId) return false;
 
-    if (!cardanoStakingPools?.length) return EVERSTAKE_POOLS.includes(accountPoolId);
+    // EVERSTAKE_POOLS is the definitive list — migration should only be offered to users
+    // outside the Everstake ecosystem entirely, not between Everstake pools.
+    if (EVERSTAKE_POOLS.includes(accountPoolId)) return true;
 
-    return cardanoStakingPools.some(pool => pool.id === accountPoolId);
+    return cardanoStakingPools?.some(pool => pool.id === accountPoolId) ?? false;
 };
 
 export const isCardanoStakedOutsideEverstake = (
     account: Account,
     cardanoStakingPools: AdaPools['pools'],
 ) => {
-    const accountPoolId = getCardanoAccountPoolId(account);
-    if (!accountPoolId) return false;
+    if (!getCardanoAccountPoolId(account)) return false;
 
-    if (!cardanoStakingPools?.length) return EVERSTAKE_POOLS.includes(accountPoolId) === false;
-
-    return cardanoStakingPools.every(pool => pool.id !== accountPoolId);
+    return !isCardanoStakedWithEverstake(account, cardanoStakingPools);
 };
 
 export const isCardanoStakedWithFiveBinaries = (account: Account) => {

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2834,6 +2834,7 @@ export const messages = {
         adaStaysFullyAccessuble: 'Your ADA stays fully accessible while earning rewards.',
         infoBanner: {
             updateProviderTitle: 'Save your ADA rewards by updating your staking provider',
+            newProviderTitle: 'Earn ~{apy}% APY with our new provider',
             updateProviderButton: 'Update provider',
             providerReducingRewards:
                 "You're earning nearly 0% in ADA rewards right now. Switch to Everstake to earn up to {apy}% APY. Your funds and past rewards are safe.",

--- a/suite-native/intl/translations/en-US.json
+++ b/suite-native/intl/translations/en-US.json
@@ -1428,6 +1428,7 @@
     "earn.trezorDesktop": "Trezor Suite for desktop or web.",
     "earn.adaStaysFullyAccessuble": "Your ADA stays fully accessible while earning rewards.",
     "earn.infoBanner.updateProviderTitle": "Save your ADA rewards by updating your staking provider",
+    "earn.infoBanner.newProviderTitle": "Earn ~{apy}% APY with our new provider",
     "earn.infoBanner.updateProviderButton": "Update provider",
     "earn.infoBanner.providerReducingRewards": "You're earning nearly 0% in ADA rewards right now. Switch to Everstake to earn up to {apy}% APY. Your funds and past rewards are safe.",
     "earn.infoBanner.updateToNewProvider": "Update to our new provider, Everstake, and earn ~{apy}% APY. Your {symbol} with our previous provider is safe, and your rewards stay intact, though rates aren’t guaranteed.",

--- a/suite-native/module-earn/src/components/CardanoStakingInfoBanner.tsx
+++ b/suite-native/module-earn/src/components/CardanoStakingInfoBanner.tsx
@@ -1,4 +1,5 @@
-import { useAccountsSelector } from '@suite-common/wallet-core';
+import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { selectAccountNetworkSymbol, useAccountsSelector } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { Box, Button, HStack, Text, VStack } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';
@@ -33,7 +34,6 @@ type CardanoStakingInfoBannerProps = {
 export const CardanoStakingInfoBanner = ({ accountKey }: CardanoStakingInfoBannerProps) => {
     const { applyStyle } = useNativeStyles();
     const openLink = useOpenLink();
-    const apy = useNativeStakingSelector(state => selectApy(state, { accountKey }));
 
     const isStakedWithFiveBinaries = useAccountsSelector(state =>
         selectIsCardanoStakedWithFiveBinaries(state, accountKey),
@@ -43,11 +43,21 @@ export const CardanoStakingInfoBanner = ({ accountKey }: CardanoStakingInfoBanne
         selectIsCardanoStakedOutsideEverstake(state, accountKey),
     );
 
+    const networkSymbol = useAccountsSelector(state =>
+        selectAccountNetworkSymbol(state, accountKey),
+    );
+
+    // Promoted (best) pool APY to switch to, not the account's own APY.
+    const apy = useNativeStakingSelector(state =>
+        selectApy(state, { networkSymbol: networkSymbol ?? undefined }),
+    );
+
     if (!isStakedWithFiveBinaries && !isStakedOutsideEverstake) {
         return null;
     }
 
     const apyValue = apy ?? <Translation id="earn.notAvailableShort" />;
+    const displaySymbol = networkSymbol ? getNetworkDisplaySymbol(networkSymbol) : '';
     const descriptionTranslationId = isStakedWithFiveBinaries
         ? 'earn.infoBanner.providerReducingRewards'
         : 'earn.infoBanner.updateToNewProvider';
@@ -66,7 +76,10 @@ export const CardanoStakingInfoBanner = ({ accountKey }: CardanoStakingInfoBanne
                         <Translation id="earn.infoBanner.updateProviderTitle" />
                     </Text>
                     <Text variant="body-sm" color="contentSecondary">
-                        <Translation id={descriptionTranslationId} values={{ apy: apyValue }} />
+                        <Translation
+                            id={descriptionTranslationId}
+                            values={{ apy: apyValue, symbol: displaySymbol }}
+                        />
                     </Text>
                 </VStack>
             </HStack>

--- a/suite-native/module-earn/src/components/CardanoStakingInfoBanner.tsx
+++ b/suite-native/module-earn/src/components/CardanoStakingInfoBanner.tsx
@@ -58,6 +58,12 @@ export const CardanoStakingInfoBanner = ({ accountKey }: CardanoStakingInfoBanne
 
     const apyValue = apy ?? <Translation id="earn.notAvailableShort" />;
     const displaySymbol = networkSymbol ? getNetworkDisplaySymbol(networkSymbol) : '';
+
+    // Staking with 5 Binaries earns almost nothing, so the heading urges migration. Staking with
+    // any other provider is fine, so it just promotes the new provider (matching desktop).
+    const titleTranslationId = isStakedWithFiveBinaries
+        ? 'earn.infoBanner.updateProviderTitle'
+        : 'earn.infoBanner.newProviderTitle';
     const descriptionTranslationId = isStakedWithFiveBinaries
         ? 'earn.infoBanner.providerReducingRewards'
         : 'earn.infoBanner.updateToNewProvider';
@@ -73,7 +79,7 @@ export const CardanoStakingInfoBanner = ({ accountKey }: CardanoStakingInfoBanne
 
                 <VStack spacing="sp2" flex={1}>
                     <Text variant="body-md">
-                        <Translation id="earn.infoBanner.updateProviderTitle" />
+                        <Translation id={titleTranslationId} values={{ apy: apyValue }} />
                     </Text>
                     <Text variant="body-sm" color="contentSecondary">
                         <Translation

--- a/suite-native/module-earn/src/components/EarnAccountCard.tsx
+++ b/suite-native/module-earn/src/components/EarnAccountCard.tsx
@@ -11,6 +11,7 @@ import {
     selectApy,
     selectCanClaimByAccountKey,
     selectClaimableAmountByAccountKey,
+    selectIsCardanoStakedOutsideEverstake,
     useSelector as useStakingSelector,
 } from '@suite-native/staking';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
@@ -74,6 +75,11 @@ export const EarnAccountCard = ({ item, onPress, onClaimPress }: EarnAccountCard
     );
 
     const apyValue = isStakingItem ? apy : item.apy;
+
+    const isAdaStakedOutsideEverstake = useStakingSelector(state =>
+        selectIsCardanoStakedOutsideEverstake(state, item.accountKey),
+    );
+
     const canClaim = useStakingSelector(state =>
         isSupportedStaking ? selectCanClaimByAccountKey(state, item.accountKey) : false,
     );
@@ -116,9 +122,13 @@ export const EarnAccountCard = ({ item, onPress, onClaimPress }: EarnAccountCard
 
                 <VStack spacing="sp2" style={applyStyle(valuesStyle)}>
                     <Text variant="body-md">{formatActiveItemBalance(item)}</Text>
-                    {apyValue != null && (
+                    {(isAdaStakedOutsideEverstake || apyValue != null) && (
                         <Text variant="body-sm" color="contentSecondary">
-                            <Translation id="earn.apyPercentage" values={{ apy: apyValue }} />
+                            {isAdaStakedOutsideEverstake ? (
+                                <Translation id="earn.notAvailableShort" />
+                            ) : (
+                                <Translation id="earn.apyPercentage" values={{ apy: apyValue }} />
+                            )}
                         </Text>
                     )}
                 </VStack>

--- a/suite-native/module-earn/src/components/EarnFormScreenFooter.tsx
+++ b/suite-native/module-earn/src/components/EarnFormScreenFooter.tsx
@@ -8,7 +8,6 @@ import Animated, {
 
 import { useFormatters } from '@suite-common/formatters';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { type AccountKey } from '@suite-common/wallet-types';
 import { calculateRewards } from '@suite-common/wallet-utils';
 import { Box, Button, ScreenFooterGradient, Text, VStack } from '@suite-native/atoms';
 import { Translation, useTranslate } from '@suite-native/intl';
@@ -36,7 +35,6 @@ const continueButtonStyle = prepareNativeStyle(utils => ({
 }));
 
 type EarnFormScreenFooterProps = {
-    accountKey: AccountKey;
     symbol: NetworkSymbol;
     amountValue: string;
     isDisabled: boolean;
@@ -45,7 +43,6 @@ type EarnFormScreenFooterProps = {
 };
 
 export const EarnFormScreenFooter = ({
-    accountKey,
     symbol,
     amountValue,
     isDisabled,
@@ -56,7 +53,7 @@ export const EarnFormScreenFooter = ({
     const { translate } = useTranslate();
     const { CryptoAmountFormatter } = useFormatters();
 
-    const apy = useSelector(state => selectApy(state, { accountKey, networkSymbol: symbol }));
+    const apy = useSelector(state => selectApy(state, { networkSymbol: symbol }));
 
     const estimatedRewards = useMemo(() => {
         if (!amountValue) return null;

--- a/suite-native/module-earn/src/components/EarnItemOverviewSection.tsx
+++ b/suite-native/module-earn/src/components/EarnItemOverviewSection.tsx
@@ -9,7 +9,11 @@ import { Badge, Box, BoxSkeleton, HStack, Text } from '@suite-native/atoms';
 import { NetworkDisplaySymbolNameFormatter } from '@suite-native/formatters';
 import { CryptoIconWithNetwork } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
-import { selectApy, useSelector as useNativeStakingSelector } from '@suite-native/staking';
+import {
+    selectApy,
+    selectIsCardanoStakedOutsideEverstake,
+    useSelector as useNativeStakingSelector,
+} from '@suite-native/staking';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 import { type EarnPromoItem } from '../types';
@@ -79,6 +83,10 @@ export const EarnItemOverviewSection = (item: EarnPromoItem) => {
 
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
 
+    const isAdaStakedOutsideEverstake = useNativeStakingSelector(state =>
+        accountKey ? selectIsCardanoStakedOutsideEverstake(state, accountKey) : false,
+    );
+
     const apyValue = item.type === 'staking' ? apy : item.apy;
 
     const iconProps =
@@ -118,12 +126,16 @@ export const EarnItemOverviewSection = (item: EarnPromoItem) => {
                 <BoxSkeleton width={70} height={20} />
             ) : (
                 <Box style={applyStyle(valuesContainerStyle)}>
-                    {apyValue != null && (
+                    {(isAdaStakedOutsideEverstake || apyValue != null) && (
                         <Text
                             variant={accountKey ? 'body-sm' : 'body-md'}
                             color={accountKey ? 'contentSecondary' : 'contentPrimary'}
                         >
-                            <Translation id="earn.apyPercentage" values={{ apy: apyValue }} />
+                            {isAdaStakedOutsideEverstake ? (
+                                <Translation id="earn.notAvailableShort" />
+                            ) : (
+                                <Translation id="earn.apyPercentage" values={{ apy: apyValue }} />
+                            )}
                         </Text>
                     )}
                 </Box>

--- a/suite-native/module-earn/src/screens/EarnFormScreen.tsx
+++ b/suite-native/module-earn/src/screens/EarnFormScreen.tsx
@@ -89,7 +89,6 @@ export const EarnFormScreen = () => {
             header={<EarnFormScreenHeader accountKey={accountKey} />}
             footer={
                 <EarnFormScreenFooter
-                    accountKey={accountKey}
                     symbol={account.symbol}
                     amountValue={amountValue}
                     isDisabled={!isValid || isFeeUnavailable || isPrecomposeError}

--- a/suite-native/module-earn/src/screens/HowStakeWorksScreen.tsx
+++ b/suite-native/module-earn/src/screens/HowStakeWorksScreen.tsx
@@ -88,7 +88,7 @@ export const HowStakeWorksScreen = () => {
     );
 
     const apy = useSelector((state: NativeStakingRootState) =>
-        selectApy(state, { accountKey: resolvedAccountKey, networkSymbol: symbol }),
+        selectApy(state, { networkSymbol: symbol }),
     );
 
     const { CryptoAmountFormatter } = useFormatters();

--- a/suite-native/staking/src/__tests__/selectors.test.ts
+++ b/suite-native/staking/src/__tests__/selectors.test.ts
@@ -271,7 +271,7 @@ describe('main staking selectors', () => {
             expect(result).toBe(2.43);
         });
 
-        it('should return best pool APY for ADA account with unrecognized poolId', () => {
+        it('should return null for ADA account staked outside known pools', () => {
             const adaAccount = {
                 symbol: 'ada',
                 accountLabel: 'ADA Account #1',
@@ -289,7 +289,7 @@ describe('main staking selectors', () => {
 
             const result = selectApy(testState as any, { accountKey: 'ada1' as AccountKey });
 
-            expect(result).toBe(5.8);
+            expect(result).toBeNull();
         });
 
         it('should return null when neither accountKey nor networkSymbol is provided', () => {


### PR DESCRIPTION
## Description

- show N/A for non-Everstake cardano stakes
- fix promo text on mobile which was missing APY, there was {apy} instead
- return pool APY of pool which is offered to a user
- do not be so strict with text when user is staking outside Everstake but not with fiveBinaries
- migration is a guess, so let's see the results later

## Related Issue

Resolve #28025
Resolve #28019
Resolve #25849
Resolve #25827

## Screenshots:
Before:
<img width="393" height="338" alt="Screenshot 2026-06-05 at 15 22 46" src="https://github.com/user-attachments/assets/b535f7db-2a39-419f-bbca-026c94bcc234" />

Now:
<img width="419" height="359" alt="Screenshot 2026-06-05 at 15 21 06" src="https://github.com/user-attachments/assets/23142a46-e673-42f2-9366-278037e76afe" />

<img width="411" height="372" alt="Screenshot 2026-06-05 at 15 23 26" src="https://github.com/user-attachments/assets/76387841-9a8d-47a9-8efb-2af9c94fc360" />

<img width="387" height="242" alt="Screenshot 2026-06-05 at 16 38 02" src="https://github.com/user-attachments/assets/5e4a09e2-4c0d-4244-a3be-f19d147f2cb7" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mobile/apy-badge&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mobile/apy-badge&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mobile/apy-badge&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-05T13:33:32.472Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-05T19:38:29.781Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mobile/apy-badge/web/](https://dev.suite.sldev.cz/suite-web/mobile/apy-badge/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->