### PR TITLE
fix(suite-native): add missing currency to definitions

### DIFF
--- a/suite-common/flags/src/fiatCurrencyFlagUtils.ts
+++ b/suite-common/flags/src/fiatCurrencyFlagUtils.ts
@@ -67,6 +67,13 @@ const fiatCurrencyToFlagMap = {
     UYU: 'UY',
     VND: 'VN',
     ZAR: 'ZA',
+    BWP: 'BW',
+    UZS: 'UZ',
+    TMT: 'TM',
+    TJS: 'TJ',
+    NAD: 'NA',
+    MZN: 'MZ',
+    LSL: 'LS',
 } as const satisfies Record<string, FlagType>;
 
 type FiatCurrencyWithFlag = keyof typeof fiatCurrencyToFlagMap;

--- a/suite-common/trading/src/currency.ts
+++ b/suite-common/trading/src/currency.ts
@@ -69,6 +69,14 @@ export const supportedFiatCurrenciesMap: Record<FiatCurrencyCode, string> = {
     uyu: 'Uruguayan Peso',
     xaf: 'Central African CFA Franc',
     xof: 'West African CFA Franc',
+    // @ts-expect-error - missing types from invity-api TODO: remove when added
+    bwp: 'Botswana Pula',
+    uzs: 'Uzbekistani Som',
+    tmt: 'Turkmenistani Manat',
+    tjs: 'Tajikistani Somoni',
+    nad: 'Namibian Dollar',
+    mzn: 'Mozambican Metical',
+    lsl: 'Lesotho Loti',
 } as const;
 
 export const isSupportedFiatCurrency = (currency: string): currency is FiatCurrencyCode =>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* add missing codes and flags 
* type from invity is out of sync, but we are receiving the flags so ignore the type for now 
<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/27873

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect two files: a trading currency utility (currency.ts) which is a broadly imported module (121 tests), and a fiat currency flag utility (fiatCurrencyFlagUtils.ts) with no static test coverage. The currency.ts change poses the highest risk to trading/coinmarket flows (buy, sell, swap) that directly handle fiat currency selection, formatting, and display. The flag utility likely affects visual currency flag icons in dropdowns. Testing strategy focuses on trading flows that directly exercise currency selection and fiat formatting, plus the general settings test that changes fiat currency.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/flags/src/fiatCurrencyFlagUtils.ts`
- `suite-common/trading/src/currency.ts`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/settings/general.test.ts` — This test directly exercises fiat currency changes (USD to EUR) and verifies currency symbol display on the dashboard. Changes to currency.ts in suite-common/trading could affect how fiat currencies are resolved, formatted, or listed, and fiatCurrencyFlagUtils.ts provides flag icons for currency selectors.
- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — This test exercises the buy flow including fiat amount entry, currency selection, and quote display with localized fiat amounts (CZK). The currency.ts module in suite-common/trading directly supports trading currency operations used in buy flows.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/trading/buy-ethereum.test.ts` — Tests the buy flow for Ethereum including fiat amount formatting and currency display in confirmation screens. Changes to trading currency utilities could affect how fiat values are presented in the buy confirmation flow.
- `suite/e2e/tests/trading/buy-negative.test.ts` — Tests buy form validation with currency selection (EUR) and amount limits. Currency-related changes could affect how minimum/maximum limits are formatted or how the fiat currency selector works.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — Tests buying a Solana token with fiat currency switching between fiat and crypto modes. Currency utility changes could affect the fiat/crypto input conversion and display logic.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — Tests the sell BTC flow with fiat amount display in confirmation details (€ prefix). Trading currency module changes could affect how fiat amounts are formatted in sell confirmation screens.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Tests sell form with fiat currency selection (EUR) and country selector. Currency utilities from suite-common/trading are likely used for currency list population and validation.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Tests sell flow for Solana with fiat amount display and provider confirmation. Currency formatting changes could affect fiat amount presentation in sell confirmation screens.
- `suite/e2e/tests/trading/navigation.test.ts` — Tests navigation to buy/sell/swap forms which involve currency selection and display. If currency.ts affects how currencies are listed or pre-selected in trading forms, this test would catch regressions.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Tests sell ETH flow with fiat amount display. Currency utility changes could affect fiat formatting in the sell confirmation, though the flow is similar to other sell tests already recommended.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Tests selling an ERC-20 token with fiat currency display. Similar to other sell flows but covers token-specific currency handling that could be affected by currency.ts changes.
- `suite/e2e/tests/analytics/events.test.ts` — Tests that SuiteReady events report localCurrency correctly, including after changing it to 'czk'. If currency.ts affects how local currency values are resolved, this analytics assertion could fail.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/flags/src/fiatCurrencyFlagUtils.ts`

_Updated: 2026-06-07T20:24:42.507Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/27873-add-missing-currency-definitions&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/27873-add-missing-currency-definitions&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/27873-add-missing-currency-definitions&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-07T20:29:42.819Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add account types ada | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-07T20:27:24.094Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/27873-add-missing-currency-definitions/web/](https://dev.suite.sldev.cz/suite-web/fix/27873-add-missing-currency-definitions/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->