### PR TITLE
Revert "chore(suite-native): allow importing from testUtils deep paths"

### DIFF
--- a/eslint-local-rules/rules.test.ts
+++ b/eslint-local-rules/rules.test.ts
@@ -14,8 +14,6 @@ ruleTester.run('no-package-deep-imports', rules['no-package-deep-imports'], {
         // Mocks entry point is allowed
         { code: "import { mock } from '@suite-common/bluetooth/mocks';" },
         { code: "import { mock } from '@suite-common/thp/mocks';" },
-        // testUtils entry point is allowed
-        { code: "import { mock } from '@suite-native/trading-state/testUtils';" },
         // Non-restricted scopes are allowed regardless of depth
         { code: "import { debounce } from 'lodash/fp';" },
         { code: "import React from 'react';" },
@@ -83,19 +81,6 @@ ruleTester.run('no-package-deep-imports', rules['no-package-deep-imports'], {
                     data: {
                         sourcePath: '@suite-common/bluetooth/mocks/createBluetoothDeviceCommon',
                         packageImportPath: '@suite-common/bluetooth/mocks',
-                    },
-                },
-            ],
-        },
-        // Deep testUtils imports should suggest the testUtils entry point
-        {
-            code: "import { createLightStore } from '@suite-native/trading-state/testUtils/createLightStore';",
-            errors: [
-                {
-                    messageId: 'doNotImportPackageDeepPath',
-                    data: {
-                        sourcePath: '@suite-native/trading-state/testUtils/createLightStore',
-                        packageImportPath: '@suite-native/trading-state/testUtils',
                     },
                 },
             ],

--- a/eslint-local-rules/rules.ts
+++ b/eslint-local-rules/rules.ts
@@ -91,15 +91,6 @@ const getSuggestedImportPath = (
         return `${packageImportPath}/mocks`;
     }
 
-    // Allow @scope/pkg/testUtils as a valid entry point
-    if (sourcePathParts[2] === 'testUtils') {
-        if (sourcePathParts.length === 3) {
-            return null;
-        }
-
-        return `${packageImportPath}/testUtils`;
-    }
-
     return packageImportPath;
 };
 


### PR DESCRIPTION

## Description
- Revert of accidentally pushed commit

<!--- Describe your changes in detail -->

## Notes for QA

Nothing to test
<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files (eslint-local-rules/rules.test.ts and eslint-local-rules/rules.ts) are ESLint custom lint rules and their unit tests. These are developer tooling files that run at lint/build time and have zero impact on application runtime behavior or any user-facing functionality. None of the 23 candidate E2E tests exercise ESLint rules, and there is no plausible path by which these changes could cause a regression in any E2E test. No E2E tests are recommended.

<details><summary><b>Changed files (2)</b></summary>

- `eslint-local-rules/rules.test.ts`
- `eslint-local-rules/rules.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (2)**
- `eslint-local-rules/rules.test.ts`
- `eslint-local-rules/rules.ts`

_Updated: 2026-06-08T14:08:03.209Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=revert-eslint-testUtils&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=revert-eslint-testUtils&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-08T14:14:19.720Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add account types ada | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-08T14:10:57.810Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/revert-eslint-testUtils/web/](https://dev.suite.sldev.cz/suite-web/revert-eslint-testUtils/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->