### PR TITLE
Revert "feat(auth-server): add rate limits"

### DIFF
--- a/packages/auth-server/package.json
+++ b/packages/auth-server/package.json
@@ -15,8 +15,7 @@
     },
     "dependencies": {
         "cors": "^2.8.6",
-        "express": "^5.2.1",
-        "express-rate-limit": "^8.5.2"
+        "express": "^5.2.1"
     },
     "devDependencies": {
         "@types/cors": "^2.8.17"

--- a/packages/auth-server/src/index.ts
+++ b/packages/auth-server/src/index.ts
@@ -1,6 +1,5 @@
 import cors, { type CorsOptions } from 'cors';
 import express, { type ErrorRequestHandler } from 'express';
-import { rateLimit } from 'express-rate-limit';
 
 const app = express();
 
@@ -22,8 +21,6 @@ const { GOOGLE_CLIENT_SECRET } = process.env; // generate testing credentials fo
 const GOOGLE_OAUTH_LOOPBACK_HOSTNAMES = ['localhost', '127.0.0.1', '[::1]'] as const;
 const GOOGLE_OAUTH_LOOPBACK_PORT = '21335';
 const GOOGLE_OAUTH_LOOPBACK_PATHNAME = '/oauth';
-const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
-const RATE_LIMIT_MAX_REQUESTS_PER_IP = 100;
 
 const checkResponse = (responseBody: object, expectedProperties: string[]) => {
     expectedProperties.forEach(property => {
@@ -99,16 +96,6 @@ app.get('/', (_req, res) => {
 app.get('/status', (_req, res) => {
     res.send({ status: 'ok' });
 });
-
-app.use(
-    rateLimit({
-        windowMs: RATE_LIMIT_WINDOW_MS,
-        limit: RATE_LIMIT_MAX_REQUESTS_PER_IP,
-        standardHeaders: true,
-        legacyHeaders: false,
-        message: 'Too many requests.',
-    }),
-);
 
 /**
  * Exchange authorization code for refresh token and access token.

--- a/scripts/list-outdated-dependencies/foundation-dependencies.txt
+++ b/scripts/list-outdated-dependencies/foundation-dependencies.txt
@@ -52,7 +52,6 @@ expo-sqlite
 expo-file-system
 expo-sharing
 express
-express-rate-limit
 fake-indexeddb
 file-saver
 globals

--- a/yarn.lock
+++ b/yarn.lock
@@ -15532,7 +15532,6 @@ __metadata:
     "@types/cors": "npm:^2.8.17"
     cors: "npm:^2.8.6"
     express: "npm:^5.2.1"
-    express-rate-limit: "npm:^8.5.2"
   peerDependencies:
     tslib: ^2.6.2
   languageName: unknown
@@ -27264,14 +27263,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"express-rate-limit@npm:^8.2.1, express-rate-limit@npm:^8.5.2":
-  version: 8.5.2
-  resolution: "express-rate-limit@npm:8.5.2"
+"express-rate-limit@npm:^8.2.1":
+  version: 8.2.1
+  resolution: "express-rate-limit@npm:8.2.1"
   dependencies:
-    ip-address: "npm:^10.2.0"
+    ip-address: "npm:10.0.1"
   peerDependencies:
     express: ">= 4.11"
-  checksum: 10/de2aa4582d3b1b1d242fdb8dba7b3b1c64e3a58dfa7a40d370681c175a61321fb550c6b190d755f47cefdf28f35eaad6c99ea196f99caec8caaffc2462fea1ae
+  checksum: 10/7cbf70df2e88e590e463d2d8f93380775b2ea181d97f2c50c2ff9f2c666c247f83109a852b21d9c99ccc5762119101f281f54a27252a2f1a0a918be6d71f955b
   languageName: node
   linkType: hard
 
@@ -30358,10 +30357,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-address@npm:^10.2.0":
-  version: 10.2.0
-  resolution: "ip-address@npm:10.2.0"
-  checksum: 10/12fec399e1af5753ac322e47a6d81a50d3a528b3abb17c09525b2a2edcaedcca628c40520706f7037bc4d8e951b0296c47e7b86d0a8e6e2335c8f0ba4afcfac1
+"ip-address@npm:10.0.1":
+  version: 10.0.1
+  resolution: "ip-address@npm:10.0.1"
+  checksum: 10/09731acda32cd8e14c46830c137e7e5940f47b36d63ffb87c737331270287d631cf25aa95570907a67d3f919fdb25f4470c404eda21e62f22e0a55927f4dd0fb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This reverts commit 1430c33d9f4736fb2b4faae858d88e2b8e2c0c8d.

No QA, this is still part of https://github.com/trezor/trezor-suite/pull/28271

## Description

This won't work, because the server is behind proxy.
Perhaps it could be configured to work with the X-ForwardedFor headers, but it would be very difficult to verify if it works (i.e. if it doesn't work, we would find out only in production)
And we have other mitigations in our infrastructure, this is not needed.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/revert/auth-server-rate-limits/web/](https://dev.suite.sldev.cz/suite-web/revert/auth-server-rate-limits/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=revert/auth-server-rate-limits&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=revert/auth-server-rate-limits&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-09T13:10:19.106Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add account types ada | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-09T13:09:03.647Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->