### PR TITLE
feat(analytics-docs): broaden Filter events search and add version fi…

### DIFF
--- a/packages/analytics-docs/src/App.tsx
+++ b/packages/analytics-docs/src/App.tsx
@@ -73,10 +73,15 @@ export const App = ({ theme }: AppProps) => {
         setQuery,
         setSort,
         setPlatform,
+        setVersion,
+        setSearchMode,
         clearAll,
         query,
         platform,
         sort,
+        version,
+        searchMode,
+        availableVersions,
         debouncedQuery,
         allEvents,
         isFiltering,
@@ -91,7 +96,7 @@ export const App = ({ theme }: AppProps) => {
         setIsSidebarLoading,
     } = useFilteredEvents();
 
-    const hasActiveFilters = !!query || platform !== 'all' || sort !== 'az';
+    const hasActiveFilters = !!query || platform !== 'all' || sort !== 'az' || version !== 'all';
 
     const versionsWithEvents = useMemo(
         () => getVersionsWithEvents(filteredEvents),
@@ -346,6 +351,11 @@ export const App = ({ theme }: AppProps) => {
                                     platform={platform}
                                     setSort={setSort}
                                     sort={sort}
+                                    version={version}
+                                    setVersion={setVersion}
+                                    versions={availableVersions}
+                                    searchMode={searchMode}
+                                    setSearchMode={setSearchMode}
                                 />
                             </Row>
                         </ContentContainer>

--- a/packages/analytics-docs/src/app/AnalyticsContent.tsx
+++ b/packages/analytics-docs/src/app/AnalyticsContent.tsx
@@ -59,7 +59,13 @@ export const AnalyticsContent = ({
 
     return (
         <Column gap={40}>
-            {eventCards}
+            {hasEventCards ? (
+                eventCards
+            ) : (
+                <Text typographyStyle="body-md" intent="neutral" priority="secondary">
+                    No matches in name, trigger, or attributes.
+                </Text>
+            )}
             {onContentReady && hasEventCards && <ScrollWhenReady onReady={onContentReady} />}
             {generatedAt && (
                 <Box>

--- a/packages/analytics-docs/src/components/EventCard.tsx
+++ b/packages/analytics-docs/src/components/EventCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 
 import {
     Badge,
@@ -174,7 +174,7 @@ type EventCardProps = {
     onEdit?: (event: EventDoc) => void;
 };
 
-export const EventCard = ({ event, onEdit }: EventCardProps) => (
+export const EventCard = memo(({ event, onEdit }: EventCardProps) => (
     <Card paddingType="small">
         <Header event={event} onEdit={onEdit} />
         <InfoItem label="Trigger" typographyStyle="body-xs">
@@ -193,4 +193,6 @@ export const EventCard = ({ event, onEdit }: EventCardProps) => (
 
         <AttributesTable attributes={event.attributes ?? {}} />
     </Card>
-);
+));
+
+EventCard.displayName = 'EventCard';

--- a/packages/analytics-docs/src/components/Filter.tsx
+++ b/packages/analytics-docs/src/components/Filter.tsx
@@ -82,6 +82,7 @@ export const Filter = ({
                                 isChecked={isFullText}
                                 onChange={checked => setSearchMode(checked ? 'fulltext' : 'name')}
                                 label="Fulltext search"
+                                size="small"
                             />
                         ),
                         closeOnClick: false,

--- a/packages/analytics-docs/src/components/Filter.tsx
+++ b/packages/analytics-docs/src/components/Filter.tsx
@@ -1,4 +1,13 @@
-import { Icon, IconButton, Input, Row, Select, useMediaQuery, variables } from '@trezor/components';
+import {
+    Dropdown,
+    Icon,
+    Input,
+    Row,
+    Select,
+    Switch,
+    useMediaQuery,
+    variables,
+} from '@trezor/components';
 import { zIndices } from '@trezor/theme';
 
 import { platforms, sorting } from '../constants';
@@ -59,36 +68,25 @@ export const Filter = ({
                         pointerEvents="none"
                     />
                 }
-                rightContent={
-                    isFullText ? (
-                        <IconButton
-                            icon="fileText"
-                            size="small"
-                            intent="neutral"
-                            priority="primary"
-                            onClick={() => setSearchMode('name')}
-                            aria-label="Toggle full-text search"
-                            tooltip={{
-                                content:
-                                    'Full-text search is ON — matching event name, trigger, descriptions, attributes and types. Click to search event titles only.',
-                            }}
-                        />
-                    ) : (
-                        <IconButton
-                            icon="fileText"
-                            size="small"
-                            intent="neutral"
-                            priority="secondary"
-                            onClick={() => setSearchMode('fulltext')}
-                            aria-label="Toggle full-text search"
-                            tooltip={{
-                                content:
-                                    'Full-text search is OFF — searching event titles only. Click to search everything (trigger, descriptions, attributes and types).',
-                            }}
-                        />
-                    )
-                }
                 onClear={() => setQuery('')}
+            />
+
+            <Dropdown
+                iconName="dotsThree"
+                iconSize="small"
+                data-testid="@analytics/search-options"
+                items={[
+                    {
+                        label: (
+                            <Switch
+                                isChecked={isFullText}
+                                onChange={checked => setSearchMode(checked ? 'fulltext' : 'name')}
+                                label="Fulltext search"
+                            />
+                        ),
+                        closeOnClick: false,
+                    },
+                ]}
             />
 
             <Select

--- a/packages/analytics-docs/src/components/Filter.tsx
+++ b/packages/analytics-docs/src/components/Filter.tsx
@@ -1,8 +1,8 @@
-import { Icon, Input, Row, Select, useMediaQuery, variables } from '@trezor/components';
+import { Icon, IconButton, Input, Row, Select, useMediaQuery, variables } from '@trezor/components';
 import { zIndices } from '@trezor/theme';
 
 import { platforms, sorting } from '../constants';
-import type { Sort } from '../types';
+import type { SearchMode, Sort } from '../types';
 
 const menuPortalTarget = typeof document !== 'undefined' ? document.body : undefined;
 
@@ -13,10 +13,34 @@ type FilterProps = {
     setPlatform: (query: string) => void;
     setSort: (sort: Sort) => void;
     sort: string;
+    version: string;
+    setVersion: (version: string) => void;
+    versions: string[];
+    searchMode: SearchMode;
+    setSearchMode: (mode: SearchMode) => void;
 };
 
-export const Filter = ({ query, setQuery, setPlatform, platform, setSort, sort }: FilterProps) => {
+export const Filter = ({
+    query,
+    setQuery,
+    setPlatform,
+    platform,
+    setSort,
+    sort,
+    version,
+    setVersion,
+    versions,
+    searchMode,
+    setSearchMode,
+}: FilterProps) => {
     const isMobile = useMediaQuery(`(max-width: ${variables.SCREEN_SIZE.SM})`);
+
+    const versionOptions = [
+        { value: 'all', label: 'All versions' },
+        ...versions.map(v => ({ value: v, label: v })),
+    ];
+
+    const isFullText = searchMode === 'fulltext';
 
     return (
         <Row gap={8} flexWrap={isMobile ? 'wrap' : undefined}>
@@ -35,6 +59,35 @@ export const Filter = ({ query, setQuery, setPlatform, platform, setSort, sort }
                         pointerEvents="none"
                     />
                 }
+                rightContent={
+                    isFullText ? (
+                        <IconButton
+                            icon="fileText"
+                            size="small"
+                            intent="neutral"
+                            priority="primary"
+                            onClick={() => setSearchMode('name')}
+                            aria-label="Toggle full-text search"
+                            tooltip={{
+                                content:
+                                    'Full-text search is ON — matching event name, trigger, descriptions, attributes and types. Click to search event titles only.',
+                            }}
+                        />
+                    ) : (
+                        <IconButton
+                            icon="fileText"
+                            size="small"
+                            intent="neutral"
+                            priority="secondary"
+                            onClick={() => setSearchMode('fulltext')}
+                            aria-label="Toggle full-text search"
+                            tooltip={{
+                                content:
+                                    'Full-text search is OFF — searching event titles only. Click to search everything (trigger, descriptions, attributes and types).',
+                            }}
+                        />
+                    )
+                }
                 onClear={() => setQuery('')}
             />
 
@@ -47,6 +100,18 @@ export const Filter = ({ query, setQuery, setPlatform, platform, setSort, sort }
                 aria-label="Platform filter"
                 size="small"
                 options={platforms}
+                menuPortalTarget={menuPortalTarget}
+                menuPortalZIndex={zIndices.pageHeader}
+            />
+            <Select
+                placeholder="Version"
+                value={versionOptions.find(v => v.value === version) ?? versionOptions[0]}
+                onChange={option => {
+                    setVersion(option.value);
+                }}
+                aria-label="Version filter"
+                size="small"
+                options={versionOptions}
                 menuPortalTarget={menuPortalTarget}
                 menuPortalZIndex={zIndices.pageHeader}
             />

--- a/packages/analytics-docs/src/types.ts
+++ b/packages/analytics-docs/src/types.ts
@@ -6,6 +6,8 @@ export type Sort = (typeof sorts)[number];
 export const platforms = ['desktop', 'mobile', 'shared'];
 export type Platform = (typeof platforms)[number];
 
+export type SearchMode = 'name' | 'fulltext';
+
 export const allPlatforms = [...platforms, 'all'];
 export type AllPlatform = (typeof allPlatforms)[number];
 

--- a/packages/analytics-docs/src/utils/__tests__/filterUtils.test.ts
+++ b/packages/analytics-docs/src/utils/__tests__/filterUtils.test.ts
@@ -1,7 +1,11 @@
 import type { EventDoc } from '../../types';
 import {
+    eventHasVersion,
+    eventMatchesFullText,
+    eventNameMatchesQuery,
     fuzzyMatch,
     fuzzyMatchExportName,
+    getAllVersions,
     getEventId,
     getVersionsWithEvents,
     toEventExportName,
@@ -79,6 +83,92 @@ describe('fuzzyMatchExportName', () => {
     });
 });
 
+const searchEvent = {
+    name: 'accounts/active-staking',
+    description: 'Tracks staking activity.',
+    descriptionTrigger: 'Fires when the user opens the staking dashboard.',
+    changelog: { entries: [] },
+    attributes: {
+        symbol: { description: 'Network symbol', changelog: { entries: [] } },
+        stakeAmount: { description: 'Amount staked in base units', changelog: { entries: [] } },
+        provider: {
+            description: 'Backup provider',
+            runtimeType: "'legacy'\n| 'dropbox'\n| 'suite-sync'",
+            changelog: { entries: [] },
+        },
+    },
+    platform: 'desktop',
+} as unknown as EventDoc;
+
+describe('eventNameMatchesQuery (simplified / titles only)', () => {
+    it('empty query matches everything', () => {
+        expect(eventNameMatchesQuery('', searchEvent)).toBe(true);
+        expect(eventNameMatchesQuery('   ', searchEvent)).toBe(true);
+    });
+
+    it('matches by event name', () => {
+        expect(eventNameMatchesQuery('accounts', searchEvent)).toBe(true);
+        expect(eventNameMatchesQuery('active staking', searchEvent)).toBe(true);
+    });
+
+    it('does NOT match terms that only appear in trigger / attributes', () => {
+        expect(eventNameMatchesQuery('user', searchEvent)).toBe(false);
+        expect(eventNameMatchesQuery('symbol', searchEvent)).toBe(false);
+        expect(eventNameMatchesQuery('suite-sync', searchEvent)).toBe(false);
+    });
+});
+
+describe('eventMatchesFullText (advanced / everything)', () => {
+    it('empty query matches everything', () => {
+        expect(eventMatchesFullText('', searchEvent)).toBe(true);
+        expect(eventMatchesFullText('   ', searchEvent)).toBe(true);
+    });
+
+    it('matches by event name', () => {
+        expect(eventMatchesFullText('accounts', searchEvent)).toBe(true);
+    });
+
+    it('matches a term in the Trigger description', () => {
+        expect(eventMatchesFullText('user', searchEvent)).toBe(true);
+        expect(eventMatchesFullText('dashboard', searchEvent)).toBe(true);
+    });
+
+    it('matches an attribute name', () => {
+        expect(eventMatchesFullText('symbol', searchEvent)).toBe(true);
+    });
+
+    it('matches an attribute description', () => {
+        expect(eventMatchesFullText('base units', searchEvent)).toBe(true);
+    });
+
+    it('matches a union member in an attribute runtime type', () => {
+        expect(eventMatchesFullText('suite-sync', searchEvent)).toBe(true);
+        expect(eventMatchesFullText('dropbox', searchEvent)).toBe(true);
+    });
+
+    it('matches the event description', () => {
+        expect(eventMatchesFullText('staking activity', searchEvent)).toBe(true);
+    });
+
+    it('is case-insensitive', () => {
+        expect(eventMatchesFullText('User', searchEvent)).toBe(
+            eventMatchesFullText('user', searchEvent),
+        );
+        expect(eventMatchesFullText('SYMBOL', searchEvent)).toBe(true);
+    });
+
+    it('returns false for a non-matching term', () => {
+        expect(eventMatchesFullText('nonexistentterm', searchEvent)).toBe(false);
+    });
+
+    it('multi-term query is token-AND across all searchable fields', () => {
+        // "user" (trigger) + "symbol" (attribute name) both present
+        expect(eventMatchesFullText('user symbol', searchEvent)).toBe(true);
+        // "user" present, "missing" absent
+        expect(eventMatchesFullText('user missing', searchEvent)).toBe(false);
+    });
+});
+
 describe('toEventExportName', () => {
     it('converts event name to export name', () => {
         expect(toEventExportName('accounts/active-staking')).toBe('accountsActiveStakingEvent');
@@ -92,6 +182,36 @@ describe('toEventExportName', () => {
 describe('getEventId', () => {
     it('produces safe DOM id from event name', () => {
         expect(getEventId('accounts/active-staking')).toBe('event-accounts-active-staking');
+    });
+});
+
+describe('version filtering', () => {
+    const eventA = {
+        name: 'accounts/active-staking',
+        descriptionTrigger: 'trigger',
+        changelog: { entries: [{ version: '1.2.0', notes: 'n' }] },
+        attributes: {
+            attr: { changelog: { entries: [{ version: '1.4.0', notes: 'n' }] } },
+        },
+        platform: 'desktop',
+    } as unknown as EventDoc;
+
+    const eventB = {
+        name: 'accounts/actions',
+        descriptionTrigger: 'trigger',
+        changelog: { entries: [{ version: '1.3.0', notes: 'n' }] },
+        attributes: {},
+        platform: 'desktop',
+    } as unknown as EventDoc;
+
+    it('getAllVersions returns distinct versions newest first', () => {
+        expect(getAllVersions([eventA, eventB])).toEqual(['1.4.0', '1.3.0', '1.2.0']);
+    });
+
+    it('eventHasVersion matches event and attribute changelog versions', () => {
+        expect(eventHasVersion(eventA, '1.2.0')).toBe(true); // event changelog
+        expect(eventHasVersion(eventA, '1.4.0')).toBe(true); // attribute changelog
+        expect(eventHasVersion(eventA, '1.3.0')).toBe(false);
     });
 });
 

--- a/packages/analytics-docs/src/utils/filterUtils.ts
+++ b/packages/analytics-docs/src/utils/filterUtils.ts
@@ -114,6 +114,65 @@ export const fuzzyMatchExportName = (query: string, exportName: string): boolean
     return true;
 };
 
+export const buildEventSearchHaystack = (e: EventDoc): string =>
+    [
+        e.name,
+        e.descriptionTrigger,
+        e.description,
+        ...Object.keys(e.attributes ?? {}),
+        ...Object.values(e.attributes ?? {}).flatMap(a => [a.description, a.runtimeType]),
+    ]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase();
+
+export const eventNameMatchesQuery = (query: string, e: EventDoc): boolean => {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) return true;
+
+    return (
+        fuzzyMatch(normalized, e.name) ||
+        fuzzyMatchExportName(normalized, toEventExportName(e.name))
+    );
+};
+
+export const eventMatchesFullText = (query: string, e: EventDoc): boolean => {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) return true;
+
+    const tokens = normalized.split(/\s+/).filter(Boolean);
+    const haystack = buildEventSearchHaystack(e);
+
+    return tokens.every(token => haystack.includes(token));
+};
+
+export const getEventVersions = (e: EventDoc): string[] => {
+    const versions = new Set<string>();
+
+    for (const entry of e.changelog?.entries ?? []) {
+        if (entry.version) versions.add(entry.version);
+    }
+    for (const attribute of Object.values(e.attributes ?? {})) {
+        for (const entry of attribute.changelog?.entries ?? []) {
+            if (entry.version) versions.add(entry.version);
+        }
+    }
+
+    return Array.from(versions);
+};
+
+export const eventHasVersion = (e: EventDoc, version: string): boolean =>
+    getEventVersions(e).includes(version);
+
+export const getAllVersions = (events: EventDoc[]): string[] => {
+    const versions = new Set<string>();
+    for (const e of events) {
+        for (const version of getEventVersions(e)) versions.add(version);
+    }
+
+    return Array.from(versions).sort(compareVersionsDesc);
+};
+
 export type VersionWithEvents = {
     version: string;
     events: EventDoc[];

--- a/packages/analytics-docs/src/utils/urlParams.ts
+++ b/packages/analytics-docs/src/utils/urlParams.ts
@@ -4,6 +4,7 @@ export type UrlParams = {
     query: string;
     platform: AllPlatform;
     sort: Sort;
+    version: string;
     sidebarOpen: boolean;
     liveLogOpen: boolean;
 };
@@ -20,6 +21,7 @@ export const getParamsFromUrl = (): UrlParams => {
         query: params.get('q') ?? '',
         platform: allPlatforms.includes(platformParam) ? platformParam : 'all',
         sort: sorts.includes(sortParam) ? sortParam : 'az',
+        version: params.get('version') ?? 'all',
         sidebarOpen: sidebarParam === 'true',
         liveLogOpen: liveLogParam === 'true',
     };
@@ -29,6 +31,7 @@ export const updateUrl = (
     query: string,
     platform: string,
     sort: string,
+    version: string,
     sidebarOpen?: boolean,
     liveLogOpen?: boolean,
 ): void => {
@@ -38,6 +41,7 @@ export const updateUrl = (
     if (query) params.set('q', query);
     if (platform !== 'all') params.set('platform', platform);
     if (sort !== 'az') params.set('sort', sort);
+    if (version !== 'all') params.set('version', version);
     if (sidebarOpen) params.set('sidebar', 'true');
     if (liveLogOpen) params.set('liveLog', 'true');
     const search = params.toString();

--- a/packages/analytics-docs/src/utils/useFilteredEvents.ts
+++ b/packages/analytics-docs/src/utils/useFilteredEvents.ts
@@ -2,19 +2,29 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { useDebounce } from '@trezor/react-utils';
 
-import type { Sort } from '../types';
+import type { SearchMode, Sort } from '../types';
 import {
     compareVersionsDesc,
-    fuzzyMatch,
-    fuzzyMatchExportName,
+    eventHasVersion,
+    eventMatchesFullText,
+    eventNameMatchesQuery,
+    getAllVersions,
     getEventAddedVersion,
     getEventUpdatedVersion,
     getEventsFromJson,
-    toEventExportName,
 } from './filterUtils';
 import { getParamsFromUrl, updateUrl } from './urlParams';
 
 const ANALYTICS_JSON_URL = `${import.meta.env.BASE_URL}analytics.json`;
+
+const SEARCH_MODE_STORAGE_KEY = 'analytics-docs:search-mode';
+
+const getInitialSearchMode = (): SearchMode => {
+    if (typeof window === 'undefined') return 'fulltext';
+    const stored = window.localStorage.getItem(SEARCH_MODE_STORAGE_KEY);
+
+    return stored === 'name' || stored === 'fulltext' ? stored : 'fulltext';
+};
 
 export const useFilteredEvents = () => {
     const initial = useMemo(getParamsFromUrl, []);
@@ -22,6 +32,8 @@ export const useFilteredEvents = () => {
     const [sort, setSort] = useState<Sort>(initial.sort);
     const [debouncedQuery, setDebouncedQuery] = useState(initial.query);
     const [platform, setPlatform] = useState<string>(initial.platform);
+    const [version, setVersion] = useState<string>(initial.version);
+    const [searchMode, setSearchMode] = useState<SearchMode>(getInitialSearchMode);
     const [isSidebarOpen, setIsSidebarOpen] = useState(initial.sidebarOpen);
     const [isLiveLogOpen, setIsLiveLogOpen] = useState(initial.liveLogOpen);
     const [isSidebarLoading, setIsSidebarLoading] = useState(false);
@@ -38,6 +50,7 @@ export const useFilteredEvents = () => {
     }, []);
 
     const allEvents = useMemo(() => getEventsFromJson(analyticsData ?? {}), [analyticsData]);
+    const availableVersions = useMemo(() => getAllVersions(allEvents), [allEvents]);
     const isAnalyticsDataGenerated =
         analyticsData !== null &&
         typeof analyticsData === 'object' &&
@@ -50,8 +63,16 @@ export const useFilteredEvents = () => {
     }, [query, debounce]);
 
     useEffect(() => {
-        updateUrl(debouncedQuery, platform, sort, isSidebarOpen, isLiveLogOpen);
-    }, [debouncedQuery, platform, sort, isSidebarOpen, isLiveLogOpen]);
+        updateUrl(debouncedQuery, platform, sort, version, isSidebarOpen, isLiveLogOpen);
+    }, [debouncedQuery, platform, sort, version, isSidebarOpen, isLiveLogOpen]);
+
+    useEffect(() => {
+        try {
+            window.localStorage.setItem(SEARCH_MODE_STORAGE_KEY, searchMode);
+        } catch {
+            return;
+        }
+    }, [searchMode]);
 
     useEffect(() => {
         const id = setTimeout(() => setIsSidebarLoading(false), 200);
@@ -70,18 +91,18 @@ export const useFilteredEvents = () => {
         const id = setTimeout(() => setIsPlatformSortFiltering(false), 300);
 
         return () => clearTimeout(id);
-    }, [debouncedQuery, platform, sort]);
+    }, [debouncedQuery, platform, sort, version]);
 
     const isFiltering = isPlatformSortFiltering;
 
     const filteredEvents = useMemo(() => {
         const byPlatformAndQuery = allEvents
             .filter(e => (platform === 'all' ? true : e.platform.includes(platform)))
+            .filter(e => (version === 'all' ? true : eventHasVersion(e, version)))
             .filter(e =>
-                normalizedQuery
-                    ? fuzzyMatch(normalizedQuery, e.name) ||
-                      fuzzyMatchExportName(normalizedQuery, toEventExportName(e.name))
-                    : true,
+                searchMode === 'fulltext'
+                    ? eventMatchesFullText(normalizedQuery, e)
+                    : eventNameMatchesQuery(normalizedQuery, e),
             );
 
         return byPlatformAndQuery.sort((a, b) => {
@@ -105,12 +126,13 @@ export const useFilteredEvents = () => {
 
             return an.localeCompare(bn);
         });
-    }, [allEvents, platform, normalizedQuery, sort]);
+    }, [allEvents, platform, version, normalizedQuery, sort, searchMode]);
 
     const clearAll = () => {
         setQuery('');
         setPlatform('all');
         setSort('az');
+        setVersion('all');
         setIsPlatformSortFiltering(true);
         setTimeout(() => setIsPlatformSortFiltering(false), 300);
     };
@@ -128,10 +150,15 @@ export const useFilteredEvents = () => {
         setQuery,
         setSort,
         setPlatform,
+        setVersion,
+        setSearchMode,
         clearAll,
         query,
         platform,
         sort,
+        version,
+        searchMode,
+        availableVersions,
         allEvents,
         debouncedQuery,
         normalizedQuery,


### PR DESCRIPTION
## Description

Improves the **Filter events** search in the standalone Analytics Events Docs tool (`packages/analytics-docs`). Previously the search matched the event title only, so searching for a word that lives in an event's details (e.g. `user`, which appears in a Trigger description) returned 0 results — making it hard to see what's already tracked and leading to duplicate events.

The matching is now a case-insensitive substring search (token-AND across fields) over:

- event name / key (`domain/eventName`)
- Trigger description
- attribute names
- attribute descriptions
- attribute **runtime types** (so union members like `suite-sync`, `dropbox`, `blockbook` are searchable)
- event description

Existing name / export-name matching is preserved, and the results UI is unchanged.

Additionally:

- Added an empty state: **"No matches in name, trigger, or attributes."**
- Added a **Version** filter (select) listing all available versions. Selecting one shows only events whose event or attribute changelog changed in that version. The choice is reflected in the URL (`?version=…`) and counts toward the active-filters / "clear filters" link.

**Decision on open question (multi-term):** multi-term queries are token-AND across the combined fields (every token must appear somewhere), not a substring of the full query string.

## Notes for QA

Run locally:

```bash
cd packages/analytics-docs
yarn dev   # generates analytics.json if missing, then serves the docs
```


## Resolve

Resolve https://github.com/trezor/trezor-suite/issues/28562

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All 9 changed files are within the `packages/analytics-docs` package, which is a standalone documentation/internal tool for viewing analytics event definitions. This package has no static mapping to any E2E tests, and based on the LLM analysis of all 92 candidate tests, none of them exercise the analytics-docs UI — they test the Trezor Suite application itself (analytics event emission, dashboard, wallet, trading, etc.), not the analytics documentation viewer. There is no plausible code path from any of these changes to any E2E test behavior. No E2E tests are recommended.

<details><summary><b>Changed files (9)</b></summary>

- `packages/analytics-docs/src/App.tsx`
- `packages/analytics-docs/src/app/AnalyticsContent.tsx`
- `packages/analytics-docs/src/components/EventCard.tsx`
- `packages/analytics-docs/src/components/Filter.tsx`
- `packages/analytics-docs/src/types.ts`
- `packages/analytics-docs/src/utils/__tests__/filterUtils.test.ts`
- `packages/analytics-docs/src/utils/filterUtils.ts`
- `packages/analytics-docs/src/utils/urlParams.ts`
- `packages/analytics-docs/src/utils/useFilteredEvents.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (9)**
- `packages/analytics-docs/src/App.tsx`
- `packages/analytics-docs/src/app/AnalyticsContent.tsx`
- `packages/analytics-docs/src/components/EventCard.tsx`
- `packages/analytics-docs/src/components/Filter.tsx`
- `packages/analytics-docs/src/types.ts`
- `packages/analytics-docs/src/utils/__tests__/filterUtils.test.ts`
- `packages/analytics-docs/src/utils/filterUtils.ts`
- `packages/analytics-docs/src/utils/urlParams.ts`
- `packages/analytics-docs/src/utils/useFilteredEvents.ts`

_Updated: 2026-06-10T12:14:33.580Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=28562-analztics-filter-events&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=28562-analztics-filter-events&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/28562-analztics-filter-events/web/](https://dev.suite.sldev.cz/suite-web/28562-analztics-filter-events/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add account types ada | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-10T12:17:27.196Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-10T12:18:58.294Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->