### PR TITLE
chore(feedback): remove unused feedback selectors, types and exports

### DIFF
--- a/suite-common/feedback/src/feedback.ts
+++ b/suite-common/feedback/src/feedback.ts
@@ -20,11 +20,11 @@ interface BasePayload extends UserData, FeedbackExtras {
     description: string;
 }
 
-export interface BugPayload extends BasePayload {
+interface BugPayload extends BasePayload {
     category: FeedbackCategory;
 }
 
-export interface SuggestionPayload extends BasePayload {
+interface SuggestionPayload extends BasePayload {
     rating?: Rating;
     category?: FeedbackCategory;
 }

--- a/suite-common/feedback/src/feedbackSelectors.ts
+++ b/suite-common/feedback/src/feedbackSelectors.ts
@@ -1,10 +1,5 @@
 import { type FeatureFeedbackRootState } from './feedbackSlice';
 
-export const selectFeatureUsageCount = <FeatureName extends string>(
-    state: FeatureFeedbackRootState<FeatureName>,
-    feature: FeatureName,
-): number => state.featureFeedback.usageCounts[feature] ?? 0;
-
 /** Returns the next feature awaiting feedback, or `null` if the queue is empty.
  * Features are processed one at a time; call `feedbackDismissed` to advance the queue. */
 export const selectPendingFeedbackFeature = <FeatureName extends string>(

--- a/suite-common/feedback/src/feedbackSlice.ts
+++ b/suite-common/feedback/src/feedbackSlice.ts
@@ -11,7 +11,7 @@ export type FeatureFeedbackRootState<FeatureName extends string = string> = {
     featureFeedback: FeatureFeedbackState<FeatureName>;
 };
 
-export const featureFeedbackInitialState: FeatureFeedbackState = {
+const featureFeedbackInitialState: FeatureFeedbackState = {
     usageCounts: {},
     pendingFeedbackFeatures: [],
 };

--- a/suite-common/feedback/src/rating.ts
+++ b/suite-common/feedback/src/rating.ts
@@ -9,7 +9,7 @@ enum RatingEmojiEnum {
     LOVE = '😍',
 }
 
-export type RatingItem = {
+type RatingItem = {
     id: Rating;
     emoji: RatingEmojiEnum;
 };


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into small isolated PRs for easy, low-risk review.

Remove unused selectFeatureUsageCount, featureFeedbackInitialState and unused payload/rating types; tighten the public API via selective exports.

The full staging branch is green (type-check + lint + format); CI verifies this subset independently.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are concentrated in the @suite-common/feedback module (feedback submission logic, Redux slice, selectors, and rating). The rating.ts file maps to 121+ tests via transitive imports, but it is a broad dependency unlikely to affect most tests. The core risk is in the feedback form submission flow — only 3 tests directly exercise user feedback/bug report functionality. The remaining 121 tests that statically reference rating.ts do so transitively and show no evidence of directly testing feedback behavior.

<details><summary><b>Changed files (4)</b></summary>

- `suite-common/feedback/src/feedback.ts`
- `suite-common/feedback/src/feedbackSelectors.ts`
- `suite-common/feedback/src/feedbackSlice.ts`
- `suite-common/feedback/src/rating.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/suite/bug-report-form.test.ts` — This test directly exercises the bug report/user feedback submission flow, which is the primary consumer of the feedback module (feedbackSlice, feedback.ts, feedbackSelectors.ts). Changes to the feedback Redux slice, selectors, or submission logic could break this form's submission and success toast.
- `suite/e2e/tests/general/suite-guide.test.ts` — This test covers sending a bug report through the Suite Guide panel and verifying a feedback success toast, directly exercising the feedback submission infrastructure. The FeedbackCategory type is imported from @suite-common/feedback, and the submission flow depends on feedbackSlice and feedback.ts.
- `suite/e2e/tests/suite/guide.test.ts` — This test submits a feedback/suggestion form through the guide panel and verifies a success toast. It directly exercises the feedback submission pipeline including the suggestion form, which uses FeedbackCategory from @suite-common/feedback and the underlying feedback slice/actions.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/feedback/src/rating.ts`

_Updated: 2026-06-10T19:18:59.315Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-feedback&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-feedback&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-feedback&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-10T19:23:45.613Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-10T19:22:19.474Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-feedback/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-feedback/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->