### PR TITLE
feat: delete evolu SQL database on Suite Wipe [DO NOT MERGE] 

### DIFF
--- a/packages/suite/src/actions/suite/__tests__/suiteThunks.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/suiteThunks.test.ts
@@ -1,0 +1,105 @@
+import { createSuiteSyncDeleteLocalDataError } from '@suite-common/suite-sync-storage';
+import { notificationsActions } from '@suite-common/toast-notifications';
+import { desktopApi } from '@trezor/suite-desktop-api';
+import { err, ok } from '@trezor/type-utils';
+
+import { resetSuiteAppThunk } from '../suiteThunks';
+
+const mockReloadApp = jest.fn();
+
+jest.mock('src/utils/suite/reload', () => ({
+    reloadApp: () => mockReloadApp(),
+}));
+
+jest.mock('@suite/router', () => ({
+    goto: () => ({ type: 'suite/goto' }),
+}));
+
+jest.mock('../storageActions', () => ({
+    removeDatabase: () => ({ type: 'suite/removeDatabase' }),
+}));
+
+jest.mock('@trezor/suite-desktop-api', () => ({
+    desktopApi: {
+        available: true,
+        appAutoStart: jest.fn(),
+        clearStore: jest.fn(),
+    },
+}));
+
+describe(resetSuiteAppThunk.name, () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('deletes Suite Sync local data when resetting the app', async () => {
+        const dispatch = jest.fn();
+        const deleteSuiteSyncLocalData = jest.fn(() => Promise.resolve(ok()));
+        const clearLocalStorage = jest.spyOn(Storage.prototype, 'clear');
+
+        await resetSuiteAppThunk()(dispatch, jest.fn(), {
+            services: {
+                suiteSync: {
+                    deleteSuiteSyncLocalData,
+                },
+            },
+        } as any);
+
+        expect(deleteSuiteSyncLocalData).toHaveBeenCalledTimes(1);
+        expect(clearLocalStorage).toHaveBeenCalledTimes(1);
+        expect(desktopApi.clearStore).toHaveBeenCalledTimes(1);
+        expect(desktopApi.appAutoStart).toHaveBeenCalledWith(false);
+        expect(mockReloadApp).toHaveBeenCalledTimes(1);
+
+        const deleteSuiteSyncLocalDataCallOrder =
+            deleteSuiteSyncLocalData.mock.invocationCallOrder[0];
+        const clearLocalStorageCallOrder = clearLocalStorage.mock.invocationCallOrder[0];
+
+        expect(deleteSuiteSyncLocalDataCallOrder).toBeDefined();
+        expect(clearLocalStorageCallOrder).toBeDefined();
+
+        if (
+            deleteSuiteSyncLocalDataCallOrder === undefined ||
+            clearLocalStorageCallOrder === undefined
+        ) {
+            throw new Error('Expected reset cleanup calls to be tracked.');
+        }
+
+        expect(deleteSuiteSyncLocalDataCallOrder).toBeLessThan(clearLocalStorageCallOrder);
+    });
+
+    it('shows error notification and rejects when Suite Sync local data deletion fails', async () => {
+        const dispatch = jest.fn();
+        const deleteLocalDataError = createSuiteSyncDeleteLocalDataError(
+            'Delete failed',
+            new Error('Delete failed'),
+        );
+        const deleteSuiteSyncLocalData = jest.fn(() => Promise.resolve(err(deleteLocalDataError)));
+        const clearLocalStorage = jest.spyOn(Storage.prototype, 'clear');
+
+        const result = await resetSuiteAppThunk()(dispatch, jest.fn(), {
+            services: {
+                suiteSync: {
+                    deleteSuiteSyncLocalData,
+                },
+            },
+        } as any);
+
+        expect(deleteSuiteSyncLocalData).toHaveBeenCalledTimes(1);
+        expect(dispatch).toHaveBeenCalledWith(
+            expect.objectContaining({
+                payload: expect.objectContaining({
+                    type: 'error',
+                    error: deleteLocalDataError.message,
+                }),
+                type: notificationsActions.addToast.type,
+            }),
+        );
+        expect(result.type).toBe(resetSuiteAppThunk.rejected.type);
+        expect(result.payload).toBe(deleteLocalDataError.message);
+        expect(clearLocalStorage).not.toHaveBeenCalled();
+        expect(desktopApi.clearStore).not.toHaveBeenCalled();
+        expect(desktopApi.appAutoStart).not.toHaveBeenCalled();
+        expect(mockReloadApp).not.toHaveBeenCalled();
+    });
+});

--- a/packages/suite/src/actions/suite/suiteThunks.ts
+++ b/packages/suite/src/actions/suite/suiteThunks.ts
@@ -1,21 +1,36 @@
 import { goto } from '@suite/router';
 import { createThunk } from '@suite-common/redux-utils';
+import { selectDeleteSuiteSyncLocalDataDep } from '@suite-common/suite-sync-types';
+import { notificationsActions } from '@suite-common/toast-notifications';
 import { desktopApi } from '@trezor/suite-desktop-api';
 
 import { reloadApp } from 'src/utils/suite/reload';
 
 import { removeDatabase } from './storageActions';
 
-export const resetSuiteAppThunk = createThunk('@suite/reset-app', async (_, { dispatch }) => {
-    localStorage.clear();
-    dispatch(removeDatabase());
-    if (desktopApi.available) {
-        // Reset the desktop-specific store.
-        desktopApi.clearStore();
-        desktopApi.appAutoStart(false);
-    } else {
-        // redirect to / and reload the web
-        await dispatch(goto({ routeName: 'suite-index' }));
-    }
-    reloadApp();
-});
+export const resetSuiteAppThunk = createThunk<void, void, { rejectValue: string }>(
+    '@suite/reset-app',
+    async (_, { dispatch, extra, rejectWithValue }) => {
+        const { deleteSuiteSyncLocalData } = selectDeleteSuiteSyncLocalDataDep(extra.services);
+
+        const result = await deleteSuiteSyncLocalData();
+
+        if (!result.success) {
+            dispatch(notificationsActions.addToast({ type: 'error', error: result.error.message }));
+
+            return rejectWithValue(result.error.message);
+        }
+
+        localStorage.clear();
+        dispatch(removeDatabase());
+        if (desktopApi.available) {
+            // Reset the desktop-specific store.
+            desktopApi.clearStore();
+            desktopApi.appAutoStart(false);
+        } else {
+            // redirect to / and reload the web
+            await dispatch(goto({ routeName: 'suite-index' }));
+        }
+        reloadApp();
+    },
+);

--- a/packages/suite/src/views/settings/SettingsDebug/WipeData.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/WipeData.tsx
@@ -41,8 +41,8 @@ export const WipeData = () => {
                 title="Wipe app data"
                 description={
                     <span>
-                        Clicking this button restarts your application and wipes all your data
-                        including locally saved labels. Your local folder is:{' '}
+                        Clicking this button restarts your application and wipes all your local
+                        application data. Your local folder is:{' '}
                         <UserDataLink onClick={openUserDataDir}>{userDataDir}</UserDataLink>
                     </span>
                 }

--- a/suite-common/suite-sync-evolu/src/evoluStorage.ts
+++ b/suite-common/suite-sync-evolu/src/evoluStorage.ts
@@ -1,6 +1,11 @@
 import { type Evolu, createOwnerWebSocketTransport } from '@evolu/common';
 
-import { type CreateSuiteStorage, type SuiteSyncStorage } from '@suite-common/suite-sync-storage';
+import {
+    type CreateSuiteStorage,
+    type SuiteSyncStorage,
+    createSuiteSyncDeleteLocalDataError,
+} from '@suite-common/suite-sync-storage';
+import { err, ok } from '@trezor/type-utils';
 
 import { type CreateEvoluInstanceDep } from './createEvoluInstance';
 import { type AccountTableSchema, EvoluAccountTable } from './data/accountTable';
@@ -49,6 +54,22 @@ export const createEvoluStorageFactory =
             },
 
             updateRelayUrl,
+            deleteLocalData: () => {
+                try {
+                    evolu.deleteDatabase();
+                } catch (error) {
+                    const message =
+                        error instanceof Error
+                            ? error.message
+                            : 'Failed to delete Suite Sync local data.';
+
+                    return Promise.resolve(
+                        err(createSuiteSyncDeleteLocalDataError(message, error)),
+                    );
+                }
+
+                return Promise.resolve(ok());
+            },
             dispose: async () => {
                 await evolu[Symbol.asyncDispose]();
             },

--- a/suite-common/suite-sync-evolu/tests/createEvoluStorageFactory.test.ts
+++ b/suite-common/suite-sync-evolu/tests/createEvoluStorageFactory.test.ts
@@ -9,9 +9,11 @@ import {
     type SuiteSyncWallet,
     asSuiteSyncOwnerId,
     asSuiteSyncOwnerSecretHex,
+    createSuiteSyncDeleteLocalDataError,
 } from '@suite-common/suite-sync-storage';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { asWalletDescriptor } from '@trezor/device-utils';
+import { err } from '@trezor/type-utils';
 import { createDeferred } from '@trezor/utils';
 
 import { testCreateRunWithEvoluDeps } from '../mocks/testCreateRunWithEvoluDeps';
@@ -32,6 +34,33 @@ const createTestStorage = async (run: Run<EvoluPlatformDeps>) => {
 };
 
 describe(createEvoluStorageFactory.name, () => {
+    it('returns error when deleting local data fails', async () => {
+        const deleteDatabaseError = new Error('Delete database failed');
+        const deleteDatabase = jest.fn(() => {
+            throw deleteDatabaseError;
+        });
+
+        const storage = await createEvoluStorageFactory({
+            createEvoluInstance: () =>
+                Promise.resolve({
+                    deleteDatabase,
+                    [Symbol.asyncDispose]: jest.fn(),
+                } as any),
+        })({ suiteSyncOwner });
+
+        const result = await storage.deleteLocalData();
+
+        expect(result).toEqual(
+            err(
+                createSuiteSyncDeleteLocalDataError(
+                    deleteDatabaseError.message,
+                    deleteDatabaseError,
+                ),
+            ),
+        );
+        expect(deleteDatabase).toHaveBeenCalledTimes(1);
+    });
+
     it('stores wallet data and notifies subscribers', async () => {
         await using run = await testCreateRunWithEvoluDeps({
             createWebSocket: testCreateWebSocket({ throwOnCreate: true }),

--- a/suite-common/suite-sync-storage/src/SuiteSyncStorage.ts
+++ b/suite-common/suite-sync-storage/src/SuiteSyncStorage.ts
@@ -1,6 +1,23 @@
+import { type Result } from '@trezor/type-utils';
+
 import { type SuiteSyncTable } from './SuiteSyncTable';
 import { type SuiteSyncSchema } from './data/SuiteSyncSchema';
 import { type SuiteSyncOwner } from './owner/suiteSyncOwner';
+
+export type SuiteSyncDeleteLocalDataError = {
+    type: 'SuiteSyncDeleteLocalDataError';
+    message: string;
+    cause: unknown;
+};
+
+export const createSuiteSyncDeleteLocalDataError = (
+    message: string,
+    cause: unknown,
+): SuiteSyncDeleteLocalDataError => ({
+    type: 'SuiteSyncDeleteLocalDataError',
+    message,
+    cause,
+});
 
 type SuiteSyncStorageData = {
     [K in keyof SuiteSyncSchema]: SuiteSyncTable<SuiteSyncSchema[K]>;
@@ -15,6 +32,7 @@ export type SuiteSyncStorage = {
     data: SuiteSyncStorageData;
 
     updateRelayUrl(url: string): Promise<void>;
+    deleteLocalData(): Promise<Result<void, SuiteSyncDeleteLocalDataError>>;
     dispose(): Promise<void>;
 };
 

--- a/suite-common/suite-sync-storage/src/index.ts
+++ b/suite-common/suite-sync-storage/src/index.ts
@@ -1,8 +1,10 @@
 export type {
+    SuiteSyncDeleteLocalDataError,
     SuiteSyncStorage,
     CreateSuiteStorage,
     CreateSuiteStorageDep,
 } from './SuiteSyncStorage';
+export { createSuiteSyncDeleteLocalDataError } from './SuiteSyncStorage';
 export {
     asSuiteSyncOwnerId,
     asSuiteSyncOwnerSecretHex,

--- a/suite-common/suite-sync-types/src/SuiteSync.ts
+++ b/suite-common/suite-sync-types/src/SuiteSync.ts
@@ -4,6 +4,7 @@ import { type UpdateAddressLabelDep } from './data/updateAddressLabel';
 import { type UpdateOutputLabelDep } from './data/updateOutputLabel';
 import { type UpdateWalletLabelDep } from './data/updateWalletLabel';
 import { type ChangeRelayUrlDep } from './relay/changeRelayUrl';
+import { type DeleteSuiteSyncLocalDataDep } from './storage/deleteSuiteSyncLocalData';
 import {
     type EnsureWalletSuiteSyncOnDep,
     type EnsureWalletSuiteSyncOnUncontrolledDep,
@@ -26,6 +27,7 @@ export type SuiteSync = ChangeRelayUrlDep &
     EnsureWalletSuiteSyncOnDep &
     EnsureWalletSuiteSyncOnUncontrolledDep &
     OnWalletSuiteSyncOnEnsuredDep &
+    DeleteSuiteSyncLocalDataDep &
     DangerouslyWipeAllLabelsFromWalletDep &
     TurnOffSuiteSyncForWalletDep &
     LabelingDep;

--- a/suite-common/suite-sync-types/src/index.ts
+++ b/suite-common/suite-sync-types/src/index.ts
@@ -11,6 +11,11 @@ export type {
     SuiteSyncStorageRepository,
     StorageId,
 } from './storage/suiteSyncStorageRepository';
+export {
+    type DeleteSuiteSyncLocalData,
+    type DeleteSuiteSyncLocalDataDep,
+    selectDeleteSuiteSyncLocalDataDep,
+} from './storage/deleteSuiteSyncLocalData';
 
 export type {
     EnsureSuiteSyncKeys,

--- a/suite-common/suite-sync-types/src/storage/deleteSuiteSyncLocalData.ts
+++ b/suite-common/suite-sync-types/src/storage/deleteSuiteSyncLocalData.ts
@@ -1,0 +1,12 @@
+import { type SuiteSyncDeleteLocalDataError } from '@suite-common/suite-sync-storage';
+import { type Result } from '@trezor/type-utils';
+
+export type DeleteSuiteSyncLocalData = () => Promise<Result<void, SuiteSyncDeleteLocalDataError>>;
+
+export type DeleteSuiteSyncLocalDataDep = {
+    deleteSuiteSyncLocalData: DeleteSuiteSyncLocalData;
+};
+
+export const selectDeleteSuiteSyncLocalDataDep = (services: any): DeleteSuiteSyncLocalDataDep => ({
+    deleteSuiteSyncLocalData: services.suiteSync.deleteSuiteSyncLocalData,
+});

--- a/suite-common/suite-sync-types/src/storage/suiteSyncStorageRepository.ts
+++ b/suite-common/suite-sync-types/src/storage/suiteSyncStorageRepository.ts
@@ -1,11 +1,15 @@
-import { type SuiteSyncStorage } from '@suite-common/suite-sync-storage';
-import { type Branded } from '@trezor/type-utils';
+import {
+    type SuiteSyncDeleteLocalDataError,
+    type SuiteSyncStorage,
+} from '@suite-common/suite-sync-storage';
+import { type Branded, type Result } from '@trezor/type-utils';
 
 export type StorageId = string & Branded<'StorageId'>;
 
 export type SuiteSyncStorageRepository = {
     get: (storageId: StorageId) => SuiteSyncStorage | null;
     delete: (storageId: StorageId) => Promise<void>;
+    deleteLocalData: () => Promise<Result<void, SuiteSyncDeleteLocalDataError>>;
     set: (storageId: StorageId, storage: SuiteSyncStorage) => void;
 };
 

--- a/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
+++ b/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
@@ -53,6 +53,7 @@ import { createRetrieveSuiteSyncOwner } from './owner/createRetrieveSuiteSyncOwn
 import { createSaveSuiteSyncOwner } from './owner/createSaveSuiteSyncOwner';
 import { createChangeRelayUrl } from './relay/createChangeRelayUrl';
 import { isUsingTrezorServer } from './relay/isUsingTrezorServer';
+import { createDeleteSuiteSyncLocalData } from './storage/createDeleteSuiteSyncLocalData';
 import { createEnsureStorage } from './storage/createEnsureStorage';
 import { createEnsureWalletSuiteSyncOn } from './storage/createEnsureWalletSuiteSyncOn';
 import { createEnsureWalletSuiteSyncOnUncontrolled } from './storage/createEnsureWalletSuiteSyncOnUncontrolled';
@@ -220,6 +221,9 @@ export const createSuiteSyncCompositionRoot = (
     const updateAddressLabel = createUpdateAddressLabel(labelingDeps);
 
     return {
+        deleteSuiteSyncLocalData: createDeleteSuiteSyncLocalData({
+            suiteSyncStorageRepository,
+        }),
         changeRelayUrl: createChangeRelayUrl({
             suiteSyncStorageRepository,
             getAllDeviceSessionIds,

--- a/suite-common/suite-sync/src/relay/tests/createChangeRelayUrl.test.ts
+++ b/suite-common/suite-sync/src/relay/tests/createChangeRelayUrl.test.ts
@@ -20,6 +20,7 @@ describe(createChangeRelayUrl.name, () => {
                 outputs: {} as any,
                 wallets: {} as any,
             },
+            deleteLocalData: mockNotExpected('deleteLocalData'),
             dispose: mockNotExpected('dispose'),
             updateRelayUrl: jest.fn(),
         };
@@ -29,6 +30,7 @@ describe(createChangeRelayUrl.name, () => {
             dispatch: (action: any) => actions.push(action),
             suiteSyncStorageRepository: {
                 delete: mockNotExpected('delete'),
+                deleteLocalData: mockNotExpected('deleteLocalData'),
                 get: jest.fn(() => mockStorage),
                 set: mockNotExpected('set'),
             },

--- a/suite-common/suite-sync/src/storage/createDeleteSuiteSyncLocalData.ts
+++ b/suite-common/suite-sync/src/storage/createDeleteSuiteSyncLocalData.ts
@@ -1,0 +1,9 @@
+import {
+    type DeleteSuiteSyncLocalData,
+    type SuiteSyncStorageRepositoryDep,
+} from '@suite-common/suite-sync-types';
+
+export const createDeleteSuiteSyncLocalData =
+    (deps: SuiteSyncStorageRepositoryDep): DeleteSuiteSyncLocalData =>
+    () =>
+        deps.suiteSyncStorageRepository.deleteLocalData();

--- a/suite-common/suite-sync/src/storage/createSuiteSyncStorageRepository.ts
+++ b/suite-common/suite-sync/src/storage/createSuiteSyncStorageRepository.ts
@@ -1,5 +1,6 @@
 import { type SuiteSyncStorage } from '@suite-common/suite-sync-storage';
 import { type StorageId, type SuiteSyncStorageRepository } from '@suite-common/suite-sync-types';
+import { err, ok } from '@trezor/type-utils';
 
 export const asStorageId = (value: string) => value as StorageId;
 
@@ -16,6 +17,21 @@ export const createSuiteSyncStorageRepository = (): SuiteSyncStorageRepository =
         delete: async (storageId: StorageId) => {
             await storages.get(storageId)?.dispose();
             storages.delete(storageId);
+        },
+
+        deleteLocalData: async () => {
+            const results = await Promise.all(
+                [...storages.values()].map(storage => storage.deleteLocalData()),
+            );
+            const failedResult = results.find(result => !result.success);
+
+            if (failedResult) {
+                return err(failedResult.error);
+            }
+
+            storages.clear();
+
+            return ok();
         },
 
         set: (storageId, storage) => {

--- a/suite-common/suite-sync/src/storage/tests/createEnsureStorage.test.ts
+++ b/suite-common/suite-sync/src/storage/tests/createEnsureStorage.test.ts
@@ -34,6 +34,7 @@ describe(createEnsureStorage.name, () => {
                 get: () => existingStorage,
                 set: null,
                 delete: null,
+                deleteLocalData: null,
             },
             createSuiteStorage: null,
             ensureSuiteSyncKeys: null,
@@ -66,6 +67,7 @@ describe(createEnsureStorage.name, () => {
                 get: () => existingStorage,
                 set: null,
                 delete: null,
+                deleteLocalData: null,
             },
             createSuiteStorage: null,
             ensureSuiteSyncKeys: () =>
@@ -94,6 +96,7 @@ describe(createEnsureStorage.name, () => {
                 get: () => null,
                 set: null,
                 delete: null,
+                deleteLocalData: null,
             },
             createSuiteStorage: null,
             ensureSuiteSyncKeys: null,
@@ -124,6 +127,7 @@ describe(createEnsureStorage.name, () => {
                 get: () => null,
                 set: null,
                 delete: null,
+                deleteLocalData: null,
             },
             createSuiteStorage: null,
             ensureSuiteSyncKeys: () => Promise.resolve(refreshError),
@@ -155,6 +159,7 @@ describe(createEnsureStorage.name, () => {
                 get: () => null,
                 set: mock(() => {}),
                 delete: null,
+                deleteLocalData: null,
             },
             createSuiteStorage: () => Promise.resolve(newStorage),
             ensureSuiteSyncKeys: () =>
@@ -189,6 +194,7 @@ describe(createEnsureStorage.name, () => {
                 get: () => null,
                 set: mock(() => {}),
                 delete: null,
+                deleteLocalData: null,
             },
             createSuiteStorage: () => Promise.resolve(newStorage),
             ensureSuiteSyncKeys: () =>
@@ -226,6 +232,7 @@ describe(createEnsureStorage.name, () => {
                 get: () => null,
                 set: mock(() => {}),
                 delete: null,
+                deleteLocalData: null,
             },
             createSuiteStorage: () => Promise.resolve(newStorage),
             ensureSuiteSyncKeys: () =>

--- a/suite-common/suite-sync/src/storage/tests/createSuiteSyncStorageRepository.test.ts
+++ b/suite-common/suite-sync/src/storage/tests/createSuiteSyncStorageRepository.test.ts
@@ -1,5 +1,9 @@
 import { mockNotExpected } from '@suite-common/dependency-injection';
-import { type SuiteSyncStorage } from '@suite-common/suite-sync-storage';
+import {
+    type SuiteSyncStorage,
+    createSuiteSyncDeleteLocalDataError,
+} from '@suite-common/suite-sync-storage';
+import { err, ok } from '@trezor/type-utils';
 
 import { createSuiteSyncStorageMock } from '../../../tests/createSuiteSyncStorageMock.mock';
 import { asStorageId, createSuiteSyncStorageRepository } from '../createSuiteSyncStorageRepository';
@@ -12,11 +16,16 @@ const storage: SuiteSyncStorage = {
         outputs: {} as any,
         wallets: {} as any,
     },
+    deleteLocalData: jest.fn().mockResolvedValue(ok()),
     dispose: jest.fn(),
     updateRelayUrl: mockNotExpected('updateRelayUrl'),
 };
 
 describe(createSuiteSyncStorageRepository.name, () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
     it('sets, gets and deletes the storage', async () => {
         const repository = createSuiteSyncStorageRepository();
 
@@ -36,5 +45,46 @@ describe(createSuiteSyncStorageRepository.name, () => {
         expect(repository.get(storageId1)).toBeNull();
         repository.set(storageId1, suiteSyncStorage);
         expect(repository.get(storageId1)).toBe(suiteSyncStorage);
+    });
+
+    it('deletes local data from all storages and clears them', async () => {
+        const storageId2 = asStorageId('2');
+        const storage2 = createSuiteSyncStorageMock({
+            deleteLocalData: jest.fn().mockResolvedValue(ok()),
+        });
+
+        const repository = createSuiteSyncStorageRepository();
+
+        repository.set(storageId1, storage);
+        repository.set(storageId2, storage2);
+
+        const result = await repository.deleteLocalData();
+
+        expect(result).toEqual(ok());
+        expect(storage.deleteLocalData).toHaveBeenCalledTimes(1);
+        expect(storage2.deleteLocalData).toHaveBeenCalledTimes(1);
+        expect(storage.dispose).not.toHaveBeenCalled();
+        expect(repository.get(storageId1)).toBeNull();
+        expect(repository.get(storageId2)).toBeNull();
+    });
+
+    it('propagates local data deletion error and keeps storages tracked', async () => {
+        const deleteLocalDataError = createSuiteSyncDeleteLocalDataError(
+            'Delete failed',
+            new Error('Delete failed'),
+        );
+        const failedStorage = createSuiteSyncStorageMock({
+            deleteLocalData: jest.fn().mockResolvedValue(err(deleteLocalDataError)),
+        });
+
+        const repository = createSuiteSyncStorageRepository();
+
+        repository.set(storageId1, failedStorage);
+
+        const result = await repository.deleteLocalData();
+
+        expect(result).toEqual(err(deleteLocalDataError));
+        expect(failedStorage.deleteLocalData).toHaveBeenCalledTimes(1);
+        expect(repository.get(storageId1)).toBe(failedStorage);
     });
 });

--- a/suite-common/suite-sync/src/storage/tests/createTurnOffSuiteSyncForWallet.test.ts
+++ b/suite-common/suite-sync/src/storage/tests/createTurnOffSuiteSyncForWallet.test.ts
@@ -21,6 +21,7 @@ describe(createTurnOffSuiteSyncForWallet.name, () => {
             suiteSyncStorageRepository: {
                 get: null,
                 delete: () => Promise.resolve(),
+                deleteLocalData: null,
                 set: null,
             },
         });

--- a/suite-common/suite-sync/tests/createSuiteSyncStorageMock.mock.ts
+++ b/suite-common/suite-sync/tests/createSuiteSyncStorageMock.mock.ts
@@ -21,6 +21,7 @@ type CreateSuiteSyncStorageMockParams = {
     addresses?: Partial<AddressTable>;
     outputs?: Partial<OutputTable>;
     updateRelayUrl?: SuiteSyncStorage['updateRelayUrl'];
+    deleteLocalData?: SuiteSyncStorage['deleteLocalData'];
     dispose?: SuiteSyncStorage['dispose'];
 };
 
@@ -32,6 +33,7 @@ export const createSuiteSyncStorageMock = (params: CreateSuiteSyncStorageMockPar
             addresses: createSuiteSyncTableMock<AddressTable>(params.addresses),
             outputs: createSuiteSyncTableMock<OutputTable>(params.outputs),
         },
+        deleteLocalData: params.deleteLocalData ?? mockNotExpected('deleteLocalData'),
         dispose: params.dispose ?? mockNotExpected('dispose'),
         updateRelayUrl: params.updateRelayUrl ?? mockNotExpected('updateRelayUrl'),
     }) satisfies SuiteSyncStorage;

--- a/suite-common/test-utils/src/extraDependenciesCommonMock.ts
+++ b/suite-common/test-utils/src/extraDependenciesCommonMock.ts
@@ -23,6 +23,7 @@ import { mockAnalytics } from '@trezor/analytics-uploader/mocks';
 import { err, ok } from '@trezor/type-utils';
 
 const suiteSyncMock: SuiteSync = {
+    deleteSuiteSyncLocalData: () => Promise.resolve(ok()),
     changeRelayUrl: () => Promise.resolve(),
     ensureWalletSuiteSyncOn: () =>
         Promise.resolve(err({ type: 'SuiteSyncUnavailableOnDeviceError' })),


### PR DESCRIPTION
Blocked by: https://github.com/evoluhq/evolu/issues/676

Wipe data shall also delete SQL databases. 

Seems it is not implemented in Evolu yet.

<img width="490" height="292" alt="Image" src="https://github.com/user-attachments/assets/4d73730f-e36d-4c00-8850-e1404882fc3d" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=wipe-data-suite-sync&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=wipe-data-suite-sync&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=wipe-data-suite-sync&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-12T12:35:53.150Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-12T12:34:23.611Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/wipe-data-suite-sync/web/](https://dev.suite.sldev.cz/suite-web/wipe-data-suite-sync/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are concentrated in the Suite Sync storage layer (evoluStorage, storage repository, deletion logic, types, and composition root) along with suiteThunks and a Settings Debug WipeData component. The highest risk is to Suite Sync / metadata labeling functionality — creating, reading, removing, and migrating labels via the Evolu relay. The suiteThunks.ts and evoluStorage.ts changes map to 121 tests but are broad dependencies; only tests that directly exercise Suite Sync or metadata labeling workflows warrant targeted testing. The recommended strategy prioritizes all Suite Sync E2E tests and legacy-to-Suite-Sync migration tests, with medium coverage for metadata lifecycle tests that interact with the changed infrastructure.

<details><summary><b>Changed files (20)</b></summary>

- `packages/suite/src/actions/suite/__tests__/suiteThunks.test.ts`
- `packages/suite/src/actions/suite/suiteThunks.ts`
- `packages/suite/src/views/settings/SettingsDebug/WipeData.tsx`
- `suite-common/suite-sync-evolu/src/evoluStorage.ts`
- `suite-common/suite-sync-evolu/tests/createEvoluStorageFactory.test.ts`
- `suite-common/suite-sync-storage/src/SuiteSyncStorage.ts`
- `suite-common/suite-sync-storage/src/index.ts`
- `suite-common/suite-sync-types/src/SuiteSync.ts`
- `suite-common/suite-sync-types/src/index.ts`
- `suite-common/suite-sync-types/src/storage/deleteSuiteSyncLocalData.ts`
- `suite-common/suite-sync-types/src/storage/suiteSyncStorageRepository.ts`
- `suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts`
- `suite-common/suite-sync/src/relay/tests/createChangeRelayUrl.test.ts`
- `suite-common/suite-sync/src/storage/createDeleteSuiteSyncLocalData.ts`
- `suite-common/suite-sync/src/storage/createSuiteSyncStorageRepository.ts`
- `suite-common/suite-sync/src/storage/tests/createEnsureStorage.test.ts`
- `suite-common/suite-sync/src/storage/tests/createSuiteSyncStorageRepository.test.ts`
- `suite-common/suite-sync/src/storage/tests/createTurnOffSuiteSyncForWallet.test.ts`
- `suite-common/suite-sync/tests/createSuiteSyncStorageMock.mock.ts`
- `suite-common/test-utils/src/extraDependenciesCommonMock.ts`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — This test directly exercises Suite Sync label creation and syncing to the Evolu Relay backend. The changes modify core Suite Sync storage infrastructure (evoluStorage.ts, createSuiteSyncStorageRepository.ts, SuiteSyncStorage.ts, deleteSuiteSyncLocalData.ts, suiteSyncStorageRepository.ts) and the composition root, which are all in the critical path for creating and syncing labels.
- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — Tests multi-wallet Suite Sync label syncing with passphrase wallets, enabling/declining Suite Sync, and verifying data reaches the Evolu Relay. Changes to storage repository, composition root, and storage types directly affect how Suite Sync initializes and persists per-wallet sync state.
- `suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts` — Tests removing Suite Sync labels and verifying null values are synced back to the Evolu relay. The changed storage deletion logic (createDeleteSuiteSyncLocalData.ts, deleteSuiteSyncLocalData.ts) and storage repository changes directly affect label removal behavior.
- `suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — Tests syncing labels FROM the Evolu relay server TO the Suite UI. The storage repository and evolu storage changes affect how data is read from the relay and presented. Also statically mapped to the WipeData.tsx change.
- `suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts` — Tests migrating labels from legacy Dropbox-based labeling to Suite Sync, seeding the Evolu relay server, and verifying the migration. Changes to evoluStorage, storage repository, and the composition root directly affect the migration target (Suite Sync infrastructure).
- `suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts` — Tests the full legacy-to-Suite-Sync migration flow including verifying labels persist after migration and data is synced to the Evolu Relay. Changes to the Suite Sync storage layer and deletion logic are directly exercised.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/metadata/legacy/metadata-lifecycle.test.ts` — Tests the full metadata labeling lifecycle including enabling, disabling, forgetting devices, and re-enabling. Changes to suiteThunks.ts (which handles suite-level actions) and the metadata storage layer could affect labeling state persistence across these transitions.
- `suite/e2e/tests/metadata/legacy/remembered-device.test.ts` — Tests metadata provider connection/disconnection and label persistence on remembered devices. The suiteThunks changes and storage repository changes could affect how metadata state is managed when providers are toggled and devices are remembered.
- `suite/e2e/tests/settings/general.test.ts` — The WipeData.tsx component is in the Settings Debug tab, and suiteThunks.ts handles core suite actions including settings changes. This test validates settings changes (fiat, theme, language, analytics toggle) which flow through suiteThunks.

</details>

⚠️ **Changes with no test coverage (15)**
- `packages/suite/src/actions/suite/__tests__/suiteThunks.test.ts`
- `suite-common/suite-sync-evolu/tests/createEvoluStorageFactory.test.ts`
- `suite-common/suite-sync-storage/src/SuiteSyncStorage.ts`
- `suite-common/suite-sync-storage/src/index.ts`
- `suite-common/suite-sync-types/src/SuiteSync.ts`
- `suite-common/suite-sync-types/src/index.ts`
- `suite-common/suite-sync-types/src/storage/deleteSuiteSyncLocalData.ts`
- `suite-common/suite-sync-types/src/storage/suiteSyncStorageRepository.ts`
- `suite-common/suite-sync/src/relay/tests/createChangeRelayUrl.test.ts`
- `suite-common/suite-sync/src/storage/createDeleteSuiteSyncLocalData.ts`
- `suite-common/suite-sync/src/storage/tests/createEnsureStorage.test.ts`
- `suite-common/suite-sync/src/storage/tests/createSuiteSyncStorageRepository.test.ts`
- `suite-common/suite-sync/src/storage/tests/createTurnOffSuiteSyncForWallet.test.ts`
- `suite-common/suite-sync/tests/createSuiteSyncStorageMock.mock.ts`
- `suite-common/test-utils/src/extraDependenciesCommonMock.ts`

_Updated: 2026-06-12T12:31:31.286Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->