### PR TITLE
Refactor/utxolib compose script

### DIFF
--- a/packages/connect-common/src/types/api/composeTransaction.ts
+++ b/packages/connect-common/src/types/api/composeTransaction.ts
@@ -5,6 +5,7 @@ import type {
 } from '@trezor/blockchain-link';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import type {
+    ComposeChangeAddress as ComposeChangeAddressBase,
     ComposeInput as ComposeInputBase,
     ComposeOutput as ComposeOutputBase,
     ComposeResultError as ComposeResultErrorBase,
@@ -15,12 +16,20 @@ import type {
 
 import type { Params, Response } from '../params';
 
-// for convenience ComposeOutput `type: "payment"` field is not required by @trezor/connect api
-export type ComposeOutputPayment = Omit<Extract<ComposeOutputBase, { type: 'payment' }>, 'type'> & {
+type OmitScript<T> = T extends unknown ? Omit<T, 'script'> : never;
+
+// for convenience ComposeOutput `type: "payment"` field is not required by the @trezor/connect api
+// `script` field is not required by the @trezor/connect api
+export type ComposeOutputPayment = Omit<
+    Extract<ComposeOutputBase, { type: 'payment' }>,
+    'type' | 'script'
+> & {
     type?: 'payment';
 };
 
-export type ComposeOutput = Exclude<ComposeOutputBase, { type: 'payment' }> | ComposeOutputPayment;
+export type ComposeOutput =
+    | OmitScript<Exclude<ComposeOutputBase, { type: 'payment' }>>
+    | ComposeOutputPayment;
 
 export type ComposeParams = {
     outputs: ComposeOutput[];
@@ -73,7 +82,7 @@ export type ComposeResultError =
 export type ComposeResultFinal = ComposeResultFinalBase<
     ComposedInputs,
     ComposeOutputBase,
-    AccountAddress
+    AccountAddress & ComposeChangeAddressBase
 >;
 
 export type ComposeResultNonFinal = ComposeResultNonFinalBase<ComposedInputs>;

--- a/packages/connect/src/api/bitcoin/TransactionComposer.ts
+++ b/packages/connect/src/api/bitcoin/TransactionComposer.ts
@@ -14,7 +14,7 @@ import type {
     ComposeOutput,
     TransactionInputOutputSortingStrategy,
 } from '@trezor/utxo-lib';
-import { composeTx, networks } from '@trezor/utxo-lib';
+import { INPUT_SCRIPT_LENGTH, address, composeTx, networks } from '@trezor/utxo-lib';
 
 import type { Blockchain } from '../../backend/BlockchainLink';
 import { getOrInitBitcoinFeeLevels } from '../../backend/fees';
@@ -65,14 +65,16 @@ export class TransactionComposer {
                   .concat(addresses.unused)
                   .concat(addresses.change)
                   .map(a => a.address);
+        const txType = options.account.type || 'p2pkh';
         this.utxos = options.utxos.flatMap(u => {
             // exclude amounts lower than dust limit if they are NOT required
             if (!u.required && new BigNumber(u.amount).lte(this.coinInfo.dustLimit)) return [];
 
             return {
                 ...u,
-                coinbase: typeof u.coinbase === 'boolean' ? u.coinbase : false, // decide it it can be spent immediately (false) or after 100 conf (true)
-                own: allAddresses.includes(u.address), // decide if it can be spent immediately (own) or after 6 conf (not own)
+                coinbase: typeof u.coinbase === 'boolean' ? u.coinbase : false,
+                own: allAddresses.includes(u.address),
+                script: { length: INPUT_SCRIPT_LENGTH[txType] },
             };
         });
     }
@@ -170,6 +172,10 @@ export class TransactionComposer {
         const lastChange: (typeof addresses.change)[number] =
             addresses.change[addresses.change.length - 1];
         const changeAddress = addresses.change.find(a => !a.transfers) || lastChange;
+        const composeChangeAddress = {
+            ...changeAddress,
+            script: address.toOutputScript(changeAddress.address, coinInfo.network),
+        };
         // const inputAmounts = coinInfo.segwit || coinInfo.forkid !== null || coinInfo.network.consensusBranchId !== null;
 
         let feePolicy: ComposeFeePolicy | undefined;
@@ -186,8 +192,7 @@ export class TransactionComposer {
             feeRate,
             longTermFeeRate: this.feeLevels.longTermFeeRate,
             sortingStrategy: this.sortingStrategy,
-            network: coinInfo.network,
-            changeAddress,
+            changeAddress: composeChangeAddress,
             dustThreshold: coinInfo.dustLimit,
             baseFee,
             feePolicy,

--- a/packages/connect/src/api/bitcoin/outputs.ts
+++ b/packages/connect/src/api/bitcoin/outputs.ts
@@ -8,7 +8,12 @@ import type {
     ProtoWithDerivationPath,
 } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
-import type { ComposeOutput as ComposeOutputBase } from '@trezor/utxo-lib';
+import {
+    type ComposeOutput as ComposeOutputBase,
+    OUTPUT_SCRIPT_LENGTH,
+    address,
+    payments,
+} from '@trezor/utxo-lib';
 
 import { isValidAddress } from '../../utils/addressUtils';
 import { convertMultisigPubKey } from '../../utils/hdnodeUtils';
@@ -79,8 +84,8 @@ export const validateHDOutput = (
     output: ComposeOutput,
     coinInfo: BitcoinNetworkInfo,
 ): ComposeOutputBase => {
-    const validateAddress = (address?: string) => {
-        if (!address || !isValidAddress(address, coinInfo)) {
+    const validateAddress = (addr?: string) => {
+        if (!addr || !isValidAddress(addr, coinInfo)) {
             throw ERRORS.TypedError(
                 'Method_InvalidParameter',
                 `Invalid ${coinInfo.label} output address format`,
@@ -95,6 +100,8 @@ export const validateHDOutput = (
             return {
                 type: 'opreturn',
                 dataHex: output.dataHex,
+                script: payments.embed({ data: [Buffer.from(output.dataHex, 'hex')] })
+                    .output as Buffer,
             };
 
         case 'send-max':
@@ -104,6 +111,7 @@ export const validateHDOutput = (
             return {
                 type: 'send-max',
                 address: output.address,
+                script: address.toOutputScript(output.address, coinInfo.network),
             };
 
         case 'payment-noaddress':
@@ -112,11 +120,13 @@ export const validateHDOutput = (
             return {
                 type: 'payment-noaddress',
                 amount: output.amount,
+                script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
             };
 
         case 'send-max-noaddress':
             return {
                 type: 'send-max-noaddress',
+                script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
             };
 
         default:
@@ -130,6 +140,7 @@ export const validateHDOutput = (
                 type: 'payment',
                 address: output.address,
                 amount: output.amount,
+                script: address.toOutputScript(output.address, coinInfo.network),
             };
     }
 };

--- a/packages/utxo-lib/src/coinselect/coinselectUtils.ts
+++ b/packages/utxo-lib/src/coinselect/coinselectUtils.ts
@@ -5,6 +5,7 @@ import {
     type CoinSelectOutput,
     type CoinSelectOutputFinal,
     type CoinSelectPaymentType,
+    type CoinSelectScript,
 } from '../types';
 
 export const ZERO = 0n;
@@ -39,8 +40,8 @@ const DUST_RELAY_FEE_RATE = 3; // 3000 sat/kB https://github.com/bitcoin/bitcoin
 /** Coinbase transaction must have at least 100 confirmations to be spendable.*/
 export const MINIMAL_COINBASE_CONFIRMATIONS = 100;
 
-type Vin = { type: CoinSelectInput['type']; script: { length: number }; weight?: number };
-type VinVout = { script: { length: number }; weight?: number };
+type Vin = { type: CoinSelectPaymentType; script: CoinSelectScript; weight?: number };
+type VinVout = { script: CoinSelectScript; weight?: number };
 
 export function getVarIntSize(length: number) {
     if (length < 253) return 1;

--- a/packages/utxo-lib/src/coinselect/index.ts
+++ b/packages/utxo-lib/src/coinselect/index.ts
@@ -1,9 +1,9 @@
 import { anyOf, sortByScore } from './coinselectUtils';
+import { type CoinSelectRequest } from '../types';
 import { accumulative } from './inputs/accumulative';
 import { branchAndBound } from './inputs/branchAndBound';
 import { split } from './outputs/split';
 import { tryConfirmed } from './tryconfirmed';
-import { type CoinSelectRequest } from '../types';
 
 export function coinselect({ inputs, outputs, feeRate, ...options }: CoinSelectRequest) {
     if (options.sendMaxOutputIndex >= 0) {

--- a/packages/utxo-lib/src/compose/request.ts
+++ b/packages/utxo-lib/src/compose/request.ts
@@ -1,15 +1,6 @@
 import { throwError } from '@trezor/utils';
 
-import { toOutputScript } from '../address';
-import {
-    INPUT_SCRIPT_LENGTH,
-    OUTPUT_SCRIPT_LENGTH,
-    inputWeight,
-    outputWeight,
-    parseBigInt,
-} from '../coinselect/coinselectUtils';
-import type { Network } from '../networks';
-import { p2data } from '../payments/embed';
+import { inputWeight, outputWeight, parseBigInt } from '../coinselect/coinselectUtils';
 import type {
     AnyComposeRequest,
     CoinSelectInput,
@@ -60,7 +51,6 @@ function transformInput(
         ...utxo,
         type: txType,
         i,
-        script: { length: INPUT_SCRIPT_LENGTH[txType] },
         value,
     };
 }
@@ -96,47 +86,35 @@ function validateAndParseUtxos(
     return result;
 }
 
-function transformOutput(
-    output: ComposeOutput,
-    txType: CoinSelectPaymentType,
-    network: Network,
-): CoinSelectOutput {
-    const script = { length: OUTPUT_SCRIPT_LENGTH[txType] };
+function transformOutput(output: ComposeOutput): CoinSelectOutput {
     if (output.type === 'payment') {
         return {
             value: parseBigInt(output.amount) ?? throwError('Invalid amount'),
-            script: toOutputScript(output.address, network),
+            script: output.script,
         };
     }
     if (output.type === 'payment-noaddress') {
         return {
             value: parseBigInt(output.amount) ?? throwError('Invalid amount'),
-            script,
+            script: output.script,
         };
     }
     if (output.type === 'opreturn') {
         return {
             value: parseBigInt('0', true),
-            script: p2data({ data: [Buffer.from(output.dataHex, 'hex')] }).output as Buffer,
+            script: output.script,
         };
     }
     if (output.type === 'send-max') {
-        return {
-            script: toOutputScript(output.address, network),
-        };
+        return { script: output.script };
     }
     if (output.type === 'send-max-noaddress') {
-        return {
-            script,
-        };
+        return { script: output.script };
     }
     throw new Error('Unknown output type');
 }
 
-function validateAndParseOutputs(
-    txType: CoinSelectPaymentType,
-    { outputs, network }: AnyComposeRequest,
-):
+function validateAndParseOutputs({ outputs }: AnyComposeRequest):
     | {
           outputs: CoinSelectOutput[];
           sendMaxOutputIndex: number;
@@ -166,7 +144,7 @@ function validateAndParseOutputs(
         }
 
         try {
-            const csOutput = transformOutput(output, txType, network);
+            const csOutput = transformOutput(output);
             csOutput.weight = outputWeight(csOutput);
             result.push(csOutput);
         } catch (error) {
@@ -180,13 +158,12 @@ function validateAndParseOutputs(
     };
 }
 
-function validateAndParseChangeOutput(
-    txType: CoinSelectPaymentType,
-    { changeAddress, network }: AnyComposeRequest,
-): CoinSelectOutput | ComposeResultError {
+function validateAndParseChangeOutput({
+    changeAddress,
+}: AnyComposeRequest): CoinSelectOutput | ComposeResultError {
     // NOTE: use "send-max" to create changeOutput. we don't know the final amount yet
     try {
-        return transformOutput({ type: 'send-max', ...changeAddress }, txType, network);
+        return transformOutput({ type: 'send-max', ...changeAddress });
     } catch (error) {
         return {
             type: 'error',
@@ -216,12 +193,12 @@ export function validateAndParseRequest(
         return inputs;
     }
 
-    const outputs = validateAndParseOutputs(txType, request);
+    const outputs = validateAndParseOutputs(request);
     if ('error' in outputs) {
         return outputs;
     }
 
-    const changeOutput = validateAndParseChangeOutput(txType, request);
+    const changeOutput = validateAndParseChangeOutput(request);
     if ('error' in changeOutput) {
         return changeOutput;
     }

--- a/packages/utxo-lib/src/compose/request.ts
+++ b/packages/utxo-lib/src/compose/request.ts
@@ -11,18 +11,15 @@ import {
 import type { Network } from '../networks';
 import { p2data } from '../payments/embed';
 import type {
+    AnyComposeRequest,
     CoinSelectInput,
     CoinSelectOutput,
     CoinSelectPaymentType,
     CoinSelectRequest,
-    ComposeChangeAddress,
     ComposeInput,
     ComposeOutput,
-    ComposeRequest,
     ComposeResultError,
 } from '../types';
-
-type Request = ComposeRequest<ComposeInput, ComposeOutput, ComposeChangeAddress>;
 
 function validateAndParseFeeRate(rate: unknown) {
     const feeRate = typeof rate === 'string' ? Number(rate) : rate;
@@ -70,7 +67,7 @@ function transformInput(
 
 function validateAndParseUtxos(
     txType: CoinSelectPaymentType,
-    { utxos }: Request,
+    { utxos }: AnyComposeRequest,
 ): ComposeResultError | CoinSelectInput[] {
     if (utxos.length === 0) {
         return { type: 'error', error: 'MISSING-UTXOS' };
@@ -138,7 +135,7 @@ function transformOutput(
 
 function validateAndParseOutputs(
     txType: CoinSelectPaymentType,
-    { outputs, network }: Request,
+    { outputs, network }: AnyComposeRequest,
 ):
     | {
           outputs: CoinSelectOutput[];
@@ -185,7 +182,7 @@ function validateAndParseOutputs(
 
 function validateAndParseChangeOutput(
     txType: CoinSelectPaymentType,
-    { changeAddress, network }: Request,
+    { changeAddress, network }: AnyComposeRequest,
 ): CoinSelectOutput | ComposeResultError {
     // NOTE: use "send-max" to create changeOutput. we don't know the final amount yet
     try {
@@ -199,7 +196,9 @@ function validateAndParseChangeOutput(
     }
 }
 
-export function validateAndParseRequest(request: Request): CoinSelectRequest | ComposeResultError {
+export function validateAndParseRequest(
+    request: AnyComposeRequest,
+): CoinSelectRequest | ComposeResultError {
     const feeRate = validateAndParseFeeRate(request.feeRate);
     if (!feeRate) {
         return { type: 'error', error: 'INCORRECT-FEE-RATE' };

--- a/packages/utxo-lib/src/index.ts
+++ b/packages/utxo-lib/src/index.ts
@@ -1,6 +1,7 @@
 import * as address from './address';
 import * as bip32 from './bip32';
 import * as bufferutils from './bufferutils';
+import { INPUT_SCRIPT_LENGTH, OUTPUT_SCRIPT_LENGTH } from './coinselect/coinselectUtils';
 import { composeTx } from './compose';
 import * as crypto from './crypto';
 import { deriveAddresses, getXpubOrDescriptorInfo } from './derivation';
@@ -22,6 +23,8 @@ export {
     script,
     networks,
     composeTx,
+    INPUT_SCRIPT_LENGTH,
+    OUTPUT_SCRIPT_LENGTH,
     deriveAddresses,
     getXpubOrDescriptorInfo,
     discovery,

--- a/packages/utxo-lib/src/types/coinselect.ts
+++ b/packages/utxo-lib/src/types/coinselect.ts
@@ -2,6 +2,10 @@ import type { ComposeFeePolicy, TransactionInputOutputSortingStrategy } from './
 
 export type CoinSelectPaymentType = 'p2pkh' | 'p2sh' | 'p2tr' | 'p2wpkh' | 'p2wsh';
 
+// Bitcoin script value is not relevant for coin selection,
+// we only need its length to calculate the transaction size and fee.
+export type CoinSelectScript = { length: number };
+
 export interface CoinSelectOptions {
     txType: CoinSelectPaymentType;
     changeOutput?: CoinSelectOutput;
@@ -25,7 +29,7 @@ export interface CoinSelectOptions {
 export interface CoinSelectInput {
     type: CoinSelectPaymentType;
     i: number;
-    script: { length: number };
+    script: CoinSelectScript;
     value: bigint;
     confirmations: number;
     coinbase?: boolean;
@@ -35,13 +39,13 @@ export interface CoinSelectInput {
 }
 
 export interface CoinSelectOutput {
-    script: { length: number };
+    script: CoinSelectScript;
     value?: bigint;
     weight?: number;
 }
 
 export interface CoinSelectOutputFinal {
-    script: { length: number };
+    script: CoinSelectScript;
     value: bigint;
 }
 

--- a/packages/utxo-lib/src/types/compose.ts
+++ b/packages/utxo-lib/src/types/compose.ts
@@ -1,5 +1,4 @@
-import type { Network } from '../networks';
-import type { CoinSelectPaymentType } from './coinselect';
+import type { CoinSelectPaymentType, CoinSelectScript } from './coinselect';
 
 // UTXO == unspent transaction output = all I can spend
 export interface ComposeInput {
@@ -10,6 +9,7 @@ export interface ComposeInput {
     own: boolean; // is the ORIGIN me (the same account)
     confirmations: number; // might be spent immediately (own) or after 6 conf (not own) see ./coinselect/tryConfirmed
     required?: boolean; // must be included into transaction
+    script: CoinSelectScript; // Bitcoin script
 }
 
 // Output parameter of coinselect algorithm which is either:
@@ -22,29 +22,34 @@ export interface ComposeOutputPayment {
     type: 'payment';
     address: string;
     amount: string;
+    script: CoinSelectScript;
 }
 
 export interface ComposeOutputPaymentNoAddress {
     type: 'payment-noaddress';
     amount: string;
+    script: CoinSelectScript;
 }
 
 export interface ComposeOutputSendMax {
-    type: 'send-max'; // only one in TX request
+    type: 'send-max';
     address: string;
     amount?: string;
+    script: CoinSelectScript;
 }
 
 export interface ComposeOutputSendMaxNoAddress {
     type: 'send-max-noaddress';
     amount?: never;
+    script: CoinSelectScript;
 }
 
 export interface ComposeOutputOpreturn {
-    type: 'opreturn'; // it doesn't need to have address
+    type: 'opreturn';
     dataHex: string;
     amount?: never;
     address?: never;
+    script: CoinSelectScript;
 }
 
 // NOTE: this interface **is not** accepted by ComposeRequest['utxos']
@@ -66,6 +71,7 @@ export type ComposeOutput = ComposeFinalOutput | ComposeNotFinalOutput;
 
 export interface ComposeChangeAddress {
     address: string;
+    script: CoinSelectScript;
 }
 
 export type TransactionInputOutputSortingStrategy =
@@ -93,7 +99,6 @@ export type ComposeRequest<
     feeRate: string | number; // in sat/byte, virtual size
     feePolicy?: ComposeFeePolicy; // explicit fee policy
     longTermFeeRate?: string | number; // dust output feeRate multiplier in sat/byte, virtual size
-    network: Network;
     changeAddress: Change;
     dustThreshold: number; // explicit dust threshold, in satoshi
     baseFee?: number; // DOGE or RBF base fee

--- a/packages/utxo-lib/src/types/compose.ts
+++ b/packages/utxo-lib/src/types/compose.ts
@@ -101,6 +101,8 @@ export type ComposeRequest<
     sortingStrategy: TransactionInputOutputSortingStrategy;
 };
 
+export type AnyComposeRequest = ComposeRequest<ComposeInput, ComposeOutput, ComposeChangeAddress>;
+
 type ComposedTransactionOutputs<T> = T extends ComposeOutputSendMax
     ? Omit<T, 'type'> & ComposeOutputPayment // NOTE: replace ComposeOutputSendMax (no amount) with ComposeOutputPayment (with amount)
     : T extends ComposeFinalOutput

--- a/packages/utxo-lib/tests/__fixtures__/compose.crosscheck.ts
+++ b/packages/utxo-lib/tests/__fixtures__/compose.crosscheck.ts
@@ -1,11 +1,20 @@
-import { UTXO } from './compose';
+import { CHANGE_ADDRESS, UTXO } from './compose';
 import { CoinSelectPaymentType } from '../../src';
-import { AnyComposeRequest } from '../../src/types/compose';
+import {
+    AnyComposeRequest,
+    ComposeChangeAddress,
+    ComposeInput,
+    ComposeOutput,
+} from '../../src/types/compose';
+
+type OmitScript<T> = T extends { script: any } ? Omit<T, 'script'> : T;
 
 type Fixture = {
     description: string;
-    request: Omit<AnyComposeRequest, 'network'> & {
-        network?: AnyComposeRequest['network'];
+    request: Omit<AnyComposeRequest, 'utxos' | 'outputs' | 'changeAddress'> & {
+        utxos: OmitScript<ComposeInput>[];
+        outputs: OmitScript<ComposeOutput>[];
+        changeAddress: OmitScript<ComposeChangeAddress>;
     };
     result: Partial<Record<`${CoinSelectPaymentType}-${CoinSelectPaymentType}`, { bytes: number }>>;
 };
@@ -14,7 +23,7 @@ export const fixturesCrossCheck: Fixture[] = [
     {
         description: '1 input, 1 output, no change',
         request: {
-            changeAddress: { address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT' },
+            changeAddress: CHANGE_ADDRESS,
             dustThreshold: 546,
             feeRate: '10',
             sortingStrategy: 'bip69',
@@ -53,7 +62,7 @@ export const fixturesCrossCheck: Fixture[] = [
     {
         description: '1 input, 1 output, 1 change',
         request: {
-            changeAddress: { address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT' },
+            changeAddress: CHANGE_ADDRESS,
             dustThreshold: 546,
             feeRate: '10',
             sortingStrategy: 'bip69',
@@ -92,7 +101,7 @@ export const fixturesCrossCheck: Fixture[] = [
     {
         description: '2 inputs, 1 output, 1 change',
         request: {
-            changeAddress: { address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT' },
+            changeAddress: CHANGE_ADDRESS,
             dustThreshold: 546,
             feeRate: '10',
             sortingStrategy: 'bip69',
@@ -143,7 +152,7 @@ export const fixturesCrossCheck: Fixture[] = [
     {
         description: '7 inputs, all-types of outputs, 1 op_return, 1 change',
         request: {
-            changeAddress: { address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT' },
+            changeAddress: CHANGE_ADDRESS,
             dustThreshold: 546,
             feeRate: '10',
             sortingStrategy: 'bip69',

--- a/packages/utxo-lib/tests/__fixtures__/compose.crosscheck.ts
+++ b/packages/utxo-lib/tests/__fixtures__/compose.crosscheck.ts
@@ -1,13 +1,6 @@
 import { UTXO } from './compose';
 import { CoinSelectPaymentType } from '../../src';
-import {
-    ComposeChangeAddress,
-    ComposeInput,
-    ComposeOutput,
-    ComposeRequest,
-} from '../../src/types/compose';
-
-type AnyComposeRequest = ComposeRequest<ComposeInput, ComposeOutput, ComposeChangeAddress>;
+import { AnyComposeRequest } from '../../src/types/compose';
 
 type Fixture = {
     description: string;

--- a/packages/utxo-lib/tests/__fixtures__/compose.ts
+++ b/packages/utxo-lib/tests/__fixtures__/compose.ts
@@ -1,11 +1,12 @@
-import { bitcoincash, doge } from '../../src/networks';
+import { INPUT_SCRIPT_LENGTH, OUTPUT_SCRIPT_LENGTH } from '../../src/';
 import {
     AnyComposeRequest,
     ComposeChangeAddress,
     ComposeInput,
     ComposeOutput,
-    ComposeResult,
+    ComposeResultError,
     ComposeResultFinal,
+    ComposeResultNonFinal,
 } from '../../src/types/compose';
 
 export const UTXO: ComposeInput & { path: number[] } = {
@@ -16,17 +17,34 @@ export const UTXO: ComposeInput & { path: number[] } = {
     vout: 0,
     txid: 'b4dc0ffeee',
     amount: '102001',
+    script: { length: INPUT_SCRIPT_LENGTH.p2pkh },
 };
 
-type AnyComposeResult = ComposeResult<ComposeInput, ComposeOutput, ComposeChangeAddress>;
-type AnyComposeFinalResult = ComposeResultFinal<ComposeInput, ComposeOutput, ComposeChangeAddress>;
+export const CHANGE_ADDRESS: ComposeChangeAddress = {
+    address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT',
+    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
+};
+
+type FixtureUtxo = ComposeInput & {
+    customField?: string;
+};
+type FixtureOutput = ComposeOutput & {
+    customField?: string;
+};
+type FixtureChangeAddress = ComposeChangeAddress & {
+    path?: number[] | string;
+};
+type AnyComposeResult =
+    | ComposeResultError
+    | ComposeResultNonFinal<FixtureUtxo>
+    | ComposeResultFinal<FixtureUtxo, FixtureOutput, FixtureChangeAddress>;
 
 type Fixture = {
     description: string;
-    request: Omit<AnyComposeRequest, 'network' | 'outputs' | 'changeAddress'> & {
-        network?: AnyComposeRequest['network'];
-        outputs: Array<AnyComposeRequest['outputs'][number] & { customField?: string }>;
-        changeAddress: AnyComposeRequest['changeAddress'] & { path?: number[] | string };
+    request: Omit<AnyComposeRequest, 'utxos' | 'outputs' | 'changeAddress'> & {
+        utxos: FixtureUtxo[];
+        outputs: FixtureOutput[];
+        changeAddress: FixtureChangeAddress;
     };
     result: AnyComposeResult;
     randomIntSequence?: number[];
@@ -36,7 +54,7 @@ export const composeTxFixture: Fixture[] = [
     {
         description: 'builds a simple tx without change',
         request: {
-            changeAddress: { address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT' },
+            changeAddress: CHANGE_ADDRESS,
             dustThreshold: 546,
             feeRate: '10',
             sortingStrategy: 'bip69',
@@ -46,6 +64,7 @@ export const composeTxFixture: Fixture[] = [
                     amount: '100000',
                     type: 'payment',
                     customField: 'prove that payment output is generic',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
                 },
             ],
             utxos: [UTXO],
@@ -63,7 +82,8 @@ export const composeTxFixture: Fixture[] = [
                     amount: '100000',
                     type: 'payment',
                     customField: 'prove that payment output is generic',
-                } as AnyComposeFinalResult['outputs'][number], // hack for `customField`
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
+                },
             ],
             outputsPermutation: [0],
             type: 'final',
@@ -72,7 +92,7 @@ export const composeTxFixture: Fixture[] = [
     {
         description: 'builds a simple tx without change and decimal fee',
         request: {
-            changeAddress: { address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT' },
+            changeAddress: CHANGE_ADDRESS,
             dustThreshold: 546,
             feeRate: '10.33',
             sortingStrategy: 'bip69',
@@ -81,6 +101,7 @@ export const composeTxFixture: Fixture[] = [
                     address: '1BitcoinEaterAddressDontSendf59kuE',
                     amount: '100000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
                 },
             ],
             utxos: [UTXO],
@@ -97,6 +118,7 @@ export const composeTxFixture: Fixture[] = [
                     address: '1BitcoinEaterAddressDontSendf59kuE',
                     amount: '100000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
                 },
             ],
             outputsPermutation: [0],
@@ -106,7 +128,7 @@ export const composeTxFixture: Fixture[] = [
     {
         description: 'builds an payment tx without change',
         request: {
-            changeAddress: { address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT' },
+            changeAddress: CHANGE_ADDRESS,
             dustThreshold: 546,
             feeRate: '10',
             sortingStrategy: 'bip69',
@@ -114,6 +136,7 @@ export const composeTxFixture: Fixture[] = [
                 {
                     amount: '100000',
                     type: 'payment-noaddress',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
                 },
             ],
             utxos: [UTXO],
@@ -131,7 +154,7 @@ export const composeTxFixture: Fixture[] = [
     {
         description: 'errors on little funds',
         request: {
-            changeAddress: { address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT' },
+            changeAddress: CHANGE_ADDRESS,
             dustThreshold: 546,
             feeRate: '10',
             sortingStrategy: 'bip69',
@@ -139,6 +162,7 @@ export const composeTxFixture: Fixture[] = [
                 {
                     amount: '100000',
                     type: 'payment-noaddress',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
                 },
             ],
             utxos: [
@@ -156,7 +180,7 @@ export const composeTxFixture: Fixture[] = [
     {
         description: 'builds a send-max with large input',
         request: {
-            changeAddress: { address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT' },
+            changeAddress: CHANGE_ADDRESS,
             dustThreshold: 546,
             feeRate: '10',
             sortingStrategy: 'bip69',
@@ -164,6 +188,7 @@ export const composeTxFixture: Fixture[] = [
                 {
                     address: '1BitcoinEaterAddressDontSendf59kuE',
                     type: 'send-max',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
                 },
             ],
             utxos: [
@@ -185,6 +210,7 @@ export const composeTxFixture: Fixture[] = [
                     address: '1BitcoinEaterAddressDontSendf59kuE',
                     amount: '49999998080',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
                 },
             ],
             outputsPermutation: [0],
@@ -194,7 +220,7 @@ export const composeTxFixture: Fixture[] = [
     {
         description: 'builds a send-max',
         request: {
-            changeAddress: { address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT' },
+            changeAddress: CHANGE_ADDRESS,
             dustThreshold: 546,
             feeRate: '10',
             sortingStrategy: 'bip69',
@@ -202,6 +228,7 @@ export const composeTxFixture: Fixture[] = [
                 {
                     address: '1BitcoinEaterAddressDontSendf59kuE',
                     type: 'send-max',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
                     customField: 'prove that send-max output is generic',
                 },
             ],
@@ -219,8 +246,9 @@ export const composeTxFixture: Fixture[] = [
                     address: '1BitcoinEaterAddressDontSendf59kuE',
                     amount: '100081',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
                     customField: 'prove that send-max output is generic',
-                } as AnyComposeFinalResult['outputs'][number], // hack for `customField`
+                },
             ],
             outputsPermutation: [0],
             type: 'final',
@@ -230,7 +258,7 @@ export const composeTxFixture: Fixture[] = [
         description: 'builds a simple tx with two outputs and change',
         request: {
             changeAddress: {
-                address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT',
+                ...CHANGE_ADDRESS,
                 path: [44, 1, 1, 0],
             },
             dustThreshold: 546,
@@ -241,11 +269,13 @@ export const composeTxFixture: Fixture[] = [
                     address: '1BitcoinEaterAddressDontSendf59kuE',
                     amount: '30000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
                 },
                 {
                     address: '1LetUsDestroyBitcoinTogether398Nrg',
                     amount: '20000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
                 },
             ],
             utxos: [UTXO],
@@ -262,18 +292,20 @@ export const composeTxFixture: Fixture[] = [
                     address: '1LetUsDestroyBitcoinTogether398Nrg',
                     amount: '20000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
                 },
                 {
                     address: '1BitcoinEaterAddressDontSendf59kuE',
                     amount: '30000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
                 },
                 {
-                    address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT',
+                    ...CHANGE_ADDRESS,
                     path: [44, 1, 1, 0],
                     amount: '49401',
                     type: 'change',
-                } as AnyComposeFinalResult['outputs'][number], // hack for `path`,
+                },
             ],
             outputsPermutation: [1, 0, 2],
             type: 'final',
@@ -283,7 +315,7 @@ export const composeTxFixture: Fixture[] = [
         description: 'builds a simple tx with two outputs and change (decimal feeRate)',
         request: {
             changeAddress: {
-                address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT',
+                ...CHANGE_ADDRESS,
                 path: "m/44'/0'/0'/1/0",
             },
             dustThreshold: 546,
@@ -294,11 +326,13 @@ export const composeTxFixture: Fixture[] = [
                     address: '1BitcoinEaterAddressDontSendf59kuE',
                     amount: '30000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
                 },
                 {
                     address: '1LetUsDestroyBitcoinTogether398Nrg',
                     amount: '20000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
                 },
             ],
             utxos: [UTXO],
@@ -315,18 +349,20 @@ export const composeTxFixture: Fixture[] = [
                     address: '1LetUsDestroyBitcoinTogether398Nrg',
                     amount: '20000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
                 },
                 {
                     address: '1BitcoinEaterAddressDontSendf59kuE',
                     amount: '30000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
                 },
                 {
+                    ...CHANGE_ADDRESS,
                     path: "m/44'/0'/0'/1/0",
-                    address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT',
                     amount: '49216',
                     type: 'change',
-                } as AnyComposeFinalResult['outputs'][number], // hack for `path`,,
+                },
             ],
             outputsPermutation: [1, 0, 2],
             type: 'final',
@@ -336,7 +372,10 @@ export const composeTxFixture: Fixture[] = [
         description: 'builds a simple tx with two outputs and change (p2sh/segwit)',
         request: {
             txType: 'p2sh',
-            changeAddress: { address: '3LRW7jeCvQCRdPF8S3yUCfRAx4eqXFmdcr' },
+            changeAddress: {
+                address: '3LRW7jeCvQCRdPF8S3yUCfRAx4eqXFmdcr',
+                script: { length: OUTPUT_SCRIPT_LENGTH.p2sh },
+            },
             dustThreshold: 546,
             feeRate: '10',
             sortingStrategy: 'bip69',
@@ -345,11 +384,13 @@ export const composeTxFixture: Fixture[] = [
                     address: '3LRW7jeCvQCRdPF8S3yUCfRAx4eqXFmdcr',
                     amount: '30000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2sh },
                 },
                 {
                     address: '3FyVFsEyyBPzHjD3qUEgX7Jsn4tcHNZFkn',
                     amount: '20000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2sh },
                 },
             ],
             utxos: [UTXO],
@@ -366,16 +407,19 @@ export const composeTxFixture: Fixture[] = [
                     address: '3FyVFsEyyBPzHjD3qUEgX7Jsn4tcHNZFkn',
                     amount: '20000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2sh },
                 },
                 {
                     address: '3LRW7jeCvQCRdPF8S3yUCfRAx4eqXFmdcr',
                     amount: '30000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2sh },
                 },
                 {
                     address: '3LRW7jeCvQCRdPF8S3yUCfRAx4eqXFmdcr',
                     amount: '50021',
                     type: 'change',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2sh },
                 },
             ],
             outputsPermutation: [1, 0, 2],
@@ -385,7 +429,7 @@ export const composeTxFixture: Fixture[] = [
     {
         description: 'prefers a more confirmed input',
         request: {
-            changeAddress: { address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT' },
+            changeAddress: CHANGE_ADDRESS,
             dustThreshold: 546,
             feeRate: '10',
             sortingStrategy: 'bip69',
@@ -394,6 +438,7 @@ export const composeTxFixture: Fixture[] = [
                     address: '1BitcoinEaterAddressDontSendf59kuE',
                     amount: '100000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
                 },
             ],
             utxos: [
@@ -421,6 +466,7 @@ export const composeTxFixture: Fixture[] = [
                     address: '1BitcoinEaterAddressDontSendf59kuE',
                     amount: '100000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
                 },
             ],
             outputsPermutation: [0],
@@ -430,7 +476,7 @@ export const composeTxFixture: Fixture[] = [
     {
         description: 'two inputs',
         request: {
-            changeAddress: { address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT' },
+            changeAddress: CHANGE_ADDRESS,
             dustThreshold: 546,
             feeRate: '10',
             sortingStrategy: 'bip69',
@@ -439,6 +485,7 @@ export const composeTxFixture: Fixture[] = [
                     address: '1BitcoinEaterAddressDontSendf59kuE',
                     amount: '200000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
                 },
             ],
             utxos: [
@@ -467,6 +514,7 @@ export const composeTxFixture: Fixture[] = [
                     address: '1BitcoinEaterAddressDontSendf59kuE',
                     amount: '200000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
                 },
             ],
             outputsPermutation: [0],
@@ -476,7 +524,7 @@ export const composeTxFixture: Fixture[] = [
     {
         description: 'sorts the inputs according to BIP69 when sortingStrategy=bip69',
         request: {
-            changeAddress: { address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT' },
+            changeAddress: CHANGE_ADDRESS,
             dustThreshold: 546,
             feeRate: '10',
             sortingStrategy: 'bip69',
@@ -485,6 +533,7 @@ export const composeTxFixture: Fixture[] = [
                     address: '1BitcoinEaterAddressDontSendf59kuE',
                     amount: '150000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
                 },
             ],
             utxos: [
@@ -510,7 +559,7 @@ export const composeTxFixture: Fixture[] = [
             ],
             outputs: [
                 {
-                    address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT',
+                    ...CHANGE_ADDRESS,
                     amount: '50262',
                     type: 'change',
                 },
@@ -518,6 +567,7 @@ export const composeTxFixture: Fixture[] = [
                     address: '1BitcoinEaterAddressDontSendf59kuE',
                     amount: '150000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
                 },
             ],
             outputsPermutation: [1, 0],
@@ -534,7 +584,7 @@ export const composeTxFixture: Fixture[] = [
             0, // Shuffling inputs (Fisher-Yates swap second with the first)
         ],
         request: {
-            changeAddress: { address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT' },
+            changeAddress: CHANGE_ADDRESS,
             dustThreshold: 546,
             feeRate: '10',
             sortingStrategy: 'random',
@@ -543,11 +593,13 @@ export const composeTxFixture: Fixture[] = [
                     address: '1BitcoinEaterAddressDontSendf59kuE',
                     amount: '100000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
                 },
                 {
                     address: '1LetUsDestroyBitcoinTogether398Nrg',
                     amount: '150000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
                 },
             ],
             utxos: [
@@ -581,9 +633,10 @@ export const composeTxFixture: Fixture[] = [
                     address: '1BitcoinEaterAddressDontSendf59kuE',
                     amount: '100000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
                 },
                 {
-                    address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT',
+                    ...CHANGE_ADDRESS,
                     amount: '50443',
                     type: 'change',
                 },
@@ -591,6 +644,7 @@ export const composeTxFixture: Fixture[] = [
                     address: '1LetUsDestroyBitcoinTogether398Nrg',
                     amount: '150000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
                 },
             ],
             outputsPermutation: [0, 2, 1],
@@ -601,7 +655,10 @@ export const composeTxFixture: Fixture[] = [
         description: 'builds a p2sh tx with two same value outputs (mixed p2sh + p2pkh) and change',
         request: {
             txType: 'p2sh',
-            changeAddress: { address: '3LRW7jeCvQCRdPF8S3yUCfRAx4eqXFmdcr' },
+            changeAddress: {
+                address: '3LRW7jeCvQCRdPF8S3yUCfRAx4eqXFmdcr',
+                script: { length: OUTPUT_SCRIPT_LENGTH.p2sh },
+            },
             dustThreshold: 546,
             feeRate: '10',
             sortingStrategy: 'bip69',
@@ -610,11 +667,13 @@ export const composeTxFixture: Fixture[] = [
                     address: '3LRW7jeCvQCRdPF8S3yUCfRAx4eqXFmdcr',
                     amount: '30000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2sh },
                 },
                 {
                     address: '1LetUsDestroyBitcoinTogether398Nrg',
                     amount: '30000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
                 },
             ],
             utxos: [UTXO],
@@ -628,22 +687,25 @@ export const composeTxFixture: Fixture[] = [
             inputs: [UTXO],
             outputs: [
                 {
-                    address: '1LetUsDestroyBitcoinTogether398Nrg',
-                    amount: '30000',
-                    type: 'payment',
-                },
-                {
                     address: '3LRW7jeCvQCRdPF8S3yUCfRAx4eqXFmdcr',
                     amount: '30000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2sh },
+                },
+                {
+                    address: '1LetUsDestroyBitcoinTogether398Nrg',
+                    amount: '30000',
+                    type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
                 },
                 {
                     address: '3LRW7jeCvQCRdPF8S3yUCfRAx4eqXFmdcr',
                     amount: '40001',
                     type: 'change',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2sh },
                 },
             ],
-            outputsPermutation: [1, 0, 2],
+            outputsPermutation: [0, 1, 2],
             type: 'final',
         },
     },
@@ -651,7 +713,10 @@ export const composeTxFixture: Fixture[] = [
         description: 'explicit dust threshold stops change (ps2h/segwit)',
         request: {
             txType: 'p2sh',
-            changeAddress: { address: '3LRW7jeCvQCRdPF8S3yUCfRAx4eqXFmdcr' },
+            changeAddress: {
+                address: '3LRW7jeCvQCRdPF8S3yUCfRAx4eqXFmdcr',
+                script: { length: OUTPUT_SCRIPT_LENGTH.p2sh },
+            },
             dustThreshold: 54600,
             feeRate: '10',
             sortingStrategy: 'bip69',
@@ -660,6 +725,7 @@ export const composeTxFixture: Fixture[] = [
                     address: '3LRW7jeCvQCRdPF8S3yUCfRAx4eqXFmdcr',
                     amount: '928960',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2sh },
                 },
             ],
             utxos: [
@@ -681,6 +747,7 @@ export const composeTxFixture: Fixture[] = [
                     address: '3LRW7jeCvQCRdPF8S3yUCfRAx4eqXFmdcr',
                     amount: '928960',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2sh },
                 },
             ],
             outputsPermutation: [0],
@@ -690,7 +757,7 @@ export const composeTxFixture: Fixture[] = [
     {
         description: 'builds a tx with 1 op-return and change',
         request: {
-            changeAddress: { address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT' },
+            changeAddress: CHANGE_ADDRESS,
             dustThreshold: 546,
             feeRate: '10',
             sortingStrategy: 'bip69',
@@ -698,6 +765,7 @@ export const composeTxFixture: Fixture[] = [
                 {
                     dataHex: 'deadbeef',
                     type: 'opreturn',
+                    script: { length: 6 },
                     customField: 'prove that opreturn output is generic',
                 },
             ],
@@ -714,10 +782,11 @@ export const composeTxFixture: Fixture[] = [
                 {
                     dataHex: 'deadbeef',
                     type: 'opreturn',
+                    script: { length: 6 },
                     customField: 'prove that opreturn output is generic',
-                } as AnyComposeFinalResult['outputs'][number], // hack for `customField`
+                },
                 {
-                    address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT',
+                    ...CHANGE_ADDRESS,
                     amount: '99931',
                     type: 'change',
                 },
@@ -729,7 +798,7 @@ export const composeTxFixture: Fixture[] = [
     {
         description: 'builds a tx with 2 op-returns and change',
         request: {
-            changeAddress: { address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT' },
+            changeAddress: CHANGE_ADDRESS,
             dustThreshold: 546,
             feeRate: '10',
             sortingStrategy: 'bip69',
@@ -737,10 +806,12 @@ export const composeTxFixture: Fixture[] = [
                 {
                     dataHex: 'deadbeef',
                     type: 'opreturn',
+                    script: { length: 6 },
                 },
                 {
                     dataHex: 'c0ffee',
                     type: 'opreturn',
+                    script: { length: 5 },
                 },
             ],
             utxos: [UTXO],
@@ -756,13 +827,15 @@ export const composeTxFixture: Fixture[] = [
                 {
                     dataHex: 'c0ffee',
                     type: 'opreturn',
+                    script: { length: 5 },
                 },
                 {
                     dataHex: 'deadbeef',
                     type: 'opreturn',
+                    script: { length: 6 },
                 },
                 {
-                    address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT',
+                    ...CHANGE_ADDRESS,
                     amount: '99791',
                     type: 'change',
                 },
@@ -775,7 +848,10 @@ export const composeTxFixture: Fixture[] = [
         description: 'builds bech32/p2wpkh tx without change (drop dust)',
         request: {
             txType: 'p2wpkh',
-            changeAddress: { address: 'bc1qafk4yhqvj4wep57m62dgrmutldusqde8adh20d' },
+            changeAddress: {
+                address: 'bc1qafk4yhqvj4wep57m62dgrmutldusqde8adh20d',
+                script: { length: OUTPUT_SCRIPT_LENGTH.p2wpkh },
+            },
             dustThreshold: 546,
             feeRate: '10',
             sortingStrategy: 'bip69',
@@ -784,6 +860,7 @@ export const composeTxFixture: Fixture[] = [
                     address: 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq',
                     amount: '100000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2wpkh },
                 },
             ],
             utxos: [
@@ -805,6 +882,7 @@ export const composeTxFixture: Fixture[] = [
                     address: 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq',
                     amount: '100000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2wpkh },
                 },
             ],
             outputsPermutation: [0],
@@ -816,7 +894,10 @@ export const composeTxFixture: Fixture[] = [
             'builds bech32/p2wpkh tx, no explicit dustThreshold (change above calculated dust)',
         request: {
             txType: 'p2wpkh',
-            changeAddress: { address: 'bc1qafk4yhqvj4wep57m62dgrmutldusqde8adh20d' },
+            changeAddress: {
+                address: 'bc1qafk4yhqvj4wep57m62dgrmutldusqde8adh20d',
+                script: { length: OUTPUT_SCRIPT_LENGTH.p2wpkh },
+            },
             dustThreshold: 0,
             feeRate: '10',
             sortingStrategy: 'bip69',
@@ -825,6 +906,7 @@ export const composeTxFixture: Fixture[] = [
                     address: 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq',
                     amount: '100000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2wpkh },
                 },
             ],
             utxos: [
@@ -846,11 +928,13 @@ export const composeTxFixture: Fixture[] = [
                     address: 'bc1qafk4yhqvj4wep57m62dgrmutldusqde8adh20d',
                     amount: '490',
                     type: 'change',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2wpkh },
                 },
                 {
                     address: 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq',
                     amount: '100000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2wpkh },
                 },
             ],
             outputsPermutation: [1, 0],
@@ -861,7 +945,10 @@ export const composeTxFixture: Fixture[] = [
         description: 'builds Legacy Segwit/p2sh tx without change (drop dust)',
         request: {
             txType: 'p2sh',
-            changeAddress: { address: '3LRW7jeCvQCRdPF8S3yUCfRAx4eqXFmdcr' },
+            changeAddress: {
+                address: '3LRW7jeCvQCRdPF8S3yUCfRAx4eqXFmdcr',
+                script: { length: OUTPUT_SCRIPT_LENGTH.p2sh },
+            },
             dustThreshold: 546,
             feeRate: '10',
             sortingStrategy: 'bip69',
@@ -870,6 +957,7 @@ export const composeTxFixture: Fixture[] = [
                     address: '3NukJ6fYZJ5Kk8bPjycAnruZkE5Q7UW7i8',
                     amount: '100000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2sh },
                 },
             ],
             utxos: [{ ...UTXO, amount: '101500' }],
@@ -886,6 +974,7 @@ export const composeTxFixture: Fixture[] = [
                     address: '3NukJ6fYZJ5Kk8bPjycAnruZkE5Q7UW7i8',
                     amount: '100000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2sh },
                 },
             ],
             outputsPermutation: [0],
@@ -897,7 +986,10 @@ export const composeTxFixture: Fixture[] = [
             'builds Legacy Segwit/p2sh tx, no explicit dustThreshold (change above calculated dust)',
         request: {
             txType: 'p2sh',
-            changeAddress: { address: '3LRW7jeCvQCRdPF8S3yUCfRAx4eqXFmdcr' },
+            changeAddress: {
+                address: '3LRW7jeCvQCRdPF8S3yUCfRAx4eqXFmdcr',
+                script: { length: OUTPUT_SCRIPT_LENGTH.p2sh },
+            },
             dustThreshold: 0,
             feeRate: '10',
             sortingStrategy: 'bip69',
@@ -906,6 +998,7 @@ export const composeTxFixture: Fixture[] = [
                     address: '3NukJ6fYZJ5Kk8bPjycAnruZkE5Q7UW7i8',
                     amount: '100000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2sh },
                 },
             ],
             utxos: [
@@ -927,11 +1020,13 @@ export const composeTxFixture: Fixture[] = [
                     address: '3LRW7jeCvQCRdPF8S3yUCfRAx4eqXFmdcr',
                     amount: '340',
                     type: 'change',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2sh },
                 },
                 {
                     address: '3NukJ6fYZJ5Kk8bPjycAnruZkE5Q7UW7i8',
                     amount: '100000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2sh },
                 },
             ],
             outputsPermutation: [1, 0],
@@ -944,6 +1039,7 @@ export const composeTxFixture: Fixture[] = [
             txType: 'p2tr',
             changeAddress: {
                 address: 'bc1pgypgja2hmcx2l6s2ssq75k6ev68ved6nujcspt47dgvkp8euc70s6uegk6',
+                script: { length: OUTPUT_SCRIPT_LENGTH.p2tr },
             },
             dustThreshold: 546,
             feeRate: '10',
@@ -953,12 +1049,14 @@ export const composeTxFixture: Fixture[] = [
                     address: 'bc1ptxs597p3fnpd8gwut5p467ulsydae3rp9z75hd99w8k3ljr9g9rqx6ynaw',
                     amount: '100000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2tr },
                 },
             ],
             utxos: [
                 {
                     ...UTXO,
                     amount: '101500',
+                    script: { length: INPUT_SCRIPT_LENGTH.p2tr },
                 },
             ],
         },
@@ -968,12 +1066,13 @@ export const composeTxFixture: Fixture[] = [
             feePerByte: '13.513513513513514',
             max: undefined,
             totalSpent: '101500',
-            inputs: [{ ...UTXO, amount: '101500' }],
+            inputs: [{ ...UTXO, amount: '101500', script: { length: INPUT_SCRIPT_LENGTH.p2tr } }],
             outputs: [
                 {
                     address: 'bc1ptxs597p3fnpd8gwut5p467ulsydae3rp9z75hd99w8k3ljr9g9rqx6ynaw',
                     amount: '100000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2tr },
                 },
             ],
             outputsPermutation: [0],
@@ -987,6 +1086,7 @@ export const composeTxFixture: Fixture[] = [
             txType: 'p2tr',
             changeAddress: {
                 address: 'bc1pgypgja2hmcx2l6s2ssq75k6ev68ved6nujcspt47dgvkp8euc70s6uegk6',
+                script: { length: OUTPUT_SCRIPT_LENGTH.p2tr },
             },
             dustThreshold: 0,
             feeRate: '10',
@@ -996,12 +1096,14 @@ export const composeTxFixture: Fixture[] = [
                     address: 'bc1ptxs597p3fnpd8gwut5p467ulsydae3rp9z75hd99w8k3ljr9g9rqx6ynaw',
                     amount: '100000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2tr },
                 },
             ],
             utxos: [
                 {
                     ...UTXO,
                     amount: '102000',
+                    script: { length: INPUT_SCRIPT_LENGTH.p2tr },
                 },
             ],
         },
@@ -1011,17 +1113,19 @@ export const composeTxFixture: Fixture[] = [
             feePerByte: '10',
             max: undefined,
             totalSpent: '101540',
-            inputs: [{ ...UTXO, amount: '102000' }],
+            inputs: [{ ...UTXO, amount: '102000', script: { length: INPUT_SCRIPT_LENGTH.p2tr } }],
             outputs: [
                 {
                     address: 'bc1pgypgja2hmcx2l6s2ssq75k6ev68ved6nujcspt47dgvkp8euc70s6uegk6',
                     amount: '460',
                     type: 'change',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2tr },
                 },
                 {
                     address: 'bc1ptxs597p3fnpd8gwut5p467ulsydae3rp9z75hd99w8k3ljr9g9rqx6ynaw',
                     amount: '100000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2tr },
                 },
             ],
             outputsPermutation: [1, 0],
@@ -1031,13 +1135,14 @@ export const composeTxFixture: Fixture[] = [
     {
         description: 'builds a send-max-noaddress',
         request: {
-            changeAddress: { address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT' },
+            changeAddress: CHANGE_ADDRESS,
             dustThreshold: 546,
             feeRate: '10',
             sortingStrategy: 'bip69',
             outputs: [
                 {
                     type: 'send-max-noaddress',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
                 },
             ],
             utxos: [UTXO],
@@ -1055,8 +1160,11 @@ export const composeTxFixture: Fixture[] = [
     {
         description: 'builds a simple tx without change (cashaddr)',
         request: {
-            changeAddress: { address: 'bitcoincash:qzppkat2v7xu9fr3yeuqdnggjqqltrs7pcg8swvhl0' },
-            network: bitcoincash,
+            changeAddress: {
+                address: 'bitcoincash:qzppkat2v7xu9fr3yeuqdnggjqqltrs7pcg8swvhl0',
+                script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
+            },
+
             dustThreshold: 546,
             feeRate: '10',
             sortingStrategy: 'bip69',
@@ -1065,6 +1173,7 @@ export const composeTxFixture: Fixture[] = [
                     address: 'bitcoincash:qp6e6enhpy0fwwu7nkvlr8rgl06ru0c9lywalz8st5',
                     amount: '100000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
                 },
             ],
             utxos: [UTXO],
@@ -1081,6 +1190,7 @@ export const composeTxFixture: Fixture[] = [
                     address: 'bitcoincash:qp6e6enhpy0fwwu7nkvlr8rgl06ru0c9lywalz8st5',
                     amount: '100000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
                 },
             ],
             outputsPermutation: [0],
@@ -1090,7 +1200,7 @@ export const composeTxFixture: Fixture[] = [
     {
         description: 'use required (coinbase + unconfirmed) instead of more suitable utxo',
         request: {
-            changeAddress: { address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT' },
+            changeAddress: CHANGE_ADDRESS,
             dustThreshold: 546,
             feeRate: '10',
             sortingStrategy: 'bip69',
@@ -1099,6 +1209,7 @@ export const composeTxFixture: Fixture[] = [
                     address: '1BitcoinEaterAddressDontSendf59kuE',
                     amount: '100000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
                 },
             ],
             utxos: [
@@ -1110,6 +1221,7 @@ export const composeTxFixture: Fixture[] = [
                     confirmations: 200,
                     own: false,
                     required: true,
+                    script: { length: INPUT_SCRIPT_LENGTH.p2pkh },
                 },
                 {
                     vout: 0,
@@ -1118,6 +1230,7 @@ export const composeTxFixture: Fixture[] = [
                     coinbase: false,
                     confirmations: 150,
                     own: true,
+                    script: { length: INPUT_SCRIPT_LENGTH.p2pkh },
                 },
                 {
                     vout: 0,
@@ -1127,6 +1240,7 @@ export const composeTxFixture: Fixture[] = [
                     confirmations: 0,
                     own: false,
                     required: true,
+                    script: { length: INPUT_SCRIPT_LENGTH.p2pkh },
                 },
                 {
                     vout: 0,
@@ -1135,6 +1249,7 @@ export const composeTxFixture: Fixture[] = [
                     coinbase: false,
                     confirmations: 1000,
                     own: true,
+                    script: { length: INPUT_SCRIPT_LENGTH.p2pkh },
                 },
             ],
         },
@@ -1153,6 +1268,7 @@ export const composeTxFixture: Fixture[] = [
                     confirmations: 200,
                     own: false,
                     required: true,
+                    script: { length: INPUT_SCRIPT_LENGTH.p2pkh },
                 },
                 {
                     txid: 'b4dc0ffeee',
@@ -1162,18 +1278,20 @@ export const composeTxFixture: Fixture[] = [
                     confirmations: 0,
                     own: false,
                     required: true,
+                    script: { length: INPUT_SCRIPT_LENGTH.p2pkh },
                 },
             ],
             outputs: [
                 {
+                    ...CHANGE_ADDRESS,
                     amount: '16842',
-                    address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT',
                     type: 'change',
                 },
                 {
                     address: '1BitcoinEaterAddressDontSendf59kuE',
                     amount: '100000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
                 },
             ],
             outputsPermutation: [1, 0],
@@ -1183,7 +1301,7 @@ export const composeTxFixture: Fixture[] = [
     {
         description: 'skip inputs/outputs permutation when sortingStrategy=none',
         request: {
-            changeAddress: { address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT' },
+            changeAddress: CHANGE_ADDRESS,
             dustThreshold: 546,
             feeRate: '10',
             sortingStrategy: 'none',
@@ -1192,6 +1310,7 @@ export const composeTxFixture: Fixture[] = [
                     address: '1BitcoinEaterAddressDontSendf59kuE',
                     amount: '70000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
                 },
             ],
             utxos: [
@@ -1202,6 +1321,7 @@ export const composeTxFixture: Fixture[] = [
                     coinbase: false,
                     confirmations: 60,
                     own: false,
+                    script: { length: INPUT_SCRIPT_LENGTH.p2pkh },
                 },
                 {
                     txid: 'b4dc0ffeee',
@@ -1210,6 +1330,7 @@ export const composeTxFixture: Fixture[] = [
                     coinbase: false,
                     confirmations: 50,
                     own: false,
+                    script: { length: INPUT_SCRIPT_LENGTH.p2pkh },
                 },
             ],
         },
@@ -1227,6 +1348,7 @@ export const composeTxFixture: Fixture[] = [
                     coinbase: false,
                     confirmations: 60,
                     own: false,
+                    script: { length: INPUT_SCRIPT_LENGTH.p2pkh },
                 },
                 {
                     txid: 'b4dc0ffeee',
@@ -1235,6 +1357,7 @@ export const composeTxFixture: Fixture[] = [
                     coinbase: false,
                     confirmations: 50,
                     own: false,
+                    script: { length: INPUT_SCRIPT_LENGTH.p2pkh },
                 },
             ],
             outputs: [
@@ -1242,10 +1365,11 @@ export const composeTxFixture: Fixture[] = [
                     address: '1BitcoinEaterAddressDontSendf59kuE',
                     amount: '70000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
                 },
                 {
+                    ...CHANGE_ADDRESS,
                     amount: '46842',
-                    address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT',
                     type: 'change',
                 },
             ],
@@ -1257,17 +1381,20 @@ export const composeTxFixture: Fixture[] = [
         description:
             'builds a Dogecoin tx with change and both input and one of the outputs above MAX_SAFE_INTEGER',
         request: {
-            changeAddress: { address: 'DKu2a8Wo6zC2dmBBYXwUG3fxWDHbKnNiPj' },
+            changeAddress: {
+                address: 'DKu2a8Wo6zC2dmBBYXwUG3fxWDHbKnNiPj',
+                script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
+            },
             dustThreshold: 999999,
             feeRate: '1000',
             sortingStrategy: 'bip69',
-            network: doge,
             feePolicy: 'doge',
             outputs: [
                 {
                     address: 'DDn7UV1CrqVefzwrHyw7H2zEZZKqfzR2ZD',
                     amount: '11556856849999734000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
                 },
             ],
             utxos: [
@@ -1278,6 +1405,7 @@ export const composeTxFixture: Fixture[] = [
                     own: false,
                     txid: '78c3ee88226c7f63060fbf27ab0450961c09241bfd56a12ce164881791c7c6e5',
                     amount: '11556856856800000000',
+                    script: { length: INPUT_SCRIPT_LENGTH.p2pkh },
                 },
             ],
         },
@@ -1295,6 +1423,7 @@ export const composeTxFixture: Fixture[] = [
                     own: false,
                     txid: '78c3ee88226c7f63060fbf27ab0450961c09241bfd56a12ce164881791c7c6e5',
                     amount: '11556856856800000000',
+                    script: { length: INPUT_SCRIPT_LENGTH.p2pkh },
                 },
             ],
             outputs: [
@@ -1302,11 +1431,13 @@ export const composeTxFixture: Fixture[] = [
                     address: 'DKu2a8Wo6zC2dmBBYXwUG3fxWDHbKnNiPj',
                     amount: '6800040000',
                     type: 'change',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
                 },
                 {
                     address: 'DDn7UV1CrqVefzwrHyw7H2zEZZKqfzR2ZD',
                     amount: '11556856849999734000',
                     type: 'payment',
+                    script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh },
                 },
             ],
             outputsPermutation: [1, 0],

--- a/packages/utxo-lib/tests/__fixtures__/compose.ts
+++ b/packages/utxo-lib/tests/__fixtures__/compose.ts
@@ -1,9 +1,9 @@
 import { bitcoincash, doge } from '../../src/networks';
 import {
+    AnyComposeRequest,
     ComposeChangeAddress,
     ComposeInput,
     ComposeOutput,
-    ComposeRequest,
     ComposeResult,
     ComposeResultFinal,
 } from '../../src/types/compose';
@@ -18,7 +18,6 @@ export const UTXO: ComposeInput & { path: number[] } = {
     amount: '102001',
 };
 
-type AnyComposeRequest = ComposeRequest<ComposeInput, ComposeOutput, ComposeChangeAddress>;
 type AnyComposeResult = ComposeResult<ComposeInput, ComposeOutput, ComposeChangeAddress>;
 type AnyComposeFinalResult = ComposeResultFinal<ComposeInput, ComposeOutput, ComposeChangeAddress>;
 

--- a/packages/utxo-lib/tests/compose.request.test.ts
+++ b/packages/utxo-lib/tests/compose.request.test.ts
@@ -1,24 +1,17 @@
 import type { ComposeRequest } from '../src';
+import { CHANGE_ADDRESS, UTXO } from './__fixtures__/compose';
 import { validateAndParseRequest as validate } from '../src/compose/request';
-import * as NETWORKS from '../src/networks';
-
-const UTXO = {
-    coinbase: false,
-    own: true,
-    confirmations: 100,
-    amount: '50000',
-};
 
 const PAYMENT = {
     type: 'send-max-noaddress',
+    script: { length: 25 },
 };
 
 const REQUEST: ComposeRequest<any, any, any> = {
     utxos: [UTXO],
     outputs: [PAYMENT],
     feeRate: 1,
-    network: NETWORKS.bitcoin,
-    changeAddress: { address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT' },
+    changeAddress: CHANGE_ADDRESS,
     dustThreshold: 526,
     sortingStrategy: 'bip69',
 };
@@ -131,29 +124,29 @@ describe('validateAndParseRequest', () => {
             message: 'Unknown output type at index 0',
         });
 
-        // invalid address
-        expect(getRequest([{ type: 'send-max', address: 'weird-address' }])).toEqual({
-            ...expectedError,
-            message: 'weird-address has no matching Script at index 0',
-        });
-
         // missing amount
-        expect(getRequest([{ type: 'payment-noaddress' }])).toEqual({
+        expect(getRequest([{ type: 'payment-noaddress', script: { length: 25 } }])).toEqual({
             ...expectedError,
             message: 'Invalid amount at index 0',
         });
         // invalid amount field (NaN)
-        expect(getRequest([{ type: 'payment-noaddress', amount: 'abcd' }])).toEqual({
+        expect(
+            getRequest([{ type: 'payment-noaddress', amount: 'abcd', script: { length: 25 } }]),
+        ).toEqual({
             ...expectedError,
             message: 'Invalid amount at index 0',
         });
         // invalid amount field (float)
-        expect(getRequest([{ type: 'payment-noaddress', amount: '1.1' }])).toEqual({
+        expect(
+            getRequest([{ type: 'payment-noaddress', amount: '1.1', script: { length: 25 } }]),
+        ).toEqual({
             ...expectedError,
             message: 'Invalid amount at index 0',
         });
         // invalid amount field (number)
-        expect(getRequest([{ type: 'payment-noaddress', amount: 1 }])).toEqual({
+        expect(
+            getRequest([{ type: 'payment-noaddress', amount: 1, script: { length: 25 } }]),
+        ).toEqual({
             ...expectedError,
             message: 'Invalid amount at index 0',
         });

--- a/packages/utxo-lib/tests/compose.test.ts
+++ b/packages/utxo-lib/tests/compose.test.ts
@@ -2,11 +2,11 @@ import { getRandomInt } from '@trezor/utils';
 
 import { verifyTxBytes } from './compose.utils';
 import { composeTx } from '../src/compose';
-import { composeTxFixture } from './__fixtures__/compose';
+import { CHANGE_ADDRESS, composeTxFixture } from './__fixtures__/compose';
 import { fixturesCrossCheck } from './__fixtures__/compose.crosscheck';
+import { INPUT_SCRIPT_LENGTH, OUTPUT_SCRIPT_LENGTH } from '../src/coinselect/coinselectUtils';
 import { getErrorResult } from '../src/compose/result';
 import { bip69SortingStrategy } from '../src/compose/sorting/bip69SortingStrategy';
-import * as NETWORKS from '../src/networks';
 
 jest.mock('@trezor/utils', () => ({
     ...jest.requireActual('@trezor/utils'),
@@ -26,20 +26,16 @@ const mockRandomInt = (randomIntSequence: number[] | undefined) => {
 
 describe(composeTx.name, () => {
     composeTxFixture.forEach(f => {
-        const network = f.request.network ?? NETWORKS.bitcoin;
-        const request = { ...f.request, network };
-        const result = { ...f.result };
-
         it(f.description, () => {
             mockRandomInt(f.randomIntSequence);
 
-            const tx = composeTx(request);
-            expect(tx).toEqual(result);
+            const tx = composeTx(f.request);
+            expect(tx).toEqual(f.result);
 
             expect(f.request.txType).not.toEqual('p2wsh');
 
             if (tx.type === 'final' && f.request.txType !== 'p2wsh') {
-                verifyTxBytes(tx, f.request.txType, network);
+                verifyTxBytes(tx, f.request.txType);
             }
         });
     });
@@ -49,42 +45,16 @@ describe('composeTx request validation errors', () => {
     it('returns MISSING-UTXOS when utxos array is empty', () => {
         const tx = composeTx({
             utxos: [],
-            outputs: [{ type: 'send-max-noaddress' }],
+            outputs: [
+                { type: 'send-max-noaddress', script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh } },
+            ],
             feeRate: 10,
-            network: NETWORKS.bitcoin,
-            changeAddress: { address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT' },
+            changeAddress: CHANGE_ADDRESS,
             dustThreshold: 546,
             sortingStrategy: 'bip69',
         });
 
         expect(tx).toEqual({ type: 'error', error: 'MISSING-UTXOS' });
-    });
-
-    it('returns INCORRECT-OUTPUT when changeAddress.address is not a valid Bitcoin address', () => {
-        const tx = composeTx({
-            utxos: [
-                {
-                    vout: 0,
-                    txid: '0000000000000000000000000000000000000000000000000000000000000000',
-                    coinbase: false,
-                    own: true,
-                    confirmations: 100,
-                    amount: '50000',
-                },
-            ],
-            outputs: [{ type: 'send-max-noaddress' }],
-            feeRate: 10,
-            network: NETWORKS.bitcoin,
-            changeAddress: { address: 'not-a-valid-address' },
-            dustThreshold: 546,
-            sortingStrategy: 'bip69',
-        });
-
-        expect(tx).toEqual({
-            type: 'error',
-            error: 'INCORRECT-OUTPUT',
-            message: 'not-a-valid-address has no matching Script',
-        });
     });
 
     it('returns INCORRECT-OUTPUT when a payment output has an unparseable amount', () => {
@@ -97,18 +67,18 @@ describe('composeTx request validation errors', () => {
                     own: true,
                     confirmations: 100,
                     amount: '50000',
+                    script: { length: INPUT_SCRIPT_LENGTH.p2pkh },
                 },
             ],
             outputs: [
                 {
+                    ...CHANGE_ADDRESS,
                     type: 'payment',
-                    address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT',
                     amount: 'not-a-number',
                 },
             ],
             feeRate: 10,
-            network: NETWORKS.bitcoin,
-            changeAddress: { address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT' },
+            changeAddress: CHANGE_ADDRESS,
             dustThreshold: 546,
             sortingStrategy: 'bip69',
         });
@@ -130,12 +100,14 @@ describe('composeTx request validation errors', () => {
                     own: true,
                     confirmations: 100,
                     amount: '50000',
+                    script: { length: INPUT_SCRIPT_LENGTH.p2pkh },
                 },
             ],
-            outputs: [{ type: 'send-max-noaddress' }],
+            outputs: [
+                { type: 'send-max-noaddress', script: { length: OUTPUT_SCRIPT_LENGTH.p2pkh } },
+            ],
             feeRate: 0,
-            network: NETWORKS.bitcoin,
-            changeAddress: { address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT' },
+            changeAddress: CHANGE_ADDRESS,
             dustThreshold: 546,
             sortingStrategy: 'bip69',
         });
@@ -174,7 +146,7 @@ describe('bip69SortingStrategy', () => {
         };
         const request = {
             outputs: [{ type: 'payment', address: 'addr-a', amount: '1000' }],
-            changeAddress: { address: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT' },
+            changeAddress: CHANGE_ADDRESS,
         };
 
         const composed = bip69SortingStrategy({
@@ -190,12 +162,12 @@ describe('bip69SortingStrategy', () => {
 
 describe('composeTx addresses cross-check', () => {
     const txTypes = ['p2pkh', 'p2sh', 'p2tr', 'p2wpkh'] as const;
-    const addrTypes = {
-        p2pkh: '1BitcoinEaterAddressDontSendf59kuE',
-        p2sh: '3LRW7jeCvQCRdPF8S3yUCfRAx4eqXFmdcr',
-        p2tr: 'bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr',
-        p2wpkh: 'bc1qafk4yhqvj4wep57m62dgrmutldusqde8adh20d',
-        p2wsh: 'bc1q6rgl33d3s9dugudw7n68yrryajkr3ha9q8q24j20zs62se4q9tsqdy0t2q',
+    const addrScriptLengths = {
+        p2pkh: OUTPUT_SCRIPT_LENGTH.p2pkh,
+        p2sh: OUTPUT_SCRIPT_LENGTH.p2sh,
+        p2tr: OUTPUT_SCRIPT_LENGTH.p2tr,
+        p2wpkh: OUTPUT_SCRIPT_LENGTH.p2wpkh,
+        p2wsh: OUTPUT_SCRIPT_LENGTH.p2wsh,
     };
 
     const amounts = {
@@ -206,11 +178,10 @@ describe('composeTx addresses cross-check', () => {
         p2wsh: '101500',
     };
 
-    const addrKeys = Object.keys(addrTypes) as Array<keyof typeof addrTypes>;
+    const addrKeys = Object.keys(addrScriptLengths) as Array<keyof typeof addrScriptLengths>;
 
     fixturesCrossCheck.forEach(f => {
         txTypes.forEach(txType => {
-            // skip test for each addressType if there is nothing to replace (example: 7 inputs test)
             const offset = f.request.outputs.find(o => 'address' in o && o.address === 'replace-me')
                 ? addrKeys.length
                 : 1;
@@ -218,29 +189,45 @@ describe('composeTx addresses cross-check', () => {
             addrKeys.slice(0, offset).forEach(addressType => {
                 const key = `${txType}-${addressType}` as keyof typeof f.result;
                 it(`${key} ${f.description}`, () => {
+                    const resolvedOutputs = f.request.outputs.map(o => {
+                        if (o.type === 'payment') {
+                            const scriptLength =
+                                o.address in addrScriptLengths
+                                    ? addrScriptLengths[o.address as keyof typeof addrScriptLengths]
+                                    : addrScriptLengths[addressType];
+
+                            return {
+                                ...o,
+                                script: { length: scriptLength },
+                            };
+                        }
+
+                        if (o.type === 'opreturn') {
+                            return {
+                                ...o,
+                                script: { length: 2 + o.dataHex.length / 2 },
+                            };
+                        }
+
+                        return {
+                            ...o,
+                            script: { length: OUTPUT_SCRIPT_LENGTH[txType] },
+                        };
+                    });
+
                     const tx = composeTx({
                         ...f.request,
-                        network: NETWORKS.bitcoin,
                         txType,
                         utxos: f.request.utxos.map(utxo => ({
                             ...utxo,
                             amount: utxo.amount === 'replace-me' ? amounts[txType] : utxo.amount,
+                            script: { length: INPUT_SCRIPT_LENGTH[txType] },
                         })),
-                        changeAddress: { address: addrTypes[txType] },
-                        outputs: f.request.outputs.map(o => {
-                            if (o.type === 'payment') {
-                                return {
-                                    ...o,
-                                    address:
-                                        o.address === 'replace-me'
-                                            ? addrTypes[addressType]
-                                            : addrTypes[o.address as keyof typeof addrTypes] ||
-                                              o.address,
-                                };
-                            }
-
-                            return o;
-                        }),
+                        changeAddress: {
+                            ...f.request.changeAddress,
+                            script: { length: addrScriptLengths[txType] },
+                        },
+                        outputs: resolvedOutputs,
                     });
 
                     if (tx.type !== 'final') throw new Error('Not final transaction!');

--- a/packages/utxo-lib/tests/compose.utils.ts
+++ b/packages/utxo-lib/tests/compose.utils.ts
@@ -10,15 +10,12 @@ import {
     ComposeInput,
     ComposeOutput,
     ComposeResultFinal,
-    Network,
 } from '../src';
-import * as baddress from '../src/address';
 import { TxWeightCalculator } from '../src/txWeightCalculator';
 
 export function verifyTxBytes(
     tx: ComposeResultFinal<ComposeInput, ComposeOutput, ComposeChangeAddress>,
     txType: Exclude<CoinSelectPaymentType, 'p2wsh'> = 'p2pkh',
-    network?: Network,
 ) {
     const calc = new TxWeightCalculator();
     tx.inputs.forEach(() => {
@@ -26,15 +23,7 @@ export function verifyTxBytes(
     });
 
     tx.outputs.forEach(out => {
-        if (out.type === 'opreturn') {
-            calc.addOutput({ length: 2 + out.dataHex.length / 2 });
-        }
-        if (out.type === 'payment') {
-            calc.addOutput({ length: baddress.toOutputScript(out.address, network).length });
-        }
-        if (out.type === 'change') {
-            calc.addOutputByKey(txType); // change output
-        }
+        calc.addOutput(out.script);
     });
 
     expect(calc.getVirtualBytes()).toEqual(tx.bytes);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation
Decouples the compose/coinselect logic from network-specific address encoding, making it possible to extract into a [standalone package](https://github.com/trezor/trezor-suite/pull/28285) with zero external dependencies.

## Summary
- Add `script: { length: number }` to `ComposeInput`, `ComposeOutput`, and `ComposeChangeAddress` — callers pre-resolve scripts before calling `composeTx`
- Remove Network parameter and DI functions (toOutputScript, p2data) from the compose module — it no longer depends on address encoding or payment construction
- TransactionComposer in @trezor/connect now resolves scripts on inputs, outputs, and change address before passing them to composeTx
- connect-common strips script from the public API types via OmitScript<T> so API consumers are unaffected

## Related issue:

https://github.com/trezor/trezor-suite/issues/4528


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/utxolib-compose-script&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/utxolib-compose-script&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/utxolib-compose-script&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-16T13:50:33.598Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-16T13:48:24.217Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/utxolib-compose-script/web/](https://dev.suite.sldev.cz/suite-web/refactor/utxolib-compose-script/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->