### PR TITLE
chore(connect-popup): remove dead  ACTION_PREFIX export

### DIFF
--- a/suite-common/connect-popup/src/connectPopupActions.ts
+++ b/suite-common/connect-popup/src/connectPopupActions.ts
@@ -7,7 +7,7 @@ import {
     type ConnectSerializedError,
 } from './connectPopupTypes';
 
-export const ACTION_PREFIX = '@suite-common/connect-popup';
+const ACTION_PREFIX = '@suite-common/connect-popup';
 
 const initiateCall = createAction(
     `${ACTION_PREFIX}/initiateCall`,

--- a/suite-common/connect-popup/src/connectPopupTypes.ts
+++ b/suite-common/connect-popup/src/connectPopupTypes.ts
@@ -72,7 +72,7 @@ type TxSimulationConnectPopupCallLoaded = {
     selectedAccountKey?: AccountKey;
 } & Omit<TxSimulationAction, 'sourceOrigin'>;
 
-export type ConnectPopupCallLoaded = {
+type ConnectPopupCallLoaded = {
     // Common properties that are always present
     methodInfo: {
         methodTitle: string;
@@ -132,7 +132,7 @@ export type ConnectPopupCallLoaded = {
       }
 );
 
-export type ConnectPopupCallError = {
+type ConnectPopupCallError = {
     state: 'error';
     error: ConnectSerializedError;
 };


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into small isolated PRs for easy, low-risk review.

Un-export the intra-file-only ACTION_PREFIX constant and the ConnectPopupCallLoaded / ConnectPopupCallError types; tighten the public API via selective exports. (CALL_SOURCE_DEEPLINK is intentionally kept — it is still used by the deeplink reconnect timeout and the ConnectCallSource union, so it is not dead.)

The full staging branch is green (type-check + lint + format); CI verifies this subset independently.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files (connectPopupActions.ts and connectPopupTypes.ts) are broadly imported across 121 tests, indicating they are foundational infrastructure. However, the connect popup module specifically handles TrezorConnect popup interactions — device confirmation prompts, connection dialogs, and external connection requests. The risk is moderate: type-only changes in connectPopupTypes.ts are unlikely to cause runtime issues, but behavioral changes in connectPopupActions.ts could affect any flow involving device prompts. The recommended strategy focuses on tests that most directly exercise connect popup functionality: the connect-popup route itself, sign/verify flows that heavily use device prompt interactions, and WalletConnect which handles external connection proposals.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/connect-popup/src/connectPopupActions.ts`
- `suite-common/connect-popup/src/connectPopupTypes.ts`

</details>

**Recommended tests (5)**

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test visits the /connect-popup route directly, which is the route most likely to be affected by changes to connectPopupActions and connectPopupTypes. If the connect popup module's actions or types break, this route may fail to render.
- `suite/e2e/tests/wallet/sign-and-verify.test.ts` — Sign & verify flows use TrezorConnect APIs that go through the connect popup infrastructure. Changes to connectPopupActions could affect how device signing/verification prompts are dispatched and handled.
- `suite/e2e/tests/wallet/sign-and-verify-eth.test.ts` — ETH sign & verify flows similarly rely on TrezorConnect interactions that route through the connect popup action layer. Changes to action types or dispatch logic could break the signing confirmation flow.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/analytics/wallet-connect-events.test.ts` — WalletConnect pairing proposals involve connect popup-like interactions for approving/rejecting external connection requests. Changes to connect popup action types could affect how these proposals are processed.
- `suite/e2e/tests/suite/bridge.test.ts` — The bridge page involves transport/connection infrastructure that intersects with connect popup logic (WebUSB selection, connect device prompt). Changes to connect popup actions could affect the bridge-to-wallet transition flow.

</details>

_Updated: 2026-06-11T05:43:06.401Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-connect-popup/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-connect-popup/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-connect-popup&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-connect-popup&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-connect-popup&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-11T05:47:46.964Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-11T05:45:58.378Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->