### PR TITLE
fix(suite-native): use eject icon for Eject wallets settings item

### DIFF
--- a/suite-native/module-settings/src/components/FeaturesSettings.tsx
+++ b/suite-native/module-settings/src/components/FeaturesSettings.tsx
@@ -38,7 +38,7 @@ export const FeaturesSettings = () => {
                 />
             )}
             <AppSettingsCardWithIconLayout
-                icon="bookmarkSimple"
+                icon="eject"
                 title={<Translation id="moduleSettings.items.features.ejectWallets.title" />}
                 subtitle={<Translation id="moduleSettings.items.features.ejectWallets.subtitle" />}
                 onPress={() => navigateTo(SettingsStackRoutes.SettingsViewOnly)}


### PR DESCRIPTION
## Description

Replaces the `bookmarkSimple` icon with the `eject` icon for the "Eject wallets" item in mobile Settings > Features. 

## Notes for QA

Open Settings > Features on mobile and verify the "Eject wallets" item now shows the eject icon.

## Related Issue

Resolve #26905

## Screenshots:
<img width="391" height="844" alt="Screenshot 2026-06-08 at 11 08 15" src="https://github.com/user-attachments/assets/7dd5d3a1-48d5-4875-a429-4299b487e20d" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/eject-wallets-icon-26905&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->