### PR TITLE
fix(suite-native): prevent biometrics resume bypass

### DIFF
--- a/suite-native/biometrics/src/__tests__/biometricsThunks.test.ts
+++ b/suite-native/biometrics/src/__tests__/biometricsThunks.test.ts
@@ -247,6 +247,37 @@ describe('biometricsThunks', () => {
             expect(LocalAuthentication.authenticateAsync).not.toHaveBeenCalled();
         });
 
+        it('should require authentication again when returning active after failed authentication', async () => {
+            mockFailedAuthentication();
+            const store = createBiometricsStore({
+                ...biometricsSliceInitialState,
+                isBiometricsEnabled: true,
+            });
+
+            await store.dispatch(authenticateUserThunk());
+
+            const backgroundResult = await store.dispatch(
+                handleBiometricsAppStateChangeThunk({ nextAppState: 'background' }),
+            );
+
+            // Clear the failed authentication call so the final expectation only checks the retry.
+            jest.mocked(LocalAuthentication.authenticateAsync).mockClear();
+
+            const activeResult = await store.dispatch(
+                handleBiometricsAppStateChangeThunk({ nextAppState: 'active' }),
+            );
+            // The app-state thunk dispatches authentication without awaiting it.
+            await Promise.resolve();
+
+            expect(backgroundResult.payload).toEqual({
+                isUserAuthenticated: false,
+                goneToBackgroundAtTimestamp: null,
+            });
+            expect(activeResult.payload).toBe(undefined);
+            expect(store.getState().biometrics.isUserAuthenticated).toBe(false);
+            expect(LocalAuthentication.authenticateAsync).toHaveBeenCalled();
+        });
+
         it('should dispatch authentication when returning active after timeout', async () => {
             const store = createBiometricsStore({
                 ...biometricsSliceInitialState,

--- a/suite-native/biometrics/src/__tests__/biometricsThunks.test.ts
+++ b/suite-native/biometrics/src/__tests__/biometricsThunks.test.ts
@@ -260,6 +260,7 @@ describe('biometricsThunks', () => {
                 handleBiometricsAppStateChangeThunk({ nextAppState: 'background' }),
             );
 
+            expect(LocalAuthentication.authenticateAsync).toHaveBeenCalled();
             // Clear the failed authentication call so the final expectation only checks the retry.
             jest.mocked(LocalAuthentication.authenticateAsync).mockClear();
 

--- a/suite-native/biometrics/src/biometricsThunks.ts
+++ b/suite-native/biometrics/src/biometricsThunks.ts
@@ -11,6 +11,7 @@ import {
     selectGoneToBackgroundAtTimestamp,
     selectIsBiometricsEnabled,
     selectIsTogglingBiometrics,
+    selectIsUserAuthenticated,
     selectShouldUserBeAuthenticated,
 } from './biometricsSelectors';
 import { getIsBiometricsFeatureAvailable, getShouldRevokeAuth } from './biometricsUtils';
@@ -33,7 +34,7 @@ type BiometricsToggleRejectReason =
 
 export type BiometricsAppStateChangePayload = {
     isUserAuthenticated?: boolean;
-    goneToBackgroundAtTimestamp?: number;
+    goneToBackgroundAtTimestamp?: number | null;
 };
 
 type BiometricsAppStateChangeRejectReason = 'biometrics-disabled' | 'unhandled-app-state';
@@ -111,7 +112,13 @@ export const handleBiometricsAppStateChangeThunk = createThunk<
         const shouldUserBeAuthenticated = selectShouldUserBeAuthenticated(getState());
         const isTogglingBiometricsInProgress = selectIsTogglingBiometrics(getState());
         const isBiometricsOptionEnabled = selectIsBiometricsEnabled(getState());
+        const isUserAuthenticated = selectIsUserAuthenticated(getState());
         const shouldRevokeAuth = getShouldRevokeAuth(goneToBackgroundAtTimestamp);
+        // Keep the first timestamp for one background session so repeated inactive/background
+        // events do not extend the keep-logged-in window.
+        const newGoneToBackgroundAtTimestamp = isUserAuthenticated
+            ? Date.now()
+            : goneToBackgroundAtTimestamp;
 
         if (!isBiometricsOptionEnabled) {
             return rejectWithValue('biometrics-disabled');
@@ -119,8 +126,9 @@ export const handleBiometricsAppStateChangeThunk = createThunk<
 
         switch (nextAppState) {
             case 'active':
+                // Returning to the foreground within the keep-logged-in window: restore prior auth.
+                // This should only be executed if user has been previously authenticated, which is controlled by the goneToBackgroundAtTimestamp.
                 if (!shouldRevokeAuth) {
-                    // Returning to the foreground within the keep-logged-in window: restore prior auth.
                     return { isUserAuthenticated: true };
                 }
 
@@ -139,19 +147,19 @@ export const handleBiometricsAppStateChangeThunk = createThunk<
 
                 return {
                     isUserAuthenticated: false,
-                    goneToBackgroundAtTimestamp: Date.now(),
+                    goneToBackgroundAtTimestamp: newGoneToBackgroundAtTimestamp,
                 };
 
             case 'inactive':
                 if (isTogglingBiometricsInProgress) {
                     // Native biometrics prompt moves the app to inactive while toggling from settings.
                     // Keep the current authentication state and only refresh the background timestamp.
-                    return { goneToBackgroundAtTimestamp: Date.now() };
+                    return { goneToBackgroundAtTimestamp: newGoneToBackgroundAtTimestamp };
                 }
 
                 return {
                     isUserAuthenticated: false,
-                    goneToBackgroundAtTimestamp: Date.now(),
+                    goneToBackgroundAtTimestamp: newGoneToBackgroundAtTimestamp,
                 };
 
             default:

--- a/suite-native/biometrics/src/types.ts
+++ b/suite-native/biometrics/src/types.ts
@@ -9,6 +9,7 @@ export type BiometricsSliceState = {
     biometricsError: AuthenticateError | null;
     isTogglingBiometricsSettingsOption: boolean;
     isAuthenticatingUser: boolean;
+    // This property is crucial for bypassing authentication when returning to the app.
     goneToBackgroundAtTimestamp: number | null;
 };
 


### PR DESCRIPTION
## Description

Fixes a biometrics resume bypass where an unauthenticated user could return to the app within the keep-logged-in window and become authenticated without a successful biometric prompt.

The background timestamp is now treated as a grace marker only for users who were already authenticated before leaving the app. Unauthenticated background/inactive transitions clear the marker, so returning active requires authentication again.

## Notes for QA

Please verify this scenario on a device with biometrics enabled:

1. Open the app when biometrics is required.
2. Make the biometric prompt fail.
3. Leave the app and open the app switcher/recent apps.
4. Return to the app within 30 seconds.
5. Confirm the app still requires biometric authentication and does not unlock automatically.

Also verify that an already authenticated user can briefly background and return to the app within 30 seconds without being prompted again.

## Related Issue

Fixes bug from https://github.com/trezor/trezor-suite/pull/23224

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=juriczech/biometric-bypass&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->