### PR TITLE
Update trading translations in tests

### DIFF
--- a/suite-native/module-trading/src/components/buy/__tests__/BuyCryptoAmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyCryptoAmountInput.test.tsx
@@ -1,4 +1,5 @@
 import { Form } from '@suite-native/forms';
+import { getTranslation } from '@suite-native/intl';
 import { act, userEvent } from '@suite-native/test-utils-store';
 import { btcAsset } from '@suite-native/trading-fixtures';
 import { type BuyFormType } from '@suite-native/trading-types';
@@ -43,7 +44,10 @@ describe('BuyCryptoAmountInput', () => {
         });
         const { getByLabelText } = renderCryptoAmountInput({}, form);
 
-        await userEvent.type(getByLabelText('You get'), '100');
+        await userEvent.type(
+            getByLabelText(getTranslation('moduleTrading.selectCoin.amountLabel')),
+            '100',
+        );
 
         expect(form.getValues('cryptoValue')).toEqual('100');
     });
@@ -52,7 +56,9 @@ describe('BuyCryptoAmountInput', () => {
         const form = renderUseTradingBuyForm();
         const { getByLabelText } = renderCryptoAmountInput({}, form);
 
-        expect(getByLabelText('You get')).toBeDisabled();
+        expect(
+            getByLabelText(getTranslation('moduleTrading.selectCoin.amountLabel')),
+        ).toBeDisabled();
     });
 
     it('should call showAssetsSheet when disabled and pressed', async () => {
@@ -60,7 +66,9 @@ describe('BuyCryptoAmountInput', () => {
         const form = renderUseTradingBuyForm();
         const { getByLabelText } = renderCryptoAmountInput({ showAssetsSheet }, form);
 
-        await userEvent.press(getByLabelText('You get'));
+        await userEvent.press(
+            getByLabelText(getTranslation('moduleTrading.selectCoin.amountLabel')),
+        );
 
         expect(showAssetsSheet).toHaveBeenCalledTimes(1);
     });
@@ -73,7 +81,9 @@ describe('BuyCryptoAmountInput', () => {
         });
         const { getByLabelText } = renderCryptoAmountInput({ showAssetsSheet }, form);
 
-        await userEvent.press(getByLabelText('You get'));
+        await userEvent.press(
+            getByLabelText(getTranslation('moduleTrading.selectCoin.amountLabel')),
+        );
 
         expect(showAssetsSheet).not.toHaveBeenCalled();
     });
@@ -85,10 +95,15 @@ describe('BuyCryptoAmountInput', () => {
         });
         const { getByLabelText } = renderCryptoAmountInput({}, form);
 
-        await userEvent.type(getByLabelText('You get'), 'asd1.123');
+        await userEvent.type(
+            getByLabelText(getTranslation('moduleTrading.selectCoin.amountLabel')),
+            'asd1.123',
+        );
 
         expect(form.getValues('cryptoValue')).toEqual('1.123');
-        expect(getByLabelText('You get')).toHaveDisplayValue('1.123');
+        expect(
+            getByLabelText(getTranslation('moduleTrading.selectCoin.amountLabel')),
+        ).toHaveDisplayValue('1.123');
     });
 
     it('should format input value to be integer when BTC asset is selected and value should be displayed in sats', async () => {
@@ -101,10 +116,15 @@ describe('BuyCryptoAmountInput', () => {
         });
         const { getByLabelText } = renderCryptoAmountInput({}, form, preloadedState);
 
-        await userEvent.type(getByLabelText('You get'), 'asd1.123');
+        await userEvent.type(
+            getByLabelText(getTranslation('moduleTrading.selectCoin.amountLabel')),
+            'asd1.123',
+        );
 
         expect(form.getValues('cryptoValue')).toEqual('1123');
-        expect(getByLabelText('You get')).toHaveDisplayValue('1123');
+        expect(
+            getByLabelText(getTranslation('moduleTrading.selectCoin.amountLabel')),
+        ).toHaveDisplayValue('1123');
     });
 
     it('should always escape non-numeric characters', async () => {
@@ -117,10 +137,15 @@ describe('BuyCryptoAmountInput', () => {
         });
         const { getByLabelText } = renderCryptoAmountInput({}, form, preloadedState);
 
-        await userEvent.type(getByLabelText('You get'), 'asd');
+        await userEvent.type(
+            getByLabelText(getTranslation('moduleTrading.selectCoin.amountLabel')),
+            'asd',
+        );
 
         expect(form.getValues('cryptoValue')).toBeUndefined();
-        expect(getByLabelText('You get')).toHaveDisplayValue('');
+        expect(
+            getByLabelText(getTranslation('moduleTrading.selectCoin.amountLabel')),
+        ).toHaveDisplayValue('');
     });
 
     it('should display loading skeleton while amountInCrypto is false and buyInfo is loading', () => {
@@ -130,7 +155,9 @@ describe('BuyCryptoAmountInput', () => {
             wallet: { trading: { buy: { isLoading: true } } },
         });
 
-        expect(getByLabelText('Searching for your best offer...')).toBeTruthy();
+        expect(
+            getByLabelText(getTranslation('moduleTrading.tradingScreen.quotesLoadingLabel')),
+        ).toBeTruthy();
     });
 
     it('should not display loading skeleton while amountInCrypto is true and buyInfo is loading', () => {
@@ -143,7 +170,9 @@ describe('BuyCryptoAmountInput', () => {
             wallet: { trading: { buy: { isLoading: true } } },
         });
 
-        expect(queryByLabelText('Searching for your best offer...')).toBeNull();
+        expect(
+            queryByLabelText(getTranslation('moduleTrading.tradingScreen.quotesLoadingLabel')),
+        ).toBeNull();
     });
 
     it('should limit value to 9 decimals', async () => {
@@ -153,7 +182,10 @@ describe('BuyCryptoAmountInput', () => {
         });
         const { getByLabelText } = renderCryptoAmountInput({}, form);
 
-        await userEvent.type(getByLabelText('You get'), '1.0123456789');
+        await userEvent.type(
+            getByLabelText(getTranslation('moduleTrading.selectCoin.amountLabel')),
+            '1.0123456789',
+        );
 
         expect(form.getValues('cryptoValue')).toEqual('1.012345678');
     });

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyFiatAmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyFiatAmountInput.test.tsx
@@ -1,4 +1,5 @@
 import { Form } from '@suite-native/forms';
+import { getTranslation } from '@suite-native/intl';
 import { act, userEvent } from '@suite-native/test-utils-store';
 import { type BuyFormType } from '@suite-native/trading-types';
 
@@ -42,7 +43,10 @@ describe('BuyFiatAmountInput', () => {
         const form = renderUseTradingBuyForm();
         const { getByLabelText } = renderFiatAmountInput(form);
 
-        await userEvent.type(getByLabelText('You pay'), '100');
+        await userEvent.type(
+            getByLabelText(getTranslation('moduleTrading.selectFiat.buy.amountLabel')),
+            '100',
+        );
 
         expect(form.getValues('fiatValue')).toEqual('100');
     });
@@ -51,20 +55,30 @@ describe('BuyFiatAmountInput', () => {
         const form = renderUseTradingBuyForm();
         const { getByLabelText } = renderFiatAmountInput(form);
 
-        await userEvent.type(getByLabelText('You pay'), 'asd1.123');
+        await userEvent.type(
+            getByLabelText(getTranslation('moduleTrading.selectFiat.buy.amountLabel')),
+            'asd1.123',
+        );
 
         expect(form.getValues('fiatValue')).toEqual('1.123');
-        expect(getByLabelText('You pay')).toHaveDisplayValue('1.123');
+        expect(
+            getByLabelText(getTranslation('moduleTrading.selectFiat.buy.amountLabel')),
+        ).toHaveDisplayValue('1.123');
     });
 
     it('should always escape non-numeric characters', async () => {
         const form = renderUseTradingBuyForm();
         const { getByLabelText } = renderFiatAmountInput(form);
 
-        await userEvent.type(getByLabelText('You pay'), 'asd');
+        await userEvent.type(
+            getByLabelText(getTranslation('moduleTrading.selectFiat.buy.amountLabel')),
+            'asd',
+        );
 
         expect(form.getValues('fiatValue')).toBeUndefined();
-        expect(getByLabelText('You pay')).toHaveDisplayValue('');
+        expect(
+            getByLabelText(getTranslation('moduleTrading.selectFiat.buy.amountLabel')),
+        ).toHaveDisplayValue('');
     });
 
     it('should display loading skeleton while amountInCrypto is true and buyInfo is loading', () => {
@@ -75,7 +89,9 @@ describe('BuyFiatAmountInput', () => {
 
         const { getByLabelText } = renderFiatAmountInput(form, withBuyLoading);
 
-        expect(getByLabelText('Searching for your best offer...')).toBeTruthy();
+        expect(
+            getByLabelText(getTranslation('moduleTrading.tradingScreen.quotesLoadingLabel')),
+        ).toBeTruthy();
     });
 
     it('should not display loading skeleton while amountInCrypto is false and buyInfo is loading', () => {
@@ -83,14 +99,19 @@ describe('BuyFiatAmountInput', () => {
 
         const { queryByLabelText } = renderFiatAmountInput(form, withBuyLoading);
 
-        expect(queryByLabelText('Searching for your best offer...')).toBeNull();
+        expect(
+            queryByLabelText(getTranslation('moduleTrading.tradingScreen.quotesLoadingLabel')),
+        ).toBeNull();
     });
 
     it('should limit value to 3 decimals', async () => {
         const form = renderUseTradingBuyForm();
         const { getByLabelText } = renderFiatAmountInput(form);
 
-        await userEvent.type(getByLabelText('You pay'), '1.0123456789');
+        await userEvent.type(
+            getByLabelText(getTranslation('moduleTrading.selectFiat.buy.amountLabel')),
+            '1.0123456789',
+        );
 
         expect(form.getValues('fiatValue')).toEqual('1.012');
     });

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyFiatCurrencyPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyFiatCurrencyPicker.test.tsx
@@ -1,6 +1,7 @@
 import { deviceInitialState } from '@suite-common/device';
 import { type useListDataFilter } from '@suite-common/trading';
 import { Form } from '@suite-native/forms';
+import { getTranslation } from '@suite-native/intl';
 import {
     act,
     fireEvent,
@@ -52,19 +53,23 @@ describe('BuyFiatCurrencyPicker', () => {
     it('should display selected currency', () => {
         const { getByLabelText } = renderFiatCurrencyPicker();
 
-        expect(getByLabelText('Select fiat currency')).toHaveTextContent(/CZK/);
+        expect(
+            getByLabelText(getTranslation('moduleTrading.selectFiat.buttonTitle')),
+        ).toHaveTextContent(/CZK/);
     });
 
     it('should allow to select currency', async () => {
         const { getByText, getByLabelText } = renderFiatCurrencyPicker();
 
-        fireEvent.press(getByLabelText('Select fiat currency'));
+        fireEvent.press(getByLabelText(getTranslation('moduleTrading.selectFiat.buttonTitle')));
         fireEvent.press(getByText('USD'));
 
         // wait for validators to run
         await act(() => Promise.resolve());
 
-        expect(getByLabelText('Select fiat currency')).toHaveTextContent(/USD/);
+        expect(
+            getByLabelText(getTranslation('moduleTrading.selectFiat.buttonTitle')),
+        ).toHaveTextContent(/USD/);
     });
 
     it('should display empty component when filtered data is empty', () => {
@@ -76,9 +81,11 @@ describe('BuyFiatCurrencyPicker', () => {
 
         const { getByText } = renderFiatCurrencyPicker();
 
-        expect(getByText('Currency not found')).toBeTruthy();
         expect(
-            getByText('Check the spelling or browse the list to select an option.'),
+            getByText(getTranslation('moduleTrading.fiatCurrencySheet.emptyTitle')),
+        ).toBeTruthy();
+        expect(
+            getByText(getTranslation('moduleTrading.fiatCurrencySheet.emptyDescription')),
         ).toBeTruthy();
     });
 });

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyForm.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyForm.test.tsx
@@ -1,4 +1,5 @@
 import { Form } from '@suite-native/forms';
+import { getTranslation } from '@suite-native/intl';
 import { act, screen } from '@suite-native/test-utils-store';
 import { btcAsset, getInitializedTradingState } from '@suite-native/trading-fixtures';
 import { type BuyFormType } from '@suite-native/trading-types';
@@ -59,15 +60,25 @@ describe('BuyForm', () => {
             result.current,
         );
 
-        expect(getByText('You pay')).toBeTruthy();
-        expect(getByLabelText('Select asset')).toHaveTextContent(/Select asset/);
-        expect(queryByText('Receive account')).toBeNull();
-        expect(queryByText('Payment method')).toBeNull();
-        expect(queryByText('Country of residence')).toBeTruthy();
-        expect(queryByText('Provider')).toBeNull();
-        expect(queryByText('Continue')).toBeNull();
+        expect(getByText(getTranslation('moduleTrading.selectFiat.buy.amountLabel'))).toBeTruthy();
+        expect(
+            getByLabelText(getTranslation('moduleTrading.selectCoin.buttonTitle')),
+        ).toHaveTextContent(
+            new RegExp(`^${getTranslation('moduleTrading.selectCoin.buttonTitle')}.$`),
+        );
+        expect(
+            queryByText(getTranslation('moduleTrading.tradingScreen.receiveAccount')),
+        ).toBeNull();
+        expect(queryByText(getTranslation('moduleTrading.tradingScreen.paymentMethod'))).toBeNull();
+        expect(
+            queryByText(getTranslation('tradingResidence.locationSettings.countryOfResidence')),
+        ).toBeTruthy();
+        expect(queryByText(getTranslation('moduleTrading.tradingScreen.provider'))).toBeNull();
+        expect(
+            queryByText(getTranslation('moduleTrading.tradingScreen.buttons.continue')),
+        ).toBeNull();
         // country
-        expect(getByText('Not selected')).toBeTruthy();
+        expect(getByText(getTranslation('moduleTrading.notSelected'))).toBeTruthy();
     });
 
     describe('with preloaded buy data', () => {
@@ -85,18 +96,32 @@ describe('BuyForm', () => {
         it('should render with default values', () => {
             const { queryByText, getByLabelText, getByText } = renderBuyForm(overrides, form);
 
-            expect(getByText('You pay')).toBeTruthy();
+            expect(
+                getByText(getTranslation('moduleTrading.selectFiat.buy.amountLabel')),
+            ).toBeTruthy();
 
-            expect(getByLabelText('Select fiat currency')).toHaveTextContent(/CZK/);
-            expect(getByLabelText('Select asset')).toHaveTextContent(/Select asset/);
+            expect(
+                getByLabelText(getTranslation('moduleTrading.selectFiat.buttonTitle')),
+            ).toHaveTextContent(/CZK/);
+            expect(
+                getByLabelText(getTranslation('moduleTrading.selectCoin.buttonTitle')),
+            ).toHaveTextContent(
+                new RegExp(`^${getTranslation('moduleTrading.selectCoin.buttonTitle')}.$`),
+            );
 
-            expect(queryByText('Receive account')).toBeNull();
+            expect(
+                queryByText(getTranslation('moduleTrading.tradingScreen.receiveAccount')),
+            ).toBeNull();
 
-            expect(getByText('Country of residence')).toBeTruthy();
+            expect(
+                getByText(getTranslation('tradingResidence.locationSettings.countryOfResidence')),
+            ).toBeTruthy();
             expect(getByText('CZE')).toBeTruthy();
 
-            expect(queryByText('Provider')).toBeNull();
-            expect(queryByText('Continue')).toBeNull();
+            expect(queryByText(getTranslation('moduleTrading.tradingScreen.provider'))).toBeNull();
+            expect(
+                queryByText(getTranslation('moduleTrading.tradingScreen.buttons.continue')),
+            ).toBeNull();
         });
 
         it('should render only BuyCard and Done when amount input is active', () => {
@@ -105,19 +130,31 @@ describe('BuyForm', () => {
             });
             const { queryByText, getByText } = renderBuyForm(overrides, form);
 
-            expect(getByText('You pay')).toBeTruthy();
-            expect(getByText('You get')).toBeTruthy();
+            expect(
+                getByText(getTranslation('moduleTrading.selectFiat.buy.amountLabel')),
+            ).toBeTruthy();
+            expect(
+                getByText(getTranslation('moduleTrading.selectFiat.sell.amountLabel')),
+            ).toBeTruthy();
 
-            expect(queryByText('Country of residence')).toBeNull();
-            expect(queryByText('Payment method')).toBeNull();
-            expect(queryByText('Provider')).toBeNull();
-            expect(queryByText('Continue')).toBeNull();
+            expect(
+                queryByText(getTranslation('tradingResidence.locationSettings.countryOfResidence')),
+            ).toBeNull();
+            expect(
+                queryByText(getTranslation('moduleTrading.tradingScreen.paymentMethod')),
+            ).toBeNull();
+            expect(queryByText(getTranslation('moduleTrading.tradingScreen.provider'))).toBeNull();
+            expect(
+                queryByText(getTranslation('moduleTrading.tradingScreen.buttons.continue')),
+            ).toBeNull();
         });
 
         it('should not render receive account when assets is not selected', () => {
             const { queryByText, getByTestId } = renderBuyForm(overrides, form);
 
-            expect(queryByText('Receive account')).toBeNull();
+            expect(
+                queryByText(getTranslation('moduleTrading.tradingScreen.receiveAccount')),
+            ).toBeNull();
             expect(getByTestId('@trading/buyCard/fiatSection')).toHaveStyle({
                 borderBottomWidth: 1,
             });
@@ -132,7 +169,9 @@ describe('BuyForm', () => {
             });
             const { getByText, getByTestId } = renderBuyForm(overrides, form);
 
-            expect(getByText('Receive account')).toBeTruthy();
+            expect(
+                getByText(getTranslation('moduleTrading.tradingScreen.receiveAccount')),
+            ).toBeTruthy();
             expect(getByTestId('@trading/buyCard/fiatSection')).toHaveStyle({
                 borderBottomWidth: 1,
             });

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyPaymentMethodPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyPaymentMethodPicker.test.tsx
@@ -107,7 +107,9 @@ describe('BuyPaymentMethodPicker', () => {
 
         const { getByLabelText } = renderPaymentMethodPicker(preloadedState);
 
-        expect(getByLabelText('Searching for your best offer...')).toBeOnTheScreen();
+        expect(
+            getByLabelText(getTranslation('moduleTrading.tradingScreen.quotesLoadingLabel')),
+        ).toBeOnTheScreen();
     });
 
     describe('with quotes loaded', () => {
@@ -117,19 +119,21 @@ describe('BuyPaymentMethodPicker', () => {
 
         it('should display "Not selected" when no method is selected in form', () => {
             const { getByLabelText } = renderPaymentMethodPicker(withQuotes);
-            expect(getByLabelText('No payment method selected')).toHaveTextContent('Not selected');
+            expect(
+                getByLabelText(getTranslation('moduleTrading.tradingScreen.noPaymentMethod')),
+            ).toHaveTextContent(getTranslation('moduleTrading.notSelected'));
         });
 
         it('should allow to select payment method', () => {
             const { getByText, getByLabelText, getByTestId } =
                 renderPaymentMethodPicker(withQuotes);
 
-            fireEvent.press(getByText('Payment method'));
+            fireEvent.press(getByText(getTranslation('moduleTrading.tradingScreen.paymentMethod')));
             fireEvent.press(getByText(creditCardPaymentMethodTranslation));
 
-            expect(getByLabelText('Selected payment method')).toHaveTextContent(
-                creditCardPaymentMethodTranslation,
-            );
+            expect(
+                getByLabelText(getTranslation('moduleTrading.tradingScreen.selectedPaymentMethod')),
+            ).toHaveTextContent(creditCardPaymentMethodTranslation);
 
             const picker = getByTestId('@trading/buy/payment-method-picker');
 
@@ -145,7 +149,9 @@ describe('BuyPaymentMethodPicker', () => {
                 }),
             );
 
-            expect(getByLabelText('Searching for your best offer...')).toBeOnTheScreen();
+            expect(
+                getByLabelText(getTranslation('moduleTrading.tradingScreen.quotesLoadingLabel')),
+            ).toBeOnTheScreen();
         });
 
         it('should display sheet even while quotes are fetched', () => {
@@ -161,7 +167,7 @@ describe('BuyPaymentMethodPicker', () => {
             store.dispatch(tradingBuyActions.saveQuotes(buyQuotes));
             const { getByText } = renderPaymentMethodPicker(undefined, store);
 
-            fireEvent.press(getByText('Payment method'));
+            fireEvent.press(getByText(getTranslation('moduleTrading.tradingScreen.paymentMethod')));
             act(() => {
                 store.dispatch(tradingBuyActions.setIsLoading(true));
             });
@@ -177,7 +183,9 @@ describe('BuyPaymentMethodPicker', () => {
             it('should fire analytics event on payment method select', () => {
                 const { getByText } = renderPaymentMethodPicker(withQuotes);
 
-                fireEvent.press(getByText('Payment method'));
+                fireEvent.press(
+                    getByText(getTranslation('moduleTrading.tradingScreen.paymentMethod')),
+                );
                 fireEvent.press(getByText(creditCardPaymentMethodTranslation));
 
                 expect(reportMock).toHaveBeenCalledWith({
@@ -196,7 +204,9 @@ describe('BuyPaymentMethodPicker', () => {
                     form.setValue('quote', cexdirectCreditCardBuyQuote);
                 });
 
-                fireEvent.press(getByText('Payment method'));
+                fireEvent.press(
+                    getByText(getTranslation('moduleTrading.tradingScreen.paymentMethod')),
+                );
                 fireEvent.press(getByText('Apple Pay'));
 
                 expect(reportMock).toHaveBeenCalledTimes(1);
@@ -209,7 +219,9 @@ describe('BuyPaymentMethodPicker', () => {
                     form.setValue('quote', cexdirectCreditCardBuyQuote);
                 });
 
-                fireEvent.press(getByText('Payment method'));
+                fireEvent.press(
+                    getByText(getTranslation('moduleTrading.tradingScreen.paymentMethod')),
+                );
                 const creditCardOption = getAllByText(creditCardPaymentMethodTranslation)[1];
                 if (!creditCardOption) throw new Error('Credit Card option [1] not found');
                 fireEvent.press(creditCardOption);

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyProviderPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyProviderPicker.test.tsx
@@ -1,6 +1,7 @@
 import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
 import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import { Form } from '@suite-native/forms';
+import { getTranslation } from '@suite-native/intl';
 import { act, fireEvent, screen } from '@suite-native/test-utils-store';
 import {
     buyCexdirect,
@@ -61,7 +62,9 @@ describe('BuyProviderPicker', () => {
             wallet: { trading: { buy: { isLoading: true, quotes: [] } } },
         });
 
-        expect(getByLabelText('Searching for your best offer...')).toBeOnTheScreen();
+        expect(
+            getByLabelText(getTranslation('moduleTrading.tradingScreen.quotesLoadingLabel')),
+        ).toBeOnTheScreen();
     });
 
     describe('with quotes loaded', () => {
@@ -94,10 +97,12 @@ describe('BuyProviderPicker', () => {
         it('should allow to select provider', () => {
             const { getByText, getByLabelText } = renderTradingProviderPicker(withQuotes);
 
-            fireEvent.press(getByText('Provider'));
+            fireEvent.press(getByText(getTranslation('moduleTrading.tradingScreen.provider')));
             fireEvent.press(getByText('Mercuryo'));
 
-            expect(getByLabelText('Selected provider')).toHaveTextContent('Mercuryo');
+            expect(
+                getByLabelText(getTranslation('moduleTrading.tradingScreen.selectedProvider')),
+            ).toHaveTextContent('Mercuryo');
         });
 
         it('should display loader while quotes are re-fetched', () => {
@@ -107,7 +112,9 @@ describe('BuyProviderPicker', () => {
                 }),
             );
 
-            expect(getByLabelText('Searching for your best offer...')).toBeOnTheScreen();
+            expect(
+                getByLabelText(getTranslation('moduleTrading.tradingScreen.quotesLoadingLabel')),
+            ).toBeOnTheScreen();
         });
 
         it('should display sheet even while quotes are fetched', () => {
@@ -117,7 +124,7 @@ describe('BuyProviderPicker', () => {
                 }),
             );
 
-            fireEvent.press(getByText('Provider'));
+            fireEvent.press(getByText(getTranslation('moduleTrading.tradingScreen.provider')));
 
             expect(getByText('Mercuryo')).toBeOnTheScreen();
         });
@@ -130,7 +137,7 @@ describe('BuyProviderPicker', () => {
             it('should fire analytics event on provider select', () => {
                 const { getByText } = renderTradingProviderPicker(withQuotes);
 
-                fireEvent.press(getByText('Provider'));
+                fireEvent.press(getByText(getTranslation('moduleTrading.tradingScreen.provider')));
                 fireEvent.press(getByText('Mercuryo'));
 
                 expect(reportMock).toHaveBeenCalledTimes(2);
@@ -152,7 +159,7 @@ describe('BuyProviderPicker', () => {
             it('should fire analytics event on provider change', () => {
                 const { getByText } = renderTradingProviderPicker(withQuotes);
 
-                fireEvent.press(getByText('Provider'));
+                fireEvent.press(getByText(getTranslation('moduleTrading.tradingScreen.provider')));
                 fireEvent.press(getByText('Mercuryo'));
 
                 expect(reportMock).toHaveBeenCalledTimes(2);
@@ -161,7 +168,7 @@ describe('BuyProviderPicker', () => {
             it('should not fire analytics event when same provider is selected', () => {
                 const { getByText, getAllByText } = renderTradingProviderPicker(withQuotes);
 
-                fireEvent.press(getByText('Provider'));
+                fireEvent.press(getByText(getTranslation('moduleTrading.tradingScreen.provider')));
                 fireEvent.press(getIndexOrThrow(getAllByText('Cexdirect'), 1));
 
                 expect(reportMock).toHaveBeenCalledTimes(1);
@@ -180,7 +187,7 @@ describe('BuyProviderPicker', () => {
                     }),
                 );
 
-                fireEvent.press(getByText('Provider'));
+                fireEvent.press(getByText(getTranslation('moduleTrading.tradingScreen.provider')));
 
                 expect(reportMock).not.toHaveBeenCalled();
             });

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyReceiveAccountPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyReceiveAccountPicker.test.tsx
@@ -1,4 +1,5 @@
 import { Form } from '@suite-native/forms';
+import { getTranslation } from '@suite-native/intl';
 import { act, fireEvent } from '@suite-native/test-utils-store';
 import { btc1NormalAccount, btcAsset } from '@suite-native/trading-fixtures';
 import {
@@ -80,7 +81,7 @@ describe('BuyReceiveAccountPicker', () => {
         setSelectedAsset(btcAsset);
         const { getByText } = renderPicker();
 
-        expect(getByText('Not selected')).toBeTruthy();
+        expect(getByText(getTranslation('moduleTrading.notSelected'))).toBeTruthy();
     });
 
     it('should display selected account name and address', () => {
@@ -105,7 +106,7 @@ describe('BuyReceiveAccountPicker', () => {
             }),
         );
 
-        fireEvent.press(getByText('Receive account'));
+        fireEvent.press(getByText(getTranslation('moduleTrading.tradingScreen.receiveAccount')));
 
         expect(mockNavigate).toHaveBeenCalledTimes(1);
         expect(mockNavigate).toHaveBeenCalledWith('ReceiveAccounts', {

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyTab.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyTab.test.tsx
@@ -1,3 +1,4 @@
+import { getTranslation } from '@suite-native/intl';
 import { act, screen, userEvent } from '@suite-native/test-utils-store';
 import { selectIsTradingBuyEnabled } from '@suite-native/trading-state';
 
@@ -41,7 +42,9 @@ describe('BuyTab', () => {
     };
 
     const expectBuyForm = () => {
-        expect(screen.getByText('You pay')).toBeTruthy();
+        expect(
+            screen.getByText(getTranslation('moduleTrading.selectFiat.buy.amountLabel')),
+        ).toBeTruthy();
     };
 
     const expectServerOffline = () => {
@@ -111,7 +114,7 @@ describe('BuyTab', () => {
 
         const { getByText } = renderBuyTab();
 
-        const reloadButton = getByText('Try again');
+        const reloadButton = getByText(getTranslation('tradingAtoms.error.serverOfflineRetry'));
 
         await act(async () => {
             await userEvent.press(reloadButton);
@@ -127,6 +130,12 @@ describe('BuyTab', () => {
         (selectIsTradingBuyEnabled as jest.Mock).mockReturnValue(false);
         const { getByText } = renderBuyTab();
 
-        expect(getByText('Buy disabled')).toBeOnTheScreen();
+        expect(
+            getByText(
+                getTranslation('tradingAtoms.error.tradingTypeDisabledTitle', {
+                    tradingType: 'Buy',
+                }),
+            ),
+        ).toBeOnTheScreen();
     });
 });

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyTradeableAssetPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyTradeableAssetPicker.test.tsx
@@ -1,4 +1,5 @@
 import { Form } from '@suite-native/forms';
+import { getTranslation } from '@suite-native/intl';
 import { type TestStore, fireEvent, screen } from '@suite-native/test-utils-store';
 import { type BuyFormType } from '@suite-native/trading-types';
 import { FirmwareType } from '@trezor/connect';
@@ -52,7 +53,11 @@ describe('BuyTradeableAssetPicker', () => {
         it('should render "Select asset" button with caret', () => {
             const { getByLabelText } = renderTradeableAssetPicker();
 
-            expect(getByLabelText('Select asset')).toHaveTextContent(/^Select asset.$/);
+            expect(
+                getByLabelText(getTranslation('moduleTrading.selectCoin.buttonTitle')),
+            ).toHaveTextContent(
+                new RegExp(`^${getTranslation('moduleTrading.selectCoin.buttonTitle')}.$`),
+            );
         });
 
         it('should render bottom sheet with all assets', () => {
@@ -72,7 +77,9 @@ describe('BuyTradeableAssetPicker', () => {
         it('should preselect BTC and do not render caret', () => {
             const { getByLabelText } = renderTradeableAssetPicker();
 
-            expect(getByLabelText('Select asset')).toHaveTextContent('BTC');
+            expect(
+                getByLabelText(getTranslation('moduleTrading.selectCoin.buttonTitle')),
+            ).toHaveTextContent('BTC');
         });
 
         it('should not render bottom sheet at all', () => {
@@ -85,10 +92,12 @@ describe('BuyTradeableAssetPicker', () => {
             const { getByLabelText } = renderTradeableAssetPicker();
 
             // no need to act as there should be no action
-            fireEvent.press(getByLabelText('Select asset'));
-            fireEvent.press(getByLabelText('You get'));
+            fireEvent.press(getByLabelText(getTranslation('moduleTrading.selectCoin.buttonTitle')));
+            fireEvent.press(getByLabelText(getTranslation('moduleTrading.selectCoin.amountLabel')));
 
-            expect(getByLabelText('Select asset')).toHaveTextContent('BTC');
+            expect(
+                getByLabelText(getTranslation('moduleTrading.selectCoin.buttonTitle')),
+            ).toHaveTextContent('BTC');
         });
     });
 });

--- a/suite-native/module-trading/src/components/concierge/__tests__/ConciergeTab.test.tsx
+++ b/suite-native/module-trading/src/components/concierge/__tests__/ConciergeTab.test.tsx
@@ -1,3 +1,4 @@
+import { getTranslation } from '@suite-native/intl';
 import { selectIsTradingConciergeEnabled } from '@suite-native/trading-state';
 
 import { renderWithTradingProvider } from '../../../__tests__/tradingTestUtils';
@@ -18,7 +19,13 @@ describe('ConciergeTab', () => {
 
         const { getByText } = renderWithTradingProvider(<ConciergeTab />);
 
-        expect(getByText('Concierge disabled')).toBeOnTheScreen();
+        expect(
+            getByText(
+                getTranslation('tradingAtoms.error.tradingTypeDisabledTitle', {
+                    tradingType: 'Concierge',
+                }),
+            ),
+        ).toBeOnTheScreen();
     });
 
     it('should not render disabled message when concierge is enabled', () => {
@@ -26,6 +33,12 @@ describe('ConciergeTab', () => {
 
         const { queryByText } = renderWithTradingProvider(<ConciergeTab />);
 
-        expect(queryByText('Concierge disabled')).toBeNull();
+        expect(
+            queryByText(
+                getTranslation('tradingAtoms.error.tradingTypeDisabledTitle', {
+                    tradingType: 'Concierge',
+                }),
+            ),
+        ).toBeNull();
     });
 });

--- a/suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalLimitSheet/__tests__/ExchangeApprovalLimitSheet.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalLimitSheet/__tests__/ExchangeApprovalLimitSheet.test.tsx
@@ -38,14 +38,18 @@ describe('ExchangeApprovalLimitSheet', () => {
     it('should render the sheet when visible', () => {
         const { getByText } = renderSheet();
 
-        expect(getByText('Unlimited')).toBeTruthy();
+        expect(
+            getByText(getTranslation('moduleTrading.tradingExchangeApprovalScreen.unlimitedLabel')),
+        ).toBeTruthy();
         expect(getByText('100 USDC')).toBeTruthy();
     });
 
     it('should render unlimited approval option with correct details', () => {
         const { getByText } = renderSheet();
 
-        expect(getByText('Unlimited')).toBeTruthy();
+        expect(
+            getByText(getTranslation('moduleTrading.tradingExchangeApprovalScreen.unlimitedLabel')),
+        ).toBeTruthy();
         expect(
             getByText(
                 getTranslation('moduleTrading.exchangeApprovalLimitSheet.unlimitedCard.info'),

--- a/suite-native/module-trading/src/components/exchange/Approval/__tests__/ApprovalButton.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/__tests__/ApprovalButton.test.tsx
@@ -1,5 +1,6 @@
 import { tradingExchangeActions } from '@suite-common/trading';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
+import { getTranslation } from '@suite-native/intl';
 import { type TestStore, renderWithStoreProvider, userEvent } from '@suite-native/test-utils-store';
 import { mercuryoFixedWorstQuote } from '@suite-native/trading-fixtures';
 
@@ -55,7 +56,9 @@ describe('ApprovalButton', () => {
     it('should render continue button when isReady is true', () => {
         const { getByText } = renderApprovalButton({ isReady: true });
 
-        expect(getByText('Continue')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.tradingScreen.buttons.continue')),
+        ).toBeOnTheScreen();
     });
 
     it('should render nothing when isReady is false', () => {
@@ -67,7 +70,9 @@ describe('ApprovalButton', () => {
     it('should navigate to TradingExchangeOutputsReview on press', async () => {
         const { getByText } = renderApprovalButton({ isReady: true });
 
-        await userEvent.press(getByText('Continue'));
+        await userEvent.press(
+            getByText(getTranslation('moduleTrading.tradingScreen.buttons.continue')),
+        );
 
         expect(mockNavigate).toHaveBeenCalledWith('TradingExchangeOutputsReview', {
             accountKey: ethAccountKey,
@@ -80,7 +85,9 @@ describe('ApprovalButton', () => {
     it('should report to analytics on press', async () => {
         const { getByText } = renderApprovalButton({ isReady: true });
 
-        await userEvent.press(getByText('Continue'));
+        await userEvent.press(
+            getByText(getTranslation('moduleTrading.tradingScreen.buttons.continue')),
+        );
 
         expect(mockAnalyticsReport).toHaveBeenCalledWith('approval-preview', 'continue');
     });
@@ -88,7 +95,9 @@ describe('ApprovalButton', () => {
     it('should navigate to TradingExchangeOutputsReview on press for flowType revoke', async () => {
         const { getByText } = renderApprovalButton({ isReady: true, flowType: 'revoke' });
 
-        await userEvent.press(getByText('Continue'));
+        await userEvent.press(
+            getByText(getTranslation('moduleTrading.tradingScreen.buttons.continue')),
+        );
 
         expect(mockNavigate).toHaveBeenCalledWith('TradingExchangeOutputsReview', {
             accountKey: ethAccountKey,
@@ -101,7 +110,9 @@ describe('ApprovalButton', () => {
     it('should report to analytics on press for flowType revoke', async () => {
         const { getByText } = renderApprovalButton({ isReady: true, flowType: 'revoke' });
 
-        await userEvent.press(getByText('Continue'));
+        await userEvent.press(
+            getByText(getTranslation('moduleTrading.tradingScreen.buttons.continue')),
+        );
 
         expect(mockAnalyticsReport).toHaveBeenCalledWith('revoke-preview', 'continue');
     });

--- a/suite-native/module-trading/src/components/exchange/Approval/__tests__/LimitPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/__tests__/LimitPicker.test.tsx
@@ -71,7 +71,11 @@ describe('LimitPicker', () => {
         const picker = getByTestId('ExchangeApproval/LimitPicker');
         const sheet = getByTestId('ExchangeApproval/LimitSheet');
 
-        await userEvent.press(within(sheet).getByText('Unlimited'));
+        await userEvent.press(
+            within(sheet).getByText(
+                getTranslation('moduleTrading.tradingExchangeApprovalScreen.unlimitedLabel'),
+            ),
+        );
 
         expect(mockOnApprovalTypeChange).toHaveBeenCalledTimes(1);
         expect(mockOnApprovalTypeChange).toHaveBeenCalledWith('INFINITE');

--- a/suite-native/module-trading/src/components/exchange/Confirmation/__tests__/ExchangeConfirmationInfo.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Confirmation/__tests__/ExchangeConfirmationInfo.test.tsx
@@ -1,6 +1,7 @@
 import type { CryptoId, ExchangeTrade } from 'invity-api';
 
 import { tradingExchangeActions } from '@suite-common/trading';
+import { getTranslation } from '@suite-native/intl';
 import { type TestStore, renderWithStoreProvider, screen } from '@suite-native/test-utils-store';
 import { mockTransaction } from '@suite-native/tokens';
 import { exchangeQuotes } from '@suite-native/trading-fixtures';
@@ -56,21 +57,29 @@ describe('ExchangeConfirmationInfo', () => {
     it('should not render date row when transaction is not available', () => {
         renderInfo({ flowType: 'approve', transaction: null });
 
-        expect(screen.queryByText('Date')).toBeNull();
+        expect(
+            screen.queryByText(getTranslation('moduleTrading.tradingConfirmationScreen.date')),
+        ).toBeNull();
     });
 
     it('should render date row when transaction has blockTime', () => {
         renderInfo({ flowType: 'approve', transaction: mockTransaction });
 
-        expect(screen.getByText('Date')).toBeOnTheScreen();
+        expect(
+            screen.getByText(getTranslation('moduleTrading.tradingConfirmationScreen.date')),
+        ).toBeOnTheScreen();
     });
 
     it('should render provider, limit and fee rows', () => {
         renderInfo({ flowType: 'approve', transaction: null });
 
         expect(screen.getByText('Mercuryo')).toBeOnTheScreen();
-        expect(screen.getByText('Limit')).toBeOnTheScreen();
-        expect(screen.getByText('Fee')).toBeOnTheScreen();
+        expect(
+            screen.getByText(
+                getTranslation('moduleTrading.tradingExchangeApprovalScreen.limitLabel'),
+            ),
+        ).toBeOnTheScreen();
+        expect(screen.getByText(getTranslation('transactions.detail.feeLabel'))).toBeOnTheScreen();
     });
 
     it('should render fee as "0" when transaction is not available and quote has no numeric fee', () => {

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeEIP712Info.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeEIP712Info.tsx
@@ -28,6 +28,7 @@ export const ExchangeEIP712Info = memo(({ exchange }: ExchangeEIP712InfoProps) =
                         values={{ providerName }}
                     />
                 }
+                testID="@trading/exchange-preview/eip712-info-header"
             />
             <TradeInfoRow>
                 <VStack>

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangePreviewContinueButton.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangePreviewContinueButton.test.tsx
@@ -1,4 +1,5 @@
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
+import { getTranslation } from '@suite-native/intl';
 import { userEvent } from '@suite-native/test-utils-store';
 import { createPrecomposedTxFinal, mercuryoFixedWorstQuote } from '@suite-native/trading-fixtures';
 import { mergeDeepObject } from '@trezor/utils';
@@ -72,19 +73,19 @@ describe('ExchangePreviewContinueButton', () => {
             { wallet: { send: { precomposedTx: { type: 'composing' } as any } } },
         );
 
-        expect(getByText('Continue')).toBeDisabled();
+        expect(getByText(getTranslation('generic.buttons.continue'))).toBeDisabled();
     });
 
     it('should render continue button', () => {
         const { getByText } = renderExchangePreviewContinueButton();
 
-        expect(getByText('Continue')).toBeOnTheScreen();
+        expect(getByText(getTranslation('generic.buttons.continue'))).toBeOnTheScreen();
     });
 
     it('should render disabled button when isDisabled prop is specified', () => {
         const { getByText } = renderExchangePreviewContinueButton({ isDisabled: true });
 
-        expect(getByText('Continue')).toBeDisabled();
+        expect(getByText(getTranslation('generic.buttons.continue'))).toBeDisabled();
     });
 
     it('should keep continue button enabled when dex quote approval prefetch is loading', () => {
@@ -136,7 +137,7 @@ describe('ExchangePreviewContinueButton', () => {
             },
         );
 
-        await userEvent.press(getByText('Continue'));
+        await userEvent.press(getByText(getTranslation('generic.buttons.continue')));
 
         expect(consoleWarnSpy).toHaveBeenCalledWith('quote or fromAccount is not defined', {
             hasQuote: false,
@@ -162,7 +163,7 @@ describe('ExchangePreviewContinueButton', () => {
             },
         );
 
-        await userEvent.press(getByText('Continue'));
+        await userEvent.press(getByText(getTranslation('generic.buttons.continue')));
 
         expect(consoleWarnSpy).toHaveBeenCalledWith('quote or fromAccount is not defined', {
             hasQuote: true,
@@ -179,7 +180,7 @@ describe('ExchangePreviewContinueButton', () => {
             onSignTransactionNavigation: mockOnSignTransactionNavigation,
         });
 
-        await userEvent.press(getByText('Continue'));
+        await userEvent.press(getByText(getTranslation('generic.buttons.continue')));
 
         expect(consoleWarnSpy).not.toHaveBeenCalled();
         expect(mockNavigate).toHaveBeenCalledWith('TradingExchangeOutputsReview', {
@@ -206,7 +207,7 @@ describe('ExchangePreviewContinueButton', () => {
             },
         );
 
-        await userEvent.press(getByText('Continue'));
+        await userEvent.press(getByText(getTranslation('generic.buttons.continue')));
 
         expect(mockNavigate).toHaveBeenCalledWith('TradingExchangeOutputsReview', {
             accountKey: btcAccountKey,

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangePreviewView.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangePreviewView.test.tsx
@@ -1,3 +1,4 @@
+import { getTranslation } from '@suite-native/intl';
 import {
     btc1NormalAccount,
     cexdirectFloatingQuote,
@@ -47,7 +48,9 @@ describe('ExchangePreviewView', () => {
 
         expect(getByText('BTC Account #1')).toBeOnTheScreen();
         expect(getByText('ETH Account #1')).toBeOnTheScreen();
-        expect(getByText('Transaction fee')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('transactionManagement.fees.description.title.general')),
+        ).toBeOnTheScreen();
         expect(getByText('ERROR_MESSAGE')).toBeOnTheScreen();
     });
 
@@ -59,15 +62,21 @@ describe('ExchangePreviewView', () => {
         expect(getByText('BTC Account #1')).toBeOnTheScreen();
         expect(getByText('ETH Account #1')).toBeOnTheScreen();
         expect(getByText('txnErrorString')).toBeOnTheScreen();
-        expect(queryByText('Transaction fee')).toBeNull();
+        expect(
+            queryByText(getTranslation('transactionManagement.fees.description.title.general')),
+        ).toBeNull();
     });
 
     it('should render EIP-712 info with provider name when quote has EIP-712 sign data', () => {
-        const { getByText } = renderExchangePreviewView({
+        const { getByTestId } = renderExchangePreviewView({
             quote: oneInchFusionPlusWithEip712SignDataQuote,
         });
 
-        expect(getByText(/^You're swapping with 1inch Fusion+\+$/)).toBeOnTheScreen();
+        expect(getByTestId('@trading/exchange-preview/eip712-info-header')).toHaveTextContent(
+            getTranslation('moduleTrading.tradingExchangePreviewScreen.eip712Info.title', {
+                providerName: '1inch Fusion+',
+            }),
+        );
     });
 
     it('should not render transaction fee for quotes with EIP-712 sign data', () => {
@@ -75,15 +84,17 @@ describe('ExchangePreviewView', () => {
             quote: oneInchFusionPlusWithEip712SignDataQuote,
         });
 
-        expect(queryByText('Transaction fee')).toBeNull();
+        expect(
+            queryByText(getTranslation('transactionManagement.fees.description.title.general')),
+        ).toBeNull();
     });
 
     it('should not render EIP-712 info when quote has no EIP-712 sign data', () => {
-        const { queryByText } = renderExchangePreviewView({
+        const { queryByTestId } = renderExchangePreviewView({
             quote: oneInchFusionPlusWithoutEip712SignDataQuote,
         });
 
-        expect(queryByText(/^You are swapping with /)).toBeNull();
+        expect(queryByTestId('@trading/exchange-preview/eip712-info-header')).toBeNull();
     });
 
     it('should render KYC warning for provider with "KYC-required"', () => {
@@ -91,7 +102,7 @@ describe('ExchangePreviewView', () => {
             quote: cexdirectFloatingQuote,
         });
 
-        expect(getByText('KYC is required.')).toBeOnTheScreen();
+        expect(getByText(getTranslation('moduleTrading.kyc.kycRequired'))).toBeOnTheScreen();
     });
 
     it('should not render KYC provider warning for providers with "noKYC"', () => {
@@ -99,6 +110,6 @@ describe('ExchangePreviewView', () => {
             quote: mercuryoFixedWorstQuote,
         });
 
-        expect(queryByText('This provider requires identity verification.')).toBeNull();
+        expect(queryByText(getTranslation('moduleTrading.kyc.kycRequired'))).toBeNull();
     });
 });

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeForm.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeForm.test.tsx
@@ -1,4 +1,5 @@
 import { Form } from '@suite-native/forms';
+import { getTranslation } from '@suite-native/intl';
 import {
     act,
     renderHookWithStoreProvider,
@@ -61,9 +62,13 @@ describe('ExchangeForm', () => {
     it('should render form', () => {
         const { getByText, queryByText } = renderExchangeForm();
 
-        expect(getByText('You get')).toBeOnTheScreen();
-        expect(queryByText('Done')).toBeNull();
-        expect(queryByText('Receive account')).toBeNull();
+        expect(
+            getByText(getTranslation('moduleTrading.selectFiat.sell.amountLabel')),
+        ).toBeOnTheScreen();
+        expect(queryByText(getTranslation('generic.buttons.done'))).toBeNull();
+        expect(
+            queryByText(getTranslation('moduleTrading.tradingScreen.receiveAccount')),
+        ).toBeNull();
     });
 
     describe('with receive asset selected', () => {
@@ -76,9 +81,13 @@ describe('ExchangeForm', () => {
         it('should display Receive account picker', () => {
             const { getByText, queryByText } = renderExchangeForm();
 
-            expect(getByText('You get')).toBeOnTheScreen();
-            expect(queryByText('Done')).toBeNull();
-            expect(getByText('Receive account')).toBeOnTheScreen();
+            expect(
+                getByText(getTranslation('moduleTrading.selectFiat.sell.amountLabel')),
+            ).toBeOnTheScreen();
+            expect(queryByText(getTranslation('generic.buttons.done'))).toBeNull();
+            expect(
+                getByText(getTranslation('moduleTrading.tradingScreen.receiveAccount')),
+            ).toBeOnTheScreen();
         });
 
         it('should display Done button when any input is active', () => {
@@ -87,9 +96,13 @@ describe('ExchangeForm', () => {
             });
             const { getByText, queryByText } = renderExchangeForm();
 
-            expect(getByText('You get')).toBeOnTheScreen();
-            expect(getByText('Done')).toBeOnTheScreen();
-            expect(queryByText('Receive account')).toBeNull();
+            expect(
+                getByText(getTranslation('moduleTrading.selectFiat.sell.amountLabel')),
+            ).toBeOnTheScreen();
+            expect(getByText(getTranslation('generic.buttons.done'))).toBeOnTheScreen();
+            expect(
+                queryByText(getTranslation('moduleTrading.tradingScreen.receiveAccount')),
+            ).toBeNull();
         });
 
         describe('with quote selected', () => {
@@ -102,7 +115,9 @@ describe('ExchangeForm', () => {
             it('should display provider', () => {
                 const { getByText } = renderExchangeForm();
 
-                expect(getByText('Provider')).toBeOnTheScreen();
+                expect(
+                    getByText(getTranslation('moduleTrading.tradingScreen.provider')),
+                ).toBeOnTheScreen();
             });
         });
     });

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeProviderPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeProviderPicker.test.tsx
@@ -1,3 +1,4 @@
+import { getTranslation } from '@suite-native/intl';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 import { type PreloadedStatePartial } from '@suite-native/test-utils-store';
 import { getWalletState, mercuryoFixedWorstQuote } from '@suite-native/trading-fixtures';
@@ -39,8 +40,10 @@ describe('ExchangeProviderPicker', () => {
             isLoading: true,
         });
 
-        expect(getByText('Provider')).toBeOnTheScreen();
-        expect(getByLabelText('Searching for your best offer...')).toBeOnTheScreen();
+        expect(getByText(getTranslation('moduleTrading.tradingScreen.provider'))).toBeOnTheScreen();
+        expect(
+            getByLabelText(getTranslation('moduleTrading.tradingScreen.quotesLoadingLabel')),
+        ).toBeOnTheScreen();
     });
 
     it('should render provider when quote is selected', () => {
@@ -48,7 +51,7 @@ describe('ExchangeProviderPicker', () => {
             selectedValue: mercuryoFixedWorstQuote,
         });
 
-        expect(getByText('Provider')).toBeOnTheScreen();
+        expect(getByText(getTranslation('moduleTrading.tradingScreen.provider'))).toBeOnTheScreen();
         expect(getByText('Mercuryo')).toBeOnTheScreen();
     });
 });

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeRateAndProviderPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeRateAndProviderPicker.test.tsx
@@ -2,6 +2,7 @@ import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
 import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import { FeatureFlag, featureFlagsInitialState } from '@suite-native/feature-flags';
 import { Form } from '@suite-native/forms';
+import { getTranslation } from '@suite-native/intl';
 import { act, userEvent } from '@suite-native/test-utils-store';
 import { exchangeQuotes, mercuryoFixedWorstQuote } from '@suite-native/trading-fixtures';
 import { type ExchangeFormType } from '@suite-native/trading-types';
@@ -76,7 +77,7 @@ describe('ExchangeRateAndProviderPicker', () => {
             wallet: { trading: { exchange: { isLoading: true } } },
         });
 
-        expect(getByText('Provider')).toBeOnTheScreen();
+        expect(getByText(getTranslation('moduleTrading.tradingScreen.provider'))).toBeOnTheScreen();
     });
 
     it('should render provider when quote is selected', () => {
@@ -86,7 +87,7 @@ describe('ExchangeRateAndProviderPicker', () => {
 
         const { getByText } = renderExchangeRateAndProviderPicker();
 
-        expect(getByText('Provider')).toBeOnTheScreen();
+        expect(getByText(getTranslation('moduleTrading.tradingScreen.provider'))).toBeOnTheScreen();
         expect(getByText('Mercuryo')).toBeOnTheScreen();
     });
 
@@ -105,7 +106,9 @@ describe('ExchangeRateAndProviderPicker', () => {
         it('should fire analytics event on provider select', async () => {
             const { getByText } = renderExchangeRateAndProviderPicker(withQuotes);
 
-            await userEvent.press(getByText('Provider'));
+            await userEvent.press(
+                getByText(getTranslation('moduleTrading.tradingScreen.provider')),
+            );
             await userEvent.press(getByText('Cexdirect'));
 
             expect(reportMock).toHaveBeenCalledTimes(2);
@@ -127,7 +130,9 @@ describe('ExchangeRateAndProviderPicker', () => {
         it('should not fire analytics event when same provider is selected', async () => {
             const { getByText, getAllByText } = renderExchangeRateAndProviderPicker(withQuotes);
 
-            await userEvent.press(getByText('Provider'));
+            await userEvent.press(
+                getByText(getTranslation('moduleTrading.tradingScreen.provider')),
+            );
             await userEvent.press(getIndexOrThrow(getAllByText('Mercuryo'), 1));
 
             expect(reportMock).toHaveBeenCalledTimes(1);

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeTab.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeTab.test.tsx
@@ -1,3 +1,5 @@
+import { getTranslation } from '@suite-native/intl';
+
 import { renderWithTradingProvider } from '../../../__tests__/tradingTestUtils';
 import { ExchangeTab } from '../ExchangeTab';
 
@@ -40,23 +42,35 @@ describe('ExchangeTab', () => {
     it('should render exchange form', () => {
         const { getByText } = renderExchangeTab();
 
-        expect(getByText('You pay')).toBeOnTheScreen();
-        expect(getByText('You get')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.selectFiat.buy.amountLabel')),
+        ).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.selectFiat.sell.amountLabel')),
+        ).toBeOnTheScreen();
     });
 
     it('should render disabled info when exchange FF is not enabled', () => {
         mockIsTradingExchangeEnabled = false;
         const { getByText, queryByText } = renderExchangeTab();
 
-        expect(getByText('Swap disabled')).toBeOnTheScreen();
-        expect(queryByText('You pay')).toBeNull();
+        expect(
+            getByText(
+                getTranslation('tradingAtoms.error.tradingTypeDisabledTitle', {
+                    tradingType: 'Swap',
+                }),
+            ),
+        ).toBeOnTheScreen();
+        expect(queryByText(getTranslation('moduleTrading.selectFiat.buy.amountLabel'))).toBeNull();
     });
 
     it('should display BTC only firmware info with BTC only wallet connected', () => {
         mockHasBitcoinOnlyFirmware = true;
         const { getByText } = renderExchangeTab();
 
-        expect(getByText('Bitcoin-only firmware')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('tradingAtoms.error.btcOnlyFirmwareTitle')),
+        ).toBeOnTheScreen();
     });
 
     it('should display Portfolio Tracker info with Portfolio Tracker "wallet" selected', () => {
@@ -65,7 +79,9 @@ describe('ExchangeTab', () => {
         mockIsDeviceInViewOnlyMode = true;
         const { getByText, queryByText } = renderExchangeTab();
 
-        expect(getByText('Portfolio Tracker')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('tradingAtoms.error.portfolioTrackerTitle')),
+        ).toBeOnTheScreen();
         expect(queryByText('View-only wallet')).toBeNull();
     });
 
@@ -73,6 +89,8 @@ describe('ExchangeTab', () => {
         mockIsDeviceInViewOnlyMode = true;
         const { getByText } = renderExchangeTab();
 
-        expect(getByText('You pay')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.selectFiat.buy.amountLabel')),
+        ).toBeOnTheScreen();
     });
 });

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeTabContent.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeTabContent.test.tsx
@@ -1,3 +1,4 @@
+import { getTranslation } from '@suite-native/intl';
 import { act, screen, userEvent } from '@suite-native/test-utils-store';
 
 import { renderWithTradingProvider } from '../../../__tests__/tradingTestUtils';
@@ -31,8 +32,12 @@ describe('ExchangeTab', () => {
     };
 
     const expectExchangeForm = () => {
-        expect(screen.getByText('You pay')).toBeOnTheScreen();
-        expect(screen.getByText('You get')).toBeOnTheScreen();
+        expect(
+            screen.getByText(getTranslation('moduleTrading.selectFiat.buy.amountLabel')),
+        ).toBeOnTheScreen();
+        expect(
+            screen.getByText(getTranslation('moduleTrading.selectFiat.sell.amountLabel')),
+        ).toBeOnTheScreen();
     };
 
     const expectServerOffline = () => {
@@ -102,7 +107,7 @@ describe('ExchangeTab', () => {
 
         const { getByText } = renderExchangeTab();
 
-        const reloadButton = getByText('Try again');
+        const reloadButton = getByText(getTranslation('tradingAtoms.error.serverOfflineRetry'));
 
         await act(async () => {
             await userEvent.press(reloadButton);

--- a/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveAccountPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveAccountPicker.test.tsx
@@ -1,4 +1,5 @@
 import { Form } from '@suite-native/forms';
+import { getTranslation } from '@suite-native/intl';
 import { act, fireEvent } from '@suite-native/test-utils-store';
 import { btc1NormalAccount, btcAsset } from '@suite-native/trading-fixtures';
 import {
@@ -87,7 +88,7 @@ describe('ExchangeReceiveAccountPicker', () => {
         setSelectedAsset(btcAsset);
         const { getByText } = renderPicker();
 
-        expect(getByText('Not selected')).toBeTruthy();
+        expect(getByText(getTranslation('moduleTrading.notSelected'))).toBeTruthy();
     });
 
     it('should display selected account name and address', () => {
@@ -112,7 +113,7 @@ describe('ExchangeReceiveAccountPicker', () => {
             }),
         );
 
-        fireEvent.press(getByText('Receive account'));
+        fireEvent.press(getByText(getTranslation('moduleTrading.tradingScreen.receiveAccount')));
 
         expect(mockNavigate).toHaveBeenCalledTimes(1);
         expect(mockNavigate).toHaveBeenCalledWith('ReceiveAccounts', {

--- a/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveAmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveAmountInput.test.tsx
@@ -1,5 +1,6 @@
 import { FeatureFlag, featureFlagsInitialState } from '@suite-native/feature-flags';
 import { Form } from '@suite-native/forms';
+import { getTranslation } from '@suite-native/intl';
 import { act, fireEvent } from '@suite-native/test-utils-store';
 import { mercuryoFixedWorstQuote, usdcAsset } from '@suite-native/trading-fixtures';
 import { type ExchangeFormType } from '@suite-native/trading-types';
@@ -55,7 +56,9 @@ describe('ExchangeReceiveAmountInput', () => {
 
         const { getByLabelText } = renderExchangeReceiveAmountInput();
 
-        expect(getByLabelText('You get')).toHaveDisplayValue('0.00083554');
+        expect(
+            getByLabelText(getTranslation('moduleTrading.selectCoin.amountLabel')),
+        ).toHaveDisplayValue('0.00083554');
     });
 
     it('should call showAssetsSheet callback on press', () => {
@@ -64,7 +67,7 @@ describe('ExchangeReceiveAmountInput', () => {
             showAssetsSheet: showAssetsSheetMock,
         });
 
-        fireEvent.press(getByLabelText('You get'));
+        fireEvent.press(getByLabelText(getTranslation('moduleTrading.selectCoin.amountLabel')));
 
         expect(showAssetsSheetMock).toHaveBeenCalled();
     });
@@ -75,6 +78,8 @@ describe('ExchangeReceiveAmountInput', () => {
             { wallet: { trading: { exchange: { isLoading: true } } } },
         );
 
-        expect(getByLabelText('Searching for your best offer...')).toBeTruthy();
+        expect(
+            getByLabelText(getTranslation('moduleTrading.tradingScreen.quotesLoadingLabel')),
+        ).toBeTruthy();
     });
 });

--- a/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeTradeableAssetPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeTradeableAssetPicker.test.tsx
@@ -1,5 +1,6 @@
 import { featureFlagsInitialState } from '@suite-native/feature-flags';
 import { Form } from '@suite-native/forms';
+import { getTranslation } from '@suite-native/intl';
 import { type TestStore, screen } from '@suite-native/test-utils-store';
 import { type ExchangeFormType } from '@suite-native/trading-types';
 import { FirmwareType } from '@trezor/connect';
@@ -53,7 +54,11 @@ describe('ExchangeTradeableAssetPicker', () => {
     it('should render "Select asset" button with caret', () => {
         const { getByLabelText } = renderTradeableAssetPicker();
 
-        expect(getByLabelText('Select asset')).toHaveTextContent(/^Select asset.$/);
+        expect(
+            getByLabelText(getTranslation('moduleTrading.selectCoin.buttonTitle')),
+        ).toHaveTextContent(
+            new RegExp(`^${getTranslation('moduleTrading.selectCoin.buttonTitle')}.$`),
+        );
     });
 
     it('should render bottom sheet with all assets', () => {

--- a/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAmountInput.test.tsx
@@ -2,6 +2,7 @@ import { type Account, type TokenAddress } from '@suite-common/wallet-types';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { featureFlagsInitialState } from '@suite-native/feature-flags';
 import { Form } from '@suite-native/forms';
+import { getTranslation } from '@suite-native/intl';
 import { act, userEvent } from '@suite-native/test-utils-store';
 import { btcAsset, usdcAsset } from '@suite-native/trading-fixtures';
 import { type ExchangeFormType } from '@suite-native/trading-types';
@@ -74,7 +75,10 @@ describe('ExchangeSendAmountInput', () => {
         });
         const { getByLabelText } = renderCryptoAmountInput({}, form);
 
-        await userEvent.type(getByLabelText('You pay'), '100');
+        await userEvent.type(
+            getByLabelText(getTranslation('moduleTrading.selectCoinToSell.amountLabel')),
+            '100',
+        );
 
         expect(form.getValues('sendCryptoAmount')).toEqual('100');
     });
@@ -83,7 +87,9 @@ describe('ExchangeSendAmountInput', () => {
         const form = renderUseTradingExchangeForm();
         const { getByLabelText } = renderCryptoAmountInput({}, form);
 
-        expect(getByLabelText('You pay')).toBeDisabled();
+        expect(
+            getByLabelText(getTranslation('moduleTrading.selectCoinToSell.amountLabel')),
+        ).toBeDisabled();
     });
 
     it('should call showAssetsSheet when disabled and pressed', async () => {
@@ -91,7 +97,9 @@ describe('ExchangeSendAmountInput', () => {
         const form = renderUseTradingExchangeForm();
         const { getByLabelText } = renderCryptoAmountInput({ showAssetsSheet }, form);
 
-        await userEvent.press(getByLabelText('You pay'));
+        await userEvent.press(
+            getByLabelText(getTranslation('moduleTrading.selectCoinToSell.amountLabel')),
+        );
 
         expect(showAssetsSheet).toHaveBeenCalledTimes(1);
     });
@@ -104,7 +112,9 @@ describe('ExchangeSendAmountInput', () => {
         });
         const { getByLabelText } = renderCryptoAmountInput({ showAssetsSheet }, form);
 
-        await userEvent.press(getByLabelText('You pay'));
+        await userEvent.press(
+            getByLabelText(getTranslation('moduleTrading.selectCoinToSell.amountLabel')),
+        );
 
         expect(showAssetsSheet).not.toHaveBeenCalled();
     });
@@ -116,10 +126,15 @@ describe('ExchangeSendAmountInput', () => {
         });
         const { getByLabelText } = renderCryptoAmountInput({}, form);
 
-        await userEvent.type(getByLabelText('You pay'), 'asd1.123');
+        await userEvent.type(
+            getByLabelText(getTranslation('moduleTrading.selectCoinToSell.amountLabel')),
+            'asd1.123',
+        );
 
         expect(form.getValues('sendCryptoAmount')).toEqual('1.123');
-        expect(getByLabelText('You pay')).toHaveDisplayValue('1.123');
+        expect(
+            getByLabelText(getTranslation('moduleTrading.selectCoinToSell.amountLabel')),
+        ).toHaveDisplayValue('1.123');
     });
 
     it('should format input value to be integer when BTC asset is selected and value should be displayed in sats', async () => {
@@ -132,10 +147,15 @@ describe('ExchangeSendAmountInput', () => {
         });
         const { getByLabelText } = renderCryptoAmountInput({}, form, satoshiOverrides);
 
-        await userEvent.type(getByLabelText('You pay'), 'asd1.123');
+        await userEvent.type(
+            getByLabelText(getTranslation('moduleTrading.selectCoinToSell.amountLabel')),
+            'asd1.123',
+        );
 
         expect(form.getValues('sendCryptoAmount')).toEqual('1123');
-        expect(getByLabelText('You pay')).toHaveDisplayValue('1123');
+        expect(
+            getByLabelText(getTranslation('moduleTrading.selectCoinToSell.amountLabel')),
+        ).toHaveDisplayValue('1123');
     });
 
     it('should always escape non-numeric characters', async () => {
@@ -148,10 +168,15 @@ describe('ExchangeSendAmountInput', () => {
         });
         const { getByLabelText } = renderCryptoAmountInput({}, form, satoshiOverrides);
 
-        await userEvent.type(getByLabelText('You pay'), 'asd');
+        await userEvent.type(
+            getByLabelText(getTranslation('moduleTrading.selectCoinToSell.amountLabel')),
+            'asd',
+        );
 
         expect(form.getValues('sendCryptoAmount')).toBeUndefined();
-        expect(getByLabelText('You pay')).toHaveDisplayValue('');
+        expect(
+            getByLabelText(getTranslation('moduleTrading.selectCoinToSell.amountLabel')),
+        ).toHaveDisplayValue('');
     });
 
     it('should limit value to decimals based on useAmountInputDecimals return value', async () => {
@@ -166,7 +191,10 @@ describe('ExchangeSendAmountInput', () => {
         });
         const { getByLabelText } = renderCryptoAmountInput({}, form);
 
-        await userEvent.type(getByLabelText('You pay'), '1.0123456789');
+        await userEvent.type(
+            getByLabelText(getTranslation('moduleTrading.selectCoinToSell.amountLabel')),
+            '1.0123456789',
+        );
 
         expect(form.getValues('sendCryptoAmount')).toEqual('1.01234567');
         expect(mockUseAmountInputDecimals).toHaveBeenLastCalledWith(

--- a/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendContent.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendContent.test.tsx
@@ -1,4 +1,5 @@
 import { Form } from '@suite-native/forms';
+import { getTranslation } from '@suite-native/intl';
 import {
     act,
     renderHookWithStoreProvider,
@@ -46,10 +47,16 @@ describe('ExchangeSendContent', () => {
         });
         const { getByText, getByLabelText } = renderExchangeSendContent();
 
-        expect(getByLabelText('Select asset')).toHaveTextContent(/USDC/);
-        expect(getByLabelText('Network name')).toHaveTextContent('Ethereum');
-        expect(getByLabelText('You pay')).toHaveDisplayValue('100');
-        expect(getByText('Balance:')).toBeOnTheScreen();
+        expect(
+            getByLabelText(getTranslation('moduleTrading.selectCoin.buttonTitle')),
+        ).toHaveTextContent(/USDC/);
+        expect(getByLabelText(getTranslation('moduleTrading.networkName'))).toHaveTextContent(
+            'Ethereum',
+        );
+        expect(
+            getByLabelText(getTranslation('moduleTrading.selectCoinToSell.amountLabel')),
+        ).toHaveDisplayValue('100');
+        expect(getByText(getTranslation('moduleTrading.tradingScreen.balance'))).toBeOnTheScreen();
         expect(getByText('- USDC')).toBeOnTheScreen();
     });
 });

--- a/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountList.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountList.test.tsx
@@ -6,7 +6,7 @@ import { initialSuiteSyncDataState, initialSuiteSyncState } from '@suite-common/
 import { extraDependenciesCommonMock } from '@suite-common/test-utils';
 import { selectTradingBuyReceiveAccountKey } from '@suite-common/trading';
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
-import { localeReducer } from '@suite-native/intl';
+import { getTranslation, localeReducer } from '@suite-native/intl';
 import {
     type TestStore,
     createLightStore,
@@ -274,7 +274,11 @@ describe('AccountList', () => {
                 pickerMode: 'account',
             });
 
-            expect(getByText('Add new')).toBeTruthy();
+            expect(
+                getByText(
+                    getTranslation('moduleAddAccounts.coinDiscoveryFinishedScreen.addButton'),
+                ),
+            ).toBeTruthy();
         });
 
         it('should NOT display footer with "Add new" button in "address" mode', () => {
@@ -286,7 +290,11 @@ describe('AccountList', () => {
                 getStateMockupBuy({ account: btc1NormalAccount }),
             );
 
-            expect(queryByText('Add new')).toBeNull();
+            expect(
+                queryByText(
+                    getTranslation('moduleAddAccounts.coinDiscoveryFinishedScreen.addButton'),
+                ),
+            ).toBeNull();
         });
     });
 

--- a/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountListAddressItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountListAddressItem.test.tsx
@@ -1,5 +1,6 @@
 import { type Account, asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
+import { getTranslation } from '@suite-native/intl';
 import { fireEvent } from '@suite-native/test-utils-store';
 import { type ReceiveAccount } from '@suite-native/trading-types';
 
@@ -131,8 +132,16 @@ describe(AccountListAddressItem.name, () => {
         expect(getByText('BTC_address')).toBeTruthy();
         expect(queryByText('My BTC account')).toBeNull();
         expect(queryByAccessibilityHint('Select to display account addresses')).toBeNull();
-        expect(getByLabelText('Balance in fiat')).toHaveTextContent('$5,000,000.00');
-        expect(getByLabelText('Balance in crypto')).toHaveTextContent('0.05 BTC');
+        expect(
+            getByLabelText(getTranslation('moduleTrading.accountScreen.balanceFiat')),
+        ).toHaveTextContent('$5,000,000.00');
+        expect(
+            getByLabelText(
+                getTranslation('moduleTrading.accountScreen.balanceCrypto', {
+                    coinLabel: 'crypto',
+                }),
+            ),
+        ).toHaveTextContent('0.05 BTC');
     });
 
     it('should display zero balance', () => {
@@ -154,8 +163,16 @@ describe(AccountListAddressItem.name, () => {
         };
         const { getByLabelText } = renderAccountListAddressItem(receiveAccount);
 
-        expect(getByLabelText('Balance in fiat')).toHaveTextContent('$0.00');
-        expect(getByLabelText('Balance in crypto')).toHaveTextContent('0 BTC');
+        expect(
+            getByLabelText(getTranslation('moduleTrading.accountScreen.balanceFiat')),
+        ).toHaveTextContent('$0.00');
+        expect(
+            getByLabelText(
+                getTranslation('moduleTrading.accountScreen.balanceCrypto', {
+                    coinLabel: 'crypto',
+                }),
+            ),
+        ).toHaveTextContent('0 BTC');
     });
 
     it('should render nothing when no address is specified', () => {

--- a/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountListItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountListItem.test.tsx
@@ -1,5 +1,6 @@
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+import { getTranslation } from '@suite-native/intl';
 import { type TestStore, fireEvent, renderWithStoreProvider } from '@suite-native/test-utils-store';
 import { type ReceiveAccount } from '@suite-native/trading-types';
 import { type StaticSessionId } from '@trezor/connect';
@@ -94,8 +95,16 @@ describe('AccountListItem', () => {
 
         expect(getByText('My BTC account')).toBeTruthy();
         expect(queryByAccessibilityHint('Select to display account addresses')).toBeNull();
-        expect(getByLabelText('Balance in fiat')).toHaveTextContent('$10,000,000.00');
-        expect(getByLabelText('Balance in crypto')).toHaveTextContent('0.1 BTC');
+        expect(
+            getByLabelText(getTranslation('moduleTrading.accountScreen.balanceFiat')),
+        ).toHaveTextContent('$10,000,000.00');
+        expect(
+            getByLabelText(
+                getTranslation('moduleTrading.accountScreen.balanceCrypto', {
+                    coinLabel: 'crypto',
+                }),
+            ),
+        ).toHaveTextContent('0.1 BTC');
     });
 
     it('should display caret when account defines addresses', () => {

--- a/suite-native/module-trading/src/components/general/AccountList/__tests__/NoAccountsComponent.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/__tests__/NoAccountsComponent.test.tsx
@@ -1,3 +1,4 @@
+import { getTranslation } from '@suite-native/intl';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 
 import { NoAccountsComponent } from '../NoAccountsComponent';
@@ -25,14 +26,22 @@ describe('NoAccountsComponent', () => {
     it('should render for not connected device', () => {
         const { queryByText } = renderNoAccountsComponent({ isConnected: false });
 
-        expect(queryByText('You need to connect your device to add new account.')).toBeTruthy();
+        expect(
+            queryByText(
+                getTranslation('moduleTrading.accountScreen.accountEmpty.viewOnly.description'),
+            ),
+        ).toBeTruthy();
     });
 
     it('should render for no account but connected device', () => {
         const { queryByText } = renderNoAccountsComponent({ isConnected: true });
 
         expect(
-            queryByText('It seems that you don’t have any account matching selected asset.'),
+            queryByText(
+                getTranslation(
+                    'moduleTrading.accountScreen.accountEmpty.networkNotEnabled.description',
+                ),
+            ),
         ).toBeTruthy();
     });
 
@@ -43,7 +52,11 @@ describe('NoAccountsComponent', () => {
         });
 
         expect(
-            queryByText('You don’t have an account for this asset imported in Portfolio Tracker.'),
+            queryByText(
+                getTranslation(
+                    'moduleTrading.accountScreen.accountEmpty.portfolioTracker.description',
+                ),
+            ),
         ).toBeTruthy();
     });
 });

--- a/suite-native/module-trading/src/components/general/Header/__tests__/Header.test.tsx
+++ b/suite-native/module-trading/src/components/general/Header/__tests__/Header.test.tsx
@@ -2,6 +2,7 @@ import { mockMessageSystemStateWithFeatureFlags } from '@suite-common/message-sy
 import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
 import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import { FeatureFlag, featureFlagsInitialState } from '@suite-native/feature-flags';
+import { getTranslation } from '@suite-native/intl';
 import { type TestStore, fireEvent } from '@suite-native/test-utils-store';
 
 import {
@@ -67,9 +68,15 @@ describe('Header', () => {
             }),
         });
 
-        expect(renderer.getByText('Buy')).toBeOnTheScreen();
-        expect(renderer.getByText('Swap')).toBeOnTheScreen();
-        expect(renderer.getByText('Sell')).toBeOnTheScreen();
+        expect(
+            renderer.getByText(getTranslation('moduleTrading.tradingScreen.tabs.buy')),
+        ).toBeOnTheScreen();
+        expect(
+            renderer.getByText(getTranslation('moduleTrading.tradingScreen.tabs.exchange')),
+        ).toBeOnTheScreen();
+        expect(
+            renderer.getByText(getTranslation('moduleTrading.tradingScreen.tabs.sell')),
+        ).toBeOnTheScreen();
     });
 
     it('should display nothing when isAmountInputActive is true', () => {
@@ -85,7 +92,9 @@ describe('Header', () => {
         const store = createTestStore();
         const { renderer } = renderHeaderWithStore(store);
 
-        fireEvent.press(renderer.getByText('Swap'));
+        fireEvent.press(
+            renderer.getByText(getTranslation('moduleTrading.tradingScreen.tabs.exchange')),
+        );
 
         expect(store.getState().wallet.trading.activeTradingType).toBe('exchange');
     });
@@ -93,7 +102,9 @@ describe('Header', () => {
     it('should display trade settings button', () => {
         const { renderer } = renderHeader();
 
-        expect(renderer.getByLabelText('Advanced settings')).toBeOnTheScreen();
+        expect(
+            renderer.getByLabelText(getTranslation('moduleTrading.tradingScreen.tabs.settings')),
+        ).toBeOnTheScreen();
     });
 
     describe('analytics', () => {
@@ -106,7 +117,9 @@ describe('Header', () => {
         it('should report TradingNavigate event on tab change', () => {
             const { renderer, reportMock } = renderHeaderWithStore(store);
 
-            fireEvent.press(renderer.getByText('Swap'));
+            fireEvent.press(
+                renderer.getByText(getTranslation('moduleTrading.tradingScreen.tabs.exchange')),
+            );
 
             expect(reportMock).toHaveBeenCalledWith({
                 type: events.tradingNavigateEvent.name,
@@ -121,10 +134,14 @@ describe('Header', () => {
         it('should not report TradingNavigate event when tab was not changed', () => {
             const { renderer, reportMock } = renderHeaderWithStore(store);
 
-            fireEvent.press(renderer.getByText('Swap'));
+            fireEvent.press(
+                renderer.getByText(getTranslation('moduleTrading.tradingScreen.tabs.exchange')),
+            );
             reportMock.mockClear();
 
-            fireEvent.press(renderer.getByText('Swap'));
+            fireEvent.press(
+                renderer.getByText(getTranslation('moduleTrading.tradingScreen.tabs.exchange')),
+            );
 
             expect(reportMock).not.toHaveBeenCalled();
         });
@@ -132,10 +149,14 @@ describe('Header', () => {
         it('should report TradingNavigate event when tab was changed to buy', () => {
             const { renderer, reportMock } = renderHeaderWithStore(store);
 
-            fireEvent.press(renderer.getByText('Swap'));
+            fireEvent.press(
+                renderer.getByText(getTranslation('moduleTrading.tradingScreen.tabs.exchange')),
+            );
             reportMock.mockClear();
 
-            fireEvent.press(renderer.getByText('Buy'));
+            fireEvent.press(
+                renderer.getByText(getTranslation('moduleTrading.tradingScreen.tabs.buy')),
+            );
 
             expect(reportMock).toHaveBeenCalledWith({
                 type: events.tradingNavigateEvent.name,

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetFilterTabs.test.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetFilterTabs.test.tsx
@@ -1,4 +1,5 @@
 import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { getTranslation } from '@suite-native/intl';
 import { fireEvent, renderWithStoreProvider } from '@suite-native/test-utils-store';
 
 import { MyAssetFilterTabs } from '../MyAssetFilterTabs';
@@ -19,7 +20,7 @@ describe('MyAssetFilterTabs', () => {
     it('should render "All" tab and one tab per available network', () => {
         const { getByText } = renderComponent();
 
-        expect(getByText('All')).toBeTruthy();
+        expect(getByText(getTranslation('moduleTrading.providerSheet.filters.all'))).toBeTruthy();
         expect(getByText('Bitcoin')).toBeTruthy();
         expect(getByText('Ethereum')).toBeTruthy();
     });
@@ -34,7 +35,7 @@ describe('MyAssetFilterTabs', () => {
             />,
         );
 
-        expect(queryByText('All')).toBeNull();
+        expect(queryByText(getTranslation('moduleTrading.providerSheet.filters.all'))).toBeNull();
         expect(queryByText('Bitcoin')).toBeNull();
         expect(queryByText('Ethereum')).toBeNull();
     });
@@ -43,7 +44,7 @@ describe('MyAssetFilterTabs', () => {
         const onSelectedNetworkFilter = jest.fn();
         const { getByText } = renderComponent(onSelectedNetworkFilter);
 
-        fireEvent.press(getByText('All'));
+        fireEvent.press(getByText(getTranslation('moduleTrading.providerSheet.filters.all')));
 
         expect(onSelectedNetworkFilter).toHaveBeenCalledWith(undefined);
     });

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetListItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetListItem.test.tsx
@@ -6,6 +6,7 @@ import {
     type TokenSymbol,
     asBaseCurrencyAmount,
 } from '@suite-common/wallet-types';
+import { getTranslation } from '@suite-native/intl';
 import { fireEvent, renderWithStoreProvider } from '@suite-native/test-utils-store';
 import { getBtcAccount, getEthAccount } from '@suite-native/trading-fixtures';
 import { type MyAsset } from '@suite-native/trading-types';
@@ -154,7 +155,7 @@ describe('MyAssetListItem', () => {
             preloadedState,
         );
 
-        expect(getByText('No pair')).toBeTruthy();
+        expect(getByText(getTranslation('moduleTrading.myAssetSheet.noPair.note'))).toBeTruthy();
     });
 
     it('should render without fiat balance when not available', () => {

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetSheet.test.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetSheet.test.tsx
@@ -2,6 +2,7 @@ import type { CryptoId } from 'invity-api';
 
 import { selectFormattedAccountType } from '@suite-common/wallet-core';
 import { asBaseCurrencyAmount } from '@suite-common/wallet-types';
+import { getTranslation } from '@suite-native/intl';
 import { fireEvent, screen } from '@suite-native/test-utils-store';
 import {
     btc1NormalAccount,
@@ -103,8 +104,10 @@ describe('MyAssetSheet', () => {
         mockedSelectAccountsWithTokensToSellSectionListByTradingType.mockReturnValue([]);
         const { getByText } = renderMyAssetsSheet();
 
-        expect(getByText('No assets found')).toBeTruthy();
-        expect(getByText('You do not have any assets available for this operation.')).toBeTruthy();
+        expect(getByText(getTranslation('moduleTrading.myAssetSheet.emptyTitle'))).toBeTruthy();
+        expect(
+            getByText(getTranslation('moduleTrading.myAssetSheet.emptyDescription')),
+        ).toBeTruthy();
     });
 
     it('should select asset and close on asset item press', () => {

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetSheetHeader.test.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetSheetHeader.test.tsx
@@ -1,4 +1,5 @@
 import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { getTranslation } from '@suite-native/intl';
 import { fireEvent, renderWithStoreProvider } from '@suite-native/test-utils-store';
 
 import { MyAssetSheetHeader } from '../MyAssetSheetHeader';
@@ -27,8 +28,8 @@ describe('MyAssetSheetHeader', () => {
     it('should display title and hide filter tabs by default', () => {
         const { getByText, queryByText } = renderComponent();
 
-        expect(getByText('Your assets')).toBeTruthy();
-        expect(queryByText('All')).toBeNull();
+        expect(getByText(getTranslation('moduleTrading.myAssetSheet.title'))).toBeTruthy();
+        expect(queryByText(getTranslation('moduleTrading.providerSheet.filters.all'))).toBeNull();
     });
 
     it('should show filter tabs after focusing the search input', () => {
@@ -36,8 +37,8 @@ describe('MyAssetSheetHeader', () => {
 
         fireEvent(getByPlaceholderText(/Search/), 'focus');
 
-        expect(getByText('All')).toBeTruthy();
-        expect(queryByText('Your assets')).toBeNull();
+        expect(getByText(getTranslation('moduleTrading.providerSheet.filters.all'))).toBeTruthy();
+        expect(queryByText(getTranslation('moduleTrading.myAssetSheet.title'))).toBeNull();
     });
 
     it('should display cancel button after focusing the search input', () => {
@@ -45,20 +46,20 @@ describe('MyAssetSheetHeader', () => {
 
         fireEvent(getByPlaceholderText(/Search/), 'focus');
 
-        expect(getByText('Cancel')).toBeTruthy();
+        expect(getByText(getTranslation('generic.buttons.cancel'))).toBeTruthy();
     });
 
     it('should not display cancel button by default', () => {
         const { queryByText } = renderComponent();
 
-        expect(queryByText('Cancel')).toBeNull();
+        expect(queryByText(getTranslation('generic.buttons.cancel'))).toBeNull();
     });
 
     it('should call onClose when close button is pressed', () => {
         const onClose = jest.fn();
         const { getByLabelText } = renderComponent({ onClose });
 
-        fireEvent.press(getByLabelText('Close'));
+        fireEvent.press(getByLabelText(getTranslation('generic.buttons.close')));
 
         expect(onClose).toHaveBeenCalled();
     });

--- a/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/NoProvidersPlaceholder.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/NoProvidersPlaceholder.test.tsx
@@ -1,3 +1,4 @@
+import { getTranslation } from '@suite-native/intl';
 import { renderWithBasicProvider } from '@suite-native/test-utils';
 
 import { NoProvidersPlaceholder } from '../NoProvidersPlaceholder';
@@ -8,7 +9,11 @@ describe('NoProvidersPlaceholder', () => {
     it('should render text and icon with label', () => {
         const { getByLabelText, getByText } = renderNoProvidersPlaceholder();
 
-        expect(getByText('No offers available.')).toBeOnTheScreen();
-        expect(getByLabelText('No offers available.')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.providerSheet.noProviders')),
+        ).toBeOnTheScreen();
+        expect(
+            getByLabelText(getTranslation('moduleTrading.providerSheet.noProviders')),
+        ).toBeOnTheScreen();
     });
 });

--- a/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderListItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderListItem.test.tsx
@@ -1,4 +1,5 @@
 import type { TradingTradeType } from '@suite-common/trading';
+import { getTranslation } from '@suite-native/intl';
 import {
     banxaCreditCardSellQuote,
     cexdirectFloatingQuote,
@@ -48,7 +49,9 @@ describe('ProviderListItem', () => {
     it('should render trading information with formatted strings', () => {
         const { getByText, queryByText } = renderProviderListItem(mercuryoApplePayBuyQuote);
 
-        expect(queryByText('Centralized exchange')).toBeNull();
+        expect(
+            queryByText(getTranslation('moduleTrading.providerListItem.centralizedExchange')),
+        ).toBeNull();
         expect(getByText('€9,998.32 / 1 BTC')).toBeOnTheScreen();
     });
 
@@ -58,7 +61,9 @@ describe('ProviderListItem', () => {
             tradingType: 'exchange',
         });
 
-        expect(getByText('Centralized exchange')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.providerListItem.centralizedExchange')),
+        ).toBeOnTheScreen();
     });
 
     it('should render KYC information when provider has KYC policy', () => {
@@ -75,8 +80,12 @@ describe('ProviderListItem', () => {
             tradingType: 'exchange',
         });
 
-        expect(getByText('Anonymous')).toBeOnTheScreen();
-        expect(getByText('Decentralized exchange')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.providerListItem.anonymous')),
+        ).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.providerListItem.decentralizedExchange')),
+        ).toBeOnTheScreen();
     });
 
     it('should not render when quote has no orderId', () => {

--- a/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderSheet.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderSheet.test.tsx
@@ -3,6 +3,7 @@ import {
     type TradingTradeType,
     type TradingType,
 } from '@suite-common/trading';
+import { getTranslation } from '@suite-native/intl';
 import { screen } from '@suite-native/test-utils-store';
 import { cexdirectFloatingQuote, mercuryoApplePayBuyQuote } from '@suite-native/trading-fixtures';
 
@@ -37,15 +38,21 @@ describe('ProviderSheet', () => {
     it('should render empty providers placeholder and no section header and for buy', () => {
         const { queryByText, getByText } = renderProviderSheet({}, {});
 
-        expect(getByText('No offers available.')).toBeOnTheScreen();
-        expect(queryByText('Fixed-rate CEX')).toBeNull();
+        expect(
+            getByText(getTranslation('moduleTrading.providerSheet.noProviders')),
+        ).toBeOnTheScreen();
+        expect(queryByText(getTranslation('moduleTrading.providerSheet.fixed.title'))).toBeNull();
     });
 
     it('should render section header and empty placeholder for exchange', () => {
         const { getByText } = renderProviderSheet({ tradingType: 'exchange' }, {});
 
-        expect(getByText('No offers available.')).toBeOnTheScreen();
-        expect(getByText('Fixed-rate CEX')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.providerSheet.noProviders')),
+        ).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.providerSheet.fixed.title')),
+        ).toBeOnTheScreen();
     });
 
     it('should render all section headers for exchange', () => {
@@ -54,8 +61,12 @@ describe('ProviderSheet', () => {
             quotes: EMPTY_GROUPED_TRADING_EXCHANGE_QUOTES,
         });
 
-        expect(getByText('Fixed-rate CEX')).toBeOnTheScreen();
-        expect(getByText('Floating-rate CEX')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.providerSheet.fixed.title')),
+        ).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.providerSheet.float.title')),
+        ).toBeOnTheScreen();
         expect(getByText('DEX')).toBeOnTheScreen();
     });
 
@@ -64,8 +75,10 @@ describe('ProviderSheet', () => {
             quotes: { fixed: [mercuryoApplePayBuyQuote] },
         });
 
-        expect(queryByText('No offers available.')).toBeNull();
-        expect(queryByText('Centralized exchange')).toBeNull();
+        expect(queryByText(getTranslation('moduleTrading.providerSheet.noProviders'))).toBeNull();
+        expect(
+            queryByText(getTranslation('moduleTrading.providerListItem.centralizedExchange')),
+        ).toBeNull();
         expect(getByText('Mercuryo')).toBeOnTheScreen();
     });
 
@@ -75,6 +88,8 @@ describe('ProviderSheet', () => {
             tradingType: 'exchange',
         });
 
-        expect(getByText('Centralized exchange')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.providerListItem.centralizedExchange')),
+        ).toBeOnTheScreen();
     });
 });

--- a/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderSheetHandle.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderSheetHandle.test.tsx
@@ -1,3 +1,4 @@
+import { getTranslation } from '@suite-native/intl';
 import { fireEvent } from '@suite-native/test-utils-store';
 
 import {
@@ -44,9 +45,13 @@ describe('ProviderSheetHandle', () => {
     it('should render component with title and filter', () => {
         const { getByText } = renderProviderSheetHandle({}, {});
 
-        expect(getByText('Providers')).toBeOnTheScreen();
-        expect(getByText('All')).toBeOnTheScreen();
-        expect(getByText('CEX')).toBeOnTheScreen();
+        expect(getByText(getTranslation('moduleTrading.providerSheet.title'))).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.providerSheet.filters.all')),
+        ).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.providerSheet.filters.cex')),
+        ).toBeOnTheScreen();
         expect(getByText('DEX')).toBeOnTheScreen();
     });
 
@@ -56,9 +61,9 @@ describe('ProviderSheetHandle', () => {
             {},
         );
 
-        expect(getByText('Providers')).toBeOnTheScreen();
-        expect(queryByText('All')).toBeNull();
-        expect(queryByText('CEX')).toBeNull();
+        expect(getByText(getTranslation('moduleTrading.providerSheet.title'))).toBeOnTheScreen();
+        expect(queryByText(getTranslation('moduleTrading.providerSheet.filters.all'))).toBeNull();
+        expect(queryByText(getTranslation('moduleTrading.providerSheet.filters.cex'))).toBeNull();
         expect(queryByText('DEX')).toBeNull();
     });
 
@@ -66,7 +71,7 @@ describe('ProviderSheetHandle', () => {
         const onClose = jest.fn();
         const { getByLabelText } = renderProviderSheetHandle({ onClose }, {});
 
-        fireEvent.press(getByLabelText('Close'));
+        fireEvent.press(getByLabelText(getTranslation('generic.buttons.close')));
 
         expect(onClose).toHaveBeenCalled();
     });
@@ -75,7 +80,7 @@ describe('ProviderSheetHandle', () => {
         const setSelectedFilter = jest.fn();
         const { getByText } = renderProviderSheetHandle({ setSelectedFilter }, {});
 
-        fireEvent.press(getByText('CEX'));
+        fireEvent.press(getByText(getTranslation('moduleTrading.providerSheet.filters.cex')));
 
         expect(setSelectedFilter).toHaveBeenCalledWith('cex');
     });

--- a/suite-native/module-trading/src/components/general/ReceiveAccount/__tests__/ReceiveAccountPicker.test.tsx
+++ b/suite-native/module-trading/src/components/general/ReceiveAccount/__tests__/ReceiveAccountPicker.test.tsx
@@ -1,3 +1,4 @@
+import { getTranslation } from '@suite-native/intl';
 import { type TestStore, fireEvent, renderWithStoreProvider } from '@suite-native/test-utils-store';
 import { btc1NormalAccount } from '@suite-native/trading-fixtures';
 
@@ -64,7 +65,7 @@ describe('ReceiveAccountPicker', () => {
             receiveAccount: undefined,
         });
 
-        expect(getByText('Not selected')).toBeTruthy();
+        expect(getByText(getTranslation('moduleTrading.notSelected'))).toBeTruthy();
     });
 
     it('should call navigate to account picker when symbol is specified and picker pressed', () => {
@@ -73,7 +74,7 @@ describe('ReceiveAccountPicker', () => {
             receiveAccount: undefined,
         });
 
-        fireEvent.press(getByText('Receive account'));
+        fireEvent.press(getByText(getTranslation('moduleTrading.tradingScreen.receiveAccount')));
 
         expect(mockNavigate).toHaveBeenCalledTimes(1);
         expect(mockNavigate).toHaveBeenCalledWith('ReceiveAccounts', {
@@ -89,7 +90,7 @@ describe('ReceiveAccountPicker', () => {
             tradingType: 'exchange',
         });
 
-        fireEvent.press(getByText('Receive account'));
+        fireEvent.press(getByText(getTranslation('moduleTrading.tradingScreen.receiveAccount')));
 
         expect(mockNavigate).toHaveBeenCalledTimes(1);
         expect(mockNavigate).toHaveBeenCalledWith('ReceiveAccounts', {
@@ -128,7 +129,9 @@ describe('ReceiveAccountPicker', () => {
                 testID: 'TEST_ID',
             });
 
-            expect(getByTestId('TEST_ID/not-selected')).toHaveTextContent('Not selected');
+            expect(getByTestId('TEST_ID/not-selected')).toHaveTextContent(
+                getTranslation('moduleTrading.notSelected'),
+            );
         });
 
         it('should render correctly with receiveAccount but no address', () => {

--- a/suite-native/module-trading/src/components/general/TradeInfo/__tests__/ProviderInfoRow.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeInfo/__tests__/ProviderInfoRow.test.tsx
@@ -1,3 +1,4 @@
+import { getTranslation } from '@suite-native/intl';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 import { getWalletState } from '@suite-native/trading-fixtures';
 
@@ -20,7 +21,7 @@ describe('ProviderInfoRow', () => {
         const { getByText } = renderProviderInfoRow({});
 
         expect(getByText('Mercuryo')).toBeOnTheScreen();
-        expect(getByText('Provider')).toBeOnTheScreen();
+        expect(getByText(getTranslation('moduleTrading.tradingScreen.provider'))).toBeOnTheScreen();
     });
 
     it('should render nothing when no provider is found', () => {

--- a/suite-native/module-trading/src/components/general/TradeInfo/__tests__/TradeFiatSideCard.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeInfo/__tests__/TradeFiatSideCard.test.tsx
@@ -1,3 +1,4 @@
+import { getTranslation } from '@suite-native/intl';
 import { renderWithBasicProvider } from '@suite-native/test-utils';
 import type { ExtendedSellCryptoPaymentMethod } from '@suite-native/trading-types';
 
@@ -15,8 +16,12 @@ describe('TradeFiatSideCard', () => {
             fiatCurrency: 'usd',
         });
 
-        expect(getByText('To')).toBeOnTheScreen();
-        expect(getByText('Credit/Debit Card')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.tradingExchangePreviewScreen.toAccount')),
+        ).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.paymentMethods.creditCard')),
+        ).toBeOnTheScreen();
     });
 
     it('should render bank transfer payment method', () => {
@@ -27,8 +32,12 @@ describe('TradeFiatSideCard', () => {
             fiatCurrency: 'usd',
         });
 
-        expect(getByText('To')).toBeOnTheScreen();
-        expect(getByText('Bank Transfer')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.tradingExchangePreviewScreen.toAccount')),
+        ).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.paymentMethods.bankTransfer')),
+        ).toBeOnTheScreen();
     });
 
     it('should render unknown payment method', () => {
@@ -39,7 +48,9 @@ describe('TradeFiatSideCard', () => {
             fiatCurrency: 'usd',
         });
 
-        expect(getByText('To')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.tradingExchangePreviewScreen.toAccount')),
+        ).toBeOnTheScreen();
         expect(getByText('customMethod')).toBeOnTheScreen();
     });
 });

--- a/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/TradeableAssetFilterTabs.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/TradeableAssetFilterTabs.test.tsx
@@ -1,4 +1,5 @@
 import { type Network } from '@suite-common/wallet-config';
+import { getTranslation } from '@suite-native/intl';
 import { fireEvent, renderWithStoreProvider } from '@suite-native/test-utils-store';
 
 import { TradeableAssetFilterTabs } from '../TradeableAssetFilterTabs';
@@ -34,7 +35,7 @@ describe('TradeableAssetFilterTabs', () => {
     it('should render all filter tabs including "All" option', () => {
         const { getByText } = renderComponent();
 
-        expect(getByText('All')).toBeTruthy();
+        expect(getByText(getTranslation('moduleTrading.providerSheet.filters.all'))).toBeTruthy();
         expect(getByText('Bitcoin')).toBeTruthy();
         expect(getByText('Ethereum')).toBeTruthy();
     });
@@ -48,7 +49,7 @@ describe('TradeableAssetFilterTabs', () => {
             />,
         );
 
-        expect(queryByText('All')).toBeNull();
+        expect(queryByText(getTranslation('moduleTrading.providerSheet.filters.all'))).toBeNull();
         expect(queryByText('Bitcoin')).toBeNull();
         expect(queryByText('Ethereum')).toBeNull();
     });
@@ -57,7 +58,7 @@ describe('TradeableAssetFilterTabs', () => {
         const onSelectedNetworkFilter = jest.fn();
         const { getByText } = renderComponent(onSelectedNetworkFilter);
 
-        fireEvent.press(getByText('All'));
+        fireEvent.press(getByText(getTranslation('moduleTrading.providerSheet.filters.all')));
 
         expect(onSelectedNetworkFilter).toHaveBeenCalledWith(undefined);
     });

--- a/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/TradeableAssetSheet.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/TradeableAssetSheet.test.tsx
@@ -1,3 +1,4 @@
+import { getTranslation } from '@suite-native/intl';
 import { fireEvent, screen } from '@suite-native/test-utils-store';
 import { adaAsset, btcAsset, usdcAsset } from '@suite-native/trading-fixtures';
 import { type TradeableAsset } from '@suite-native/trading-types';
@@ -64,9 +65,11 @@ describe('TradeableAssetSheet', () => {
             assets: [],
         });
 
-        expect(getByText('Coin not found')).toBeTruthy();
         expect(
-            getByText('Check the spelling or browse the list to select an option.'),
+            getByText(getTranslation('moduleTrading.tradeableAssetsSheet.emptyTitle')),
+        ).toBeTruthy();
+        expect(
+            getByText(getTranslation('moduleTrading.fiatCurrencySheet.emptyDescription')),
         ).toBeTruthy();
     });
 });

--- a/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/TradeableAssetSheetHeader.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/TradeableAssetSheetHeader.test.tsx
@@ -1,4 +1,5 @@
 import { type Network } from '@suite-common/wallet-config';
+import { getTranslation } from '@suite-native/intl';
 import { fireEvent, renderWithStoreProvider } from '@suite-native/test-utils-store';
 
 import { TradeableAssetSheetHeader } from '../TradeableAssetSheetHeader';
@@ -25,38 +26,44 @@ describe('TradeableAssetSheetHeader', () => {
     it('should display "Coins" and do not display tabs by default', () => {
         const { getByText, queryByText } = renderComponent();
 
-        expect(getByText('Assets')).toBeTruthy();
-        expect(queryByText('All')).toBeNull();
+        expect(getByText(getTranslation('moduleTrading.tradeableAssetsSheet.title'))).toBeTruthy();
+        expect(queryByText(getTranslation('moduleTrading.providerSheet.filters.all'))).toBeNull();
     });
 
     it('should display tabs after focusing search input', () => {
         const { getByPlaceholderText, getByText, queryByText } = renderComponent();
 
-        fireEvent(getByPlaceholderText(/Search/), 'focus');
+        fireEvent(
+            getByPlaceholderText(new RegExp(getTranslation('moduleTrading.defaultSearchLabel'))),
+            'focus',
+        );
 
-        expect(getByText('All')).toBeTruthy();
-        expect(queryByText('Coins')).toBeNull();
+        expect(getByText(getTranslation('moduleTrading.providerSheet.filters.all'))).toBeTruthy();
+        expect(queryByText(getTranslation('moduleTrading.tradeableAssetsSheet.title'))).toBeNull();
     });
 
     it('should not display cancel button by default', () => {
         const { queryByText } = renderComponent();
 
-        expect(queryByText('Cancel')).toBeNull();
+        expect(queryByText(getTranslation('generic.buttons.cancel'))).toBeNull();
     });
 
     it('should display cancel button after focusing search input', () => {
         const { getByPlaceholderText, getByText } = renderComponent();
 
-        fireEvent(getByPlaceholderText(/Search/), 'focus');
+        fireEvent(
+            getByPlaceholderText(new RegExp(getTranslation('moduleTrading.defaultSearchLabel'))),
+            'focus',
+        );
 
-        expect(getByText('Cancel')).toBeTruthy();
+        expect(getByText(getTranslation('generic.buttons.cancel'))).toBeTruthy();
     });
 
     it('should call onClose when close button is pressed ', () => {
         const onClose = jest.fn();
         const { getByLabelText } = renderComponent(onClose);
 
-        fireEvent.press(getByLabelText('Close'));
+        fireEvent.press(getByLabelText(getTranslation('generic.buttons.close')));
 
         expect(onClose).toHaveBeenCalled();
     });

--- a/suite-native/module-trading/src/components/general/__tests__/FiatCurrencyButton.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/FiatCurrencyButton.test.tsx
@@ -1,3 +1,4 @@
+import { getTranslation } from '@suite-native/intl';
 import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
 
 import { FiatCurrencyButton, type FiatCurrencyButtonProps } from '../FiatCurrencyButton';
@@ -11,14 +12,16 @@ describe('FiatCurrencyButton', () => {
     it('should render fiat currency uppercase', () => {
         const { getByLabelText } = renderFiatCurrencyButton({});
 
-        expect(getByLabelText('Select fiat currency')).toHaveTextContent(/CZK/);
+        expect(
+            getByLabelText(getTranslation('moduleTrading.selectFiat.buttonTitle')),
+        ).toHaveTextContent(/CZK/);
     });
 
     it('should call onPress callback when pressed', () => {
         const onPress = jest.fn();
         const { getByLabelText } = renderFiatCurrencyButton({ onPress });
 
-        fireEvent.press(getByLabelText('Select fiat currency'));
+        fireEvent.press(getByLabelText(getTranslation('moduleTrading.selectFiat.buttonTitle')));
 
         expect(onPress).toHaveBeenCalledTimes(1);
     });

--- a/suite-native/module-trading/src/components/general/__tests__/HistoryButton.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/HistoryButton.test.tsx
@@ -1,4 +1,5 @@
 import { type TradingTransaction } from '@suite-common/trading';
+import { getTranslation } from '@suite-native/intl';
 import { fireEvent } from '@suite-native/test-utils-store';
 import { getBuyTrade } from '@suite-native/trading-fixtures';
 
@@ -48,7 +49,9 @@ describe('HistoryButton', () => {
         it('should render button when at least one trade is specified', () => {
             const { getByText } = renderHistoryButton({});
 
-            expect(getByText('Trade history')).toBeOnTheScreen();
+            expect(
+                getByText(getTranslation('moduleTrading.tradeHistory.list.title')),
+            ).toBeOnTheScreen();
         });
 
         it('should render nothing when isAmountInputActive is true', () => {
@@ -66,7 +69,7 @@ describe('HistoryButton', () => {
         it('should navigate on press', () => {
             const { getByText } = renderHistoryButton({});
 
-            fireEvent.press(getByText('Trade history'));
+            fireEvent.press(getByText(getTranslation('moduleTrading.tradeHistory.list.title')));
 
             expect(mockNavigate).toHaveBeenCalledWith('TradingHistory');
         });

--- a/suite-native/module-trading/src/components/general/__tests__/SelectTradeableAssetButton.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/SelectTradeableAssetButton.test.tsx
@@ -1,3 +1,4 @@
+import { getTranslation } from '@suite-native/intl';
 import { renderWithBasicProvider } from '@suite-native/test-utils';
 import { adaAsset } from '@suite-native/trading-fixtures';
 
@@ -9,15 +10,18 @@ describe('SelectTradeableAssetButton', () => {
             <SelectTradeableAssetButton onPress={jest.fn()} selectedAsset={undefined} caret />,
         );
 
-        const button = getByLabelText('Select asset');
-        expect(button).toHaveTextContent(/^Select asset.$/);
+        const button = getByLabelText(getTranslation('moduleTrading.selectCoin.buttonTitle'));
+
+        expect(button).toHaveTextContent(
+            new RegExp(`^${getTranslation('moduleTrading.selectCoin.buttonTitle')}.$`),
+        );
     });
 
     it('should render TradeableAssetButton when network is selected', () => {
         const { getByLabelText } = renderWithBasicProvider(
             <SelectTradeableAssetButton onPress={jest.fn()} selectedAsset={adaAsset} caret />,
         );
-        const button = getByLabelText('Select asset');
+        const button = getByLabelText(getTranslation('moduleTrading.selectCoin.buttonTitle'));
         expect(button).toHaveTextContent(/^ADA.$/);
     });
 
@@ -25,7 +29,7 @@ describe('SelectTradeableAssetButton', () => {
         const { getByLabelText } = renderWithBasicProvider(
             <SelectTradeableAssetButton onPress={jest.fn()} selectedAsset={adaAsset} />,
         );
-        const button = getByLabelText('Select asset');
+        const button = getByLabelText(getTranslation('moduleTrading.selectCoin.buttonTitle'));
         expect(button).toHaveTextContent('ADA');
     });
 });

--- a/suite-native/module-trading/src/components/general/__tests__/SimpleSheetHeader.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/SimpleSheetHeader.test.tsx
@@ -1,3 +1,4 @@
+import { getTranslation } from '@suite-native/intl';
 import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
 
 import { SimpleSheetHeader, type SimpleSheetHeaderProps } from '../SimpleSheetHeader';
@@ -21,7 +22,7 @@ describe('SimpleSheetHeader', () => {
             onClose: onCloseMock,
         });
 
-        const closeButton = getByLabelText('Close');
+        const closeButton = getByLabelText(getTranslation('generic.buttons.close'));
         fireEvent.press(closeButton);
 
         expect(onCloseMock).toHaveBeenCalledTimes(1);

--- a/suite-native/module-trading/src/components/general/__tests__/TradeableAssetAccountBalance.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/TradeableAssetAccountBalance.test.tsx
@@ -1,3 +1,4 @@
+import { getTranslation } from '@suite-native/intl';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 import {
     btcAsset,
@@ -45,7 +46,7 @@ describe('TradeableAssetAccountBalance', () => {
         (asset, expectedSymbol) => {
             const { getByText } = renderTradeableAssetAccountBalance({ asset });
 
-            expect(getByText('Balance:')).toBeDefined();
+            expect(getByText(getTranslation('moduleTrading.tradingScreen.balance'))).toBeDefined();
             expect(getByText(`- ${expectedSymbol}`)).toBeDefined();
         },
     );
@@ -63,7 +64,7 @@ describe('TradeableAssetAccountBalance', () => {
             testID: undefined,
         });
 
-        expect(getByText('Balance:')).toBeDefined();
+        expect(getByText(getTranslation('moduleTrading.tradingScreen.balance'))).toBeDefined();
         expect(getByText('- BTC')).toBeDefined();
     });
 
@@ -87,7 +88,7 @@ describe('TradeableAssetAccountBalance', () => {
                 preloadedState,
             );
 
-            expect(getByText('Balance:')).toBeDefined();
+            expect(getByText(getTranslation('moduleTrading.tradingScreen.balance'))).toBeDefined();
             expect(getByTestId('TEST_ID/value')).toHaveTextContent(expectedBalance);
         });
     });

--- a/suite-native/module-trading/src/components/general/__tests__/TradeableAssetNetworkInfo.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/TradeableAssetNetworkInfo.test.tsx
@@ -1,3 +1,4 @@
+import { getTranslation } from '@suite-native/intl';
 import { renderWithBasicProvider } from '@suite-native/test-utils';
 import { btcAsset, ethOnBaseAsset, usdcAsset } from '@suite-native/trading-fixtures';
 
@@ -20,20 +21,24 @@ describe('TradeableAssetNetworkInfo', () => {
         const { queryByHintText, queryByLabelText } = renderTradeableAssetNetworkInfo(btcAsset);
 
         expect(queryByHintText('Network Icon')).toBeNull();
-        expect(queryByLabelText('Network name')).toBeNull();
+        expect(queryByLabelText(getTranslation('moduleTrading.networkName'))).toBeNull();
     });
 
     it('should render network icon and name for l2 networks = op, arb, base and ETH as icon', () => {
         const { getByHintText, getByLabelText } = renderTradeableAssetNetworkInfo(ethOnBaseAsset);
 
         expect(getByHintText('Network Icon')).toBeTruthy();
-        expect(getByLabelText('Network name')).toHaveTextContent('Base');
+        expect(getByLabelText(getTranslation('moduleTrading.networkName'))).toHaveTextContent(
+            'Base',
+        );
     });
 
     it('should render network icon and name for contracts', () => {
         const { getByHintText, getByLabelText } = renderTradeableAssetNetworkInfo(usdcAsset);
 
         expect(getByHintText('Network Icon')).toBeTruthy();
-        expect(getByLabelText('Network name')).toHaveTextContent('Ethereum');
+        expect(getByLabelText(getTranslation('moduleTrading.networkName'))).toHaveTextContent(
+            'Ethereum',
+        );
     });
 });

--- a/suite-native/module-trading/src/components/general/__tests__/TradingTabContent.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/TradingTabContent.test.tsx
@@ -1,4 +1,5 @@
 import { mockMessageSystemStateWithFeatureFlags } from '@suite-common/message-system/mocks';
+import { getTranslation } from '@suite-native/intl';
 import { screen } from '@suite-native/test-utils-store';
 import { tradingInitialState } from '@suite-native/trading-state';
 
@@ -42,15 +43,21 @@ describe('TradingTabContent', () => {
         });
 
     const expectDeviceOffline = () => {
-        expect(screen.getByText('Trading is not available offline')).toBeOnTheScreen();
+        expect(
+            screen.getByText(getTranslation('tradingAtoms.error.deviceOfflineTitle')),
+        ).toBeOnTheScreen();
     };
 
     const expectTradingNotAllowedInCountry = () => {
-        expect(screen.getByText('Trading is not yet available in your country')).toBeOnTheScreen();
+        expect(
+            screen.getByText(getTranslation('tradingAtoms.error.notAvailableInCountryTitle')),
+        ).toBeOnTheScreen();
     };
 
     const expectBuyForm = () => {
-        expect(screen.getByText('You pay')).toBeOnTheScreen();
+        expect(
+            screen.getByText(getTranslation('moduleTrading.selectFiat.buy.amountLabel')),
+        ).toBeOnTheScreen();
     };
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/components/reviewOutputs/__tests__/ReviewOutputsBody.test.tsx
+++ b/suite-native/module-trading/src/components/reviewOutputs/__tests__/ReviewOutputsBody.test.tsx
@@ -1,4 +1,5 @@
 import { type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
+import { getTranslation } from '@suite-native/intl';
 import { oneInchFusionPlusWithEip712SignDataQuote } from '@suite-native/trading-fixtures';
 
 import { renderWithTradingProvider } from '../../../__tests__/tradingTestUtils';
@@ -28,7 +29,13 @@ describe('ReviewOutputsBody', () => {
         const { getByText, queryByTestId } = renderReviewOutputsBody({});
 
         // invalid account id is provided, expect error
-        expect(getByText(/Account not found/)).toBeOnTheScreen();
+        expect(
+            getByText(
+                new RegExp(
+                    getTranslation('moduleTrading.accountScreen.accountEmpty.viewOnly.title'),
+                ),
+            ),
+        ).toBeOnTheScreen();
         expect(queryByTestId('@trading/outputs-review/skeleton')).not.toBeOnTheScreen();
     });
 
@@ -49,8 +56,12 @@ describe('ReviewOutputsBody', () => {
             },
         );
 
-        expect(getByText('Sign EIP-712 typed data')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.tradingReviewOutputs.signData.heading')),
+        ).toBeOnTheScreen();
         // ReviewOutputItemList renders "Account not found" for invalid keys; sign-data skips it
-        expect(queryByText(/Account not found/)).toBeNull();
+        expect(
+            queryByText(getTranslation('moduleTrading.accountScreen.accountEmpty.viewOnly.title')),
+        ).toBeNull();
     });
 });

--- a/suite-native/module-trading/src/components/reviewOutputs/__tests__/ReviewOutputsFooter.test.tsx
+++ b/suite-native/module-trading/src/components/reviewOutputs/__tests__/ReviewOutputsFooter.test.tsx
@@ -1,3 +1,4 @@
+import { getTranslation } from '@suite-native/intl';
 import { userEvent } from '@suite-native/test-utils-store';
 
 import {
@@ -25,14 +26,18 @@ describe('ReviewOutputsFooter', () => {
     it('should display "Send transaction" button', () => {
         const { getByTestId } = renderReviewOutputsFooter({});
 
-        expect(getByTestId('TEST_ID/submit-button')).toHaveTextContent('Send transaction');
+        expect(getByTestId('TEST_ID/submit-button')).toHaveTextContent(
+            getTranslation('moduleTrading.tradingReviewOutputs.submitButton'),
+        );
         expect(getByTestId('TEST_ID/submit-button')).toBeEnabled();
     });
 
     it('should be disabled when isConsentRequested is false', () => {
         const { getByText } = renderReviewOutputsFooter({ isConsentRequested: false });
 
-        expect(getByText('Send transaction')).toBeDisabled();
+        expect(
+            getByText(getTranslation('moduleTrading.tradingReviewOutputs.submitButton')),
+        ).toBeDisabled();
     });
 
     it('should display "all set" info when transaction is signed', () => {
@@ -50,7 +55,9 @@ describe('ReviewOutputsFooter', () => {
             },
         );
 
-        expect(getByText("You're all set")).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('transactionManagement.review.outputs.signSuccessMessage')),
+        ).toBeOnTheScreen();
     });
 
     it('should resolveConsent on press', async () => {

--- a/suite-native/module-trading/src/components/reviewOutputs/__tests__/SignDataMessageReview.test.tsx
+++ b/suite-native/module-trading/src/components/reviewOutputs/__tests__/SignDataMessageReview.test.tsx
@@ -1,4 +1,5 @@
 import { type AccountKey } from '@suite-common/wallet-types';
+import { getTranslation } from '@suite-native/intl';
 import {
     getEthAccount,
     oneInchFusionPlusWithEip712SignDataQuote,
@@ -98,7 +99,9 @@ describe('SignDataMessageReview', () => {
     it('should render heading', () => {
         const { getByText } = renderSignDataMessageReview();
 
-        expect(getByText('Sign EIP-712 typed data')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.tradingReviewOutputs.signData.heading')),
+        ).toBeOnTheScreen();
     });
 
     it('should render domain card with simplified JSON', () => {
@@ -111,7 +114,9 @@ describe('SignDataMessageReview', () => {
     it('should render message card with labeled field rows', () => {
         const { getByText } = renderSignDataMessageReview();
 
-        expect(getByText('Message')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.tradingReviewOutputs.signData.message')),
+        ).toBeOnTheScreen();
         expect(getByText('maker')).toBeOnTheScreen();
         expect(getByText('0x9cd02a26cd336d0fe784fb7995f6e5c9e3776258')).toBeOnTheScreen();
         expect(getByText('makingAmount')).toBeOnTheScreen();
@@ -124,7 +129,9 @@ describe('SignDataMessageReview', () => {
     it('should render address card when send account is available', () => {
         const { getByText } = renderSignDataMessageReview();
 
-        expect(getByText('Address')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.tradingReviewOutputs.signData.address')),
+        ).toBeOnTheScreen();
     });
 
     it('should not render address card when send account is not found', () => {
@@ -139,6 +146,8 @@ describe('SignDataMessageReview', () => {
             },
         });
 
-        expect(queryByText('Address')).toBeNull();
+        expect(
+            queryByText(getTranslation('moduleTrading.tradingReviewOutputs.signData.address')),
+        ).toBeNull();
     });
 });

--- a/suite-native/module-trading/src/components/sell/SellPreview/BankAccount/__tests__/SellBankAccountItem.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/BankAccount/__tests__/SellBankAccountItem.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { getTranslation } from '@suite-native/intl';
 import { renderWithBasicProvider, userEvent } from '@suite-native/test-utils';
 import { unverifiedBankAccount, verifiedBankAccount } from '@suite-native/trading-fixtures';
 
@@ -33,7 +34,9 @@ describe('SellBankAccountItem', () => {
                 bankAccount: verifiedBankAccount,
             });
 
-            expect(getByText('Verified')).toBeOnTheScreen();
+            expect(
+                getByText(getTranslation('moduleTrading.tradingSellPreviewScreen.verified')),
+            ).toBeOnTheScreen();
             expect(getByTestId('check-icon')).toBeOnTheScreen();
         });
 
@@ -42,7 +45,9 @@ describe('SellBankAccountItem', () => {
                 bankAccount: unverifiedBankAccount,
             });
 
-            expect(getByText('Not verified')).toBeOnTheScreen();
+            expect(
+                getByText(getTranslation('moduleTrading.tradingSellPreviewScreen.notVerified')),
+            ).toBeOnTheScreen();
             expect(queryByTestId('check-icon')).not.toBeOnTheScreen();
         });
     });

--- a/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellFromAccountTradePreviewCard.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellFromAccountTradePreviewCard.test.tsx
@@ -1,4 +1,5 @@
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
+import { getTranslation } from '@suite-native/intl';
 import { banxaCreditCardSellQuote, eth1NormalAccount } from '@suite-native/trading-fixtures';
 
 import { renderWithTradingProvider } from '../../../../__tests__/tradingTestUtils';
@@ -41,7 +42,9 @@ describe('SellFromAccountTradePreviewCard', () => {
             quote: banxaCreditCardSellQuote,
         });
 
-        expect(getByText('From')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.tradingExchangePreviewScreen.fromAccount')),
+        ).toBeOnTheScreen();
         expect(getByText('ETH Account #1')).toBeOnTheScreen();
         expect(getByText('-0.0233 ETH')).toBeOnTheScreen();
         expect(getByText('0.0233-ethereum')).toBeOnTheScreen();

--- a/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellPreviewContinueButton.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellPreviewContinueButton.test.tsx
@@ -1,4 +1,5 @@
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
+import { getTranslation } from '@suite-native/intl';
 import { userEvent } from '@suite-native/test-utils-store';
 import { banxaCreditCardSellQuote, createPrecomposedTxFinal } from '@suite-native/trading-fixtures';
 import { mergeDeepObject } from '@trezor/utils';
@@ -72,13 +73,17 @@ describe('SellPreviewContinueButton', () => {
     it('should render continue button', () => {
         const { getByText } = renderSellPreviewContinueButton();
 
-        expect(getByText('Continue')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.tradingScreen.buttons.continue')),
+        ).toBeOnTheScreen();
     });
 
     it('should render disabled button when isDisabled prop is specified', () => {
         const { getByText } = renderSellPreviewContinueButton({ isDisabled: true });
 
-        expect(getByText('Continue')).toBeDisabled();
+        expect(
+            getByText(getTranslation('moduleTrading.tradingScreen.buttons.continue')),
+        ).toBeDisabled();
     });
 
     it('should fire console.warn and do not navigate when quote is not specified', async () => {
@@ -89,7 +94,9 @@ describe('SellPreviewContinueButton', () => {
             onSignTransactionNavigation: mockOnSignTransactionNavigation,
         });
 
-        await userEvent.press(getByText('Continue'));
+        await userEvent.press(
+            getByText(getTranslation('moduleTrading.tradingScreen.buttons.continue')),
+        );
 
         expect(consoleWarnSpy).toHaveBeenCalledWith('quote or fromAccount is not defined', {
             hasQuote: false,
@@ -115,7 +122,9 @@ describe('SellPreviewContinueButton', () => {
             },
         );
 
-        await userEvent.press(getByText('Continue'));
+        await userEvent.press(
+            getByText(getTranslation('moduleTrading.tradingScreen.buttons.continue')),
+        );
 
         expect(consoleWarnSpy).toHaveBeenCalledWith('quote or fromAccount is not defined', {
             hasQuote: true,
@@ -132,7 +141,9 @@ describe('SellPreviewContinueButton', () => {
             onSignTransactionNavigation: mockOnSignTransactionNavigation,
         });
 
-        await userEvent.press(getByText('Continue'));
+        await userEvent.press(
+            getByText(getTranslation('moduleTrading.tradingScreen.buttons.continue')),
+        );
 
         expect(consoleWarnSpy).not.toHaveBeenCalled();
         expect(mockNavigate).toHaveBeenCalledWith('TradingSellOutputsReview', {

--- a/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellPreviewScreenHeader.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellPreviewScreenHeader.test.tsx
@@ -1,3 +1,4 @@
+import { getTranslation } from '@suite-native/intl';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 
 import { SellPreviewScreenHeader } from '../SellPreviewScreenHeader';
@@ -9,6 +10,8 @@ describe('SellPreviewScreenHeader', () => {
     it('should render screen header with correct title', () => {
         const { getByText } = renderSellPreviewScreenHeader();
 
-        expect(getByText('Sell')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.tradingSellPreviewScreen.title')),
+        ).toBeOnTheScreen();
     });
 });

--- a/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellToFiatTradePreviewCard.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellToFiatTradePreviewCard.test.tsx
@@ -1,3 +1,4 @@
+import { getTranslation } from '@suite-native/intl';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 import {
     banxaBankTransferSellQuote,
@@ -55,8 +56,12 @@ describe('SellToFiatTradePreviewCard', () => {
             quote: banxaCreditCardSellQuote,
         });
 
-        expect(getByText('To')).toBeOnTheScreen();
-        expect(getByText('Credit/Debit Card')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.tradingExchangePreviewScreen.toAccount')),
+        ).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.paymentMethods.creditCard')),
+        ).toBeOnTheScreen();
         expect(getByText('+$90.17')).toBeOnTheScreen();
     });
 
@@ -65,8 +70,12 @@ describe('SellToFiatTradePreviewCard', () => {
             quote: banxaBankTransferSellQuote,
         });
 
-        expect(getByText('To')).toBeOnTheScreen();
-        expect(getByText('Bank Transfer')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.tradingExchangePreviewScreen.toAccount')),
+        ).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.paymentMethods.bankTransfer')),
+        ).toBeOnTheScreen();
         expect(getByText('+$100.00')).toBeOnTheScreen();
     });
 });

--- a/suite-native/module-trading/src/components/sell/__tests__/SellCard.test.tsx
+++ b/suite-native/module-trading/src/components/sell/__tests__/SellCard.test.tsx
@@ -1,4 +1,5 @@
 import { Form } from '@suite-native/forms';
+import { getTranslation } from '@suite-native/intl';
 import {
     act,
     renderHookWithStoreProvider,
@@ -52,12 +53,20 @@ describe('SellCard', () => {
         });
         const { getByText, getByLabelText } = renderSellCard(false);
 
-        expect(getByText('You pay')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.selectFiat.buy.amountLabel')),
+        ).toBeOnTheScreen();
         expect(getByText('$99.00')).toBeOnTheScreen();
-        expect(getByLabelText('Select asset')).toHaveTextContent(/USDC/);
-        expect(getByLabelText('Network name')).toHaveTextContent('Ethereum');
-        expect(getByLabelText('You pay')).toHaveDisplayValue('100');
-        expect(getByText('Balance:')).toBeOnTheScreen();
+        expect(
+            getByLabelText(getTranslation('moduleTrading.selectCoin.buttonTitle')),
+        ).toHaveTextContent(/USDC/);
+        expect(getByLabelText(getTranslation('moduleTrading.networkName'))).toHaveTextContent(
+            'Ethereum',
+        );
+        expect(
+            getByLabelText(getTranslation('moduleTrading.selectFiat.buy.amountLabel')),
+        ).toHaveDisplayValue('100');
+        expect(getByText(getTranslation('moduleTrading.tradingScreen.balance'))).toBeOnTheScreen();
         expect(getByText('- USDC')).toBeOnTheScreen();
     });
 
@@ -75,7 +84,9 @@ describe('SellCard', () => {
         it('should render receive method', () => {
             const { getByText } = renderSellCard(false);
 
-            expect(getByText('Receive method')).toBeOnTheScreen();
+            expect(
+                getByText(getTranslation('moduleTrading.tradingScreen.receiveMethod')),
+            ).toBeOnTheScreen();
         });
     });
 });

--- a/suite-native/module-trading/src/components/sell/__tests__/SellForm.test.tsx
+++ b/suite-native/module-trading/src/components/sell/__tests__/SellForm.test.tsx
@@ -1,6 +1,7 @@
 import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
 import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import { Form } from '@suite-native/forms';
+import { getTranslation } from '@suite-native/intl';
 import { act, screen } from '@suite-native/test-utils-store';
 import {
     banxaBankTransferSellQuote,
@@ -64,9 +65,17 @@ describe('SellForm', () => {
         const { result } = renderFormHook();
         const { getByText, getByLabelText } = renderSellForm({}, result.current);
 
-        expect(getByText('You pay')).toBeOnTheScreen();
-        expect(getByText('You get')).toBeOnTheScreen();
-        expect(getByLabelText('Select asset')).toHaveTextContent(/Select asset/);
+        expect(
+            getByText(getTranslation('moduleTrading.selectFiat.buy.amountLabel')),
+        ).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.selectFiat.sell.amountLabel')),
+        ).toBeOnTheScreen();
+        expect(
+            getByLabelText(getTranslation('moduleTrading.selectCoin.buttonTitle')),
+        ).toHaveTextContent(
+            new RegExp(`^${getTranslation('moduleTrading.selectCoin.buttonTitle')}.$`),
+        );
     });
 
     describe('with preloaded sell data', () => {
@@ -93,11 +102,21 @@ describe('SellForm', () => {
         it('should render with default values', () => {
             const { getByLabelText, getByText } = renderSellForm(overrides, form);
 
-            expect(getByText('You pay')).toBeOnTheScreen();
-            expect(getByLabelText('Select fiat currency')).toBeOnTheScreen();
-            expect(getByLabelText('Select asset')).toHaveTextContent(/BTC/);
-            expect(getByText('Country of residence')).toBeOnTheScreen();
-            expect(getByText('Provider')).toBeOnTheScreen();
+            expect(
+                getByText(getTranslation('moduleTrading.selectFiat.buy.amountLabel')),
+            ).toBeOnTheScreen();
+            expect(
+                getByLabelText(getTranslation('moduleTrading.selectFiat.buttonTitle')),
+            ).toBeOnTheScreen();
+            expect(
+                getByLabelText(getTranslation('moduleTrading.selectCoin.buttonTitle')),
+            ).toHaveTextContent(/BTC/);
+            expect(
+                getByText(getTranslation('tradingResidence.locationSettings.countryOfResidence')),
+            ).toBeOnTheScreen();
+            expect(
+                getByText(getTranslation('moduleTrading.tradingScreen.provider')),
+            ).toBeOnTheScreen();
         });
 
         it('should render only SellCard and Done when amount input is active', () => {
@@ -106,12 +125,20 @@ describe('SellForm', () => {
             });
             const { queryByText, getByText } = renderSellForm(overrides, form);
 
-            expect(getByText('You pay')).toBeOnTheScreen();
-            expect(getByText('You get')).toBeOnTheScreen();
+            expect(
+                getByText(getTranslation('moduleTrading.selectFiat.buy.amountLabel')),
+            ).toBeOnTheScreen();
+            expect(
+                getByText(getTranslation('moduleTrading.selectFiat.sell.amountLabel')),
+            ).toBeOnTheScreen();
 
-            expect(queryByText('Continue')).toBeNull();
-            expect(queryByText('Country of residence')).toBeNull();
-            expect(queryByText('Provider')).toBeNull();
+            expect(
+                queryByText(getTranslation('moduleTrading.tradingScreen.buttons.continue')),
+            ).toBeNull();
+            expect(
+                queryByText(getTranslation('tradingResidence.locationSettings.countryOfResidence')),
+            ).toBeNull();
+            expect(queryByText(getTranslation('moduleTrading.tradingScreen.provider'))).toBeNull();
         });
     });
 

--- a/suite-native/module-trading/src/components/sell/__tests__/SellTab.test.tsx
+++ b/suite-native/module-trading/src/components/sell/__tests__/SellTab.test.tsx
@@ -1,4 +1,5 @@
 import { mockMessageSystemStateWithFeatureFlags } from '@suite-common/message-system/mocks';
+import { getTranslation } from '@suite-native/intl';
 import { act } from '@suite-native/test-utils-store';
 
 import { renderWithTradingProvider } from '../../../__tests__/tradingTestUtils';
@@ -48,7 +49,13 @@ describe('SellTab', () => {
             messageSystem: mockMessageSystemStateWithFeatureFlags({ 'trading.sell': false }),
         });
 
-        expect(getByText('Sell disabled')).toBeOnTheScreen();
+        expect(
+            getByText(
+                getTranslation('tradingAtoms.error.tradingTypeDisabledTitle', {
+                    tradingType: 'Sell',
+                }),
+            ),
+        ).toBeOnTheScreen();
     });
 
     it('should display Portfolio Tracker info with Portfolio Tracker "wallet" selected', async () => {
@@ -57,7 +64,9 @@ describe('SellTab', () => {
         mockIsDeviceInViewOnlyMode = true;
         const { getByText, queryByText } = await renderSellTab({});
 
-        expect(getByText('Portfolio Tracker')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('tradingAtoms.error.portfolioTrackerTitle')),
+        ).toBeOnTheScreen();
         expect(queryByText('View-only wallet')).toBeNull();
     });
 
@@ -65,12 +74,12 @@ describe('SellTab', () => {
         mockIsDeviceInViewOnlyMode = true;
         const { getByText } = await renderSellTab({});
 
-        expect(getByText('Select asset')).toBeOnTheScreen();
+        expect(getByText(getTranslation('moduleTrading.selectCoin.buttonTitle'))).toBeOnTheScreen();
     });
 
     it('should display form otherwise', async () => {
         const { getByText } = await renderSellTab({});
 
-        expect(getByText('Select asset')).toBeOnTheScreen();
+        expect(getByText(getTranslation('moduleTrading.selectCoin.buttonTitle'))).toBeOnTheScreen();
     });
 });

--- a/suite-native/module-trading/src/components/sell/__tests__/SellTabContent.test.tsx
+++ b/suite-native/module-trading/src/components/sell/__tests__/SellTabContent.test.tsx
@@ -1,3 +1,4 @@
+import { getTranslation } from '@suite-native/intl';
 import { act, screen, userEvent } from '@suite-native/test-utils-store';
 
 import { renderWithTradingProvider } from '../../../__tests__/tradingTestUtils';
@@ -34,11 +35,15 @@ describe('SellTabContent', () => {
     };
 
     const expectSellForm = () => {
-        expect(screen.getByText('You pay')).toBeOnTheScreen();
+        expect(
+            screen.getByText(getTranslation('moduleTrading.selectFiat.sell.title')),
+        ).toBeOnTheScreen();
     };
 
     const expectServerOffline = () => {
-        expect(screen.getByText("It's not you, it's us.")).toBeOnTheScreen();
+        expect(
+            screen.getByText(getTranslation('tradingAtoms.error.serverOfflineTitle')),
+        ).toBeOnTheScreen();
     };
 
     it('should render Sell skeleton when isLoading is true', () => {
@@ -104,7 +109,7 @@ describe('SellTabContent', () => {
 
         const { getByText } = renderSellTabContent();
 
-        const reloadButton = getByText('Try again');
+        const reloadButton = getByText(getTranslation('tradingAtoms.error.serverOfflineRetry'));
 
         await act(async () => {
             await userEvent.press(reloadButton);

--- a/suite-native/module-trading/src/components/sell/fiat/__tests__/SellFiatAmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/__tests__/SellFiatAmountInput.test.tsx
@@ -1,4 +1,5 @@
 import { Form } from '@suite-native/forms';
+import { getTranslation } from '@suite-native/intl';
 import { userEvent } from '@suite-native/test-utils-store';
 import { type SellFormType } from '@suite-native/trading-types';
 
@@ -30,7 +31,10 @@ describe('SellFiatAmountInput', () => {
         const form = renderUseTradingSellForm();
         const { getByLabelText } = renderFiatAmountInput(form);
 
-        await userEvent.type(getByLabelText('You get'), '100');
+        await userEvent.type(
+            getByLabelText(getTranslation('moduleTrading.selectFiat.sell.amountLabel')),
+            '100',
+        );
 
         expect(form.getValues('fiatStringAmount')).toEqual('100');
     });
@@ -39,27 +43,40 @@ describe('SellFiatAmountInput', () => {
         const form = renderUseTradingSellForm();
         const { getByLabelText } = renderFiatAmountInput(form);
 
-        await userEvent.type(getByLabelText('You get'), 'asd1.123');
+        await userEvent.type(
+            getByLabelText(getTranslation('moduleTrading.selectFiat.sell.amountLabel')),
+            'asd1.123',
+        );
 
         expect(form.getValues('fiatStringAmount')).toEqual('1.123');
-        expect(getByLabelText('You get')).toHaveDisplayValue('1.123');
+        expect(
+            getByLabelText(getTranslation('moduleTrading.selectFiat.sell.amountLabel')),
+        ).toHaveDisplayValue('1.123');
     });
 
     it('should always escape non-numeric characters', async () => {
         const form = renderUseTradingSellForm();
         const { getByLabelText } = renderFiatAmountInput(form);
 
-        await userEvent.type(getByLabelText('You get'), 'asd');
+        await userEvent.type(
+            getByLabelText(getTranslation('moduleTrading.selectFiat.sell.amountLabel')),
+            'asd',
+        );
 
         expect(form.getValues('fiatStringAmount')).toBeUndefined();
-        expect(getByLabelText('You get')).toHaveDisplayValue('');
+        expect(
+            getByLabelText(getTranslation('moduleTrading.selectFiat.sell.amountLabel')),
+        ).toHaveDisplayValue('');
     });
 
     it('should limit value to 3 decimals', async () => {
         const form = renderUseTradingSellForm();
         const { getByLabelText } = renderFiatAmountInput(form);
 
-        await userEvent.type(getByLabelText('You get'), '1.0123456789');
+        await userEvent.type(
+            getByLabelText(getTranslation('moduleTrading.selectFiat.sell.amountLabel')),
+            '1.0123456789',
+        );
 
         expect(form.getValues('fiatStringAmount')).toEqual('1.012');
     });

--- a/suite-native/module-trading/src/components/sell/fiat/__tests__/SellFiatCurrencyPicker.test.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/__tests__/SellFiatCurrencyPicker.test.tsx
@@ -1,5 +1,6 @@
 import { type useListDataFilter } from '@suite-common/trading';
 import { Form } from '@suite-native/forms';
+import { getTranslation } from '@suite-native/intl';
 import {
     act,
     fireEvent,
@@ -48,19 +49,23 @@ describe('SellFiatCurrencyPicker', () => {
     it('should display selected currency', () => {
         const { getByLabelText } = renderFiatCurrencyPicker();
 
-        expect(getByLabelText('Select fiat currency')).toHaveTextContent(/USD/);
+        expect(
+            getByLabelText(getTranslation('moduleTrading.selectFiat.buttonTitle')),
+        ).toHaveTextContent(/USD/);
     });
 
     it('should allow to select currency', async () => {
         const { getByText, getByLabelText } = renderFiatCurrencyPicker();
 
-        fireEvent.press(getByLabelText('Select fiat currency'));
+        fireEvent.press(getByLabelText(getTranslation('moduleTrading.selectFiat.buttonTitle')));
         fireEvent.press(getByText('PLN'));
 
         // wait for validators to run
         await act(() => Promise.resolve());
 
-        expect(getByLabelText('Select fiat currency')).toHaveTextContent(/PLN/);
+        expect(
+            getByLabelText(getTranslation('moduleTrading.selectFiat.buttonTitle')),
+        ).toHaveTextContent(/PLN/);
     });
 
     it('should display empty component when filtered data is empty', () => {
@@ -72,9 +77,11 @@ describe('SellFiatCurrencyPicker', () => {
 
         const { getByText } = renderFiatCurrencyPicker();
 
-        expect(getByText('Currency not found')).toBeTruthy();
         expect(
-            getByText('Check the spelling or browse the list to select an option.'),
+            getByText(getTranslation('moduleTrading.fiatCurrencySheet.emptyTitle')),
+        ).toBeTruthy();
+        expect(
+            getByText(getTranslation('moduleTrading.fiatCurrencySheet.emptyDescription')),
         ).toBeTruthy();
     });
 });

--- a/suite-native/module-trading/src/components/sell/fiat/__tests__/SellReceiveMethodPicker.test.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/__tests__/SellReceiveMethodPicker.test.tsx
@@ -67,7 +67,9 @@ describe('SellReceiveMethodPicker', () => {
             wallet: { trading: { sell: { isLoading: true } } },
         });
 
-        expect(getByLabelText('Searching for your best offer...')).toBeOnTheScreen();
+        expect(
+            getByLabelText(getTranslation('moduleTrading.tradingScreen.quotesLoadingLabel')),
+        ).toBeOnTheScreen();
     });
 
     it('should render "Not selected" when no quote is selected', () => {
@@ -75,7 +77,9 @@ describe('SellReceiveMethodPicker', () => {
             wallet: { trading: { sell: { quotes: sellQuotes } } },
         });
 
-        expect(getByLabelText('No receive method selected')).toHaveTextContent('Not selected');
+        expect(
+            getByLabelText(getTranslation('moduleTrading.tradingScreen.noReceiveMethod')),
+        ).toHaveTextContent(getTranslation('moduleTrading.notSelected'));
     });
 
     describe('with quotes loaded', () => {
@@ -92,7 +96,9 @@ describe('SellReceiveMethodPicker', () => {
         it('should render selected receive method', () => {
             const { getByLabelText, getByTestId } = renderSellReceiveMethodPicker(withQuotes);
 
-            expect(getByLabelText('Selected receive method')).toHaveTextContent('Bank Transfer');
+            expect(
+                getByLabelText(getTranslation('moduleTrading.tradingScreen.selectedReceiveMethod')),
+            ).toHaveTextContent(getTranslation('moduleTrading.paymentMethods.bankTransfer'));
 
             const picker = getByTestId('@trading/sell/receive-method-picker');
             expect(within(picker).getByTestId('@icons/payment-method-icon/bank')).toBeTruthy();
@@ -103,18 +109,20 @@ describe('SellReceiveMethodPicker', () => {
                 wallet: { trading: { sell: { quotes: sellQuotes, isLoading: true } } },
             });
 
-            expect(getByLabelText('Searching for your best offer...')).toBeOnTheScreen();
+            expect(
+                getByLabelText(getTranslation('moduleTrading.tradingScreen.quotesLoadingLabel')),
+            ).toBeOnTheScreen();
         });
 
         it('should allow to select receive method', () => {
             const { getByText, getByLabelText } = renderSellReceiveMethodPicker(withQuotes);
 
-            fireEvent.press(getByText('Receive method'));
+            fireEvent.press(getByText(getTranslation('moduleTrading.tradingScreen.receiveMethod')));
             fireEvent.press(getByText(creditCardPaymentMethodTranslation));
 
-            expect(getByLabelText('Selected receive method')).toHaveTextContent(
-                creditCardPaymentMethodTranslation,
-            );
+            expect(
+                getByLabelText(getTranslation('moduleTrading.tradingScreen.selectedReceiveMethod')),
+            ).toHaveTextContent(creditCardPaymentMethodTranslation);
         });
 
         describe('analytics', () => {
@@ -125,7 +133,9 @@ describe('SellReceiveMethodPicker', () => {
             it('should fire analytics event on receive method select', () => {
                 const { getByText } = renderSellReceiveMethodPicker(withQuotes);
 
-                fireEvent.press(getByText('Receive method'));
+                fireEvent.press(
+                    getByText(getTranslation('moduleTrading.tradingScreen.receiveMethod')),
+                );
                 fireEvent.press(getByText(creditCardPaymentMethodTranslation));
 
                 expect(reportMock).toHaveBeenCalledWith({
@@ -140,8 +150,18 @@ describe('SellReceiveMethodPicker', () => {
             it('should not fire analytics event when same receive method is selected', () => {
                 const { getAllByText } = renderSellReceiveMethodPicker(withQuotes);
 
-                fireEvent.press(getIndexOrThrow(getAllByText('Bank Transfer'), 0));
-                fireEvent.press(getIndexOrThrow(getAllByText('Bank Transfer'), 1));
+                fireEvent.press(
+                    getIndexOrThrow(
+                        getAllByText(getTranslation('moduleTrading.paymentMethods.bankTransfer')),
+                        0,
+                    ),
+                );
+                fireEvent.press(
+                    getIndexOrThrow(
+                        getAllByText(getTranslation('moduleTrading.paymentMethods.bankTransfer')),
+                        1,
+                    ),
+                );
 
                 expect(reportMock).toHaveBeenCalledTimes(0);
             });

--- a/suite-native/module-trading/src/components/sell/payment/__tests__/SellProviderPicker.test.tsx
+++ b/suite-native/module-trading/src/components/sell/payment/__tests__/SellProviderPicker.test.tsx
@@ -1,6 +1,7 @@
 import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
 import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import { Form } from '@suite-native/forms';
+import { getTranslation } from '@suite-native/intl';
 import {
     act,
     fireEvent,
@@ -62,7 +63,9 @@ describe('SellProviderPicker', () => {
             wallet: { trading: { sell: { isLoading: true } } },
         });
 
-        expect(getByLabelText('Searching for your best offer...')).toBeOnTheScreen();
+        expect(
+            getByLabelText(getTranslation('moduleTrading.tradingScreen.quotesLoadingLabel')),
+        ).toBeOnTheScreen();
     });
 
     describe('with quotes loaded', () => {
@@ -81,22 +84,28 @@ describe('SellProviderPicker', () => {
                 wallet: { trading: { sell: { quotes: sellQuotes, isLoading: true } } },
             });
 
-            expect(getByLabelText('Searching for your best offer...')).toBeOnTheScreen();
+            expect(
+                getByLabelText(getTranslation('moduleTrading.tradingScreen.quotesLoadingLabel')),
+            ).toBeOnTheScreen();
         });
 
         it('should render selected payment provider', () => {
             const { getByLabelText } = renderSellProviderPicker(withQuotes);
 
-            expect(getByLabelText('Selected provider')).toHaveTextContent('Banxa');
+            expect(
+                getByLabelText(getTranslation('moduleTrading.tradingScreen.selectedProvider')),
+            ).toHaveTextContent('Banxa');
         });
 
         it('should allow to select provider', () => {
             const { getByText, getByLabelText } = renderSellProviderPicker(withQuotes);
 
-            fireEvent.press(getByText('Provider'));
+            fireEvent.press(getByText(getTranslation('moduleTrading.tradingScreen.provider')));
             fireEvent.press(getByText('MoonPay'));
 
-            expect(getByLabelText('Selected provider')).toHaveTextContent('MoonPay');
+            expect(
+                getByLabelText(getTranslation('moduleTrading.tradingScreen.selectedProvider')),
+            ).toHaveTextContent('MoonPay');
         });
 
         describe('analytics', () => {
@@ -107,7 +116,7 @@ describe('SellProviderPicker', () => {
             it('should fire analytics event on provider select', () => {
                 const { getByText } = renderSellProviderPicker(withQuotes);
 
-                fireEvent.press(getByText('Provider'));
+                fireEvent.press(getByText(getTranslation('moduleTrading.tradingScreen.provider')));
                 fireEvent.press(getByText('MoonPay'));
 
                 expect(reportMock).toHaveBeenCalledTimes(2);
@@ -146,7 +155,7 @@ describe('SellProviderPicker', () => {
                     wallet: { trading: { sell: { quotes: sellQuotes, isLoading: true } } },
                 });
 
-                fireEvent.press(getByText('Provider'));
+                fireEvent.press(getByText(getTranslation('moduleTrading.tradingScreen.provider')));
 
                 expect(reportMock).not.toHaveBeenCalled();
             });

--- a/suite-native/module-trading/src/components/sell/send/__tests__/SellSendAmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/sell/send/__tests__/SellSendAmountInput.test.tsx
@@ -1,6 +1,7 @@
 import { type Account, type TokenAddress } from '@suite-common/wallet-types';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { Form } from '@suite-native/forms';
+import { getTranslation } from '@suite-native/intl';
 import { act, userEvent } from '@suite-native/test-utils-store';
 import { btcAsset, usdcAsset } from '@suite-native/trading-fixtures';
 import { type SellFormType } from '@suite-native/trading-types';
@@ -60,7 +61,10 @@ describe('SellSendAmountInput', () => {
         });
         const { getByLabelText } = renderCryptoAmountInput({}, form);
 
-        await userEvent.type(getByLabelText('You pay'), '100');
+        await userEvent.type(
+            getByLabelText(getTranslation('moduleTrading.selectCoinToSell.amountLabel')),
+            '100',
+        );
 
         expect(form.getValues('cryptoStringAmount')).toEqual('100');
     });
@@ -69,7 +73,9 @@ describe('SellSendAmountInput', () => {
         const form = renderUseTradingSellForm();
         const { getByLabelText } = renderCryptoAmountInput({}, form);
 
-        expect(getByLabelText('You pay')).toBeDisabled();
+        expect(
+            getByLabelText(getTranslation('moduleTrading.selectCoinToSell.amountLabel')),
+        ).toBeDisabled();
     });
 
     it('should call showAssetsSheet when disabled and pressed', async () => {
@@ -77,7 +83,9 @@ describe('SellSendAmountInput', () => {
         const form = renderUseTradingSellForm();
         const { getByLabelText } = renderCryptoAmountInput({ showAssetsSheet }, form);
 
-        await userEvent.press(getByLabelText('You pay'));
+        await userEvent.press(
+            getByLabelText(getTranslation('moduleTrading.selectCoinToSell.amountLabel')),
+        );
 
         expect(showAssetsSheet).toHaveBeenCalledTimes(1);
     });
@@ -90,7 +98,9 @@ describe('SellSendAmountInput', () => {
         });
         const { getByLabelText } = renderCryptoAmountInput({ showAssetsSheet }, form);
 
-        await userEvent.press(getByLabelText('You pay'));
+        await userEvent.press(
+            getByLabelText(getTranslation('moduleTrading.selectCoinToSell.amountLabel')),
+        );
 
         expect(showAssetsSheet).not.toHaveBeenCalled();
     });
@@ -102,10 +112,15 @@ describe('SellSendAmountInput', () => {
         });
         const { getByLabelText } = renderCryptoAmountInput({}, form);
 
-        await userEvent.type(getByLabelText('You pay'), 'asd1.123');
+        await userEvent.type(
+            getByLabelText(getTranslation('moduleTrading.selectCoinToSell.amountLabel')),
+            'asd1.123',
+        );
 
         expect(form.getValues('cryptoStringAmount')).toEqual('1.123');
-        expect(getByLabelText('You pay')).toHaveDisplayValue('1.123');
+        expect(
+            getByLabelText(getTranslation('moduleTrading.selectCoinToSell.amountLabel')),
+        ).toHaveDisplayValue('1.123');
     });
 
     it('should format input value to be integer when BTC asset is selected and value should be displayed in sats', async () => {
@@ -118,10 +133,15 @@ describe('SellSendAmountInput', () => {
         });
         const { getByLabelText } = renderCryptoAmountInput({}, form, overrides);
 
-        await userEvent.type(getByLabelText('You pay'), 'asd1.123');
+        await userEvent.type(
+            getByLabelText(getTranslation('moduleTrading.selectCoinToSell.amountLabel')),
+            'asd1.123',
+        );
 
         expect(form.getValues('cryptoStringAmount')).toEqual('1123');
-        expect(getByLabelText('You pay')).toHaveDisplayValue('1123');
+        expect(
+            getByLabelText(getTranslation('moduleTrading.selectCoinToSell.amountLabel')),
+        ).toHaveDisplayValue('1123');
     });
 
     it('should always escape non-numeric characters', async () => {
@@ -134,10 +154,15 @@ describe('SellSendAmountInput', () => {
         });
         const { getByLabelText } = renderCryptoAmountInput({}, form, overrides);
 
-        await userEvent.type(getByLabelText('You pay'), 'asd');
+        await userEvent.type(
+            getByLabelText(getTranslation('moduleTrading.selectCoinToSell.amountLabel')),
+            'asd',
+        );
 
         expect(form.getValues('cryptoStringAmount')).toBeUndefined();
-        expect(getByLabelText('You pay')).toHaveDisplayValue('');
+        expect(
+            getByLabelText(getTranslation('moduleTrading.selectCoinToSell.amountLabel')),
+        ).toHaveDisplayValue('');
     });
 
     it('should limit value to decimals based on useAmountInputDecimals return value', async () => {
@@ -152,7 +177,10 @@ describe('SellSendAmountInput', () => {
         });
         const { getByLabelText } = renderCryptoAmountInput({}, form);
 
-        await userEvent.type(getByLabelText('You pay'), '1.0123456789');
+        await userEvent.type(
+            getByLabelText(getTranslation('moduleTrading.selectCoinToSell.amountLabel')),
+            '1.0123456789',
+        );
 
         expect(form.getValues('cryptoStringAmount')).toEqual('1.01234567');
         expect(mockUseAmountInputDecimals).toHaveBeenLastCalledWith(
@@ -171,7 +199,9 @@ describe('SellSendAmountInput', () => {
 
         const { getByLabelText } = renderCryptoAmountInput({}, form, overrides);
 
-        expect(getByLabelText('Searching for your best offer...')).toBeTruthy();
+        expect(
+            getByLabelText(getTranslation('moduleTrading.tradingScreen.quotesLoadingLabel')),
+        ).toBeTruthy();
     });
 
     it('should not display loading skeleton when amountInCrypto is true', () => {
@@ -184,6 +214,8 @@ describe('SellSendAmountInput', () => {
 
         const { queryByLabelText } = renderCryptoAmountInput({}, form, overrides);
 
-        expect(queryByLabelText('Searching for your best offer...')).toBeNull();
+        expect(
+            queryByLabelText(getTranslation('moduleTrading.tradingScreen.quotesLoadingLabel')),
+        ).toBeNull();
     });
 });

--- a/suite-native/module-trading/src/components/settings/__tests__/MaxSlippageForm.test.tsx
+++ b/suite-native/module-trading/src/components/settings/__tests__/MaxSlippageForm.test.tsx
@@ -3,7 +3,7 @@ import { combineReducers } from '@reduxjs/toolkit';
 import { extraDependenciesCommonMock } from '@suite-common/test-utils';
 import { selectTradingMaxSlippagePercentage } from '@suite-common/trading';
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
-import { localeReducer } from '@suite-native/intl';
+import { getTranslation, localeReducer } from '@suite-native/intl';
 import {
     type TestStore,
     act,
@@ -49,7 +49,9 @@ describe('MaxSlippageForm', () => {
 
         expect(getByTestId(SLIPPAGE_INPUT_TEST_ID)).toHaveDisplayValue('1');
         expect(queryByText('Slippage must be between 0.01 and 50')).toBeNull();
-        expect(getByText('Confirm custom slippage')).toBeEnabled();
+        expect(
+            getByText(getTranslation('moduleTrading.advancedSettings.slippage.confirm')),
+        ).toBeEnabled();
     });
 
     it('should display validation error on invalid value', async () => {
@@ -59,7 +61,9 @@ describe('MaxSlippageForm', () => {
         await userEvent.type(getByTestId(SLIPPAGE_INPUT_TEST_ID), '999');
 
         expect(getByText('Slippage must be between 0.01 and 50')).toBeOnTheScreen();
-        expect(getByText('Confirm custom slippage')).toBeDisabled();
+        expect(
+            getByText(getTranslation('moduleTrading.advancedSettings.slippage.confirm')),
+        ).toBeDisabled();
     });
 
     it('should save slippage to store and call onSubmit', async () => {
@@ -70,7 +74,9 @@ describe('MaxSlippageForm', () => {
 
         await userEvent.clear(input);
         await userEvent.type(input, '20');
-        await userEvent.press(getByText('Confirm custom slippage'));
+        await userEvent.press(
+            getByText(getTranslation('moduleTrading.advancedSettings.slippage.confirm')),
+        );
 
         expect(selectTradingMaxSlippagePercentage(store.getState())).toBe('20');
         expect(onSubmit).toHaveBeenCalled();

--- a/suite-native/module-trading/src/screens/__tests__/TradingConfirmingScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingConfirmingScreen.test.tsx
@@ -279,7 +279,9 @@ describe('TradingConfirmingScreen', () => {
 
         const { getByText } = renderScreen();
 
-        expect(getByText('Date')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.tradingConfirmationScreen.date')),
+        ).toBeOnTheScreen();
     });
 
     it('should clear selected quote on back navigation', () => {

--- a/suite-native/module-trading/src/screens/__tests__/TradingExchangeApprovalScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingExchangeApprovalScreen.test.tsx
@@ -148,7 +148,9 @@ describe('TradingExchangeApprovalScreen', () => {
     it('should open bottom sheet when limit row is pressed', async () => {
         const { findByText } = renderScreen();
 
-        const pressableElement = await findByText('Limit');
+        const pressableElement = await findByText(
+            getTranslation('moduleTrading.tradingExchangeApprovalScreen.limitLabel'),
+        );
 
         fireEvent.press(pressableElement);
         expect(mockShowSheet).toHaveBeenCalledTimes(1);

--- a/suite-native/module-trading/src/screens/__tests__/TradingExchangePreviewScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingExchangePreviewScreen.test.tsx
@@ -334,7 +334,9 @@ describe('TradingExchangePreviewScreen', () => {
         const { result, reportMock } = renderTradingExchangePreviewScreen();
         reportMock.mockClear();
 
-        await userEvent.press(result.getByText('Continue'));
+        await userEvent.press(
+            result.getByText(getTranslation('moduleTrading.tradingScreen.buttons.continue')),
+        );
 
         expect(reportMock).toHaveBeenCalledTimes(1);
         expect(reportMock).toHaveBeenCalledWith({

--- a/suite-native/module-trading/src/screens/__tests__/TradingReceiveAccountsPickerScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingReceiveAccountsPickerScreen.test.tsx
@@ -2,6 +2,7 @@ import { type RouteProp } from '@react-navigation/native';
 
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
+import { getTranslation } from '@suite-native/intl';
 import { type RootStackParamList, type RootStackRoutes } from '@suite-native/navigation';
 import { accounts } from '@suite-native/trading-fixtures';
 
@@ -70,7 +71,7 @@ describe('TradingReceiveAccountsPickerScreen', () => {
 
         const { getByText } = renderScreen(overridesWithAccounts([]));
 
-        expect(getByText('Select account')).toBeTruthy();
+        expect(getByText(getTranslation('moduleTrading.accountScreen.titleStep1'))).toBeTruthy();
     });
 
     it('should render account list with accounts', () => {
@@ -94,7 +95,9 @@ describe('TradingReceiveAccountsPickerScreen', () => {
 
         const { getByText } = renderScreen(overridesWithAccounts([]));
 
-        expect(getByText('Account not found')).toBeTruthy();
+        expect(
+            getByText(getTranslation('moduleTrading.accountScreen.accountEmpty.viewOnly.title')),
+        ).toBeTruthy();
     });
 
     it('should render add account button', () => {
@@ -102,6 +105,8 @@ describe('TradingReceiveAccountsPickerScreen', () => {
 
         const { getByText } = renderScreen(overridesWithAccounts([]));
 
-        expect(getByText('Add new')).toBeTruthy();
+        expect(
+            getByText(getTranslation('moduleAddAccounts.coinDiscoveryFinishedScreen.addButton')),
+        ).toBeTruthy();
     });
 });

--- a/suite-native/module-trading/src/screens/__tests__/TradingScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingScreen.test.tsx
@@ -1,4 +1,5 @@
 import { mockMessageSystemStateWithFeatureFlags } from '@suite-common/message-system/mocks';
+import { getTranslation } from '@suite-native/intl';
 
 import {
     type PreloadedStatePartial,
@@ -86,6 +87,8 @@ describe('TradingScreen', () => {
             featureFlags: createTradingFeatureFlags({}),
         });
 
-        expect(getByText('You pay')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.selectFiat.buy.amountLabel')),
+        ).toBeOnTheScreen();
     });
 });

--- a/suite-native/module-trading/src/screens/__tests__/TradingSellPreviewScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingSellPreviewScreen.test.tsx
@@ -100,9 +100,15 @@ describe('TradingSellPreviewScreen', () => {
             wallet: { trading: { sell: { selectedQuote: banxaCreditCardSellQuote } } },
         });
 
-        expect(getByText('Sell')).toBeOnTheScreen();
-        expect(getByText('To')).toBeOnTheScreen();
-        expect(getByText('Credit/Debit Card')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.tradingSellPreviewScreen.title')),
+        ).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.tradingExchangePreviewScreen.toAccount')),
+        ).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.paymentMethods.creditCard')),
+        ).toBeOnTheScreen();
     });
 
     it('should call doBankAccountVerificationCheck on mount', async () => {
@@ -120,7 +126,9 @@ describe('TradingSellPreviewScreen', () => {
         });
 
         // Should render with selectedQuote
-        expect(getByText('To')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.tradingExchangePreviewScreen.toAccount')),
+        ).toBeOnTheScreen();
     });
 
     it('should use trade data when available', async () => {
@@ -149,7 +157,9 @@ describe('TradingSellPreviewScreen', () => {
         });
 
         // Should render with trade data
-        expect(getByText('To')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.tradingExchangePreviewScreen.toAccount')),
+        ).toBeOnTheScreen();
     });
 
     it('should render SellPreviewContinueButton with correct props', async () => {
@@ -159,7 +169,9 @@ describe('TradingSellPreviewScreen', () => {
 
         // SellPreviewContinueButton should be rendered (it's part of the screen)
         // We can verify by checking that the screen renders without errors
-        expect(getByText('To')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('moduleTrading.tradingExchangePreviewScreen.toAccount')),
+        ).toBeOnTheScreen();
     });
 
     it('should call fetchFeesAndCompose when quote has SEND_CRYPTO status on mount', async () => {

--- a/suite-native/trading-atoms/src/components/Error/__tests__/ServerOffline.test.tsx
+++ b/suite-native/trading-atoms/src/components/Error/__tests__/ServerOffline.test.tsx
@@ -1,3 +1,4 @@
+import { getTranslation } from '@suite-native/intl';
 import { act, fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
 
 import { ServerOffline, type ServerOfflineProps } from '../ServerOffline';
@@ -10,7 +11,7 @@ describe('ServerOffline', () => {
         const retryPressMock = jest.fn();
         const { getByText } = renderServerOffline({ onRetryPress: retryPressMock });
 
-        const retryButton = getByText('Try again');
+        const retryButton = getByText(getTranslation('tradingAtoms.error.serverOfflineRetry'));
 
         act(() => {
             fireEvent.press(retryButton);

--- a/suite-native/trading-atoms/src/components/TradeInfo/TradeInfoHeader.tsx
+++ b/suite-native/trading-atoms/src/components/TradeInfo/TradeInfoHeader.tsx
@@ -7,11 +7,14 @@ import { TradeInfoRow } from './TradeInfoRow';
 type TradeInfoHeaderProps = {
     title: ReactNode;
     rightContent?: ReactNode;
+    testID?: string;
 };
 
-export const TradeInfoHeader = ({ title, rightContent }: TradeInfoHeaderProps) => (
+export const TradeInfoHeader = ({ title, rightContent, testID }: TradeInfoHeaderProps) => (
     <TradeInfoRow noBorder>
-        <Text variant="body-sm">{title}</Text>
+        <Text variant="body-sm" testID={testID}>
+            {title}
+        </Text>
         {rightContent}
     </TradeInfoRow>
 );

--- a/suite-native/trading-atoms/src/components/__tests__/AmountEditingDoneButton.test.tsx
+++ b/suite-native/trading-atoms/src/components/__tests__/AmountEditingDoneButton.test.tsx
@@ -1,5 +1,6 @@
 import { Keyboard } from 'react-native';
 
+import { getTranslation } from '@suite-native/intl';
 import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
 
 import { AmountEditingDoneButton } from '../AmountEditingDoneButton';
@@ -9,7 +10,7 @@ describe('AmountEditingDoneButton', () => {
         const keyboardDismissSpy = jest.spyOn(Keyboard, 'dismiss');
         const { getByText } = renderWithBasicProvider(<AmountEditingDoneButton />);
 
-        fireEvent.press(getByText('Done'));
+        fireEvent.press(getByText(getTranslation('generic.buttons.done')));
 
         expect(keyboardDismissSpy).toHaveBeenCalledTimes(1);
     });

--- a/suite-native/trading-atoms/src/components/__tests__/BottomSheetSearchInputWithCancel.test.tsx
+++ b/suite-native/trading-atoms/src/components/__tests__/BottomSheetSearchInputWithCancel.test.tsx
@@ -1,4 +1,5 @@
 import { type BottomSheetSearchInputProps } from '@suite-native/atoms';
+import { getTranslation } from '@suite-native/intl';
 import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
 
 import { BottomSheetSearchInputWithCancel } from '../BottomSheetSearchInputWithCancel';
@@ -24,7 +25,7 @@ describe('SearchInputWithCancel', () => {
     it('should render without "Cancel" button by default', async () => {
         const { queryByText } = await renderSearchInputWithCancel({});
 
-        expect(queryByText('Cancel')).toBeNull();
+        expect(queryByText(getTranslation('generic.buttons.cancel'))).toBeNull();
     });
 
     it('should call onChange callback when text is typed', () => {
@@ -46,7 +47,7 @@ describe('SearchInputWithCancel', () => {
 
         fireEvent(getByPlaceholderText('Search'), 'focus');
 
-        expect(getByText('Cancel')).toBeTruthy();
+        expect(getByText(getTranslation('generic.buttons.cancel'))).toBeTruthy();
         expect(focusMock).toHaveBeenCalledTimes(1);
     });
 
@@ -68,7 +69,7 @@ describe('SearchInputWithCancel', () => {
         });
 
         fireEvent(getByPlaceholderText('Search'), 'focus');
-        fireEvent.press(getByText('Cancel'));
+        fireEvent.press(getByText(getTranslation('generic.buttons.cancel')));
 
         expect(onChangeMock).toHaveBeenCalledWith('');
     });

--- a/suite-native/trading-atoms/src/components/__tests__/NetworkBadge.test.tsx
+++ b/suite-native/trading-atoms/src/components/__tests__/NetworkBadge.test.tsx
@@ -1,4 +1,5 @@
 import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { getTranslation } from '@suite-native/intl';
 import { renderWithBasicProvider } from '@suite-native/test-utils';
 
 import { NetworkBadge } from '../NetworkBadge';
@@ -10,6 +11,8 @@ describe('NetworkBadge', () => {
     it('should render badge with platform name', () => {
         const { getByLabelText } = renderPlatformBadge('eth');
 
-        expect(getByLabelText('Network name')).toHaveTextContent('Ethereum');
+        expect(getByLabelText(getTranslation('moduleTrading.networkName'))).toHaveTextContent(
+            'Ethereum',
+        );
     });
 });

--- a/suite-native/trading-browser-auth/src/components/__tests__/ConfirmationFailed.test.tsx
+++ b/suite-native/trading-browser-auth/src/components/__tests__/ConfirmationFailed.test.tsx
@@ -1,3 +1,4 @@
+import { getTranslation } from '@suite-native/intl';
 import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
 
 import { ConfirmationFailed } from '../ConfirmationFailed';
@@ -17,7 +18,13 @@ describe('ConfirmationFailed', () => {
     it('should navigate back on button press', () => {
         const { getByText } = renderConfirmationFailed();
 
-        fireEvent.press(getByText('Start a new sell'));
+        fireEvent.press(
+            getByText(
+                getTranslation(
+                    'moduleTrading.tradingSellPreviewScreen.providerStatus.cannotBeCompletedAlert.button',
+                ),
+            ),
+        );
 
         expect(mockNavigateBack).toHaveBeenCalledTimes(1);
     });

--- a/suite-native/trading-browser-auth/src/components/__tests__/ProviderConfirmationStatusInfo.test.tsx
+++ b/suite-native/trading-browser-auth/src/components/__tests__/ProviderConfirmationStatusInfo.test.tsx
@@ -1,3 +1,4 @@
+import { getTranslation } from '@suite-native/intl';
 import { renderWithBasicProvider } from '@suite-native/test-utils';
 import { type ProviderConfirmationStatus } from '@suite-native/trading-types';
 
@@ -29,9 +30,22 @@ describe('ProviderConfirmationStatusInfo', () => {
     );
 
     it.each<[string, ProviderConfirmationStatus]>([
-        ['Provider is confirming your sell', 'window_closed_incomplete'],
-        ['Waiting for the provider’s receive address', 'window_closed_with_success'],
-        ['Your sell couldn’t be completed', 'confirmation_failed'],
+        [
+            getTranslation('moduleTrading.tradingSellPreviewScreen.providerStatus.confirming'),
+            'window_closed_incomplete',
+        ],
+        [
+            getTranslation(
+                'moduleTrading.tradingSellPreviewScreen.providerStatus.waitingForAddress',
+            ),
+            'window_closed_with_success',
+        ],
+        [
+            getTranslation(
+                'moduleTrading.tradingSellPreviewScreen.providerStatus.cannotBeCompletedAlert.title',
+            ),
+            'confirmation_failed',
+        ],
     ])(
         'should render "%s" when providerConfirmationStatus is [%s]',
         (expectedTitle, providerConfirmationStatus) => {

--- a/suite-native/trading-history/src/components/TradeDetailSheet/__tests__/TradeDetailFooter.test.tsx
+++ b/suite-native/trading-history/src/components/TradeDetailSheet/__tests__/TradeDetailFooter.test.tsx
@@ -1,4 +1,5 @@
 import { type TradingTransaction } from '@suite-common/trading';
+import { getTranslation } from '@suite-native/intl';
 import { fireEvent, renderWithStoreProvider } from '@suite-native/test-utils-store';
 import { getInitializedTradingState, getSellTrade } from '@suite-native/trading-fixtures';
 
@@ -44,11 +45,11 @@ describe('TradeDetailFooter', () => {
             { preloadedState },
         );
 
-        fireEvent.press(getByText('Copy'));
+        fireEvent.press(getByText(getTranslation('generic.buttons.copy')));
 
         expect(mockCopyToClipboard).toHaveBeenCalledWith(
             sellTrade.data.orderId!,
-            'Saved to clipboard',
+            getTranslation('generic.savedToClipboard'),
         );
     });
 });

--- a/suite-native/trading-history/src/components/TradeDetailSheet/__tests__/TradeDetailHeader.test.tsx
+++ b/suite-native/trading-history/src/components/TradeDetailSheet/__tests__/TradeDetailHeader.test.tsx
@@ -1,4 +1,5 @@
 import { type TradingTransaction } from '@suite-common/trading';
+import { getTranslation } from '@suite-native/intl';
 import {
     getBuyTrade,
     getExchangeTrade,
@@ -58,35 +59,47 @@ describe('TradeDetailHeader', () => {
             const buyTrade = getBuyTrade({ status: 'ERROR' });
             const { getByText } = renderHeader(buyTrade.data.orderId!, [buyTrade]);
 
-            expect(getByText('Transaction failed')).toBeTruthy();
+            expect(
+                getByText(getTranslation('moduleTrading.tradeHistory.detail.errorAlert.title')),
+            ).toBeTruthy();
         });
 
         it('should render waiting alert for buy trade submitted status', () => {
             const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
             const { getByText } = renderHeader(buyTrade.data.orderId!, [buyTrade]);
 
-            expect(getByText('Waiting for your payment ...')).toBeTruthy();
+            expect(
+                getByText(getTranslation('moduleTrading.tradeHistory.detail.waitingAlert.title')),
+            ).toBeTruthy();
         });
 
         it('should render converting alert for exchange converting status', () => {
             const exchangeTrade = getExchangeTrade({ status: 'CONVERTING' });
             const { getByText } = renderHeader(exchangeTrade.data.orderId!, [exchangeTrade]);
 
-            expect(getByText('Converting your crypto...')).toBeTruthy();
+            expect(
+                getByText(
+                    getTranslation('moduleTrading.tradeHistory.detail.convertingAlert.title'),
+                ),
+            ).toBeTruthy();
         });
 
         it('should render kyc alert for exchange kyc status', () => {
             const exchangeTrade = getExchangeTrade({ status: 'KYC' });
             const { getByText } = renderHeader(exchangeTrade.data.orderId!, [exchangeTrade]);
 
-            expect(getByText('KYC is required')).toBeTruthy();
+            expect(
+                getByText(getTranslation('moduleTrading.tradeHistory.detail.kycAlert.title')),
+            ).toBeTruthy();
         });
 
         it('should render sending alert for exchange sending status', () => {
             const exchangeTrade = getExchangeTrade({ status: 'SENDING' });
             const { getByText } = renderHeader(exchangeTrade.data.orderId!, [exchangeTrade]);
 
-            expect(getByText('Sending your crypto...')).toBeTruthy();
+            expect(
+                getByText(getTranslation('moduleTrading.tradeHistory.detail.sendingAlert.title')),
+            ).toBeTruthy();
         });
     });
 });

--- a/suite-native/trading-history/src/components/TradeDetailSheet/__tests__/TradeDetailTransactionInfo.test.tsx
+++ b/suite-native/trading-history/src/components/TradeDetailSheet/__tests__/TradeDetailTransactionInfo.test.tsx
@@ -1,4 +1,5 @@
 import type { TradingTransaction } from '@suite-common/trading';
+import { getTranslation } from '@suite-native/intl';
 import {
     MOCK_ACCOUNT_DEVICE_SESSION_ID,
     accounts,
@@ -89,7 +90,9 @@ describe('TradeDetailTransactionInfo', () => {
 
         expect(getByText('$1,234.00')).toBeTruthy();
         expect(getByText('0.462586 ETH')).toBeTruthy();
-        expect(queryByText('From')).toBeNull();
+        expect(
+            queryByText(getTranslation('moduleTrading.tradeHistory.detail.fromAccount')),
+        ).toBeNull();
     });
 
     it('should render correct account name for buy trade', () => {
@@ -148,7 +151,7 @@ describe('TradeDetailTransactionInfo', () => {
 
         const { getAllByText } = renderComponent(exchangeTrade.data.orderId!, overridesState);
 
-        expect(getAllByText('Unknown')).toHaveLength(2);
+        expect(getAllByText(getTranslation('generic.unknown'))).toHaveLength(2);
     });
 
     it('should render sell trade transaction info correctly', () => {
@@ -161,7 +164,9 @@ describe('TradeDetailTransactionInfo', () => {
 
         expect(getByText('1.22 BTC')).toBeTruthy();
         expect(getByText('$100.00')).toBeTruthy();
-        expect(queryByText('From')).toBeTruthy();
+        expect(
+            queryByText(getTranslation('moduleTrading.tradeHistory.detail.fromAccount')),
+        ).toBeTruthy();
     });
 
     it('should render correct account name for sell trade', () => {

--- a/suite-native/trading-history/src/components/TradeHistoryListItem/__tests__/TradeHistoryListItem.test.tsx
+++ b/suite-native/trading-history/src/components/TradeHistoryListItem/__tests__/TradeHistoryListItem.test.tsx
@@ -1,4 +1,5 @@
 import { type TradingTransaction } from '@suite-common/trading';
+import { getTranslation } from '@suite-native/intl';
 import { getBuyTrade } from '@suite-native/trading-fixtures';
 
 import { renderWithTradingHistoryProvider } from '../../../__tests__/tradingHistoryTestUtils';
@@ -18,8 +19,16 @@ describe('TradeHistoryListItem', () => {
         expect(getByText('Mercuryo')).toBeTruthy();
         expect(getByText('$1,234.00')).toBeTruthy();
         expect(getByText('0.462586 ETH')).toBeTruthy();
-        expect(getByText('Trans. ID: d3ef3451-8f68-4250-9e08-580ece5e7d12')).toBeTruthy();
-        expect(getByText('Submitted')).toBeTruthy();
+        expect(
+            getByText(
+                getTranslation('moduleTrading.tradeHistory.transactionId', {
+                    orderId: 'd3ef3451-8f68-4250-9e08-580ece5e7d12',
+                }),
+            ),
+        ).toBeTruthy();
+        expect(
+            getByText(getTranslation('moduleTrading.tradeHistory.status.submitted')),
+        ).toBeTruthy();
     });
 
     it('should render date and time', () => {

--- a/suite-native/trading-history/src/components/__tests__/TradingHistory.test.tsx
+++ b/suite-native/trading-history/src/components/__tests__/TradingHistory.test.tsx
@@ -1,3 +1,4 @@
+import { getTranslation } from '@suite-native/intl';
 import { fireEvent } from '@suite-native/test-utils-store';
 import { accounts, getBuyTrade } from '@suite-native/trading-fixtures';
 
@@ -85,11 +86,17 @@ describe('TradingHistoryScreen', () => {
     it('should show bottom sheet when trade item is clicked', () => {
         const { getByText, queryAllByText } = renderTradingHistory();
 
-        fireEvent.press(getByText('Trans. ID: d3ef3451-8f68-4250-9e08-580ece5e7d12'));
+        fireEvent.press(
+            getByText(
+                getTranslation('moduleTrading.tradeHistory.transactionId', {
+                    orderId: 'd3ef3451-8f68-4250-9e08-580ece5e7d12',
+                }),
+            ),
+        );
 
         expect(mockShowSheet).toHaveBeenCalledTimes(1);
 
-        expect(getByText('You paid')).toBeTruthy();
+        expect(getByText(getTranslation('moduleTrading.tradeHistory.detail.paid'))).toBeTruthy();
         // one for history list and one for detail in sheet
         expect(queryAllByText('0.462586 ETH').length).toBe(2);
     });

--- a/suite-native/trading-residence/src/components/__tests__/OnboardingButtons.test.tsx
+++ b/suite-native/trading-residence/src/components/__tests__/OnboardingButtons.test.tsx
@@ -1,7 +1,7 @@
 import { combineReducers } from '@reduxjs/toolkit';
 
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
-import { localeReducer } from '@suite-native/intl';
+import { getTranslation, localeReducer } from '@suite-native/intl';
 import {
     type TestStore,
     createLightStore,
@@ -44,8 +44,12 @@ describe('OnboardingButtons', () => {
     it('should render correctly', () => {
         const { getByText } = renderOnboardingButtons({ afterPress: () => {} });
 
-        expect(getByText('Confirm location')).toBeOnTheScreen();
-        expect(getByText('Not now')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('tradingResidence.locationSettings.confirmButton')),
+        ).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('tradingResidence.locationSettings.skipButton')),
+        ).toBeOnTheScreen();
 
         // make sure preconditions are met
         expect(selectTradingResidenceCountry(store.getState())).toBeUndefined();
@@ -56,7 +60,9 @@ describe('OnboardingButtons', () => {
         const afterPressMock = jest.fn();
         const { getByText } = renderOnboardingButtons({ afterPress: afterPressMock });
 
-        fireEvent.press(getByText('Confirm location'));
+        fireEvent.press(
+            getByText(getTranslation('tradingResidence.locationSettings.confirmButton')),
+        );
 
         // from expo-localization mock
         expect(selectTradingResidenceCountry(store.getState())).toBe('PL');
@@ -68,7 +74,7 @@ describe('OnboardingButtons', () => {
         const afterPressMock = jest.fn();
         const { getByText } = renderOnboardingButtons({ afterPress: afterPressMock });
 
-        fireEvent.press(getByText('Not now'));
+        fireEvent.press(getByText(getTranslation('tradingResidence.locationSettings.skipButton')));
 
         expect(selectTradingResidenceCountry(store.getState())).toBeUndefined();
         expect(selectWasTradingResidenceOnboardingVisited(store.getState())).toBe(true);

--- a/suite-native/trading-residence/src/components/__tests__/SkipButton.test.tsx
+++ b/suite-native/trading-residence/src/components/__tests__/SkipButton.test.tsx
@@ -1,3 +1,4 @@
+import { getTranslation } from '@suite-native/intl';
 import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
 
 import { SkipButton, type SkipButtonProps } from '../SkipButton';
@@ -20,14 +21,14 @@ describe('SkipButton', () => {
         const onPressMock = jest.fn();
 
         const { getByText } = renderSkipButton({ onPress: onPressMock });
-        fireEvent.press(getByText('Not now'));
+        fireEvent.press(getByText(getTranslation('tradingResidence.locationSettings.skipButton')));
 
         expect(onPressMock).toHaveBeenCalled();
     });
 
     it('should log cancel event on press', () => {
         const { getByText } = renderSkipButton({});
-        fireEvent.press(getByText('Not now'));
+        fireEvent.press(getByText(getTranslation('tradingResidence.locationSettings.skipButton')));
 
         expect(mockAnalyticsReport).toHaveBeenCalledTimes(1);
         expect(mockAnalyticsReport).toHaveBeenCalledWith('cancel');

--- a/suite-native/trading-residence/src/components/__tests__/TradingAvailability.test.tsx
+++ b/suite-native/trading-residence/src/components/__tests__/TradingAvailability.test.tsx
@@ -1,3 +1,4 @@
+import { getTranslation } from '@suite-native/intl';
 import { renderWithBasicProvider } from '@suite-native/test-utils';
 
 import { TradingAvailability } from '../TradingAvailability';
@@ -16,7 +17,9 @@ describe('TradingAvailability', () => {
 
         const { getByText } = renderTradingAvailability();
 
-        expect(getByText("Trading isn't available")).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('tradingResidence.locationSettings.tradingUnavailable')),
+        ).toBeOnTheScreen();
     });
 
     it('should render positive message when selected country is whitelisted', () => {
@@ -24,6 +27,8 @@ describe('TradingAvailability', () => {
 
         const { getByText } = renderTradingAvailability();
 
-        expect(getByText('Trading is available')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('tradingResidence.locationSettings.tradingAvailable')),
+        ).toBeOnTheScreen();
     });
 });

--- a/suite-native/trading-residence/src/components/__tests__/TradingLocationSettings.test.tsx
+++ b/suite-native/trading-residence/src/components/__tests__/TradingLocationSettings.test.tsx
@@ -59,8 +59,12 @@ describe('TradingLocationSettings', () => {
         });
 
         expect(getByText('Test Children')).toBeOnTheScreen();
-        expect(getByText('Trading is available')).toBeOnTheScreen();
-        expect(getByText('Country of residence')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('tradingResidence.locationSettings.tradingAvailable')),
+        ).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('tradingResidence.locationSettings.countryOfResidence')),
+        ).toBeOnTheScreen();
         expect(getByText('POL')).toBeOnTheScreen();
     });
 

--- a/suite-native/trading-residence/src/screens/__tests__/SettingsTradingLocationScreen.test.tsx
+++ b/suite-native/trading-residence/src/screens/__tests__/SettingsTradingLocationScreen.test.tsx
@@ -5,7 +5,7 @@ import { messageSystemInitialState } from '@suite-common/message-system';
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
 import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
 import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
-import { localeReducer } from '@suite-native/intl';
+import { getTranslation, localeReducer } from '@suite-native/intl';
 import { type SettingsStackParamList, type SettingsStackRoutes } from '@suite-native/navigation';
 import {
     createLightStore,
@@ -65,17 +65,25 @@ describe('TradingLocationSettingsScreen', () => {
     it('should render all components', () => {
         const { getByText, queryByText, getByLabelText } = renderTradingLocationSettingsScreen();
 
-        expect(getByText('Trading is now available')).toBeOnTheScreen();
-        expect(getByText('Confirm location')).toBeOnTheScreen();
-        expect(queryByText('Not now')).toBeNull();
+        expect(
+            getByText(getTranslation('tradingResidence.locationSettings.title')),
+        ).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('tradingResidence.locationSettings.confirmButton')),
+        ).toBeOnTheScreen();
+        expect(
+            queryByText(getTranslation('tradingResidence.locationSettings.skipButton')),
+        ).toBeNull();
 
-        expect(getByLabelText('Go back')).toBeOnTheScreen();
+        expect(getByLabelText(getTranslation('generic.buttons.goBack'))).toBeOnTheScreen();
     });
 
     it('should goBack on `Confirm location` press', async () => {
         const { getByText } = renderTradingLocationSettingsScreen();
 
-        await userEvent.press(getByText('Confirm location'));
+        await userEvent.press(
+            getByText(getTranslation('tradingResidence.locationSettings.confirmButton')),
+        );
 
         expect(mockNavigationGoBack).toHaveBeenCalledTimes(1);
     });
@@ -83,7 +91,9 @@ describe('TradingLocationSettingsScreen', () => {
     it('should log analytics event on country change', async () => {
         const { getByText } = renderTradingLocationSettingsScreen();
 
-        await userEvent.press(getByText('Country of residence'));
+        await userEvent.press(
+            getByText(getTranslation('tradingResidence.locationSettings.countryOfResidence')),
+        );
         await userEvent.press(getByText('Argentina'));
 
         expect(reportMock).toHaveBeenCalledTimes(1);
@@ -99,7 +109,7 @@ describe('TradingLocationSettingsScreen', () => {
     it('should go back and log analytics event on back button press', async () => {
         const { getByLabelText } = renderTradingLocationSettingsScreen();
 
-        await userEvent.press(getByLabelText('Go back'));
+        await userEvent.press(getByLabelText(getTranslation('generic.buttons.goBack')));
 
         expect(reportMock).toHaveBeenCalledTimes(1);
         expect(reportMock).toHaveBeenCalledWith({

--- a/suite-native/trading-residence/src/screens/__tests__/TradingLocationModalScreen.test.tsx
+++ b/suite-native/trading-residence/src/screens/__tests__/TradingLocationModalScreen.test.tsx
@@ -5,7 +5,7 @@ import { messageSystemInitialState } from '@suite-common/message-system';
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
 import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
 import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
-import { localeReducer } from '@suite-native/intl';
+import { getTranslation, localeReducer } from '@suite-native/intl';
 import { type RootStackParamList, RootStackRoutes } from '@suite-native/navigation';
 import {
     createLightStore,
@@ -83,17 +83,25 @@ describe('TradingLocationModalScreen', () => {
     it('should render all components', () => {
         const { getByText, queryByLabelText } = renderTradingLocationModalScreen();
 
-        expect(getByText('Trading is now available')).toBeOnTheScreen();
-        expect(getByText('Confirm location')).toBeOnTheScreen();
-        expect(getByText('Not now')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('tradingResidence.locationSettings.title')),
+        ).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('tradingResidence.locationSettings.confirmButton')),
+        ).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('tradingResidence.locationSettings.skipButton')),
+        ).toBeOnTheScreen();
 
-        expect(queryByLabelText('Go back')).toBeNull();
+        expect(queryByLabelText(getTranslation('generic.buttons.goBack'))).toBeNull();
     });
 
     it('should log analytics event on country change', async () => {
         const { getByText } = renderTradingLocationModalScreen();
 
-        await userEvent.press(getByText('Country of residence'));
+        await userEvent.press(
+            getByText(getTranslation('tradingResidence.locationSettings.countryOfResidence')),
+        );
         await userEvent.press(getByText('Argentina'));
 
         expect(reportMock).toHaveBeenCalledTimes(1);
@@ -109,7 +117,9 @@ describe('TradingLocationModalScreen', () => {
     it('should reset navigation on button press', async () => {
         const { getByText } = renderTradingLocationModalScreen();
 
-        await userEvent.press(getByText('Not now'));
+        await userEvent.press(
+            getByText(getTranslation('tradingResidence.locationSettings.skipButton')),
+        );
 
         expect(mockNavigationDispatch).toHaveBeenCalledTimes(1);
         expect(mockNavigationDispatch).toHaveBeenCalledWith({

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputItemList.test.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputItemList.test.tsx
@@ -1,4 +1,5 @@
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
+import { getTranslation } from '@suite-native/intl';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 
 import {
@@ -57,28 +58,48 @@ describe('ReviewOutputItemList', () => {
             accountKey: mockAccountKey({ symbol: 'btc', descriptor: 'btcAccount3' }),
         });
 
-        expect(getByText('Error: Account not found.')).toBeOnTheScreen();
+        expect(
+            getByText(`Error: ${getTranslation('transactionManagement.review.outputs.noAccount')}`),
+        ).toBeOnTheScreen();
     });
 
     it('should render outputs list', () => {
         const { getByText } = renderReviewOutputItemList({});
 
-        expect(getByText('Recipient address')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('transactionManagement.review.outputs.addressLabel')),
+        ).toBeOnTheScreen();
         expect(getByText('abcd efgh ijkl mnop qrst uvwx')).toBeOnTheScreen();
-        expect(getByText('TimeBounds')).toBeOnTheScreen();
-        expect(getByText('No restriction')).toBeOnTheScreen();
-        expect(getByText('Amount')).toBeOnTheScreen();
-        expect(getByText('Maximum fee')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('transactionManagement.review.outputs.timeboundsLabel')),
+        ).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('transactionManagement.review.outputs.timeboundsNotSet')),
+        ).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('transactionManagement.review.outputs.amountLabel')),
+        ).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('transactionManagement.review.outputs.summary.maxFee')),
+        ).toBeOnTheScreen();
     });
 
     it('should render empty list when reviewOutputs are undefined', () => {
         mockSelectTransactionReviewOutputsFromDraftReturnValue = null;
         const { queryByText } = renderReviewOutputItemList({});
 
-        expect(queryByText('Recipient address')).toBeNull();
-        expect(queryByText('TimeBounds')).toBeNull();
-        expect(queryByText('Amount')).toBeNull();
-        expect(queryByText('Maximum fee')).toBeNull();
+        expect(
+            queryByText(getTranslation('transactionManagement.review.outputs.addressLabel')),
+        ).toBeNull();
+        expect(
+            queryByText(getTranslation('transactionManagement.review.outputs.timeboundsLabel')),
+        ).toBeNull();
+        expect(
+            queryByText(getTranslation('transactionManagement.review.outputs.amountLabel')),
+        ).toBeNull();
+        expect(
+            queryByText(getTranslation('transactionManagement.review.outputs.summary.maxFee')),
+        ).toBeNull();
     });
 
     describe('SlidingFooterOverlay', () => {

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputSummaryItem.test.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputSummaryItem.test.tsx
@@ -1,5 +1,6 @@
 import { type TokenAddress } from '@suite-common/wallet-types';
 import { Text as MockText } from '@suite-native/atoms';
+import { getTranslation } from '@suite-native/intl';
 import { renderWithBasicProvider } from '@suite-native/test-utils';
 
 import { ETH_ACCOUNT_KEY } from '../../../__fixtures__/walletState';
@@ -48,7 +49,9 @@ describe('ReviewOutputSummaryItem', () => {
             },
         });
 
-        expect(getByText('Total including fee')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('transactionManagement.review.outputs.summary.label')),
+        ).toBeOnTheScreen();
 
         // note that this test mocks the ReviewOutputItemValues component
         expect(
@@ -73,7 +76,9 @@ describe('ReviewOutputSummaryItem', () => {
             symbol: 'eth',
         });
 
-        expect(getByText('Total including fee')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('transactionManagement.review.outputs.summary.label')),
+        ).toBeOnTheScreen();
 
         // note that this test mocks the ReviewOutputItemValues component
         expect(
@@ -126,7 +131,9 @@ describe('ReviewOutputSummaryItem', () => {
             tokenContract: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as TokenAddress,
         });
 
-        expect(getByText('Total including fee')).toBeOnTheScreen();
+        expect(
+            getByText(getTranslation('transactionManagement.review.outputs.summary.label')),
+        ).toBeOnTheScreen();
 
         // note that this test mocks the ReviewOutputItemValues component
         expect(

--- a/suite-native/transaction-management/src/components/fees/CustomFee/__tests__/CustomFee.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/__tests__/CustomFee.test.tsx
@@ -1,6 +1,7 @@
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type AccountKey, type FormState } from '@suite-common/wallet-types';
 import { Form } from '@suite-native/forms';
+import { getTranslation } from '@suite-native/intl';
 import {
     act,
     renderHookWithStoreProvider,
@@ -111,7 +112,9 @@ describe('CustomFee', () => {
         });
 
         expect(getByTestId('@transactionManagement/fees-level-custom')).toBeTruthy();
-        expect(getByText('Add custom fee')).toBeTruthy();
+        expect(
+            getByText(getTranslation('transactionManagement.fees.custom.addButton')),
+        ).toBeTruthy();
     });
 
     it('should render custom fee card when custom fee is selected', () => {
@@ -127,8 +130,8 @@ describe('CustomFee', () => {
         });
 
         expect(getByText(/Custom/)).toBeTruthy();
-        expect(getByText('Cancel')).toBeTruthy();
-        expect(getByText('Edit')).toBeTruthy();
+        expect(getByText(getTranslation('generic.buttons.cancel'))).toBeTruthy();
+        expect(getByText(getTranslation('generic.buttons.edit'))).toBeTruthy();
     });
 
     it('should not render for solana network', () => {
@@ -216,9 +219,13 @@ describe('CustomFee', () => {
             form,
         });
 
-        await userEvent.press(getByText('Edit'));
+        await userEvent.press(getByText(getTranslation('generic.buttons.edit')));
 
-        expect(getByText('Gas limit')).toBeTruthy();
+        expect(
+            getByText(
+                getTranslation('transactionManagement.fees.custom.bottomSheet.label.gasLimit'),
+            ),
+        ).toBeTruthy();
     });
 
     it('should handle different account keys', () => {

--- a/suite-native/transaction-management/src/components/fees/CustomFee/__tests__/CustomFeeCard.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/__tests__/CustomFeeCard.test.tsx
@@ -1,6 +1,7 @@
 import { type AccountKey } from '@suite-common/wallet-types';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { Form } from '@suite-native/forms';
+import { getTranslation } from '@suite-native/intl';
 import {
     renderHookWithStoreProvider,
     renderWithStoreProvider,
@@ -69,8 +70,8 @@ describe('CustomFeeCard', () => {
             });
 
             expect(getByText(/Custom/)).toBeTruthy();
-            expect(getByText('Cancel')).toBeTruthy();
-            expect(getByText('Edit')).toBeTruthy();
+            expect(getByText(getTranslation('generic.buttons.cancel'))).toBeTruthy();
+            expect(getByText(getTranslation('generic.buttons.edit'))).toBeTruthy();
         });
 
         it('should display fee amount correctly', () => {
@@ -112,7 +113,7 @@ describe('CustomFeeCard', () => {
                 form,
             });
 
-            await userEvent.press(getByText('Edit'));
+            await userEvent.press(getByText(getTranslation('generic.buttons.edit')));
 
             expect(defaultProps.onEdit).toHaveBeenCalledTimes(1);
         });
@@ -123,7 +124,7 @@ describe('CustomFeeCard', () => {
                 form,
             });
 
-            await userEvent.press(getByText('Cancel'));
+            await userEvent.press(getByText(getTranslation('generic.buttons.cancel')));
 
             expect(defaultProps.onCancel).toHaveBeenCalledTimes(1);
         });

--- a/suite-native/transaction-management/src/components/fees/CustomFee/__tests__/CustomFeeInputs.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/__tests__/CustomFeeInputs.test.tsx
@@ -1,6 +1,7 @@
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { Form } from '@suite-native/forms';
+import { getTranslation } from '@suite-native/intl';
 import {
     type TestStore,
     createStoreFromPreloadedState,
@@ -82,7 +83,11 @@ describe('CustomFeeInputs', () => {
             const { getByText, getByTestId } = renderCustomFeeInputs({
                 form,
             });
-            expect(getByText('Fee rate')).toBeTruthy();
+            expect(
+                getByText(
+                    getTranslation('transactionManagement.fees.custom.bottomSheet.label.feeRate'),
+                ),
+            ).toBeTruthy();
             expect(getByTestId('@transactionManagement/customFeePerUnit-input')).toBeTruthy();
         });
 
@@ -93,7 +98,11 @@ describe('CustomFeeInputs', () => {
                 props: { symbol: 'eth' },
             });
 
-            expect(getByText('Gas price')).toBeTruthy();
+            expect(
+                getByText(
+                    getTranslation('transactionManagement.fees.custom.bottomSheet.label.gasPrice'),
+                ),
+            ).toBeTruthy();
             expect(getByTestId('@transactionManagement/customFeePerUnit-input')).toBeTruthy();
         });
 
@@ -104,7 +113,11 @@ describe('CustomFeeInputs', () => {
                 props: { symbol: 'eth' },
             });
 
-            expect(getByText('Gas limit')).toBeTruthy();
+            expect(
+                getByText(
+                    getTranslation('transactionManagement.fees.custom.bottomSheet.label.gasLimit'),
+                ),
+            ).toBeTruthy();
             expect(getByTestId('@transactionManagement/customFeeLimit-input')).toBeTruthy();
         });
 
@@ -114,7 +127,11 @@ describe('CustomFeeInputs', () => {
                 form,
                 props: { symbol: 'btc' },
             });
-            expect(queryByText('Gas limit')).toBeNull();
+            expect(
+                queryByText(
+                    getTranslation('transactionManagement.fees.custom.bottomSheet.label.gasLimit'),
+                ),
+            ).toBeNull();
             expect(queryByTestId('@transactionManagement/customFeeLimit-input')).toBeNull();
         });
 
@@ -139,7 +156,13 @@ describe('CustomFeeInputs', () => {
                 form,
                 props: { symbol: 'btc' },
             });
-            expect(getByText('The minimum fee rate is 1 sat/vB')).toBeTruthy();
+            expect(
+                getByText(
+                    getTranslation('transactionManagement.fees.custom.bottomSheet.minimumLabel', {
+                        feePerUnit: '1 sat/vB',
+                    }),
+                ),
+            ).toBeTruthy();
         });
 
         it('should not show minimum fee hint for ethereum', () => {
@@ -148,7 +171,13 @@ describe('CustomFeeInputs', () => {
                 form,
                 props: { symbol: 'eth' },
             });
-            expect(queryByText('The minimum fee rate is 1 Gwei')).toBeNull();
+            expect(
+                queryByText(
+                    getTranslation('transactionManagement.fees.custom.bottomSheet.minimumLabel', {
+                        feePerUnit: '1 Gwei',
+                    }),
+                ),
+            ).toBeNull();
         });
     });
 });

--- a/suite-native/transaction-management/src/components/fees/__tests__/FeeSummaryCard.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/__tests__/FeeSummaryCard.test.tsx
@@ -1,3 +1,4 @@
+import { getTranslation } from '@suite-native/intl';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 
 import { getWalletState } from '../../../__fixtures__/walletState';
@@ -25,13 +26,17 @@ describe('FeeSummaryCard', () => {
     it('should render fee label for bitcoin', () => {
         const { getByText } = renderCard();
 
-        expect(getByText('Transaction fee')).toBeTruthy();
+        expect(
+            getByText(getTranslation('transactionManagement.fees.description.title.general')),
+        ).toBeTruthy();
     });
 
     it('should render ethereum-specific label for ethereum network', () => {
         const { getByText } = renderCard({ networkType: 'ethereum', symbol: 'eth' });
 
-        expect(getByText('Maximum fee')).toBeTruthy();
+        expect(
+            getByText(getTranslation('transactionManagement.fees.description.title.ethereum')),
+        ).toBeTruthy();
     });
 
     it('should render pressable card with testID', () => {

--- a/suite-native/transaction-management/src/components/fees/__tests__/FeesContent.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/__tests__/FeesContent.test.tsx
@@ -2,6 +2,7 @@ import { yup } from '@suite-common/validators';
 import { type FormState } from '@suite-common/wallet-types';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { Form, useForm } from '@suite-native/forms';
+import { getTranslation } from '@suite-native/intl';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 
 import { createFeeLevels } from '../../../__fixtures__/feeLevels';
@@ -77,9 +78,11 @@ describe('FeesContent', () => {
     it('should render title and description', () => {
         const { getByText } = renderFeesContent();
 
-        expect(getByText('Transaction fee')).toBeTruthy();
         expect(
-            getByText('Fees are paid directly to validators for processing your transactions.'),
+            getByText(getTranslation('transactionManagement.fees.description.title.general')),
+        ).toBeTruthy();
+        expect(
+            getByText(getTranslation('transactionManagement.fees.description.body')),
         ).toBeTruthy();
     });
 
@@ -126,7 +129,9 @@ describe('FeesContent', () => {
             symbol: 'eth',
         });
 
-        expect(getByText('Transaction fee')).toBeTruthy();
+        expect(
+            getByText(getTranslation('transactionManagement.fees.description.title.general')),
+        ).toBeTruthy();
     });
 
     it('should render with form draft data', () => {

--- a/suite-native/transaction-management/src/components/fees/__tests__/FeesFooter.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/__tests__/FeesFooter.test.tsx
@@ -3,6 +3,7 @@ import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type TokenAddress } from '@suite-common/wallet-types';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { Form, useForm } from '@suite-native/forms';
+import { getTranslation } from '@suite-native/intl';
 import {
     type TestStore,
     createStoreFromPreloadedState,
@@ -107,7 +108,7 @@ describe('FeesFooter', () => {
     it('should render mainnet summary when no token contract is provided', () => {
         const { getByText } = renderFeesFooter();
 
-        expect(getByText('Total amount')).toBeTruthy();
+        expect(getByText(getTranslation('transactionManagement.fees.totalAmount'))).toBeTruthy();
     });
 
     it('should render token summary when token contract is provided', () => {
@@ -115,8 +116,8 @@ describe('FeesFooter', () => {
             tokenContract: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as TokenAddress,
         });
 
-        expect(getByText('Amount')).toBeTruthy();
-        expect(getByText('Fee')).toBeTruthy();
+        expect(getByText(getTranslation('transactionManagement.fees.amount'))).toBeTruthy();
+        expect(getByText(getTranslation('transactions.detail.feeLabel'))).toBeTruthy();
     });
 
     it('should display total amount correctly', () => {
@@ -190,7 +191,7 @@ describe('FeesFooter', () => {
             withSubmitButton: true,
         });
 
-        expect(getByText('Review and sign')).toBeTruthy();
+        expect(getByText(getTranslation('transactionManagement.fees.submitButton'))).toBeTruthy();
     });
 
     it.each([
@@ -202,7 +203,9 @@ describe('FeesFooter', () => {
         props => {
             const { queryByText } = renderFeesFooter(props);
 
-            expect(queryByText('Review and sign')).toBeNull();
+            expect(
+                queryByText(getTranslation('transactionManagement.fees.submitButton')),
+            ).toBeNull();
         },
     );
 
@@ -212,6 +215,6 @@ describe('FeesFooter', () => {
             // withSubmitButton not provided, should default to true
         });
 
-        expect(getByText('Review and sign')).toBeTruthy();
+        expect(getByText(getTranslation('transactionManagement.fees.submitButton'))).toBeTruthy();
     });
 });


### PR DESCRIPTION
Use `getTranslation` utility everywhere

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=update-trading-translations-in-tests&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->