### PR TITLE
fix(trading): hide payment method before quote

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingBuyFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingBuyFormInputs.tsx
@@ -39,7 +39,7 @@ export const TradingBuyFormInputs = () => {
 
     const { isLoading } = useSelector(selectTradingLoadingAndTimestamp);
 
-    const { device, setAmountLimits, getValues, setValue, quotes } = context;
+    const { device, setAmountLimits, getValues, setValue, quotes, isAmountEmpty } = context;
     const {
         [TRADING_FORM_CRYPTO_CURRENCY_SELECT]: cryptoSelect,
         [TRADING_FORM_CRYPTO_INPUT]: cryptoInput,
@@ -111,7 +111,7 @@ export const TradingBuyFormInputs = () => {
             </TradingFormCard>
 
             <TradingFormCard>
-                {quotes?.length > 0 && (
+                {quotes?.length > 0 && !isAmountEmpty && (
                     <TradingFormInputPaymentMethod label="TR_TRADING_PAYMENT_METHOD" />
                 )}
                 <TradingFormInputCountry label="TR_TRADING_COUNTRY" />

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingSellFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingSellFormInputs.tsx
@@ -49,6 +49,7 @@ export const TradingSellFormInputs = () => {
         showReserveBanner,
         quotes,
         defaultCountry,
+        isAmountEmpty,
     } = context;
     const { getValues } = useFormContext<TradingSellFormProps>();
     const { outputs, sendCryptoSelect, amountInCrypto, countrySelect } = getValues();
@@ -137,7 +138,7 @@ export const TradingSellFormInputs = () => {
                     composedLevels={composedLevels}
                     changeFeeLevel={changeFeeLevel}
                 />
-                {!!quotes.length && (
+                {!!quotes.length && !isAmountEmpty && (
                     <TradingFormInputPaymentMethod label="TR_TRADING_RECEIVE_METHOD" />
                 )}
 


### PR DESCRIPTION
## Description

- hide the BUY payment method selector until the form has a non-empty amount and quotes are available
- align the SELL receive method selector with the same non-empty amount guard
- keep the change scoped to the trading form input render conditions only

## Notes for QA

- In Buy & Sell, fill out the form to load a quote, then clear the amount input and verify that the payment methods disappear immediately

## Related Issue

Resolve #28357

## Screenshots:

N/A

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect two core form input components: TradingBuyFormInputs.tsx and TradingSellFormInputs.tsx. These are directly rendered in buy and sell trading flows, making any test that interacts with form inputs high risk. The highest priority tests are those that directly validate input behavior (buy-negative, sell-inputs, buy-bitcoin). Secondary coverage from buy-ethereum, buy-solana-token, and sell-solana ensures different asset types and code paths are exercised. The dashboard/assets test is omitted as it only tangentially touches buy form rendering via a navigation click.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingBuyFormInputs.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingSellFormInputs.tsx`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/trading/buy-negative.test.ts` — This test directly validates buy form input behavior including error states, amount validation, and button disabling — all driven by TradingBuyFormInputs.tsx. Changes to the buy form inputs component could break validation logic, error display, or input field rendering.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — This test directly exercises sell form input behavior including decimal validation, balance percentage buttons, max amount calculation, currency switching, and error messages — all rendered by TradingSellFormInputs.tsx. It also statically maps to TradingBuyFormInputs.tsx since it navigates through buy/sell flows.
- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — This test fills in the buy form's fiat amount input and interacts with the receive address selector — core elements rendered by TradingBuyFormInputs.tsx. Changes to form inputs could break amount entry, quote fetching, or the overall buy flow.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/trading/buy-ethereum.test.ts` — This test exercises the buy form with ETH including fiat amount entry and receive account selection via TradingBuyFormInputs.tsx. It covers a different asset path (ETH vs BTC) which may reveal asset-specific regressions in the form inputs.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — This test exercises the buy form with a Solana token including crypto/fiat input mode switching and receive account selection, which are features rendered by TradingBuyFormInputs.tsx. The fiat/crypto toggle is a distinct code path worth covering.
- `suite/e2e/tests/trading/sell-solana.test.ts` — This test fills in the sell form with a crypto amount for Solana, exercising TradingSellFormInputs.tsx. It covers the sell flow end-to-end including confirmation, providing coverage for a different network than sell-inputs.test.ts.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — This test verifies that buy/sell/swap forms open correctly with the right pre-selected asset. While it renders both TradingBuyFormInputs and TradingSellFormInputs, it primarily tests navigation routing rather than form input behavior. A regression is possible if form rendering breaks entirely.

</details>

_Updated: 2026-06-08T11:54:17.769Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/28357-trading-payment-method-selector&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/28357-trading-payment-method-selector&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-08T12:00:15.147Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add account types ada | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-08T11:57:29.464Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/28357-trading-payment-method-selector/web/](https://dev.suite.sldev.cz/suite-web/fix/28357-trading-payment-method-selector/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->