### PR TITLE
chore(formatters): remove unused TIME_FORMAT and convertFiatToCryptoAmount

### DIFF
--- a/suite-common/formatters/src/formatters/prepareTimeFormatter.ts
+++ b/suite-common/formatters/src/formatters/prepareTimeFormatter.ts
@@ -4,7 +4,7 @@ import { enUS } from 'date-fns/locale';
 import { makeFormatter } from '../makeFormatter';
 import { type FormatterConfig } from '../types';
 
-export const TIME_FORMAT = {
+const TIME_FORMAT = {
     HOURS_24: 'HH:mm',
     HOURS_12: 'hh:mm a',
 };

--- a/suite-common/formatters/src/utils/convert.ts
+++ b/suite-common/formatters/src/utils/convert.ts
@@ -1,12 +1,6 @@
-import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type BaseCurrencyAmount } from '@suite-common/wallet-types';
-import {
-    convertAmountUnitsToSubunits,
-    formatNetworkAmount,
-    fromBaseCurrencyToCryptoUnit,
-    toFiatCurrency,
-} from '@suite-common/wallet-utils';
-import { BigNumber } from '@trezor/utils';
+import { formatNetworkAmount, toFiatCurrency } from '@suite-common/wallet-utils';
 
 type ConvertInput = {
     amount: string | null;
@@ -31,27 +25,4 @@ export const convertCryptoToFiatAmount = ({
     const networkAmount = isAmountInSats ? formatNetworkAmount(amount, symbol) : amount;
 
     return toFiatCurrency({ amount: networkAmount, rate });
-};
-
-/**
- * @deprecated use `fromBaseCurrencyToCryptoUnit` directly
- */
-export const convertFiatToCryptoAmount = ({
-    amount,
-    symbol,
-    isAmountInSats = true,
-    rate,
-}: ConvertInput): BigNumber | null => {
-    if (!amount) {
-        return null;
-    }
-
-    const { decimals } = getNetwork(symbol);
-    const cryptoAmount = fromBaseCurrencyToCryptoUnit({ fiatAmount: amount, rate });
-
-    if (!cryptoAmount || !isAmountInSats) {
-        return cryptoAmount;
-    }
-
-    return new BigNumber(convertAmountUnitsToSubunits(new BigNumber(cryptoAmount), decimals));
 };

--- a/suite-common/formatters/src/utils/tests/convert.test.ts
+++ b/suite-common/formatters/src/utils/tests/convert.test.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from '@trezor/utils';
 
-import { convertCryptoToFiatAmount, convertFiatToCryptoAmount } from '../convert';
+import { convertCryptoToFiatAmount } from '../convert';
 
 describe('convertCryptoToFiatAmount', () => {
     test.each([
@@ -22,32 +22,6 @@ describe('convertCryptoToFiatAmount', () => {
     ])('amount=%s isAmountInSats=%s', (amount, isAmountInSats, expectedAmount) => {
         expect(
             convertCryptoToFiatAmount({
-                amount,
-                symbol: 'btc',
-                isAmountInSats,
-                rate: 22666,
-            }),
-        ).toEqual(expectedAmount);
-    });
-});
-
-describe('convertFiatToCryptoAmount', () => {
-    test.each([
-        [null, undefined, null],
-        [null, true, null],
-        [null, false, null],
-        ['0.00', undefined, new BigNumber('0')],
-        ['0.00', true, new BigNumber('0')],
-        ['0.00', false, new BigNumber('0.00000000')],
-        ['0.06', undefined, new BigNumber('264.71366804906')],
-        ['0.06', true, new BigNumber('264.71366804906')],
-        ['0.06', false, new BigNumber('0.0000026471366804906')],
-        ['22666.00', undefined, new BigNumber('100000000')],
-        ['22666.00', true, new BigNumber('100000000')],
-        ['22666.00', false, new BigNumber('1.00000000')],
-    ])('amount=%s isAmountInSats=%s', (amount, isAmountInSats, expectedAmount) => {
-        expect(
-            convertFiatToCryptoAmount({
                 amount,
                 symbol: 'btc',
                 isAmountInSats,


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into small isolated PRs for easy, low-risk review.

Remove the unused TIME_FORMAT constant and convertFiatToCryptoAmount helper; switch makeFormatter re-export to a selective export type.

The full staging branch is green (type-check + lint + format); CI verifies this subset independently.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are confined to formatting utilities: a time formatter and a convert utility with its unit test. The prepareTimeFormatter maps to 121+ E2E tests, indicating it is a deeply shared global utility. Most E2E tests only transitively import it without directly exercising time formatting in their assertions. Only tests that explicitly assert on formatted dates/times are meaningfully at risk. The convert utility has no static E2E coverage at all, but has its own unit test being updated. Overall risk is low — the unit test change suggests the convert utility logic is being tested at the unit level, and the time formatter change would only surface in tests that render and assert on time-formatted strings.

<details><summary><b>Changed files (3)</b></summary>

- `suite-common/formatters/src/formatters/prepareTimeFormatter.ts`
- `suite-common/formatters/src/utils/convert.ts`
- `suite-common/formatters/src/utils/tests/convert.test.ts`

</details>

**Recommended tests (2)**

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/wallet/transactions.test.ts` — This test cycles through graph time range filters (day, week, month, year, all) and verifies date-related labels. The prepareTimeFormatter change directly affects how time/date values are formatted in the UI, and time range labels are explicitly asserted in this test.
- `suite/e2e/tests/trading/swap-history.test.ts` — This test verifies that swap trade rows display locale-formatted dates for each transaction. Changes to prepareTimeFormatter or the convert utility could affect how these dates render, and the test explicitly asserts on formatted date values.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-common/formatters/src/utils/convert.ts`
- `suite-common/formatters/src/utils/tests/convert.test.ts`

_Updated: 2026-06-10T19:18:53.554Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-formatters&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-formatters&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-formatters&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-10T19:23:31.646Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-10T19:22:35.775Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-formatters/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-formatters/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->