### PR TITLE
test(suite): add missing invity dependency

### DIFF
--- a/suite/e2e/.depcheckrc.json
+++ b/suite/e2e/.depcheckrc.json
@@ -2,7 +2,6 @@
     "ignore-patterns": ["libDev", "lib"],
     "ignores": [
         "node-loader",
-        "invity-api",
         "@playwright/browser-chromium",
         "@playwright/browser-firefox",
         "@playwright/browser-webkit"

--- a/suite/e2e/package.json
+++ b/suite/e2e/package.json
@@ -62,6 +62,7 @@
         "@trezor/type-utils": "workspace:*",
         "@trezor/urls": "workspace:*",
         "@trezor/utils": "workspace:*",
+        "@types/invity-api": "^1.1.15",
         "@types/lodash": "^4.17.16",
         "@walletconnect/sign-client": "^2.23.9",
         "@walletconnect/types": "^2.23.9",

--- a/suite/e2e/support/pageObjects/trading/assetsModal.ts
+++ b/suite/e2e/support/pageObjects/trading/assetsModal.ts
@@ -1,5 +1,5 @@
 import { Locator, Page } from '@playwright/test';
-import { CryptoId } from 'invity-api';
+import type { CryptoId } from 'invity-api';
 
 import type { NetworkSymbol } from '@suite-common/wallet-config';
 

--- a/suite/e2e/support/types/index.ts
+++ b/suite/e2e/support/types/index.ts
@@ -1,4 +1,4 @@
-import { CryptoId } from 'invity-api';
+import type { CryptoId } from 'invity-api';
 import { RequireExactlyOne } from 'type-fest';
 
 import { AnalyticsDesktopEvents } from '@suite/analytics';

--- a/suite/e2e/tests/trading/buy-solana-token.test.ts
+++ b/suite/e2e/tests/trading/buy-solana-token.test.ts
@@ -1,4 +1,4 @@
-import { CryptoId } from 'invity-api';
+import type { CryptoId } from 'invity-api';
 
 import { localizeNumber } from '@suite-common/wallet-utils';
 import { capitalizeFirstLetter } from '@trezor/utils';

--- a/suite/e2e/tests/trading/swap-coin-to-token.test.ts
+++ b/suite/e2e/tests/trading/swap-coin-to-token.test.ts
@@ -1,4 +1,4 @@
-import { CryptoId } from 'invity-api';
+import type { CryptoId } from 'invity-api';
 
 import { localizeNumber } from '@suite-common/wallet-utils';
 

--- a/suite/e2e/tests/trading/swap-tokens.test.ts
+++ b/suite/e2e/tests/trading/swap-tokens.test.ts
@@ -1,4 +1,4 @@
-import { CryptoId } from 'invity-api';
+import type { CryptoId } from 'invity-api';
 
 import { localizeNumber } from '@suite-common/wallet-utils';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -16358,6 +16358,7 @@ __metadata:
     "@trezor/type-utils": "workspace:*"
     "@trezor/urls": "workspace:*"
     "@trezor/utils": "workspace:*"
+    "@types/invity-api": "npm:^1.1.15"
     "@types/lodash": "npm:^4.17.16"
     "@walletconnect/sign-client": "npm:^2.23.9"
     "@walletconnect/types": "npm:^2.23.9"


### PR DESCRIPTION
based on knip [analysis](https://github.com/trezor/trezor-suite/pull/25987/changes/BASE..477c21d83f1191b2bdca9e2dbd79a7f53e9660ea#diff-bae06167ad2763b3bb3380452e2a56014de1ee703f10e19b2ce920395d6e0081) 

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-invity-dep&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-invity-dep&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-08T08:01:57.254Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add account types ada | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-08T08:00:05.438Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-invity-dep/web/](https://dev.suite.sldev.cz/suite-web/fix-invity-dep/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->