### PR TITLE
Fix: historical fiat rates can be stored under wrong timestamps

### DIFF
--- a/suite-common/fiat-services/src/blockbook.test.ts
+++ b/suite-common/fiat-services/src/blockbook.test.ts
@@ -1,0 +1,32 @@
+import { getFiatRatesForTimestamps } from './blockbook';
+import { fetchUrl } from './fetch';
+
+jest.mock('../src/fetch', () => ({
+    fetchUrl: jest.fn(),
+}));
+
+const fetchUrlMock = jest.mocked(fetchUrl);
+
+describe(getFiatRatesForTimestamps.name, () => {
+    it('preserves timestamps returned by Blockbook', async () => {
+        fetchUrlMock.mockResolvedValue(
+            new Response(
+                JSON.stringify([
+                    {
+                        ts: 1746144000,
+                        rates: { usd: 0.25 },
+                    },
+                ]),
+            ),
+        );
+
+        const result = await getFiatRatesForTimestamps('btc', [1746057600], 'usd');
+
+        expect(result?.tickers).toEqual([
+            {
+                ts: 1746144000,
+                rates: { usd: 0.25 },
+            },
+        ]);
+    });
+});

--- a/suite-common/fiat-services/src/blockbook.ts
+++ b/suite-common/fiat-services/src/blockbook.ts
@@ -63,12 +63,7 @@ const getMultiTickers = async (
         rates && {
             ts: new Date().getTime(),
             symbol: ticker,
-            tickers: rates.map((rate, i) => {
-                // @ts-expect-error: indexing with noUncheckedIndexedAccess
-                const ts: (typeof timestamps)[number] = timestamps[i];
-
-                return { ...rate, ts };
-            }),
+            tickers: rates,
         }
     );
 };

--- a/suite-common/fiat-services/src/rates.test.ts
+++ b/suite-common/fiat-services/src/rates.test.ts
@@ -1,0 +1,211 @@
+import TrezorConnect from '@trezor/connect';
+
+import * as blockbookService from './blockbook';
+import * as coingeckoService from './coingecko';
+import { getFiatRatesForTimestamps } from './rates';
+
+jest.mock('@trezor/connect', () => ({
+    __esModule: true,
+    default: {
+        blockchainGetFiatRatesForTimestamps: jest.fn(),
+    },
+}));
+
+jest.mock('../src/blockbook', () => ({
+    getFiatRatesForTimestamps: jest.fn(),
+}));
+
+jest.mock('../src/coingecko', () => ({
+    getFiatRatesForTimestamps: jest.fn(),
+}));
+
+const getFiatRatesForTimestampsMock = jest.mocked(
+    TrezorConnect.blockchainGetFiatRatesForTimestamps,
+);
+const getBlockbookFiatRatesForTimestampsMock = jest.mocked(
+    blockbookService.getFiatRatesForTimestamps,
+);
+const getCoingeckoFiatRatesForTimestampsMock = jest.mocked(
+    coingeckoService.getFiatRatesForTimestamps,
+);
+
+describe(getFiatRatesForTimestamps.name, () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        getCoingeckoFiatRatesForTimestampsMock.mockResolvedValue(null);
+    });
+
+    it('fills unavailable Blockbook rates from CoinGecko', async () => {
+        const timestamps = [1575288000, 1780987510];
+
+        getFiatRatesForTimestampsMock.mockResolvedValue({
+            success: true,
+            payload: {
+                tickers: [
+                    {
+                        ts: 1575288000,
+                        rates: { usd: -1 },
+                    },
+                    {
+                        ts: 1780986661,
+                        rates: { usd: 0.324998 },
+                    },
+                ],
+            },
+        });
+        getCoingeckoFiatRatesForTimestampsMock.mockResolvedValue({
+            symbol: 'eth',
+            ts: Date.now(),
+            tickers: [
+                {
+                    ts: 1575288000,
+                    rates: { usd: 0.15 },
+                },
+            ],
+        });
+
+        const result = await getFiatRatesForTimestamps({ symbol: 'eth' }, timestamps, 'usd', false);
+
+        expect(getCoingeckoFiatRatesForTimestampsMock).toHaveBeenCalledWith(
+            { symbol: 'eth' },
+            [1575288000],
+            'usd',
+        );
+        expect(result).toMatchObject({
+            symbol: 'eth',
+            tickers: [
+                {
+                    ts: 1575288000,
+                    rates: { usd: 0.15 },
+                },
+                {
+                    ts: 1780987510,
+                    rates: { usd: 0.324998 },
+                },
+            ],
+        });
+    });
+
+    it('replaces Blockbook rates returned for a different UTC day with CoinGecko rates', async () => {
+        const timestamps = [1746057600, 1746144000];
+
+        getFiatRatesForTimestampsMock.mockResolvedValue({
+            success: true,
+            payload: {
+                tickers: [
+                    {
+                        ts: 1746144000,
+                        rates: { usd: 0.25 },
+                    },
+                    {
+                        ts: 1746147600,
+                        rates: { usd: 0.26 },
+                    },
+                ],
+            },
+        });
+        getCoingeckoFiatRatesForTimestampsMock.mockResolvedValue({
+            symbol: 'eth',
+            ts: Date.now(),
+            tickers: [
+                {
+                    ts: 1746057600,
+                    rates: { usd: 0.24 },
+                },
+            ],
+        });
+
+        const result = await getFiatRatesForTimestamps({ symbol: 'eth' }, timestamps, 'usd', false);
+
+        expect(result).toMatchObject({
+            symbol: 'eth',
+            tickers: [
+                {
+                    ts: 1746057600,
+                    rates: { usd: 0.24 },
+                },
+                {
+                    ts: 1746144000,
+                    rates: { usd: 0.26 },
+                },
+            ],
+        });
+    });
+
+    it('keeps a timestamp unavailable when CoinGecko has no fallback rate', async () => {
+        const timestamps = [1575288000, 1780987510];
+
+        getFiatRatesForTimestampsMock.mockResolvedValue({
+            success: true,
+            payload: {
+                tickers: [
+                    {
+                        ts: 1575288000,
+                        rates: { usd: -1 },
+                    },
+                    {
+                        ts: 1780986661,
+                        rates: { usd: 0.324998 },
+                    },
+                ],
+            },
+        });
+
+        const result = await getFiatRatesForTimestamps({ symbol: 'eth' }, timestamps, 'usd', false);
+
+        expect(result).toMatchObject({
+            symbol: 'eth',
+            tickers: [
+                {
+                    ts: 1780987510,
+                    rates: { usd: 0.324998 },
+                },
+            ],
+        });
+    });
+
+    it('fills unavailable rates returned by the direct Blockbook service', async () => {
+        const timestamps = [1575288000, 1780987510];
+
+        getBlockbookFiatRatesForTimestampsMock.mockResolvedValue({
+            symbol: 'btc',
+            ts: Date.now(),
+            tickers: [
+                {
+                    ts: 1575288000,
+                    rates: { usd: -1 },
+                },
+                {
+                    ts: 1780987510,
+                    rates: { usd: 0.324998 },
+                },
+            ],
+        });
+        getCoingeckoFiatRatesForTimestampsMock.mockResolvedValue({
+            symbol: 'btc',
+            ts: Date.now(),
+            tickers: [
+                {
+                    ts: 1575288000,
+                    rates: { usd: 0.15 },
+                },
+            ],
+        });
+
+        const result = await getFiatRatesForTimestamps({ symbol: 'btc' }, timestamps, 'usd', true);
+
+        expect(result).toMatchObject({
+            symbol: 'btc',
+            tickers: [
+                {
+                    ts: 1575288000,
+                    rates: { usd: 0.15 },
+                },
+                {
+                    ts: 1780987510,
+                    rates: { usd: 0.324998 },
+                },
+            ],
+        });
+    });
+});

--- a/suite-common/fiat-services/src/rates.ts
+++ b/suite-common/fiat-services/src/rates.ts
@@ -6,6 +6,7 @@ import type {
     HistoricRates,
     TickerId,
     Timestamp,
+    TimestampedRates,
 } from '@suite-common/wallet-types';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 import TrezorConnect from '@trezor/connect';
@@ -21,8 +22,93 @@ import { ParallelRequestsCache } from './cache';
 import * as coingeckoService from './coingecko';
 
 const CONNECT_FETCH_TIMEOUT = 10_000;
+const SECONDS_PER_DAY = 24 * 60 * 60;
 
 const parallelRequestsCache = new ParallelRequestsCache();
+
+const isSameUTCDay = (firstTimestamp: number, secondTimestamp: number): boolean =>
+    Math.floor(firstTimestamp / SECONDS_PER_DAY) === Math.floor(secondTimestamp / SECONDS_PER_DAY);
+
+type GetAvailableTickersParams = {
+    tickers: TimestampedRates[];
+    timestamps: number[];
+    baseCurrencyCode: BaseCurrencyCode;
+};
+
+const getAvailableTickers = ({
+    tickers,
+    timestamps,
+    baseCurrencyCode,
+}: GetAvailableTickersParams): TimestampedRates[] =>
+    tickers.flatMap((ticker, index) => {
+        const timestamp = timestamps[index];
+        const rate = ticker.rates[baseCurrencyCode];
+
+        if (
+            timestamp === undefined ||
+            rate === undefined ||
+            rate < 0 ||
+            !isSameUTCDay(timestamp, ticker.ts)
+        ) {
+            return [];
+        }
+
+        return [{ ...ticker, ts: timestamp }];
+    });
+
+type GetTickersWithFallbackParams = GetAvailableTickersParams & {
+    ticker: TickerId;
+};
+
+const getTickersWithFallback = async ({
+    ticker,
+    tickers,
+    timestamps,
+    baseCurrencyCode,
+}: GetTickersWithFallbackParams): Promise<TimestampedRates[]> => {
+    const availableTickers = getAvailableTickers({
+        tickers,
+        timestamps,
+        baseCurrencyCode,
+    });
+    const availableTickersByTimestamp = new Map(
+        availableTickers.map(availableTicker => [availableTicker.ts, availableTicker]),
+    );
+    const missingTimestamps = timestamps.filter(
+        timestamp => !availableTickersByTimestamp.has(timestamp),
+    );
+
+    if (missingTimestamps.length === 0) {
+        return availableTickers;
+    }
+
+    const coingeckoResponse = await coingeckoService.getFiatRatesForTimestamps(
+        ticker,
+        missingTimestamps,
+        baseCurrencyCode,
+    );
+    const coingeckoTickersByTimestamp = new Map(
+        coingeckoResponse?.tickers.map(coingeckoTicker => [coingeckoTicker.ts, coingeckoTicker]) ??
+            [],
+    );
+
+    return timestamps.flatMap(timestamp => {
+        const availableTicker = availableTickersByTimestamp.get(timestamp);
+
+        if (availableTicker) {
+            return [availableTicker];
+        }
+
+        const coingeckoTicker = coingeckoTickersByTimestamp.get(timestamp);
+        const rate = coingeckoTicker?.rates[baseCurrencyCode];
+
+        if (!coingeckoTicker || rate === undefined || rate < 0) {
+            return [];
+        }
+
+        return [coingeckoTicker];
+    });
+};
 
 type FiatRatesParams = {
     ticker: TickerId;
@@ -234,15 +320,15 @@ export const getFiatRatesForTimestamps = (
 
                     if (!result.success) return null;
 
-                    // in case blockbook does not know fiat rate, it returns -1
-                    const validTickers = result.payload.tickers.filter(
-                        tick => tick.rates[baseCurrencyCode] && tick.rates[baseCurrencyCode] >= 0,
-                    );
-
                     return {
                         ts: new Date().getTime(),
                         symbol: ticker.symbol,
-                        tickers: validTickers,
+                        tickers: await getTickersWithFallback({
+                            ticker,
+                            tickers: result.payload.tickers,
+                            timestamps,
+                            baseCurrencyCode,
+                        }),
                     };
                 }
 
@@ -252,7 +338,17 @@ export const getFiatRatesForTimestamps = (
                     baseCurrencyCode,
                 );
 
-                if (blockbookResponse) return blockbookResponse;
+                if (blockbookResponse) {
+                    return {
+                        ...blockbookResponse,
+                        tickers: await getTickersWithFallback({
+                            ticker,
+                            tickers: blockbookResponse.tickers,
+                            timestamps,
+                            baseCurrencyCode,
+                        }),
+                    };
+                }
             }
 
             const coingeckoResponse = await coingeckoService.getFiatRatesForTimestamps(

--- a/suite-common/graph/src/graphDataFetching.ts
+++ b/suite-common/graph/src/graphDataFetching.ts
@@ -319,12 +319,10 @@ const getFiatRatesForNetworkInTimeFrame = async ({
     );
     if (G.isNullable(fiatRates)) return null;
 
-    const formattedFiatRates: FiatRatesItem[] = fiatRates.tickers.flatMap((ticker, index) => {
-        const time = timestamps[index];
-        if (time === undefined) return [];
-
-        return [{ time, rates: ticker.rates }];
-    });
+    const formattedFiatRates: FiatRatesItem[] = fiatRates.tickers.map(ticker => ({
+        time: ticker.ts,
+        rates: ticker.rates,
+    }));
 
     fiatRatesCache[cacheKey] = formattedFiatRates;
 
@@ -504,8 +502,8 @@ export const getMultipleAccountBalanceHistoryWithFiat = async ({
     );
 
     const coinsFiatRates: Record<CoinKey, FiatRatesItem[]> = D.fromPairs(
-        // Some coins might not have fiat rates, so we need to filter them out
-        pairs.filter(([, res]) => res?.[0]?.rates?.[baseCurrencyCode] !== -1),
+        // Some coins might not have fiat rates, so filter them out.
+        pairs.filter(([, fiatRates]) => fiatRates.length > 0),
     );
 
     if (A.length(accountsWithBalanceHistoryFlattened) === 1) {

--- a/suite-common/wallet-utils/src/fiatRatesUtils.test.ts
+++ b/suite-common/wallet-utils/src/fiatRatesUtils.test.ts
@@ -1,12 +1,29 @@
-import { type Timestamp, type TokenAddress } from '@suite-common/wallet-types';
+import { getFiatRatesForTimestamps } from '@suite-common/fiat-services';
+import {
+    type TickerResult,
+    type Timestamp,
+    type TokenAddress,
+    asTimestamp,
+} from '@suite-common/wallet-types';
 
 import {
+    fetchTransactionsRates,
     getFiatRateKey,
     getFiatRateKeyFromTicker,
     roundTimestampToNearestPastHour,
 } from './fiatRatesUtils';
 
+jest.mock('@suite-common/fiat-services', () => ({
+    getFiatRatesForTimestamps: jest.fn(),
+}));
+
+const getFiatRatesForTimestampsMock = jest.mocked(getFiatRatesForTimestamps);
+
 describe('fiat rates utils', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
     it('formats fiat rate key', () => {
         expect(getFiatRateKey('eth', 'usd')).toMatch('eth-usd');
 
@@ -36,5 +53,41 @@ describe('fiat rates utils', () => {
         const expected = new Date('2024-03-19T15:00:00Z').getTime() / 1000;
 
         expect(roundTimestampToNearestPastHour(timestamp as Timestamp)).toBe(expected);
+    });
+
+    it('maps fetched transaction rates by ticker timestamp', async () => {
+        const rates: TickerResult[] = [];
+
+        getFiatRatesForTimestampsMock.mockResolvedValue({
+            symbol: 'eth',
+            ts: Date.now(),
+            tickers: [
+                {
+                    ts: 7200,
+                    rates: { usd: 2 },
+                },
+            ],
+        });
+
+        await fetchTransactionsRates(
+            { symbol: 'eth' },
+            [asTimestamp(3600), asTimestamp(7200)],
+            'usd',
+            false,
+            rates,
+        );
+
+        expect(rates).toEqual([
+            {
+                tickerId: { symbol: 'eth' },
+                localCurrency: 'usd',
+                rates: [
+                    {
+                        rate: 2,
+                        lastTickerTimestamp: 7200,
+                    },
+                ],
+            },
+        ]);
     });
 });

--- a/suite-common/wallet-utils/src/fiatRatesUtils.ts
+++ b/suite-common/wallet-utils/src/fiatRatesUtils.ts
@@ -160,15 +160,10 @@ export const fetchTransactionsRates = async (
             rates.push({
                 tickerId,
                 localCurrency,
-                rates: results.tickers.map((ticker, index) => {
-                    // @ts-expect-error: indexing with noUncheckedIndexedAccess
-                    const lastTickerTimestamp: Timestamp = uniqueTimestamps[index];
-
-                    return {
-                        rate: ticker?.rates[localCurrency],
-                        lastTickerTimestamp,
-                    };
-                }),
+                rates: results.tickers.map(ticker => ({
+                    rate: ticker.rates[localCurrency],
+                    lastTickerTimestamp: asTimestamp(ticker.ts),
+                })),
             });
         }
     } catch (error) {

--- a/suite-native/module-accounts-management/src/hooks/useDayCoinPriceChange.ts
+++ b/suite-native/module-accounts-management/src/hooks/useDayCoinPriceChange.ts
@@ -56,7 +56,9 @@ export const useDayCoinPriceChange = (
                     isCoingeckoForce,
                 );
 
-                const [weekAgo, today] = timestampedFiatRates?.tickers ?? [];
+                const tickers = timestampedFiatRates?.tickers ?? [];
+                const weekAgo = tickers.find(ticker => ticker.ts === weekAgoTimestamp);
+                const today = tickers.find(ticker => ticker.ts === currentTimestamp);
 
                 setWeekAgoValue(weekAgo?.rates[fiatCurrencyCode] ?? null);
                 const currentRate = today?.rates[fiatCurrencyCode];


### PR DESCRIPTION
## Description

When a historical fiat rate is unavailable for the requested day, Blockbook currently returns the closest available ticker. This can be a rate from a different day, including the current rate, and Suite may consequently store a completely unrelated rate under the requested timestamp.

[Blockbook PR #1545](https://github.com/trezor/blockbook/pull/1545) changes this behavior to return `-1` when no rate is available for the requested day. Suite must safely handle both the current behavior and the new response contract.

Suite also previously assumed that multi-ticker responses matched requested timestamps by array position. Removing an unavailable entry could therefore shift later rates and store them under incorrect timestamps.

This PR:

- validates that each Blockbook rate is non-negative and belongs to the same UTC day as the requested timestamp
- preserves Blockbook's actual response timestamps so they can be validated
- requests CoinGecko fallback rates only for timestamps missing a valid Blockbook rate
- keeps valid Blockbook rates and merges fallback rates in the original request order
- maps transaction, graph, and native price-change rates by timestamp instead of array position
- adds regression coverage for unavailable rates, wrong-day rates, partial fallbacks, and the direct Blockbook path

## Notes for QA

Focus on historical fiat values in transaction history, portfolio graphs, and the native 7-day price change.

Test a mixed response where:

- one requested day returns the closest positive rate from a different UTC day;
- one requested day returns `-1`, as introduced by [Blockbook PR #1545](https://github.com/trezor/blockbook/pull/1545);
- one requested day returns a valid rate from the same UTC day.

Expected behavior:

- same-day Blockbook rates are retained;
- unavailable and wrong-day rates are fetched from CoinGecko;
- rates remain associated with their requested timestamps;
- a timestamp remains without a rate when neither provider has data;
- valid rates for other timestamps remain visible.

## Related Issue

Resolve #28445

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=28445-historical-fiat-rates-can-be-stored-under-wrong-timestamps&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=28445-historical-fiat-rates-can-be-stored-under-wrong-timestamps&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=28445-historical-fiat-rates-can-be-stored-under-wrong-timestamps&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is concentrated in fiat rate fetching/conversion and graph data fetching services. The highest-risk regressions are user-visible fiat values and currency switching, so prioritize settings, dashboard discreet mode, and staking form tests. Graph coverage is weaker; include the transactions test as the only graph-interacting E2E. The suite-native hook and the unit test files themselves have no E2E coverage.

<details><summary><b>Changed files (8)</b></summary>

- `suite-common/fiat-services/src/blockbook.test.ts`
- `suite-common/fiat-services/src/blockbook.ts`
- `suite-common/fiat-services/src/rates.test.ts`
- `suite-common/fiat-services/src/rates.ts`
- `suite-common/graph/src/graphDataFetching.ts`
- `suite-common/wallet-utils/src/fiatRatesUtils.test.ts`
- `suite-common/wallet-utils/src/fiatRatesUtils.ts`
- `suite-native/module-accounts-management/src/hooks/useDayCoinPriceChange.ts`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — This test directly asserts fiat-denominated values ($0.00, $###) across the dashboard, device switcher, and asset sections. A regression in fiat rate fetching or conversion would immediately break these visible fiat amounts.
- `suite/e2e/tests/settings/general.test.ts` — The test changes the fiat currency from USD to EUR and verifies the dashboard updates to €0.00, directly exercising the fiat rate service and currency conversion path affected by the changed files.
- `suite/e2e/tests/staking/staking-form.test.ts` — This test switches between crypto (ETH) and fiat (USD) input modes and asserts values convert correctly using the mocked exchange rate, directly touching fiat rate conversion logic.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/wallet/transactions.test.ts` — The test cycles through transaction graph time range filters on the account overview. This is the only available E2E test that interacts with graph UI components, providing weak but relevant coverage for graphDataFetching changes.

</details>

⚠️ **Changes with no test coverage (4)**
- `suite-common/fiat-services/src/blockbook.test.ts`
- `suite-common/fiat-services/src/rates.test.ts`
- `suite-common/wallet-utils/src/fiatRatesUtils.test.ts`
- `suite-native/module-accounts-management/src/hooks/useDayCoinPriceChange.ts`

_Updated: 2026-08-04T15:48:27.971Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/28445-historical-fiat-rates-can-be-stored-under-wrong-timestamps/web/](https://dev.suite.sldev.cz/suite-web/28445-historical-fiat-rates-can-be-stored-under-wrong-timestamps/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T15:50:39.747Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T15:50:04.399Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->