### PR TITLE
fix(suite-native-28183): add payment iconlogo into trade form

### DIFF
--- a/suite-native/module-trading/src/components/buy/BuyPaymentMethodPicker.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyPaymentMethodPicker.tsx
@@ -7,15 +7,12 @@ import { selectTradingBuyIsLoading } from '@suite-common/trading';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Text } from '@suite-native/atoms';
 import { Translation, useTranslate } from '@suite-native/intl';
-import {
-    OverviewRow,
-    OverviewValueSkeleton,
-    PaymentMethodTranslation,
-} from '@suite-native/trading-atoms';
+import { OverviewRow, OverviewValueSkeleton } from '@suite-native/trading-atoms';
 import { selectBuyBestQuotesForAvailablePaymentMethods } from '@suite-native/trading-state';
 
 import { useBuyFormContext } from '../../hooks/buy/useBuyFormContext';
 import { useSheetControls } from '../../hooks/general/useSheetControls';
+import { PaymentMethodPickerValue } from '../general/PaymentMethodPickerValue';
 import { PaymentMethodSheet } from '../general/PaymentMethodSheet/PaymentMethodSheet';
 
 const PAYMENT_METHOD_PICKER_TEST_ID = '@trading/buy/payment-method-picker';
@@ -37,17 +34,12 @@ const BuyPaymentMethodPickerRight = ({
 
     if (selectedValue) {
         return (
-            <Text
-                color="contentPrimary"
-                variant="body-sm"
+            <PaymentMethodPickerValue
+                paymentMethod={selectedValue.paymentMethod}
+                paymentMethodName={selectedValue.paymentMethodName}
                 accessibilityLabel={translate('moduleTrading.tradingScreen.selectedPaymentMethod')}
                 testID={PAYMENT_METHOD_PICKER_TEST_ID + '/value'}
-            >
-                <PaymentMethodTranslation
-                    paymentMethod={selectedValue.paymentMethod}
-                    paymentMethodName={selectedValue.paymentMethodName}
-                />
-            </Text>
+            />
         );
     }
 

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyPaymentMethodPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyPaymentMethodPicker.test.tsx
@@ -17,6 +17,7 @@ import {
     renderHookWithStoreProvider,
     renderWithStoreProvider,
     screen,
+    within,
 } from '@suite-native/test-utils-store';
 import {
     buyQuotes,
@@ -129,7 +130,12 @@ describe('BuyPaymentMethodPicker', () => {
             expect(getByLabelText('Selected payment method')).toHaveTextContent(
                 creditCardPaymentMethodTranslation,
             );
-            expect(getByTestId('@icons/payment-method-icon/creditCard')).toBeOnTheScreen();
+
+            const picker = getByTestId('@trading/buy/payment-method-picker');
+
+            expect(
+                within(picker).getByTestId('@icons/payment-method-icon/creditCard'),
+            ).toBeTruthy();
         });
 
         it('should display loader while quotes are fetched', () => {

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyPaymentMethodPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyPaymentMethodPicker.test.tsx
@@ -120,7 +120,8 @@ describe('BuyPaymentMethodPicker', () => {
         });
 
         it('should allow to select payment method', () => {
-            const { getByText, getByLabelText } = renderPaymentMethodPicker(withQuotes);
+            const { getByText, getByLabelText, getByTestId } =
+                renderPaymentMethodPicker(withQuotes);
 
             fireEvent.press(getByText('Payment method'));
             fireEvent.press(getByText(creditCardPaymentMethodTranslation));
@@ -128,6 +129,7 @@ describe('BuyPaymentMethodPicker', () => {
             expect(getByLabelText('Selected payment method')).toHaveTextContent(
                 creditCardPaymentMethodTranslation,
             );
+            expect(getByTestId('@icons/payment-method-icon/creditCard')).toBeOnTheScreen();
         });
 
         it('should display loader while quotes are fetched', () => {

--- a/suite-native/module-trading/src/components/general/PaymentMethodPickerValue.tsx
+++ b/suite-native/module-trading/src/components/general/PaymentMethodPickerValue.tsx
@@ -1,0 +1,38 @@
+import { type BuyCryptoPaymentMethod, type SellCryptoPaymentMethod } from 'invity-api';
+
+import { Box, HStack, Text } from '@suite-native/atoms';
+import { PaymentMethodIcon } from '@suite-native/icons';
+import { PaymentMethodTranslation } from '@suite-native/trading-atoms';
+
+type PaymentMethodPickerValueProps = {
+    paymentMethod?: SellCryptoPaymentMethod | BuyCryptoPaymentMethod;
+    paymentMethodName?: string;
+    accessibilityLabel: string;
+    testID: string;
+};
+
+export const PaymentMethodPickerValue = ({
+    paymentMethod,
+    paymentMethodName,
+    accessibilityLabel,
+    testID,
+}: PaymentMethodPickerValueProps) => (
+    <HStack spacing="sp4" alignItems="center" justifyContent="flex-end" flexShrink={1}>
+        <PaymentMethodIcon paymentMethod={paymentMethod} />
+        <Box flexShrink={1}>
+            <Text
+                color="contentPrimary"
+                variant="body-sm"
+                accessibilityLabel={accessibilityLabel}
+                testID={testID}
+                numberOfLines={1}
+                ellipsizeMode="tail"
+            >
+                <PaymentMethodTranslation
+                    paymentMethod={paymentMethod}
+                    paymentMethodName={paymentMethodName}
+                />
+            </Text>
+        </Box>
+    </HStack>
+);

--- a/suite-native/module-trading/src/components/sell/fiat/SellReceiveMethodPicker.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/SellReceiveMethodPicker.tsx
@@ -8,16 +8,13 @@ import { selectTradingSellIsLoading } from '@suite-common/trading';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { AnimatedBox, Text } from '@suite-native/atoms';
 import { Translation, useTranslate } from '@suite-native/intl';
-import {
-    OverviewRow,
-    OverviewValueSkeleton,
-    PaymentMethodTranslation,
-} from '@suite-native/trading-atoms';
+import { OverviewRow, OverviewValueSkeleton } from '@suite-native/trading-atoms';
 import { selectSellBestQuotesForAvailablePaymentMethods } from '@suite-native/trading-state';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 import { useSheetControls } from '../../../hooks/general/useSheetControls';
 import { useSellFormContext } from '../../../hooks/sell/useSellFormContext';
+import { PaymentMethodPickerValue } from '../../general/PaymentMethodPickerValue';
 import { PaymentMethodSheet } from '../../general/PaymentMethodSheet/PaymentMethodSheet';
 
 const RECEIVE_METHOD_PICKER_TEST_ID = '@trading/sell/receive-method-picker';
@@ -44,17 +41,12 @@ const SellReceiveMethodPickerRight = ({
 
     if (selectedValue) {
         return (
-            <Text
-                color="contentPrimary"
-                variant="body-sm"
+            <PaymentMethodPickerValue
+                paymentMethod={selectedValue.paymentMethod}
+                paymentMethodName={selectedValue.paymentMethodName}
                 accessibilityLabel={translate('moduleTrading.tradingScreen.selectedReceiveMethod')}
                 testID={RECEIVE_METHOD_PICKER_TEST_ID + '/value'}
-            >
-                <PaymentMethodTranslation
-                    paymentMethod={selectedValue.paymentMethod}
-                    paymentMethodName={selectedValue.paymentMethodName}
-                />
-            </Text>
+            />
         );
     }
 

--- a/suite-native/module-trading/src/components/sell/fiat/__tests__/SellReceiveMethodPicker.test.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/__tests__/SellReceiveMethodPicker.test.tsx
@@ -89,9 +89,10 @@ describe('SellReceiveMethodPicker', () => {
         });
 
         it('should render selected receive method', () => {
-            const { getByLabelText } = renderSellReceiveMethodPicker(withQuotes);
+            const { getByLabelText, getByTestId } = renderSellReceiveMethodPicker(withQuotes);
 
             expect(getByLabelText('Selected receive method')).toHaveTextContent('Bank Transfer');
+            expect(getByTestId('@icons/payment-method-icon/bank')).toBeOnTheScreen();
         });
 
         it('should render loading skeleton when quotes are loaded and new quotes are loading', () => {

--- a/suite-native/module-trading/src/components/sell/fiat/__tests__/SellReceiveMethodPicker.test.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/__tests__/SellReceiveMethodPicker.test.tsx
@@ -8,6 +8,7 @@ import {
     renderHookWithStoreProvider,
     renderWithStoreProvider,
     screen,
+    within,
 } from '@suite-native/test-utils-store';
 import { banxaBankTransferSellQuote, sellQuotes } from '@suite-native/trading-fixtures';
 import { type SellFormType } from '@suite-native/trading-types';
@@ -92,7 +93,9 @@ describe('SellReceiveMethodPicker', () => {
             const { getByLabelText, getByTestId } = renderSellReceiveMethodPicker(withQuotes);
 
             expect(getByLabelText('Selected receive method')).toHaveTextContent('Bank Transfer');
-            expect(getByTestId('@icons/payment-method-icon/bank')).toBeOnTheScreen();
+
+            const picker = getByTestId('@trading/sell/receive-method-picker');
+            expect(within(picker).getByTestId('@icons/payment-method-icon/bank')).toBeTruthy();
         });
 
         it('should render loading skeleton when quotes are loaded and new quotes are loading', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* add missing icons to pickers
<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/28183

## Screenshots:
<img width="320"  alt="simulator_screenshot_2990A9C4-DB2C-4601-9DDC-55DA188ED646" src="https://github.com/user-attachments/assets/8a7f9682-25ce-406d-bc8f-90bd424088d2" />
<img width="320" alt="simulator_screenshot_EBBF6C83-7996-4C2E-B328-DE0985C4E8EF" src="https://github.com/user-attachments/assets/2489d529-b53c-4fb2-a109-8f1d835b8efd" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/28183-add-payment-iconlogo-into-trade-form&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->