### PR TITLE
fix(suite-native-28179): remove CEX label from buy and sell provider sheets

### DIFF
--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItem.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItem.tsx
@@ -19,6 +19,7 @@ export type ProviderListItemProps<T extends TradingTradeType> = {
     isSelected: boolean;
     onPress: (quote: T) => void;
     quote: T;
+    shouldShowExchangeType: boolean;
     tradingType: TradingType;
 };
 
@@ -30,6 +31,7 @@ export const ProviderListItem = <T extends TradingTradeType>({
     isSelected,
     onPress,
     quote,
+    shouldShowExchangeType,
     tradingType,
 }: ProviderListItemProps<T>) => {
     const { applyStyle } = useNativeStyles();
@@ -63,7 +65,11 @@ export const ProviderListItem = <T extends TradingTradeType>({
                             isChecked={isSelected}
                         />
                     </HStack>
-                    <ProviderListItemInfo provider={provider} quote={quote} />
+                    <ProviderListItemInfo
+                        provider={provider}
+                        quote={quote}
+                        shouldShowExchangeType={shouldShowExchangeType}
+                    />
                     <CardDivider />
                     <ProviderListItemValueRow quote={quote} />
                 </VStack>

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItemInfo.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItemInfo.tsx
@@ -12,11 +12,13 @@ import { getKycPolicyWarningTranslation } from '../../../utils/general/kycUtils'
 export type ProviderListItemInfoProps<T extends TradingTradeType> = {
     quote: T;
     provider: TradingProviderInfo;
+    shouldShowExchangeType: boolean;
 };
 
 export const ProviderListItemInfo = <T extends TradingTradeType>({
     quote,
     provider,
+    shouldShowExchangeType,
 }: ProviderListItemInfoProps<T>) => {
     let isDex = false;
     let isAnonymous = false;
@@ -35,16 +37,18 @@ export const ProviderListItemInfo = <T extends TradingTradeType>({
 
     return (
         <>
-            <InfoLineItem
-                iconName="info"
-                text={
-                    isDex ? (
-                        <Translation id="moduleTrading.providerListItem.decentralizedExchange" />
-                    ) : (
-                        <Translation id="moduleTrading.providerListItem.centralizedExchange" />
-                    )
-                }
-            />
+            {shouldShowExchangeType && (
+                <InfoLineItem
+                    iconName="info"
+                    text={
+                        isDex ? (
+                            <Translation id="moduleTrading.providerListItem.decentralizedExchange" />
+                        ) : (
+                            <Translation id="moduleTrading.providerListItem.centralizedExchange" />
+                        )
+                    }
+                />
+            )}
             {isAnonymous && (
                 <InfoLineItem
                     iconName="info"

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderSheet.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderSheet.tsx
@@ -39,6 +39,7 @@ export const ProviderSheet = <
     tradingType,
 }: ProviderSheetProps<K, T>) => {
     const shouldShowFilters = tradingType === 'exchange';
+    const shouldShowExchangeType = tradingType === 'exchange';
 
     const { filterItems, filteredSections, selectedFilter, setSelectedFilter } = useProviderFilters(
         quotes,
@@ -59,6 +60,7 @@ export const ProviderSheet = <
                     onPress={onQuoteSelectCallback}
                     isSelected={item.orderId === selectedQuote?.orderId}
                     quote={item}
+                    shouldShowExchangeType={shouldShowExchangeType}
                     tradingType={tradingType}
                 />
             )}

--- a/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderListItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderListItem.test.tsx
@@ -32,6 +32,7 @@ describe('ProviderListItem', () => {
                 isSelected={false}
                 onPress={jest.fn()}
                 quote={quote}
+                shouldShowExchangeType={false}
                 tradingType="buy"
                 {...props}
             />,
@@ -45,10 +46,19 @@ describe('ProviderListItem', () => {
     });
 
     it('should render trading information with formatted strings', () => {
-        const { getByText } = renderProviderListItem(mercuryoApplePayBuyQuote);
+        const { getByText, queryByText } = renderProviderListItem(mercuryoApplePayBuyQuote);
+
+        expect(queryByText('Centralized exchange')).toBeNull();
+        expect(getByText('€9,998.32 / 1 BTC')).toBeOnTheScreen();
+    });
+
+    it('should render centralized exchange information for CEX providers when enabled', () => {
+        const { getByText } = renderProviderListItem(cexdirectFloatingQuote, {
+            shouldShowExchangeType: true,
+            tradingType: 'exchange',
+        });
 
         expect(getByText('Centralized exchange')).toBeOnTheScreen();
-        expect(getByText('€9,998.32 / 1 BTC')).toBeOnTheScreen();
     });
 
     it('should render KYC information when provider has KYC policy', () => {
@@ -61,6 +71,7 @@ describe('ProviderListItem', () => {
 
     it('should render anonymous information for DEX providers', () => {
         const { getByText } = renderProviderListItem(invityDexQuote, {
+            shouldShowExchangeType: true,
             tradingType: 'exchange',
         });
 

--- a/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderSheet.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderSheet.test.tsx
@@ -4,7 +4,7 @@ import {
     type TradingType,
 } from '@suite-common/trading';
 import { screen } from '@suite-native/test-utils-store';
-import { mercuryoApplePayBuyQuote } from '@suite-native/trading-fixtures';
+import { cexdirectFloatingQuote, mercuryoApplePayBuyQuote } from '@suite-native/trading-fixtures';
 
 import {
     type PreloadedStatePartial,
@@ -65,6 +65,16 @@ describe('ProviderSheet', () => {
         });
 
         expect(queryByText('No offers available.')).toBeNull();
+        expect(queryByText('Centralized exchange')).toBeNull();
         expect(getByText('Mercuryo')).toBeOnTheScreen();
+    });
+
+    it('should render exchange type information for exchange quotes', () => {
+        const { getByText } = renderProviderSheet({
+            quotes: { fixed: [cexdirectFloatingQuote] },
+            tradingType: 'exchange',
+        });
+
+        expect(getByText('Centralized exchange')).toBeOnTheScreen();
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Hide the provider exchange-type line in native buy and sell provider sheets.
- Keep CEX/DEX labels visible for the exchange flow only.
- Update provider sheet tests to cover both behaviors.


## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/28179

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/28179-remove-cex-from-buysell&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->