### PR TITLE
Tron freeze tx review modal

### DIFF
--- a/packages/suite/src/actions/wallet/tron-stake/cancelSignTronFreezeTx.ts
+++ b/packages/suite/src/actions/wallet/tron-stake/cancelSignTronFreezeTx.ts
@@ -1,0 +1,17 @@
+import { closeModal } from '@suite/modal';
+import { createThunk } from '@suite-common/redux-utils';
+import { TRON_STAKE_PREFIX, selectTronStakeTxReview } from '@suite-common/wallet-core';
+import TrezorConnect from '@trezor/connect';
+
+export const cancelSignTronFreezeTx = createThunk(
+    `${TRON_STAKE_PREFIX}/thunk/cancelSignTronFreezeTx`,
+    (_params, { dispatch, getState }) => {
+        const { serializedTx } = selectTronStakeTxReview(getState());
+
+        if (!serializedTx) {
+            TrezorConnect.cancel({ reason: 'tx-cancelled' });
+        }
+
+        dispatch(closeModal());
+    },
+);

--- a/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeActions.ts
+++ b/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeActions.ts
@@ -1,4 +1,5 @@
 import { useDevice } from '@suite/device';
+import { closeModal, openDeferredModal, preserveModal } from '@suite/modal';
 import {
     type TronStakeError,
     type TronStakeStepId,
@@ -89,7 +90,20 @@ export const useTronStakeActions = ({
         switch (step) {
             case 'freeze': {
                 const { amount, resourceType } = form.methods.getValues();
-                dispatch(submitTronFreezeThunk({ account, device, amount, resourceType }));
+                dispatch(
+                    submitTronFreezeThunk({
+                        account,
+                        device,
+                        amount,
+                        resourceType,
+                        requestPushApproval: async () =>
+                            Boolean(
+                                await dispatch(openDeferredModal({ type: 'review-transaction' })),
+                            ),
+                        onSigningStart: () => dispatch(preserveModal()),
+                        onSettled: () => dispatch(closeModal()),
+                    }),
+                );
                 break;
             }
             case 'vote':

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModal.tsx
@@ -6,10 +6,11 @@ import {
     selectStablecoinYieldTxReview,
     selectStake,
     selectStakePrecomposedForm,
+    selectTronStakeTxReview,
     sendFormActions,
     stakeActions,
 } from '@suite-common/wallet-core';
-import { type PrecomposedTransactionFinal } from '@suite-common/wallet-types';
+import { type FormState, type PrecomposedTransactionFinal } from '@suite-common/wallet-types';
 
 import {
     removeSendFormDraftThunk,
@@ -20,13 +21,14 @@ import {
     cancelSignTx as cancelSignStakingTx,
     signTransaction,
 } from 'src/actions/wallet/stakeActions';
+import { cancelSignTronFreezeTx } from 'src/actions/wallet/tron-stake/cancelSignTronFreezeTx';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
 import { TransactionReviewModalBody } from './TransactionReviewModalBody';
 import { TransactionReviewModalExchange } from './TransactionReviewModalExchange';
 import { type TransactionReviewModalProps } from './TransactionReviewModalProps';
 import { TransactionReviewModalSell } from './TransactionReviewModalSell';
-import { isStakeState } from './utils';
+import { type TxInfoState } from './utils';
 
 // This modal is opened either in Device (button request) or User (push tx) context
 // contexts are distinguished by `type` prop
@@ -34,35 +36,51 @@ export const TransactionReviewModal = ({ type, decision }: TransactionReviewModa
     const send = useSelector(state => state.wallet.send);
     const stake = useSelector(selectStake);
     const yieldTxReview = useSelector(selectStablecoinYieldTxReview);
+    const tronStakeTxReview = useSelector(selectTronStakeTxReview);
+    const sendPrecomposedForm = useSelector(selectPrecomposedSendForm);
+    const stakePrecomposedForm = useSelector(selectStakePrecomposedForm);
     const selectedAccount = useSelector(selectFullSelectedAccount);
     const dispatch = useDispatch();
 
-    const isYield = Boolean(yieldTxReview.precomposedTx);
-    const isSend = !isYield && Boolean(send?.precomposedTx);
-    // Only one state should be available when the modal is open
-    // eslint-disable-next-line no-nested-ternary
-    const txInfoState = isSend ? send : isYield ? yieldTxReview : stake;
+    const getReviewSource = (): {
+        txInfoState: TxInfoState;
+        precomposedForm: FormState | undefined;
+        cancelSignTx: () => void;
+    } => {
+        if (tronStakeTxReview.precomposedTx) {
+            return {
+                txInfoState: tronStakeTxReview,
+                precomposedForm: tronStakeTxReview.precomposedForm,
+                cancelSignTx: () => dispatch(cancelSignTronFreezeTx()),
+            };
+        }
+        if (yieldTxReview.precomposedTx) {
+            return {
+                txInfoState: yieldTxReview,
+                precomposedForm: yieldTxReview.precomposedForm,
+                cancelSignTx: () => dispatch(cancelSignYieldTx()),
+            };
+        }
+        if (send?.precomposedTx) {
+            return {
+                txInfoState: send,
+                precomposedForm: sendPrecomposedForm,
+                cancelSignTx: () => dispatch(cancelSignSendFormTransactionThunk()),
+            };
+        }
 
-    const precomposedForm = useSelector(state => {
-        if (isYield) return yieldTxReview.precomposedForm;
-        if (isStakeState(txInfoState)) return selectStakePrecomposedForm(state);
+        return {
+            txInfoState: stake,
+            precomposedForm: stakePrecomposedForm,
+            cancelSignTx: () => dispatch(cancelSignStakingTx()),
+        };
+    };
 
-        return selectPrecomposedSendForm(state);
-    });
+    const { txInfoState, precomposedForm, cancelSignTx } = getReviewSource();
 
     const isRbfConfirmedError = type === 'review-transaction-rbf-previous-transaction-mined-error';
     const isExchange = precomposedForm?.trading?.activeSection === 'exchange';
     const isSell = precomposedForm?.trading?.activeSection === 'sell';
-
-    const handleCancelSignTx = () => {
-        if (isSend) {
-            dispatch(cancelSignSendFormTransactionThunk());
-        } else if (isYield) {
-            dispatch(cancelSignYieldTx());
-        } else {
-            dispatch(cancelSignStakingTx());
-        }
-    };
 
     const handleSignAndPushSendTx = async () => {
         try {
@@ -107,7 +125,7 @@ export const TransactionReviewModal = ({ type, decision }: TransactionReviewModa
             <TransactionReviewModalExchange
                 decision={decision}
                 txInfoState={txInfoState}
-                cancelSignTx={handleCancelSignTx}
+                cancelSignTx={cancelSignTx}
                 isRbfConfirmedError={isRbfConfirmedError}
                 precomposedForm={precomposedForm}
             />
@@ -119,7 +137,7 @@ export const TransactionReviewModal = ({ type, decision }: TransactionReviewModa
             <TransactionReviewModalSell
                 decision={decision}
                 txInfoState={txInfoState}
-                cancelSignTx={handleCancelSignTx}
+                cancelSignTx={cancelSignTx}
                 isRbfConfirmedError={isRbfConfirmedError}
                 precomposedForm={precomposedForm}
             />
@@ -131,7 +149,7 @@ export const TransactionReviewModal = ({ type, decision }: TransactionReviewModa
             decision={decision}
             txInfoState={txInfoState}
             tryAgainSignTx={handleTryAgainSignTx}
-            cancelSignTx={handleCancelSignTx}
+            cancelSignTx={cancelSignTx}
             isRbfConfirmedError={isRbfConfirmedError}
             precomposedForm={precomposedForm}
         />

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx
@@ -188,8 +188,10 @@ export const TransactionReviewModalBodyInner = ({
     };
 
     const isCancelRbfAction = isRbfCancelTransaction(precomposedTx);
+    const isTronStakeFreeze = networkType === 'tron' && Boolean(precomposedForm.tronStakeResource);
     const showSummary =
-        !(isBumpFeeRbfAction && networkType === 'bitcoin') && networkType !== 'tron';
+        !(isBumpFeeRbfAction && networkType === 'bitcoin') &&
+        (networkType !== 'tron' || isTronStakeFreeze);
 
     const showTxValidityTimer = shouldShowTxValidityTimer({
         deadline,

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
@@ -124,6 +124,7 @@ const getTranslationValues = (
     stakeType?: StakeType,
     evmTxType?: EvmTransactionPurpose,
     device?: TrezorDevice,
+    isTronStakeFreeze?: boolean,
 ): Record<'value' | 'label', TranslationKey> | null => {
     const isEvmApproval = isEvmApprovalTxByTextSignature(evmTxType);
 
@@ -148,6 +149,10 @@ const getTranslationValues = (
             value: 'TR_EARN_YIELD_REVIEW_CLAIM_TITLE',
             label: 'TR_EARN_YIELD_REVIEW_CLAIM_TITLE',
         };
+    }
+
+    if (isTronStakeFreeze) {
+        return { value: 'TR_ADDRESS', label: 'TR_ADDRESS' };
     }
 
     return null;
@@ -176,8 +181,15 @@ const getOutputTitle = (
     evmTxType?: EvmTransactionPurpose,
     device?: TrezorDevice,
     receiveAddress?: string,
+    isTronStakeFreeze?: boolean,
 ): ReactNode | undefined => {
-    const translation = getTranslationValues(networkType, stakeType, evmTxType, device);
+    const translation = getTranslationValues(
+        networkType,
+        stakeType,
+        evmTxType,
+        device,
+        isTronStakeFreeze,
+    );
     const contractTitle = getContractTitle(networkType, isApprovalFlowSupported(device), evmTxType);
 
     switch (type) {
@@ -562,6 +574,7 @@ export type TransactionReviewOutputProps = {
     isTrading?: boolean;
     evmTxType?: EvmTransactionPurpose;
     nativeToken?: TokenInfo;
+    isTronStakeFreeze?: boolean;
 } & ReviewOutput;
 
 export const TransactionReviewOutput = (props: TransactionReviewOutputProps) => {
@@ -580,6 +593,7 @@ export const TransactionReviewOutput = (props: TransactionReviewOutputProps) => 
         isTrading,
         evmTxType,
         nativeToken,
+        isTronStakeFreeze,
     } = props;
     const rewards = type === 'rewards' ? props.rewards : undefined;
     const receiveAddress = type === 'traded_assets' ? props.receiveAddress : undefined;
@@ -603,6 +617,7 @@ export const TransactionReviewOutput = (props: TransactionReviewOutputProps) => 
         evmTxType,
         device,
         receiveAddress,
+        isTronStakeFreeze,
     );
 
     const outputLines = getOutputLines({

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
@@ -116,6 +116,8 @@ export const TransactionReviewOutputList = ({
         ({ type }) => !['address', 'amount', 'opreturn'].includes(type),
     );
 
+    const isTronStakeFreeze = networkType === 'tron' && Boolean(precomposedForm.tronStakeResource);
+
     const nativeToken =
         account.accountType === 'placeholder' && 'nativeToken' in precomposedTx
             ? precomposedTx.nativeToken
@@ -184,31 +186,33 @@ export const TransactionReviewOutputList = ({
                                 stakeType={stakeType}
                                 evmTxType={evmTxType}
                                 nativeToken={nativeToken}
+                                isTronStakeFreeze={isTronStakeFreeze}
                             />
                         </Column>
                     </Wrapper>
                 );
             })}
 
-            {!(isRbfAction && networkType === 'bitcoin') && networkType !== 'tron' && (
-                <Wrapper ref={totalOutputRef}>
-                    <Column gap={spacings.sm}>
-                        {isMultirecipient && summaryIndex === -1 && (
-                            <H4 margin={{ top: spacings.xs }}>
-                                <Translation id="TR_SUMMARY" />
-                            </H4>
-                        )}
-                        <TransactionReviewTotalOutput
-                            account={account}
-                            state={reviewState}
-                            precomposedTx={precomposedTx}
-                            precomposedForm={precomposedForm}
-                            stakeType={stakeType}
-                            isRbf={isRbfAction}
-                        />
-                    </Column>
-                </Wrapper>
-            )}
+            {!(isRbfAction && networkType === 'bitcoin') &&
+                (networkType !== 'tron' || isTronStakeFreeze) && (
+                    <Wrapper ref={totalOutputRef}>
+                        <Column gap={spacings.sm}>
+                            {isMultirecipient && summaryIndex === -1 && (
+                                <H4 margin={{ top: spacings.xs }}>
+                                    <Translation id="TR_SUMMARY" />
+                                </H4>
+                            )}
+                            <TransactionReviewTotalOutput
+                                account={account}
+                                state={reviewState}
+                                precomposedTx={precomposedTx}
+                                precomposedForm={precomposedForm}
+                                stakeType={stakeType}
+                                isRbf={isRbfAction}
+                            />
+                        </Column>
+                    </Wrapper>
+                )}
         </Column>
     );
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewTotalOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewTotalOutput.tsx
@@ -1,4 +1,4 @@
-import { Translation } from '@suite/intl';
+import { Translation, useTranslation } from '@suite/intl';
 import { isApprovalFlowSupported, selectSelectedDevice } from '@suite-common/device';
 import { type NetworkType } from '@suite-common/wallet-config';
 import {
@@ -38,6 +38,8 @@ interface GetLinesParams {
     stakeType?: StakeType;
     nativeToken?: TokenInfo;
     isClearSignedTradingSwap: boolean;
+    isTronStakeFreeze: boolean;
+    tronResourceLabel: string;
 }
 
 const getLines = ({
@@ -49,6 +51,8 @@ const getLines = ({
     stakeType,
     nativeToken,
     isClearSignedTradingSwap,
+    isTronStakeFreeze,
+    tronResourceLabel,
 }: GetLinesParams): OutputElementLine[] => {
     const isUpdatedSendFlow = getIsUpdatedSendFlow(device);
     const isUpdatedEthereumSendFlow = getIsUpdatedEthereumSendFlow(device, networkType, stakeType);
@@ -74,6 +78,23 @@ const getLines = ({
     const amountWithoutFee = new BigNumber(precomposedTx.totalSpent)
         .minus(precomposedTx.fee)
         .toString();
+
+    if (isTronStakeFreeze) {
+        return [
+            {
+                id: 'amount',
+                label: <Translation id="AMOUNT" />,
+                value: amountWithoutFee,
+                type: 'amount',
+            },
+            {
+                id: 'resource',
+                label: <Translation id="TR_TRON_RESOURCE" />,
+                value: tronResourceLabel,
+                type: 'default',
+            },
+        ];
+    }
 
     if (precomposedForm.trading?.isSlip24Active || isClearSignedTradingSwap) {
         return [
@@ -173,12 +194,18 @@ export const TransactionReviewTotalOutput = ({
     isRbf,
 }: TransactionReviewTotalOutputProps) => {
     const device = useSelector(selectSelectedDevice);
+    const { translationString } = useTranslation();
 
     if (!device) {
         return null;
     }
 
     const { networkType } = account;
+    const isTronStakeFreeze = networkType === 'tron' && Boolean(precomposedForm.tronStakeResource);
+    const tronResourceLabel =
+        precomposedForm.tronStakeResource === 'energy'
+            ? translationString('TR_TRON_ENERGY')
+            : translationString('TR_TRON_BANDWIDTH');
     const nativeToken =
         account.accountType === 'placeholder' && 'nativeToken' in precomposedTx
             ? precomposedTx.nativeToken
@@ -200,11 +227,14 @@ export const TransactionReviewTotalOutput = ({
         stakeType,
         nativeToken,
         isClearSignedTradingSwap,
+        isTronStakeFreeze,
+        tronResourceLabel,
     });
 
     const titleId = (() => {
         if (isClearSignedTradingSwap) return 'TR_NETWORK_FEE';
         if (precomposedForm.trading?.isSlip24Active) return 'TR_SUMMARY';
+        if (isTronStakeFreeze) return 'TR_SUMMARY';
 
         return 'TR_TOTAL_INCLUDING_FEE';
     })();

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/utils.ts
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/utils.ts
@@ -2,10 +2,15 @@ import {
     type SendState,
     type StablecoinYieldTxReviewState,
     type StakeState,
+    type TronStakeTxReviewState,
 } from '@suite-common/wallet-core';
 import { type FormState } from '@suite-common/wallet-types';
 
-export type TxInfoState = SendState | StakeState | StablecoinYieldTxReviewState;
+export type TxInfoState =
+    | SendState
+    | StakeState
+    | StablecoinYieldTxReviewState
+    | TronStakeTxReviewState;
 
 export const isStakeState = (state: TxInfoState): state is StakeState => 'data' in state;
 

--- a/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
@@ -17,6 +17,7 @@ const SIGN_TX_ROUTES = [
     'earn-yield-deposit',
     'earn-yield-withdraw',
     'earn-yield-claim',
+    'earn-staking-tron',
 ] as const;
 
 const SIGN_TX_CONNECT_METHODS = [
@@ -31,6 +32,9 @@ const getAccountForButtonRequest = (state: AppState) => {
 
     const yieldAccountKey = state.wallet.stablecoinYield.txReview.accountKey;
     if (yieldAccountKey) return selectAccountByKey(state, yieldAccountKey);
+
+    const tronStakeAccountKey = state.wallet.tronStake.txReview.accountKey;
+    if (tronStakeAccountKey) return selectAccountByKey(state, tronStakeAccountKey);
 
     const sendAccountKey = state.wallet.send.accountKey;
     if (sendAccountKey) return selectAccountByKey(state, sendAccountKey);

--- a/packages/suite/src/utils/suite/transactionReview.ts
+++ b/packages/suite/src/utils/suite/transactionReview.ts
@@ -110,5 +110,9 @@ export const getTransactionReviewModalActionTranslation = ({
         return { id: source === 'heading' ? 'TR_EARN_CLAIM_REWARDS' : 'TR_EARN_YIELD_CLAIM' };
     }
 
+    if (precomposedForm.tronStakeResource) {
+        return { id: 'TR_EARN_TRON_FREEZE' };
+    }
+
     return { id: 'SEND_TRANSACTION' };
 };

--- a/suite-common/wallet-core/src/stake/tron/__tests__/tronStakeReducer.test.ts
+++ b/suite-common/wallet-core/src/stake/tron/__tests__/tronStakeReducer.test.ts
@@ -1,19 +1,26 @@
-import { type AccountKey } from '@suite-common/wallet-types';
+import { type AccountKey, type PrecomposedTransactionFinal } from '@suite-common/wallet-types';
 
-import { tronStakeActions, tronStakeReducer } from '../tronStakeReducer';
-import { submitTronFreezeThunk } from '../tronStakeThunks';
+import { initialTronStakeTxReview, tronStakeActions, tronStakeReducer } from '../tronStakeReducer';
 
 const KEY = 'account-1' as AccountKey;
 
-const submitAction = (type: string, extra?: object) => ({
-    type,
-    meta: { arg: { account: { key: KEY } } },
-    ...extra,
-});
+const PRECOMPOSED_TX = {
+    type: 'final',
+    totalSpent: '100',
+    fee: '1',
+    feePerByte: '0',
+    bytes: 10,
+    inputs: [],
+    outputs: [],
+    outputsPermutation: [],
+} as PrecomposedTransactionFinal;
 
 describe('tronStakeReducer', () => {
-    it('starts with no sessions', () => {
-        expect(tronStakeReducer(undefined, { type: '@@INIT' })).toEqual({});
+    it('starts with no sessions and an empty review', () => {
+        const state = tronStakeReducer(undefined, { type: '@@INIT' });
+
+        expect(state.sessions).toEqual({});
+        expect(state.txReview).toEqual(initialTronStakeTxReview);
     });
 
     it('goToStep updates the step for the account', () => {
@@ -22,7 +29,7 @@ describe('tronStakeReducer', () => {
             tronStakeActions.goToStep({ accountKey: KEY, step: 'complete' }),
         );
 
-        expect(state[KEY]?.step).toBe('complete');
+        expect(state.sessions[KEY]?.step).toBe('complete');
     });
 
     it('reset returns to the freeze step', () => {
@@ -32,73 +39,77 @@ describe('tronStakeReducer', () => {
         );
         const state = tronStakeReducer(advanced, tronStakeActions.reset({ accountKey: KEY }));
 
-        expect(state[KEY]?.step).toBe('freeze');
+        expect(state.sessions[KEY]?.step).toBe('freeze');
     });
 
-    it('submit pending sets isSubmitting and clears error', () => {
+    it('submitStarted sets isSubmitting and clears error', () => {
         const errored = tronStakeReducer(
             undefined,
             tronStakeActions.pendingTransactionFailed({ accountKey: KEY }),
         );
-        const state = tronStakeReducer(errored, submitAction(submitTronFreezeThunk.pending.type));
+        const state = tronStakeReducer(
+            errored,
+            tronStakeActions.submitStarted({ accountKey: KEY }),
+        );
 
-        expect(state[KEY]?.isSubmitting).toBe(true);
-        expect(state[KEY]?.error).toBeNull();
+        expect(state.sessions[KEY]?.isSubmitting).toBe(true);
+        expect(state.sessions[KEY]?.error).toBeNull();
     });
 
-    it('submit fulfilled records pendingTxid and stops submitting (no step change yet)', () => {
+    it('submitFinished records pendingTxid and stops submitting (no step change yet)', () => {
         const submitting = tronStakeReducer(
             undefined,
-            submitAction(submitTronFreezeThunk.pending.type),
+            tronStakeActions.submitStarted({ accountKey: KEY }),
         );
         const state = tronStakeReducer(
             submitting,
-            submitAction(submitTronFreezeThunk.fulfilled.type, { payload: { txid: 'abc123' } }),
+            tronStakeActions.submitFinished({ accountKey: KEY, txid: 'abc123' }),
         );
 
-        expect(state[KEY]?.isSubmitting).toBe(false);
-        expect(state[KEY]?.pendingTxid).toBe('abc123');
-        expect(state[KEY]?.step).toBe('freeze');
+        expect(state.sessions[KEY]?.isSubmitting).toBe(false);
+        expect(state.sessions[KEY]?.pendingTxid).toBe('abc123');
+        expect(state.sessions[KEY]?.step).toBe('freeze');
     });
 
-    it('submit rejected sets the error', () => {
+    it('submitFinished with an error sets the error', () => {
         const state = tronStakeReducer(
             undefined,
-            submitAction(submitTronFreezeThunk.rejected.type, {
-                payload: { kind: 'broadcast-failed' },
+            tronStakeActions.submitFinished({
+                accountKey: KEY,
+                error: { kind: 'broadcast-failed' },
             }),
         );
 
-        expect(state[KEY]?.isSubmitting).toBe(false);
-        expect(state[KEY]?.error).toEqual({ kind: 'broadcast-failed' });
+        expect(state.sessions[KEY]?.isSubmitting).toBe(false);
+        expect(state.sessions[KEY]?.error).toEqual({ kind: 'broadcast-failed' });
     });
 
-    it('submit rejected with a cancellation does not set an error', () => {
+    it('submitFinished with a cancellation does not set an error', () => {
         const submitting = tronStakeReducer(
             undefined,
-            submitAction(submitTronFreezeThunk.pending.type),
+            tronStakeActions.submitStarted({ accountKey: KEY }),
         );
         const state = tronStakeReducer(
             submitting,
-            submitAction(submitTronFreezeThunk.rejected.type, { payload: { kind: 'cancelled' } }),
+            tronStakeActions.submitFinished({ accountKey: KEY, error: { kind: 'cancelled' } }),
         );
 
-        expect(state[KEY]?.isSubmitting).toBe(false);
-        expect(state[KEY]?.error).toBeNull();
+        expect(state.sessions[KEY]?.isSubmitting).toBe(false);
+        expect(state.sessions[KEY]?.error).toBeNull();
     });
 
     it('pendingTransactionConfirmed clears the txid and advances the step', () => {
         const pending = tronStakeReducer(
             undefined,
-            submitAction(submitTronFreezeThunk.fulfilled.type, { payload: { txid: 'abc123' } }),
+            tronStakeActions.submitFinished({ accountKey: KEY, txid: 'abc123' }),
         );
         const state = tronStakeReducer(
             pending,
             tronStakeActions.pendingTransactionConfirmed({ accountKey: KEY }),
         );
 
-        expect(state[KEY]?.pendingTxid).toBeNull();
-        expect(state[KEY]?.step).toBe('vote');
+        expect(state.sessions[KEY]?.pendingTxid).toBeNull();
+        expect(state.sessions[KEY]?.step).toBe('vote');
     });
 
     it('pendingTransactionConfirmed on the last step keeps the step', () => {
@@ -111,37 +122,67 @@ describe('tronStakeReducer', () => {
             tronStakeActions.pendingTransactionConfirmed({ accountKey: KEY }),
         );
 
-        expect(state[KEY]?.step).toBe('complete');
+        expect(state.sessions[KEY]?.step).toBe('complete');
     });
 
     it('pendingTransactionFailed clears the txid and records a confirmation error', () => {
         const pending = tronStakeReducer(
             undefined,
-            submitAction(submitTronFreezeThunk.fulfilled.type, { payload: { txid: 'abc123' } }),
+            tronStakeActions.submitFinished({ accountKey: KEY, txid: 'abc123' }),
         );
         const state = tronStakeReducer(
             pending,
             tronStakeActions.pendingTransactionFailed({ accountKey: KEY }),
         );
 
-        expect(state[KEY]?.pendingTxid).toBeNull();
-        expect(state[KEY]?.error).toEqual({ kind: 'confirmation-failed' });
-        expect(state[KEY]?.step).toBe('freeze');
+        expect(state.sessions[KEY]?.pendingTxid).toBeNull();
+        expect(state.sessions[KEY]?.error).toEqual({ kind: 'confirmation-failed' });
+        expect(state.sessions[KEY]?.step).toBe('freeze');
     });
 
     it('keeps sessions isolated per account', () => {
         const KEY2 = 'account-2' as AccountKey;
         const pending = tronStakeReducer(
             undefined,
-            submitAction(submitTronFreezeThunk.fulfilled.type, { payload: { txid: 'abc123' } }),
+            tronStakeActions.submitFinished({ accountKey: KEY, txid: 'abc123' }),
         );
         const state = tronStakeReducer(
             pending,
             tronStakeActions.goToStep({ accountKey: KEY2, step: 'vote' }),
         );
 
-        expect(state[KEY]?.pendingTxid).toBe('abc123');
-        expect(state[KEY2]?.pendingTxid).toBeNull();
-        expect(state[KEY2]?.step).toBe('vote');
+        expect(state.sessions[KEY]?.pendingTxid).toBe('abc123');
+        expect(state.sessions[KEY2]?.pendingTxid).toBeNull();
+        expect(state.sessions[KEY2]?.step).toBe('vote');
+    });
+
+    it('stores and discards the transaction review payload', () => {
+        const form = { outputs: [] } as never;
+        const stored = tronStakeReducer(
+            undefined,
+            tronStakeActions.storePrecomposedTransaction({
+                precomposedTx: PRECOMPOSED_TX,
+                precomposedForm: form,
+                accountKey: KEY,
+            }),
+        );
+
+        expect(stored.txReview.precomposedTx).toBe(PRECOMPOSED_TX);
+        expect(stored.txReview.precomposedForm).toBe(form);
+        expect(stored.txReview.accountKey).toBe(KEY);
+        expect(stored.txReview.serializedTx).toBeUndefined();
+
+        const signed = tronStakeReducer(
+            stored,
+            tronStakeActions.storeSignedTransaction({
+                serializedTx: { tx: '0xdead', symbol: 'trx' },
+            }),
+        );
+
+        expect(signed.txReview.serializedTx).toEqual({ tx: '0xdead', symbol: 'trx' });
+
+        const discarded = tronStakeReducer(signed, tronStakeActions.discardTransaction());
+
+        expect(discarded.txReview).toEqual(initialTronStakeTxReview);
     });
 });

--- a/suite-common/wallet-core/src/stake/tron/tronStakeReducer.ts
+++ b/suite-common/wallet-core/src/stake/tron/tronStakeReducer.ts
@@ -1,9 +1,13 @@
 import { type PayloadAction, createSlice } from '@reduxjs/toolkit';
 
-import { type AccountKey } from '@suite-common/wallet-types';
+import {
+    type AccountKey,
+    type FormState,
+    type PrecomposedTransactionFinal,
+} from '@suite-common/wallet-types';
 
-import { submitTronFreezeThunk } from './tronStakeThunks';
 import { TRON_STAKE_FLOW_STEPS, type TronStakeError, type TronStakeStepId } from './tronStakeTypes';
+import { type SerializedTx } from '../../send/sendFormTypes';
 
 export const TRON_STAKE_PREFIX = '@suite-common/wallet-core/tron-stake';
 
@@ -14,11 +18,23 @@ export type TronStakeState = {
     pendingTxid: string | null;
 };
 
+export type TronStakeTxReviewState = {
+    precomposedTx?: PrecomposedTransactionFinal;
+    precomposedForm?: FormState;
+    serializedTx?: SerializedTx;
+    accountKey?: AccountKey;
+};
+
 export type TronStakeSessionsState = Record<AccountKey, TronStakeState>;
+
+export type TronStakeReducerState = {
+    sessions: TronStakeSessionsState;
+    txReview: TronStakeTxReviewState;
+};
 
 export type TronStakeRootState = {
     wallet: {
-        tronStake: TronStakeSessionsState;
+        tronStake: TronStakeReducerState;
     };
 };
 
@@ -29,7 +45,17 @@ export const initialTronStakeSession: TronStakeState = {
     pendingTxid: null,
 };
 
-const initialState: TronStakeSessionsState = {};
+export const initialTronStakeTxReview: TronStakeTxReviewState = {
+    precomposedTx: undefined,
+    precomposedForm: undefined,
+    serializedTx: undefined,
+    accountKey: undefined,
+};
+
+const initialState: TronStakeReducerState = {
+    sessions: {},
+    txReview: initialTronStakeTxReview,
+};
 
 const getNextStep = (step: TronStakeStepId): TronStakeStepId => {
     const index = TRON_STAKE_FLOW_STEPS.indexOf(step);
@@ -43,56 +69,71 @@ export const tronStakeSlice = createSlice({
     reducers: {
         goToStep(state, action: PayloadAction<{ accountKey: AccountKey; step: TronStakeStepId }>) {
             const { accountKey, step } = action.payload;
-            state[accountKey] = { ...(state[accountKey] ?? initialTronStakeSession), step };
+            state.sessions[accountKey] = {
+                ...(state.sessions[accountKey] ?? initialTronStakeSession),
+                step,
+            };
         },
         pendingTransactionConfirmed(state, action: PayloadAction<{ accountKey: AccountKey }>) {
-            const session = state[action.payload.accountKey] ?? initialTronStakeSession;
-            state[action.payload.accountKey] = {
+            const session = state.sessions[action.payload.accountKey] ?? initialTronStakeSession;
+            state.sessions[action.payload.accountKey] = {
                 ...session,
                 pendingTxid: null,
                 step: getNextStep(session.step),
             };
         },
         pendingTransactionFailed(state, action: PayloadAction<{ accountKey: AccountKey }>) {
-            state[action.payload.accountKey] = {
-                ...(state[action.payload.accountKey] ?? initialTronStakeSession),
+            state.sessions[action.payload.accountKey] = {
+                ...(state.sessions[action.payload.accountKey] ?? initialTronStakeSession),
                 pendingTxid: null,
                 error: { kind: 'confirmation-failed' },
             };
         },
         reset(state, action: PayloadAction<{ accountKey: AccountKey }>) {
-            state[action.payload.accountKey] = { ...initialTronStakeSession };
+            state.sessions[action.payload.accountKey] = { ...initialTronStakeSession };
         },
-    },
-    extraReducers: builder => {
-        builder
-            .addCase(submitTronFreezeThunk.pending, (state, action) => {
-                const { key } = action.meta.arg.account;
-                state[key] = {
-                    ...(state[key] ?? initialTronStakeSession),
-                    isSubmitting: true,
-                    error: null,
-                };
-            })
-            .addCase(submitTronFreezeThunk.fulfilled, (state, action) => {
-                const { key } = action.meta.arg.account;
-                state[key] = {
-                    ...(state[key] ?? initialTronStakeSession),
-                    isSubmitting: false,
-                    pendingTxid: action.payload.txid,
-                };
-            })
-            .addCase(submitTronFreezeThunk.rejected, (state, action) => {
-                const { key } = action.meta.arg.account;
-                state[key] = {
-                    ...(state[key] ?? initialTronStakeSession),
-                    isSubmitting: false,
-                    error:
-                        action.payload?.kind === 'cancelled'
-                            ? null
-                            : (action.payload ?? { kind: 'sign-failed' }),
-                };
-            });
+        submitStarted(state, action: PayloadAction<{ accountKey: AccountKey }>) {
+            state.sessions[action.payload.accountKey] = {
+                ...(state.sessions[action.payload.accountKey] ?? initialTronStakeSession),
+                isSubmitting: true,
+                error: null,
+            };
+        },
+        submitFinished(
+            state,
+            action: PayloadAction<{
+                accountKey: AccountKey;
+                txid?: string;
+                error?: TronStakeError;
+            }>,
+        ) {
+            const { accountKey, txid, error } = action.payload;
+            state.sessions[accountKey] = {
+                ...(state.sessions[accountKey] ?? initialTronStakeSession),
+                isSubmitting: false,
+                pendingTxid: txid ?? null,
+                error: error && error.kind !== 'cancelled' ? error : null,
+            };
+        },
+        storePrecomposedTransaction(
+            state,
+            action: PayloadAction<{
+                precomposedTx: PrecomposedTransactionFinal;
+                precomposedForm: FormState;
+                accountKey: AccountKey;
+            }>,
+        ) {
+            state.txReview.precomposedTx = action.payload.precomposedTx;
+            state.txReview.precomposedForm = action.payload.precomposedForm;
+            state.txReview.accountKey = action.payload.accountKey;
+            state.txReview.serializedTx = undefined;
+        },
+        storeSignedTransaction(state, action: PayloadAction<{ serializedTx: SerializedTx }>) {
+            state.txReview.serializedTx = action.payload.serializedTx;
+        },
+        discardTransaction(state) {
+            state.txReview = { ...initialTronStakeTxReview };
+        },
     },
 });
 

--- a/suite-common/wallet-core/src/stake/tron/tronStakeSelectors.ts
+++ b/suite-common/wallet-core/src/stake/tron/tronStakeSelectors.ts
@@ -3,10 +3,14 @@ import { type AccountKey } from '@suite-common/wallet-types';
 import {
     type TronStakeRootState,
     type TronStakeState,
+    type TronStakeTxReviewState,
     initialTronStakeSession,
 } from './tronStakeReducer';
 
 export const selectTronStakeSession = (
     state: TronStakeRootState,
     accountKey: AccountKey,
-): TronStakeState => state.wallet.tronStake[accountKey] ?? initialTronStakeSession;
+): TronStakeState => state.wallet.tronStake.sessions[accountKey] ?? initialTronStakeSession;
+
+export const selectTronStakeTxReview = (state: TronStakeRootState): TronStakeTxReviewState =>
+    state.wallet.tronStake.txReview;

--- a/suite-common/wallet-core/src/stake/tron/tronStakeThunks.ts
+++ b/suite-common/wallet-core/src/stake/tron/tronStakeThunks.ts
@@ -3,6 +3,7 @@ import { type TrezorDevice } from '@suite-common/suite-types';
 import { getNetwork } from '@suite-common/wallet-config';
 import {
     type Account,
+    type FormState,
     type PrecomposedLevels,
     type PrecomposedTransactionFinal,
 } from '@suite-common/wallet-types';
@@ -18,6 +19,7 @@ import { BigNumber } from '@trezor/utils';
 
 import { signTronContract } from './signTronContract';
 import { buildFreezeBalanceV2Contract } from './tronStakeContracts';
+import { tronStakeActions } from './tronStakeReducer';
 import { type TronResourceType, type TronStakeError } from './tronStakeTypes';
 import { addFakePendingTronTxThunk } from '../../transactions/transactionsThunks';
 
@@ -50,6 +52,17 @@ const buildFreezeContract = (account: Account, amount: string, resourceType: Tro
         resourceType,
     });
 };
+
+const buildFreezeReviewForm = (resourceType: TronResourceType): FormState => ({
+    outputs: [],
+    feePerUnit: '0',
+    feeLimit: '',
+    options: ['broadcast'],
+    tronStakeResource: resourceType,
+    isCoinControlEnabled: false,
+    hasCoinControlBeenOpened: false,
+    selectedUtxos: [],
+});
 
 export const composeTronFreezeFeeLevelsThunk = createThunk<
     PrecomposedLevels,
@@ -99,82 +112,156 @@ export const composeTronFreezeFeeLevelsThunk = createThunk<
             feePerByte: feeLevel.feePerUnit ?? '0',
             bytes,
             inputs: [],
-            outputs: [],
-            outputsPermutation: [],
+            outputs: [{ address: account.descriptor, amount: amountInSun }],
+            outputsPermutation: [0],
         };
 
         return { normal: tx };
     },
 );
 
-export const submitTronFreezeThunk = createThunk<
-    { txid: string },
-    FreezeThunkArguments & { device: TrezorDevice },
-    { rejectValue: TronStakeError }
->(
+interface SubmitFreezeThunkArguments extends FreezeThunkArguments {
+    device: TrezorDevice;
+    requestPushApproval: () => Promise<boolean>;
+    onSigningStart?: () => void;
+    onSettled?: () => void;
+}
+
+export const submitTronFreezeThunk = createThunk<void, SubmitFreezeThunkArguments>(
     `${TRON_STAKE_MODULE}/submitTronFreezeThunk`,
-    async ({ account, device, amount, resourceType }, { dispatch, rejectWithValue }) => {
+    async (
+        { account, device, amount, resourceType, requestPushApproval, onSigningStart, onSettled },
+        { dispatch },
+    ) => {
+        const { key: accountKey } = account;
+
         if (account.networkType !== 'tron') {
-            return rejectWithValue({ kind: 'compose-failed', message: 'Invalid network type.' });
+            dispatch(
+                tronStakeActions.submitFinished({
+                    accountKey,
+                    error: { kind: 'compose-failed', message: 'Invalid network type.' },
+                }),
+            );
+
+            return;
         }
 
         const contract = buildFreezeContract(account, amount, resourceType);
 
         if (!contract) {
-            return rejectWithValue({ kind: 'compose-failed', message: 'Invalid owner address.' });
+            dispatch(
+                tronStakeActions.submitFinished({
+                    accountKey,
+                    error: { kind: 'compose-failed', message: 'Invalid owner address.' },
+                }),
+            );
+
+            return;
         }
 
-        const signResult = await signTronContract({ account, device, contract });
+        dispatch(tronStakeActions.submitStarted({ accountKey }));
 
-        if ('error' in signResult) {
-            return rejectWithValue(signResult.error);
-        }
+        try {
+            const composed = await dispatch(
+                composeTronFreezeFeeLevelsThunk({ account, amount, resourceType }),
+            )
+                .unwrap()
+                .catch(() => undefined);
+            const precomposedTx = composed?.normal?.type === 'final' ? composed.normal : undefined;
 
-        const pushResult = await TrezorConnect.pushTransaction({
-            tx: signResult.serializedTx,
-            coin: account.symbol,
-            identity: getAccountIdentity(account),
-        });
+            if (!precomposedTx) {
+                dispatch(
+                    tronStakeActions.submitFinished({
+                        accountKey,
+                        error: { kind: 'compose-failed' },
+                    }),
+                );
 
-        if (!pushResult.success) {
-            return rejectWithValue({ kind: 'broadcast-failed', message: pushResult.error.message });
-        }
+                return;
+            }
 
-        const { txid } = pushResult.payload;
+            dispatch(
+                tronStakeActions.storePrecomposedTransaction({
+                    precomposedTx,
+                    precomposedForm: buildFreezeReviewForm(resourceType),
+                    accountKey,
+                }),
+            );
 
-        const stakeAmount = unitsToSubunits({
-            value: asAmountUnit(new BigNumber(amount)),
-            decimals: getNetwork(account.symbol).decimals,
-        }).toString();
+            onSigningStart?.();
 
-        const composed = await dispatch(
-            composeTronFreezeFeeLevelsThunk({ account, amount, resourceType }),
-        )
-            .unwrap()
-            .catch(() => undefined);
-        const composedTx = composed?.normal?.type === 'final' ? composed.normal : undefined;
+            const signResult = await signTronContract({ account, device, contract });
 
-        dispatch(
-            addFakePendingTronTxThunk({
-                account,
-                txid,
-                amount: '0',
-                fee: composedTx?.fee ?? '0',
-                type: 'self',
-                target: { addresses: [account.descriptor], amount: stakeAmount },
-                tronSpecific: {
-                    contractType: 'FreezeBalanceV2Contract',
-                    operation: 'freeze',
-                    resource: resourceType === 'energy' ? 'ENERGY' : 'BANDWIDTH',
-                    stakeAmount,
-                    bandwidthUsage:
-                        composedTx && new BigNumber(composedTx.fee).isZero()
-                            ? String(composedTx.bytes)
+            if ('error' in signResult) {
+                dispatch(tronStakeActions.submitFinished({ accountKey, error: signResult.error }));
+
+                return;
+            }
+
+            dispatch(
+                tronStakeActions.storeSignedTransaction({
+                    serializedTx: { tx: signResult.serializedTx, symbol: account.symbol },
+                }),
+            );
+
+            const isPushApproved = await requestPushApproval();
+
+            if (!isPushApproved) {
+                dispatch(
+                    tronStakeActions.submitFinished({ accountKey, error: { kind: 'cancelled' } }),
+                );
+
+                return;
+            }
+
+            const pushResult = await TrezorConnect.pushTransaction({
+                tx: signResult.serializedTx,
+                coin: account.symbol,
+                identity: getAccountIdentity(account),
+            });
+
+            if (!pushResult.success) {
+                dispatch(
+                    tronStakeActions.submitFinished({
+                        accountKey,
+                        error: { kind: 'broadcast-failed', message: pushResult.error.message },
+                    }),
+                );
+
+                return;
+            }
+
+            const { txid } = pushResult.payload;
+
+            const stakeAmount = unitsToSubunits({
+                value: asAmountUnit(new BigNumber(amount)),
+                decimals: getNetwork(account.symbol).decimals,
+            }).toString();
+
+            dispatch(
+                addFakePendingTronTxThunk({
+                    account,
+                    txid,
+                    amount: '0',
+                    fee: precomposedTx.fee ?? '0',
+                    type: 'self',
+                    target: { addresses: [account.descriptor], amount: stakeAmount },
+                    tronSpecific: {
+                        contractType: 'FreezeBalanceV2Contract',
+                        operation: 'freeze',
+                        resource: resourceType === 'energy' ? 'ENERGY' : 'BANDWIDTH',
+                        stakeAmount,
+                        bandwidthUsage: new BigNumber(precomposedTx.fee).isZero()
+                            ? String(precomposedTx.bytes)
                             : undefined,
-                },
-            }),
-        );
+                    },
+                }),
+            );
 
-        return { txid };
+            dispatch(tronStakeActions.submitFinished({ accountKey, txid }));
+        } finally {
+            onSettled?.();
+            dispatch(tronStakeActions.discardTransaction());
+        }
     },
 );

--- a/suite-common/wallet-types/src/sendForm.ts
+++ b/suite-common/wallet-types/src/sendForm.ts
@@ -83,6 +83,7 @@ export interface FormState {
     ethereumAdjustGasLimit?: string; // if used, final gas limit = estimated limit * ethereumAdjustGasLimit
     transactionData?: string; // used for solana serialized txn from trading api, ethereum or tron txn hex data
     destinationTag?: string; // For Ripple, Stellar, Solana, and Tron
+    tronStakeResource?: 'bandwidth' | 'energy';
     rbfParams?: RbfTransactionParams;
     isCoinControlEnabled: boolean;
     hasCoinControlBeenOpened: boolean;

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.ts
@@ -345,6 +345,7 @@ const constructNewFlow = ({
     const isSolana = account.networkType === 'solana';
     const isStellar = account.networkType === 'stellar';
     const isTron = account.networkType === 'tron';
+    const isTronStakeFreeze = isTron && Boolean(precomposedForm.tronStakeResource);
     const evmApprovalTxData = Calldata.evm.erc20.approve.decode(precomposedForm.transactionData);
     const isEvmApproval = isEvmApprovalTx(precomposedForm.transactionData);
     const stakeType = getStakeType(precomposedForm, outputs);
@@ -548,7 +549,7 @@ const constructNewFlow = ({
                     outputs.push({ type: 'address', value: o.address });
                 }
 
-                if (!isSolana && !isUpdatedEthereumSendFlow) {
+                if (!isSolana && !isUpdatedEthereumSendFlow && !isTronStakeFreeze) {
                     outputs.push({
                         type: 'amount',
                         value: o.amount.toString(),

--- a/suite/account/src/selectedAccountReducer.ts
+++ b/suite/account/src/selectedAccountReducer.ts
@@ -6,6 +6,7 @@ import {
     type AccountsRootState,
     type SendRootState,
     type StablecoinYieldState,
+    type TronStakeReducerState,
     accountsActions,
     selectAccountByKey,
 } from '@suite-common/wallet-core';
@@ -24,6 +25,7 @@ export type SelectedAccountRootStateWithTrading = SelectedAccountRootState &
         wallet: {
             trading: TradingState;
             stablecoinYield: StablecoinYieldState;
+            tronStake: TronStakeReducerState;
         };
         connectPopup: ConnectPopupState;
     };
@@ -68,6 +70,11 @@ export const selectAccountIncludingChosenInTrading = (
     const stablecoinYieldAccountKey = state.wallet.stablecoinYield.txReview.accountKey;
     if (stablecoinYieldAccountKey) {
         return selectAccountByKey(state, stablecoinYieldAccountKey) ?? undefined;
+    }
+
+    const tronStakeAccountKey = state.wallet.tronStake.txReview.accountKey;
+    if (tronStakeAccountKey) {
+        return selectAccountByKey(state, tronStakeAccountKey) ?? undefined;
     }
 
     const sendAccountKey = state.wallet.send.accountKey;

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -5416,6 +5416,10 @@ export const messages = defineMessages({
         id: 'TR_TRON_ENERGY',
         defaultMessage: 'Energy',
     },
+    TR_TRON_RESOURCE: {
+        id: 'TR_TRON_RESOURCE',
+        defaultMessage: 'Resource',
+    },
     TR_TRON_BANDWIDTH_TOOLTIP: {
         id: 'TR_TRON_BANDWIDTH_TOOLTIP',
         defaultMessage:
@@ -10146,6 +10150,10 @@ export const messages = defineMessages({
     TR_EARN_TRON_FREEZE_TRANSACTION: {
         id: 'TR_EARN_TRON_FREEZE_TRANSACTION',
         defaultMessage: 'Freeze TRX transaction',
+    },
+    TR_EARN_TRON_FREEZE: {
+        id: 'TR_EARN_TRON_FREEZE',
+        defaultMessage: 'Freeze',
     },
     TR_EARN_TRON_VOTE_TRANSACTION: {
         id: 'TR_EARN_TRON_VOTE_TRANSACTION',


### PR DESCRIPTION
## Description

This PR adds the transaction review modal to the Tron freeze flow, but before merging this:
- [x] Merge https://github.com/trezor/trezor-suite/pull/28503 first and rebase this branch

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/28499

## Screenshots:
<img width="621" height="577" alt="Screenshot 2026-06-09 at 16 22 41" src="https://github.com/user-attachments/assets/d9849216-fade-4cb7-aad5-c9436fff5ef4" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/tron-freeze-tx-review-modal&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/tron-freeze-tx-review-modal&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/tron-freeze-tx-review-modal&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-10T13:09:04.665Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add account types ada | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-10T13:07:16.817Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/tron-freeze-tx-review-modal/web/](https://dev.suite.sldev.cz/suite-web/feat/tron-freeze-tx-review-modal/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->