### PR TITLE
wip

### DIFF
--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -37,9 +37,14 @@ process.traceProcessWarnings = true;
 // @ts-expect-error using internal electron API to set suite version in dev mode correctly
 if (isDevEnv || process.env.PLAYWRIGHT_RUN) app.setVersion(process.env.VERSION);
 
-global.resourcesPath = isDevEnv
-    ? path.join(__dirname, '..', 'build', 'static')
-    : process.resourcesPath;
+// During e2e tests the app is built in production mode (NODE_ENV=production) but launched
+// unpacked, so bundled binaries (tor, coinjoin, ...) live in build/static/bin, not in
+// process.resourcesPath. PLAYWRIGHT_RUN is set by the e2e launcher and is not inlined at build
+// time, so it can be used to point resourcesPath at the unpacked build output.
+global.resourcesPath =
+    isDevEnv || process.env.PLAYWRIGHT_RUN
+        ? path.join(__dirname, '..', 'build', 'static')
+        : process.resourcesPath;
 
 const parseRemoveUserDataSwitch = () => {
     if (hasSwitch('remove-user-data-on-start')) {

--- a/suite/e2e/docs/e2e-tor-network-leak.md
+++ b/suite/e2e/docs/e2e-tor-network-leak.md
@@ -1,0 +1,168 @@
+# Tor network-leak e2e test
+
+Verifies that, **with Tor enabled, the Trezor Suite desktop app never opens a TCP connection
+outside of `localhost`**. When Tor is on, all Suite traffic must be routed through the local Tor
+SOCKS proxy; only the separate bundled `tor` process is allowed to reach the internet.
+
+Test file: [`suite/e2e/tests/tor/tor-network-leak.test.ts`](../tests/tor/tor-network-leak.test.ts)
+
+> This test needs a **live internet connection** (to bootstrap Tor) and shells out to `lsof`. It is
+> intended to be run **locally on demand**. It is tagged `@desktopOnly @T3T1 @nightlyOnly` and is
+> additionally gated behind the `TOR_NETWORK_LEAK_E2E` env var, so it never runs in CI by default.
+
+---
+
+## What the test does
+
+1. Launches the desktop app already Tor-enabled (via the `--tor` switch).
+2. Completes onboarding with a seeded device (`mnemonic_all`).
+3. Waits until `state.tor.torStatus === 'Enabled'` (Tor finished bootstrapping).
+4. Enables **all mainnet networks** and runs account discovery to generate outbound traffic.
+5. While the app is active, samples established TCP connections of the Suite's Electron process
+   tree (`lsof`) and asserts that **none** has a non-localhost remote endpoint.
+
+---
+
+## Prerequisites
+
+All paths are relative to the repo root.
+
+1. **Docker** running.
+2. **trezor-user-env** running: in the `trezor-user-env` repo, run `./run.sh`. Provides bridge +
+   emulators.
+3. **Local relay server** (suite sync): `yarn workspace @trezor/suite-e2e docker:suite-sync`.
+4. **`.env`** in `suite/e2e` created from `.example.env`.
+5. **`lsof`** available on the host (Linux/macOS).
+6. A **live internet connection** so Tor can bootstrap.
+
+---
+
+## Build steps
+
+The e2e launcher (`suite/e2e/support/electron.ts`) runs the **unpacked** desktop app
+(`packages/suite-desktop/dist/app.js`). You must build **both** the main process and the renderer
+**in production mode**. Building either in development mode breaks this test (see Troubleshooting).
+
+```bash
+# 1. Renderer (electron-renderer) — production. TEST_BUILD mocks the bundled message-system config.
+TEST_BUILD=true yarn workspace @trezor/suite-desktop build:ui
+
+# 2. Main process (electron-main) — production. build:app sets NODE_ENV=production internally.
+yarn workspace @trezor/suite-desktop build:app
+```
+
+When to rebuild:
+
+| You changed code in…                           | Rebuild     |
+| ---------------------------------------------- | ----------- |
+| `suite`, `suite-desktop-ui` (renderer)         | `build:ui`  |
+| `connect`, `suite-desktop-core` (main process) | `build:app` |
+| only `suite/e2e/**` (test + support files)     | nothing     |
+
+> Do **not** run `yarn workspace @trezor/suite-desktop dev` (or `dev:local`) — it overwrites
+> `packages/suite-desktop/build` with a development renderer that expects the dev server on
+> `localhost:8000`.
+
+---
+
+## Running the test
+
+```bash
+TOR_NETWORK_LEAK_E2E=1 \
+  yarn workspace @trezor/suite-e2e test:e2e:desktop --project=T3T1 tor/tor-network-leak.test.ts
+```
+
+Useful env vars / flags:
+
+- `TOR_NETWORK_LEAK_E2E=1` — **required**, otherwise the test is skipped.
+- `PRINT_ELECTRON_LOGS=1` — stream the desktop app's main-process logs (Tor bootstrap, bridge, …)
+  to the terminal in addition to the log file.
+- `--headed` — show the app window.
+- `--project=T3T1` — run against a single device model.
+
+---
+
+## Artifacts & debugging
+
+Everything lands in `suite/e2e/test-results/<test-name>/` and is attached to the Playwright report:
+
+- **`electron-logs.txt`** — full main-process log. Look for `tor` / `process-tor` entries, e.g.
+  `process-tor: Starting process: - Path: .../build/static/bin/tor/linux-x64/tor` and bootstrap
+  progress.
+- **`netlog.json`** — Chromium net log (enabled by `electronConf: { netLog: true }`). Open it in
+  the [netlog viewer](https://netlog-viewer.appspot.com/). For each request you can see the URL,
+  the **source** (renderer vs. a Chromium background service such as Safe Browsing / connectivity
+  check / component updater), and the **proxy** used (`DIRECT` = a leak). This is the fastest way to
+  attribute an external connection to a specific request.
+- **`trace.zip`**, **video**, **screenshots** — standard Playwright artifacts.
+
+The test also prints the collected external connections to stdout (`externalConnections`, each with
+`command`, `pid`, `remoteHost`, and the raw `lsof` line).
+
+### Identifying which process owns a connection (manual)
+
+```bash
+readlink -f /proc/<pid>/exe   # the binary behind the pid (Suite's electron vs. another app)
+pstree -sp <pid>              # ancestry
+sudo ss -tp 'dst :443'        # pid/program per socket, no reverse-DNS noise
+```
+
+---
+
+## How the pieces fit together
+
+| Concern                      | Where                                                                                                |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------- |
+| Launch app with Tor on       | `--tor` switch → `hasSwitch('tor')` in `suite-desktop-core/src/modules/tor.ts`                       |
+| `tor` launch option plumbing | `suite/e2e/support/electron.ts` (`LaunchSuiteParams.tor`), `support/types/index.ts` (`ElectronConf`) |
+| Connection sampling          | `suite/e2e/support/networkAnalyzer.ts` (`lsof`, scoped to the app's PID tree)                        |
+| Net log capture + attach     | `support/electron.ts` (`netLog` → `--log-net-log`), `support/setup.ts` (attach)                      |
+| Terminal log mirror          | `support/electron.ts` (`PRINT_ELECTRON_LOGS`)                                                        |
+| Bundled binary path (e2e)    | `suite-desktop-core/src/app.ts` (`global.resourcesPath`), `libs/processes/BaseProcess.ts`            |
+
+### Why `NetworkAnalyzer` is scoped to a PID tree
+
+`lsof` matches every process named `electron`/`node` on the machine — including the editor running
+the tests (Cursor/VSCode are Electron apps and talk to Google). The analyzer takes the launched
+app's main pid (`electronApp.process().pid`), expands it to the full descendant set via
+`ps -e -o pid=,ppid=`, and only counts connections from that tree, so other apps can't be
+misreported as Suite leaks.
+
+---
+
+## Troubleshooting
+
+### `ENOENT … electron/resources/bin/tor/linux-x64/tor` (Tor won't start)
+
+The bundled Tor binary lives in `packages/suite-desktop/build/static/bin/tor/<system>/tor` for the
+unpacked e2e build, but `global.resourcesPath` only points there when running dev/e2e. Because the
+e2e build is compiled with `NODE_ENV=production` (so `isDevEnv` is baked to `false`), `app.ts`
+resolves `resourcesPath` for Playwright runs using the `PLAYWRIGHT_RUN` env var (set by the
+launcher):
+
+```ts
+global.resourcesPath =
+    isDevEnv || process.env.PLAYWRIGHT_RUN
+        ? path.join(__dirname, '..', 'build', 'static')
+        : process.resourcesPath;
+```
+
+If you hit the ENOENT: confirm `build:ui` ran (it copies the binaries into `build/static/bin`), then
+rebuild `build:app` so the updated `app.js` is used.
+
+### `Failed to load URL: http://localhost:8000/  ERR_CONNECTION_REFUSED`
+
+The **renderer** was built in development mode (it embeds the `webpack-plugin-serve` HMR client that
+points at the dev server on `localhost:8000`). Rebuild the renderer in production:
+
+```bash
+TEST_BUILD=true yarn workspace @trezor/suite-desktop build:ui
+```
+
+…and make sure no `yarn dev` / `dev:local` watcher is overwriting `build/`.
+
+### External connections to Google (`*.1e100.net`, `142.251.x`, `172.217.x`, `173.194.x`)
+
+These are Google IPs on port 443 (HTTPS, not DNS). First confirm the owning process is actually the
+Suite (the scoped analyzer now does this automatically). If it is the Suite, open `netlog.json` to
+see whether the request went `DIRECT` (a real Tor leak) and what its source is.

--- a/suite/e2e/support/electron.ts
+++ b/suite/e2e/support/electron.ts
@@ -20,6 +20,7 @@ export type LaunchSuiteParams = {
     bridgeDaemon?: boolean;
     exposeConnectWs?: boolean;
     offlineMode?: boolean;
+    tor?: boolean;
     locale?: string;
     colorScheme?: 'light' | 'dark' | 'no-preference' | null | undefined;
     artefactFolder: string;
@@ -69,6 +70,11 @@ const buildArgs = (params: LaunchSuiteParams) => {
         args.push('--offline-mode');
     }
 
+    // Starts the app with Tor already enabled (see `hasSwitch('tor')` in suite-desktop-core).
+    if (params.tor) {
+        args.push('--tor');
+    }
+
     const deleteUserData = !params.keepUserData;
     if (deleteUserData) {
         args.push(removeUserDataArgument);
@@ -82,10 +88,22 @@ const setupLoggingToFile = (electronApp: ElectronApplication, params: LaunchSuit
     ensureDirSync(params.artefactFolder);
     const logStream = createWriteStream(logFilePath, { flags: 'a' });
 
-    electronApp.process().stdout?.on('data', data => logStream.write(data.toString()));
-    electronApp
-        .process()
-        .stderr?.on('data', data => logStream.write(formatErrorLogMessage(data.toString())));
+    // Set PRINT_ELECTRON_LOGS=1 to also stream the desktop app's main-process logs (Tor
+    // bootstrap, bridge, etc.) to the terminal while the test runs, on top of the log file.
+    const printToConsole = process.env.PRINT_ELECTRON_LOGS === '1';
+
+    electronApp.process().stdout?.on('data', data => {
+        logStream.write(data.toString());
+        if (printToConsole) {
+            process.stdout.write(data.toString());
+        }
+    });
+    electronApp.process().stderr?.on('data', data => {
+        logStream.write(formatErrorLogMessage(data.toString()));
+        if (printToConsole) {
+            process.stderr.write(formatErrorLogMessage(data.toString()));
+        }
+    });
     electronApp.process().on('close', () => {
         logStream.end();
     });

--- a/suite/e2e/support/networkAnalyzer.ts
+++ b/suite/e2e/support/networkAnalyzer.ts
@@ -1,55 +1,119 @@
 import { exec } from 'child_process';
 
-import type { IntervalId } from '@trezor/type-utils';
+export type TcpConnection = {
+    command: string;
+    pid: string;
+    localEndpoint: string;
+    remoteEndpoint: string;
+    remoteHost: string;
+    remotePort: string;
+    raw: string;
+};
 
-export class NetworkAnalyzer {
-    interval?: string | number | IntervalId;
-    tcp: string[];
+// Loopback addresses whose traffic never leaves the machine. When Tor is enabled, the Suite
+// (electron/node) processes must only talk to the local Tor SOCKS proxy and other localhost
+// services. The bundled `tor` process is the only one allowed to reach the outside world.
+const isLoopbackHost = (host: string): boolean => {
+    const normalized = host.replace(/^\[/, '').replace(/\]$/, '').toLowerCase();
 
-    constructor() {
-        this.tcp = [];
+    return (
+        normalized === 'localhost' ||
+        normalized === '::1' ||
+        normalized === '::' ||
+        normalized === '0.0.0.0' ||
+        normalized.startsWith('127.')
+    );
+};
+
+const parseRemoteEndpoint = (remoteEndpoint: string): { host: string; port: string } => {
+    // IPv6 endpoints are wrapped in brackets, e.g. [2600:9000:207f::1]:443
+    const ipv6Match = remoteEndpoint.match(/^\[(?<host>.+)\]:(?<port>\d+|\*)$/);
+    if (ipv6Match?.groups?.host && ipv6Match.groups.port) {
+        return { host: ipv6Match.groups.host, port: ipv6Match.groups.port };
     }
 
-    checkTCP() {
-        return new Promise((resolve, reject) => {
-            try {
-                // When running in Tests the electron process has name `electron`,
-                // but when running without the tests is is `trezor-su`.
-                exec('lsof -i TCP | grep electron', (_, stdout) => {
-                    const outputGroupParser = (message: string) =>
-                        message && message.trim().match(/electron .*/gm);
-                    const group = outputGroupParser(stdout);
-                    if (group) {
-                        const groupParsed = group.map(output => {
-                            const parsed = output
-                                .trim()
-                                .match(/^electron .* TCP.*->(?<url>[\s\S]* )/);
+    const lastColon = remoteEndpoint.lastIndexOf(':');
 
-                            return parsed?.groups?.url ?? '';
-                        });
-                        // Removing empty strings.
-                        const requests = groupParsed.filter(entry => entry.trim() !== '');
-                        resolve(requests);
-                    }
-                });
-            } catch (error) {
-                reject(error);
-            }
+    return {
+        host: remoteEndpoint.slice(0, lastColon),
+        port: remoteEndpoint.slice(lastColon + 1),
+    };
+};
+
+const parseLsofLine = (line: string): TcpConnection | null => {
+    // electron 169557 user 130u IPv4 1909466 0t0 TCP 127.0.0.1:45022->142.250.1.1:443 (ESTABLISHED)
+    const match = line.match(
+        /^(?<command>\S+)\s+(?<pid>\d+)\s+.*\bTCP\s+(?<local>\S+)->(?<remote>\S+)\s+\(ESTABLISHED\)/,
+    );
+    const groups = match?.groups;
+    if (!groups?.command || !groups.pid || !groups.local || !groups.remote) {
+        return null;
+    }
+
+    const { host, port } = parseRemoteEndpoint(groups.remote);
+
+    return {
+        command: groups.command,
+        pid: groups.pid,
+        localEndpoint: groups.local,
+        remoteEndpoint: groups.remote,
+        remoteHost: host,
+        remotePort: port,
+        raw: line.trim(),
+    };
+};
+
+// Inspects established TCP connections opened by the Suite (electron) and node processes,
+// mirroring the manual command used to verify Tor routing:
+//   watch -n 1 "lsof -i TCP | grep -E 'electron|node'"
+export class NetworkAnalyzer {
+    private interval?: ReturnType<typeof setInterval>;
+    // Keyed by remote endpoint to de-duplicate connections observed across polling cycles.
+    private readonly externalConnections = new Map<string, TcpConnection>();
+
+    // `-n` disables hostname resolution and `-P` disables port-name resolution, so the output
+    // always contains numeric addresses, which makes localhost detection reliable.
+    private static readonly LSOF_COMMAND = 'lsof -nP -iTCP -sTCP:ESTABLISHED';
+
+    getConnections(): Promise<TcpConnection[]> {
+        return new Promise(resolve => {
+            // lsof exits with code 1 when there are no matching connections, so the error
+            // argument is intentionally ignored and only stdout is parsed.
+            exec(NetworkAnalyzer.LSOF_COMMAND, (_error, stdout) => {
+                const connections = stdout
+                    .split('\n')
+                    .filter(line => /^(electron|node)\b/.test(line))
+                    .map(parseLsofLine)
+                    .filter((connection): connection is TcpConnection => connection !== null);
+
+                resolve(connections);
+            });
         });
     }
 
-    start() {
+    async getExternalConnections(): Promise<TcpConnection[]> {
+        const connections = await this.getConnections();
+
+        return connections.filter(connection => !isLoopbackHost(connection.remoteHost));
+    }
+
+    start(intervalMs = 1000): void {
         this.interval = setInterval(async () => {
-            const requests = (await this.checkTCP()) as string[];
-            this.tcp.push(...requests);
-        }, 1000);
+            const external = await this.getExternalConnections();
+            external.forEach(connection => {
+                this.externalConnections.set(connection.remoteEndpoint, connection);
+            });
+        }, intervalMs);
     }
 
-    stop() {
-        clearInterval(this.interval);
+    stop(): void {
+        if (this.interval) {
+            clearInterval(this.interval);
+            this.interval = undefined;
+        }
     }
 
-    getRequests() {
-        return this.tcp;
+    getCollectedExternalConnections(): TcpConnection[] {
+        return Array.from(this.externalConnections.values());
     }
 }

--- a/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
+++ b/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
@@ -86,7 +86,7 @@ export class OnboardingPage {
     @step()
     async verifySuiteIsLoaded() {
         await expect(this.welcomeBody, 'expect Suite to load in under 30s').toBeVisible({
-            timeout: 30_000,
+            timeout: 60_000,
         });
     }
 

--- a/suite/e2e/support/testExtends/enhancePage.ts
+++ b/suite/e2e/support/testExtends/enhancePage.ts
@@ -80,7 +80,7 @@ export const enhancePage = (page: Page): Page => {
                     await discoveryBar.waitFor({ state: 'detached', timeout: 120_000 });
                 }
                 await expect(discoveryBar).toBeHidden();
-            }).toPass({ timeout: 120_000 });
+            }).toPass({ timeout: 1920_000 });
         });
     };
 

--- a/suite/e2e/support/types/index.ts
+++ b/suite/e2e/support/types/index.ts
@@ -47,7 +47,7 @@ declare global {
 
 export type ElectronConf = Pick<
     LaunchSuiteParams,
-    'keepUserData' | 'bridgeDaemon' | 'exposeConnectWs' | 'offlineMode'
+    'keepUserData' | 'bridgeDaemon' | 'exposeConnectWs' | 'offlineMode' | 'tor'
 >;
 
 export type TrezorUserEnv = Pick<

--- a/suite/e2e/tests/tor/tor-network-leak.test.ts
+++ b/suite/e2e/tests/tor/tor-network-leak.test.ts
@@ -1,0 +1,91 @@
+import { getMainnets } from '@suite-common/wallet-config';
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { expect, test } from '../../support/fixtures';
+import { NetworkAnalyzer } from '../../support/networkAnalyzer';
+import { createTestAnnotation } from '../../support/reporters/annotations';
+
+// Launches the Suite with Tor enabled and verifies that the Suite processes (electron/node)
+// never open a TCP connection to a non-localhost address. With Tor on, all Suite traffic must
+// be routed through the local Tor SOCKS proxy; only the separate bundled `tor` process is
+// allowed to reach the outside world.
+//
+// This test shells out to `lsof` and needs a live internet connection to bootstrap Tor, so it
+// is meant to be run locally on demand:
+//   TOR_NETWORK_LEAK_E2E=1 yarn workspace @trezor/suite-e2e test:e2e:desktop --project=T3T1 tor/tor-network-leak.test.ts
+
+test.use({
+    deviceSetup: { mnemonic: 'mnemonic_all' },
+    // netLog captures a Chromium net log (open it with https://netlog-viewer.appspot.com/) so any
+    // connection that bypasses the Tor proxy can be traced back to its request URL and source.
+    electronConf: { tor: true },
+});
+
+test.describe('Tor - no network leak', { tag: ['@desktopOnly', '@T3T1', '@nightlyOnly'] }, () => {
+    test.skip(
+        !process.env.TOR_NETWORK_LEAK_E2E,
+        'Local-only test: requires a live internet connection to bootstrap Tor. Run with TOR_NETWORK_LEAK_E2E=1.',
+    );
+
+    test(
+        'Suite keeps all connections on localhost while Tor is enabled',
+        {
+            annotation: createTestAnnotation({
+                testCase:
+                    'With Tor enabled, the Suite processes must not open any TCP connection outside of localhost.',
+                prerequisites: [
+                    'Live internet connection so Tor can bootstrap',
+                    '`lsof` available',
+                ],
+                steps: [
+                    'Launch Trezor Suite with Tor enabled',
+                    'Complete onboarding and wait for Tor to reach the Enabled state',
+                    'Run account discovery to generate outbound network traffic',
+                    'While the app is active, inspect electron/node TCP connections with lsof',
+                    'Verify no connection has a non-localhost remote endpoint',
+                ],
+                category: TestCategory.Settings,
+                priority: TestPriority.Critical,
+                stream: TestStream.Foundation,
+            }),
+        },
+        async ({ onboardingPage, settingsPage, page }) => {
+            const networkAnalyzer = new NetworkAnalyzer();
+            // Sample connections in the background while the app boots, onboards and discovers.
+
+            try {
+                await test.step('Complete onboarding with Tor enabled', async () => {
+                    await onboardingPage.completeOnboarding();
+                });
+
+                networkAnalyzer.start();
+                await test.step('Verify Tor is enabled', async () => {
+                    await page.ensureStoreOnDesktop();
+                    await expect
+                        .poll(() => page.getReduxObject('tor.torStatus'), {
+                            message: 'Tor should reach the Enabled state',
+                            timeout: 90_000,
+                        })
+                        .toBe('Enabled');
+                });
+
+                await test.step('Run account discovery to generate outbound traffic', async () => {
+                    const allMainnetSymbols = getMainnets().map(network => network.symbol);
+                    await settingsPage.changeNetworks({ enableNetworks: allMainnetSymbols });
+                });
+            } finally {
+                networkAnalyzer.stop();
+            }
+
+            const externalConnections = networkAnalyzer.getCollectedExternalConnections();
+            console.log('externalConnections', externalConnections);
+            const details = externalConnections.map(connection => connection.raw).join('\n');
+            console.log('details', details);
+
+            expect(
+                externalConnections,
+                `Suite opened non-localhost TCP connections while Tor was enabled:\n${details}`,
+            ).toEqual([]);
+        },
+    );
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies core E2E test infrastructure (onboardingPage, enhancePage, types, electron utilities, networkAnalyzer) alongside the desktop app entry point (app.ts) and a Tor network leak test. The highest risk is in the Tor/bridge tests that directly use the changed electron utilities and network analyzer. The onboardingPage changes affect virtually all tests but the risk is concentrated in tests that exercise specific onboarding sub-flows (THP pairing, firmware checks, entropy checks). Desktop-specific tests using the Electron launcher and suite-desktop-core app.ts should also be validated. The types/index.ts change is likely a type definition update with low runtime risk.

<details><summary><b>Changed files (7)</b></summary>

- `packages/suite-desktop-core/src/app.ts`
- `suite/e2e/support/electron.ts`
- `suite/e2e/support/networkAnalyzer.ts`
- `suite/e2e/support/pageObjects/onboarding/onboardingPage.ts`
- `suite/e2e/support/testExtends/enhancePage.ts`
- `suite/e2e/support/types/index.ts`
- `suite/e2e/tests/tor/tor-network-leak.test.ts`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/tor/tor-network-leak.test.ts` — This test file itself was changed. It directly tests Tor network leak detection, which relies on the networkAnalyzer support module (also changed). Must run to verify the test itself works correctly.
- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — This desktop/Electron test uses launchSuiteElectronApp from support/electron.ts (changed) and tests bridge daemon spawning which relates to app.ts changes in suite-desktop-core. Both the Electron launch utilities and the desktop app entry point are modified.
- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — This test uses launchSuite from support/electron.ts (changed) and exercises the Electron app lifecycle including bridge spawning, which is directly affected by changes to suite-desktop-core/src/app.ts.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/suite/initial-run.test.ts` — This test exercises the onboarding/initial-run flow including analytics consent, firmware checks, THP pairing, and page reloads — all paths that go through onboardingPage.ts (changed) and enhancePage.ts (changed). It specifically tests persistence across reloads which could be affected by enhancePage changes.
- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — Directly exercises onboardingPage (changed) for analytics consent, THP pairing, and complete onboarding flow. Changes to the onboarding page object could break these specific interactions.
- `suite/e2e/tests/onboarding/firmware-check.test.ts` — Uses onboardingPage methods including disableNecessaryFirmwareChecks and expectFirmwareToBeReady, which are defined in the changed onboardingPage.ts. Firmware check is a core onboarding path.
- `suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts` — Exercises multiple onboardingPage sub-flows (firmware, backup, wallet creation, seed type selection) that are defined in the changed onboardingPage.ts. Tests error handling paths during onboarding.
- `suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts` — Heavily uses onboardingPage methods including THP pairing, firmware checks, Shamir backup, and PIN setup — all defined in the changed onboardingPage.ts. T3W1 has unique THP flow paths.
- `suite/e2e/tests/trezor-connect/error.test.ts` — Desktop Electron test that uses onboardingPage.completeOnboarding and runs in suite-desktop core mode, directly affected by both onboardingPage.ts and app.ts changes.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — Uses enhancePage test extension (changed) for page setup and tests Bridge session management across multiple browser contexts. Changes to enhancePage.ts could affect how pages are initialized.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — Desktop Electron test that depends on suite-desktop-core app initialization (app.ts changed) and uses onboardingPage. Silent mode IPC behavior could be affected by app.ts changes.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Desktop Electron test using suite-desktop core mode (app.ts changed) and onboardingPage for setup. Permissions flow relies on the desktop app's connect websocket exposure.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/e2e/support/types/index.ts`

_Updated: 2026-06-15T13:44:36.489Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=e2e-test-tor&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=e2e-test-tor&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-15T13:48:23.413Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-15T13:48:03.350Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/e2e-test-tor/web/](https://dev.suite.sldev.cz/suite-web/e2e-test-tor/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->