### PR TITLE
fix(guide): Support all banner intents in guide

### DIFF
--- a/packages/components/src/components/Markdown/Markdown.tsx
+++ b/packages/components/src/components/Markdown/Markdown.tsx
@@ -59,6 +59,16 @@ const StyledMarkdown = styled.div`
         }
     }
 
+    section[data-testid='guide-banner'] {
+        p {
+            margin: 0;
+        }
+
+        a {
+            color: inherit;
+        }
+    }
+
     img {
         max-width: 100%;
     }

--- a/packages/suite/src/components/guide/GuideHint.tsx
+++ b/packages/suite/src/components/guide/GuideHint.tsx
@@ -6,11 +6,20 @@ import {
     isValidElement,
 } from 'react';
 
-import { Banner } from '@trezor/components';
+import { Banner, type BannerIntent } from '@trezor/components';
 
-const BULB_EMOJI = '💡';
-const WARNING_EMOJI = '⚠️';
-const REGEX = new RegExp(`^(${BULB_EMOJI}|${WARNING_EMOJI})\\s*`);
+// The displayed Banner intent is determined by an emoji at the start of the markdown quote.
+// The mapping is exhaustive over BannerIntent so Guide hints support every Banner intent.
+const INTENT_EMOJI = {
+    brand: '💡',
+    info: 'ℹ️',
+    warning: '⚠️',
+    critical: '🚨',
+    neutral: '📝',
+} as const satisfies Record<BannerIntent, string>;
+
+const HINT_INTENTS = Object.keys(INTENT_EMOJI) as BannerIntent[];
+const EMOJI_REGEX = new RegExp(`^(${Object.values(INTENT_EMOJI).join('|')})\\s*`);
 
 // This is a hack to sneak a bit more complex component into the generated markup.
 // We use markdown quotes in the source to render hints and warnings in Guide.
@@ -27,13 +36,16 @@ export const GuideHint = ({ children }: BlockquoteHTMLAttributes<HTMLQuoteElemen
 
         return false;
     })?.filter(child => !!child);
-    const intent = message?.[0]?.startsWith(WARNING_EMOJI) ? 'warning' : 'brand';
+
+    const intent =
+        HINT_INTENTS.find(candidate => message?.[0]?.startsWith(INTENT_EMOJI[candidate])) ??
+        'brand';
 
     let updatedMessage: string[] | undefined;
     if (message?.[0]) {
         // Copy the array and mutate the first element so that it does not affect the original array nested in the children prop
         updatedMessage = [...message];
-        updatedMessage[0] = updatedMessage[0]?.replace(REGEX, '') ?? '';
+        updatedMessage[0] = updatedMessage[0]?.replace(EMOJI_REGEX, '') ?? '';
     } else {
         // If the object does not have the expected format, log an error but display the component anyway.
         console.error('Unexpected intent of Guide hint.');
@@ -51,5 +63,5 @@ export const GuideHint = ({ children }: BlockquoteHTMLAttributes<HTMLQuoteElemen
         return child;
     });
 
-    return <Banner icon intent={intent} description={clonedChildren} margin={{ bottom: 16 }} />;
+    return <Banner icon intent={intent} title={clonedChildren} margin={{ bottom: 16 }} />;
 };

--- a/packages/suite/src/components/guide/GuideHint.tsx
+++ b/packages/suite/src/components/guide/GuideHint.tsx
@@ -63,5 +63,13 @@ export const GuideHint = ({ children }: BlockquoteHTMLAttributes<HTMLQuoteElemen
         return child;
     });
 
-    return <Banner icon intent={intent} title={clonedChildren} margin={{ bottom: 16 }} />;
+    return (
+        <Banner
+            data-testid="guide-banner"
+            icon
+            intent={intent}
+            description={clonedChildren}
+            margin={{ bottom: 16 }}
+        />
+    );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

It's possible to show all banner intents in suite:

```
before:
> 💡 green
> ⚠️ yellow

now also:
> 📝 gray
> 🚨 red
> ℹ️ blue
```

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect two files: a shared Markdown rendering component and a GuideHint component within the Suite guide module. The Markdown component maps to 121 tests (extremely broad dependency), so only tests that specifically render markdown content in their core flow should be prioritized. The GuideHint component is guide-specific, making the suite-guide and guide tests the primary targets. The risk is low-to-moderate — a Markdown rendering regression would be most visible in guide article content, and a GuideHint issue would affect contextual help hints. Running the 2-3 guide-related tests provides high confidence with minimal test execution.

<details><summary><b>Changed files (2)</b></summary>

- `packages/components/src/components/Markdown/Markdown.tsx`
- `packages/suite/src/components/guide/GuideHint.tsx`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/general/suite-guide.test.ts` — GuideHint.tsx is a component in the guide module, and this test directly exercises the Suite Guide panel — opening it, navigating articles, searching, and submitting bug reports. The Markdown component is likely rendered when displaying guide article content. Changes to either file could break guide article rendering or layout.
- `suite/e2e/tests/suite/guide.test.ts` — This test covers opening the guide panel, navigating guide content nodes, viewing article details, submitting feedback, and searching — all of which directly exercise the guide UI where GuideHint.tsx is used. Markdown rendering of guide content means changes to Markdown.tsx are also directly exercised here.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/suite/bug-report-form.test.ts` — This test opens the Guide panel and navigates to Support and Feedback to submit a bug report. GuideHint.tsx is part of the guide component tree that renders in this flow, so changes there could affect the guide panel's rendering or interaction.

</details>

_Updated: 2026-06-10T08:49:21.386Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=support-all-intents-in-guide&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=support-all-intents-in-guide&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-10T08:54:01.947Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add account types ada | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-10T08:52:04.778Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/support-all-intents-in-guide/web/](https://dev.suite.sldev.cz/suite-web/support-all-intents-in-guide/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->