### PR TITLE
chore(delegated-identity-key): unexport internal param and dep types

### DIFF
--- a/suite-common/delegated-identity-key/src/delegatedIdentityKeyCompositionRoot.ts
+++ b/suite-common/delegated-identity-key/src/delegatedIdentityKeyCompositionRoot.ts
@@ -12,7 +12,7 @@ import {
 } from './retrieveDelegatedIdentityKeyFromDevice';
 import { createSaveDelegatedIdentityKey } from './saveDelegatedIdentityKey';
 
-export type DelegatedIdentityKeyCompositionRootDeps = {
+type DelegatedIdentityKeyCompositionRootDeps = {
     dispatch: Dispatch;
     getState: () => DeviceRootState;
     trezorConnect: RetrieveDelegatedIdentityKeyFromDeviceDeps['trezorConnect'];

--- a/suite-common/delegated-identity-key/src/getProofOfDelegatedIdentity.ts
+++ b/suite-common/delegated-identity-key/src/getProofOfDelegatedIdentity.ts
@@ -11,7 +11,7 @@ export const ProofOfDelegatedSignFailed = (caused: any): ProofOfDelegatedSignFai
     caused,
 });
 
-export type GetProofOfDelegatedIdentityParams = {
+type GetProofOfDelegatedIdentityParams = {
     delegatedKey: DelegatedIdentityKey;
     header: string;
     appendMessageBuffer?: Buffer;

--- a/suite-common/delegated-identity-key/src/index.ts
+++ b/suite-common/delegated-identity-key/src/index.ts
@@ -1,4 +1,3 @@
 export { delegatedIdentityKeyCompositionRoot } from './delegatedIdentityKeyCompositionRoot';
-export type { ProofOfDelegatedSignFailed } from './getProofOfDelegatedIdentity';
 export { getProofOfDelegatedIdentity } from './getProofOfDelegatedIdentity';
 export { getPublicIdentityKeyFromDelegatedKey } from './getPublicIdentityKeyFromDeletegatedKey';

--- a/suite-common/delegated-identity-key/src/loadDelegatedIdentityKeyFromState.ts
+++ b/suite-common/delegated-identity-key/src/loadDelegatedIdentityKeyFromState.ts
@@ -5,12 +5,12 @@ import { type EncryptedHex, type PlatformEncryptionDep } from '@suite-common/pla
 import { type DelegatedIdentityKey } from '@suite-common/suite-types';
 import { exhaustive } from '@trezor/type-utils';
 
-export type LoadDelegatedIdentityKeyFromStateDeps = {
+type LoadDelegatedIdentityKeyFromStateDeps = {
     getDeviceDelegatedIdentityKey: (deviceId: string) => EncryptedHex<DelegatedIdentityKey> | null;
     dispatch: Dispatch;
 } & PlatformEncryptionDep;
 
-export type LoadDelegatedIdentityKeyFromStateParams = {
+type LoadDelegatedIdentityKeyFromStateParams = {
     deviceId: string;
 };
 

--- a/suite-common/delegated-identity-key/src/saveDelegatedIdentityKey.ts
+++ b/suite-common/delegated-identity-key/src/saveDelegatedIdentityKey.ts
@@ -5,7 +5,7 @@ import { type PlatformEncryptionDep } from '@suite-common/platform-encryption';
 import { type DelegatedIdentityKey } from '@suite-common/suite-types';
 import { exhaustive } from '@trezor/type-utils';
 
-export type SaveDelegatedIdentityKeyDeps = {
+type SaveDelegatedIdentityKeyDeps = {
     dispatch: Dispatch;
 } & PlatformEncryptionDep;
 


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into small isolated PRs for easy, low-risk review.

Unexport intra-file parameter/dependency types and drop the dead ProofOfDelegatedSignFailed re-export.

The full staging branch is green (type-check + lint + format); CI verifies this subset independently.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are concentrated in the `suite-common/delegated-identity-key` package, which handles delegated identity key creation, saving, loading, and proof generation for the Suite Sync (Evolu) labeling feature. While these files are transitively imported by 121 tests via the main application bundle, only the Suite Sync metadata tests directly exercise the delegated identity key functionality. The risk is moderate — a bug here would break Suite Sync label synchronization but would not affect the broader application. Testing should focus exclusively on Suite Sync tests that create, load, or use delegated identity keys.

<details><summary><b>Changed files (5)</b></summary>

- `suite-common/delegated-identity-key/src/delegatedIdentityKeyCompositionRoot.ts`
- `suite-common/delegated-identity-key/src/getProofOfDelegatedIdentity.ts`
- `suite-common/delegated-identity-key/src/index.ts`
- `suite-common/delegated-identity-key/src/loadDelegatedIdentityKeyFromState.ts`
- `suite-common/delegated-identity-key/src/saveDelegatedIdentityKey.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — Delegated identity key is a core component of Suite Sync / Evolu integration. This test exercises the full Suite Sync label creation flow including device confirmation for sync setup, which likely triggers delegated identity key generation, saving, and proof-of-delegation. Changes to key composition, loading, saving, or proof generation could break Suite Sync initialization.
- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — This test creates delegated identity keys for multiple wallets (default + passphrase wallets), enabling Suite Sync on each. It directly exercises the ownership/identity key derivation per wallet, which is the core domain of the changed files. Issues with key composition or saving would manifest as sync failures across wallets.
- `suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — This test initiates Suite Sync setup which requires device confirmation for delegated identity key creation. It verifies labels are synced from the Evolu relay, which depends on correct identity key loading and proof of delegation. The test explicitly calls setupQuotaManager and initiateSuiteSyncSetup, both of which rely on the delegated identity key infrastructure.
- `suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts` — This test enables Suite Sync, verifies previously stored labels are fetched, then removes them and verifies null values are synced back. The entire flow depends on delegated identity key being correctly loaded from state and used for Evolu relay authentication.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts` — This test migrates labels from Dropbox to Suite Sync. The migration path involves enabling Suite Sync which requires delegated identity key setup via the Evolu relay. Changes to key saving or proof generation could break the migration flow.
- `suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts` — This test covers migrating local file labels to Suite Sync, which involves enabling Suite Sync and verifying data reaches the Evolu relay. The delegated identity key is needed for Evolu authentication during the migration.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/delegated-identity-key/src/index.ts`

_Updated: 2026-06-10T08:28:20.202Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-delegated-identity-key&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-delegated-identity-key&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-delegated-identity-key&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-10T08:32:07.897Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add account types ada | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-10T08:30:31.839Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-delegated-identity-key/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-delegated-identity-key/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->