### PR TITLE
ci: make sfw optional

### DIFF
--- a/.github/actions/minimal-yarn-install/action.yml
+++ b/.github/actions/minimal-yarn-install/action.yml
@@ -39,4 +39,4 @@ runs:
 
     - name: Install dependencies using Yarn
       shell: bash
-      run: $(command -v sfw > /dev/null && echo sfw) yarn --immutable
+      run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn --immutable

--- a/.github/actions/minimal-yarn-install/action.yml
+++ b/.github/actions/minimal-yarn-install/action.yml
@@ -31,6 +31,7 @@ runs:
 
     - name: Install Socket Firewall
       uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+      continue-on-error: true
       with:
         mode: firewall-free
         job-summary: errors
@@ -38,4 +39,4 @@ runs:
 
     - name: Install dependencies using Yarn
       shell: bash
-      run: sfw yarn --immutable
+      run: $(command -v sfw > /dev/null && echo sfw) yarn --immutable

--- a/.github/actions/release-connect-npm/action.yml
+++ b/.github/actions/release-connect-npm/action.yml
@@ -66,7 +66,7 @@ runs:
 
     - name: Install dependencies
       shell: bash
-      run: $(command -v sfw > /dev/null && echo sfw) yarn install --immutable
+      run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable
 
     - name: Check version
       shell: bash

--- a/.github/actions/release-connect-npm/action.yml
+++ b/.github/actions/release-connect-npm/action.yml
@@ -58,6 +58,7 @@ runs:
 
     - name: Install Socket Firewall
       uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+      continue-on-error: true
       with:
         mode: firewall-free
         job-summary: errors
@@ -65,7 +66,7 @@ runs:
 
     - name: Install dependencies
       shell: bash
-      run: sfw yarn install --immutable
+      run: $(command -v sfw > /dev/null && echo sfw) yarn install --immutable
 
     - name: Check version
       shell: bash

--- a/.github/actions/release-connect/action.yml
+++ b/.github/actions/release-connect/action.yml
@@ -65,6 +65,7 @@ runs:
 
     - name: Install Socket Firewall
       uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+      continue-on-error: true
       with:
         mode: firewall-free
         job-summary: errors
@@ -73,7 +74,7 @@ runs:
     - name: Install dependencies
       shell: bash
       run: |
-        sfw yarn install --immutable # focus install is not used here to make sure that all global patches are applied for the release.
+        $(command -v sfw > /dev/null && echo sfw) yarn install --immutable # focus install is not used here to make sure that all global patches are applied for the release.
 
     - name: Build connect-explorer-theme
       shell: bash

--- a/.github/actions/release-connect/action.yml
+++ b/.github/actions/release-connect/action.yml
@@ -74,7 +74,7 @@ runs:
     - name: Install dependencies
       shell: bash
       run: |
-        $(command -v sfw > /dev/null && echo sfw) yarn install --immutable # focus install is not used here to make sure that all global patches are applied for the release.
+        $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable # focus install is not used here to make sure that all global patches are applied for the release.
 
     - name: Build connect-explorer-theme
       shell: bash

--- a/.github/workflows/bot-crowdin-sync.yml
+++ b/.github/workflows/bot-crowdin-sync.yml
@@ -39,12 +39,13 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
       - name: Install dependencies
-        run: sfw yarn install
+        run: $(command -v sfw > /dev/null && echo sfw) yarn install
 
       - name: Set source branch
         run: echo "SOURCE_BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV

--- a/.github/workflows/bot-crowdin-sync.yml
+++ b/.github/workflows/bot-crowdin-sync.yml
@@ -45,7 +45,7 @@ jobs:
           job-summary: errors
           firewall-version: 1.11.0
       - name: Install dependencies
-        run: $(command -v sfw > /dev/null && echo sfw) yarn install
+        run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn install
 
       - name: Set source branch
         run: echo "SOURCE_BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV

--- a/.github/workflows/build-analytics-docs.yml
+++ b/.github/workflows/build-analytics-docs.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @trezor/analytics-docs
+          $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @trezor/analytics-docs
 
       - name: Build analytics-docs
         env:

--- a/.github/workflows/build-analytics-docs.yml
+++ b/.github/workflows/build-analytics-docs.yml
@@ -38,6 +38,7 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
@@ -45,7 +46,7 @@ jobs:
       - name: Install dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          sfw yarn workspaces focus @trezor/analytics-docs
+          $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @trezor/analytics-docs
 
       - name: Build analytics-docs
         env:

--- a/.github/workflows/build-desktop-apps.yml
+++ b/.github/workflows/build-desktop-apps.yml
@@ -43,13 +43,14 @@ jobs:
           node-version-file: ".nvmrc"
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
       - name: Install deps and build libs
         run: |
-          sfw yarn install --immutable
+          $(command -v sfw > /dev/null && echo sfw) yarn install --immutable
           yarn message-system-sign-config
           yarn workspace @trezor/suite-data build:lib
           yarn workspace @trezor/transport-bridge build:lib
@@ -96,13 +97,14 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
       - name: Install deps and build libs
         run: |
-          sfw yarn install --immutable
+          $(command -v sfw > /dev/null && echo sfw) yarn install --immutable
           yarn message-system-sign-config
           yarn workspace @trezor/suite-data build:lib
           yarn workspace @trezor/transport-bridge build:lib
@@ -157,13 +159,14 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
       - name: Install deps and build libs
         run: |
-          sfw yarn install --immutable
+          $(command -v sfw > /dev/null && echo sfw) yarn install --immutable
           yarn message-system-sign-config
 
       - name: Build libs

--- a/.github/workflows/build-desktop-apps.yml
+++ b/.github/workflows/build-desktop-apps.yml
@@ -50,7 +50,7 @@ jobs:
           firewall-version: 1.11.0
       - name: Install deps and build libs
         run: |
-          $(command -v sfw > /dev/null && echo sfw) yarn install --immutable
+          $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable
           yarn message-system-sign-config
           yarn workspace @trezor/suite-data build:lib
           yarn workspace @trezor/transport-bridge build:lib
@@ -104,7 +104,7 @@ jobs:
           firewall-version: 1.11.0
       - name: Install deps and build libs
         run: |
-          $(command -v sfw > /dev/null && echo sfw) yarn install --immutable
+          $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable
           yarn message-system-sign-config
           yarn workspace @trezor/suite-data build:lib
           yarn workspace @trezor/transport-bridge build:lib
@@ -166,7 +166,7 @@ jobs:
           firewall-version: 1.11.0
       - name: Install deps and build libs
         run: |
-          $(command -v sfw > /dev/null && echo sfw) yarn install --immutable
+          $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable
           yarn message-system-sign-config
 
       - name: Build libs

--- a/.github/workflows/build-llm-test-analysis-nightly.yml
+++ b/.github/workflows/build-llm-test-analysis-nightly.yml
@@ -51,13 +51,14 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
       - name: Install dependencies
         shell: bash
-        run: sfw yarn workspaces focus @trezor/e2e-utils
+        run: $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @trezor/e2e-utils
 
       - name: Delete existing LLM analysis cache from S3 (no_cache)
         if: ${{ inputs.no_cache }}

--- a/.github/workflows/build-llm-test-analysis-nightly.yml
+++ b/.github/workflows/build-llm-test-analysis-nightly.yml
@@ -58,7 +58,7 @@ jobs:
           firewall-version: 1.11.0
       - name: Install dependencies
         shell: bash
-        run: $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @trezor/e2e-utils
+        run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @trezor/e2e-utils
 
       - name: Delete existing LLM analysis cache from S3 (no_cache)
         if: ${{ inputs.no_cache }}

--- a/.github/workflows/build-node-bridge.yml
+++ b/.github/workflows/build-node-bridge.yml
@@ -33,13 +33,14 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
       - name: Install deps and build libs
         run: |
-          sfw yarn install --immutable
+          $(command -v sfw > /dev/null && echo sfw) yarn install --immutable
 
       - name: Build bin.js file
         run: |

--- a/.github/workflows/build-node-bridge.yml
+++ b/.github/workflows/build-node-bridge.yml
@@ -40,7 +40,7 @@ jobs:
           firewall-version: 1.11.0
       - name: Install deps and build libs
         run: |
-          $(command -v sfw > /dev/null && echo sfw) yarn install --immutable
+          $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable
 
       - name: Build bin.js file
         run: |

--- a/.github/workflows/build-storybook-native.yml
+++ b/.github/workflows/build-storybook-native.yml
@@ -46,6 +46,7 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
@@ -53,7 +54,7 @@ jobs:
       - name: Install Yarn dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          sfw yarn install
+          $(command -v sfw > /dev/null && echo sfw) yarn install
 
       - name: Build storybook
         working-directory: ./suite-native/storybook

--- a/.github/workflows/build-storybook-native.yml
+++ b/.github/workflows/build-storybook-native.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install Yarn dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          $(command -v sfw > /dev/null && echo sfw) yarn install
+          $(command -v sfw > /dev/null && echo sfw --verbose) yarn install
 
       - name: Build storybook
         working-directory: ./suite-native/storybook

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Install dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @trezor/components
-          $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @trezor/product-components
+          $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @trezor/components
+          $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @trezor/product-components
 
       - name: Build storybook
         env:

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -33,6 +33,7 @@ jobs:
           cache: yarn
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
@@ -40,8 +41,8 @@ jobs:
       - name: Install dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          sfw yarn workspaces focus @trezor/components
-          sfw yarn workspaces focus @trezor/product-components
+          $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @trezor/components
+          $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @trezor/product-components
 
       - name: Build storybook
         env:

--- a/.github/workflows/build-suite-desktop-e2e.yml
+++ b/.github/workflows/build-suite-desktop-e2e.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install dependencies, build libs
         shell: bash
         run: |
-          $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @trezor/suite-desktop @trezor/suite-desktop-core @trezor/suite-build @trezor/suite @trezor/suite-data @trezor/transport-bridge @suite-common/message-system @trezor/suite-desktop-ui
+          $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @trezor/suite-desktop @trezor/suite-desktop-core @trezor/suite-build @trezor/suite @trezor/suite-data @trezor/transport-bridge @suite-common/message-system @trezor/suite-desktop-ui
           yarn message-system-sign-config
           yarn workspace @trezor/suite-data build:lib
           yarn workspace @trezor/transport-bridge build:lib

--- a/.github/workflows/build-suite-desktop-e2e.yml
+++ b/.github/workflows/build-suite-desktop-e2e.yml
@@ -28,6 +28,7 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
@@ -35,7 +36,7 @@ jobs:
       - name: Install dependencies, build libs
         shell: bash
         run: |
-          sfw yarn workspaces focus @trezor/suite-desktop @trezor/suite-desktop-core @trezor/suite-build @trezor/suite @trezor/suite-data @trezor/transport-bridge @suite-common/message-system @trezor/suite-desktop-ui
+          $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @trezor/suite-desktop @trezor/suite-desktop-core @trezor/suite-build @trezor/suite @trezor/suite-data @trezor/transport-bridge @suite-common/message-system @trezor/suite-desktop-ui
           yarn message-system-sign-config
           yarn workspace @trezor/suite-data build:lib
           yarn workspace @trezor/transport-bridge build:lib

--- a/.github/workflows/build-suite-native-adhoc.yml
+++ b/.github/workflows/build-suite-native-adhoc.yml
@@ -40,13 +40,14 @@ jobs:
           token: ${{ secrets.EXPO_TOKEN_DEVELOP }}
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
       - name: Install libs
         run: |
-          sfw yarn workspaces focus @suite-native/app
+          $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @suite-native/app
       - name: Trigger adhoc build Android
         working-directory: suite-native/app
         if: ${{ github.event.inputs.PLATFORM == 'android' || github.event.inputs.PLATFORM == 'all' }}

--- a/.github/workflows/build-suite-native-adhoc.yml
+++ b/.github/workflows/build-suite-native-adhoc.yml
@@ -47,7 +47,7 @@ jobs:
           firewall-version: 1.11.0
       - name: Install libs
         run: |
-          $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @suite-native/app
+          $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @suite-native/app
       - name: Trigger adhoc build Android
         working-directory: suite-native/app
         if: ${{ github.event.inputs.PLATFORM == 'android' || github.event.inputs.PLATFORM == 'all' }}

--- a/.github/workflows/build-suite-native-preview.yml
+++ b/.github/workflows/build-suite-native-preview.yml
@@ -57,7 +57,7 @@ jobs:
           firewall-version: 1.11.0
       - name: Install libs
         run: |
-          $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @suite-native/app
+          $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @suite-native/app
 
       - name: Check runtimeVersion builds
         run: |

--- a/.github/workflows/build-suite-native-preview.yml
+++ b/.github/workflows/build-suite-native-preview.yml
@@ -50,13 +50,14 @@ jobs:
           token: ${{ secrets.EXPO_TOKEN_DEVELOP }}
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
       - name: Install libs
         run: |
-          sfw yarn workspaces focus @suite-native/app
+          $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @suite-native/app
 
       - name: Check runtimeVersion builds
         run: |

--- a/.github/workflows/build-suite-web-e2e.yml
+++ b/.github/workflows/build-suite-web-e2e.yml
@@ -49,6 +49,7 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
@@ -57,7 +58,7 @@ jobs:
         shell: bash
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          sfw yarn workspaces focus @trezor/suite-web @trezor/suite-data @trezor/suite-build
+          $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @trezor/suite-web @trezor/suite-data @trezor/suite-build
 
       - name: Build Suite Web
         shell: bash

--- a/.github/workflows/build-suite-web-e2e.yml
+++ b/.github/workflows/build-suite-web-e2e.yml
@@ -58,7 +58,7 @@ jobs:
         shell: bash
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @trezor/suite-web @trezor/suite-data @trezor/suite-build
+          $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @trezor/suite-web @trezor/suite-data @trezor/suite-build
 
       - name: Build Suite Web
         shell: bash

--- a/.github/workflows/build-suite-web.yml
+++ b/.github/workflows/build-suite-web.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Install dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @trezor/suite-web @trezor/suite-data @trezor/suite-build
+          $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @trezor/suite-web @trezor/suite-data @trezor/suite-build
 
       - name: Build suite-web
         env:

--- a/.github/workflows/build-suite-web.yml
+++ b/.github/workflows/build-suite-web.yml
@@ -59,6 +59,7 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
@@ -66,7 +67,7 @@ jobs:
       - name: Install dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          sfw yarn workspaces focus @trezor/suite-web @trezor/suite-data @trezor/suite-build
+          $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @trezor/suite-web @trezor/suite-data @trezor/suite-build
 
       - name: Build suite-web
         env:

--- a/.github/workflows/check-code-validation.yml
+++ b/.github/workflows/check-code-validation.yml
@@ -44,7 +44,7 @@ jobs:
       # We can skip the build for all dependencies, even for those whitelisted, because this process is used only to validate the yarn.lock file and populate the cache.
       - name: Install deps
         run: |
-          $(command -v sfw > /dev/null && echo sfw) yarn --immutable --mode=skip-build
+          $(command -v sfw > /dev/null && echo sfw --verbose) yarn --immutable --mode=skip-build
 
   type-check:
     name: Type Checking
@@ -180,7 +180,7 @@ jobs:
           job-summary: errors
           firewall-version: 1.11.0
       - name: Yarn Dedupe check
-        run: $(command -v sfw > /dev/null && echo sfw) yarn dedupe --check
+        run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn dedupe --check
       - name: Check dependency domain lists
         run: ./scripts/ci/list-missing-dependencies.sh
       - name: Verify Workspace Resolutions

--- a/.github/workflows/check-code-validation.yml
+++ b/.github/workflows/check-code-validation.yml
@@ -26,6 +26,7 @@ jobs:
           node-version-file: ".nvmrc"
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
@@ -43,7 +44,7 @@ jobs:
       # We can skip the build for all dependencies, even for those whitelisted, because this process is used only to validate the yarn.lock file and populate the cache.
       - name: Install deps
         run: |
-          sfw yarn --immutable --mode=skip-build
+          $(command -v sfw > /dev/null && echo sfw) yarn --immutable --mode=skip-build
 
   type-check:
     name: Type Checking
@@ -173,12 +174,13 @@ jobs:
         run: yarn depcheck
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
       - name: Yarn Dedupe check
-        run: sfw yarn dedupe --check
+        run: $(command -v sfw > /dev/null && echo sfw) yarn dedupe --check
       - name: Check dependency domain lists
         run: ./scripts/ci/list-missing-dependencies.sh
       - name: Verify Workspace Resolutions

--- a/.github/workflows/check-test-health-nightly.yml
+++ b/.github/workflows/check-test-health-nightly.yml
@@ -44,7 +44,7 @@ jobs:
           firewall-version: 1.11.0
       - name: Install dependencies
         shell: bash
-        run: $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @trezor/e2e-utils
+        run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @trezor/e2e-utils
 
       - name: Check test health and manage quarantine
         env:

--- a/.github/workflows/check-test-health-nightly.yml
+++ b/.github/workflows/check-test-health-nightly.yml
@@ -37,13 +37,14 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
       - name: Install dependencies
         shell: bash
-        run: sfw yarn workspaces focus @trezor/e2e-utils
+        run: $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @trezor/e2e-utils
 
       - name: Check test health and manage quarantine
         env:

--- a/.github/workflows/check-test-health.yml
+++ b/.github/workflows/check-test-health.yml
@@ -56,7 +56,7 @@ jobs:
           firewall-version: 1.11.0
       - name: Install dependencies
         shell: bash
-        run: $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @trezor/e2e-utils
+        run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @trezor/e2e-utils
 
       - name: Check test health and manage quarantine
         env:

--- a/.github/workflows/check-test-health.yml
+++ b/.github/workflows/check-test-health.yml
@@ -49,13 +49,14 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
       - name: Install dependencies
         shell: bash
-        run: sfw yarn workspaces focus @trezor/e2e-utils
+        run: $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @trezor/e2e-utils
 
       - name: Check test health and manage quarantine
         env:

--- a/.github/workflows/chore-purge-android-e2e-build.yml
+++ b/.github/workflows/chore-purge-android-e2e-build.yml
@@ -35,6 +35,7 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
@@ -42,7 +43,7 @@ jobs:
       - name: Install Yarn dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          sfw yarn install
+          $(command -v sfw > /dev/null && echo sfw) yarn install
 
       - name: Prebuild native expo project
         working-directory: ./suite-native/app

--- a/.github/workflows/chore-purge-android-e2e-build.yml
+++ b/.github/workflows/chore-purge-android-e2e-build.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install Yarn dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          $(command -v sfw > /dev/null && echo sfw) yarn install
+          $(command -v sfw > /dev/null && echo sfw --verbose) yarn install
 
       - name: Prebuild native expo project
         working-directory: ./suite-native/app

--- a/.github/workflows/release-connect-bump-versions.yml
+++ b/.github/workflows/release-connect-bump-versions.yml
@@ -51,7 +51,7 @@ jobs:
           job-summary: errors
           firewall-version: 1.11.0
       - name: Install dependencies
-        run: $(command -v sfw > /dev/null && echo sfw) yarn install
+        run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn install
 
       # The script connect-bump-versions.ts needs to build packages so dependencies are required.
       - name: Build dependencies

--- a/.github/workflows/release-connect-bump-versions.yml
+++ b/.github/workflows/release-connect-bump-versions.yml
@@ -45,12 +45,13 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
       - name: Install dependencies
-        run: sfw yarn install
+        run: $(command -v sfw > /dev/null && echo sfw) yarn install
 
       # The script connect-bump-versions.ts needs to build packages so dependencies are required.
       - name: Build dependencies

--- a/.github/workflows/release-connect-npm.yml
+++ b/.github/workflows/release-connect-npm.yml
@@ -58,12 +58,13 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
       - name: Install dependencies
-        run: sfw yarn install
+        run: $(command -v sfw > /dev/null && echo sfw) yarn install
 
       - name: Get packages that need release
         id: set-packages-need-release

--- a/.github/workflows/release-connect-npm.yml
+++ b/.github/workflows/release-connect-npm.yml
@@ -64,7 +64,7 @@ jobs:
           job-summary: errors
           firewall-version: 1.11.0
       - name: Install dependencies
-        run: $(command -v sfw > /dev/null && echo sfw) yarn install
+        run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn install
 
       - name: Get packages that need release
         id: set-packages-need-release

--- a/.github/workflows/release-suite-coin-icons.yml
+++ b/.github/workflows/release-suite-coin-icons.yml
@@ -36,7 +36,7 @@ jobs:
           firewall-version: 1.11.0
       - name: Download crypto icons
         run: |
-          $(command -v sfw > /dev/null && echo sfw) yarn install
+          $(command -v sfw > /dev/null && echo sfw --verbose) yarn install
           cd suite-common/icons
           yarn download-crypto-icons
 

--- a/.github/workflows/release-suite-coin-icons.yml
+++ b/.github/workflows/release-suite-coin-icons.yml
@@ -29,13 +29,14 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
       - name: Download crypto icons
         run: |
-          sfw yarn install
+          $(command -v sfw > /dev/null && echo sfw) yarn install
           cd suite-common/icons
           yarn download-crypto-icons
 

--- a/.github/workflows/release-suite-definitions.yml
+++ b/.github/workflows/release-suite-definitions.yml
@@ -39,6 +39,7 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
@@ -46,7 +47,7 @@ jobs:
       - name: Build and sign ${{ github.event.inputs.environment }} token-definitions
         if: ${{ github.event.inputs.environment == 'develop-definitions' && github.ref == 'refs/heads/develop' }}
         run: |
-          sfw yarn install
+          $(command -v sfw > /dev/null && echo sfw) yarn install
           cd suite-common/token-definitions
 
           yarn nfts simple ethereum polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche
@@ -59,7 +60,7 @@ jobs:
           IS_CODESIGN_BUILD: "true"
           JWS_PRIVATE_KEY_ENV: ${{ secrets.JWS_PRIVATE_KEY_ENV }}
         run: |
-          sfw yarn install
+          $(command -v sfw > /dev/null && echo sfw) yarn install
           cd suite-common/token-definitions
 
           yarn nfts simple ethereum polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche

--- a/.github/workflows/release-suite-definitions.yml
+++ b/.github/workflows/release-suite-definitions.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Build and sign ${{ github.event.inputs.environment }} token-definitions
         if: ${{ github.event.inputs.environment == 'develop-definitions' && github.ref == 'refs/heads/develop' }}
         run: |
-          $(command -v sfw > /dev/null && echo sfw) yarn install
+          $(command -v sfw > /dev/null && echo sfw --verbose) yarn install
           cd suite-common/token-definitions
 
           yarn nfts simple ethereum polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche
@@ -60,7 +60,7 @@ jobs:
           IS_CODESIGN_BUILD: "true"
           JWS_PRIVATE_KEY_ENV: ${{ secrets.JWS_PRIVATE_KEY_ENV }}
         run: |
-          $(command -v sfw > /dev/null && echo sfw) yarn install
+          $(command -v sfw > /dev/null && echo sfw --verbose) yarn install
           cd suite-common/token-definitions
 
           yarn nfts simple ethereum polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche

--- a/.github/workflows/release-suite-desktop-web-staging.yml
+++ b/.github/workflows/release-suite-desktop-web-staging.yml
@@ -64,13 +64,14 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
       - name: Install deps and build libs
         run: |
-          sfw yarn install --immutable
+          $(command -v sfw > /dev/null && echo sfw) yarn install --immutable
           yarn message-system-sign-config
           yarn workspace @trezor/suite-data build:lib
           yarn workspace @trezor/transport-bridge build:lib
@@ -192,6 +193,7 @@ jobs:
           cache: yarn
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
@@ -199,7 +201,7 @@ jobs:
       - name: Install dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          sfw yarn install --immutable # focus install is not used here to make sure that all global patches are applied for the release.
+          $(command -v sfw > /dev/null && echo sfw) yarn install --immutable # focus install is not used here to make sure that all global patches are applied for the release.
 
       - name: Build suite-web
         env:
@@ -251,13 +253,14 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
       - name: Install deps and build libs
         run: |
-          sfw yarn install --immutable
+          $(command -v sfw > /dev/null && echo sfw) yarn install --immutable
           yarn message-system-sign-config
           yarn workspace @trezor/suite-data build:lib
           yarn workspace @trezor/transport-bridge build:lib

--- a/.github/workflows/release-suite-desktop-web-staging.yml
+++ b/.github/workflows/release-suite-desktop-web-staging.yml
@@ -71,7 +71,7 @@ jobs:
           firewall-version: 1.11.0
       - name: Install deps and build libs
         run: |
-          $(command -v sfw > /dev/null && echo sfw) yarn install --immutable
+          $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable
           yarn message-system-sign-config
           yarn workspace @trezor/suite-data build:lib
           yarn workspace @trezor/transport-bridge build:lib
@@ -201,7 +201,7 @@ jobs:
       - name: Install dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          $(command -v sfw > /dev/null && echo sfw) yarn install --immutable # focus install is not used here to make sure that all global patches are applied for the release.
+          $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable # focus install is not used here to make sure that all global patches are applied for the release.
 
       - name: Build suite-web
         env:
@@ -260,7 +260,7 @@ jobs:
           firewall-version: 1.11.0
       - name: Install deps and build libs
         run: |
-          $(command -v sfw > /dev/null && echo sfw) yarn install --immutable
+          $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable
           yarn message-system-sign-config
           yarn workspace @trezor/suite-data build:lib
           yarn workspace @trezor/transport-bridge build:lib

--- a/.github/workflows/release-suite-message-system-config.yml
+++ b/.github/workflows/release-suite-message-system-config.yml
@@ -33,6 +33,7 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
@@ -42,7 +43,7 @@ jobs:
           IS_CODESIGN_BUILD: ${{ env.RELEASE_ENV == 'production' && 'true' || 'false' }}
           JWS_PRIVATE_KEY_ENV: ${{ secrets.JWS_PRIVATE_KEY_ENV }}
         run: |
-          sfw yarn install
+          $(command -v sfw > /dev/null && echo sfw) yarn install
           yarn message-system-sign-config
 
       - name: Upload ${{ env.RELEASE_ENV }}  message-system config file

--- a/.github/workflows/release-suite-message-system-config.yml
+++ b/.github/workflows/release-suite-message-system-config.yml
@@ -43,7 +43,7 @@ jobs:
           IS_CODESIGN_BUILD: ${{ env.RELEASE_ENV == 'production' && 'true' || 'false' }}
           JWS_PRIVATE_KEY_ENV: ${{ secrets.JWS_PRIVATE_KEY_ENV }}
         run: |
-          $(command -v sfw > /dev/null && echo sfw) yarn install
+          $(command -v sfw > /dev/null && echo sfw --verbose) yarn install
           yarn message-system-sign-config
 
       - name: Upload ${{ env.RELEASE_ENV }}  message-system config file

--- a/.github/workflows/release-suite-native-develop.yml
+++ b/.github/workflows/release-suite-native-develop.yml
@@ -35,13 +35,14 @@ jobs:
           token: ${{ secrets.EXPO_TOKEN }}
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
       - name: Install libs
         run: |
-          sfw yarn workspaces focus @suite-native/app
+          $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @suite-native/app
       - name: Build on EAS Android
         run: eas build
           --platform android

--- a/.github/workflows/release-suite-native-develop.yml
+++ b/.github/workflows/release-suite-native-develop.yml
@@ -42,7 +42,7 @@ jobs:
           firewall-version: 1.11.0
       - name: Install libs
         run: |
-          $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @suite-native/app
+          $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @suite-native/app
       - name: Build on EAS Android
         run: eas build
           --platform android

--- a/.github/workflows/release-suite-native-production.yml
+++ b/.github/workflows/release-suite-native-production.yml
@@ -49,7 +49,7 @@ jobs:
           firewall-version: 1.11.0
       - name: Install libs
         run: |
-          $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @suite-native/app
+          $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @suite-native/app
       - name: Build on EAS iOS
         run: eas build
           --platform ios
@@ -85,7 +85,7 @@ jobs:
           firewall-version: 1.11.0
       - name: Install libs
         run: |
-          $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @suite-native/app
+          $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @suite-native/app
       - name: Build on EAS Android
         run: eas build
           --platform android
@@ -127,7 +127,7 @@ jobs:
           firewall-version: 1.11.0
       - name: Install libs
         run: |
-          $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @suite-native/app
+          $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @suite-native/app
 
       - name: Get Suite version
         id: get_version

--- a/.github/workflows/release-suite-native-production.yml
+++ b/.github/workflows/release-suite-native-production.yml
@@ -42,13 +42,14 @@ jobs:
           token: ${{ secrets.EXPO_TOKEN }}
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
       - name: Install libs
         run: |
-          sfw yarn workspaces focus @suite-native/app
+          $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @suite-native/app
       - name: Build on EAS iOS
         run: eas build
           --platform ios
@@ -77,13 +78,14 @@ jobs:
           token: ${{ secrets.EXPO_TOKEN }}
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
       - name: Install libs
         run: |
-          sfw yarn workspaces focus @suite-native/app
+          $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @suite-native/app
       - name: Build on EAS Android
         run: eas build
           --platform android
@@ -118,13 +120,14 @@ jobs:
           aws-region: eu-central-1
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
       - name: Install libs
         run: |
-          sfw yarn workspaces focus @suite-native/app
+          $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @suite-native/app
 
       - name: Get Suite version
         id: get_version

--- a/.github/workflows/template-connect-test-params.yml
+++ b/.github/workflows/template-connect-test-params.yml
@@ -70,11 +70,11 @@ jobs:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
-      - run: $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @trezor/connect
+      - run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @trezor/connect
       - if: ${{ inputs.testEnv == 'web' }}
         run: |
-          $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @trezor/connect-web
-          $(command -v sfw > /dev/null && echo sfw) yarn && yarn build:libs
+          $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @trezor/connect-web
+          $(command -v sfw > /dev/null && echo sfw --verbose) yarn && yarn build:libs
       - name: Install Playwright chromium
         if: ${{ inputs.testEnv == 'web' }}
         run: yarn workspace @trezor/connect-web exec playwright install --with-deps chromium

--- a/.github/workflows/template-connect-test-params.yml
+++ b/.github/workflows/template-connect-test-params.yml
@@ -65,15 +65,16 @@ jobs:
           cache: yarn
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
-      - run: sfw yarn workspaces focus @trezor/connect
+      - run: $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @trezor/connect
       - if: ${{ inputs.testEnv == 'web' }}
         run: |
-          sfw yarn workspaces focus @trezor/connect-web
-          sfw yarn && yarn build:libs
+          $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @trezor/connect-web
+          $(command -v sfw > /dev/null && echo sfw) yarn && yarn build:libs
       - name: Install Playwright chromium
         if: ${{ inputs.testEnv == 'web' }}
         run: yarn workspace @trezor/connect-web exec playwright install --with-deps chromium

--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -74,6 +74,7 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
@@ -81,7 +82,7 @@ jobs:
       - name: Install Yarn dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          sfw yarn install
+          $(command -v sfw > /dev/null && echo sfw) yarn install
 
       # Detox runtime may indirectly import the built config, and that would crash if message-system is not built
       - name: Sign message system config

--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Install Yarn dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          $(command -v sfw > /dev/null && echo sfw) yarn install
+          $(command -v sfw > /dev/null && echo sfw --verbose) yarn install
 
       # Detox runtime may indirectly import the built config, and that would crash if message-system is not built
       - name: Sign message system config

--- a/.github/workflows/template-suite-native-prepare-test-app-android.yml
+++ b/.github/workflows/template-suite-native-prepare-test-app-android.yml
@@ -47,6 +47,7 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
@@ -54,7 +55,7 @@ jobs:
       - name: Install Yarn dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          sfw yarn install
+          $(command -v sfw > /dev/null && echo sfw) yarn install
 
       - name: Setup Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5

--- a/.github/workflows/template-suite-native-prepare-test-app-android.yml
+++ b/.github/workflows/template-suite-native-prepare-test-app-android.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install Yarn dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          $(command -v sfw > /dev/null && echo sfw) yarn install
+          $(command -v sfw > /dev/null && echo sfw --verbose) yarn install
 
       - name: Setup Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5

--- a/.github/workflows/template-suite-run-e2e.yml
+++ b/.github/workflows/template-suite-run-e2e.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Install PW Dependencies
         shell: bash
         run: |
-          $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @trezor/suite-e2e ${{ inputs.workspace-dependencies }}
+          $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @trezor/suite-e2e ${{ inputs.workspace-dependencies }}
 
       - name: Install Playwright Browsers
         if: inputs.target == 'web' && steps.playwright-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/template-suite-run-e2e.yml
+++ b/.github/workflows/template-suite-run-e2e.yml
@@ -152,6 +152,7 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
@@ -159,7 +160,7 @@ jobs:
       - name: Install PW Dependencies
         shell: bash
         run: |
-          sfw yarn workspaces focus @trezor/suite-e2e ${{ inputs.workspace-dependencies }}
+          $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @trezor/suite-e2e ${{ inputs.workspace-dependencies }}
 
       - name: Install Playwright Browsers
         if: inputs.target == 'web' && steps.playwright-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/test-blockchain-link.yml
+++ b/.github/workflows/test-blockchain-link.yml
@@ -41,7 +41,7 @@ jobs:
           job-summary: errors
           firewall-version: 1.11.0
       - name: Install dependencies
-        run: $(command -v sfw > /dev/null && echo sfw) yarn --immutable
+        run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn --immutable
 
       - name: Build dependencies
         run: yarn build:libs

--- a/.github/workflows/test-blockchain-link.yml
+++ b/.github/workflows/test-blockchain-link.yml
@@ -35,12 +35,13 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
       - name: Install dependencies
-        run: sfw yarn --immutable
+        run: $(command -v sfw > /dev/null && echo sfw) yarn --immutable
 
       - name: Build dependencies
         run: yarn build:libs

--- a/.github/workflows/test-connect-misc.yml
+++ b/.github/workflows/test-connect-misc.yml
@@ -79,7 +79,7 @@ jobs:
           job-summary: errors
           firewall-version: 1.11.0
       - name: Install dependencies
-        run: $(command -v sfw > /dev/null && echo sfw) yarn install
+        run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn install
 
       - name: Pack packages
         run: yarn tsx ./scripts/ci/pack-packages.ts
@@ -115,5 +115,5 @@ jobs:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
-      - run: $(command -v sfw > /dev/null && echo sfw) yarn install --immutable
+      - run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable
       - run: yarn workspace @trezor/protobuf update:protobuf

--- a/.github/workflows/test-connect-misc.yml
+++ b/.github/workflows/test-connect-misc.yml
@@ -73,12 +73,13 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
       - name: Install dependencies
-        run: sfw yarn install
+        run: $(command -v sfw > /dev/null && echo sfw) yarn install
 
       - name: Pack packages
         run: yarn tsx ./scripts/ci/pack-packages.ts
@@ -109,9 +110,10 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
-      - run: sfw yarn install --immutable
+      - run: $(command -v sfw > /dev/null && echo sfw) yarn install --immutable
       - run: yarn workspace @trezor/protobuf update:protobuf

--- a/.github/workflows/test-misc.yml
+++ b/.github/workflows/test-misc.yml
@@ -28,11 +28,12 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
-      - run: sfw yarn install --immutable
+      - run: $(command -v sfw > /dev/null && echo sfw) yarn install --immutable
       - run: yarn workspace @suite/intl translations:list-unused
 
   media-duplicates:
@@ -62,11 +63,12 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
-      - run: sfw yarn install --immutable
+      - run: $(command -v sfw > /dev/null && echo sfw) yarn install --immutable
       - run: ./scripts/circular-dependencies/check-circular-dependencies.sh
 
   test-unit:
@@ -85,11 +87,12 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
-      - run: sfw yarn install --immutable
+      - run: $(command -v sfw > /dev/null && echo sfw) yarn install --immutable
       - run: yarn message-system-sign-config
       - name: Unit Tests - Suite, Connect, Common
         run: yarn test:unit:all --exclude='@suite-native/*' -- --silent
@@ -126,11 +129,12 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
-      - run: sfw yarn install --immutable
+      - run: $(command -v sfw > /dev/null && echo sfw) yarn install --immutable
       - run: yarn generate-package @trezor/meow-package
       - run: rm -rf packages/meow-package
 
@@ -147,9 +151,10 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
-      - run: sfw yarn install --immutable
+      - run: $(command -v sfw > /dev/null && echo sfw) yarn install --immutable
       - run: yarn tsx ./packages/components/scripts/test-img-paths-exist.ts

--- a/.github/workflows/test-misc.yml
+++ b/.github/workflows/test-misc.yml
@@ -33,7 +33,7 @@ jobs:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
-      - run: $(command -v sfw > /dev/null && echo sfw) yarn install --immutable
+      - run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable
       - run: yarn workspace @suite/intl translations:list-unused
 
   media-duplicates:
@@ -68,7 +68,7 @@ jobs:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
-      - run: $(command -v sfw > /dev/null && echo sfw) yarn install --immutable
+      - run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable
       - run: ./scripts/circular-dependencies/check-circular-dependencies.sh
 
   test-unit:
@@ -92,7 +92,7 @@ jobs:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
-      - run: $(command -v sfw > /dev/null && echo sfw) yarn install --immutable
+      - run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable
       - run: yarn message-system-sign-config
       - name: Unit Tests - Suite, Connect, Common
         run: yarn test:unit:all --exclude='@suite-native/*' -- --silent
@@ -134,7 +134,7 @@ jobs:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
-      - run: $(command -v sfw > /dev/null && echo sfw) yarn install --immutable
+      - run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable
       - run: yarn generate-package @trezor/meow-package
       - run: rm -rf packages/meow-package
 
@@ -156,5 +156,5 @@ jobs:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
-      - run: $(command -v sfw > /dev/null && echo sfw) yarn install --immutable
+      - run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable
       - run: yarn tsx ./packages/components/scripts/test-img-paths-exist.ts

--- a/.github/workflows/test-request-manager.yml
+++ b/.github/workflows/test-request-manager.yml
@@ -32,9 +32,10 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
-      - run: sfw yarn install --immutable
+      - run: $(command -v sfw > /dev/null && echo sfw) yarn install --immutable
       - run: yarn workspace @trezor/request-manager test:all

--- a/.github/workflows/test-request-manager.yml
+++ b/.github/workflows/test-request-manager.yml
@@ -37,5 +37,5 @@ jobs:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
-      - run: $(command -v sfw > /dev/null && echo sfw) yarn install --immutable
+      - run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable
       - run: yarn workspace @trezor/request-manager test:all

--- a/.github/workflows/test-suite-manual-release.yml
+++ b/.github/workflows/test-suite-manual-release.yml
@@ -48,6 +48,7 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
@@ -56,7 +57,7 @@ jobs:
         shell: bash
         run: |
           echo "Installing Playwright dependencies"
-          sfw yarn workspaces focus @trezor/suite-e2e
+          $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @trezor/suite-e2e
           # Playwright runtime may indirectly import the built config, and that would crash if message-system is not built
           yarn message-system-sign-config
 

--- a/.github/workflows/test-suite-manual-release.yml
+++ b/.github/workflows/test-suite-manual-release.yml
@@ -57,7 +57,7 @@ jobs:
         shell: bash
         run: |
           echo "Installing Playwright dependencies"
-          $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @trezor/suite-e2e
+          $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @trezor/suite-e2e
           # Playwright runtime may indirectly import the built config, and that would crash if message-system is not built
           yarn message-system-sign-config
 

--- a/.github/workflows/test-suite-native-e2e-ios.yml
+++ b/.github/workflows/test-suite-native-e2e-ios.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install Yarn dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          $(command -v sfw > /dev/null && echo sfw) yarn install
+          $(command -v sfw > /dev/null && echo sfw --verbose) yarn install
 
       - name: Use latest stable Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
@@ -137,7 +137,7 @@ jobs:
       - name: Install Yarn dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          $(command -v sfw > /dev/null && echo sfw) yarn install
+          $(command -v sfw > /dev/null && echo sfw --verbose) yarn install
 
       # Detox runtime may indirectly import the built config, and that would crash if message-system is not built
       - name: Sign message system config

--- a/.github/workflows/test-suite-native-e2e-ios.yml
+++ b/.github/workflows/test-suite-native-e2e-ios.yml
@@ -52,6 +52,7 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
@@ -59,7 +60,7 @@ jobs:
       - name: Install Yarn dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          sfw yarn install
+          $(command -v sfw > /dev/null && echo sfw) yarn install
 
       - name: Use latest stable Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
@@ -128,6 +129,7 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
@@ -135,7 +137,7 @@ jobs:
       - name: Install Yarn dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          sfw yarn install
+          $(command -v sfw > /dev/null && echo sfw) yarn install
 
       # Detox runtime may indirectly import the built config, and that would crash if message-system is not built
       - name: Sign message system config

--- a/.github/workflows/test-suite-native-e2e-manual-reporter.yml
+++ b/.github/workflows/test-suite-native-e2e-manual-reporter.yml
@@ -45,6 +45,7 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
@@ -52,7 +53,7 @@ jobs:
       - name: Install Yarn dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          sfw yarn install
+          $(command -v sfw > /dev/null && echo sfw) yarn install
 
       - name: Extract Release Build
         id: extract_branch

--- a/.github/workflows/test-suite-native-e2e-manual-reporter.yml
+++ b/.github/workflows/test-suite-native-e2e-manual-reporter.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install Yarn dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          $(command -v sfw > /dev/null && echo sfw) yarn install
+          $(command -v sfw > /dev/null && echo sfw --verbose) yarn install
 
       - name: Extract Release Build
         id: extract_branch

--- a/.github/workflows/test-suite-web-desktop-e2e-nightly.yml
+++ b/.github/workflows/test-suite-web-desktop-e2e-nightly.yml
@@ -148,7 +148,7 @@ jobs:
           firewall-version: 1.11.0
 
       - name: Install dependencies
-        run: $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @trezor/e2e-utils
+        run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @trezor/e2e-utils
 
       - name: Download per-test coverage map artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/.github/workflows/test-suite-web-desktop-e2e-nightly.yml
+++ b/.github/workflows/test-suite-web-desktop-e2e-nightly.yml
@@ -141,13 +141,14 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
 
       - name: Install dependencies
-        run: sfw yarn workspaces focus @trezor/e2e-utils
+        run: $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @trezor/e2e-utils
 
       - name: Download per-test coverage map artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/.github/workflows/test-transport.yml
+++ b/.github/workflows/test-transport.yml
@@ -42,13 +42,14 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
       - name: Install dependencies
         run: |
-          sfw yarn workspaces focus @trezor/transport-test
+          $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @trezor/transport-test
 
       - name: Setup containers
         run: |
@@ -85,6 +86,7 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
@@ -92,7 +94,7 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: |
-          sfw yarn workspaces focus @trezor/transport -A
+          $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @trezor/transport -A
 
       - name: Build transport tester
         run: |

--- a/.github/workflows/test-transport.yml
+++ b/.github/workflows/test-transport.yml
@@ -49,7 +49,7 @@ jobs:
           firewall-version: 1.11.0
       - name: Install dependencies
         run: |
-          $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @trezor/transport-test
+          $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @trezor/transport-test
 
       - name: Setup containers
         run: |
@@ -94,7 +94,7 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: |
-          $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @trezor/transport -A
+          $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @trezor/transport -A
 
       - name: Build transport tester
         run: |

--- a/.github/workflows/test-trezor-user-env-link-e2e.yml
+++ b/.github/workflows/test-trezor-user-env-link-e2e.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @trezor/trezor-user-env-link
+          $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @trezor/trezor-user-env-link
 
       - name: Run e2e tests
         run: |

--- a/.github/workflows/test-trezor-user-env-link-e2e.yml
+++ b/.github/workflows/test-trezor-user-env-link-e2e.yml
@@ -34,6 +34,7 @@ jobs:
           cache: yarn
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
@@ -41,7 +42,7 @@ jobs:
       - name: Install dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          sfw yarn workspaces focus @trezor/trezor-user-env-link
+          $(command -v sfw > /dev/null && echo sfw) yarn workspaces focus @trezor/trezor-user-env-link
 
       - name: Run e2e tests
         run: |

--- a/.github/workflows/test-urls.yml
+++ b/.github/workflows/test-urls.yml
@@ -30,5 +30,5 @@ jobs:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
-      - run: $(command -v sfw > /dev/null && echo sfw) yarn install --immutable
+      - run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable
       - run: yarn workspace @trezor/urls test:e2e

--- a/.github/workflows/test-urls.yml
+++ b/.github/workflows/test-urls.yml
@@ -25,9 +25,10 @@ jobs:
 
       - name: Install Socket Firewall
         uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
         with:
           mode: firewall-free
           job-summary: errors
           firewall-version: 1.11.0
-      - run: sfw yarn install --immutable
+      - run: $(command -v sfw > /dev/null && echo sfw) yarn install --immutable
       - run: yarn workspace @trezor/urls test:e2e


### PR DESCRIPTION
## Description

Currently, if there is an outage interrupting sfw installation in CI, it fails the whole action.
https://github.com/trezor/trezor-suite/actions/runs/27121075436/job/80038682386?pr=28453
https://github.com/trezor/trezor-suite/actions/runs/27121075427/job/80038129747?pr=28453
https://github.com/trezor/trezor-suite/actions/runs/27121075518/job/80038144773?pr=28453

→ make sfw optional
→ make it verbose, so we know if it was applied or not. Since 1.11.0 the verbosity is acceptable, just 2 lines :slightly_smiling_face: 
```
Protected by Socket Firewall
sfw report written to: /home/runner/work/_temp/9d484d8c-281d-4a3d-b3ce-20adaae4da44.json
```

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=ci/make-sfw-optional&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=ci/make-sfw-optional&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=ci/make-sfw-optional&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-08T09:48:03.831Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add account types ada | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-08T09:45:44.251Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/ci/make-sfw-optional/web/](https://dev.suite.sldev.cz/suite-web/ci/make-sfw-optional/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->