### PR TITLE
chore(test-utils): remove dead conditionalDescribe and unexport internal mocks

### DIFF
--- a/suite-common/test-utils/src/conditionalDescribe.ts
+++ b/suite-common/test-utils/src/conditionalDescribe.ts
@@ -1,7 +1,0 @@
-export const conditionalDescribe = (condition: boolean, title: string, fn: jest.EmptyFunction) => {
-    if (condition) {
-        describe(title, fn);
-    } else {
-        describe.skip(title, fn);
-    }
-};

--- a/suite-common/test-utils/src/configureMockStore.ts
+++ b/suite-common/test-utils/src/configureMockStore.ts
@@ -26,7 +26,7 @@ import { extraDependenciesCommonMock } from './extraDependenciesCommonMock';
 export const filterThunkActionTypes = (actions: AnyAction[]) =>
     actions.filter(action => !isPending(action) && !isFulfilled(action));
 
-export type MockStoreConfig<S = any, A extends AnyAction = AnyAction> = {
+type MockStoreConfig<S = any, A extends AnyAction = AnyAction> = {
     middleware?: any[];
     extra?: ExtraDependenciesPartial;
     // The third generic (PreloadedState) sits in a contravariant position in redux's Reducer

--- a/suite-common/test-utils/src/extraDependenciesCommonMock.ts
+++ b/suite-common/test-utils/src/extraDependenciesCommonMock.ts
@@ -53,7 +53,7 @@ const platformEncryptionMock: PlatformEncryption = {
         Promise.resolve(ok(value as unknown as T)),
 };
 
-export const analyticsMock = mockAnalytics<AnalyticsSharedEvents>();
+const analyticsMock = mockAnalytics<AnalyticsSharedEvents>();
 
 const connectInitSettings: ConnectInitSettings = {
     debug: false,

--- a/suite-common/test-utils/src/index.ts
+++ b/suite-common/test-utils/src/index.ts
@@ -1,7 +1,6 @@
 export * from './mocks';
 export * from './configureMockStore';
 export * from './extraDependenciesCommonMock';
-export * from './conditionalDescribe';
 export { renderHookWithStoreProvider, type TestStore } from './renderWithStore';
 
 export * from '@testing-library/react';


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into small isolated PRs for easy, low-risk review.

Delete the unused conditionalDescribe.ts and unexport intra-file MockStoreConfig type and analyticsMock.

The full staging branch is green (type-check + lint + format); CI verifies this subset independently.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are all within `suite-common/test-utils/src/`, which is a unit test utility package providing helpers like `conditionalDescribe`, `configureMockStore`, and `extraDependenciesCommonMock`. These are used exclusively by unit tests and integration tests (Jest/Vitest), not by Playwright E2E tests. None of the 113 candidate E2E tests reference or depend on these test utility files — they operate against the running application UI via page objects, device emulators, and mock servers. There is no static mapping and no inferrable connection between these test-utility changes and any E2E test behavior. The risk to E2E functionality is effectively zero; no E2E tests need to be run for this change.

<details><summary><b>Changed files (4)</b></summary>

- `suite-common/test-utils/src/conditionalDescribe.ts`
- `suite-common/test-utils/src/configureMockStore.ts`
- `suite-common/test-utils/src/extraDependenciesCommonMock.ts`
- `suite-common/test-utils/src/index.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (4)**
- `suite-common/test-utils/src/conditionalDescribe.ts`
- `suite-common/test-utils/src/configureMockStore.ts`
- `suite-common/test-utils/src/extraDependenciesCommonMock.ts`
- `suite-common/test-utils/src/index.ts`

_Updated: 2026-06-10T08:27:16.146Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-test-utils&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-test-utils&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-test-utils&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-10T08:31:06.418Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add account types ada | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-10T08:29:56.615Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-test-utils/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-test-utils/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->