### PR TITLE
refactor(utxo-lib): `composeTx` dependency injection (network)

### DIFF
--- a/packages/connect/src/api/bitcoin/TransactionComposer.ts
+++ b/packages/connect/src/api/bitcoin/TransactionComposer.ts
@@ -14,7 +14,7 @@ import type {
     ComposeOutput,
     TransactionInputOutputSortingStrategy,
 } from '@trezor/utxo-lib';
-import { composeTx, networks } from '@trezor/utxo-lib';
+import { address, composeTx, networks, payments } from '@trezor/utxo-lib';
 
 import type { Blockchain } from '../../backend/BlockchainLink';
 import { getOrInitBitcoinFeeLevels } from '../../backend/fees';
@@ -186,7 +186,9 @@ export class TransactionComposer {
             feeRate,
             longTermFeeRate: this.feeLevels.longTermFeeRate,
             sortingStrategy: this.sortingStrategy,
-            network: coinInfo.network,
+            toOutputScript: addr => address.toOutputScript(addr, coinInfo.network),
+            toOpReturnScript: dataHex =>
+                payments.embed({ data: [Buffer.from(dataHex, 'hex')] }).output as Buffer,
             changeAddress,
             dustThreshold: coinInfo.dustLimit,
             baseFee,

--- a/packages/utxo-lib/src/compose/request.ts
+++ b/packages/utxo-lib/src/compose/request.ts
@@ -1,6 +1,5 @@
 import { throwError } from '@trezor/utils';
 
-import { toOutputScript } from '../address';
 import {
     INPUT_SCRIPT_LENGTH,
     OUTPUT_SCRIPT_LENGTH,
@@ -8,8 +7,6 @@ import {
     outputWeight,
     parseBigInt,
 } from '../coinselect/coinselectUtils';
-import type { Network } from '../networks';
-import { p2data } from '../payments/embed';
 import type {
     CoinSelectInput,
     CoinSelectOutput,
@@ -102,13 +99,14 @@ function validateAndParseUtxos(
 function transformOutput(
     output: ComposeOutput,
     txType: CoinSelectPaymentType,
-    network: Network,
+    toOutputScript: (address: string) => { length: number },
+    toOpReturnScript: (dataHex: string) => { length: number },
 ): CoinSelectOutput {
     const script = { length: OUTPUT_SCRIPT_LENGTH[txType] };
     if (output.type === 'payment') {
         return {
             value: parseBigInt(output.amount) ?? throwError('Invalid amount'),
-            script: toOutputScript(output.address, network),
+            script: toOutputScript(output.address),
         };
     }
     if (output.type === 'payment-noaddress') {
@@ -120,12 +118,12 @@ function transformOutput(
     if (output.type === 'opreturn') {
         return {
             value: parseBigInt('0', true),
-            script: p2data({ data: [Buffer.from(output.dataHex, 'hex')] }).output as Buffer,
+            script: toOpReturnScript(output.dataHex),
         };
     }
     if (output.type === 'send-max') {
         return {
-            script: toOutputScript(output.address, network),
+            script: toOutputScript(output.address),
         };
     }
     if (output.type === 'send-max-noaddress') {
@@ -138,7 +136,7 @@ function transformOutput(
 
 function validateAndParseOutputs(
     txType: CoinSelectPaymentType,
-    { outputs, network }: Request,
+    { outputs, toOutputScript, toOpReturnScript }: Request,
 ):
     | {
           outputs: CoinSelectOutput[];
@@ -169,7 +167,7 @@ function validateAndParseOutputs(
         }
 
         try {
-            const csOutput = transformOutput(output, txType, network);
+            const csOutput = transformOutput(output, txType, toOutputScript, toOpReturnScript);
             csOutput.weight = outputWeight(csOutput);
             result.push(csOutput);
         } catch (error) {
@@ -185,11 +183,16 @@ function validateAndParseOutputs(
 
 function validateAndParseChangeOutput(
     txType: CoinSelectPaymentType,
-    { changeAddress, network }: Request,
+    { changeAddress, toOutputScript, toOpReturnScript }: Request,
 ): CoinSelectOutput | ComposeResultError {
     // NOTE: use "send-max" to create changeOutput. we don't know the final amount yet
     try {
-        return transformOutput({ type: 'send-max', ...changeAddress }, txType, network);
+        return transformOutput(
+            { type: 'send-max', ...changeAddress },
+            txType,
+            toOutputScript,
+            toOpReturnScript,
+        );
     } catch (error) {
         return {
             type: 'error',

--- a/packages/utxo-lib/src/types/compose.ts
+++ b/packages/utxo-lib/src/types/compose.ts
@@ -1,4 +1,3 @@
-import type { Network } from '../networks';
 import type { CoinSelectPaymentType } from './coinselect';
 
 // UTXO == unspent transaction output = all I can spend
@@ -93,7 +92,8 @@ export type ComposeRequest<
     feeRate: string | number; // in sat/byte, virtual size
     feePolicy?: ComposeFeePolicy; // explicit fee policy
     longTermFeeRate?: string | number; // dust output feeRate multiplier in sat/byte, virtual size
-    network: Network;
+    toOutputScript: (address: string) => { length: number };
+    toOpReturnScript: (dataHex: string) => { length: number };
     changeAddress: Change;
     dustThreshold: number; // explicit dust threshold, in satoshi
     baseFee?: number; // DOGE or RBF base fee

--- a/packages/utxo-lib/tests/__fixtures__/compose.crosscheck.ts
+++ b/packages/utxo-lib/tests/__fixtures__/compose.crosscheck.ts
@@ -11,9 +11,7 @@ type AnyComposeRequest = ComposeRequest<ComposeInput, ComposeOutput, ComposeChan
 
 type Fixture = {
     description: string;
-    request: Omit<AnyComposeRequest, 'network'> & {
-        network?: AnyComposeRequest['network'];
-    };
+    request: Omit<AnyComposeRequest, 'toOutputScript' | 'toOpReturnScript'>;
     result: Partial<Record<`${CoinSelectPaymentType}-${CoinSelectPaymentType}`, { bytes: number }>>;
 };
 

--- a/packages/utxo-lib/tests/__fixtures__/compose.ts
+++ b/packages/utxo-lib/tests/__fixtures__/compose.ts
@@ -1,4 +1,4 @@
-import { bitcoincash, doge } from '../../src/networks';
+import { Network, bitcoincash, doge } from '../../src/networks';
 import {
     ComposeChangeAddress,
     ComposeInput,
@@ -24,8 +24,11 @@ type AnyComposeFinalResult = ComposeResultFinal<ComposeInput, ComposeOutput, Com
 
 type Fixture = {
     description: string;
-    request: Omit<AnyComposeRequest, 'network' | 'outputs' | 'changeAddress'> & {
-        network?: AnyComposeRequest['network'];
+    request: Omit<
+        AnyComposeRequest,
+        'toOutputScript' | 'toOpReturnScript' | 'outputs' | 'changeAddress'
+    > & {
+        network?: Network;
         outputs: Array<AnyComposeRequest['outputs'][number] & { customField?: string }>;
         changeAddress: AnyComposeRequest['changeAddress'] & { path?: number[] | string };
     };

--- a/packages/utxo-lib/tests/compose.request.test.ts
+++ b/packages/utxo-lib/tests/compose.request.test.ts
@@ -1,6 +1,7 @@
 import type { ComposeRequest } from '../src';
+import * as baddress from '../src/address';
 import { validateAndParseRequest as validate } from '../src/compose/request';
-import * as NETWORKS from '../src/networks';
+import { p2data } from '../src/payments/embed';
 
 const UTXO = {
     coinbase: false,
@@ -17,7 +18,9 @@ const REQUEST: ComposeRequest<any, any, any> = {
     utxos: [UTXO],
     outputs: [PAYMENT],
     feeRate: 1,
-    network: NETWORKS.bitcoin,
+    toOutputScript: (addr: string) => baddress.toOutputScript(addr),
+    toOpReturnScript: (dataHex: string) =>
+        p2data({ data: [Buffer.from(dataHex, 'hex')] }).output as Buffer,
     changeAddress: { address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT' },
     dustThreshold: 526,
     sortingStrategy: 'bip69',

--- a/packages/utxo-lib/tests/compose.test.ts
+++ b/packages/utxo-lib/tests/compose.test.ts
@@ -4,14 +4,22 @@ import { verifyTxBytes } from './compose.utils';
 import { composeTx } from '../src/compose';
 import { composeTxFixture } from './__fixtures__/compose';
 import { fixturesCrossCheck } from './__fixtures__/compose.crosscheck';
+import * as address from '../src/address';
 import { getErrorResult } from '../src/compose/result';
 import { bip69SortingStrategy } from '../src/compose/sorting/bip69SortingStrategy';
 import * as NETWORKS from '../src/networks';
+import { p2data } from '../src/payments/embed';
 
 jest.mock('@trezor/utils', () => ({
     ...jest.requireActual('@trezor/utils'),
     getRandomInt: jest.fn(),
 }));
+
+const scriptFnsFromNetwork = (network: NETWORKS.Network) => ({
+    toOutputScript: (addr: string) => address.toOutputScript(addr, network),
+    toOpReturnScript: (dataHex: string) =>
+        p2data({ data: [Buffer.from(dataHex, 'hex')] }).output as Buffer,
+});
 
 const mockRandomInt = (randomIntSequence: number[] | undefined) => {
     let fakeRandomIndex = 0;
@@ -27,7 +35,7 @@ const mockRandomInt = (randomIntSequence: number[] | undefined) => {
 describe(composeTx.name, () => {
     composeTxFixture.forEach(f => {
         const network = f.request.network ?? NETWORKS.bitcoin;
-        const request = { ...f.request, network };
+        const request = { ...f.request, ...scriptFnsFromNetwork(network) };
         const result = { ...f.result };
 
         it(f.description, () => {
@@ -51,7 +59,7 @@ describe('composeTx request validation errors', () => {
             utxos: [],
             outputs: [{ type: 'send-max-noaddress' }],
             feeRate: 10,
-            network: NETWORKS.bitcoin,
+            ...scriptFnsFromNetwork(NETWORKS.bitcoin),
             changeAddress: { address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT' },
             dustThreshold: 546,
             sortingStrategy: 'bip69',
@@ -74,7 +82,7 @@ describe('composeTx request validation errors', () => {
             ],
             outputs: [{ type: 'send-max-noaddress' }],
             feeRate: 10,
-            network: NETWORKS.bitcoin,
+            ...scriptFnsFromNetwork(NETWORKS.bitcoin),
             changeAddress: { address: 'not-a-valid-address' },
             dustThreshold: 546,
             sortingStrategy: 'bip69',
@@ -107,7 +115,7 @@ describe('composeTx request validation errors', () => {
                 },
             ],
             feeRate: 10,
-            network: NETWORKS.bitcoin,
+            ...scriptFnsFromNetwork(NETWORKS.bitcoin),
             changeAddress: { address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT' },
             dustThreshold: 546,
             sortingStrategy: 'bip69',
@@ -134,7 +142,7 @@ describe('composeTx request validation errors', () => {
             ],
             outputs: [{ type: 'send-max-noaddress' }],
             feeRate: 0,
-            network: NETWORKS.bitcoin,
+            ...scriptFnsFromNetwork(NETWORKS.bitcoin),
             changeAddress: { address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT' },
             dustThreshold: 546,
             sortingStrategy: 'bip69',
@@ -220,7 +228,7 @@ describe('composeTx addresses cross-check', () => {
                 it(`${key} ${f.description}`, () => {
                     const tx = composeTx({
                         ...f.request,
-                        network: NETWORKS.bitcoin,
+                        ...scriptFnsFromNetwork(NETWORKS.bitcoin),
                         txType,
                         utxos: f.request.utxos.map(utxo => ({
                             ...utxo,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Prerequisite for https://github.com/trezor/trezor-suite/pull/28285

Part 2 of [removing network parameter](https://github.com/trezor/trezor-suite/pull/28366)  from the `composeTx` module.

replace network with 2 functions passed in params:
- toOutputScript
- toOpReturnScript

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes modify Bitcoin UTXO transaction composition logic (TransactionComposer, compose/request.ts, compose types) and their unit tests/fixtures. The core risk is that transaction composition — amount calculation, fee estimation, output handling, and edge cases like MAX_SAFE_INTEGER amounts — could regress. The recommended strategy focuses on tests that directly exercise Bitcoin-like send flows (BTC, DOGE, LTC) and trading flows that depend on composed transaction info (swap fees, sell with fees). The compose.ts types file maps to 121 tests but is a broad shared type definition; only tests that actually exercise UTXO transaction composition are included.

<details><summary><b>Changed files (7)</b></summary>

- `packages/connect/src/api/bitcoin/TransactionComposer.ts`
- `packages/utxo-lib/src/compose/request.ts`
- `packages/utxo-lib/src/types/compose.ts`
- `packages/utxo-lib/tests/__fixtures__/compose.crosscheck.ts`
- `packages/utxo-lib/tests/__fixtures__/compose.ts`
- `packages/utxo-lib/tests/compose.request.test.ts`
- `packages/utxo-lib/tests/compose.test.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test exercises the Bitcoin send form with multiple outputs, locktime, OP_RETURN, and unit switching — all of which directly depend on the UTXO transaction composition logic in TransactionComposer.ts and compose/request.ts. Changes to how transactions are composed or requested could break output management, amount calculation, or transaction submission.
- `suite/e2e/tests/wallet/send-doge.test.ts` — This test specifically validates sending a DOGE amount exceeding MAX_SAFE_INTEGER, which directly exercises edge cases in transaction composition and amount handling in TransactionComposer and compose/request.ts. The test verifies error handling for invalid amounts during signing, which is core to the changed code.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — This test verifies custom fee rate settings for BTC swap transactions and checks that fee, total amount, and fee rate are correctly calculated and displayed. It directly validates the composed transaction info from the Redux state (wallet.trading.composedTransactionInfo), which is populated by TransactionComposer using compose/request.ts.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — This test completes a full sell BTC flow including fee calculation and send transaction initiation. It verifies Bitcoin fee is calculated and displayed correctly, which depends on the transaction composition pipeline. Changes to compose types or request logic could affect fee computation.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — This test validates sell form input behavior including the Max button calculation (total balance minus custom fee), custom fee rate setting, and percentage-based amount calculation for BTC — all of which rely on the transaction composition logic to compute available amounts and fees.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — This test sends LTC with a MimbleWimble peg-out output, using set-max amount and broadcast mode. It exercises the UTXO transaction composition for a non-BTC Bitcoin-like coin, which is handled by the same TransactionComposer and compose/request.ts code paths.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/wallet/pending-transactions.test.ts` — This test sends multiple Bitcoin transactions on regtest with multiple outputs. While it primarily tests pending transaction UI, the actual transaction creation flows through TransactionComposer, so composition changes could cause send failures.

</details>

⚠️ **Changes with no test coverage (4)**
- `packages/utxo-lib/tests/__fixtures__/compose.crosscheck.ts`
- `packages/utxo-lib/tests/__fixtures__/compose.ts`
- `packages/utxo-lib/tests/compose.request.test.ts`
- `packages/utxo-lib/tests/compose.test.ts`

_Updated: 2026-06-08T15:13:04.322Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/utxolib-compose-network&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/utxolib-compose-network&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/utxolib-compose-network&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-08T15:17:37.309Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add account types ada | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-08T15:15:45.183Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/utxolib-compose-network/web/](https://dev.suite.sldev.cz/suite-web/refactor/utxolib-compose-network/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->