### PR TITLE
fix(suite-native): apply max slippage when confirming DEX exchange trade

### DIFF
--- a/suite-native/module-trading/src/hooks/exchange/Approval/__tests__/useApprovalFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/Approval/__tests__/useApprovalFlow.test.ts
@@ -1,6 +1,11 @@
-import { exchangeThunks, selectTradingExchangeSelectedQuote } from '@suite-common/trading';
+import {
+    exchangeThunks,
+    selectTradingExchangeSelectedQuote,
+    tradingSettingsActions,
+} from '@suite-common/trading';
+import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
-import { invityDexQuote } from '@suite-native/trading-fixtures';
+import { getEthAccount, invityDexQuote } from '@suite-native/trading-fixtures';
 
 import { createTradingLightStore } from '../../../../__tests__/tradingTestUtils';
 import { useApprovalFlow } from '../useApprovalFlow';
@@ -11,6 +16,8 @@ const mockConfirmApprovalThunk: any = () => () => ({
 jest.spyOn(exchangeThunks, 'confirmApprovalThunk').mockImplementation(mockConfirmApprovalThunk);
 
 describe('useApprovalFlow', () => {
+    const ethAccount = getEthAccount({ descriptor: asAccountDescriptor('ethAccount') });
+
     it('should return selected quote from exchange state', () => {
         const store = createTradingLightStore({
             tradeType: 'exchange',
@@ -54,5 +61,40 @@ describe('useApprovalFlow', () => {
             ...quote,
             approvalType: 'INFINITE',
         });
+    });
+
+    it('should confirm approval with maxSlippage value', async () => {
+        const store = createTradingLightStore({
+            tradeType: 'exchange',
+            overrides: {
+                wallet: {
+                    accounts: [ethAccount],
+                    trading: {
+                        exchange: {
+                            selectedQuote: invityDexQuote,
+                            tradingAccountKey: ethAccount.key,
+                            receiveAccountKey: ethAccount.key,
+                        },
+                    },
+                },
+            },
+        });
+
+        store.dispatch(tradingSettingsActions.setMaxSlippagePercentage('2.5'));
+
+        const { result } = renderHookWithStoreProvider(() => useApprovalFlow(), { store });
+
+        await act(async () => {
+            await result.current.confirmApproval(invityDexQuote);
+        });
+
+        expect(exchangeThunks.confirmApprovalThunk).toHaveBeenCalledWith(
+            expect.objectContaining({
+                trade: expect.objectContaining({
+                    quoteId: invityDexQuote.quoteId,
+                    swapSlippage: '2.5',
+                }),
+            }),
+        );
     });
 });

--- a/suite-native/module-trading/src/hooks/exchange/Approval/useApprovalFlow.ts
+++ b/suite-native/module-trading/src/hooks/exchange/Approval/useApprovalFlow.ts
@@ -6,6 +6,7 @@ import type { DexApprovalType, ExchangeTrade } from 'invity-api';
 import {
     exchangeThunks,
     selectTradingExchangeSelectedQuote,
+    selectTradingMaxSlippagePercentage,
     tradingExchangeActions,
 } from '@suite-common/trading';
 import { useTranslate } from '@suite-native/intl';
@@ -14,6 +15,7 @@ import {
     selectExchangeSelectedSendAccount,
 } from '@suite-native/trading-state';
 
+import { applyMaxSlippageToExchangeQuote } from '../../../utils/exchange/applyMaxSlippageToExchangeQuote';
 import { getReceiveAccountAddressText } from '../../../utils/general/receiveAccountUtils';
 
 export const useApprovalFlow = () => {
@@ -23,6 +25,7 @@ export const useApprovalFlow = () => {
     const quote = useSelector(selectTradingExchangeSelectedQuote);
     const sendAccount = useSelector(selectExchangeSelectedSendAccount);
     const toAccount = useSelector(selectExchangeSelectedReceiveAccount);
+    const swapSlippage = useSelector(selectTradingMaxSlippagePercentage);
     const receiveAddress = getReceiveAccountAddressText(toAccount);
 
     const [isConfirming, setIsConfirming] = useState(false);
@@ -38,9 +41,14 @@ export const useApprovalFlow = () => {
             setError(null);
 
             try {
+                const quoteWithSlippage = applyMaxSlippageToExchangeQuote(
+                    quoteToConfirm,
+                    swapSlippage,
+                );
+
                 const response = await dispatch(
                     exchangeThunks.confirmApprovalThunk({
-                        trade: quoteToConfirm,
+                        trade: quoteWithSlippage,
                         receiveAddress,
                         account: sendAccount,
                         processResponseData: () => {},
@@ -63,7 +71,7 @@ export const useApprovalFlow = () => {
                 setIsConfirming(false);
             }
         },
-        [dispatch, receiveAddress, sendAccount, translate],
+        [dispatch, receiveAddress, sendAccount, swapSlippage, translate],
     );
 
     const isReady = !!sendAccount && !!receiveAddress;

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeFlow.test.ts
@@ -7,6 +7,7 @@ import { type TestStore, act, renderHookWithStoreProvider } from '@suite-native/
 import {
     getBtcAccount,
     getInitializedTradingStateWithQuotes,
+    invityDexQuote,
 } from '@suite-native/trading-fixtures';
 
 import { createTradingTestStore } from '../../../__tests__/tradingTestUtils';
@@ -45,11 +46,17 @@ const btc2Account = getBtcAccount({ descriptor: asAccountDescriptor('btc2') });
 describe('useExchangeFlow', () => {
     const getMockAccounts = () => [btc1Account, btc2Account];
 
-    const getInitializedStore = ({ withDevice = false }: { withDevice?: boolean } = {}) => {
+    const getInitializedStore = ({
+        maxSlippagePercentage,
+        withDevice = false,
+    }: { maxSlippagePercentage?: string; withDevice?: boolean } = {}) => {
         const tradingState = getInitializedTradingStateWithQuotes();
         tradingState.exchange.tradingAccountKey = btc1Account.key;
         tradingState.exchange.receiveAccountKey = btc2Account.key;
         tradingState.exchange.selectedQuote = tradingState.exchange.quotes[0];
+        if (maxSlippagePercentage) {
+            tradingState.settings.maxSlippagePercentage = maxSlippagePercentage;
+        }
 
         return createTradingTestStore({
             tradeType: 'exchange',
@@ -152,6 +159,31 @@ describe('useExchangeFlow', () => {
                 },
                 unwrap: expect.any(Function),
             });
+        });
+
+        it('should call confirmTradeThunk with maxSlippage value for dex trade', async () => {
+            const store = getInitializedStore({ maxSlippagePercentage: '2.5' });
+            const mockNextStep = jest.fn();
+
+            const { result } = renderUseExchangeFlow({ store });
+
+            await act(async () => {
+                await result.current.confirmTrade({
+                    receiveAddress: 'test-address',
+                    trade: invityDexQuote,
+                    approvalFlow: false,
+                    nextStep: mockNextStep,
+                });
+            });
+
+            expect(mockConfirmTradeThunk).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    trade: expect.objectContaining({
+                        quoteId: invityDexQuote.quoteId,
+                        swapSlippage: '2.5',
+                    }),
+                }),
+            );
         });
 
         it('should return false when confirmTradeThunk returns false', async () => {

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeSelectQuote.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeSelectQuote.test.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { useServices } from '@suite-common/dependency-injection';
-import { tradingExchangeActions, tradingSettingsActions } from '@suite-common/trading';
+import { tradingExchangeActions } from '@suite-common/trading';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { type TestStore, act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
@@ -262,27 +262,6 @@ describe('useExchangeSelectQuote', () => {
                         quote: expect.objectContaining({
                             quoteId: mercuryoFixedBestQuote?.quoteId,
                         }),
-                    }),
-                }),
-            );
-        });
-
-        it('should call selectQuoteThunk with correct maxSlippage value', () => {
-            const dispatchSpy = jest.spyOn(store, 'dispatch');
-            act(() => {
-                store.dispatch(tradingSettingsActions.setMaxSlippagePercentage('1.5'));
-            });
-            const { result } = renderUseExchangeSelectQuote();
-
-            act(() => {
-                result.current.selectQuote();
-            });
-
-            expect(dispatchSpy).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    type: 'selectQuoteThunkMock',
-                    payload: expect.objectContaining({
-                        quote: expect.objectContaining({ swapSlippage: '1.5' }),
                     }),
                 }),
             );

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeFlow.tsx
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeFlow.tsx
@@ -10,6 +10,7 @@ import {
     type TradingSendRejectedProps,
     exchangeThunks,
     selectTradingExchangeSelectedQuote,
+    selectTradingMaxSlippagePercentage,
 } from '@suite-common/trading';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { type TxKeyPath } from '@suite-native/intl';
@@ -22,6 +23,7 @@ import {
 import { buildTradingUrl, useBrowserAuth } from '@suite-native/trading-browser-auth';
 import { selectExchangeSelectedSendAccount } from '@suite-native/trading-state';
 
+import { applyMaxSlippageToExchangeQuote } from '../../utils/exchange/applyMaxSlippageToExchangeQuote';
 import {
     type TradingTransactionSignAndSendProps,
     useTradingTransaction,
@@ -58,6 +60,7 @@ export const useExchangeFlow = ({ flowType }: UseExchangeFlowProps = {}) => {
     const quote = useSelector(selectTradingExchangeSelectedQuote);
     const device = useSelector(selectSelectedDevice);
     const sendAccount = useSelector(selectExchangeSelectedSendAccount);
+    const swapSlippage = useSelector(selectTradingMaxSlippagePercentage);
 
     const { openBrowserForFormData } = useBrowserAuth('exchange');
     const quoteStatus = quote?.status;
@@ -157,6 +160,7 @@ export const useExchangeFlow = ({ flowType }: UseExchangeFlowProps = {}) => {
 
             const { returnUrl, triggerAnalyticsTradeConfirmation, processResponseData } =
                 commonFunctions;
+            const tradeWithSlippage = applyMaxSlippageToExchangeQuote(trade, swapSlippage);
 
             const promiseAction = dispatch(
                 exchangeThunks.confirmTradeThunk({
@@ -164,7 +168,7 @@ export const useExchangeFlow = ({ flowType }: UseExchangeFlowProps = {}) => {
                     receiveAddress,
                     account: sendAccount,
                     extraField,
-                    trade,
+                    trade: tradeWithSlippage,
                     approvalFlow,
                     triggerAnalyticsTradeConfirmation,
                     processResponseData,
@@ -175,7 +179,7 @@ export const useExchangeFlow = ({ flowType }: UseExchangeFlowProps = {}) => {
 
             return !!(await promiseAction.unwrap());
         },
-        [getCommonFunctions, sendAccount, dispatch],
+        [getCommonFunctions, sendAccount, dispatch, swapSlippage],
     );
 
     const abortConfirmTrade = useCallback(() => {

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeSelectQuote.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeSelectQuote.ts
@@ -10,7 +10,6 @@ import {
     requiresTokenApproval,
     selectTradingExchangeDexQuoteApprovalPrefetchLoadingByQuoteId,
     selectTradingExchangeIsLoading,
-    selectTradingMaxSlippagePercentage,
     tradingExchangeActions,
 } from '@suite-common/trading';
 import {
@@ -52,7 +51,6 @@ export const useExchangeSelectQuote = (form: ExchangeFormType) => {
     );
     const sendAccount = useSelector(selectExchangeSelectedSendAccount);
     const receiveAccount = useSelector(selectExchangeSelectedReceiveAccount);
-    const swapSlippage = useSelector(selectTradingMaxSlippagePercentage);
 
     const navigation = useNavigation<NavigationProps>();
 
@@ -92,7 +90,7 @@ export const useExchangeSelectQuote = (form: ExchangeFormType) => {
 
         await dispatch(
             exchangeThunks.selectQuoteThunk({
-                quote: { ...candidateQuote, swapSlippage },
+                quote: candidateQuote,
                 nextStep: () => {
                     clearExchangeFormQuoteData(form);
                     nextStep(getApprovalStatus(candidateQuote));

--- a/suite-native/module-trading/src/utils/exchange/applyMaxSlippageToExchangeQuote.ts
+++ b/suite-native/module-trading/src/utils/exchange/applyMaxSlippageToExchangeQuote.ts
@@ -1,0 +1,6 @@
+import type { ExchangeTrade } from 'invity-api';
+
+export const applyMaxSlippageToExchangeQuote = (
+    quote: ExchangeTrade,
+    maxSlippagePercentage: string,
+): ExchangeTrade => (quote.isDex ? { ...quote, swapSlippage: maxSlippagePercentage } : quote);


### PR DESCRIPTION
apply changed slippage in confirm trade

## Notes for QA

changing slippage should work

## Related Issue

Resolve #28509

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=28509-mobile-swap-custom-slippage-is-not-propagated-2&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->