### PR TITLE
feat(workflow): Make project assignment workflow more strict

### DIFF
--- a/.github/workflows/check-project-assignment.yml
+++ b/.github/workflows/check-project-assignment.yml
@@ -132,3 +132,47 @@ jobs:
 
           echo "Pass: PR is assigned to a project and all required fields are filled (when applicable)."
           exit 0
+
+  check-pr-description:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR description has at least one section filled (Description / Notes for QA / Screenshots)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # The PR description must contain meaningful information for QA.
+          # We require at least one of these sections to be filled in, ignoring the
+          # template's HTML comment placeholders. CI-generated content (preview
+          # deployments, Currents, quarantine list) lives under its own "##" headings,
+          # so it is never counted as content of the "Screenshots" section.
+          PR_BODY=$(gh pr view ${{ github.event.pull_request.number }} -R ${{ github.repository }} --json body --jq '.body // ""')
+          printf '%s' "$PR_BODY" > pr_body.md
+
+          # Sections where at least one must be filled in by the author
+          REQUIRED_SECTIONS=("Description" "Notes for QA" "Screenshots")
+
+          FILLED=""
+          for section in "${REQUIRED_SECTIONS[@]}"; do
+            # Capture everything between this heading and the next "## " heading,
+            # strip HTML comments and whitespace, then check if anything remains.
+            CONTENT=$(awk -v h="$section" '
+              $0 ~ "^##[[:space:]]+" h "[[:space:]]*:?[[:space:]]*$" { capture=1; next }
+              capture && /^##[[:space:]]/ { capture=0 }
+              capture { print }
+            ' pr_body.md | perl -0777 -pe 's/<!--.*?-->//gs' | tr -d '[:space:]')
+
+            if [ -n "$CONTENT" ]; then
+              echo "Pass: Section '$section' is filled in."
+              FILLED="yes"
+            fi
+          done
+
+          if [ -z "$FILLED" ]; then
+            echo "Error: The PR description must have at least one of these sections filled in: 'Description', 'Notes for QA' or 'Screenshots'."
+            echo "Please describe your changes so the QA team can test them effectively."
+            exit 1
+          fi
+
+          echo "Pass: The PR description has at least one required section filled in."
+          exit 0

--- a/.github/workflows/check-project-assignment.yml
+++ b/.github/workflows/check-project-assignment.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Check if PR is assigned to a project or an issue
+      - name: Check if PR is assigned to a project (with required fields) or an issue
         env:
           GITHUB_TOKEN: ${{ steps.trezor-bot-token.outputs.token }}
         run: |
@@ -57,15 +57,78 @@ jobs:
             exit 0
           fi
 
-          # Check for associated projects
-          PROJECT_COUNT=$(gh pr view ${{ github.event.pull_request.number }} --json projectItems --jq '.projectItems | length')
+          # Project fields that must be filled in once a PR is assigned to the Suite project
+          REQUIRED_FIELDS=("Platform" "Team" "Release")
+          REQUIRED_FIELDS_PROJECT="Suite"
 
-          if [ "$PROJECT_COUNT" -gt 0 ]; then
-            echo "Pass: This PR is assigned to a project."
-            exit 0
+          # Fetch associated project items together with their populated field names.
+          # In Projects v2, unset fields are simply omitted from fieldValues.nodes,
+          # so the names returned below are exactly the fields that have a value.
+          PROJECT_ITEMS=$(gh api graphql -f query='
+          query($owner: String!, $repo: String!, $number: Int!) {
+            repository(owner: $owner, name: $repo) {
+              pullRequest(number: $number) {
+                projectItems(first: 10) {
+                  nodes {
+                    project { title }
+                    fieldValues(first: 50) {
+                      nodes {
+                        ... on ProjectV2ItemFieldTextValue { field { ... on ProjectV2FieldCommon { name } } }
+                        ... on ProjectV2ItemFieldDateValue { field { ... on ProjectV2FieldCommon { name } } }
+                        ... on ProjectV2ItemFieldNumberValue { field { ... on ProjectV2FieldCommon { name } } }
+                        ... on ProjectV2ItemFieldSingleSelectValue { field { ... on ProjectV2FieldCommon { name } } }
+                        ... on ProjectV2ItemFieldIterationValue { field { ... on ProjectV2FieldCommon { name } } }
+                        ... on ProjectV2ItemFieldLabelValue { field { ... on ProjectV2FieldCommon { name } } }
+                        ... on ProjectV2ItemFieldMilestoneValue { field { ... on ProjectV2FieldCommon { name } } }
+                        ... on ProjectV2ItemFieldPullRequestValue { field { ... on ProjectV2FieldCommon { name } } }
+                        ... on ProjectV2ItemFieldRepositoryValue { field { ... on ProjectV2FieldCommon { name } } }
+                        ... on ProjectV2ItemFieldReviewerValue { field { ... on ProjectV2FieldCommon { name } } }
+                        ... on ProjectV2ItemFieldUserValue { field { ... on ProjectV2FieldCommon { name } } }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }' -F owner=${{ github.repository_owner }} -F repo=${{ github.event.repository.name }} -F number=${{ github.event.pull_request.number }})
+
+          PROJECT_COUNT=$(echo "$PROJECT_ITEMS" | jq '.data.repository.pullRequest.projectItems.nodes | length')
+
+          if [ "$PROJECT_COUNT" -eq 0 ]; then
+            echo "Error: This PR is not assigned to any project, not linked to a valid issue, and does not have the 'no-project' label."
+            echo "Please assign the PR to a project or link it to an issue. Alternatively, add the 'no-project' label if not applicable."
+            exit 1
           fi
 
-          # If no condition passes
-          echo "Error: This PR is not assigned to any project, not linked to a valid issue, and does not have the 'no-project' label."
-          echo "Please assign the PR to a project or link it to an issue. Alternatively, add the 'no-project' label if not applicable."
-          exit 1
+          # Validate that the required fields are filled in on the Suite project item.
+          # Other projects only need to be assigned (no field validation).
+          HAS_ERROR=""
+          for i in $(seq 0 $((PROJECT_COUNT - 1))); do
+            TITLE=$(echo "$PROJECT_ITEMS" | jq -r ".data.repository.pullRequest.projectItems.nodes[$i].project.title")
+
+            if [ "$TITLE" != "$REQUIRED_FIELDS_PROJECT" ]; then
+              continue
+            fi
+
+            POPULATED=$(echo "$PROJECT_ITEMS" | jq -r ".data.repository.pullRequest.projectItems.nodes[$i].fieldValues.nodes[].field.name // empty")
+
+            MISSING=""
+            for f in "${REQUIRED_FIELDS[@]}"; do
+              if ! echo "$POPULATED" | grep -qx "$f"; then
+                MISSING="$MISSING $f"
+              fi
+            done
+
+            if [ -n "$MISSING" ]; then
+              echo "Error: Project '$TITLE' is missing required field(s):$MISSING"
+              HAS_ERROR="yes"
+            fi
+          done
+
+          if [ -n "$HAS_ERROR" ]; then
+            echo "Please fill in Platform, Team and Release in the '$REQUIRED_FIELDS_PROJECT' project before merging."
+            exit 1
+          fi
+
+          echo "Pass: PR is assigned to a project and all required fields are filled (when applicable)."
+          exit 0

--- a/.github/workflows/check-project-assignment.yml
+++ b/.github/workflows/check-project-assignment.yml
@@ -3,6 +3,7 @@ name: "[Check] Project/Issue Assignment"
 on:
   pull_request:
     types:
+      - opened
       - ready_for_review
       - labeled
       - synchronize
@@ -126,7 +127,7 @@ jobs:
           done
 
           if [ -n "$HAS_ERROR" ]; then
-            echo "Please fill in Platform and Team in the '$REQUIRED_FIELDS_PROJECT' project before merging."
+            echo "Please fill in the following field(s) in the '$REQUIRED_FIELDS_PROJECT' project before merging: ${REQUIRED_FIELDS[*]}."
             exit 1
           fi
 

--- a/.github/workflows/check-project-assignment.yml
+++ b/.github/workflows/check-project-assignment.yml
@@ -3,7 +3,6 @@ name: "[Check] Project/Issue Assignment"
 on:
   pull_request:
     types:
-      - opened
       - ready_for_review
       - labeled
       - synchronize
@@ -14,6 +13,7 @@ concurrency:
 
 jobs:
   check-project-or-issue:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App token

--- a/.github/workflows/check-project-assignment.yml
+++ b/.github/workflows/check-project-assignment.yml
@@ -58,7 +58,7 @@ jobs:
           fi
 
           # Project fields that must be filled in once a PR is assigned to the Suite project
-          REQUIRED_FIELDS=("Platform" "Team" "Release")
+          REQUIRED_FIELDS=("Platform" "Team")
           REQUIRED_FIELDS_PROJECT="Suite"
 
           # Fetch associated project items together with their populated field names.
@@ -126,7 +126,7 @@ jobs:
           done
 
           if [ -n "$HAS_ERROR" ]; then
-            echo "Please fill in Platform, Team and Release in the '$REQUIRED_FIELDS_PROJECT' project before merging."
+            echo "Please fill in Platform and Team in the '$REQUIRED_FIELDS_PROJECT' project before merging."
             exit 1
           fi
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Check is not triggered until it's marked as `ready for review` (it doesn't run when it's`draft`)
- CI fails if it's not filled `platform` and ` team` in `Suite` project
- For non Suite projects it's enough to fill just project
- [NEW] Check PR description has at least one section filled (Description / Notes for QA / Screenshots)



  

<!--- Describe your changes in detail -->

## Notes for QA


<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->


## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

   

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/update-project-assignment-workflow/web/](https://dev.suite.sldev.cz/suite-web/update-project-assignment-workflow/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=update-project-assignment-workflow&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=update-project-assignment-workflow&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy BTC > Buy Bitcoin from best offer | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-22T12:22:55.668Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-22T12:20:45.844Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->