### PR TITLE
chore(device): remove dead device selectors and actions

### DIFF
--- a/suite-common/device/src/deviceActions.ts
+++ b/suite-common/device/src/deviceActions.ts
@@ -114,7 +114,7 @@ const updateSelectedDevice = createAction(
 );
 
 // Remove button requests for specific device by button request code or all button requests if no code is provided.
-export const removeButtonRequests = createAction(
+const removeButtonRequests = createAction(
     `${DEVICE_MODULE_PREFIX}/removeButtonRequests`,
     (payload: { device?: TrezorDevice; buttonRequestCode?: ButtonRequest['code'] }) => ({
         payload,

--- a/suite-common/device/src/deviceReducer.ts
+++ b/suite-common/device/src/deviceReducer.ts
@@ -545,7 +545,7 @@ const removeButtonRequests = (
     );
 };
 
-export const setDeviceAuthenticity = (
+const setDeviceAuthenticity = (
     draft: DeviceReducerState,
     deviceId: TrezorDevice['id'],
     result?: StoredAuthenticateDeviceResult,

--- a/suite-common/device/src/deviceSelectors.ts
+++ b/suite-common/device/src/deviceSelectors.ts
@@ -3,7 +3,6 @@ import { A, pipe } from '@mobily/ts-belt';
 import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import {
     type BackupType,
-    type FirmwareRevision,
     LANGUAGES,
     type Locale,
     type TrezorDevice,
@@ -23,15 +22,9 @@ import {
     getSortedDevicesWithoutInstances,
     getStatus,
 } from '@suite-common/suite-utils';
-import {
-    type Device,
-    type DeviceState,
-    type StaticSessionId,
-    asBluetoothDeviceId,
-} from '@trezor/connect';
+import { type Device, type DeviceState, type StaticSessionId } from '@trezor/connect';
 import {
     DeviceModelInternal,
-    type FirmwareVersionString,
     getFirmwareRevision,
     getFirmwareVersion,
     getFirmwareVersionArray,
@@ -93,22 +86,19 @@ export const selectIsDeviceUnlocked = createMemoizedSelector(
     device => !!device?.features?.unlocked,
 );
 
-export const selectDeviceType = createMemoizedSelector(
-    [selectSelectedDevice],
-    device => device?.type,
-);
+const selectDeviceType = createMemoizedSelector([selectSelectedDevice], device => device?.type);
 
 export const selectDevicePath = createMemoizedSelector(
     [selectSelectedDevice],
     device => device?.path,
 );
 
-export const selectDeviceFeatures = createMemoizedSelector(
+const selectDeviceFeatures = createMemoizedSelector(
     [selectSelectedDevice],
     device => device?.features,
 );
 
-export const selectDeviceCapabilities = createMemoizedSelector(
+const selectDeviceCapabilities = createMemoizedSelector(
     [selectDeviceFeatures],
     features => features?.capabilities,
 );
@@ -163,7 +153,7 @@ export const selectDeviceLanguage = createMemoizedSelector(
     features => (features?.language as Locale) ?? null,
 );
 
-export const selectAvailableDeviceTranslations = createMemoizedSelector(
+const selectAvailableDeviceTranslations = createMemoizedSelector(
     [selectSelectedDevice],
     device => device?.availableTranslations ?? {},
 );
@@ -193,7 +183,7 @@ export const selectSupportedDeviceLanguages = createMemoizedSelector(
     },
 );
 
-export const selectDeviceButtonRequests = createMemoizedSelector(
+const selectDeviceButtonRequests = createMemoizedSelector(
     [selectSelectedDevice],
     device => device?.buttonRequests ?? [],
 );
@@ -207,7 +197,7 @@ export const selectDeviceButtonRequestsCodes = createMemoizedSelector(
         ),
 );
 
-export const selectDeviceMode = createMemoizedSelector(
+const selectDeviceMode = createMemoizedSelector(
     [selectSelectedDevice],
     device => device?.mode ?? null,
 );
@@ -268,21 +258,12 @@ export const selectIsDeviceConnectedViaBluetoothLowOnBattery = createMemoizedSel
     },
 );
 
-export const selectDeviceBluetoothId = createMemoizedSelector([selectSelectedDevice], device =>
-    device?.descriptor?.apiType === 'bluetooth' && device.descriptor.id
-        ? asBluetoothDeviceId(device.descriptor.id)
-        : undefined,
-);
-
 export const selectIsConnectedDeviceUninitialized = createMemoizedSelector(
     [selectSelectedDevice, selectIsDeviceInitialized],
     (device, isDeviceInitialized) => device && !isDeviceInitialized,
 );
 
-export const selectDeviceState = createMemoizedSelector(
-    [selectSelectedDevice],
-    device => device?.state,
-);
+const selectDeviceState = createMemoizedSelector([selectSelectedDevice], device => device?.state);
 
 export const selectIsDeviceAuthorized = createMemoizedSelector(
     [selectDeviceState],
@@ -343,8 +324,7 @@ export const selectDeviceById = createMemoizedSelector(
     (devices, deviceId) => devices.find(device => device.id === deviceId),
 );
 
-export const selectDeviceAuthenticity = (state: DeviceRootState) =>
-    state.device.persistentDeviceData;
+const selectDeviceAuthenticity = (state: DeviceRootState) => state.device.persistentDeviceData;
 
 export const selectDeviceAuthenticityByDeviceId = createMemoizedSelector(
     [(_state: DeviceRootState, deviceId: TrezorDevice['id']) => deviceId, selectDeviceAuthenticity],
@@ -489,7 +469,7 @@ export const selectIsDeviceRemembered = createMemoizedSelector(
     getIsDeviceRemembered,
 );
 
-export const selectRememberedStandardWallets = createMemoizedSelector(
+const selectRememberedStandardWallets = createMemoizedSelector(
     [selectPhysicalDeviceWallets],
     devices =>
         returnStableArrayIfEmpty(
@@ -502,7 +482,7 @@ export const selectRememberedStandardWalletsCount = createMemoizedSelector(
     wallets => wallets.length,
 );
 
-export const selectRememberedHiddenWallets = createMemoizedSelector(
+const selectRememberedHiddenWallets = createMemoizedSelector(
     [selectPhysicalDeviceWallets],
     devices =>
         returnStableArrayIfEmpty(
@@ -599,7 +579,7 @@ export const selectFirmwareChangelog = (state: DeviceRootState) => {
     return device?.firmwareReleaseConfigInfo?.release.changelog;
 };
 
-export const selectDeviceUnitPackaging = createMemoizedSelector(
+const selectDeviceUnitPackaging = createMemoizedSelector(
     [selectDeviceFeatures],
     features => features?.unit_packaging ?? 0,
 );
@@ -654,52 +634,6 @@ export const selectDeviceDelegatedIdentityKey = createMemoizedSelector(
     [selectPersistentDeviceData, (_state, deviceId: string) => deviceId],
     (persistentDeviceData, deviceId) =>
         persistentDeviceData.find(d => d.device_id === deviceId)?.delegatedIdentityKey ?? null,
-);
-
-type DeviceUtmParams = {
-    utm_model?: DeviceModelInternal;
-    utm_fw?: FirmwareVersionString;
-    utm_rev?: FirmwareRevision;
-    utm_passphrase?: 'true' | 'false';
-};
-
-export const selectSupportChatDeviceUtmParams = createMemoizedSelector(
-    [
-        selectDeviceInternalModel,
-        selectDeviceFirmwareVersion,
-        selectDeviceFirmwareRevision,
-        selectIsDeviceUsingPassphrase,
-        selectIsPortfolioTrackerDevice,
-    ],
-    (
-        deviceModel,
-        firmwareVersion,
-        firmwareRevision,
-        isDeviceUsingPassphrase,
-        isPortfolioTrackerDevice,
-    ) => {
-        const result: DeviceUtmParams = {};
-
-        if (isPortfolioTrackerDevice) {
-            return result;
-        }
-
-        if (deviceModel) {
-            result.utm_model = deviceModel;
-        }
-
-        if (firmwareVersion) {
-            result.utm_fw = firmwareVersion;
-        }
-
-        if (firmwareRevision) {
-            result.utm_rev = firmwareRevision;
-        }
-
-        result.utm_passphrase = isDeviceUsingPassphrase ? 'true' : 'false';
-
-        return result;
-    },
 );
 
 export const selectIsReconnectRequested = createMemoizedSelector(


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into small isolated PRs for easy, low-risk review.

Remove unused selectDeviceBluetoothId, selectDeviceMode, selectDeviceState and setDeviceAuthenticity; unexport internal selectors and tighten the public API via selective exports.

The full staging branch is green (type-check + lint + format); CI verifies this subset independently.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect three core device management files (deviceActions, deviceReducer, deviceSelectors) that are imported by all 121 E2E tests, making them extremely broad shared dependencies. Since these files manage device connection state, wallet instances, passphrase handling, and device features, the highest-risk tests are those that directly exercise device connect/disconnect transitions, multi-session management, device switching, passphrase wallet lifecycle, and device settings mutations. The recommended strategy focuses on ~20 targeted tests that specifically validate device state management behaviors rather than running all 121 tests. Tests involving device disconnect/reconnect, session management, passphrase wallets, and device settings changes should be prioritized as they most directly exercise the changed code paths.

<details><summary><b>Changed files (3)</b></summary>

- `suite-common/device/src/deviceActions.ts`
- `suite-common/device/src/deviceReducer.ts`
- `suite-common/device/src/deviceSelectors.ts`

</details>

**Recommended tests (20)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test directly exercises device session management (acquire/enumerate, session stealing, reclaiming), device status selectors (TR_USE_HERE vs TR_CONNECTED), and device switching — all of which depend heavily on deviceActions, deviceReducer, and deviceSelectors for managing device connection state and session tracking.
- `suite/e2e/tests/backup/t2t1-fail.test.ts` — Tests device disconnect/reconnect handling during backup, including device disconnected status indicators and toast notifications on reconnection. The deviceReducer and deviceActions directly manage the device connected/disconnected state transitions this test validates.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — This test validates device disconnect/reconnect with passphrase wallet preservation in the device switcher, passphrase caching after reconnection, and device status indicators — all critically dependent on deviceReducer state management and deviceSelectors for wallet/device status.
- `suite/e2e/tests/suite/initial-run.test.ts` — Tests that after completing onboarding, the @deviceStatus-connected element is visible on reload — directly exercising device selectors for connection state. Also tests THP pairing flow which dispatches device actions.

</details>

<details><summary>🟡 <b>Medium priority (14)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — DeviceConnect and DeviceDisconnect analytics events are generated based on device state changes managed by deviceActions/deviceReducer. The test validates device metadata (firmware version, model, PIN/passphrase protection) which comes from deviceSelectors.
- `suite/e2e/tests/backup/t2t1-misc.test.ts` — Tests backup behavior when device is disconnected (remembered device state) — the '@backup/no-device' element visibility depends on device selectors determining the device is absent, managed by deviceReducer.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — Tests device switcher operations (eject wallet, add standard wallet) which dispatch device actions and rely on device reducer state for wallet management and device switching logic.
- `suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts` — This test explicitly dispatches deviceActions.setSimulatedEntropyCheckFail via window.store.dispatch, directly exercising the deviceActions module. Changes to action signatures or reducer handling would break this test.
- `suite/e2e/tests/passphrase/passphrase-numbering.test.ts` — Tests sequential numbering of passphrase wallets through add/eject/re-add operations — the wallet indexing and numbering logic is managed by deviceReducer state and deviceSelectors for wallet ordering.
- `suite/e2e/tests/passphrase/passphrase-duplicate.test.ts` — Tests duplicate passphrase detection which requires deviceReducer to track existing wallets and deviceSelectors to identify duplicates when adding a hidden wallet with the same passphrase.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — Comprehensive passphrase wallet test covering adding/switching hidden wallets, device switcher state, passphrase caching, and mismatch handling — all relying on device state management in the changed files.
- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts` — Tests device disconnect/reconnect detection (deviceDisconnectedStatus, deviceConnectedStatus) with passphrase re-entry after reconnection — directly dependent on device state transitions in deviceReducer.
- `suite/e2e/tests/wallet/without-device.test.ts` — Tests device disconnected status indicator visibility, connection modal on send with disconnected device, and disconnected device banner in settings — all driven by deviceSelectors and deviceReducer state.
- `suite/e2e/tests/settings/passphrase.test.ts` — Tests enabling passphrase protection on device through settings, which dispatches device actions to update device features in the reducer. The confirm-on-device prompt and settings-applied toast depend on device state management.
- `suite/e2e/tests/settings/t2t1-device-settings.test.ts` — Tests changing device name (reflected in menu label via deviceSelectors), display rotation, and device wipe — all operations that dispatch device actions and update device state in the reducer.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-fail.test.ts` — Tests device disconnect/reconnect during recovery with retry flow — the connect device prompt appearance after power-off depends on deviceReducer tracking device connection state.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts` — Tests recovery persistence across device disconnect/reconnect and page reload — validates that device state (recovery mode) is properly managed through deviceReducer across reconnections.
- `suite/e2e/tests/wallet/discovery.test.ts` — Tests wallet discovery status tracking through Redux state (wallet.discovery status) and device status indicator (@deviceStatus-connected), which depends on deviceSelectors for connection state.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/metadata/legacy/metadata-lifecycle.test.ts` — Tests wallet switching, adding hidden wallets, and forgetting devices — operations that dispatch device actions and modify device reducer state. However, the primary focus is metadata labeling rather than device management.
- `suite/e2e/tests/recovery/dry-run.test.ts` — Tests device disconnection (bridge stop) during recovery dry run and recovery after reconnection. Device connection state changes are managed by deviceReducer but the primary focus is the recovery flow.

</details>

_Updated: 2026-06-11T13:50:59.313Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-device&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-device&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-device&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-11T13:56:01.110Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-11T13:53:50.530Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-device/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-device/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->