### PR TITLE
Fix useYieldOpportunity

### DIFF
--- a/suite-common/earn-stablecoin-api/src/hooks/useYieldOpportunity.ts
+++ b/suite-common/earn-stablecoin-api/src/hooks/useYieldOpportunity.ts
@@ -1,3 +1,5 @@
+import { useMemo, useRef } from 'react';
+
 import { type YieldDto } from '@suite-common/earn-stablecoin-defs';
 import { commonQueryKeys, useQuery } from '@suite-common/react-query';
 
@@ -15,16 +17,24 @@ export function useYieldOpportunity<T extends YieldDto[keyof YieldDto] | YieldDt
     vaultId: string | undefined,
     { select = defaultSelect }: UseYieldOpportunityProps<T> = {},
 ) {
-    return useQuery({
+    const queryResult = useQuery({
         enabled: Boolean(vaultId),
         queryKey: commonQueryKeys.yieldOpportunities(vaultId),
-        async queryFn({ signal }) {
-            const yieldOpportunity = await getYield({
+        queryFn: ({ signal }) =>
+            getYield({
                 routeParams: { vaultId: vaultId! },
                 signal,
-            });
-
-            return select(yieldOpportunity);
-        },
+            }),
     });
+
+    const selectRef = useRef(select);
+    const selectedData = useMemo(
+        () => (queryResult.data ? selectRef.current(queryResult.data) : undefined),
+        [queryResult.data],
+    );
+
+    return {
+        ...queryResult,
+        data: selectedData,
+    };
 }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix data selection in `useYieldOpportunity` hook.

## Notes for QA

Approval / revoke modals are being displayed in Yield without crashing the app.

https://satoshilabs.slack.com/archives/C07CNUB6HGC/p1780995342504229 

## Related Issue

Resolve #27733

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change modifies useYieldOpportunity.ts in the earn-stablecoin-api package, which likely provides yield/staking opportunity data to the UI. There is no static test coverage mapping for this file, so all recommendations are inferred from behavioral analysis. The primary risk area is the staking/earn UI flows that consume yield opportunity data — particularly ETH and SOL staking tests that validate staking form availability, amount calculations, and dashboard displays. The Cardano staking tests are less likely affected since ADA staking uses a distinct Cardano-specific staking mechanism rather than the earn-stablecoin-api.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/earn-stablecoin-api/src/hooks/useYieldOpportunity.ts`

</details>

**Recommended tests (5)**

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — The changed file is useYieldOpportunity.ts in earn-stablecoin-api, which likely powers yield/staking opportunity data. ETH initial staking tests exercise the staking form, staking dashboard, and staking amounts display — all of which could consume yield opportunity data to determine available staking options and display staking parameters.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — The stake-more flow for ETH exercises staking form availability, balance display, and staking amount calculations. The useYieldOpportunity hook likely provides yield/opportunity metadata that influences whether staking actions are available and what parameters are shown in the staking UI.
- `suite/e2e/tests/staking/staking-form.test.ts` — The staking form test validates input validation, percentage buttons, max amount calculation, and crypto/fiat switching for ETH staking. The useYieldOpportunity hook from earn-stablecoin-api could affect staking form availability, minimum amounts, or balance calculations displayed in the staking form.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — SOL initial staking exercises staking opportunity display and form flow. While the hook name references 'stablecoin', yield opportunity hooks may be shared across earn/staking features for different networks including Solana.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — SOL stake-more exercises the staking dashboard and additional staking flow. If useYieldOpportunity is used broadly across earn/staking features, changes could affect how staking opportunities are presented for Solana accounts.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/earn-stablecoin-api/src/hooks/useYieldOpportunity.ts`

_Updated: 2026-06-09T14:59:24.198Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/use-yield-opportunity/web/](https://dev.suite.sldev.cz/suite-web/fix/use-yield-opportunity/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/use-yield-opportunity&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/use-yield-opportunity&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/use-yield-opportunity&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-09T15:04:10.489Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add account types ada | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-09T15:03:09.633Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->