### PR TITLE
Improve account search and filtering

### DIFF
--- a/suite-native/accounts/src/components/AccountsList/AccountsListEmptyPlaceholder.tsx
+++ b/suite-native/accounts/src/components/AccountsList/AccountsListEmptyPlaceholder.tsx
@@ -3,9 +3,8 @@ import { useSelector } from 'react-redux';
 import { useRoute } from '@react-navigation/native';
 
 import { selectIsDeviceConnected } from '@suite-common/device';
-import { Box, PictogramTitleHeader } from '@suite-native/atoms';
-import { type IconName } from '@suite-native/icons';
-import { Translation, type TxKeyPath } from '@suite-native/intl';
+import { Box, PictogramTitleHeader, type PictogramTitleHeaderProps } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
 import { ReceiveStackRoutes } from '@suite-native/navigation';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
@@ -33,40 +32,41 @@ export const AccountsListEmptyPlaceholder = ({
 
     const isDeviceConnected = useSelector(selectIsDeviceConnected);
 
-    const getIcon = (): IconName => {
+    const pictogramTitleHeaderProps: Omit<PictogramTitleHeaderProps, 'variant'> = (() => {
         if (!isFilterEmpty) {
-            return 'magnifyingGlass';
+            return {
+                icon: 'magnifyingGlass',
+                title: <Translation id="moduleAccounts.emptyState.searchTitle" />,
+            };
         }
         if (isReceiveRoute) {
-            return 'arrowLineDown';
+            return {
+                icon: 'arrowLineDown',
+                title: <Translation id="moduleAccounts.emptyState.title" />,
+                titleVariant: 'headline-md',
+                subtitle: <Translation id="moduleAccounts.emptyState.receiveSubtitle" />,
+            };
         }
 
-        return 'coins';
-    };
-
-    const getSubtitle = (): TxKeyPath => {
-        if (!isFilterEmpty) {
-            return 'moduleAccounts.emptyState.searchAgain';
-        }
-        if (isReceiveRoute) {
-            return 'moduleAccounts.emptyState.receiveSubtitle';
-        }
-        if (isDeviceConnected) {
-            return 'moduleAccounts.emptyState.addSubtitle';
-        }
-
-        return 'moduleAccounts.emptyState.subtitle';
-    };
+        return {
+            icon: 'coins',
+            title: <Translation id="moduleAccounts.emptyState.title" />,
+            titleVariant: 'headline-md',
+            subtitle: (
+                <Translation
+                    id={
+                        isDeviceConnected
+                            ? 'moduleAccounts.emptyState.addSubtitle'
+                            : 'moduleAccounts.emptyState.subtitle'
+                    }
+                />
+            ),
+        };
+    })();
 
     return (
         <Box style={applyStyle(titleVariant)}>
-            <PictogramTitleHeader
-                variant="info"
-                icon={getIcon()}
-                title={<Translation id="moduleAccounts.emptyState.title" />}
-                subtitle={<Translation id={getSubtitle()} />}
-                titleVariant="headline-md"
-            />
+            <PictogramTitleHeader variant="info" {...pictogramTitleHeaderProps} />
         </Box>
     );
 };

--- a/suite-native/accounts/src/components/AccountsListWithFilter.tsx
+++ b/suite-native/accounts/src/components/AccountsListWithFilter.tsx
@@ -44,6 +44,7 @@ export const AccountsListWithFilter = ({
     const networkFilterOptions = useSelector((state: NativeAccountsRootState) =>
         selectNetworkFilterOptions(state, isSendFlow),
     );
+    const isNetworkFilterVisible = networkFilterOptions.length > 1;
 
     useEffect(() => {
         setFilteredNetworks(networksFilter);
@@ -69,7 +70,7 @@ export const AccountsListWithFilter = ({
                 flowType={flowType}
                 closeActionType={closeActionType}
                 closeAction={closeAction}
-                onFilterPress={handleFilterPress}
+                onFilterPress={isNetworkFilterVisible ? handleFilterPress : undefined}
                 activeFilterCount={filteredNetworks.length}
             />
             {children}
@@ -80,7 +81,7 @@ export const AccountsListWithFilter = ({
                     networkFilter={filteredNetworks}
                     isSendFlow={isSendFlow}
                 />
-                {filteredNetworks.length > 0 && (
+                {isNetworkFilterVisible && filteredNetworks.length > 0 && (
                     <Box alignItems="center">
                         <Button
                             size="medium"

--- a/suite-native/accounts/src/components/AccountsListWithFilter.tsx
+++ b/suite-native/accounts/src/components/AccountsListWithFilter.tsx
@@ -59,7 +59,6 @@ export const AccountsListWithFilter = ({
 
     const handleClearFilters = () => {
         setFilteredNetworks([]);
-        setSearchValue('');
     };
 
     return (
@@ -67,7 +66,6 @@ export const AccountsListWithFilter = ({
             <SearchableAccountsListHeader
                 title={title}
                 onSearchInputChange={setSearchValue}
-                searchValue={searchValue}
                 flowType={flowType}
                 closeActionType={closeActionType}
                 closeAction={closeAction}
@@ -82,7 +80,7 @@ export const AccountsListWithFilter = ({
                     networkFilter={filteredNetworks}
                     isSendFlow={isSendFlow}
                 />
-                {(filteredNetworks.length > 0 || searchValue.length > 0) && (
+                {filteredNetworks.length > 0 && (
                     <Box alignItems="center">
                         <Button
                             size="medium"

--- a/suite-native/accounts/src/components/AccountsSearchForm.tsx
+++ b/suite-native/accounts/src/components/AccountsSearchForm.tsx
@@ -48,7 +48,7 @@ export const AccountsSearchForm = ({ onPressCancel, onInputChange }: AccountsSea
             )}
             exiting={FadeOut.duration(SEARCH_INPUT_ANIMATION_DURATION)}
         >
-            <HStack marginHorizontal="sp16" spacing="sp16" justifyContent="space-between">
+            <HStack marginRight="sp16" spacing="sp16" justifyContent="space-between">
                 <Animated.View
                     entering={SlideInLeft.duration(SEARCH_INPUT_ANIMATION_DURATION).delay(
                         SEARCH_INPUT_ANIMATION_DELAY,
@@ -60,6 +60,8 @@ export const AccountsSearchForm = ({ onPressCancel, onInputChange }: AccountsSea
                         placeholder={translate('accounts.searchForm.placeholder')}
                         onChange={setInputText}
                         maxLength={MAX_SEARCH_VALUE_LENGTH}
+                        //  eslint-disable-next-line jsx-a11y/no-autofocus
+                        autoFocus
                     />
                 </Animated.View>
 

--- a/suite-native/accounts/src/components/SearchableAccountsListHeader.tsx
+++ b/suite-native/accounts/src/components/SearchableAccountsListHeader.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useEffect, useState } from 'react';
+import { type ReactNode, useState } from 'react';
 import { View } from 'react-native';
 import Animated, {
     type EntryExitAnimationFunction,
@@ -19,7 +19,6 @@ import { FilterCountBadge } from './FilterCountBadge';
 type SearchableAccountsListHeaderProps = {
     title: ReactNode;
     onSearchInputChange: (value: string) => void;
-    searchValue?: string;
     flowType?: AddCoinFlowType;
     closeActionType?: CloseActionType;
     closeAction?: () => void;
@@ -38,7 +37,6 @@ const searchFormContainerStyle = prepareNativeStyle(({ spacings }) => ({
 export const SearchableAccountsListHeader = ({
     title,
     onSearchInputChange,
-    searchValue,
     flowType,
     closeActionType,
     closeAction,
@@ -49,12 +47,6 @@ export const SearchableAccountsListHeader = ({
     const { applyStyle } = useNativeStyles();
 
     const [isSearchActive, setIsSearchActive] = useState(false);
-
-    useEffect(() => {
-        if (searchValue === '') {
-            setIsSearchActive(false);
-        }
-    }, [searchValue]);
 
     const handleHideFilter = () => {
         setIsSearchActive(false);

--- a/suite-native/atoms/src/Input/BaseSearchInput.tsx
+++ b/suite-native/atoms/src/Input/BaseSearchInput.tsx
@@ -13,6 +13,7 @@ import { useSearchInputCallbacks } from './useSearchInputCallbacks';
 export type BaseSearchInputProps = {
     onChange: (value: string) => void;
     placeholder?: string;
+    autoFocus?: boolean;
     isDisabled?: boolean;
     maxLength?: number;
     elevation?: SurfaceElevation;
@@ -21,7 +22,16 @@ export type BaseSearchInputProps = {
 };
 export const BaseSearchInput = forwardRef<TextInput, BaseSearchInputProps>(
     (
-        { onChange, placeholder, maxLength, isDisabled = false, elevation = '0', onFocus, onBlur },
+        {
+            onChange,
+            placeholder,
+            maxLength,
+            autoFocus,
+            isDisabled = false,
+            elevation = '0',
+            onFocus,
+            onBlur,
+        },
         ref,
     ) => {
         const { applyStyle, utils } = useNativeStyles();
@@ -45,6 +55,8 @@ export const BaseSearchInput = forwardRef<TextInput, BaseSearchInputProps>(
                         onChangeText={handleOnChangeText}
                         placeholder={placeholder}
                         placeholderTextColor={utils.colors.contentSecondary}
+                        // eslint-disable-next-line jsx-a11y/no-autofocus
+                        autoFocus={autoFocus}
                         editable={!isDisabled}
                         onFocus={() => {
                             setIsFocused(true);

--- a/suite-native/atoms/src/Input/SearchInput.tsx
+++ b/suite-native/atoms/src/Input/SearchInput.tsx
@@ -7,8 +7,9 @@ import { BaseSearchInput } from './BaseSearchInput';
 export type SearchInputProps = {
     onChange: (value: string) => void;
     placeholder?: string;
-    isDisabled?: boolean;
     maxLength?: number;
+    autoFocus?: boolean;
+    isDisabled?: boolean;
     elevation?: SurfaceElevation;
     onFocus?: () => void;
     onBlur?: () => void;
@@ -18,6 +19,7 @@ export const SearchInput = ({
     onChange,
     placeholder,
     maxLength,
+    autoFocus,
     isDisabled = false,
     elevation = '0',
     onFocus,
@@ -30,6 +32,8 @@ export const SearchInput = ({
             onChange={onChange}
             placeholder={placeholder}
             maxLength={maxLength}
+            // eslint-disable-next-line jsx-a11y/no-autofocus
+            autoFocus={autoFocus}
             isDisabled={isDisabled}
             elevation={elevation}
             onFocus={onFocus}

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -1871,6 +1871,7 @@ export const messages = {
             subtitle: 'Connect your Trezor or sync coins to view and track assets.',
             addSubtitle: 'Start adding coins you want to use.',
             receiveSubtitle: 'Connect your Trezor or sync coins to view and receive assets.',
+            searchTitle: 'No results found',
             searchAgain: 'Search again',
         },
         viewOnlyAddAccountAlert: {


### PR DESCRIPTION
- `autoFocus` and correct margin for account search input used.
- Empty search value does not close account search form.
- Network filter not visible when only one network is enabled.
- Account search empty state title and variant changed.

## Related Issue

Resolve #28360

## Screenshots:

| Single network | Multiple networks | No results found |
| --- | --- | --- |
| <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/08311fec-b381-46b9-b835-45db1722689b" /> | <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/9570af3e-ccd7-4da8-889c-3513a665d165" /> | <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/2ac2996c-bcd3-40a6-a043-d9ff08858c19" /> |

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/account-search&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->