### PR TITLE
fix(suite): always show DeFi tab on EVM accounts

### DIFF
--- a/packages/suite/src/views/wallet/tokens/TokensNavigation.tsx
+++ b/packages/suite/src/views/wallet/tokens/TokensNavigation.tsx
@@ -34,6 +34,8 @@ type SubTabItem = {
 
 const getSubTabConfig = ({ isNft, tokens, goToRoute, networkType }: SubTabConfig) => {
     const [erc4626Tokens, normalTokens] = arrayPartition(tokens.shownWithBalance, isErc4626);
+    // DeFi section is relevant only for EVM networks, but there it is always available.
+    const showDefiTab = !isNft && networkType === 'ethereum';
 
     const baseConfig: SubTabItem[] = [
         {
@@ -43,7 +45,7 @@ const getSubTabConfig = ({ isNft, tokens, goToRoute, networkType }: SubTabConfig
             count: normalTokens.length,
             labelId: isNft ? 'TR_NAV_COLLECTIONS' : 'TR_NAV_TOKENS',
         },
-        ...(erc4626Tokens.length
+        ...(showDefiTab
             ? [
                   {
                       id: 'wallet-tokens-defi',

--- a/packages/suite/src/views/wallet/tokens/defi/DefiTokensTable.tsx
+++ b/packages/suite/src/views/wallet/tokens/defi/DefiTokensTable.tsx
@@ -15,6 +15,7 @@ import {
     sortTokensWithRates,
 } from 'src/utils/wallet/tokenUtils';
 
+import { NoTokens } from '../common/NoTokens';
 import { TokensTable } from '../common/TokensTable/TokensTable';
 
 interface DefiTokensTableProps {
@@ -55,20 +56,27 @@ export const DefiTokensTable = ({ selectedAccount, searchQuery }: DefiTokensTabl
         [enhancedTokens, account.symbol, coinDefinitions, searchQuery],
     );
 
+    const hasShownTokens =
+        tokens.shownWithBalance.length > 0 || tokens.shownWithoutBalance.length > 0;
+
     return (
         <Column gap={14}>
             <Banner intent="info" description={<Translation id="TR_DEFI_BANNER_TEXT" />} />
 
-            <TokensTable
-                type="defi"
-                account={account}
-                tokenStatusType={TokenManagementAction.HIDE}
-                tokensWithBalance={tokens.shownWithBalance}
-                tokensWithoutBalance={tokens.shownWithoutBalance}
-                network={network}
-                searchQuery={searchQuery}
-                yieldOpportunities={yieldOpportunities}
-            />
+            {hasShownTokens || searchQuery ? (
+                <TokensTable
+                    type="defi"
+                    account={account}
+                    tokenStatusType={TokenManagementAction.HIDE}
+                    tokensWithBalance={tokens.shownWithBalance}
+                    tokensWithoutBalance={tokens.shownWithoutBalance}
+                    network={network}
+                    searchQuery={searchQuery}
+                    yieldOpportunities={yieldOpportunities}
+                />
+            ) : (
+                <NoTokens title={<Translation id="TR_DEFI_TOKENS_EMPTY" />} />
+            )}
         </Column>
     );
 };

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -1788,6 +1788,10 @@ export const messages = defineMessages({
         defaultMessage:
             'These tokens represent your DeFi positions. Sending or swapping them will transfer ownership of those positions.',
     },
+    TR_DEFI_TOKENS_EMPTY: {
+        id: 'TR_DEFI_TOKENS_EMPTY',
+        defaultMessage: 'No DeFi tokens',
+    },
     TR_DEFI_YIELD_TOKEN_BANNER_TITLE: {
         id: 'TR_DEFI_YIELD_TOKEN_BANNER_TITLE',
         defaultMessage: '{token} represents your position in the vault.',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- defi table should be always visible even without tokens

## Related Issue

Resolve #28126

## Screenshots

<img width="1181" height="585" alt="Screenshot 2026-06-10 at 9 34 14" src="https://github.com/user-attachments/assets/6bfee201-a32b-44e4-820d-25a5f3765b37" />
<img width="1184" height="491" alt="Screenshot 2026-06-10 at 8 36 02" src="https://github.com/user-attachments/assets/ef80710b-dcb4-4e03-88db-4c24a6c1148b" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes touch wallet token navigation (TokensNavigation.tsx), a DeFi tokens table component (DefiTokensTable.tsx), and the internationalization messages file (messages.ts). The navigation component change poses the highest risk for breaking token-related trading entry points and route rendering. The messages.ts change is a broad shared file but likely only adds/modifies translation keys relevant to the token views. DefiTokensTable.tsx has no direct static test coverage, though the check-links test visits the /accounts/tokens/defi route. The recommended strategy is to run the trading navigation test as the primary validation, with the live swap and link-check tests as secondary coverage.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/views/wallet/tokens/TokensNavigation.tsx`
- `packages/suite/src/views/wallet/tokens/defi/DefiTokensTable.tsx`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — This test directly exercises navigation to Buy/Sell/Swap forms from various entry points including token-level trading links (openBuyTradingOfToken, openSellTradingOfToken, openSwapTradingOfToken). Changes to TokensNavigation.tsx could break these token-level navigation paths, and the test explicitly verifies that navigating from a specific token opens the correct trading form.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/trading-live/live-swap-coin-to-token.test.ts` — This live swap test is statically mapped to TokensNavigation.tsx and involves swapping between coins and tokens, which likely renders token navigation UI. However, as a live trading test it primarily exercises the swap flow rather than token navigation directly, so the risk is moderate.
- `suite/e2e/tests/general/check-links.test.ts` — This test visits all application routes including /accounts/tokens, /accounts/tokens/hidden, /accounts/tokens/inactive, and /accounts/tokens/defi. Changes to TokensNavigation.tsx (which likely renders navigation tabs for these token sub-routes) and DefiTokensTable.tsx (rendered on /accounts/tokens/defi) could cause these routes to fail to load properly. The test verifies page content elements are attached to the DOM for each route.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/views/wallet/tokens/defi/DefiTokensTable.tsx`
- `suite/intl/src/messages.ts`

_Updated: 2026-06-10T06:46:06.272Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/defi-table-visible&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/defi-table-visible&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-10T06:50:35.258Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add account types ada | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-10T06:48:35.232Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/defi-table-visible/web/](https://dev.suite.sldev.cz/suite-web/feat/defi-table-visible/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->