### PR TITLE
fix(trading): hide empty offer amount

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer/TradingFormOffer.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer/TradingFormOffer.tsx
@@ -36,13 +36,15 @@ export const TradingFormOffer = () => {
 
     return (
         <Column gap={12}>
-            <TradingFormOfferAmount
-                amount={receiveAmount}
-                sendAmount={sendAmount}
-                selectedAssetCryptoId={selectedAssetCryptoId ?? undefined}
-                shouldDisplayFiatAmount={shouldDisplayFiatAmount}
-                amountLabels={amountLabels}
-            />
+            {selectedAssetCryptoId && (
+                <TradingFormOfferAmount
+                    amount={receiveAmount}
+                    sendAmount={sendAmount}
+                    selectedAssetCryptoId={selectedAssetCryptoId}
+                    shouldDisplayFiatAmount={shouldDisplayFiatAmount}
+                    amountLabels={amountLabels}
+                />
+            )}
             <TradingFormOfferWarnings hasQuote={!!quote} />
             {noOffersWithTor && <TradingUtilsTorWarning tradingType={type} noOffer={!quote} />}
             {getActionsComponent(type)}


### PR DESCRIPTION
## Description

- Hide the trading offer amount block until a quote is available.
- Remove the empty-state fiat amount/selector from the offer panel.
- Keep trading warnings and action controls visible while no quote is loaded.

## Notes for QA

- Verify that Fiat Amount is not visible before quote is loaded

## Related Issue

Resolve #28169

## Screenshots:

<img width="1076" height="621" alt="image" src="https://github.com/user-attachments/assets/1ab40992-39cd-4b9c-9c07-56975a967756" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trading-empty-offer-28169&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trading-empty-offer-28169&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-09T07:51:25.826Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add account types ada | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-09T07:50:12.251Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/trading-empty-offer-28169/web/](https://dev.suite.sldev.cz/suite-web/fix/trading-empty-offer-28169/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is to TradingFormOffer.tsx, a component that renders offer details (best offer button, provider name, KYC warning, crypto amount, offer comparison) across all trading flows (buy, sell, swap). This is a focused UI component change with high potential for visual or functional regressions in the trading offer display. The highest priority tests are the core buy and sell flows that directly assert on offer rendering. Swap tests are medium priority since they also render through this component but may exercise slightly different code paths. No static coverage mapping was available, so all recommendations are inferred from LLM analysis of test behaviors and source hints.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer/TradingFormOffer.tsx`

</details>

**Recommended tests (16)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — TradingFormOffer is the component that renders offer details (best offer button, provider name, KYC warning, crypto amount) in the trading buy flow. This test directly exercises the best offer display, provider name rendering, and offer confirmation which are core behaviors of TradingFormOffer.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — This test exercises the buy flow for Ethereum including best offer quote display and trade confirmation, directly rendering through TradingFormOffer to show offer amounts and provider details.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — Tests the buy flow for a Solana SPL token, asserting on best offer amount and provider name display which are rendered by TradingFormOffer. Covers a different asset type path through the same component.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — The sell flow uses TradingFormOffer to display the best sell offer button with provider name, KYC warning, and SVG icon. This test directly asserts on sellBestOfferButton content and offer comparison which are TradingFormOffer responsibilities.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Tests the sell flow for Solana including best offer display, offer comparison modal, and selecting alternative offers — all rendered through TradingFormOffer. Also tests the compare offers flow which likely involves TradingFormOffer.

</details>

<details><summary>🟡 <b>Medium priority (9)</b></summary>

- `suite/e2e/tests/trading/buy-negative.test.ts` — Tests that the buy best offer button is disabled under various invalid input conditions and that 'no offers found' state is shown. The disabled state of buyBestOfferButton and selectedProvider visibility are likely controlled by TradingFormOffer.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Tests the Ethereum sell flow with custom gas fees, asserting on best offer amount and provider name display which flow through TradingFormOffer.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Tests selling an ERC-20 token (USDC) through the sell flow, asserting on best offer amount and provider name rendered by TradingFormOffer.
- `suite/e2e/tests/trading/swap-coins.test.ts` — The swap flow uses TradingFormOffer to display the best swap offer quote (swapBestOfferButton). This test asserts on the best offer amount and confirmation flow which renders through the offer component.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Tests swapping SOL to USDC token, asserting on best offer amount display which is rendered by TradingFormOffer in the swap context.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Tests swapping a token (USDT) to Bitcoin, with assertions on best offer amount display rendered by TradingFormOffer.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Tests swapping between SPL tokens (USDT to USDC), asserting on best offer amount display which flows through TradingFormOffer.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — Tests that provider information is displayed in swap quotes even for disabled networks. The selectedProvider visibility assertion is likely rendered by TradingFormOffer.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — Tests swap form interactions including best offer amount display and selected provider visibility, which are rendered through TradingFormOffer. Also tests choosing different offers.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — While primarily focused on fee display on the device emulator, this test does click the swapBestOfferButton which is part of TradingFormOffer, so a rendering regression could block the flow.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Similar to swap-fees-bitcoin, this test clicks the best offer button rendered by TradingFormOffer before proceeding to fee verification on the device.

</details>

_Updated: 2026-06-09T07:47:03.809Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->