### PR TITLE
Fix/28177/configurable earn worker url

### DIFF
--- a/packages/suite/src/actions/suite/initAction.ts
+++ b/packages/suite/src/actions/suite/initAction.ts
@@ -5,10 +5,7 @@ import { recoveryActions, selectRecoveryStatus } from '@suite/recovery';
 import { initialRedirection, routerInit } from '@suite/router';
 import { selectEarnYieldWorkerBaseUrl, suiteSettingsActions } from '@suite/settings';
 import * as trezorConnectActions from '@suite-common/connect-init';
-import {
-    defaultEarnYieldWorkerBaseUrl,
-    earnYieldWorkerBaseUrl,
-} from '@suite-common/earn-stablecoin-api';
+import { earnYieldWorkerBaseUrl } from '@suite-common/earn-stablecoin-api';
 import { initMessageSystemThunk, prepareCachedEnvData } from '@suite-common/message-system';
 import { periodicCheckTokenDefinitionsThunk } from '@suite-common/token-definitions';
 import {
@@ -48,9 +45,7 @@ export const init = () => async (dispatch: Dispatch, getState: GetState) => {
     dispatch({ type: SUITE.INIT });
 
     // apply the earn yield worker base url from debug settings (or the default for this build)
-    earnYieldWorkerBaseUrl.set(
-        selectEarnYieldWorkerBaseUrl(getState()) ?? defaultEarnYieldWorkerBaseUrl,
-    );
+    earnYieldWorkerBaseUrl.set(selectEarnYieldWorkerBaseUrl(getState()));
 
     await dispatch(initDevices());
 

--- a/packages/suite/src/views/settings/SettingsDebug/EarnApi.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/EarnApi.tsx
@@ -3,7 +3,6 @@ import { useMemo } from 'react';
 import { selectEarnYieldWorkerBaseUrl, suiteSettingsActions } from '@suite/settings';
 import {
     type EarnYieldWorkerBaseUrl,
-    defaultEarnYieldWorkerBaseUrl,
     earnYieldWorkerBaseUrl,
     earnYieldWorkerBaseUrls,
 } from '@suite-common/earn-stablecoin-api';
@@ -23,12 +22,15 @@ export const EarnApi = () => {
         [],
     );
 
-    const selectedValue =
-        options.find(option => option.value === storedValue) ?? defaultEarnYieldWorkerBaseUrl;
+    const selectedValue = options.find(option => option.value === storedValue);
 
     const handleChange = (item: { value: EarnYieldWorkerBaseUrl; label: string }) => {
         dispatch(suiteSettingsActions.setDebugMode({ earnYieldWorkerBaseUrl: item.value }));
         earnYieldWorkerBaseUrl.set(item.value);
+
+        // We need somehow to invalidate current Yield API state so it re-fetches with the new base URL.
+        // Since this is debug setting, the easiest way is to just reload the app.
+        globalThis.location.reload();
     };
 
     return (

--- a/suite-common/earn-stablecoin-defs/orval.config.ts
+++ b/suite-common/earn-stablecoin-defs/orval.config.ts
@@ -27,6 +27,7 @@ function renameAllExportsToCamelCase(implementation: string): string {
 }
 
 const API_DIR = resolve(import.meta.dirname, './src/api');
+// TODO: take it from `suite-common/earn-stablecoin-api/src/context` once the @suite-common/earn-stablecoin-defs gets merged with @suite-common/earn-stablecoin-api.
 const YIELD_BASE_URL: EarnYieldWorkerBaseUrl = 'https://dev-earn.suite.sldev.cz/yield';
 
 // eslint-disable-next-line import/no-default-export

--- a/suite/settings/package.json
+++ b/suite/settings/package.json
@@ -13,6 +13,7 @@
     },
     "dependencies": {
         "@reduxjs/toolkit": "2.11.2",
+        "@suite-common/earn-stablecoin-api": "workspace:*",
         "@suite-common/earn-stablecoin-defs": "workspace:*",
         "@suite-common/metadata-types": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",

--- a/suite/settings/src/settingsSelectors.ts
+++ b/suite/settings/src/settingsSelectors.ts
@@ -1,4 +1,5 @@
 import { type ExperimentalFeature } from '@suite/experimental';
+import { defaultEarnYieldWorkerBaseUrl } from '@suite-common/earn-stablecoin-api';
 
 import { type SuiteSettingsRootState } from './settingsSlice';
 
@@ -26,7 +27,7 @@ export const selectShowConnectLogs = (state: SuiteSettingsRootState) =>
 export const selectInvityServerEnvironment = (state: SuiteSettingsRootState) =>
     state.suiteSettings.debug.invityServerEnvironment;
 export const selectEarnYieldWorkerBaseUrl = (state: SuiteSettingsRootState) =>
-    state.suiteSettings.debug.earnYieldWorkerBaseUrl;
+    state.suiteSettings.debug.earnYieldWorkerBaseUrl ?? defaultEarnYieldWorkerBaseUrl;
 export const selectOAuthServerEnvironment = (state: SuiteSettingsRootState) =>
     state.suiteSettings.debug.oauthServerEnvironment;
 export const selectExperimentalFeatures = (state: SuiteSettingsRootState) =>

--- a/suite/settings/tsconfig.json
+++ b/suite/settings/tsconfig.json
@@ -3,6 +3,9 @@
     "compilerOptions": { "outDir": "libDev" },
     "references": [
         {
+            "path": "../../suite-common/earn-stablecoin-api"
+        },
+        {
             "path": "../../suite-common/earn-stablecoin-defs"
         },
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14803,6 +14803,7 @@ __metadata:
   resolution: "@suite/settings@workspace:suite/settings"
   dependencies:
     "@reduxjs/toolkit": "npm:2.11.2"
+    "@suite-common/earn-stablecoin-api": "workspace:*"
     "@suite-common/earn-stablecoin-defs": "workspace:*"
     "@suite-common/metadata-types": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix default value (`undefined`) of Earn worker API base URL in `Debug` settings.

## Related Issue

Resolve #28177


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set touches the core Suite initialization action (initAction.ts), settings infrastructure (settingsSelectors.ts, package.json, tsconfig.json), and a debug settings component for earn/staking API (EarnApi.tsx). The initAction.ts change carries the highest risk since it maps to 121 tests and controls app startup, but most tests only transitively depend on it. The settings package changes (selectors, package.json, tsconfig.json) are likely refactoring or dependency updates. Focus testing on initialization flow correctness and settings state management, with secondary coverage of staking if the EarnApi debug component change is substantive.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/actions/suite/initAction.ts`
- `packages/suite/src/views/settings/SettingsDebug/EarnApi.tsx`
- `suite/settings/package.json`
- `suite/settings/src/settingsSelectors.ts`
- `suite/settings/tsconfig.json`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/suite/initial-run.test.ts` — initAction.ts is the core Suite initialization action that controls the initial run/onboarding flow. This test directly validates that the initial run persistence, analytics consent, and onboarding completion work correctly across page reloads — all of which depend on the init action's behavior.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/analytics/toggle.test.ts` — The analytics toggle test validates analytics state persistence across app reloads and the initialRun flag management, both of which are orchestrated by initAction.ts. Changes to initialization logic could affect whether analytics state is correctly restored.
- `suite/e2e/tests/settings/general.test.ts` — settingsSelectors.ts likely provides selectors used by settings UI components. This test exercises general settings behaviors (fiat currency, theme, language, analytics toggle) that may depend on settings selectors for reading state. The EarnApi.tsx change is also in the settings debug area.
- `suite/e2e/tests/suite/db-migration.test.ts` — Database migration tests validate that persisted state (including settings) survives version upgrades. initAction.ts handles loading persisted state on startup, so changes there could break the migration path for existing user data.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — The SuiteReady analytics event is fired during initialization and includes settings state (enabledNetworks, theme, etc.). Changes to initAction.ts or settingsSelectors.ts could affect the timing or content of this event payload.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — EarnApi.tsx is a debug settings component for the earn/staking API configuration. While it's a debug-only view, changes could affect how staking API endpoints are configured in development/test environments, potentially impacting staking E2E tests.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/suite/src/views/settings/SettingsDebug/EarnApi.tsx`
- `suite/settings/package.json`
- `suite/settings/tsconfig.json`

_Updated: 2026-06-08T09:55:38.488Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/28177/configurable-earn-worker-url/web/](https://dev.suite.sldev.cz/suite-web/fix/28177/configurable-earn-worker-url/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/28177/configurable-earn-worker-url&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/28177/configurable-earn-worker-url&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/28177/configurable-earn-worker-url&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-08T10:01:06.207Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add account types ada | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-08T09:58:42.226Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->