### PR TITLE
feat(suite-native): update tokens and staking network labels

### DIFF
--- a/suite-native/coin-enabling/package.json
+++ b/suite-native/coin-enabling/package.json
@@ -27,7 +27,6 @@
         "@suite-native/intl": "workspace:*",
         "@suite-native/navigation": "workspace:*",
         "@suite-native/toasts": "workspace:*",
-        "@suite-native/tokens": "workspace:*",
         "@trezor/styles-native": "workspace:*",
         "react": "19.2.4",
         "react-native": "0.83.2",

--- a/suite-native/coin-enabling/src/components/DiscoveryCoinsFilter.tsx
+++ b/suite-native/coin-enabling/src/components/DiscoveryCoinsFilter.tsx
@@ -31,7 +31,7 @@ const NetworkGroup = ({ networks, handleToggle, showTestnetsLabel }: NetworkGrou
     <VStack spacing="sp12">
         {showTestnetsLabel && (
             <Text variant="body-sm">
-                <Translation id="moduleSettings.coinEnabling.testnetsLabel" />
+                <Translation id="moduleSettings.coinEnabling.labels.testnets" />
             </Text>
         )}
         {networks.map(({ symbol }) => (

--- a/suite-native/coin-enabling/src/components/NetworkListItem.tsx
+++ b/suite-native/coin-enabling/src/components/NetworkListItem.tsx
@@ -5,7 +5,6 @@ import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import { Card, HStack, PressableOpacity, Text, VStack } from '@suite-native/atoms';
 import { NetworkIcon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
-import { isNetworkWithTokens } from '@suite-native/tokens';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 import { NetworkBackendsButton } from './NetworkBackendsButton';
@@ -39,7 +38,9 @@ export const NetworkListItem = ({
 }: NetworkListItemProps) => {
     const { applyStyle } = useNativeStyles();
 
-    const { name } = getNetwork(symbol);
+    const { name, features } = getNetwork(symbol);
+    const isTokensFeatureSupported = features.includes('tokens');
+    const isStakingFeatureSupported = features.includes('staking');
 
     return (
         <Card noPadding>
@@ -60,9 +61,15 @@ export const NetworkListItem = ({
                     >
                         <VStack spacing={0}>
                             <Text variant="body-sm-strong">{name}</Text>
-                            {isNetworkWithTokens(symbol) && (
+                            {isTokensFeatureSupported && (
                                 <Text variant="body-sm" color="contentSecondary">
-                                    <Translation id="generic.tokens" />
+                                    <Translation
+                                        id={
+                                            isStakingFeatureSupported
+                                                ? 'moduleSettings.coinEnabling.labels.tokensAndStaking'
+                                                : 'moduleSettings.coinEnabling.labels.tokens'
+                                        }
+                                    />
                                 </Text>
                             )}
                         </VStack>

--- a/suite-native/coin-enabling/tsconfig.json
+++ b/suite-native/coin-enabling/tsconfig.json
@@ -24,7 +24,6 @@
         { "path": "../intl" },
         { "path": "../navigation" },
         { "path": "../toasts" },
-        { "path": "../tokens" },
         { "path": "../../packages/styles-native" }
     ]
 }

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -1252,8 +1252,12 @@ export const messages = {
                 'Enable coins to buy or receive assets. Disable unused coins to improve loading speed.',
         },
         coinEnabling: {
-            testnetsLabel: 'Testnet networks',
             unsupportedSubtitle: 'Not supported on this device',
+            labels: {
+                testnets: 'Testnet networks',
+                tokens: 'Including tokens',
+                tokensAndStaking: 'Including tokens and staking',
+            },
             bottomNote:
                 'Didn’t find what you’re looking for? Check if it’s not a token running one of the listed coin’s network.',
             toasts: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11830,7 +11830,6 @@ __metadata:
     "@suite-native/intl": "workspace:*"
     "@suite-native/navigation": "workspace:*"
     "@suite-native/toasts": "workspace:*"
-    "@suite-native/tokens": "workspace:*"
     "@trezor/styles-native": "workspace:*"
     react: "npm:19.2.4"
     react-native: "npm:0.83.2"


### PR DESCRIPTION
_+ Tokens_ replaced as requested in [Figma](https://www.figma.com/design/7XszcGNCeQS7AGpH6rmoSe/Assets?node-id=4454-48850&t=3rSP1tBIT4TmIfHg-4).

## Related Issue

Resolve #28086

## Screenshots:

| Onboarding | Settings | My assets |
| --- | --- | --- |
| <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/7fc8ac66-c7b3-4268-a5f4-702aec07708b" /> | <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/2b013167-af5c-489b-8451-571b4d7d5f75" /> | <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/de50763a-fa57-46f9-bd2a-eabe3789c6f7" /> |

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All changed files are in the `suite-native/` directory, which is the React Native mobile app codebase. The changes affect native-only components (`DiscoveryCoinsFilter.tsx`, `NetworkListItem.tsx`) and their package configuration (`package.json`, `tsconfig.json`), plus a native intl messages file. The E2E test suite exclusively covers the desktop/web Trezor Suite application (Electron and browser), not the React Native mobile app. Therefore, none of the 114 candidate E2E tests exercise the changed code paths, and no tests are recommended. The risk to the desktop/web application is negligible.

<details><summary><b>Changed files (5)</b></summary>

- `suite-native/coin-enabling/package.json`
- `suite-native/coin-enabling/src/components/DiscoveryCoinsFilter.tsx`
- `suite-native/coin-enabling/src/components/NetworkListItem.tsx`
- `suite-native/coin-enabling/tsconfig.json`
- `suite-native/intl/src/messages.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (5)**
- `suite-native/coin-enabling/package.json`
- `suite-native/coin-enabling/src/components/DiscoveryCoinsFilter.tsx`
- `suite-native/coin-enabling/src/components/NetworkListItem.tsx`
- `suite-native/coin-enabling/tsconfig.json`
- `suite-native/intl/src/messages.ts`

_Updated: 2026-06-05T19:47:41.378Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/tokens-and-staking-labels&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/tokens-and-staking-labels&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/tokens-and-staking-labels&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-05T13:48:09.313Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-05T19:51:10.762Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/native/tokens-and-staking-labels/web/](https://dev.suite.sldev.cz/suite-web/feat/native/tokens-and-staking-labels/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->