### PR TITLE
fix(transport): close session lock races and lock leaks (fuzzing + e2e)

### DIFF
--- a/.github/workflows/test-misc.yml
+++ b/.github/workflows/test-misc.yml
@@ -77,6 +77,33 @@ jobs:
       - name: Unit Tests - Native
         run: yarn test:unit:all --exclude='@trezor/*,@suite/*,@suite-common/*' -- --silent
 
+  test-fuzz:
+    # Randomized property/fuzz tests are excluded from the unit suite and run
+    # here on the nightly schedule (and on demand via workflow_dispatch). A fresh
+    # seed each night widens the explored interleavings over time; a failure
+    # prints the seed + shrunk counterexample for deterministic reproduction.
+    runs-on: ubuntu-latest
+    if: github.repository == 'trezor/trezor-suite'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
+        with:
+          mode: firewall-free
+          job-summary: errors
+          firewall-version: 1.11.0
+      - run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable
+      - name: Fuzz Tests - Transport sessions lock
+        run: yarn workspace @trezor/transport-common test:fuzz
+
   test-unit-windows:
     runs-on: windows-latest
     if: github.repository == 'trezor/trezor-suite'

--- a/packages/transport-bridge/src/core.ts
+++ b/packages/transport-bridge/src/core.ts
@@ -166,6 +166,10 @@ export const createCore = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) =>
         logger?.debug(`core: openDevice: result: ${JSON.stringify(openDeviceResult)}`);
 
         if (!openDeviceResult.success) {
+            // release the lock taken by acquireIntent without committing a session,
+            // otherwise the device is locked forever and every later acquire deadlocks
+            await sessionsClient.acquireDone({ path: acquireInput.path, abort: true });
+
             return openDeviceResult;
         }
         await sessionsClient.acquireDone({
@@ -177,23 +181,25 @@ export const createCore = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) =>
     };
 
     const release = async ({ session }: Omit<ReleaseInput, 'path'>) => {
-        await sessionsClient.releaseIntent({ session });
+        const releaseIntentResult = await sessionsClient.releaseIntent({ session });
 
-        const sessionsResult = await sessionsClient.getPathBySession({
-            session,
-        });
-
-        if (!sessionsResult.success) {
-            return sessionsResult;
+        // on failure releaseIntent already freed the lock (or never took it); use
+        // the path it returned instead of a second getPathBySession lookup, which
+        // could race and leak the held lock when it fails.
+        if (!releaseIntentResult.success) {
+            return releaseIntentResult;
         }
 
-        const closeRes = await api.closeDevice(sessionsResult.payload.path);
+        const { path } = releaseIntentResult.payload;
+
+        const closeRes = await api.closeDevice(path);
 
         if (!closeRes.success) {
             logger?.error(`core: release: api.closeDevice error: ${closeRes.error}`);
         }
 
-        return sessionsClient.releaseDone({ path: sessionsResult.payload.path });
+        // always reached, even when closeDevice failed, so the lock is freed
+        return sessionsClient.releaseDone({ path });
     };
 
     const getProtocol = (protocolName: BridgeProtocolMessage['protocol']) => {

--- a/packages/transport-bridge/tests/core.test.ts
+++ b/packages/transport-bridge/tests/core.test.ts
@@ -1,0 +1,84 @@
+import { AbstractApi, PathPublic } from '@trezor/transport-common';
+
+import { createCore } from '../src/core';
+
+/**
+ * Lock-safety of the node-bridge core acquire/release wrappers around
+ * SessionsBackground. acquireIntent/releaseIntent take the session lock; if the
+ * subsequent openDevice/closeDevice step fails, the lock must still be released,
+ * otherwise the device wedges and every later acquire deadlocks.
+ *
+ * These run against the real SessionsBackground via a fake low-level api whose
+ * openDevice result we control.
+ */
+
+const muteLogger = {
+    enabled: false,
+    info: () => {},
+    debug: () => {},
+    log: () => {},
+    warn: () => {},
+    error: () => {},
+} as any;
+
+// enough microtask turns to let an unblocked acquire chain reach openDevice
+const flushMicrotasks = async () => {
+    for (let i = 0; i < 16; i += 1) {
+        await Promise.resolve();
+    }
+};
+
+const createFakeApi = (override: Record<string, unknown> = {}) =>
+    ({
+        chunkSize: 64,
+        listen: () => {},
+        on: () => {},
+        off: () => {},
+        enumerate: () => Promise.resolve({ success: true, payload: [{ path: '1' }] }),
+        openDevice: () => Promise.resolve({ success: true, payload: undefined }),
+        closeDevice: () => Promise.resolve({ success: true, payload: undefined }),
+        dispose: () => {},
+        ...override,
+    }) as unknown as AbstractApi;
+
+describe('transport-bridge core lock safety', () => {
+    it('acquire releases the session lock when openDevice fails', async () => {
+        const openDevice = jest
+            .fn()
+            .mockResolvedValueOnce({ success: false, error: 'device disconnected during action' })
+            .mockResolvedValue({ success: true, payload: undefined });
+
+        const core = createCore(createFakeApi({ openDevice }), muteLogger);
+        const { signal } = new AbortController();
+
+        try {
+            await core.enumerate({ signal });
+
+            const first = await core.acquire({
+                path: PathPublic('1'),
+                previous: 'null',
+                signal,
+                sessionOwner: 'A',
+            });
+            expect(first.success).toBe(false);
+
+            // The second acquire must reach openDevice again, i.e. the lock taken by
+            // the first (failed) acquireIntent was released. On the buggy code the
+            // lock leaks and the second acquireIntent blocks in the queue, so
+            // openDevice is never called a second time within microtasks.
+            const secondPromise = core.acquire({
+                path: PathPublic('1'),
+                previous: 'null',
+                signal,
+                sessionOwner: 'A',
+            });
+            await flushMicrotasks();
+            expect(openDevice).toHaveBeenCalledTimes(2);
+
+            const second = await secondPromise;
+            expect(second.success).toBe(true);
+        } finally {
+            core.dispose();
+        }
+    });
+});

--- a/packages/transport-common/jest.config.cjs
+++ b/packages/transport-common/jest.config.cjs
@@ -6,4 +6,7 @@ module.exports = {
     collectCoverageFrom: ['src/**/*.ts'],
     watchPathIgnorePatterns: ['<rootDir>/libDev', '<rootDir>/lib'],
     testEnvironment: '../../JestCustomEnv.js',
+    // Fuzz/property tests are randomized and slower; they run on demand via
+    // `yarn test:fuzz` (jest.config.fuzz.cjs), not as part of the unit suite.
+    testPathIgnorePatterns: [...baseConfig.testPathIgnorePatterns, '\\.fuzz\\.test\\.[tj]sx?$'],
 };

--- a/packages/transport-common/jest.config.fuzz.cjs
+++ b/packages/transport-common/jest.config.fuzz.cjs
@@ -1,0 +1,12 @@
+const unitConfig = require('./jest.config.cjs');
+
+// Runs only the randomized fuzz/property tests, which are excluded from the
+// default unit suite (see jest.config.cjs). Invoked via `yarn test:fuzz`.
+module.exports = {
+    ...unitConfig,
+    collectCoverage: false,
+    testMatch: ['**/*.fuzz.test.[tj]s?(x)'],
+    testPathIgnorePatterns: unitConfig.testPathIgnorePatterns.filter(
+        pattern => !pattern.includes('fuzz'),
+    ),
+};

--- a/packages/transport-common/package.json
+++ b/packages/transport-common/package.json
@@ -45,11 +45,13 @@
         "type-check": "yarn g:tsc --build tsconfig.json",
         "build:lib": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/publish/replace-imports.sh ./lib",
         "test:unit": "jest",
+        "test:fuzz": "jest -c jest.config.fuzz.cjs",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
     },
     "devDependencies": {
         "@trezor/eslint": "workspace:*",
         "@types/node": "22.13.10",
+        "fast-check": "3.23.2",
         "jest": "29.7.0"
     },
     "dependencies": {

--- a/packages/transport-common/src/sessions/background.ts
+++ b/packages/transport-common/src/sessions/background.ts
@@ -218,8 +218,13 @@ export class SessionsBackground
         if (!pathInternal || !this.descriptors[pathInternal]) {
             return error({ code: ERRORS.DEVICE_NOT_FOUND });
         }
-        this.descriptors[pathInternal].session = Session(`${this.lastSessionId}`);
-        this.descriptors[pathInternal].sessionOwner = payload.sessionOwner;
+
+        // abort: openDevice failed after acquireIntent reserved the session. The
+        // lock is already released above; do not commit a phantom session.
+        if (!payload.abort) {
+            this.descriptors[pathInternal].session = Session(`${this.lastSessionId}`);
+            this.descriptors[pathInternal].sessionOwner = payload.sessionOwner;
+        }
 
         return Promise.resolve(success({ descriptors: Object.values(this.descriptors) }));
     }

--- a/packages/transport-common/src/sessions/background.ts
+++ b/packages/transport-common/src/sessions/background.ts
@@ -184,10 +184,16 @@ export class SessionsBackground
             return error({ code: ERRORS.SESSION_WRONG_PREVIOUS });
         }
 
+        // Snapshot the session value before yielding: `previous` is a live
+        // reference to the descriptor, so comparing previous.session after the
+        // await would compare the post-await value against itself and let two
+        // concurrent acquires of a free device both pass the guard below.
+        const previousSession = previous.session;
+
         await this.waitInQueue();
 
         // in case there are 2 simultaneous acquireIntents, one goes through, the other one waits and gets error here
-        if (previous.session !== this.descriptors[pathInternal]?.session) {
+        if (previousSession !== this.descriptors[pathInternal]?.session) {
             this.clearLock();
 
             return error({ code: ERRORS.SESSION_WRONG_PREVIOUS });
@@ -227,6 +233,15 @@ export class SessionsBackground
         const { path } = pathResult.payload;
 
         await this.waitInQueue();
+
+        // Re-check ownership after the lock: the session may have been stolen
+        // while we waited. Without this, releaseDone (which clears the session
+        // unconditionally) would destroy the new owner's session.
+        if (this.descriptors[path]?.session !== payload.session) {
+            this.clearLock();
+
+            return error({ code: ERRORS.SESSION_NOT_FOUND });
+        }
 
         return success({ path });
     }

--- a/packages/transport-common/src/sessions/types.ts
+++ b/packages/transport-common/src/sessions/types.ts
@@ -37,6 +37,11 @@ export type AcquireIntentResponse = BackgroundResponseWithError<
 export type AcquireDoneRequest = {
     path: PathPublic;
     sessionOwner?: string;
+    /**
+     * Set when openDevice failed after acquireIntent already reserved the session:
+     * release the held lock without committing a (phantom) session.
+     */
+    abort?: boolean;
 };
 
 export type AcquireDoneResponse = BackgroundResponseWithError<

--- a/packages/transport-common/src/transports/abstractApi.ts
+++ b/packages/transport-common/src/transports/abstractApi.ts
@@ -132,10 +132,14 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                 );
 
                 if (!openDeviceResult.success) {
+                    // release the lock taken by acquireIntent without committing a
+                    // session, otherwise the device deadlocks on the next acquire
+                    await this.sessionsClient.acquireDone({ path, abort: true });
+
                     return openDeviceResult;
                 }
 
-                this.sessionsClient.acquireDone({ path, sessionOwner: this.id });
+                await this.sessionsClient.acquireDone({ path, sessionOwner: this.id });
 
                 return success(acquireIntentResponse.payload.session);
             },

--- a/packages/transport-common/tests/sessions.fuzz.test.ts
+++ b/packages/transport-common/tests/sessions.fuzz.test.ts
@@ -1,0 +1,390 @@
+import fc from 'fast-check';
+
+import { SessionsBackground } from '../src/sessions/background';
+import { SessionsClient } from '../src/sessions/client';
+import { Descriptor, PathInternal, PathPublic, Session } from '../src/types';
+
+/**
+ * Concurrency fuzz harness for the sessions lock / stealing protocol.
+ *
+ * The hand-written tests in sessions.test.ts are strictly sequential: every
+ * message is awaited before the next is sent, so two handleMessage calls are
+ * never in flight at once - which is exactly the window where lock races live.
+ *
+ * SessionsBackground is a single-threaded message processor whose only
+ * non-determinism is the order in which concurrent clients' messages arrive and
+ * interleave at internal `await` points. So we let fast-check fuzz that arrival
+ * order: each client is a small state machine, we "fire" its next message
+ * without awaiting, and flush microtasks between fires. A message that must wait
+ * for the lock simply stays pending until another client's message frees it -
+ * real lock mechanics, no fake timers, no safety-net involved.
+ *
+ * Each client either acquires a device it believes is free (previous: null) or
+ * STEALS it from the current owner (previous: last observed session) - the
+ * session-takeover flow Suite uses against the bridge.
+ *
+ * The session lifecycle under test:
+ *   acquireIntent(previous) -> reserves a fresh session under the lock,
+ *                              returns it (+ a releaseRequest when stealing)
+ *   acquireDone(path)       -> commits the session, releases the lock
+ *   releaseIntent(session)  -> takes the lock if the session is current
+ *   releaseDone(path)       -> clears the session, releases the lock
+ *
+ * The system under test is the real SessionsBackground - no mocks - so any
+ * counterexample is a real defect, and fast-check shrinks the arrival order to
+ * the minimal interleaving that breaks the invariant.
+ */
+
+const DEVICE_INTERNAL = PathInternal('dev-1');
+// enumerateDone assigns incrementing public paths starting at '1' for the
+// first device it sees.
+const DEVICE_PUBLIC = PathPublic('1');
+
+// Enough microtask turns to let any unblocked handleMessage chain settle. The
+// lock's only macrotask is a 4s safety-net timer we intentionally never wait
+// for, so draining microtasks is all that is needed to observe steady state.
+const flushMicrotasks = async () => {
+    for (let i = 0; i < 16; i += 1) {
+        await Promise.resolve();
+    }
+};
+
+const setupSingleDevice = async () => {
+    const background = new SessionsBackground();
+    const admin = new SessionsClient(background);
+    await admin.handshake();
+    await admin.enumerateDone({
+        descriptors: [{ path: DEVICE_INTERNAL, type: 1, apiType: 'usb' }],
+    });
+
+    return background;
+};
+
+const committedSession = (descriptors: Descriptor[]): Session | null =>
+    descriptors.find(d => d.path === DEVICE_PUBLIC)?.session ?? null;
+
+type Phase = 'idle' | 'acquired' | 'committed' | 'releasing' | 'done';
+
+interface Actor {
+    index: number;
+    client: SessionsClient;
+    steals: boolean; // false: acquire with previous=null; true: steal current session
+    phase: Phase;
+    busy: boolean; // a request is in flight; a real client awaits its reply before sending the next
+    claimedPrevious: Session | null; // the `previous` this client passed to acquireIntent
+    granted: Session | null; // session handed out by acquireIntent
+    internalPath: PathInternal | null;
+}
+
+interface RunState {
+    // The owners that currently believe they hold the device: committed, not yet
+    // released, and NOT yet told to release. The protocol's only "you have been
+    // superseded" signal is the releaseRequest event - so an owner stays here
+    // until either it releases itself or it receives a releaseRequest. Two
+    // standing owners means someone took the device without the previous owner
+    // being notified.
+    owners: { client: number; session: Session }[];
+    maxOwners: number;
+    // shared "what a client last saw as the current session", used as steal target
+    observedCurrent: Session | null;
+    // Every session some client DELIBERATELY claimed as `previous` (i.e. tried to
+    // steal). A releaseRequest only legitimately supersedes an owner if that
+    // owner's session is in here - otherwise the releaseRequest is spurious (the
+    // acquireIntent dead-guard, race #1, kicking the current owner while granting
+    // an acquire that claimed the device was FREE), and the kicked owner must
+    // stay standing so INV-1 can observe the double-grant.
+    claimedPreviouses: Session[];
+}
+
+interface RunOptions {
+    withRelease: boolean;
+}
+
+/**
+ * Advance one client by firing its next message (fire-and-forget). The client
+ * never pipelines: while a request is in flight (`busy`) it does nothing, which
+ * is how a real client behaves.
+ */
+const advance = (actor: Actor, state: RunState, options: RunOptions) => {
+    if (actor.busy || actor.phase === 'done') return;
+
+    if (actor.phase === 'idle') {
+        const previous = actor.steals ? state.observedCurrent : null;
+        actor.claimedPrevious = previous;
+        // Record a deliberate steal so the releaseRequest oracle can tell a
+        // legitimate supersede from the spurious one race #1 produces.
+        if (previous !== null) state.claimedPreviouses.push(previous);
+        actor.busy = true;
+        actor.client.acquireIntent({ path: DEVICE_PUBLIC, previous }).then(
+            res => {
+                actor.busy = false;
+                if (res.success) {
+                    actor.granted = res.payload.session;
+                    actor.phase = 'acquired';
+                } else {
+                    actor.phase = 'done';
+                }
+            },
+            () => {
+                actor.busy = false;
+                actor.phase = 'done';
+            },
+        );
+    } else if (actor.phase === 'acquired') {
+        actor.busy = true;
+        actor.client.acquireDone({ path: DEVICE_PUBLIC }).then(
+            res => {
+                actor.busy = false;
+                if (res.success && actor.granted) {
+                    // Become an owner. Superseding the previous owner is the
+                    // protocol's job via releaseRequest (handled in runChurn); if
+                    // that signal never fired, the previous owner is still standing
+                    // here and we now have two owners of one device - the bug.
+                    state.owners.push({ client: actor.index, session: actor.granted });
+                    state.maxOwners = Math.max(state.maxOwners, state.owners.length);
+                    state.observedCurrent = committedSession(res.payload.descriptors);
+                }
+                actor.phase = options.withRelease ? 'committed' : 'done';
+            },
+            () => {
+                actor.busy = false;
+                actor.phase = 'done';
+            },
+        );
+    } else if (actor.phase === 'committed') {
+        actor.busy = true;
+        actor.client.releaseIntent({ session: actor.granted as Session }).then(
+            res => {
+                actor.busy = false;
+                if (res.success) {
+                    actor.internalPath = res.payload.path;
+                    actor.phase = 'releasing';
+                } else {
+                    actor.phase = 'done';
+                }
+            },
+            () => {
+                actor.busy = false;
+                actor.phase = 'done';
+            },
+        );
+    } else if (actor.phase === 'releasing') {
+        actor.busy = true;
+        actor.client.releaseDone({ path: actor.internalPath as PathInternal }).then(
+            res => {
+                actor.busy = false;
+                const owned = state.owners.findIndex(o => o.client === actor.index);
+                if (owned >= 0) state.owners.splice(owned, 1);
+                if (res.success) state.observedCurrent = committedSession(res.payload.descriptors);
+                actor.phase = 'done';
+            },
+            () => {
+                actor.busy = false;
+                actor.phase = 'done';
+            },
+        );
+    }
+};
+
+interface RunResult {
+    maxOwners: number;
+    allReachedDone: boolean;
+}
+
+/**
+ * Run a fuzzed arrival order against a fresh background, then fairly drive every
+ * client to completion. Returns the metrics the invariants assert on.
+ */
+const runChurn = async (
+    script: number[],
+    clientCount: number,
+    steals: boolean[],
+    options: RunOptions,
+): Promise<RunResult> => {
+    const background = await setupSingleDevice();
+    const state: RunState = {
+        owners: [],
+        maxOwners: 0,
+        observedCurrent: null,
+        claimedPreviouses: [],
+    };
+
+    // The protocol's "you have been superseded, please release" signal. When it
+    // fires for a session, that owner now knows to step down, so it stops
+    // counting as a standing owner - but ONLY if some client deliberately stole
+    // that session (claimed it as `previous`). A releaseRequest for a session
+    // nobody claimed is the acquireIntent dead-guard (race #1): an acquire that
+    // declared the device FREE still kicked the live owner. Honoring it would
+    // mask the double-grant, so we ignore it and let INV-1 see two owners.
+    background.on('releaseRequest', descriptor => {
+        const superseded = descriptor.session;
+        if (superseded === null || !state.claimedPreviouses.includes(superseded)) return;
+        const notified = state.owners.findIndex(o => o.session === superseded);
+        if (notified >= 0) state.owners.splice(notified, 1);
+    });
+
+    try {
+        const actors: Actor[] = Array.from({ length: clientCount }, (_, i) => ({
+            index: i,
+            client: new SessionsClient(background),
+            steals: steals[i] ?? false,
+            phase: 'idle',
+            busy: false,
+            claimedPrevious: null,
+            granted: null,
+            internalPath: null,
+        }));
+
+        // Phase 1: fuzzed arrival order.
+        for (const pick of script) {
+            const actor = actors[pick % clientCount];
+            if (actor) advance(actor, state, options);
+
+            await flushMicrotasks();
+        }
+
+        // Phase 2 (liveness): fairly drive everyone to completion. A correct lock
+        // lets every client finish without the 4s safety-net; an orphaned lock
+        // leaves someone stuck, so a full round with no phase change means the
+        // device is wedged.
+        for (let round = 0; round < clientCount * 20; round += 1) {
+            if (actors.every(a => a.phase === 'done')) break;
+            const before = actors.map(a => a.phase).join('|');
+            actors.forEach(a => advance(a, state, options));
+
+            await flushMicrotasks();
+            if (actors.map(a => a.phase).join('|') === before) break;
+        }
+
+        return {
+            maxOwners: state.maxOwners,
+            allReachedDone: actors.every(a => a.phase === 'done'),
+        };
+    } finally {
+        // clears any still-pending lock safety-net timers so jest sees no open handles
+        background.dispose();
+    }
+};
+
+const churn = (maxClients: number) =>
+    fc.integer({ min: 2, max: maxClients }).chain(clientCount =>
+        fc.record({
+            clientCount: fc.constant(clientCount),
+            steals: fc.array(fc.boolean(), { minLength: clientCount, maxLength: clientCount }),
+            script: fc.array(fc.integer({ min: 0, max: clientCount - 1 }), {
+                minLength: 2,
+                maxLength: 20,
+            }),
+        }),
+    );
+
+describe('sessions fuzz (concurrency + stealing)', () => {
+    /**
+     * INV-1 (safety): a device has at most one owner at a time.
+     * An owner holds from a successful acquire until it releases. A legitimate
+     * steal supersedes the owner it claimed via `previous`; a client that
+     * acquires "from free" (previous: null) while someone already owns the
+     * device must be rejected. Two standing owners == the device was granted
+     * twice.
+     *
+     * Because the oracle only counts an owner as superseded when some client
+     * DELIBERATELY stole its session (see `claimedPreviouses` in runChurn), this
+     * one invariant fails on BOTH bugs:
+     *  - race #1 (acquireIntent dead-guard): a second "from free" acquire wins
+     *    against a busy device and kicks the owner with a spurious releaseRequest
+     *    nobody asked for -> the owner stays standing -> two owners.
+     *  - race #2 (release racing a steal): the late release clobbers the new
+     *    owner's session while the previous owner is still standing -> two owners.
+     */
+    it('INV-1: a device is never owned by two clients at once', async () => {
+        await fc.assert(
+            fc.asyncProperty(churn(4), async ({ clientCount, steals, script }) => {
+                const { maxOwners } = await runChurn(script, clientCount, steals, {
+                    withRelease: true,
+                });
+                expect(maxOwners).toBeLessThanOrEqual(1);
+            }),
+            // race #1 is caught nearly every run; race #2 surfaces in only ~0.5% of
+            // interleavings, so run enough schedules that INV-1 (not just the
+            // deterministic VERIFY below) reliably exercises it.
+            { numRuns: 2000 },
+        );
+    }, 30000);
+
+    /**
+     * VERIFY (deterministic, no model): the exact race INV-1 shrank to. A
+     * release issued while the caller still owned the device, but landing after
+     * another client stole and committed, must NOT destroy the new owner's
+     * session. The guard is that releaseIntent re-checks ownership after the
+     * lock; without it releaseDone (which nulls unconditionally) wipes c1's
+     * freshly stolen session while c1 is never told it lost ownership.
+     */
+    it('VERIFY: a release racing a steal must not destroy the new owner session', async () => {
+        const background = await setupSingleDevice();
+        const c0 = new SessionsClient(background);
+        const c1 = new SessionsClient(background);
+
+        const releaseRequests: (Session | null)[] = [];
+        background.on('releaseRequest', d => releaseRequests.push(d.session));
+
+        try {
+            // c0 acquires the free device -> session "1"
+            await c0.acquireIntent({ path: DEVICE_PUBLIC, previous: null });
+            await c0.acquireDone({ path: DEVICE_PUBLIC });
+
+            // c1 steals it (previous "1"); intent succeeds and KEEPS the lock
+            const a1 = await c1.acquireIntent({ path: DEVICE_PUBLIC, previous: Session('1') });
+            expect(a1).toMatchObject({ success: true });
+
+            // c0, asked to release, starts releasing - blocks behind c1's lock
+            const rel0Promise = c0.releaseIntent({ session: Session('1') });
+
+            // c1 commits the steal -> device session becomes "2", unblocks c0
+            await c1.acquireDone({ path: DEVICE_PUBLIC });
+
+            const rel0 = await rel0Promise;
+            if (rel0.success) {
+                await c0.releaseDone({ path: rel0.payload.path });
+            }
+
+            const sessions = await c0.getSessions();
+            const current = committedSession(sessions.payload.descriptors);
+
+            // c0 was notified it was superseded; c1 was not (it is the new owner).
+            // These two document the protocol contract but hold on both the fixed
+            // and unfixed code - they are not what distinguishes the race.
+            expect(releaseRequests).toContain(Session('1'));
+            expect(releaseRequests).not.toContain(Session('2'));
+            // LOAD-BEARING: this is the assertion that fails on the unfixed code -
+            // without the releaseIntent re-check, c0's release clobbers c1's
+            // freshly stolen session and `current` is null instead of "2".
+            expect(current).toBe(Session('2'));
+        } finally {
+            background.dispose();
+        }
+    });
+
+    /**
+     * INV-2 (liveness): the lock never leaks; the device stays operable.
+     * After any interleaving, every client can be driven to completion without
+     * the 4s safety-net firing. A client left stuck means a lock was orphaned
+     * (e.g. clearLock freeing the queue head instead of the caller's own lock).
+     *
+     * Note: this guards SessionsBackground liveness only. The lock LEAK this PR
+     * fixes lives one layer up - in the transport-bridge core / AbstractApiTransport
+     * wrappers (acquire/release around openDevice/closeDevice) - which this harness
+     * does not instantiate; that leak is covered by transport-bridge/tests/core.test.ts.
+     * INV-2 is kept as a forward-looking regression guard for the lock itself.
+     */
+    it('INV-2: the device never wedges (no orphaned lock)', async () => {
+        await fc.assert(
+            fc.asyncProperty(churn(4), async ({ clientCount, steals, script }) => {
+                const { allReachedDone } = await runChurn(script, clientCount, steals, {
+                    withRelease: true,
+                });
+                expect(allReachedDone).toBe(true);
+            }),
+            { numRuns: 300 },
+        );
+    }, 30000);
+});

--- a/packages/transport-common/tests/sessions.test.ts
+++ b/packages/transport-common/tests/sessions.test.ts
@@ -199,6 +199,42 @@ describe('sessions', () => {
         });
     });
 
+    test('acquireDone with abort releases the lock without committing a session', async () => {
+        const client1 = new SessionsClient(background);
+        await client1.handshake();
+        await client1.enumerateDone({
+            descriptors: [{ path: PathInternal('1'), type: 1, apiType: 'usb' }],
+        });
+
+        const acquireIntent = await client1.acquireIntent({
+            path: PathPublic('1'),
+            previous: null,
+        });
+        expect(acquireIntent).toMatchObject({ success: true });
+
+        // openDevice failed after the intent reserved the session: abort must
+        // release the lock without committing a phantom session.
+        await client1.acquireDone({ path: PathPublic('1'), abort: true });
+
+        // session stays null (no phantom commit)
+        const sessions = await client1.getSessions();
+        expect(sessions).toMatchObject({
+            success: true,
+            payload: { descriptors: [{ path: '1', session: null }] },
+        });
+
+        // and the lock is free: a fresh acquire from null succeeds
+        const acquireAgain = await client1.acquireIntent({
+            path: PathPublic('1'),
+            previous: null,
+        });
+        expect(acquireAgain).toMatchObject({ success: true });
+
+        // cleanup: release the lock acquireAgain just took, otherwise it stays
+        // held with the 4s safety-net timer pending after the test ends
+        await client1.acquireDone({ path: PathPublic('1'), abort: true });
+    });
+
     // CURRENTLY LEAKS — see PR #27978 for the fix.
     //
     // SessionsClient subscribes to 'descriptors' and 'releaseRequest' on the background in

--- a/scripts/list-outdated-dependencies/qa-dependencies.txt
+++ b/scripts/list-outdated-dependencies/qa-dependencies.txt
@@ -19,6 +19,7 @@ babel-jest
 detox
 dotenv
 eslint-plugin-playwright
+fast-check
 jest
 jest-canvas-mock
 jest-diff

--- a/suite/e2e/tests/suite/multiple-sessions.test.ts
+++ b/suite/e2e/tests/suite/multiple-sessions.test.ts
@@ -56,27 +56,13 @@ test.describe('Multiple sessions', { tag: ['@T3W1', '@T3T1'] }, () => {
                 await expect(dashboardPage.deviceStatus).toHaveTranslation('TR_CONNECTED');
             });
 
-            // Possible change of behaviour to this instead of rest of the test.
-            // ATM discussed with Varmuza
-            // await test.step('Reload inactive suite session to take Bridge session back', async () => {
-            //     await stealBridgeSession();
-            //     await expect(dashboardPage.deviceStatus).toHaveTranslation('TR_USE_HERE');
-            //     await page.reload();
-            //     await expect(page.getByTestId('@deviceStatus-connected').first()).toBeVisible({
-            //         timeout: 30_000,
-            //     });
-            // });
-
-            await test.step('After reloading inactive suite session does not take Bridge session back', async () => {
-                await expect(dashboardPage.deviceStatus).toHaveTranslation('TR_USE_HERE', {
+            await test.step('Reloading the Suite tab automatically takes the Bridge session back', async () => {
+                await stealBridgeSession();
+                await expect(dashboardPage.deviceStatus).toHaveTranslation('TR_USE_HERE');
+                await page.reload();
+                await expect(dashboardPage.deviceStatus).toHaveTranslation('TR_CONNECTED', {
                     timeout: 30_000,
                 });
-            });
-
-            await test.step('Take Bridge session back', async () => {
-                await dashboardPage.deviceSwitchingOpenButton.click();
-                await dashboardPage.solveIssuesButton.click();
-                await expect(page.getByTestId('@deviceStatus-connected').first()).toBeVisible();
             });
         },
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -16906,6 +16906,7 @@ __metadata:
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
     "@types/node": "npm:22.13.10"
+    fast-check: "npm:3.23.2"
     jest: "npm:29.7.0"
   peerDependencies:
     tslib: ^2.6.2
@@ -27411,6 +27412,15 @@ __metadata:
   bin:
     fantasticon: bin/fantasticon
   checksum: 10/4e16843475645d1dd036af936a775cc32852787a460402fd0daf87b34835453961841dce33301ad8560fdc0c3706b2f13103f3c82acf0443aee96aa2214bcc7a
+  languageName: node
+  linkType: hard
+
+"fast-check@npm:3.23.2":
+  version: 3.23.2
+  resolution: "fast-check@npm:3.23.2"
+  dependencies:
+    pure-rand: "npm:^6.1.0"
+  checksum: 10/dab344146b778e8bc2973366ea55528d1b58d3e3037270262b877c54241e800c4d744957722c24705c787020d702aece11e57c9e3dbd5ea19c3e10926bf1f3fe
   languageName: node
   linkType: hard
 
@@ -39262,10 +39272,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pure-rand@npm:^6.0.0":
-  version: 6.0.1
-  resolution: "pure-rand@npm:6.0.1"
-  checksum: 10/c39512a6564692fbb294b36faabe2edfeffe497d46a7decd7374c540f750f943b4ada3914a4542b89b899156b2163afa96b53f3b765338621bbdb47c9434a8c2
+"pure-rand@npm:^6.0.0, pure-rand@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "pure-rand@npm:6.1.0"
+  checksum: 10/256aa4bcaf9297256f552914e03cbdb0039c8fe1db11fa1e6d3f80790e16e563eb0a859a1e61082a95e224fc0c608661839439f8ecc6a3db4e48d46d99216ee4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

## Summary

Adds a fast-check property fuzz harness for the sessions lock and fixes the concurrency / stealing races and lock leaks it — plus a live e2e run — surfaced across `SessionsBackground` and the node-bridge wrappers that build on it. Also fixes the `multiple-sessions` e2e that guards this area. The existing `sessions.test.ts` is strictly sequential — every message is awaited before the next is sent — so two `handleMessage` calls are never in flight at once, which is exactly the window where these races live.

## The model

N clients compete for one device guarded by a single lock (a FIFO queue). Each client walks the lifecycle below; the harness fuzzes the order in which clients send their messages. `acquireIntent → acquireDone` and `releaseIntent → releaseDone` are critical sections that the lock must serialize, and `device.session` (`null`, `S1`, `S2`, …) is the single source of truth for who owns the device.

```mermaid
stateDiagram-v2
    [*] --> idle
    idle --> acquired: acquireIntent(prev) ✓ (takes lock)
    idle --> done: acquireIntent ✗ wrong-previous
    acquired --> committed: acquireDone (commit + unlock)
    committed --> releasing: releaseIntent ✓ (takes lock)
    committed --> done: releaseRequest (superseded by a steal)
    committed --> done: releaseIntent ✗ stolen
    releasing --> done: releaseDone (clear + unlock)
    done --> [*]
```

## How the harness works

`SessionsBackground` is a single-threaded message processor whose only non-determinism is the order in which concurrent clients' messages interleave at internal `await` points. The harness fuzzes that arrival order: each client is a small state machine, its next message is fired without awaiting, and microtasks are flushed between fires. A message that must wait for the lock simply stays pending until another client's message frees it — real lock mechanics, no mocks, no fake timers. On failure fast-check shrinks the schedule to the minimal interleaving and prints a reproducible seed.

Note on tooling: fast-check's `scheduler` / `waitOne` does not fit this system — operations block on internal deferreds that are only resolved by *other* operations, so `waitOne` (which awaits the released task) deadlocks. Fuzzing the message arrival order is the right primitive for a single-threaded message processor.

## Invariants

- INV-1 (safety): a device is owned by at most one client at a time. An owner holds from a successful acquire until it releases; a legitimate steal supersedes the previous owner via a `releaseRequest`. The oracle only treats a `releaseRequest` as a legitimate supersede when some client *deliberately* stole that session (claimed it as `previous`) — so it catches **both** races: race # 2's clobber, and race # 1's spurious supersede (an acquire that declared the device free still kicks the live owner via a `releaseRequest` nobody asked for). Two standing owners means the device was granted twice.
- INV-2 (liveness): the lock never leaks; every client can be driven to completion without the 4s safety-net timer firing. This guards `SessionsBackground` liveness only — the lock *leak* fixed in this PR lives one layer up in the bridge wrappers (covered by `transport-bridge/tests/core.test.ts`), so INV-2 is green before and after and is kept as a forward-looking regression guard for the lock itself.
- VERIFY: a deterministic, no-model reproduction of the steal/release race; the load-bearing assertion is that the device still reflects the new owner's session (`S2`), which is null on the unfixed code.

## Race #1 — double-acquire (`acquireIntent`)

Two clients both see the device as free and both win.

```mermaid
sequenceDiagram
    participant c0
    participant c1
    participant B as SessionsBackground
    Note over B: device.session = null · lock []
    c0->>B: acquireIntent(prev=null)
    Note over B: prev matches · takes lock · grants S1 · lock [c0]
    B-->>c0: ✓ S1 (lock still held)
    c1->>B: acquireIntent(prev=null)
    Note over B: device still null → passes pre-check · waits · lock [c0,c1]
    c0->>B: acquireDone
    Note over B: device.session = S1 · unlock · lock [c1]
    Note over B: re-check prev.session ≠ device.session?<br/>prev is the live descriptor → S1 ≠ S1 → false (dead guard)
    B-->>c1: ✓ S2
    Note over c0,c1: ❌ c0 owns S1 and c1 owns S2 at the same time
```

Cause: `previous` is a live reference to the descriptor, so the post-lock re-check compares the session against itself and never fires.

One subtlety the harness has to account for: because `previous.session` is now non-null when the dead guard is bypassed, this same `acquireIntent` *also* emits a `releaseRequest` for the just-committed session. So the buggy outcome is not two silent owners — it is a wrongful supersede: the second client (which claimed the device was free) is granted a session and the legitimate owner is kicked by a `releaseRequest` it never warranted. INV-1 still catches this because its oracle only nets out an owner when some client deliberately claimed that session as `previous`; here nobody did, so the kicked owner stays standing and INV-1 observes two owners.

Fix — snapshot the value before yielding the lock:

```diff
+ const previousSession = previous.session;   // captured before await
  await this.waitInQueue();
- if (previous.session !== this.descriptors[pathInternal]?.session) {   // S1 !== S1 → false
+ if (previousSession  !== this.descriptors[pathInternal]?.session) {   // null !== S1 → reject
      this.clearLock();
      return error({ code: ERRORS.SESSION_WRONG_PREVIOUS });
  }
```

## Race #2 — steal/release clobber (`releaseIntent` / `releaseDone`)

A release issued while the caller owned the device lands after a steal and destroys the new owner's session.

```mermaid
sequenceDiagram
    participant c0
    participant c1
    participant B as SessionsBackground
    Note over B: device.session = S1 (c0 owns) · lock []
    c1->>B: acquireIntent(prev=S1) — steal
    Note over B: matches · takes lock · grants S2 · lock [c1]
    B-->>c1: ✓ S2 (lock held)
    B-->>c0: releaseRequest(S1)
    c0->>B: releaseIntent(S1)
    Note over B: getPathBySession(S1) ✓ (device still S1) · waits · lock [c1,c0]
    c1->>B: acquireDone
    Note over B: device.session = S2 · unlock · lock [c0]
    B-->>c0: releaseIntent ✓ — no re-check that S1 is still current!
    c0->>B: releaseDone
    Note over B: device.session = null ❌ clobbers S2 · lock []
    Note over c0,c1: device looks free, but c1 still believes it owns S2 (never told)
```

Cause: `releaseIntent` validates ownership before the lock but never again after it, and `releaseDone` clears the session unconditionally.

Fix — re-check ownership after acquiring the lock:

```diff
  await this.waitInQueue();
+ if (this.descriptors[path]?.session !== payload.session) {   // S2 !== S1 → reject
+     this.clearLock();
+     return error({ code: ERRORS.SESSION_NOT_FOUND });
+ }
  return success({ path });
```

Both races share one shape: a decision is made before an `await` but checked against state that changed during the `await` (#1 via aliasing, #2 via a missing re-check). The fix is the same principle in both — re-validate after waking up.

## Bridge-core lock safety (acquire / release on api failure)

The node-bridge core (`@trezor/transport-bridge`) and the local `AbstractApiTransport` wrap `SessionsBackground`: `acquireIntent` / `releaseIntent` take the session lock, then `openDevice` / `closeDevice` runs. If that api step failed, the lock was never released — the device wedged and every later acquire deadlocked. The `multiple-sessions` e2e exercises exactly this layer (both Suite and trezor-user-env run the node-bridge), so these leaks are a real flakiness source for it.

- `SessionsBackground.acquireDone` honours a new `abort` flag — it releases the lock without committing a (phantom) session.
- `core.acquire` and `AbstractApiTransport.acquire` call `acquireDone({ abort: true })` when `openDevice` fails (and `AbstractApiTransport` now also awaits `acquireDone`).
- `core.release` uses the path returned by `releaseIntent` and always reaches `releaseDone`, dropping a redundant `getPathBySession` lookup that could leak the lock when it failed.

Backed by `transport-bridge/tests/core.test.ts` (a failed `openDevice` must free the lock so the next acquire succeeds) and a `SessionsBackground` abort unit test.

Note: aborting a *steal* does not roll back the supersede. A successful `acquireIntent(previous=S1)` already emitted a `releaseRequest` to the prior owner, so if `openDevice` then fails and the client aborts, the device ends up **free** (the prior owner steps down) rather than still owned by S1. This is consistent — no double-owner, no leaked lock — and the next enumerate/acquire recovers; `openDevice` failing right after a successful intent is rare in practice.

## E2E

The `multiple-sessions` "Session overtaken by another" test asserted that reloading an inactive Suite tab does NOT take the Bridge session back (expected TR_USE_HERE), but the setup that would produce that state (steal + reload) was commented out, so the step waited 30s for TR_USE_HERE while the device stayed TR_CONNECTED and always timed out. Verified live against trezor-user-env that Suite actually auto-reacquires on reload; the test now steals + reloads and asserts TR_CONNECTED. Both tests in the file pass.

This test is currently quarantined, so it runs on every PR e2e build but its result does not gate CI — its outcome is recorded in Currents. It now passes on this branch: [Currents test record — "Session overtaken by another" (passed)](https://app.currents.dev/instance/8fb6302a2371a54d/test/06b935386c34735c3906-b7fba12febc8a17775fe?testExplorerTab=attempts).

## Running

Fuzz tests are randomized and slower, so they run on demand via `yarn workspace @trezor/transport-common test:fuzz` (their own `jest.config.fuzz.cjs`) and are excluded from `test:unit` to keep the unit suite fast and deterministic.

## Commits

1. `test(transport-common)` — fuzz harness, invariants and a deterministic repro, documenting the two `SessionsBackground` races (red).
2. `fix(transport-common)` — the two race fixes, turning INV-1 + VERIFY green (INV-2 was already green; the bridge-core lock leak is covered separately by commit 5 / `core.test.ts`).
3. `test(e2e)` — fix the `multiple-sessions` reload assertion (verified live).
4. `test(transport)` — document the bridge-core lock leak on `openDevice` failure (red).
5. `fix(transport)` — release the session lock on acquire/release api failure (green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/transport-session-race-fuzz&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/transport-session-race-fuzz&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy BTC > Buy Bitcoin from best offer | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-22T07:53:18.546Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-22T07:52:10.449Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/transport-session-race-fuzz/web/](https://dev.suite.sldev.cz/suite-web/mroz22/transport-session-race-fuzz/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

