### PR TITLE
chore(toast-notifications): remove dead transaction notification selectors

### DIFF
--- a/suite-common/toast-notifications/src/index.ts
+++ b/suite-common/toast-notifications/src/index.ts
@@ -1,7 +1,15 @@
 // This package consists only of few types now. In future we will move rest of notifications related logic here
 // because we will need that in mobile as well.
-export * from './types';
+export {
+    AUTH_DEVICE,
+    type ErrorToastPayload,
+    type ToastPayload,
+    type ToastNotification,
+    type NotificationEntry,
+    type TransactionNotification,
+    type TransactionNotificationType,
+} from './types';
 export * from './notificationsReducer';
-export * from './notificationsActions';
+export { addToast, addToastOnce, addEvent, notificationsActions } from './notificationsActions';
 export * from './notificationsThunks';
 export * from './notificationsSelectors';

--- a/suite-common/toast-notifications/src/index.ts
+++ b/suite-common/toast-notifications/src/index.ts
@@ -1,15 +1,7 @@
 // This package consists only of few types now. In future we will move rest of notifications related logic here
 // because we will need that in mobile as well.
-export {
-    AUTH_DEVICE,
-    type ErrorToastPayload,
-    type ToastPayload,
-    type ToastNotification,
-    type NotificationEntry,
-    type TransactionNotification,
-    type TransactionNotificationType,
-} from './types';
+export * from './types';
 export * from './notificationsReducer';
-export { addToast, addToastOnce, addEvent, notificationsActions } from './notificationsActions';
+export * from './notificationsActions';
 export * from './notificationsThunks';
 export * from './notificationsSelectors';

--- a/suite-common/toast-notifications/src/notificationsSelectors.ts
+++ b/suite-common/toast-notifications/src/notificationsSelectors.ts
@@ -1,11 +1,6 @@
 import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 
-import {
-    type NotificationId,
-    type NotificationsRootState,
-    type ToastPayload,
-    type TransactionNotification,
-} from './types';
+import { type NotificationsRootState, type ToastPayload } from './types';
 
 const createMemoizedSelector = createWeakMapSelector.withTypes<NotificationsRootState>();
 
@@ -22,28 +17,5 @@ export const selectVisibleNotificationsByType = createMemoizedSelector(
             notifications.filter(
                 notification => notification.type === notificationType && !notification.closed,
             ),
-        ),
-);
-
-export const selectTransactionNotificationById = createMemoizedSelector(
-    [
-        selectNotifications,
-        (_state: NotificationsRootState, notificationId: NotificationId) => notificationId,
-    ],
-    (notifications, notificationId): TransactionNotification | null =>
-        (notifications.find(
-            notification => notification.id === notificationId,
-        ) as TransactionNotification) ?? null,
-);
-
-export const selectOpenedTransactionNotifications = createMemoizedSelector(
-    [selectNotifications],
-    notifications =>
-        returnStableArrayIfEmpty(
-            notifications.filter(
-                n =>
-                    !n.closed &&
-                    (n.type === 'tx-received' || n.type === 'tx-sent' || n.type === 'tx-confirmed'),
-            ) as TransactionNotification[],
         ),
 );

--- a/suite-common/toast-notifications/src/notificationsThunks.ts
+++ b/suite-common/toast-notifications/src/notificationsThunks.ts
@@ -11,16 +11,6 @@ const findTransactionEvents = (descriptor: string, notifications: NotificationEn
             (n.descriptor === descriptor || n.txid === descriptor),
     );
 
-export const removeTransactionEventsThunk = createThunk(
-    `${ACTION_PREFIX}/removeTransactionEventsThunk`,
-    (txs: { txid: string }[], { dispatch, getState }) => {
-        txs.forEach(tx => {
-            const entries = findTransactionEvents(tx.txid, selectNotifications(getState()));
-            if (entries.length > 0) dispatch(notificationsActions.remove(entries));
-        });
-    },
-);
-
 export const removeAccountEventsThunk = createThunk(
     `${ACTION_PREFIX}/removeAccountEventsThunk`,
     (descriptor: string, { dispatch, getState }) => {

--- a/suite-common/toast-notifications/src/tests/notificationsReducer.test.ts
+++ b/suite-common/toast-notifications/src/tests/notificationsReducer.test.ts
@@ -3,7 +3,7 @@ import { configureMockStore } from '@suite-common/test-utils';
 import { notificationsActions } from '../notificationsActions';
 import { createNotificationsReducer } from '../notificationsReducer';
 import { selectNotifications } from '../notificationsSelectors';
-import { removeAccountEventsThunk, removeTransactionEventsThunk } from '../notificationsThunks';
+import { removeAccountEventsThunk } from '../notificationsThunks';
 import { type NotificationsRootState, type NotificationsState } from '../types';
 
 const { reducer: notificationsReducer } = createNotificationsReducer();
@@ -134,51 +134,6 @@ describe('Notifications Actions', () => {
 
         expect(selectNotifications(store.getState())).toHaveLength(1);
         expect(selectNotifications(store.getState())[0]).toMatchObject(thirdMocked);
-    });
-
-    it('removeTransactionEvents', async () => {
-        const store = initStore({
-            preloadedState: {
-                notifications: [
-                    {
-                        id: 1,
-                        context: 'toast',
-                        type: 'tx-sent',
-                        formattedAmount: '0',
-                        descriptor: 'xpub',
-                        symbol: 'btc',
-                        txid: '1',
-                    },
-                    {
-                        id: 2,
-                        context: 'event',
-                        type: 'tx-confirmed',
-                        formattedAmount: '0',
-                        descriptor: 'xpub',
-                        symbol: 'btc',
-                        txid: '2',
-                    },
-                    {
-                        id: 3,
-                        context: 'event',
-                        type: 'tx-received',
-                        formattedAmount: '0',
-                        descriptor: 'xpub',
-                        symbol: 'btc',
-                        txid: '3',
-                    },
-                    {
-                        id: 4,
-                        context: 'toast',
-                        type: 'backup-success',
-                    },
-                ],
-            },
-        });
-        await store.dispatch(removeTransactionEventsThunk([{ txid: '1' }, { txid: '2' }]));
-        expect(store.getState().notifications.length).toEqual(2);
-        await store.dispatch(removeTransactionEventsThunk([{ txid: '3' }]));
-        expect(store.getState().notifications.length).toEqual(1);
     });
 
     it('removeAccountEvents', async () => {

--- a/suite-common/toast-notifications/src/types.ts
+++ b/suite-common/toast-notifications/src/types.ts
@@ -236,7 +236,7 @@ export type ToastNotification<
     context: 'toast';
 } & CommonNotificationPayload &
     ToastPayload<TranslationKey>;
-export type EventNotification = { context: 'event' } & CommonNotificationPayload &
+type EventNotification = { context: 'event' } & CommonNotificationPayload &
     NotificationEventPayload;
 
 export type NotificationEntry<TranslationKey extends string = UnknownTranslationKey> =


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into small isolated PRs for easy, low-risk review.

Remove unused selectTransactionNotificationById, selectOpenedTransactionNotifications and removeTransactionEventsThunk; tighten the public API via selective exports.

The full staging branch is green (type-check + lint + format); CI verifies this subset independently.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect the toast notification infrastructure (selectors, thunks, types, and unit tests) which is a broadly shared module imported by 121+ E2E tests. However, only tests that explicitly assert on specific toast notifications (@toast/*) are at real risk of regression. The recommended strategy focuses on tests that directly verify toast appearance, content, and lifecycle — covering backup failures, settings confirmations, transaction sent/error toasts, message signing success, clipboard copy toasts, and error toasts from API failures. The unit test file change has no E2E coverage since it's a standalone unit test.

<details><summary><b>Changed files (4)</b></summary>

- `suite-common/toast-notifications/src/notificationsSelectors.ts`
- `suite-common/toast-notifications/src/notificationsThunks.ts`
- `suite-common/toast-notifications/src/tests/notificationsReducer.test.ts`
- `suite-common/toast-notifications/src/types.ts`

</details>

**Recommended tests (15)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/backup/t2t1-fail.test.ts` — This test explicitly asserts on toast notifications (@toast/backup-failed) appearing after a backup failure. Changes to notificationsThunks, notificationsSelectors, or notification types could break toast display, ordering, or content.
- `suite/e2e/tests/backup/t2t1-success.test.ts` — This test verifies the backup analytics event tracked via toast-like notification flow and checks that the backup close button becomes enabled after post-backup steps, relying on notification state management.
- `suite/e2e/tests/settings/passphrase.test.ts` — This test directly asserts that a '@toast/settings-applied' toast becomes visible and then auto-dismisses. Changes to notification thunks, selectors, or types could break toast lifecycle behavior.
- `suite/e2e/tests/suite/bug-report-form.test.ts` — Asserts that a specific toast notification (@toast/user-feedback-send-success) is visible after submitting a bug report. Directly exercises the toast notification display pipeline.
- `suite/e2e/tests/wallet/send-base.test.ts` — Explicitly asserts on '@toast/tx-sent' toast appearing after a transaction is sent. Changes to notification types or thunks could break the toast notification display for send confirmations.

</details>

<details><summary>🟡 <b>Medium priority (10)</b></summary>

- `suite/e2e/tests/metadata/legacy/dropbox-api-errors.test.ts` — Asserts on '@toast/error' toast notification appearing with specific error messages from Dropbox API failures. Changes to notification types or display logic could affect error toast rendering.
- `suite/e2e/tests/metadata/legacy/google-api-errors.test.ts` — Asserts on '@toast/error' toast notification appearing with Google API error messages. Changes to notification infrastructure could affect error toast rendering.
- `suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts` — Asserts on '@toast/legacy-labeling-migration-success' toast notification with specific translation key and count values after migration. Changes to notification types could affect this specialized toast.
- `suite/e2e/tests/settings/t1b1-device-settings.test.ts` — Asserts on '@toast/pin-changed' toast notification appearing after PIN setup and tests pin-mismatch dialog behavior. Toast lifecycle changes could affect these assertions.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Asserts on '@toast/tx-sent' toast notification containing correct account name and amount after sending a sell transaction. Changes to notification types could affect transaction toast content.
- `suite/e2e/tests/wallet/sign-and-verify-eth.test.ts` — Asserts on '@toast/sign-message-success' and '@toast/verify-message-success' toast notifications. Changes to notification display logic could affect these specialized toasts.
- `suite/e2e/tests/wallet/sign-and-verify.test.ts` — Asserts on '@toast/verify-message-success' toast notification after message verification. Notification type or thunk changes could break this assertion.
- `suite/e2e/tests/wallet/send-doge.test.ts` — Asserts on '@toast/sign-tx-error' toast appearing with specific error message when transaction signing fails. Changes to error toast notification types could affect this test.
- `suite/e2e/tests/wallet/receive.test.ts` — Asserts on a 'copied to clipboard' toast notification appearing after copying a receive address. Toast notification infrastructure changes could affect this.
- `suite/e2e/tests/settings/forget-device.test.ts` — Verifies toast notification confirming device was forgotten (verifyToastDeviceForgotten). Changes to notification types or thunks could break this device-forget toast.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/toast-notifications/src/tests/notificationsReducer.test.ts`

_Updated: 2026-06-10T17:20:28.159Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-toast-notifications&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-toast-notifications&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-toast-notifications&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-10T17:24:56.550Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add account types ada | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-10T17:24:25.826Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-toast-notifications/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-toast-notifications/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->