### PR TITLE
chore(walletconnect): remove dead getAllMethods and ACTION_PREFIX

### DIFF
--- a/suite-common/walletconnect/src/adapters/index.ts
+++ b/suite-common/walletconnect/src/adapters/index.ts
@@ -26,8 +26,6 @@ export const getAdapterByMethod = (method: string) =>
 export const getAdapterByNetwork = (networkType: string) =>
     adapters.find(adapter => adapter.networkType === networkType);
 
-export const getAllMethods = () => adapters.flatMap(adapter => adapter.methods);
-
 export const getNamespaces = (accounts: Account[]) => {
     const accountsDeduped: Account[] = [];
     accounts.forEach(account => {

--- a/suite-common/walletconnect/src/walletConnectActions.ts
+++ b/suite-common/walletconnect/src/walletConnectActions.ts
@@ -2,7 +2,7 @@ import { createAction } from '@reduxjs/toolkit';
 
 import { type PendingConnectionProposal, type WalletConnectSession } from './walletConnectTypes';
 
-export const ACTION_PREFIX = '@suite-common/walletconnect';
+const ACTION_PREFIX = '@suite-common/walletconnect';
 
 const saveSession = createAction(
     `${ACTION_PREFIX}/saveSession`,

--- a/suite-common/walletconnect/src/walletConnectReducer.ts
+++ b/suite-common/walletconnect/src/walletConnectReducer.ts
@@ -5,7 +5,7 @@ import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
 import { walletConnectActions } from './walletConnectActions';
 import { type PendingConnectionProposal, type WalletConnectSession } from './walletConnectTypes';
 
-export type WalletConnectState = {
+type WalletConnectState = {
     sessions: WalletConnectSession[];
     pendingProposal: PendingConnectionProposal | undefined;
 };

--- a/suite-common/walletconnect/src/walletConnectThunks.ts
+++ b/suite-common/walletconnect/src/walletConnectThunks.ts
@@ -30,7 +30,7 @@ import { type PendingConnectionProposalNetwork } from './walletConnectTypes';
 
 let walletKit: IWalletKit;
 
-export const sessionAuthenticateThunk = createThunk<
+const sessionAuthenticateThunk = createThunk<
     void,
     {
         event: WalletKitTypes.SessionAuthenticate;
@@ -116,7 +116,7 @@ export const sessionAuthenticateThunk = createThunk<
     }
 });
 
-export const sessionProposalThunk = createThunk<
+const sessionProposalThunk = createThunk<
     void,
     {
         event: WalletKitTypes.SessionProposal;
@@ -147,7 +147,7 @@ export const sessionProposalThunk = createThunk<
     });
 });
 
-export const sessionRequestThunk = createThunk<
+const sessionRequestThunk = createThunk<
     void,
     {
         event: WalletKitTypes.SessionRequest;


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into small isolated PRs for easy, low-risk review.

Remove the unused getAllMethods helper and ACTION_PREFIX constant; unexport intra-file WalletConnectState and tighten the public API via selective exports.

The full staging branch is green (type-check + lint + format); CI verifies this subset independently.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All four changed files are in the `suite-common/walletconnect` module covering WalletConnect actions, thunks, reducer, and adapters. While these files statically map to 121 tests (indicating they are bundled as a broad dependency in the app), only one test — `wallet-connect-events.test.ts` — directly exercises WalletConnect-specific functionality (pairing, proposals, initialization). The remaining 120 tests have no specific WalletConnect behavior and merely transitively import this module as part of the full Redux store. The recommended strategy is to run only the WalletConnect events test at high priority, as it is the only test that can meaningfully catch regressions in this change.

<details><summary><b>Changed files (4)</b></summary>

- `suite-common/walletconnect/src/adapters/index.ts`
- `suite-common/walletconnect/src/walletConnectActions.ts`
- `suite-common/walletconnect/src/walletConnectReducer.ts`
- `suite-common/walletconnect/src/walletConnectThunks.ts`

</details>

**Recommended tests (1)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/analytics/wallet-connect-events.test.ts` — This test directly exercises WalletConnect functionality including initialization, proposal approval, and proposal rejection — all of which depend on the changed walletConnectActions, walletConnectThunks, walletConnectReducer, and adapters. It verifies WalletConnect analytics events (WalletConnectInit, WalletConnectPaired, WalletConnectProposal, WalletConnectProposalApproved/Rejected) that are likely emitted from the changed thunks and actions.

</details>

_Updated: 2026-06-10T18:31:29.507Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-walletconnect&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-walletconnect&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-walletconnect&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-10T18:36:40.436Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-10T18:35:11.569Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-walletconnect/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-walletconnect/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->