### PR TITLE
feat(request-manager): replace node-fetch with nodejs native undici for fetch

### DIFF
--- a/.github/workflows/test-request-manager.yml
+++ b/.github/workflows/test-request-manager.yml
@@ -20,7 +20,9 @@ jobs:
     if: github.repository == 'trezor/trezor-suite'
     timeout-minutes: 60
     env:
-      TEST_SCRIPT: ${{ github.event_name == 'workflow_dispatch' && 'test:e2e' || 'test:all' }}
+      # Run the (unflagged) real-Tor e2e suite on manual dispatch AND on the nightly schedule, so the
+      # flaky-gated circuit-isolation suites are exercised at least daily; PRs still run test:all.
+      TEST_SCRIPT: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && 'test:e2e' || 'test:all' }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6

--- a/packages/request-manager/e2e/interceptor.test.ts
+++ b/packages/request-manager/e2e/interceptor.test.ts
@@ -1,4 +1,5 @@
 import http from 'http';
+import nodeFetch from 'node-fetch';
 import path from 'path';
 import WebSocket from 'ws';
 
@@ -33,6 +34,13 @@ describe('Interceptor', () => {
     let torIdentities: TorIdentities;
 
     const torSettings = { running: true, host: hostIp, port };
+    const fetchImplementations = [
+        ['global.fetch', (...args: Parameters<typeof fetch>) => fetch(...args)],
+        ['node-fetch', nodeFetch],
+    ] as const;
+
+    const extractIp = async (response: { text: () => Promise<string> }) =>
+        (await response.text()).match(ipRegex)?.[0];
 
     const interceptorOptions: InterceptorOptions = {
         getWhitelistedDomains: () => [
@@ -81,58 +89,61 @@ describe('Interceptor', () => {
     // guarantee that the IPs of 2 different Tor circuits are different. And this is
     // part of the Tor nature.
     conditionalTest('Check if IPs are different', () => {
-        it('HTTP GET - Each identity has different ip address', async () => {
-            const identityDefault = await fetch(testGetUrlHttp, {
-                headers: { 'proxy-authorization': 'Basic default' },
-            });
-            const identityDefault2 = await fetch(testGetUrlHttp, {
-                headers: { 'Proxy-Authorization': 'Basic user' },
-            });
-            const iPIdentitieA = ((await identityDefault.text()) as any).match(ipRegex)[0];
-
-            const iPIdentitieB = ((await identityDefault2.text()) as any).match(ipRegex)[0];
-            expect(iPIdentitieA).not.toEqual(iPIdentitieB);
-        });
-
-        it('HTTPS GET - Each identity has different ip address', async () => {
-            const identityA = await fetch(testGetUrlHttps, {
-                headers: { 'proxy-authorization': 'Basic default' },
-            });
-            const identityB = await fetch(testGetUrlHttps, {
-                headers: { 'Proxy-Authorization': 'Basic user' },
-            });
-            // Parsing IP address from html provided by check.torproject.org.
-            const iPIdentitieA = ((await identityA.text()) as any).match(ipRegex)[0];
-            const iPIdentitieB = ((await identityB.text()) as any).match(ipRegex)[0];
-            // Check if identities are different when using different identity.
-            expect(iPIdentitieA).not.toEqual(iPIdentitieB);
-
-            // reset existing circuit using identity with password
-            const identityB2 = await fetch(testGetUrlHttps, {
-                headers: { 'Proxy-Authorization': 'Basic user:password' },
-            });
-            const iPIdentitieB2 = ((await identityB2.text()) as any).match(ipRegex)[0];
-            // ip for "user" did change
-            expect(iPIdentitieB2).not.toEqual(iPIdentitieB);
-        });
-
-        it('HTTPS POST - Each identity has different ip address', async () => {
-            const identityA = await fetch(testPostUrlHttps, {
+        const testCases = [
+            {
+                name: 'HTTP GET',
+                url: testGetUrlHttp,
+                method: 'GET',
+                body: undefined,
+            },
+            {
+                name: 'HTTPS GET',
+                url: testGetUrlHttps,
+                method: 'GET',
+                body: undefined,
+            },
+            {
+                name: 'HTTPS POST',
+                url: testPostUrlHttps,
                 method: 'POST',
                 body: JSON.stringify({ test: 'test' }),
-                headers: { 'proxy-authorization': 'Basic default' },
-            });
-            const identityB = await fetch(testPostUrlHttps, {
-                method: 'POST',
-                body: JSON.stringify({ test: 'test' }),
-                headers: { 'Proxy-Authorization': 'Basic user' },
-            });
+            },
+        ];
 
-            const iPIdentitieA = ((await identityA.json()) as any).origin;
-            const iPIdentitieB = ((await identityB.json()) as any).origin;
+        describe.each(fetchImplementations)('%s', (_, fetchFn) => {
+            it.each(testCases)(
+                '$name - Each identity has different ip address',
+                async ({ url, method, body }) => {
+                    const identityA = await fetchFn(url, {
+                        method,
+                        body,
+                        headers: { 'proxy-authorization': 'Basic default' },
+                    });
+                    const identityB = await fetchFn(url, {
+                        method,
+                        body,
+                        headers: { 'Proxy-Authorization': 'Basic user' },
+                    });
 
-            // Check if identities are different when using different identity.
-            expect(iPIdentitieA).not.toEqual(iPIdentitieB);
+                    const ipA = await extractIp(identityA);
+                    const ipB = await extractIp(identityB);
+
+                    expect(ipA).not.toEqual(ipB);
+                },
+            );
+
+            it(`Reset identity by changing password`, async () => {
+                const identityA = await fetchFn(testGetUrlHttps, {
+                    headers: { 'Proxy-Authorization': 'Basic user' },
+                });
+                // Reset existing circuit by changing password
+                const identityB = await fetchFn(testGetUrlHttps, {
+                    headers: { 'Proxy-Authorization': 'Basic user:password' },
+                });
+                const ipB = await extractIp(identityA);
+                const ipB2 = await extractIp(identityB);
+                expect(ipB2).not.toEqual(ipB);
+            });
         });
     });
 
@@ -180,12 +191,12 @@ describe('Interceptor', () => {
     });
 
     conditionalTest('TorControl', () => {
-        it('closing circuits', async () => {
-            await fetch(testGetUrlHttps, {
+        it.each(fetchImplementations)('%s closing circuits', async (_label, fetchFn) => {
+            await fetchFn(testGetUrlHttps, {
                 headers: { 'Proxy-Authorization': 'Basic user-circuit-1' },
             });
 
-            await fetch(testGetUrlHttps, {
+            await fetchFn(testGetUrlHttps, {
                 headers: { 'Proxy-Authorization': 'Basic user-circuit-2' },
             });
 
@@ -250,87 +261,85 @@ describe('Interceptor', () => {
 
         afterAll(() => new Promise(resolve => serverInit.server.close(resolve)));
 
-        const fetchHeaders = (url: string, options: RequestInit) =>
-            fetch(url, options).then(r => r.json());
+        const fetchHeaders = (pr: Promise<any>) => pr.then(r => r.json());
 
-        it('POST request headers', async () => {
-            const { serverUrl, host } = serverInit;
-
-            // default headers
-            await expect(
-                fetchHeaders(serverUrl, {
-                    method: 'POST',
-                    body: JSON.stringify({ test: 'test' }),
-                    headers: { 'User-Agent': 'TrezorSuite' },
-                }),
-            ).resolves.toEqual(
-                expect.objectContaining({
-                    host,
+        const headerTestCases = [
+            {
+                method: 'POST',
+                body: JSON.stringify({ test: 'test' }),
+                defaultHeaders: { 'User-Agent': 'TrezorSuite' },
+                expectedDefault: {
                     accept: '*/*',
                     'content-length': '15',
                     'content-type': 'text/plain;charset=UTF-8',
                     'user-agent': 'TrezorSuite',
-                }),
-            );
-
-            // restricted headers
-            await expect(
-                fetchHeaders(serverUrl, {
-                    method: 'POST',
-                    body: JSON.stringify({ test: 'test' }),
-                    headers: {
-                        'User-Agent': 'TrezorSuite',
-                        'Allowed-Headers': 'AcCePt-EnCoDiNg;content-type;Content-Length;HOST', // case insensitive
-                    },
-                }),
-            ).resolves.toEqual(
-                expect.objectContaining({
-                    host,
+                },
+                allowedHeaders: 'AcCePt-EnCoDiNg;content-type;Content-Length;HOST', // case insensitive
+                expectedRestricted: {
                     'content-length': '15',
                     'content-type': 'text/plain;charset=UTF-8',
-                }),
-            );
-        });
-
-        it('GET request headers', async () => {
-            const { serverUrl, host } = serverInit;
-
-            // default headers
-            await expect(
-                fetchHeaders(serverUrl, {
-                    method: 'GET',
-                    headers: { 'User-Agent': 'TrezorSuite' },
-                }),
-            ).resolves.toEqual(
-                expect.objectContaining({
-                    host,
+                },
+            },
+            {
+                method: 'GET',
+                body: undefined,
+                defaultHeaders: { 'User-Agent': 'TrezorSuite' },
+                expectedDefault: {
                     accept: '*/*',
                     'user-agent': 'TrezorSuite',
-                }),
-            );
+                },
+                allowedHeaders: 'Accept-Encoding;Content-Type;Content-Length;Host',
+                expectedRestricted: {},
+            },
+        ];
 
-            // restricted headers
-            await expect(
-                fetchHeaders(serverUrl, {
-                    method: 'GET',
-                    headers: {
-                        'User-Agent': 'TrezorSuite',
-                        'Allowed-Headers': 'Accept-Encoding;Content-Type;Content-Length;Host',
-                    },
-                }),
-            ).resolves.toEqual(
-                expect.objectContaining({
-                    host,
-                }),
+        describe.each(fetchImplementations)('%s', (_, fetchFn) => {
+            it.each(headerTestCases)(
+                '$method request headers',
+                async ({
+                    method,
+                    body,
+                    defaultHeaders,
+                    expectedDefault,
+                    allowedHeaders,
+                    expectedRestricted,
+                }) => {
+                    const { serverUrl, host } = serverInit;
+
+                    // default headers
+                    await expect(
+                        fetchHeaders(
+                            fetchFn(serverUrl, {
+                                method,
+                                body,
+                                headers: defaultHeaders,
+                            }),
+                        ),
+                    ).resolves.toEqual(expect.objectContaining({ host, ...expectedDefault }));
+
+                    // restricted headers
+                    await expect(
+                        fetchHeaders(
+                            fetchFn(serverUrl, {
+                                method,
+                                body,
+                                headers: {
+                                    ...defaultHeaders,
+                                    'Allowed-Headers': allowedHeaders,
+                                },
+                            }),
+                        ),
+                    ).resolves.toEqual(expect.objectContaining({ host, ...expectedRestricted }));
+                },
             );
         });
     });
 
-    it('Block unauthorized requests', async () => {
+    it.each(fetchImplementations)('%s Block unauthorized requests', async (_, fetchFn) => {
         torSettings.running = false;
 
         await expect(
-            fetch(testPostUrlHttps, {
+            fetchFn(testPostUrlHttps, {
                 method: 'POST',
                 body: JSON.stringify({ test: 'test' }),
                 headers: { 'Proxy-Authorization': 'Basic default' },

--- a/packages/request-manager/package.json
+++ b/packages/request-manager/package.json
@@ -17,12 +17,13 @@
     "dependencies": {
         "@trezor/node-utils": "workspace:^",
         "@trezor/utils": "workspace:*",
-        "node-fetch": "^3.3.2",
         "socks-proxy-agent": "8.0.5",
+        "undici": "8.5.0",
         "ws": "^8.20.0"
     },
     "devDependencies": {
         "@trezor/eslint": "workspace:*",
+        "node-fetch": "^3.3.2",
         "tsx": "^4.21.0"
     }
 }

--- a/packages/request-manager/package.json
+++ b/packages/request-manager/package.json
@@ -6,9 +6,9 @@
     "sideEffects": false,
     "main": "src/index.ts",
     "scripts": {
-        "test:all": "SKIP_FLAKY_TESTS=1 yarn g:jest",
-        "test:unit": "yarn g:jest --testPathIgnorePatterns e2e",
-        "test:e2e": "yarn g:jest --runInBand --testPathIgnorePatterns tests",
+        "test:all": "SKIP_FLAKY_TESTS=1 yarn g:jest --verbose",
+        "test:unit": "yarn g:jest --verbose --testPathIgnorePatterns e2e",
+        "test:e2e": "yarn g:jest --verbose --runInBand --testPathIgnorePatterns tests",
         "type-check": "yarn g:tsc --build tsconfig.json",
         "test:stress": "tsx ./e2e/identities-stress.ts",
         "depcheck": "yarn g:depcheck",

--- a/packages/request-manager/src/interceptor/fetchHeaders.ts
+++ b/packages/request-manager/src/interceptor/fetchHeaders.ts
@@ -1,0 +1,50 @@
+const getHeaderEntries = (headers?: HeadersInit): [string, string][] => {
+    if (!headers) {
+        return [];
+    }
+
+    return [...new Headers(headers).entries()];
+};
+
+export const getHeaderValue = (headers: HeadersInit | undefined, name: string) => {
+    if (!headers) {
+        return undefined;
+    }
+
+    return new Headers(headers).get(name) ?? undefined;
+};
+
+// Internal control headers that must never reach the destination server, regardless of the
+// allow-list: `Proxy-Authorization` carries the Tor identity credentials and `Allowed-Headers` is
+// our own routing-control header.
+const internalControlHeaders = ['proxy-authorization', 'allowed-headers'];
+
+const isInternalControlHeader = (key: string) => internalControlHeaders.includes(key.toLowerCase());
+
+const isHeaderAllowed = (key: string, allowedHeadersValue: string) => {
+    const allowedKeys = allowedHeadersValue.split(';');
+    const normalizedKey = key.toLowerCase();
+
+    // Prefix match, case-insensitive - same semantics as the original socket-level stripping. Uses
+    // `startsWith` rather than a `RegExp` so allow-list values containing regex metacharacters are
+    // matched literally.
+    return allowedKeys.some(allowed => normalizedKey.startsWith(allowed.toLowerCase()));
+};
+
+// Builds the headers sent through the Tor SOCKS5 dispatcher. Internal control headers are always
+// stripped first so they can never leak. When `Allowed-Headers` is present only the allow-listed
+// headers are then kept; otherwise all remaining headers are forwarded.
+export const buildTorHeaders = (headers?: HeadersInit): Record<string, string> => {
+    const entries = getHeaderEntries(headers);
+
+    const allowedHeadersValue = getHeaderValue(headers, 'Allowed-Headers');
+
+    const withoutControlHeaders = entries.filter(([key]) => !isInternalControlHeader(key));
+
+    const filtered =
+        allowedHeadersValue !== undefined
+            ? withoutControlHeaders.filter(([key]) => isHeaderAllowed(key, allowedHeadersValue))
+            : withoutControlHeaders;
+
+    return Object.fromEntries(filtered);
+};

--- a/packages/request-manager/src/interceptor/fetchPool.ts
+++ b/packages/request-manager/src/interceptor/fetchPool.ts
@@ -1,0 +1,72 @@
+import { type InterceptorContext } from './interceptorTypes';
+
+const requestTimeoutLimit = 1000 * 30;
+
+type MonitorFetchParams<T extends { status: number }> = {
+    context: InterceptorContext;
+    host: string;
+    identity?: string;
+    request: Promise<T>;
+};
+
+// Reports timing and error events for a fetch routed through undici. This mirrors the monitoring
+// that `httpPool` attaches to `http.ClientRequest`, which undici does not go through.
+export const monitorFetch = <T extends { status: number }>({
+    context,
+    host,
+    identity,
+    request,
+}: MonitorFetchParams<T>): Promise<T> => {
+    const requestTime = Date.now();
+
+    return request.then(
+        response => {
+            const timeRequestTook = Date.now() - requestTime;
+
+            const isNetworkMisbehaving = timeRequestTook > requestTimeoutLimit;
+            if (isNetworkMisbehaving) {
+                context.handler({
+                    type: 'NETWORK_MISBEHAVING',
+                });
+            }
+
+            context.handler({
+                type: 'INTERCEPTED_RESPONSE',
+                host,
+                time: timeRequestTook,
+                statusCode: response.status,
+            });
+
+            return response;
+        },
+        (error: Error) => {
+            // undici wraps connection failures in a generic error and exposes the underlying cause
+            // on the `cause` field, so we inspect both. A SocksClientError thrown by the 'socks'
+            // package carries an `options` field, while socket resets surface as 'ECONNRESET'; both
+            // indicate a misbehaving Tor circuit.
+            const cause = 'cause' in error ? (error.cause as unknown) : undefined;
+
+            const isCircuitMisbehaving = [error, cause].some(
+                candidate =>
+                    typeof candidate === 'object' &&
+                    candidate !== null &&
+                    (('code' in candidate && candidate.code === 'ECONNRESET') ||
+                        'options' in candidate),
+            );
+
+            if (isCircuitMisbehaving) {
+                context.handler({
+                    type: 'CIRCUIT_MISBEHAVING',
+                    identity: identity?.split(':')[0],
+                });
+            } else {
+                context.handler({
+                    type: 'ERROR',
+                    error,
+                });
+            }
+
+            throw error;
+        },
+    );
+};

--- a/packages/request-manager/src/interceptor/interceptFetch.ts
+++ b/packages/request-manager/src/interceptor/interceptFetch.ts
@@ -1,44 +1,92 @@
-// TODO: Nodejs fetch APIs use undici which is based on totally different design,
-// proxy-agent package is not compatible with undici, and can only be used with
-// old API like http.request.
-// See issue: https://github.com/TooTallNate/proxy-agents/issues/239 .
-import type { RequestOptions } from 'https';
-import nodeFetch, { type RequestInit } from 'node-fetch';
+// Node's global `fetch` is backed by undici, which - unlike the legacy `http`/`https` modules - does
+// not go through this package's `http.request` interception.
+// Using native nodejs undici's `Socks5ProxyAgent` to route Tor traffic.
+// https://github.com/nodejs/undici/blob/main/docs/docs/api/Socks5ProxyAgent.md
+import { fetch as undiciFetch } from 'undici';
 
+import { isWhitelistedHost } from '@trezor/utils';
+
+import { buildTorHeaders, getHeaderValue } from './fetchHeaders';
+import { monitorFetch } from './fetchPool';
 import { type Interceptor } from './interceptorTypes';
-import { getIsTorRequired } from './overloadHttpRequest';
+import { getIdentityName } from './overloadHttpRequest';
+
+const resolveHostname = (url: RequestInfo | URL) => {
+    if (typeof url === 'object' && 'hostname' in url) {
+        // case url type of URL
+        return url.hostname;
+    }
+    if (typeof url === 'object' && 'url' in url) {
+        // case url type of globalThis.Request
+        return new URL(url.url).hostname;
+    }
+    if (typeof url === 'string') {
+        // case url type of string
+        return new URL(url).hostname;
+    }
+
+    return 'unknown';
+};
 
 export const interceptFetch: Interceptor = ({ context, validateRequest }) => {
     const originalFetch = global.fetch;
 
-    global.fetch = (url, options): Promise<Response> => {
-        const isTorEnabled = context.getTorSettings().running;
-        const isTorRequired = getIsTorRequired(options as Readonly<RequestOptions>);
+    global.fetch = (url, options) => {
+        // Native `fetch` never throws synchronously, it always returns a promise.
+        try {
+            const isTorEnabled = context.getTorSettings().running;
+            const proxyAuthorization = getHeaderValue(options?.headers, 'Proxy-Authorization');
+            const isTorRequired = proxyAuthorization !== undefined;
+            const headers = buildTorHeaders(options?.headers);
+            const fetchOptions = { ...options, headers };
 
-        if (isTorEnabled) {
-            return nodeFetch(url as string, options as RequestInit) as Promise<any>;
-        }
+            const hostname = resolveHostname(url);
+            validateRequest({ hostname });
 
-        if (isTorRequired && !context.allowTorBypass) {
-            return Promise.reject(
-                new Error('Blocked request with Proxy-Authorization. TOR not enabled.'),
+            // Hosts that don't require Tor (e.g. localhost, dev domains) connect directly, matching the
+            // behavior of the http(s) interceptor in `overloadHttpRequest`.
+            if (isWhitelistedHost(hostname, context.notRequiredTorDomainsList)) {
+                return originalFetch(url, fetchOptions);
+            }
+
+            if (!isTorEnabled) {
+                if (isTorRequired && !context.allowTorBypass) {
+                    throw new Error('Blocked request with Proxy-Authorization. TOR not enabled.');
+                }
+
+                return originalFetch(url, fetchOptions);
+            }
+
+            // Use the Proxy-Authorization header to select the Tor circuit, falling back to 'default'.
+            const identity = getIdentityName(proxyAuthorization) || 'default';
+            const dispatcher = context.torIdentities.getDispatcher(identity);
+
+            context.handler({
+                type: 'INTERCEPTED_REQUEST',
+                method: 'fetch',
+                details: `${hostname} with identity ${identity}`,
+            });
+
+            // The type mismatch is a TypeScript artifact:
+            // the compiler sees lib.dom.Request/Response as different from undici.Request even though at runtime in Node.js they're the same class.
+            const request = undiciFetch(
+                ...([
+                    url,
+                    {
+                        ...fetchOptions,
+                        dispatcher,
+                    },
+                ] as Parameters<typeof undiciFetch>),
             );
+
+            return monitorFetch({
+                context,
+                host: hostname,
+                identity,
+                request,
+            }) as unknown as Promise<Response>;
+        } catch (error) {
+            return Promise.reject(error);
         }
-
-        let hostname = 'unknown';
-        if (typeof url === 'object' && 'hostname' in url) {
-            // case url type of URL
-            hostname = url.hostname;
-        } else if (typeof url === 'object' && 'url' in url) {
-            // case url type of globalThis.Request
-            hostname = url.url;
-        } else if (typeof url === 'string') {
-            // case url type of string
-            hostname = new URL(url).hostname;
-        }
-
-        validateRequest({ hostname });
-
-        return originalFetch(url, options);
     };
 };

--- a/packages/request-manager/src/interceptor/interceptNetSocketConnect.ts
+++ b/packages/request-manager/src/interceptor/interceptNetSocketConnect.ts
@@ -9,6 +9,8 @@ export const interceptNetSocketConnect: Interceptor = ({ context, validateReques
     //    https://github.com/nodejs/node/blob/e48763840625c037282681456ecd1e1cb034f636/lib/_http_outgoing.js#L508-L510
     // 2. node-fetch always(!) adds "User-Agent", "Accept", "Connection"...
     //    https://github.com/node-fetch/node-fetch/blob/7b86e946b02dfdd28f4f8fca3d73a022cbb5ca1e/src/request.js#L226
+    // This socket-level stripping applies to the legacy http(s) module path. Global `fetch` now goes
+    // through undici (see `interceptFetch`), which filters "Allowed-Headers" at the options level.
     const originalSocketWrite = net.Socket.prototype.write;
 
     net.Socket.prototype.write = function (data, ...args) {

--- a/packages/request-manager/src/interceptor/overloadHttpRequest.ts
+++ b/packages/request-manager/src/interceptor/overloadHttpRequest.ts
@@ -19,7 +19,7 @@ const getHeaderValue = (headers: http.OutgoingHttpHeaders | undefined, name: str
     return { key, value };
 };
 
-const getIdentityName = (proxyAuthorization?: http.OutgoingHttpHeader) => {
+export const getIdentityName = (proxyAuthorization?: http.OutgoingHttpHeader) => {
     const identity = Array.isArray(proxyAuthorization) ? proxyAuthorization[0] : proxyAuthorization;
 
     // Only return identity name if it is explicitly defined.

--- a/packages/request-manager/src/torIdentities.ts
+++ b/packages/request-manager/src/torIdentities.ts
@@ -1,16 +1,64 @@
 import { SocksProxyAgent } from 'socks-proxy-agent';
+import { Socks5ProxyAgent } from 'undici';
 
 import type { TorSettings } from './types';
+
+// undici's Socks5ProxyAgent emits a one-time `ExperimentalWarning` from its constructor. We swallow
+// only that specific warning (leaving every other warning untouched) so it doesn't pollute logs.
+const createSocks5ProxyAgent = (proxyUrl: URL) => {
+    const originalEmitWarning = process.emitWarning;
+
+    process.emitWarning = (...args) => {
+        const [warning, options] = args;
+        const type = typeof options === 'string' ? options : (options as { type?: string })?.type;
+
+        if (
+            type === 'ExperimentalWarning' &&
+            String(warning).includes('SOCKS5 proxy support is experimental')
+        ) {
+            return;
+        }
+
+        return originalEmitWarning(...(args as Parameters<typeof process.emitWarning>));
+    };
+
+    try {
+        return new Socks5ProxyAgent(proxyUrl);
+    } finally {
+        process.emitWarning = originalEmitWarning;
+    }
+};
 
 export class TorIdentities {
     private readonly getTorSettings: () => TorSettings;
     private readonly identities: { [key: string]: SocksProxyAgent };
+    private readonly dispatchers: { [key: string]: Socks5ProxyAgent };
     private readonly passwords: { [key: string]: string };
 
     constructor(getTorSettings: () => TorSettings) {
         this.getTorSettings = getTorSettings;
         this.identities = {};
+        this.dispatchers = {};
         this.passwords = {};
+    }
+
+    private buildSocksServerUrl(user: string, password: string) {
+        const { host, port } = this.getTorSettings();
+
+        const socksServerUrl = new URL(`socks://${host}:${port}`);
+        socksServerUrl.username = user;
+        socksServerUrl.password = password;
+
+        return socksServerUrl;
+    }
+
+    // When a new password is requested for an existing identity we drop the cached agents so that
+    // a fresh Tor circuit is created for the new credentials.
+    private resetIdentityIfPasswordChanged(user: string, password: string) {
+        if (password && this.passwords[user] !== password) {
+            this.removeIdentity(user);
+            this.passwords[user] = password;
+        }
     }
 
     public getIdentity(
@@ -22,21 +70,11 @@ export class TorIdentities {
         const user = identityParts[0] ?? '';
         const password = identityParts[1] ?? '';
 
-        if (password && this.passwords[user] !== password) {
-            if (this.identities[user]) {
-                this.removeIdentity(user);
-            }
-            this.passwords[user] = password;
-        }
-
-        const { host, port } = this.getTorSettings();
+        this.resetIdentityIfPasswordChanged(user, password);
 
         // TODO clean agents when host/port changes?
         if (!this.identities[user]) {
-            const socksServerUrl = new URL(`socks://${host}:${port}`);
-            socksServerUrl.username = user;
-            socksServerUrl.password = password;
-            this.identities[user] = new SocksProxyAgent(socksServerUrl, {
+            this.identities[user] = new SocksProxyAgent(this.buildSocksServerUrl(user, password), {
                 timeout,
             });
         }
@@ -50,13 +88,32 @@ export class TorIdentities {
         return agent;
     }
 
+    // Returns an undici dispatcher routing through the Tor SOCKS5 proxy for the given identity.
+    // Used by the fetch interceptor, since undici bypasses the http(s) module interception.
+    public getDispatcher(identity: string): Socks5ProxyAgent {
+        const identityParts = identity.split(':');
+        const user = identityParts[0] ?? '';
+        const password = identityParts[1] ?? user; // undici's Socks5ProxyAgent requires a password if user is set
+
+        this.resetIdentityIfPasswordChanged(user, password);
+
+        if (!this.dispatchers[user]) {
+            this.dispatchers[user] = createSocks5ProxyAgent(
+                this.buildSocksServerUrl(user, password),
+            );
+        }
+
+        return this.dispatchers[user];
+    }
+
     public removeIdentity(user: string) {
         // looks like destroy does nothing, but just in case
-        const { identities } = this;
-        // @ts-expect-error: indexing with noUncheckedIndexedAccess
-        const identity: SocksProxyAgent = identities[user];
-        identity.destroy();
+        this.identities[user]?.destroy();
         delete this.identities[user];
+
+        this.dispatchers[user]?.destroy();
+        delete this.dispatchers[user];
+
         delete this.passwords[user];
     }
 }

--- a/packages/request-manager/tests/interceptor-whitelist.test.ts
+++ b/packages/request-manager/tests/interceptor-whitelist.test.ts
@@ -86,6 +86,17 @@ describe('Interceptor', () => {
     });
 
     ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'].forEach(method => {
+        it(`Blocks all not whitelisted global.fetch requests for: ${method}`, async () => {
+            // undici wraps DNS failures as "fetch failed". the actual cause is in error.cause
+            await expect(fetch(`https://${WHITELISTED_DOMAIN}`, { method })).rejects.toThrow(
+                `fetch failed`,
+            );
+
+            await expect(fetch(`https://${NOT_WHITELISTED_DOMAIN}`, { method })).rejects.toThrow(
+                `Request blocked, not whitelisted domain: ${NOT_WHITELISTED_DOMAIN}`,
+            );
+        });
+
         it(`Blocks all not whitelisted node-fetch requests for: ${method}`, async () => {
             await expect(nodeFetch(`https://${WHITELISTED_DOMAIN}`, { method })).rejects.toThrow(
                 OK_ERROR_HTTPS,
@@ -155,22 +166,5 @@ describe('Interceptor', () => {
                 `Request blocked, not whitelisted domain: ${NOT_WHITELISTED_DOMAIN}`,
             );
         }
-    });
-
-    ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'].forEach(method => {
-        it(`Blocks all not whitelisted native fetch for: ${method}`, async () => {
-            await expect(fetch(`https://${WHITELISTED_DOMAIN}`, { method })).rejects.toThrow(
-                'fetch failed',
-            );
-
-            try {
-                await fetch(`https://${NOT_WHITELISTED_DOMAIN}/`, { method });
-                expect('').toBe('Should throw an error');
-            } catch (error) {
-                expect(error.message).toBe(
-                    `Request blocked, not whitelisted domain: ${NOT_WHITELISTED_DOMAIN}`,
-                );
-            }
-        });
     });
 });

--- a/scripts/list-outdated-dependencies/connect-dependencies.txt
+++ b/scripts/list-outdated-dependencies/connect-dependencies.txt
@@ -72,6 +72,7 @@ tailwindcss
 tiny-worker
 ts-mixer
 ts-node
+undici
 usb
 version-bump-prompt
 ws

--- a/yarn.lock
+++ b/yarn.lock
@@ -16923,6 +16923,7 @@ __metadata:
     node-fetch: "npm:^3.3.2"
     socks-proxy-agent: "npm:8.0.5"
     tsx: "npm:^4.21.0"
+    undici: "npm:8.5.0"
     ws: "npm:^8.20.0"
   languageName: unknown
   linkType: soft
@@ -45659,6 +45660,13 @@ __metadata:
   version: 6.20.0
   resolution: "undici-types@npm:6.20.0"
   checksum: 10/583ac7bbf4ff69931d3985f4762cde2690bb607844c16a5e2fbb92ed312fe4fa1b365e953032d469fa28ba8b224e88a595f0b10a449332f83fa77c695e567dbe
+  languageName: node
+  linkType: hard
+
+"undici@npm:8.5.0":
+  version: 8.5.0
+  resolution: "undici@npm:8.5.0"
+  checksum: 10/e95913777afd47d76babfe62547bb4e9a94b93f44b50c84b4e0b6fa41c00364e31ff4f433a955b1592c3162f43e8757e2e0feae6eea195187730594523393568
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Since there is fetch native in nodejs which is backed by undici and it supports Socks5 with its Socks5ProxyAgent, then we can use it to intercept nodejs gobal fetch requests with the native Socks5ProxyAgent when using Tor and not relaying on node-fetch for it.

Documentation for undici Socks5ProxyAgent is: https://github.com/nodejs/undici/blob/main/docs/docs/api/Socks5ProxyAgent.md

## Notes for QA

Make sure that Tor works as expected with all the networks.


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are entirely within the `packages/request-manager` package, affecting HTTP/fetch interception, socket connect overloading, fetch pooling/headers, and Tor identity management. This is low-level networking infrastructure. The package has its own unit/integration tests (interceptor.test.ts, interceptor-whitelist.test.ts) included in this changeset. None of the 19 candidate E2E tests have direct static coverage mapping to these files, and most E2E tests interact with this infrastructure only indirectly through higher-level app layers. The risk to E2E-visible behavior is low, but bridge communication is the most plausible affected surface.

<details><summary><b>Changed files (9)</b></summary>

- `packages/request-manager/e2e/interceptor.test.ts`
- `packages/request-manager/package.json`
- `packages/request-manager/src/interceptor/fetchHeaders.ts`
- `packages/request-manager/src/interceptor/fetchPool.ts`
- `packages/request-manager/src/interceptor/interceptFetch.ts`
- `packages/request-manager/src/interceptor/interceptNetSocketConnect.ts`
- `packages/request-manager/src/interceptor/overloadHttpRequest.ts`
- `packages/request-manager/src/torIdentities.ts`
- `packages/request-manager/tests/interceptor-whitelist.test.ts`

</details>

**Recommended tests (2)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — The request-manager package handles HTTP request interception, fetch pooling, and Tor identity management, which are part of the networking infrastructure used by the bridge/daemon communication layer. Changes to interceptFetch, overloadHttpRequest, and interceptNetSocketConnect could affect how the app communicates with the bridge HTTP endpoint. This is the most closely related E2E test to network-level request handling changes.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test makes HTTP requests to validate links across the app and handles HTTP responses including retry logic. Changes to fetch interception (interceptFetch, fetchHeaders, fetchPool) could theoretically affect how outbound HTTP requests are made during link checking, though the test likely uses Playwright's own request context rather than the app's intercepted fetch.

</details>

⚠️ **Changes with no test coverage (9)**
- `packages/request-manager/e2e/interceptor.test.ts`
- `packages/request-manager/package.json`
- `packages/request-manager/src/interceptor/fetchHeaders.ts`
- `packages/request-manager/src/interceptor/fetchPool.ts`
- `packages/request-manager/src/interceptor/interceptFetch.ts`
- `packages/request-manager/src/interceptor/interceptNetSocketConnect.ts`
- `packages/request-manager/src/interceptor/overloadHttpRequest.ts`
- `packages/request-manager/src/torIdentities.ts`
- `packages/request-manager/tests/interceptor-whitelist.test.ts`

_Updated: 2026-07-01T14:45:23.671Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/undici-socks/web/](https://dev.suite.sldev.cz/suite-web/undici-socks/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=undici-socks&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=undici-socks&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-13T15:36:21.302Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-13T15:36:36.547Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->