### PR TITLE
fix(guide): Fix guide parser

### DIFF
--- a/packages/suite-data/src/guide/transformer.ts
+++ b/packages/suite-data/src/guide/transformer.ts
@@ -11,10 +11,12 @@ const clean = (markdown: string): string => markdown.replace(/^---\n.*?\n---\n/s
  * Transforms HTML notation produced by GitBook to stadard markdown which can be parsed by react-markdown lib.
  *
  * <figure><img src=".gitbook/assets/example.png" alt=""><figcaption></figcaption></figure> to ![](.gitbook/assets/example.png)
+ *
+ * The `<img>` tag may carry extra attributes (e.g. `width`), so anything after the `src` up to the closing `>` is ignored.
  */
 export const transformImagesMarkdown = (markdown: string) =>
     markdown.replace(
-        /<figure><img src="([^"]+)" alt=""><figcaption><\/figcaption><\/figure>/g,
+        /<figure><img src="([^"]+)"[^>]*><figcaption><\/figcaption><\/figure>/g,
         '![]($1)',
     );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to the guide content transformer in packages/suite-data/src/guide/transformer.ts, which processes guide/help article data for the Suite Guide panel. The primary risk is that guide content rendering, navigation, and search functionality could break. Two tests directly exercise guide content viewing and search, making them critical to run. The bug report form test also traverses the guide panel UI. Overall risk is moderate and well-scoped to the guide feature area.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite-data/src/guide/transformer.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/suite/guide.test.ts` — The guide transformer (packages/suite-data/src/guide/transformer.ts) is responsible for transforming guide content data. This test directly exercises the Suite Guide panel including navigating guide content nodes, viewing article details, and searching for topics — all of which depend on properly transformed guide data.
- `suite/e2e/tests/general/suite-guide.test.ts` — This test opens the Suite Guide panel, searches for a support article by name ('Install firmware'), and verifies the article content is displayed correctly. The guide transformer directly affects how guide articles are processed and made available for search and display.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/suite/bug-report-form.test.ts` — This test navigates through the Guide panel to reach the Support and Feedback section and submit a bug report. While the bug report form itself may not depend on the transformer, the Guide panel navigation infrastructure that hosts it could be affected by changes to guide data transformation.

</details>

_Updated: 2026-06-09T12:35:56.158Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-guide-parser&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-guide-parser&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-09T12:41:33.085Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add account types ada | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-09T12:38:51.261Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-guide-parser/web/](https://dev.suite.sldev.cz/suite-web/fix-guide-parser/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->