### PR TITLE
chore(wallet-config): remove dead network and staking config exports

### DIFF
--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -731,7 +731,7 @@ export type NetworkConfigWithoutTestnets = Exclude<NetworkConfig, { testnet: tru
 
 export type NetworkDisplaySymbol = NetworkConfig['displaySymbol'];
 
-export type NetworkWithFeature<TFeature extends NetworkFeature> = {
+type NetworkWithFeature<TFeature extends NetworkFeature> = {
     [S in keyof NetworksConfigs]: TFeature extends NetworksConfigs[S]['features'][number]
         ? NetworksConfigs[S]
         : never;
@@ -764,5 +764,3 @@ export const [STAKING_SYMBOLS, STAKING_TYPES, PROD_STAKING_SYMBOLS] = typedObjec
     readonly StakingNetworkType[],
     readonly (StakingNetworkSymbol & NetworkConfigWithoutTestnets['symbol'])[],
 ];
-
-export type ProdStakingNetworkSymbol = (typeof PROD_STAKING_SYMBOLS)[number];

--- a/suite-common/wallet-config/src/stakingProviders.ts
+++ b/suite-common/wallet-config/src/stakingProviders.ts
@@ -1,7 +1,7 @@
 import { EVERSTAKE_POOLS, FIVE_BINARIES_POOLS } from '@suite-common/wallet-constants';
 import { EVERSTAKE_VOTER_PUBKEYS } from '@trezor/coins-solana/constants';
 
-export type StakingProviderId = 'everstake' | 'fivebinaries';
+type StakingProviderId = 'everstake' | 'fivebinaries';
 
 export type StakingProvider = {
     id: StakingProviderId;
@@ -11,7 +11,7 @@ export type StakingProvider = {
     ethereumPoolNames: string[];
 };
 
-export const EVERSTAKE_PROVIDER: StakingProvider = {
+const EVERSTAKE_PROVIDER: StakingProvider = {
     id: 'everstake',
     name: 'Everstake',
     solanaVoterPubkeys: EVERSTAKE_VOTER_PUBKEYS,
@@ -19,7 +19,7 @@ export const EVERSTAKE_PROVIDER: StakingProvider = {
     ethereumPoolNames: ['Everstake'],
 };
 
-export const FIVEBINARIES_PROVIDER: StakingProvider = {
+const FIVEBINARIES_PROVIDER: StakingProvider = {
     id: 'fivebinaries',
     name: 'FiveBinaries',
     solanaVoterPubkeys: [],
@@ -27,10 +27,7 @@ export const FIVEBINARIES_PROVIDER: StakingProvider = {
     ethereumPoolNames: [],
 };
 
-export const STAKING_PROVIDERS: readonly StakingProvider[] = [
-    EVERSTAKE_PROVIDER,
-    FIVEBINARIES_PROVIDER,
-];
+const STAKING_PROVIDERS: readonly StakingProvider[] = [EVERSTAKE_PROVIDER, FIVEBINARIES_PROVIDER];
 
 export const getStakingProviderBySolanaVoterPubkey = (
     voterPubkey: string,

--- a/suite-common/wallet-config/src/types.ts
+++ b/suite-common/wallet-config/src/types.ts
@@ -1,6 +1,5 @@
 import { type YieldDtoNetwork } from '@suite-common/earn-stablecoin-defs';
 import { type DeviceModelInternal } from '@trezor/device-utils';
-import { type RequiredKey } from '@trezor/type-utils';
 
 export type NetworkSymbol =
     | 'btc'
@@ -61,10 +60,8 @@ export const TREZOR_CONNECT_BACKENDS = [
     'evm-rpc',
 ] as const;
 
-export const NON_STANDARD_BACKENDS = ['coinjoin'] as const;
-
 export type TrezorConnectBackendType = (typeof TREZOR_CONNECT_BACKENDS)[number];
-export type NonStandardBackendType = (typeof NON_STANDARD_BACKENDS)[number];
+type NonStandardBackendType = 'coinjoin';
 export type BackendType = TrezorConnectBackendType | NonStandardBackendType;
 
 export type NetworkFeature =
@@ -111,13 +108,12 @@ type NetworkAccountWithSpecificKey<TKey extends AccountType> = {
     isDebugOnlyAccountType?: boolean;
 };
 export type NetworkAccount = NetworkAccountWithSpecificKey<AccountType>;
-export type NormalizedNetworkAccount = RequiredKey<NetworkAccount, 'features'>;
 
-export type NetworkAccountTypes = Partial<{
+type NetworkAccountTypes = Partial<{
     [key in AccountType]: NetworkAccountWithSpecificKey<key>;
 }>;
 
-export type NetworkDeviceSupport = Partial<Record<DeviceModelInternal, string>>;
+type NetworkDeviceSupport = Partial<Record<DeviceModelInternal, string>>;
 
 type NetworkWithSpecificKey<TKey extends NetworkSymbol> = {
     symbol: TKey;


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into small isolated PRs for easy, low-risk review.

Remove unused NON_STANDARD_BACKENDS, NetworkWithFeature, NormalizedNetworkAccount and related dead types; tighten public API via selective exports.

The full staging branch is green (type-check + lint + format); CI verifies this subset independently.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect three core wallet-config files: networksConfig.ts (network definitions), stakingProviders.ts (staking provider configuration), and types.ts (TypeScript types for network config). Since these are foundational shared modules imported by virtually all 121 candidate tests, the testing strategy focuses on tests that directly exercise network configuration (coin enabling, discovery, backend settings) and staking flows (ETH, ADA, SOL staking/unstaking/claiming) where changes would most likely manifest as regressions. Tests unrelated to network enumeration or staking (e.g., backup, browser compatibility, metadata labeling, passphrase) are omitted since they only transitively depend on these modules without exercising the changed functionality.

<details><summary><b>Changed files (3)</b></summary>

- `suite-common/wallet-config/src/networksConfig.ts`
- `suite-common/wallet-config/src/stakingProviders.ts`
- `suite-common/wallet-config/src/types.ts`

</details>

**Recommended tests (21)**

<details><summary>🔴 <b>High priority (7)</b></summary>

- `suite/e2e/tests/wallet/discovery.test.ts` — This test activates multiple cryptocurrency networks (btc, eth, ltc, etc, bch, doge, xrp, zec) and verifies discovery completes with visible balances. Changes to networksConfig.ts directly affect which networks are available and how they're configured, making discovery the most sensitive integration point.
- `suite/e2e/tests/settings/coins.test.ts` — This test explicitly validates coin network activation/deactivation, testnet visibility toggling, and custom backend configuration — all of which rely on the network definitions in networksConfig.ts. It also verifies the full list of default mainnet and testnet network symbols, so any addition/removal/renaming in networksConfig would break assertions.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — Directly tests enabling coins (BTC, ETH) and configuring custom blockbook backends via the coins settings page. Changes to networksConfig (e.g., backend types, network symbols, or network properties) would directly affect backend configuration and discovery behavior.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Tests first-time ETH staking end-to-end including Everstake pool contract interaction. Changes to stakingProviders.ts could alter staking pool addresses, provider configuration, or supported staking networks, directly breaking this flow.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Tests staking additional ETH on an already-staked account, referencing the Everstake staking contract address. Changes to stakingProviders.ts could modify pool addresses or staking configuration, directly impacting this flow.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — Tests the full ETH unstake and claim flow referencing the Everstake staking pool contract. Staking provider configuration changes would directly affect unstaking transaction construction and claim detection.
- `suite/e2e/tests/staking/ada/stake.test.ts` — Tests Cardano staking including stake delegation to a pool and vote delegation to a dRep. Changes to stakingProviders.ts could modify Cardano pool IDs or dRep key hashes, directly breaking device confirmation assertions.

</details>

<details><summary>🟡 <b>Medium priority (14)</b></summary>

- `suite/e2e/tests/staking/ada/unstake.test.ts` — Tests Cardano unstaking with stake key deregistration and deposit return. Related to stakingProviders changes as it uses the staking registration deposit constant and staking configuration.
- `suite/e2e/tests/staking/ada/claim.test.ts` — Tests Cardano reward claiming which depends on staking configuration. If stakingProviders changes affect how rewards are detected or claimed, this test would catch regressions.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Tests first-time Solana staking on Everstake. Changes to stakingProviders could affect Solana staking validator addresses or provider configuration.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — Tests Solana unstaking and claiming flow. Staking provider configuration changes could affect how stake accounts are managed or claimed.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — Tests adding more SOL to existing stake, referencing Everstake provider. Provider configuration changes in stakingProviders.ts could affect this flow.
- `suite/e2e/tests/staking/sol/rewards.test.ts` — Tests Solana staking rewards display and refresh. Staking provider changes could affect how rewards are fetched or displayed.
- `suite/e2e/tests/staking/staking-form.test.ts` — Tests ETH staking form validation including minimum amounts and balance calculations. Network config changes (e.g., decimals) or staking provider changes could affect form validation logic.
- `suite/e2e/tests/dashboard/assets.test.ts` — Tests enabling new assets and viewing them in grid/table view on the dashboard. Network configuration changes in networksConfig.ts directly affect which assets are available and how they appear in the Activate Assets modal.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — Tests adding different account types (normal, taproot, segwit, legacy) for multiple coins. The account type definitions and network symbols come from networksConfig, and the types from types.ts define NetworkSymbol used in assertions.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — Tests custom blockbook backend configuration for BTC and LTC. Network backend type definitions in networksConfig.ts directly affect backend configuration options.
- `suite/e2e/tests/analytics/events.test.ts` — The SuiteReady analytics event payload includes enabledNetworks list derived from networksConfig. Changes to network definitions could alter the expected payload values in assertions.
- `suite/e2e/tests/analytics/staking-events.test.ts` — Tests StakingNavigate analytics events for ETH and ADA, referencing NetworkSymbol type. Changes to network configuration could affect staking navigation availability.
- `suite/e2e/tests/wallet/cardano.test.ts` — Tests Cardano account details, send form, and receive flow. Network-specific configuration for ADA (derivation paths, account types) comes from networksConfig.ts.
- `suite/e2e/tests/wallet/receive.test.ts` — Tests receiving for BTC, ETH, SOL, and TRX — covering multiple network types. Address format validation depends on network configuration from networksConfig.ts.

</details>

_Updated: 2026-06-10T19:22:44.073Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-wallet-config&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-wallet-config&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-wallet-config&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-10T19:24:56.148Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-10T19:22:27.539Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-wallet-config/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-wallet-config/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->