### PR TITLE
feat(suite-native): warn on ERC-681 QR network mismatch, auto-switch account

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2223,6 +2223,8 @@ export const messages = {
                     },
                 },
                 addressQrLabel: 'Scan recipient address',
+                qrNetworkMismatch:
+                    'QR code is for {qrNetwork}, but your account is on {accountNetwork}. Make sure to switch to the right network.',
                 amountLabel: 'Amount to be sent',
                 maxButton: 'Send max',
                 destinationTag: {

--- a/suite-native/module-send/src/components/AddressInput.tsx
+++ b/suite-native/module-send/src/components/AddressInput.tsx
@@ -1,17 +1,22 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 
+import { useNavigation } from '@react-navigation/native';
+
 import { type AddressCorrection, autocorrectAddress, isAddressValid } from '@suite-common/address';
 import { useServices } from '@suite-common/dependency-injection';
+import { type DeviceRootState } from '@suite-common/device';
 import { parseErc681TransferUri } from '@suite-common/suite-utils';
 import { formInputsMaxLength } from '@suite-common/validators';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
     type TransactionsRootState,
     selectAccountByKey,
     selectAccountNetworkSymbol,
+    selectVisibleDeviceAccounts,
 } from '@suite-common/wallet-core';
-import { type AccountKey } from '@suite-common/wallet-types';
+import { type AccountKey, toTokenAddress } from '@suite-common/wallet-types';
 import { convertAmountSubunitsToUnits } from '@suite-common/wallet-utils';
 import { type NativeAccountsRootState, selectFreshAccountAddress } from '@suite-native/accounts';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
@@ -19,6 +24,12 @@ import { Button, HStack, Text, VStack } from '@suite-native/atoms';
 import { isDebugEnv } from '@suite-native/config';
 import { TextInputField, useFormContext } from '@suite-native/forms';
 import { Translation, type TxKeyPath } from '@suite-native/intl';
+import {
+    type RootStackParamList,
+    type SendStackParamList,
+    SendStackRoutes,
+    type StackToStackCompositeNavigationProps,
+} from '@suite-native/navigation';
 import { HELP_CENTER_EVM_ADDRESS_CHECKSUM, HELP_CENTER_SOLANA_HELP_URL } from '@trezor/urls';
 
 import { AddressInfoMessage } from './AddressInfoMessage';
@@ -36,11 +47,18 @@ const autocorrectMessageKeys: Record<NonNullable<AddressCorrection>['type'], TxK
     bchPrefix: 'moduleSend.outputs.recipients.autocorrect.addedBitcoincashPrefix',
 };
 
+type AddressInputNavigationProp = StackToStackCompositeNavigationProps<
+    SendStackParamList,
+    SendStackRoutes.SendOutputs,
+    RootStackParamList
+>;
+
 type AddressInputProps = {
     index: number;
     accountKey: AccountKey;
+    onQrNetworkMismatch?: (qrNetworkSymbol: NetworkSymbol | null) => void;
 };
-export const AddressInput = ({ index, accountKey }: AddressInputProps) => {
+export const AddressInput = ({ index, accountKey, onQrNetworkMismatch }: AddressInputProps) => {
     const addressFieldName = getOutputFieldName(index, 'address');
     const utxoLabelFieldName = getOutputFieldName(index, 'label');
     const amountFieldName = getOutputFieldName(index, 'amount');
@@ -53,6 +71,10 @@ export const AddressInput = ({ index, accountKey }: AddressInputProps) => {
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
     );
+    const deviceAccounts = useSelector((state: AccountsRootState & DeviceRootState) =>
+        selectVisibleDeviceAccounts(state),
+    );
+    const navigation = useNavigation<AddressInputNavigationProp>();
 
     const { checkSolAssociatedTokenAddress, isSolATA } = useSolAssociatedTokenAddress();
 
@@ -103,18 +125,47 @@ export const AddressInput = ({ index, accountKey }: AddressInputProps) => {
         const erc681 =
             account?.networkType === 'ethereum' ? parseErc681TransferUri(qrCodeData) : null;
         if (erc681) {
+            // Token amount is in subunits; convert it to display units using the holding
+            // account's decimals (the target account when switching networks, see below).
+            const toDisplayAmount = (tokenAccount: typeof account) => {
+                if (!erc681.contractAddress || erc681.tokenAmount === undefined) return undefined;
+
+                const token = tokenAccount?.tokens?.find(
+                    t => t.contract.toLowerCase() === erc681.contractAddress!.toLowerCase(),
+                );
+
+                return token
+                    ? convertAmountSubunitsToUnits(erc681.tokenAmount, token.decimals)
+                    : undefined;
+            };
+
+            if (erc681.networkSymbol && erc681.networkSymbol !== symbol) {
+                // EVM accounts share the same address across networks, so descriptor matches.
+                const matchingAccount = deviceAccounts.find(
+                    a => a.symbol === erc681.networkSymbol && a.descriptor === account?.descriptor,
+                );
+                if (matchingAccount) {
+                    navigation.replace(SendStackRoutes.SendOutputs, {
+                        accountKey: matchingAccount.key,
+                        tokenContract: erc681.contractAddress
+                            ? toTokenAddress(erc681.contractAddress)
+                            : undefined,
+                        initialAddress: erc681.recipientAddress,
+                        initialAmount: toDisplayAmount(matchingAccount),
+                    });
+
+                    return;
+                }
+                onQrNetworkMismatch?.(erc681.networkSymbol);
+            } else {
+                onQrNetworkMismatch?.(null);
+            }
             setValue(addressFieldName, erc681.recipientAddress, { shouldValidate: true });
             if (erc681.contractAddress) {
                 setValue(tokenFieldName, erc681.contractAddress, { shouldDirty: true });
-                const token = account?.tokens?.find(
-                    t => t.contract.toLowerCase() === erc681.contractAddress!.toLowerCase(),
-                );
-                if (token && erc681.tokenAmount !== undefined) {
-                    setValue(
-                        amountFieldName,
-                        convertAmountSubunitsToUnits(erc681.tokenAmount, token.decimals),
-                        { shouldValidate: true },
-                    );
+                const displayAmount = toDisplayAmount(account);
+                if (displayAmount !== undefined) {
+                    setValue(amountFieldName, displayAmount, { shouldValidate: true });
                 }
             }
             analytics.report({
@@ -125,6 +176,7 @@ export const AddressInput = ({ index, accountKey }: AddressInputProps) => {
             return;
         }
 
+        onQrNetworkMismatch?.(null);
         const corrected = correctAddress(qrCodeData);
         setValue(addressFieldName, corrected, { shouldValidate: true });
         if (symbol && isAddressValid(corrected, symbol)) {
@@ -136,6 +188,7 @@ export const AddressInput = ({ index, accountKey }: AddressInputProps) => {
     };
 
     const handleChangeValue = (newValue: string) => {
+        onQrNetworkMismatch?.(null);
         const corrected = correctAddress(newValue);
         if (corrected !== newValue) {
             setValue(addressFieldName, corrected, { shouldValidate: true });

--- a/suite-native/module-send/src/components/CorrectNetworkMessageCard.tsx
+++ b/suite-native/module-send/src/components/CorrectNetworkMessageCard.tsx
@@ -1,5 +1,5 @@
 import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
-import { Card, HStack, Text } from '@suite-native/atoms';
+import { Card, HStack, InlineAlertBox, Text } from '@suite-native/atoms';
 import { NetworkIcon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 import { Link } from '@suite-native/link';
@@ -17,12 +17,33 @@ const cardStyle = prepareNativeStyle(utils => ({
 
 type CorrectNetworkMessageCardProps = {
     symbol: NetworkSymbol;
+    qrNetworkSymbol?: NetworkSymbol | null;
 };
 
-export const CorrectNetworkMessageCard = ({ symbol }: CorrectNetworkMessageCardProps) => {
+export const CorrectNetworkMessageCard = ({
+    symbol,
+    qrNetworkSymbol,
+}: CorrectNetworkMessageCardProps) => {
     const { applyStyle } = useNativeStyles();
 
     const network = getNetwork(symbol);
+
+    if (qrNetworkSymbol) {
+        return (
+            <InlineAlertBox
+                variant="warning"
+                title={
+                    <Translation
+                        id="moduleSend.outputs.recipients.qrNetworkMismatch"
+                        values={{
+                            qrNetwork: getNetwork(qrNetworkSymbol).name,
+                            accountNetwork: network.name,
+                        }}
+                    />
+                }
+            />
+        );
+    }
 
     if (network.networkType !== 'ethereum') return null;
 

--- a/suite-native/module-send/src/components/RecipientInputs.tsx
+++ b/suite-native/module-send/src/components/RecipientInputs.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Animated, { LinearTransition } from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
 
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { CardDivider, VStack } from '@suite-native/atoms';
@@ -14,11 +15,13 @@ type RecipientInputsProps = {
     index: number;
     accountKey: AccountKey;
     maxSpendableAmount?: string;
+    onQrNetworkMismatch?: (qrNetworkSymbol: NetworkSymbol | null) => void;
 };
 export const RecipientInputs = ({
     index,
     accountKey,
     maxSpendableAmount,
+    onQrNetworkMismatch,
 }: RecipientInputsProps) => {
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
@@ -30,7 +33,11 @@ export const RecipientInputs = ({
 
     return (
         <VStack spacing="sp16">
-            <AddressInput index={index} accountKey={accountKey} />
+            <AddressInput
+                index={index}
+                accountKey={accountKey}
+                onQrNetworkMismatch={onQrNetworkMismatch}
+            />
             <CardDivider />
             <AmountInputs index={index} maxSpendableAmount={maxSpendableAmount} />
             {hasDestinationTag && (

--- a/suite-native/module-send/src/components/SendOutputFields.tsx
+++ b/suite-native/module-send/src/components/SendOutputFields.tsx
@@ -1,7 +1,8 @@
+import { useState } from 'react';
 import { useFieldArray } from 'react-hook-form';
 import { useSelector } from 'react-redux';
 
-import { getNetworkType } from '@suite-common/wallet-config';
+import { type NetworkSymbol, getNetworkType } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
     selectAccountFormattedBalance,
@@ -42,6 +43,7 @@ export const SendOutputFields = ({
 }: SendOutputFieldsProps) => {
     const { applyStyle } = useNativeStyles();
     const { control, watch } = useFormContext<SendOutputsFormValues>();
+    const [qrNetworkSymbol, setQrNetworkSymbol] = useState<NetworkSymbol | null>(null);
     const symbol = useSelector((state: AccountsRootState) =>
         selectAccountNetworkSymbol(state, accountKey),
     );
@@ -65,7 +67,9 @@ export const SendOutputFields = ({
             <Text variant="headline-sm">
                 <Translation id="moduleSend.outputs.recipients.title" />
             </Text>
-            {symbol && <CorrectNetworkMessageCard symbol={symbol} />}
+            {symbol && (
+                <CorrectNetworkMessageCard symbol={symbol} qrNetworkSymbol={qrNetworkSymbol} />
+            )}
             <Card style={applyStyle(cardStyle)}>
                 <VStack spacing="sp12">
                     {outputsFieldArray.fields.map((output, index) => (
@@ -74,6 +78,7 @@ export const SendOutputFields = ({
                             index={index}
                             accountKey={accountKey}
                             maxSpendableAmount={maxAmount}
+                            onQrNetworkMismatch={setQrNetworkSymbol}
                         />
                     ))}
                     {/*

--- a/suite-native/module-send/src/screens/SendOutputsScreen.tsx
+++ b/suite-native/module-send/src/screens/SendOutputsScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import Animated, { FadeInDown, FadeOutDown } from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
 
@@ -26,12 +26,14 @@ import { SendOutputsScreenFooter } from '../components/SendOutputsScreenFooter';
 import { useSendForm } from '../hooks/useSendForm';
 import { useShowDeviceDisconnectedAlert } from '../hooks/useShowDeviceDisconnectedAlert';
 import { useUtxoSelection } from '../hooks/useUtxoSelection';
+import { getOutputFieldName } from '../utils';
 
 export const SendOutputsScreen = ({
     route: { params },
     navigation,
 }: StackProps<SendStackParamList, SendStackRoutes.SendOutputs>) => {
-    const { accountKey, tokenContract, postNavigationAction } = params;
+    const { accountKey, tokenContract, postNavigationAction, initialAddress, initialAmount } =
+        params;
     const sendForm = useSendForm(accountKey, tokenContract);
     const { totalSelectedAmount, selectedUtxos } = useUtxoSelection(accountKey);
     const formDraft = useSelector((state: SendRootState) =>
@@ -50,6 +52,20 @@ export const SendOutputsScreen = ({
             showDeviceDisconnectedAlert();
         }, [navigation, postNavigationAction, showDeviceDisconnectedAlert]),
     );
+
+    const initialValuesApplied = useRef(false);
+    useEffect(() => {
+        if (initialValuesApplied.current || !sendForm) return;
+        initialValuesApplied.current = true;
+        if (initialAddress)
+            sendForm.form.setValue(getOutputFieldName(0, 'address'), initialAddress, {
+                shouldValidate: true,
+            });
+        if (initialAmount)
+            sendForm.form.setValue(getOutputFieldName(0, 'amount'), initialAmount, {
+                shouldValidate: true,
+            });
+    }, [sendForm, initialAddress, initialAmount]);
 
     if (!sendForm) {
         return null;

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -163,6 +163,8 @@ export type SendStackParamList = {
         accountKey: AccountKey;
         tokenContract?: TokenAddress;
         postNavigationAction?: 'deviceDisconnectedAlert';
+        initialAddress?: string;
+        initialAmount?: string;
     };
     [SendStackRoutes.SendUtxo]: {
         accountKey: AccountKey;


### PR DESCRIPTION
## Description

When a user scans an ERC-681 QR code whose chain ID doesn't match the currently selected send account, the app now detects the mismatch. 
If a matching account (same descriptor, correct network) exists on the device, it automatically navigates to that account's send screen with the address and amount pre-filled. Two new optional route params (`initialAddress`, `initialAmount`) were added to `SendOutputs` to support pre-filling after the navigation replace.
If no matching account is found, a warning banner is shown instead. 

## Notes for QA

<img width="300" height="300" alt="7b08df56b7b6b1970d52a337f676104e" src="https://github.com/user-attachments/assets/183f7540-28d4-4fc3-a54c-e551b5de6981" />

- Go to send from Ethereum network
- Scan above QR code
- It Base is enabled, it should switch automatically
- If Base is not enabled, it should show a warning toast

## Screenshots:

<img width="400" alt="Simulator Screenshot - iPhone Air - 2026-06-09 at 13 27 58" src="https://github.com/user-attachments/assets/08b7e963-bc61-432d-b2f2-1d1ba0f9125a" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All changed files are in the `suite-native/` directory, which is the React Native mobile app codebase. The E2E tests in the `suite/e2e/tests/` directory are all Playwright-based tests targeting the web and desktop (Electron) versions of Trezor Suite. None of the 123 candidate E2E tests exercise the suite-native mobile app code paths — they test `suite-web` and `suite-desktop` functionality. The changes to `AddressInput.tsx`, `SendOutputsScreen.tsx`, `navigators.ts`, `messages.ts`, and `package.json` in the native module are completely outside the scope of these E2E tests. No E2E tests from this suite need to be run for this change set.

<details><summary><b>Changed files (5)</b></summary>

- `suite-native/intl/src/messages.ts`
- `suite-native/module-send/package.json`
- `suite-native/module-send/src/components/AddressInput.tsx`
- `suite-native/module-send/src/screens/SendOutputsScreen.tsx`
- `suite-native/navigation/src/navigators.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (5)**
- `suite-native/intl/src/messages.ts`
- `suite-native/module-send/package.json`
- `suite-native/module-send/src/components/AddressInput.tsx`
- `suite-native/module-send/src/screens/SendOutputsScreen.tsx`
- `suite-native/navigation/src/navigators.ts`

_Updated: 2026-06-09T10:33:16.162Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-09T10:38:10.495Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add account types ada | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-09T10:36:50.639Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/warn-erc681-network-mismatch/web/](https://dev.suite.sldev.cz/suite-web/warn-erc681-network-mismatch/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=warn-erc681-network-mismatch&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=warn-erc681-network-mismatch&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->