### PR TITLE
fix(suite): clarify yield deposit steps

### DIFF
--- a/packages/suite/src/components/earn/yield/common/YieldActionStep.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldActionStep.tsx
@@ -13,7 +13,7 @@ import { YieldPendingTransaction } from './YieldPendingTransaction';
 
 const actionStepTranslationMap = {
     deposit: {
-        amountLabelTranslationId: 'TR_EARN_YIELD_AMOUNT_TO_SUPPLY',
+        amountLabelTranslationId: 'AMOUNT',
         submitTranslationId: 'TR_EARN_YIELD_SUPPLY',
         balanceLabelTranslationId: 'TR_BALANCE',
     },

--- a/packages/suite/src/components/earn/yield/common/YieldAmountCard.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldAmountCard.tsx
@@ -75,12 +75,7 @@ export const YieldAmountCard = ({
             <Column gap={8} width="100%" padding={{ vertical: 16, horizontal: 20 }}>
                 <Row justifyContent="space-between" alignItems="center" gap={16}>
                     <Text typographyStyle="body-md">
-                        <Translation
-                            id={
-                                heading?.amountLabelTranslationId ??
-                                'TR_EARN_YIELD_AMOUNT_TO_SUPPLY'
-                            }
-                        />
+                        <Translation id={heading?.amountLabelTranslationId ?? 'AMOUNT'} />
                     </Text>
                     {unitToggle && (
                         <TextButton

--- a/packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx
@@ -15,7 +15,7 @@ import type { YieldApprovalAction } from '../yieldFlowUtils';
 
 const approveStepTranslationMap = {
     deposit: {
-        amountLabelTranslationId: 'TR_EARN_YIELD_AMOUNT_TO_SUPPLY',
+        amountLabelTranslationId: 'AMOUNT',
         balanceLabelTranslationId: 'TR_BALANCE',
     },
     withdraw: {
@@ -25,6 +25,7 @@ const approveStepTranslationMap = {
 } as const;
 
 type ApproveButtonTranslationId =
+    | 'TR_EARN_YIELD_APPROVE_TOKEN_BUTTON'
     | 'TR_EARN_YIELD_REVOKE_APPROVAL'
     | 'TR_EARN_YIELD_INCREASE_APPROVAL'
     | 'TR_APPROVE_DATA_TITLE'
@@ -37,6 +38,10 @@ type GetApproveButtonTranslationIdParams = {
 const getApproveButtonTranslationId = ({
     approvalAction,
 }: GetApproveButtonTranslationIdParams): ApproveButtonTranslationId => {
+    if (approvalAction === 'approve') {
+        return 'TR_EARN_YIELD_APPROVE_TOKEN_BUTTON';
+    }
+
     if (approvalAction === 'revoke') {
         return 'TR_EARN_YIELD_REVOKE_APPROVAL';
     }
@@ -136,7 +141,7 @@ export const YieldApproveStep = ({
                         isDisabled={isDisabled || !!pendingApproveTransaction || !onApprovalSubmit}
                         isLoading={isLoading}
                     >
-                        <Translation id={approveButtonId} />
+                        <Translation id={approveButtonId} values={{ tokenSymbol: token.symbol }} />
                     </Button>
 
                     {approvalAction === 'revoke' && !isDisabled && (

--- a/packages/suite/src/components/earn/yield/supply/YieldSupplyForm.tsx
+++ b/packages/suite/src/components/earn/yield/supply/YieldSupplyForm.tsx
@@ -51,11 +51,7 @@ export const YieldSupplyForm = () => {
         flow,
     } = useYieldSupplyContext();
 
-    const {
-        approve: approveStepState,
-        action: actionStepState,
-        complete: completeStepState,
-    } = flow.stepStates;
+    const { approve: approveStepState, action: actionStepState } = flow.stepStates;
 
     const { approvalPendingTransaction, actionPendingTransaction: supplyPendingTransaction } =
         splitYieldPendingTransaction(pendingTransaction, 'deposit');
@@ -190,27 +186,51 @@ export const YieldSupplyForm = () => {
                                 />
                             )}
 
-                            <BulletList bulletSize="small" bulletGap={12} gap={24} titleGap={16}>
+                            <BulletList
+                                isOrdered
+                                bulletSize="large"
+                                bulletGap={12}
+                                gap={24}
+                                titleGap={16}
+                            >
                                 <BulletList.Item
                                     state={approveStepState}
                                     title={
-                                        <Row
-                                            justifyContent="space-between"
-                                            alignItems="center"
-                                            width="100%"
-                                        >
-                                            <Translation id="TR_EARN_YIELD_SELECT_AMOUNT_AND_APPROVE" />
-                                            {approveStepState === 'done' && (
-                                                <Button
-                                                    size="small"
-                                                    intent="neutral"
-                                                    priority="secondary"
-                                                    onClick={handleOnModify}
-                                                >
-                                                    <Translation id="TR_MODIFY" />
-                                                </Button>
-                                            )}
-                                        </Row>
+                                        <Column gap={8} width="100%">
+                                            <Text
+                                                typographyStyle="body-xs"
+                                                intent="neutral"
+                                                priority="secondary"
+                                                case="uppercase"
+                                            >
+                                                <Translation
+                                                    id="TR_STEP_OF_TOTAL"
+                                                    values={{
+                                                        index: 1,
+                                                        total: 2,
+                                                    }}
+                                                />
+                                            </Text>
+
+                                            <Row
+                                                justifyContent="space-between"
+                                                alignItems="center"
+                                                width="100%"
+                                                gap={16}
+                                            >
+                                                <Translation id="TR_EARN_YIELD_SELECT_AMOUNT_AND_APPROVE" />
+                                                {approveStepState === 'done' && (
+                                                    <Button
+                                                        size="small"
+                                                        intent="neutral"
+                                                        priority="secondary"
+                                                        onClick={handleOnModify}
+                                                    >
+                                                        <Translation id="TR_MODIFY" />
+                                                    </Button>
+                                                )}
+                                            </Row>
+                                        </Column>
                                     }
                                 >
                                     <YieldApproveStep
@@ -252,7 +272,33 @@ export const YieldSupplyForm = () => {
 
                                 <BulletList.Item
                                     state={actionStepState}
-                                    title={<Translation id="TR_EARN_YIELD_SUPPLY" />}
+                                    title={
+                                        <Column gap={8} width="100%">
+                                            <Text
+                                                typographyStyle="body-xs"
+                                                intent="neutral"
+                                                priority="secondary"
+                                                case="uppercase"
+                                            >
+                                                <Translation
+                                                    id="TR_STEP_OF_TOTAL"
+                                                    values={{
+                                                        index: 2,
+                                                        total: 2,
+                                                    }}
+                                                />
+                                            </Text>
+
+                                            <Row
+                                                justifyContent="space-between"
+                                                alignItems="center"
+                                                width="100%"
+                                                gap={16}
+                                            >
+                                                <Translation id="TR_EARN_YIELD_SUPPLY" />
+                                            </Row>
+                                        </Column>
+                                    }
                                 >
                                     {actionStepState === 'active' && (
                                         <YieldActionStep
@@ -291,11 +337,6 @@ export const YieldSupplyForm = () => {
                                         />
                                     )}
                                 </BulletList.Item>
-
-                                <BulletList.Item
-                                    state={completeStepState}
-                                    title={<Translation id="TR_EARN_YIELD_SUPPLY_COMPLETE" />}
-                                />
                             </BulletList>
                         </>
                     )}

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10170,6 +10170,10 @@ export const messages = defineMessages({
         id: 'TR_EARN_YIELD_APPROVE_SPENDING_TRANSACTION',
         defaultMessage: 'Approve spending transaction',
     },
+    TR_EARN_YIELD_APPROVE_TOKEN_BUTTON: {
+        id: 'TR_EARN_YIELD_APPROVE_TOKEN_BUTTON',
+        defaultMessage: 'Approve {tokenSymbol}',
+    },
     TR_EARN_SIGN_SUPPLYING_TRANSACTION: {
         id: 'TR_EARN_SIGN_SUPPLYING_TRANSACTION',
         defaultMessage: 'Sign deposit transaction',


### PR DESCRIPTION
## Description

- show Stablecoin Yield deposit as a two-step flow
- remove the “Deposit complete” step from the step list
- change the deposit amount field label to “Amount”
- include the token symbol in the approve CTA

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/28343

## Screenshots:

<img width="587" height="542" alt="image" src="https://github.com/user-attachments/assets/d5055486-6817-4e92-905c-eb0158a3ef7a" />

<img width="605" height="544" alt="image" src="https://github.com/user-attachments/assets/76a7b4a7-1da4-4239-8482-df1cc3ff7638" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are focused on earn/yield UI components (YieldActionStep, YieldAmountCard, YieldApproveStep, YieldSupplyForm) and the shared intl messages file. The yield components map to 121 tests via static analysis because they're bundled into the main app, but only staking/earn tests actually render these components. The messages.ts change is a shared dependency affecting all tests but is only relevant where changed translation keys are used. The recommended strategy prioritizes ETH staking tests (which most directly exercise these yield components), followed by SOL and ADA staking tests for cross-network coverage.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/components/earn/yield/common/YieldActionStep.tsx`
- `packages/suite/src/components/earn/yield/common/YieldAmountCard.tsx`
- `packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx`
- `packages/suite/src/components/earn/yield/supply/YieldSupplyForm.tsx`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test exercises the ETH staking flow including the staking form, amount display, and confirmation steps — directly exercising YieldSupplyForm, YieldAmountCard, and YieldActionStep components that were changed. The staking form validation, amount rendering, and step progression are core to these components.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — The stake-more flow uses the yield supply form to add additional ETH stake, directly rendering YieldSupplyForm, YieldAmountCard (for balance/amount display), and YieldActionStep (for the confirmation flow). Changes to these components could break the stake-more user journey.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — The unstake and claim flows exercise YieldActionStep (for device confirmation steps), YieldAmountCard (for displaying unstaking/claiming amounts), and YieldApproveStep. Changes to these shared yield components could break the unstake/claim user experience.
- `suite/e2e/tests/staking/staking-form.test.ts` — This test directly validates the ETH staking form inputs, validation errors, percentage buttons, max button, and crypto/fiat switching — all functionality rendered by YieldSupplyForm and YieldAmountCard. It's the most targeted form validation test for these components.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — SOL initial staking uses the yield supply form and action step components. While the primary changes target yield/earn components, Solana staking may use different code paths, so this provides cross-network coverage of the changed components.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — SOL stake-more exercises the YieldSupplyForm for adding additional SOL stake and YieldAmountCard for balance display, providing Solana-specific coverage of the changed yield components.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — SOL unstake and claim flows exercise YieldActionStep for the device confirmation steps and YieldAmountCard for displaying amounts, providing Solana-specific coverage for these changed components.
- `suite/e2e/tests/staking/ada/stake.test.ts` — Cardano staking exercises the staking nutshell modal and stake form which may render YieldSupplyForm and YieldAmountCard components. Provides ADA-specific coverage of yield component changes.
- `suite/e2e/tests/staking/ada/claim.test.ts` — ADA claim rewards exercises YieldActionStep for the device confirmation flow and YieldAmountCard for reward amount display. Changes to these components could affect the claim UX.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — ADA unstake exercises the yield action step flow and amount display components, providing Cardano-specific coverage for the changed yield components.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/staking/sol/rewards.test.ts` — SOL rewards display tests the staking dashboard which renders amount cards. While it doesn't exercise the supply form directly, YieldAmountCard changes could affect how staked/reward amounts are displayed.
- `suite/e2e/tests/general/check-links.test.ts` — This test visits earn/yield routes (/earn/yield/deposit, /earn/yield/withdraw, /earn/yield/claim) which render the changed components. If the components have rendering errors, these routes would fail to load.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/intl/src/messages.ts`

_Updated: 2026-06-08T20:01:55.278Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/yield-deposit-steps&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/yield-deposit-steps&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-08T14:55:28.330Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add account types ada | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-08T14:52:47.231Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/yield-deposit-steps/web/](https://dev.suite.sldev.cz/suite-web/fix/yield-deposit-steps/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->