### PR TITLE
Enable to wrap and deposit WETH to Trezor ETH vault

### DIFF
--- a/packages/components/src/components/Banner/Banner.tsx
+++ b/packages/components/src/components/Banner/Banner.tsx
@@ -36,9 +36,9 @@ const Layout = styled.div`
     align-items: center;
 `;
 
-const IconCell = styled.div`
+const IconCell = styled.div<{ $isCentered: boolean }>`
     grid-column: 1;
-    grid-row: 1;
+    grid-row: ${({ $isCentered }) => ($isCentered ? '1 / span 2' : '1')};
     margin-right: ${spacingsPx.sm};
 `;
 
@@ -71,6 +71,8 @@ export type BannerProps = AllowedFrameProps & {
     intent?: BannerIntent;
     rightContent?: ReactNode;
     icon?: IconComponent | true;
+    /** Centers the icon against the whole title + description block instead of the title row. */
+    isIconCentered?: boolean;
     'data-testid'?: string;
     isLoading?: boolean;
 } & ({ title: ReactNode; description?: ReactNode } | { title?: ReactNode; description: ReactNode });
@@ -80,6 +82,7 @@ export const Banner = ({
     description,
     intent = DEFAULT_INTENT,
     icon,
+    isIconCentered = false,
     rightContent,
     'data-testid': dataTest,
     isLoading = false,
@@ -104,7 +107,7 @@ export const Banner = ({
         >
             <Layout>
                 {(isLoading || withIcon) && (
-                    <IconCell>
+                    <IconCell $isCentered={isIconCentered && Boolean(title && description)}>
                         {isLoading && <Spinner size={20} isDisabled={true} />}
                         {!isLoading && withIcon && (
                             <Icon

--- a/packages/product-components/src/components/Notifications/TransactionNotification.stories.tsx
+++ b/packages/product-components/src/components/Notifications/TransactionNotification.stories.tsx
@@ -151,6 +151,16 @@ const transactionNotificationConfig: Record<
             },
         },
     },
+    'tx-yield-wrap': {
+        toastIcon: ArrowUpIcon,
+        intent: 'brand',
+        message: 'Wrapped from Ethereum #1',
+        amount: '0.5 ETH',
+        transaction: {
+            notificationType: 'tx-yield-wrap',
+            symbol: 'eth',
+        },
+    },
     'tx-yield-withdraw': {
         toastIcon: ArrowUpIcon,
         intent: 'brand',

--- a/packages/product-components/src/components/Notifications/TransactionNotification.stories.tsx
+++ b/packages/product-components/src/components/Notifications/TransactionNotification.stories.tsx
@@ -161,6 +161,16 @@ const transactionNotificationConfig: Record<
             symbol: 'eth',
         },
     },
+    'tx-yield-unwrap': {
+        toastIcon: ArrowDownIcon,
+        intent: 'brand',
+        message: 'Unwrapped from Ethereum #1',
+        amount: '0.5 WETH',
+        transaction: {
+            notificationType: 'tx-yield-unwrap',
+            symbol: 'eth',
+        },
+    },
     'tx-yield-withdraw': {
         toastIcon: ArrowUpIcon,
         intent: 'brand',

--- a/packages/product-components/src/components/Notifications/notificationsTypes.ts
+++ b/packages/product-components/src/components/Notifications/notificationsTypes.ts
@@ -28,6 +28,7 @@ export type TransactionNotificationType =
     | 'tx-revoked'
     | 'tx-yield-deposit'
     | 'tx-yield-wrap'
+    | 'tx-yield-unwrap'
     | 'tx-yield-withdraw'
     | 'tx-yield-claim';
 

--- a/packages/product-components/src/components/Notifications/notificationsTypes.ts
+++ b/packages/product-components/src/components/Notifications/notificationsTypes.ts
@@ -27,6 +27,7 @@ export type TransactionNotificationType =
     | 'tx-approved'
     | 'tx-revoked'
     | 'tx-yield-deposit'
+    | 'tx-yield-wrap'
     | 'tx-yield-withdraw'
     | 'tx-yield-claim';
 

--- a/packages/suite/src/actions/wallet/stablecoin-yield/composeYieldEvmTransaction.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/composeYieldEvmTransaction.ts
@@ -1,0 +1,110 @@
+import { notificationsActions } from '@suite-common/toast-notifications';
+import { getNetwork } from '@suite-common/wallet-config';
+import { buildYieldUnsignedTransaction, selectRawNetworkFeeInfo } from '@suite-common/wallet-core';
+import { ethereumGetCurrentNonceThunk } from '@suite-common/wallet-core/src/send/sendFormEthereumThunks';
+import { type Account } from '@suite-common/wallet-types';
+import { getAccountIdentity, getConvertedOrDefaultFeeInfo } from '@suite-common/wallet-utils';
+import TrezorConnect from '@trezor/connect';
+
+import type { AppState, Dispatch } from 'src/types/suite';
+
+export type ComposeYieldEvmTransactionParams = {
+    account: Account & { networkType: 'ethereum' };
+    to: string;
+    data: string;
+    value?: string;
+    backupGasLimit: string;
+    vaultChainId?: number;
+    dispatch: Dispatch;
+    getState: () => AppState;
+};
+
+/**
+ * Composes an unsigned EVM transaction of a yield flow: resolves the confirmed
+ * nonce, estimates the gas limit (falling back to the flow's backup), applies
+ * the normal fee level and serializes the result for signing.
+ */
+export const composeYieldEvmTransaction = async ({
+    account,
+    to,
+    data,
+    value,
+    backupGasLimit,
+    vaultChainId,
+    dispatch,
+    getState,
+}: ComposeYieldEvmTransactionParams): Promise<string> => {
+    const network = getNetwork(account.symbol);
+
+    if (!network.chainId) {
+        throw new Error(`Network ${account.symbol} is missing chainId.`);
+    }
+
+    if (vaultChainId !== undefined && vaultChainId !== network.chainId) {
+        throw new Error(
+            `Account network chainId ${network.chainId} does not match vault chainId ${vaultChainId}.`,
+        );
+    }
+
+    const nonceTask = dispatch(
+        ethereumGetCurrentNonceThunk({ selectedAccount: account, fetchConfirmedNonce: true }),
+    ).unwrap();
+
+    const estimatedFeeTask = TrezorConnect.blockchainEstimateFee({
+        coin: account.symbol,
+        identity: getAccountIdentity(account),
+        request: {
+            blocks: [2],
+            specific: {
+                from: account.descriptor,
+                to,
+                data,
+                value: value ?? '0x0',
+            },
+        },
+    });
+
+    const [{ nonce }, estimatedFee] = await Promise.all([nonceTask, estimatedFeeTask]);
+
+    const estimatedGasLimit = estimatedFee.success
+        ? estimatedFee.payload.levels[0]?.feeLimit
+        : undefined;
+
+    if (!estimatedGasLimit) {
+        dispatch(notificationsActions.addToast({ type: 'estimated-fee-error' }));
+    }
+
+    const gasLimit = estimatedGasLimit ?? backupGasLimit;
+
+    const feeInfo = getConvertedOrDefaultFeeInfo({
+        networkType: account.networkType,
+        feeInfo: selectRawNetworkFeeInfo(getState(), account.symbol),
+    });
+    const normalLevel = feeInfo.levels.find(level => level.label === 'normal') ?? feeInfo.levels[0];
+
+    if (!normalLevel) {
+        throw new Error(`Fee info is not available.`);
+    }
+
+    const unsignedTx = buildYieldUnsignedTransaction({
+        chainId: network.chainId,
+        data,
+        feeLevel: normalLevel,
+        from: account.descriptor,
+        gasLimit,
+        nonce: Number(nonce),
+        to,
+        value,
+    });
+
+    // Both the value and the whole fee are debited from the native balance — reject
+    // a transaction that cannot be paid for instead of letting broadcasting fail.
+    const feePerGas = 'maxFeePerGas' in unsignedTx ? unsignedTx.maxFeePerGas : unsignedTx.gasPrice;
+    const maxDebit = BigInt(unsignedTx.value) + BigInt(unsignedTx.gasLimit) * BigInt(feePerGas);
+
+    if (maxDebit > BigInt(account.availableBalance)) {
+        throw new Error('Insufficient native balance to cover the transaction value and fee.');
+    }
+
+    return JSON.stringify(unsignedTx);
+};

--- a/packages/suite/src/actions/wallet/stablecoin-yield/composeYieldEvmTransaction.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/composeYieldEvmTransaction.ts
@@ -14,7 +14,8 @@ export type ComposeYieldEvmTransactionParams = {
     data: string;
     value?: string;
     backupGasLimit: string;
-    vaultChainId?: number;
+    /** When given (even null), it must equal the account network's chainId. */
+    vaultChainId?: number | null;
     dispatch: Dispatch;
     getState: () => AppState;
 };

--- a/packages/suite/src/actions/wallet/stablecoin-yield/composeYieldWithdrawTransaction.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/composeYieldWithdrawTransaction.ts
@@ -1,21 +1,16 @@
 import { asEvmAddress } from '@suite-common/calldata';
 import { getYieldVault } from '@suite-common/earn-stablecoin-api';
-import { notificationsActions } from '@suite-common/toast-notifications';
-import { getNetwork } from '@suite-common/wallet-config';
 import { ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT } from '@suite-common/wallet-constants';
 import {
     type YieldFlowResolvedData,
     type YieldWithdrawFlowType,
-    buildYieldUnsignedTransaction,
     buildYieldWithdrawCalldata,
-    selectRawNetworkFeeInfo,
 } from '@suite-common/wallet-core';
-import { ethereumGetCurrentNonceThunk } from '@suite-common/wallet-core/src/send/sendFormEthereumThunks';
 import { type Account } from '@suite-common/wallet-types';
-import { getAccountIdentity, getConvertedOrDefaultFeeInfo } from '@suite-common/wallet-utils';
-import TrezorConnect from '@trezor/connect';
 
 import type { AppState, Dispatch } from 'src/types/suite';
+
+import { composeYieldEvmTransaction } from './composeYieldEvmTransaction';
 
 export type ComposeYieldWithdrawTransactionParams = {
     account: Account & { networkType: 'ethereum' };
@@ -42,17 +37,6 @@ export const composeYieldWithdrawTransaction = async ({
             vaultId: vault.id,
         },
     });
-    const network = getNetwork(account.symbol);
-
-    if (!network.chainId) {
-        throw new Error(`Network ${account.symbol} is missing chainId.`);
-    }
-
-    if (vault.chainId !== network.chainId) {
-        throw new Error(
-            `Account network chainId ${network.chainId} does not match vault chainId ${vault.chainId}.`,
-        );
-    }
 
     const ownerAddress = asEvmAddress(account.descriptor);
     const calldata = buildYieldWithdrawCalldata({
@@ -63,55 +47,13 @@ export const composeYieldWithdrawTransaction = async ({
         flowType,
     });
 
-    const nonceTask = dispatch(
-        ethereumGetCurrentNonceThunk({ selectedAccount: account, fetchConfirmedNonce: true }),
-    ).unwrap();
-
-    const estimatedFeeTask = TrezorConnect.blockchainEstimateFee({
-        coin: account.symbol,
-        identity: getAccountIdentity(account),
-        request: {
-            blocks: [2],
-            specific: {
-                from: account.descriptor,
-                to: vaultAddress,
-                data: calldata,
-                value: '0x0',
-            },
-        },
-    });
-
-    const [{ nonce }, estimatedFee] = await Promise.all([nonceTask, estimatedFeeTask]);
-
-    const estimatedGasLimit = estimatedFee.success
-        ? estimatedFee.payload.levels[0]?.feeLimit
-        : undefined;
-
-    if (!estimatedGasLimit) {
-        dispatch(notificationsActions.addToast({ type: 'estimated-fee-error' }));
-    }
-
-    const gasLimit = estimatedGasLimit ?? ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT;
-
-    const feeInfo = getConvertedOrDefaultFeeInfo({
-        networkType: account.networkType,
-        feeInfo: selectRawNetworkFeeInfo(getState(), account.symbol),
-    });
-    const normalLevel = feeInfo.levels.find(level => level.label === 'normal') ?? feeInfo.levels[0];
-
-    if (!normalLevel) {
-        throw new Error(`Fee info is not available.`);
-    }
-
-    const unsignedTx = buildYieldUnsignedTransaction({
-        chainId: network.chainId,
-        data: calldata,
-        feeLevel: normalLevel,
-        from: account.descriptor,
-        gasLimit,
-        nonce: Number(nonce),
+    return composeYieldEvmTransaction({
+        account,
         to: vaultAddress,
+        data: calldata,
+        backupGasLimit: ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT,
+        vaultChainId: vault.chainId,
+        dispatch,
+        getState,
     });
-
-    return JSON.stringify(unsignedTx);
 };

--- a/packages/suite/src/actions/wallet/stablecoin-yield/composeYieldWrapTransaction.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/composeYieldWrapTransaction.ts
@@ -1,0 +1,52 @@
+import { WRAPPED_NATIVE_TOKEN_DECIMALS, isWrappedNativeToken } from '@suite-common/wallet-config';
+import { WETH_DEPOSIT_BACKUP_GAS_LIMIT } from '@suite-common/wallet-constants';
+import {
+    type YieldFlowResolvedData,
+    buildYieldWrapTransactionData,
+} from '@suite-common/wallet-core';
+import { type Account } from '@suite-common/wallet-types';
+
+import type { AppState, Dispatch } from 'src/types/suite';
+
+import { composeYieldEvmTransaction } from './composeYieldEvmTransaction';
+
+export type ComposeYieldWrapTransactionParams = {
+    account: Account & { networkType: 'ethereum' };
+    flowData: YieldFlowResolvedData;
+    wrapAmount: string;
+    dispatch: Dispatch;
+    getState: () => AppState;
+};
+
+export const composeYieldWrapTransaction = ({
+    account,
+    flowData,
+    wrapAmount,
+    dispatch,
+    getState,
+}: ComposeYieldWrapTransactionParams): Promise<string> => {
+    const { vault, token } = flowData;
+    const wethAddress = token.contractAddress;
+
+    // Never compose a value-carrying transaction to anything but the canonical
+    // wrapped-native contract of the account network.
+    if (!isWrappedNativeToken(account.symbol, wethAddress) || !wethAddress) {
+        throw new Error('Vault token is not the wrapped native token of the account network.');
+    }
+
+    const { data, value } = buildYieldWrapTransactionData({
+        wrapAmount,
+        decimals: WRAPPED_NATIVE_TOKEN_DECIMALS,
+    });
+
+    return composeYieldEvmTransaction({
+        account,
+        to: wethAddress,
+        data,
+        value,
+        backupGasLimit: WETH_DEPOSIT_BACKUP_GAS_LIMIT,
+        vaultChainId: vault.chainId,
+        dispatch,
+        getState,
+    });
+};

--- a/packages/suite/src/actions/wallet/stablecoin-yield/index.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/index.ts
@@ -1,5 +1,6 @@
 export * from './cancelSignYieldTx';
 export * from './claimMerklRewardsThunk';
 export * from './submitYieldDepositThunk';
+export * from './submitYieldUnwrapThunk';
 export * from './submitYieldWithdrawThunk';
 export * from './submitYieldWrapThunk';

--- a/packages/suite/src/actions/wallet/stablecoin-yield/index.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/index.ts
@@ -2,3 +2,4 @@ export * from './cancelSignYieldTx';
 export * from './claimMerklRewardsThunk';
 export * from './submitYieldDepositThunk';
 export * from './submitYieldWithdrawThunk';
+export * from './submitYieldWrapThunk';

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldUnwrapThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldUnwrapThunk.ts
@@ -1,0 +1,176 @@
+import { asTypedDesktopAnalytics, events } from '@suite/analytics';
+import { openDeferredModal } from '@suite/modal';
+import { type StablecoinYieldTxSimulationParams } from '@suite-common/earn-stablecoin/src/tx-simulation';
+import { createThunk } from '@suite-common/redux-utils';
+import { notificationsActions } from '@suite-common/toast-notifications';
+import {
+    WRAPPED_NATIVE_TOKEN_DECIMALS,
+    getWrappedNativeAddress,
+    isWrappedNativeToken,
+} from '@suite-common/wallet-config';
+import {
+    STABLECOIN_YIELD_PREFIX,
+    type YieldFlowDisplayToken,
+    type YieldFlowResolvedData,
+    type YieldWithdrawFlowType,
+    stablecoinYieldActions,
+} from '@suite-common/wallet-core';
+import { BigNumber } from '@trezor/utils';
+
+import { getYieldErrorTranslationKey, sendYieldTransaction } from './signingHelpers';
+import { composeWethUnwrapTransaction } from '../weth/composeWethUnwrapTransaction';
+
+type SubmitYieldUnwrapPayload = {
+    flowKey: string;
+    flowType: YieldWithdrawFlowType;
+    flowData: YieldFlowResolvedData;
+    /** Wrapped-native amount to unwrap — the withdrawn amount by default. */
+    unwrapAmount: string;
+};
+
+export const submitYieldUnwrapThunk = createThunk(
+    `${STABLECOIN_YIELD_PREFIX}/thunk/submitUnwrap`,
+    async (
+        { flowKey, flowType, flowData, unwrapAmount }: SubmitYieldUnwrapPayload,
+        { dispatch, getState, extra },
+    ) => {
+        try {
+            if (flowData.account.networkType !== 'ethereum') {
+                throw new Error('Yield actions currently support only EVM accounts.');
+            }
+
+            dispatch(stablecoinYieldActions.startSubmittingUnwrap({ flowType, flowKey }));
+
+            const { account } = flowData;
+            const wethAddress = getWrappedNativeAddress(account.symbol);
+
+            if (!wethAddress) {
+                throw new Error(`Network ${account.symbol} has no wrapped native token.`);
+            }
+
+            const wethToken = account.tokens?.find(token =>
+                isWrappedNativeToken(account.symbol, token.contract),
+            );
+            // The withdrawn amount can exceed the refreshed balance by vault rounding
+            // dust — never try to unwrap more than the account actually holds.
+            const amount = BigNumber.min(
+                unwrapAmount,
+                wethToken?.balance ?? unwrapAmount,
+            ).toString();
+
+            const unsignedTransaction = await composeWethUnwrapTransaction({
+                account,
+                amount,
+                dispatch,
+                getState,
+            });
+
+            const userAcceptedTxSimulation = await dispatch(
+                openDeferredModal({
+                    type: 'earn-yield-tx-simulation',
+                    data: {
+                        flow: 'unwrap',
+                        unsignedTx: unsignedTransaction,
+                        account,
+                    } satisfies StablecoinYieldTxSimulationParams,
+                }),
+            );
+
+            asTypedDesktopAnalytics(extra.services.analytics).report({
+                type: events.yieldWithdrawEvent.name,
+                payload: {
+                    type: 'tx-simulation-modal',
+                    operation: flowType,
+                    action: userAcceptedTxSimulation?.value === false ? 'cancel' : 'continue',
+                    networkSymbol: account.symbol,
+                    vaultId: flowData.vault.id,
+                },
+            });
+
+            if (userAcceptedTxSimulation?.value === false) {
+                return;
+            }
+
+            const selectedFee = userAcceptedTxSimulation?.selectedFee ?? null;
+
+            const wethDisplayToken: YieldFlowDisplayToken = {
+                networkSymbol: account.symbol,
+                symbol: wethToken?.symbol ?? 'WETH',
+                // Pinned like the wrap value — never scaled by remote token metadata.
+                decimals: WRAPPED_NATIVE_TOKEN_DECIMALS,
+                contractAddress: wethAddress,
+            };
+
+            const result = await sendYieldTransaction({
+                account,
+                amount,
+                token: wethDisplayToken,
+                unsignedTransaction,
+                dispatch,
+                getState,
+                selectedFee,
+            });
+
+            userAcceptedTxSimulation?.resolve();
+
+            if (!result) {
+                asTypedDesktopAnalytics(extra.services.analytics).report({
+                    type: events.yieldWithdrawEvent.name,
+                    payload: {
+                        type: 'error',
+                        operation: flowType,
+                        action: 'continue',
+                        networkSymbol: account.symbol,
+                        vaultId: flowData.vault.id,
+                        errorMessage: 'submit-failed',
+                    },
+                });
+
+                return;
+            }
+
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'tx-yield-unwrap',
+                    descriptor: account.descriptor,
+                    symbol: account.symbol,
+                    txid: result.txid,
+                }),
+            );
+
+            dispatch(
+                stablecoinYieldActions.setPendingTx({
+                    flowType,
+                    flowKey,
+                    tx: {
+                        type: 'unwrap',
+                        txid: result.txid,
+                        amount,
+                    },
+                }),
+            );
+        } catch (error) {
+            console.error(error);
+            asTypedDesktopAnalytics(extra.services.analytics).report({
+                type: events.yieldWithdrawEvent.name,
+                payload: {
+                    type: 'error',
+                    operation: flowType,
+                    action: 'continue',
+                    networkSymbol: flowData.account.symbol,
+                    vaultId: flowData.vault.id,
+                    errorMessage: 'submit-failed',
+                },
+            });
+            dispatch(
+                stablecoinYieldActions.setError({
+                    flowType,
+                    flowKey,
+                    error: getYieldErrorTranslationKey(error),
+                }),
+            );
+        } finally {
+            dispatch(stablecoinYieldActions.finishSubmittingUnwrap({ flowType, flowKey }));
+        }
+    },
+);

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWrapThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWrapThunk.ts
@@ -1,0 +1,163 @@
+import { asTypedDesktopAnalytics, events } from '@suite/analytics';
+import { openDeferredModal } from '@suite/modal';
+import { type StablecoinYieldTxSimulationParams } from '@suite-common/earn-stablecoin/src/tx-simulation';
+import { createThunk } from '@suite-common/redux-utils';
+import { notificationsActions } from '@suite-common/toast-notifications';
+import {
+    WRAPPED_NATIVE_TOKEN_DECIMALS,
+    getNetworkDisplaySymbol,
+} from '@suite-common/wallet-config';
+import {
+    STABLECOIN_YIELD_PREFIX,
+    type YieldFlowDisplayToken,
+    type YieldFlowResolvedData,
+    setYieldGenericError,
+    stablecoinYieldActions,
+} from '@suite-common/wallet-core';
+
+import { composeYieldWrapTransaction } from './composeYieldWrapTransaction';
+import { sendYieldTransaction } from './signingHelpers';
+
+type SubmitYieldWrapPayload = {
+    flowKey: string;
+    flowData: YieldFlowResolvedData;
+    /** Native coin amount to wrap — the value carried by the transaction. */
+    wrapAmount: string;
+    /** Held WETH + wrapAmount — the deposit total the approve step is prefilled with. */
+    totalDepositAmount: string;
+};
+
+export const submitYieldWrapThunk = createThunk(
+    `${STABLECOIN_YIELD_PREFIX}/thunk/submitWrap`,
+    async (
+        { flowKey, flowData, wrapAmount, totalDepositAmount }: SubmitYieldWrapPayload,
+        { dispatch, getState, extra },
+    ) => {
+        const flowType = 'deposit' as const;
+
+        try {
+            if (flowData.account.networkType !== 'ethereum') {
+                throw new Error('Yield actions currently support only EVM accounts.');
+            }
+
+            dispatch(
+                stablecoinYieldActions.startSubmittingWrap({
+                    flowType,
+                    flowKey,
+                    amount: totalDepositAmount,
+                }),
+            );
+
+            const { account } = flowData;
+
+            const unsignedTransaction = await composeYieldWrapTransaction({
+                account,
+                flowData,
+                wrapAmount,
+                dispatch,
+                getState,
+            });
+
+            const userAcceptedTxSimulation = await dispatch(
+                openDeferredModal({
+                    type: 'earn-yield-tx-simulation',
+                    data: {
+                        flow: 'wrap',
+                        unsignedTx: unsignedTransaction,
+                        account,
+                    } satisfies StablecoinYieldTxSimulationParams,
+                }),
+            );
+
+            asTypedDesktopAnalytics(extra.services.analytics).report({
+                type: events.yieldDepositEvent.name,
+                payload: {
+                    type: 'tx-simulation-modal',
+                    action: userAcceptedTxSimulation?.value === false ? 'cancel' : 'continue',
+                    networkSymbol: account.symbol,
+                    vaultId: flowData.vault.id,
+                },
+            });
+
+            if (userAcceptedTxSimulation?.value === false) {
+                return;
+            }
+
+            const selectedFee = userAcceptedTxSimulation?.selectedFee ?? null;
+
+            // No contract address — the wrapped amount is spent as native value,
+            // which makes the review modal compute totalSpent = amount + fee.
+            const nativeDisplayToken: YieldFlowDisplayToken = {
+                networkSymbol: account.symbol,
+                symbol: getNetworkDisplaySymbol(account.symbol),
+                // Pin to the wrapped-native decimals the wrap value was built with,
+                // rather than trusting remote vault-token metadata.
+                decimals: WRAPPED_NATIVE_TOKEN_DECIMALS,
+                contractAddress: null,
+            };
+
+            const result = await sendYieldTransaction({
+                account,
+                amount: wrapAmount,
+                token: nativeDisplayToken,
+                unsignedTransaction,
+                dispatch,
+                getState,
+                selectedFee,
+            });
+
+            userAcceptedTxSimulation?.resolve();
+
+            if (!result) {
+                asTypedDesktopAnalytics(extra.services.analytics).report({
+                    type: events.yieldDepositEvent.name,
+                    payload: {
+                        type: 'error',
+                        action: 'continue',
+                        networkSymbol: account.symbol,
+                        vaultId: flowData.vault.id,
+                        errorMessage: 'submit-failed',
+                    },
+                });
+
+                return;
+            }
+
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'tx-yield-wrap',
+                    descriptor: account.descriptor,
+                    symbol: account.symbol,
+                    txid: result.txid,
+                }),
+            );
+
+            dispatch(
+                stablecoinYieldActions.setPendingTx({
+                    flowType,
+                    flowKey,
+                    tx: {
+                        type: 'wrap',
+                        txid: result.txid,
+                        amount: wrapAmount,
+                    },
+                }),
+            );
+        } catch (error) {
+            console.error(error);
+            asTypedDesktopAnalytics(extra.services.analytics).report({
+                type: events.yieldDepositEvent.name,
+                payload: {
+                    type: 'error',
+                    action: 'continue',
+                    networkSymbol: flowData.account.symbol,
+                    vaultId: flowData.vault.id,
+                    errorMessage: 'submit-failed',
+                },
+            });
+            setYieldGenericError({ dispatch, flowType, flowKey });
+        } finally {
+            dispatch(stablecoinYieldActions.finishSubmittingWrap({ flowType, flowKey }));
+        }
+    },
+);

--- a/packages/suite/src/actions/wallet/weth/composeWethUnwrapTransaction.ts
+++ b/packages/suite/src/actions/wallet/weth/composeWethUnwrapTransaction.ts
@@ -1,0 +1,70 @@
+import { Calldata } from '@suite-common/calldata';
+import {
+    WRAPPED_NATIVE_TOKEN_DECIMALS,
+    getWrappedNativeAddress,
+    isWrappedNativeToken,
+} from '@suite-common/wallet-config';
+import { ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT } from '@suite-common/wallet-constants';
+import { type Account } from '@suite-common/wallet-types';
+import { asAmountUnit, unitsToSubunits } from '@suite-common/wallet-utils';
+import { BigNumber } from '@trezor/utils';
+
+import type { AppState, Dispatch } from 'src/types/suite';
+
+import { composeYieldEvmTransaction } from '../stablecoin-yield/composeYieldEvmTransaction';
+
+export type ComposeWethUnwrapTransactionParams = {
+    account: Account & { networkType: 'ethereum' };
+    amount: string;
+    dispatch: Dispatch;
+    getState: () => AppState;
+};
+
+const toWrappedNativeSubunits = (amount: string) =>
+    unitsToSubunits({
+        value: asAmountUnit(new BigNumber(amount)),
+        decimals: WRAPPED_NATIVE_TOKEN_DECIMALS,
+    });
+
+export const composeWethUnwrapTransaction = ({
+    account,
+    amount,
+    dispatch,
+    getState,
+}: ComposeWethUnwrapTransactionParams): Promise<string> => {
+    const wethAddress = getWrappedNativeAddress(account.symbol);
+
+    if (!wethAddress) {
+        throw new Error(`Network ${account.symbol} has no wrapped native token.`);
+    }
+
+    const wethToken = account.tokens?.find(token =>
+        isWrappedNativeToken(account.symbol, token.contract),
+    );
+
+    // The balance also feeds the INSUFFICIENT_BALANCE builder check below — never
+    // compose an unwrap without a proven wrapped-native balance.
+    if (!wethToken?.balance) {
+        throw new Error('Account holds no wrapped native token to unwrap.');
+    }
+
+    const wad = toWrappedNativeSubunits(amount);
+    const wethBalance = BigInt(toWrappedNativeSubunits(wethToken.balance).toFixed(0));
+
+    const builderResult = Calldata.evm.weth.withdraw.encode({ wad }, { balance: wethBalance });
+
+    if (!builderResult.isValid || !builderResult.data) {
+        const issues = builderResult.errors.map(issue => issue.code).join(', ');
+
+        throw new Error(`Failed to encode unwrap calldata${issues ? `: ${issues}` : '.'}`);
+    }
+
+    return composeYieldEvmTransaction({
+        account,
+        to: wethAddress,
+        data: builderResult.data,
+        backupGasLimit: ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT,
+        dispatch,
+        getState,
+    });
+};

--- a/packages/suite/src/actions/wallet/weth/index.ts
+++ b/packages/suite/src/actions/wallet/weth/index.ts
@@ -1,0 +1,2 @@
+export * from './composeWethUnwrapTransaction';
+export * from './submitWethUnwrapThunk';

--- a/packages/suite/src/actions/wallet/weth/submitWethUnwrapThunk.ts
+++ b/packages/suite/src/actions/wallet/weth/submitWethUnwrapThunk.ts
@@ -1,0 +1,146 @@
+import { asTypedDesktopAnalytics, events } from '@suite/analytics';
+import { openDeferredModal } from '@suite/modal';
+import { type StablecoinYieldTxSimulationParams } from '@suite-common/earn-stablecoin/src/tx-simulation';
+import { createThunk } from '@suite-common/redux-utils';
+import { notificationsActions } from '@suite-common/toast-notifications';
+import {
+    WRAPPED_NATIVE_TOKEN_DECIMALS,
+    getWrappedNativeAddress,
+    isWrappedNativeToken,
+} from '@suite-common/wallet-config';
+import { type Account } from '@suite-common/wallet-types';
+
+import { composeWethUnwrapTransaction } from './composeWethUnwrapTransaction';
+import { sendYieldTransaction } from '../stablecoin-yield/signingHelpers';
+
+type SubmitWethUnwrapPayload = {
+    account: Account;
+    amount: string;
+};
+
+export const submitWethUnwrapThunk = createThunk(
+    '@suite/weth/submitUnwrapThunk',
+    async (
+        { account, amount }: SubmitWethUnwrapPayload,
+        { dispatch, getState, extra },
+    ): Promise<string | undefined> => {
+        try {
+            if (account.networkType !== 'ethereum') {
+                throw new Error('Unwrapping currently supports only EVM accounts.');
+            }
+
+            const wethAddress = getWrappedNativeAddress(account.symbol);
+
+            if (!wethAddress) {
+                throw new Error(`Network ${account.symbol} has no wrapped native token.`);
+            }
+
+            const unsignedTransaction = await composeWethUnwrapTransaction({
+                account,
+                amount,
+                dispatch,
+                getState,
+            });
+
+            const userAcceptedTxSimulation = await dispatch(
+                openDeferredModal({
+                    type: 'earn-yield-tx-simulation',
+                    data: {
+                        flow: 'unwrap',
+                        unsignedTx: unsignedTransaction,
+                        account,
+                    } satisfies StablecoinYieldTxSimulationParams,
+                }),
+            );
+
+            asTypedDesktopAnalytics(extra.services.analytics).report({
+                type: events.wethUnwrapEvent.name,
+                payload: {
+                    type: 'tx-simulation-modal',
+                    action: userAcceptedTxSimulation?.value === false ? 'cancel' : 'continue',
+                    networkSymbol: account.symbol,
+                },
+            });
+
+            if (userAcceptedTxSimulation?.value === false) {
+                return;
+            }
+
+            const selectedFee = userAcceptedTxSimulation?.selectedFee ?? null;
+
+            const wethToken = account.tokens?.find(token =>
+                isWrappedNativeToken(account.symbol, token.contract),
+            );
+
+            const result = await sendYieldTransaction({
+                account,
+                amount,
+                token: {
+                    networkSymbol: account.symbol,
+                    symbol: wethToken?.symbol ?? 'WETH',
+                    decimals: WRAPPED_NATIVE_TOKEN_DECIMALS,
+                    contractAddress: wethAddress,
+                },
+                unsignedTransaction,
+                dispatch,
+                getState,
+                selectedFee,
+            });
+
+            userAcceptedTxSimulation?.resolve();
+
+            if (!result) {
+                asTypedDesktopAnalytics(extra.services.analytics).report({
+                    type: events.wethUnwrapEvent.name,
+                    payload: {
+                        type: 'error',
+                        action: 'continue',
+                        networkSymbol: account.symbol,
+                        errorMessage: 'submit-failed',
+                    },
+                });
+
+                return;
+            }
+
+            asTypedDesktopAnalytics(extra.services.analytics).report({
+                type: events.wethUnwrapEvent.name,
+                payload: {
+                    type: 'unwrap',
+                    action: 'continue',
+                    networkSymbol: account.symbol,
+                },
+            });
+
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'tx-sent',
+                    formattedAmount: `${amount} ${wethToken?.symbol ?? 'WETH'}`,
+                    token: wethToken,
+                    descriptor: account.descriptor,
+                    symbol: account.symbol,
+                    txid: result.txid,
+                }),
+            );
+
+            return result.txid;
+        } catch (error) {
+            console.error(error);
+            asTypedDesktopAnalytics(extra.services.analytics).report({
+                type: events.wethUnwrapEvent.name,
+                payload: {
+                    type: 'error',
+                    action: 'continue',
+                    networkSymbol: account.symbol,
+                    errorMessage: 'submit-failed',
+                },
+            });
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'sign-tx-error',
+                    error: error instanceof Error ? error.message : String(error),
+                }),
+            );
+        }
+    },
+);

--- a/packages/suite/src/components/earn/dashboard/common/EarnStakingVsYieldHint.tsx
+++ b/packages/suite/src/components/earn/dashboard/common/EarnStakingVsYieldHint.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useRef } from 'react';
+
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
+import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
+import { Icon, Row, Text, Tooltip } from '@trezor/components';
+import { InfoIcon } from '@trezor/icons';
+
+const HINT_TOOLTIP_REPORT_DELAY_MS = 1000;
+
+export const EarnStakingVsYieldHint = () => {
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
+    const reportTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    useEffect(
+        () => () => {
+            if (reportTimerRef.current !== null) {
+                clearTimeout(reportTimerRef.current);
+            }
+        },
+        [],
+    );
+
+    const handleMouseEnter = () => {
+        if (reportTimerRef.current !== null) {
+            clearTimeout(reportTimerRef.current);
+        }
+        reportTimerRef.current = setTimeout(() => {
+            analytics.report({
+                type: events.yieldInteractionEvent.name,
+                payload: {
+                    element: 'staking-vs-yield-tooltip',
+                },
+            });
+            reportTimerRef.current = null;
+        }, HINT_TOOLTIP_REPORT_DELAY_MS);
+    };
+
+    const handleMouseLeave = () => {
+        if (reportTimerRef.current !== null) {
+            clearTimeout(reportTimerRef.current);
+            reportTimerRef.current = null;
+        }
+    };
+
+    return (
+        <Tooltip
+            hasArrow
+            content={
+                <Text typographyStyle="body-sm">
+                    <Translation id="TR_EARN_STAKING_VS_YIELD_DESCRIPTION" />
+                </Text>
+            }
+        >
+            <div onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+                <Row gap={4} alignItems="center">
+                    <Icon as={InfoIcon} size={16} intent="neutral" priority="secondary" />
+                    <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
+                        <Translation id="TR_EARN_STAKING_VS_YIELD_TITLE" />
+                    </Text>
+                </Row>
+            </div>
+        </Tooltip>
+    );
+};

--- a/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldTableData.ts
+++ b/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldTableData.ts
@@ -5,6 +5,7 @@ import { type NetworkSymbol, getNetworkByYieldXyzId } from '@suite-common/wallet
 import {
     doTokensMatch,
     getConvertedOutputTokenBalanceToInputTokenAmount,
+    getYieldDepositableBalance,
     selectDeviceSupportedNetworks,
 } from '@suite-common/wallet-core';
 import { type Account, type TokenInfoBranded, toTokenSymbol } from '@suite-common/wallet-types';
@@ -84,7 +85,13 @@ const getYieldOpportunityData = ({
         outputTokenBalance: matchedOutputToken?.balance,
         pricePerShareState: vault.state?.pricePerShareState,
     });
-    const additionalDepositAmount = matchedInputToken?.balance ?? '0';
+    // For wrapped-native vaults the native balance counts in (it can be wrapped on deposit).
+    const additionalDepositAmount = getYieldDepositableBalance({
+        networkSymbol,
+        nativeFormattedBalance: account.formattedBalance,
+        vaultTokenAddress: vault.token.address,
+        matchedTokenBalance: matchedInputToken?.balance,
+    });
     const hasRewardsData =
         new BigNumber(depositedAmount).gt(0) || new BigNumber(additionalDepositAmount).gt(0);
 
@@ -154,7 +161,8 @@ export const useYieldTableData = ({
         const noBalanceOpportunities: YieldAccountOpportunity[] = [];
 
         allOpportunities.forEach(opportunity => {
-            const hasMatchedInputToken = opportunity.matchedInputToken !== undefined;
+            // A depositable balance without a matched token can only come from the
+            // wrappable native balance of a wrapped-native vault.
             const hasDepositableBalance = new BigNumber(opportunity.additionalDepositAmount).gt(0);
 
             if (opportunity.hasVaultPosition) {
@@ -163,7 +171,7 @@ export const useYieldTableData = ({
                 return;
             }
 
-            if (hasMatchedInputToken && hasDepositableBalance) {
+            if (hasDepositableBalance) {
                 depositableOpportunities.push(opportunity);
 
                 return;

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/YieldEarnInANutshellModal.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/YieldEarnInANutshellModal.tsx
@@ -8,6 +8,7 @@ import {
     type EarnProvider,
     type EarnYieldContext,
 } from '@suite-common/suite-types/src/staking';
+import { getNetworkDisplaySymbol, isWrappedNativeToken } from '@suite-common/wallet-config';
 import { type YieldFlowType } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { getApyPercent, isStakingNetworkType } from '@suite-common/wallet-utils';
@@ -55,6 +56,9 @@ export const YieldEarnInANutshellModal = ({
 
     const depositSymbol = vault?.token.symbol ?? '';
     const vaultSymbol = vault?.outputToken?.symbol;
+    const isWrappedNativeVault =
+        !!vault && isWrappedNativeToken(account.symbol, vault.token.address);
+    const nativeSymbol = getNetworkDisplaySymbol(account.symbol);
     const rewardsSymbols = vault?.rewardRate.components
         .filter(c => c.yieldSource === 'protocol_incentive')
         .map(c => c.token.symbol);
@@ -65,7 +69,11 @@ export const YieldEarnInANutshellModal = ({
         {
             processType: 'deposit',
             heading: <Translation id="TR_EARN_DEPOSITING_PROCESS" />,
-            badge: <Translation id="TR_TX_FEE_COUNT" values={{ count: 2 }} />,
+            badge: isWrappedNativeVault ? (
+                <Translation id="TR_TX_FEE_COUNT_UP_TO" values={{ count: 3 }} />
+            ) : (
+                <Translation id="TR_TX_FEE_COUNT" values={{ count: 2 }} />
+            ),
             content: (
                 <YieldDepositingInfo
                     apy={yieldApy}
@@ -73,6 +81,8 @@ export const YieldEarnInANutshellModal = ({
                     networkSymbol={account.symbol}
                     depositSymbol={depositSymbol}
                     vaultSymbol={vaultSymbol}
+                    showWrapStep={isWrappedNativeVault}
+                    nativeSymbol={nativeSymbol}
                 />
             ),
         },
@@ -80,7 +90,13 @@ export const YieldEarnInANutshellModal = ({
             processType: 'withdraw',
             heading: <Translation id="TR_EARN_WITHDRAWING_PROCESS" />,
             badge: <Translation id="TR_TX_FEE_COUNT" values={{ count: 1 }} />,
-            content: <YieldWithdrawingInfo depositSymbol={depositSymbol} />,
+            content: (
+                <YieldWithdrawingInfo
+                    depositSymbol={depositSymbol}
+                    showUnwrapHint={isWrappedNativeVault}
+                    nativeSymbol={nativeSymbol}
+                />
+            ),
         },
         ...(rewardsSymbols !== undefined && rewardsSymbols.length > 0
             ? [
@@ -149,6 +165,7 @@ export const YieldEarnInANutshellModal = ({
                 depositSymbol={depositSymbol}
                 vaultSymbol={vaultSymbol}
                 rewardsSymbols={rewardsSymbols}
+                nativeSymbol={isWrappedNativeVault ? nativeSymbol : undefined}
             />
             <Divider margin={{ top: 24, bottom: 16 }} />
             <EarnInANutshellProcesses items={processes} onItemToggle={handleProcessToggle} />

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/components/YieldDepositingInfo.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/components/YieldDepositingInfo.tsx
@@ -14,6 +14,8 @@ type YieldDepositingInfoProps = {
     networkSymbol: NetworkSymbol;
     depositSymbol: string;
     vaultSymbol: string | undefined;
+    showWrapStep?: boolean;
+    nativeSymbol?: string;
 };
 
 export const YieldDepositingInfo = ({
@@ -22,8 +24,27 @@ export const YieldDepositingInfo = ({
     networkSymbol,
     depositSymbol,
     vaultSymbol,
+    showWrapStep = false,
+    nativeSymbol,
 }: YieldDepositingInfoProps) => (
     <StepList bulletGap={12} gap={16} bulletSize="small" titleGap={2}>
+        {showWrapStep && (
+            <EarnInfoRow
+                heading={
+                    <Translation
+                        id="TR_EARN_YIELD_NUTSHELL_WRAP"
+                        values={{ nativeSymbol, supplySymbol: depositSymbol }}
+                    />
+                }
+                subheading={
+                    <Translation
+                        id="TR_EARN_YIELD_NUTSHELL_WRAP_SUB"
+                        values={{ nativeSymbol, supplySymbol: depositSymbol }}
+                    />
+                }
+                content={{ text: <Translation id="TR_TRADING_NETWORK_FEE" />, isBadge: true }}
+            />
+        )}
         <EarnInfoRow
             heading={
                 <Translation

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/components/YieldEarnInANutshellHighlights.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/components/YieldEarnInANutshellHighlights.tsx
@@ -1,7 +1,13 @@
 import { FormattedList } from 'react-intl';
 
 import { Translation } from '@suite/intl';
-import { CoinsIcon, HandCoinsIcon, LockSimpleIcon, PlusCircleIcon } from '@trezor/icons';
+import {
+    ArrowsDownUpIcon,
+    CoinsIcon,
+    HandCoinsIcon,
+    LockSimpleIcon,
+    PlusCircleIcon,
+} from '@trezor/icons';
 
 import {
     type EarnInANutshellHighlight,
@@ -12,14 +18,30 @@ interface YieldEarnInANutshellHighlightsProps {
     depositSymbol: string;
     vaultSymbol?: string;
     rewardsSymbols?: string[];
+    /** Set for wrapped-native vaults — the native coin can be deposited too. */
+    nativeSymbol?: string;
 }
 
 export const YieldEarnInANutshellHighlights = ({
     depositSymbol,
     vaultSymbol,
     rewardsSymbols,
+    nativeSymbol,
 }: YieldEarnInANutshellHighlightsProps) => {
     const highlights: EarnInANutshellHighlight[] = [
+        ...(nativeSymbol !== undefined
+            ? [
+                  {
+                      icon: ArrowsDownUpIcon,
+                      content: (
+                          <Translation
+                              id="TR_EARN_YIELD_NUTSHELL_DEPOSIT_EITHER"
+                              values={{ nativeSymbol, supplySymbol: depositSymbol }}
+                          />
+                      ),
+                  },
+              ]
+            : []),
         {
             icon: LockSimpleIcon,
             content: (

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/components/YieldWithdrawingInfo.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/components/YieldWithdrawingInfo.tsx
@@ -5,9 +5,15 @@ import { EarnInfoRow } from './EarnInfoRow';
 
 interface YieldWithdrawingInfoProps {
     depositSymbol: string;
+    showUnwrapHint?: boolean;
+    nativeSymbol?: string;
 }
 
-export const YieldWithdrawingInfo = ({ depositSymbol }: YieldWithdrawingInfoProps) => (
+export const YieldWithdrawingInfo = ({
+    depositSymbol,
+    showUnwrapHint = false,
+    nativeSymbol,
+}: YieldWithdrawingInfoProps) => (
     <StepList bulletGap={12} gap={16} bulletSize="small" titleGap={2}>
         <EarnInfoRow
             heading={<Translation id="TR_EARN_SIGN_WITHDRAWAL_TRANSACTION" />}
@@ -28,5 +34,16 @@ export const YieldWithdrawingInfo = ({ depositSymbol }: YieldWithdrawingInfoProp
             }
             content={{ text: <Translation id="TR_EARN_INSTANTLY" /> }}
         />
+        {showUnwrapHint && (
+            <EarnInfoRow
+                heading={
+                    <Translation
+                        id="TR_EARN_YIELD_NUTSHELL_UNWRAP_HINT"
+                        values={{ nativeSymbol, supplySymbol: depositSymbol }}
+                    />
+                }
+                subheading={<Translation id="TR_EARN_YIELD_NUTSHELL_UNWRAP_HINT_SUB" />}
+            />
+        )}
     </StepList>
 );

--- a/packages/suite/src/components/earn/yield/__tests__/yieldFlowUtils.test.ts
+++ b/packages/suite/src/components/earn/yield/__tests__/yieldFlowUtils.test.ts
@@ -4,6 +4,7 @@ describe('yieldFlowUtils', () => {
     describe('getYieldFlowSteps', () => {
         it('describes deposit steps on the approve step', () => {
             expect(getYieldFlowSteps('deposit', 'approve')).toEqual({
+                wrap: { state: 'done', indicator: { index: 0, total: 2 } },
                 approve: { state: 'active', indicator: { index: 1, total: 2 } },
                 action: { state: 'pending', indicator: { index: 2, total: 2 } },
                 complete: { state: 'pending', indicator: { index: 0, total: 2 } },
@@ -12,6 +13,7 @@ describe('yieldFlowUtils', () => {
 
         it('describes deposit steps on the action step', () => {
             expect(getYieldFlowSteps('deposit', 'action')).toEqual({
+                wrap: { state: 'done', indicator: { index: 0, total: 2 } },
                 approve: { state: 'done', indicator: { index: 1, total: 2 } },
                 action: { state: 'active', indicator: { index: 2, total: 2 } },
                 complete: { state: 'pending', indicator: { index: 0, total: 2 } },
@@ -20,9 +22,19 @@ describe('yieldFlowUtils', () => {
 
         it('describes deposit steps on the complete step', () => {
             expect(getYieldFlowSteps('deposit', 'complete')).toEqual({
+                wrap: { state: 'done', indicator: { index: 0, total: 2 } },
                 approve: { state: 'done', indicator: { index: 1, total: 2 } },
                 action: { state: 'done', indicator: { index: 2, total: 2 } },
                 complete: { state: 'active', indicator: { index: 0, total: 2 } },
+            });
+        });
+
+        it('describes the wrap step as the leading step of a wrapped-native deposit', () => {
+            expect(getYieldFlowSteps('deposit', 'wrap', ['wrap', 'approve', 'action'])).toEqual({
+                wrap: { state: 'active', indicator: { index: 1, total: 3 } },
+                approve: { state: 'pending', indicator: { index: 2, total: 3 } },
+                action: { state: 'pending', indicator: { index: 3, total: 3 } },
+                complete: { state: 'pending', indicator: { index: 0, total: 3 } },
             });
         });
 
@@ -30,6 +42,7 @@ describe('yieldFlowUtils', () => {
             expect(
                 getYieldFlowSteps('deposit', 'approve', ['approve', 'action', 'complete']),
             ).toEqual({
+                wrap: { state: 'done', indicator: { index: 0, total: 3 } },
                 approve: { state: 'active', indicator: { index: 1, total: 3 } },
                 action: { state: 'pending', indicator: { index: 2, total: 3 } },
                 complete: { state: 'pending', indicator: { index: 3, total: 3 } },
@@ -38,6 +51,7 @@ describe('yieldFlowUtils', () => {
 
         it('reports steps outside the flow as passed', () => {
             expect(getYieldFlowSteps('withdraw', 'action')).toEqual({
+                wrap: { state: 'done', indicator: { index: 0, total: 1 } },
                 approve: { state: 'done', indicator: { index: 0, total: 1 } },
                 action: { state: 'active', indicator: { index: 1, total: 1 } },
                 complete: { state: 'pending', indicator: { index: 0, total: 1 } },

--- a/packages/suite/src/components/earn/yield/__tests__/yieldFlowUtils.test.ts
+++ b/packages/suite/src/components/earn/yield/__tests__/yieldFlowUtils.test.ts
@@ -7,6 +7,7 @@ describe('yieldFlowUtils', () => {
                 wrap: { state: 'done', indicator: { index: 0, total: 2 } },
                 approve: { state: 'active', indicator: { index: 1, total: 2 } },
                 action: { state: 'pending', indicator: { index: 2, total: 2 } },
+                unwrap: { state: 'done', indicator: { index: 0, total: 2 } },
                 complete: { state: 'pending', indicator: { index: 0, total: 2 } },
             });
         });
@@ -16,6 +17,7 @@ describe('yieldFlowUtils', () => {
                 wrap: { state: 'done', indicator: { index: 0, total: 2 } },
                 approve: { state: 'done', indicator: { index: 1, total: 2 } },
                 action: { state: 'active', indicator: { index: 2, total: 2 } },
+                unwrap: { state: 'done', indicator: { index: 0, total: 2 } },
                 complete: { state: 'pending', indicator: { index: 0, total: 2 } },
             });
         });
@@ -25,6 +27,7 @@ describe('yieldFlowUtils', () => {
                 wrap: { state: 'done', indicator: { index: 0, total: 2 } },
                 approve: { state: 'done', indicator: { index: 1, total: 2 } },
                 action: { state: 'done', indicator: { index: 2, total: 2 } },
+                unwrap: { state: 'done', indicator: { index: 0, total: 2 } },
                 complete: { state: 'active', indicator: { index: 0, total: 2 } },
             });
         });
@@ -34,7 +37,18 @@ describe('yieldFlowUtils', () => {
                 wrap: { state: 'active', indicator: { index: 1, total: 3 } },
                 approve: { state: 'pending', indicator: { index: 2, total: 3 } },
                 action: { state: 'pending', indicator: { index: 3, total: 3 } },
+                unwrap: { state: 'done', indicator: { index: 0, total: 3 } },
                 complete: { state: 'pending', indicator: { index: 0, total: 3 } },
+            });
+        });
+
+        it('describes the unwrap step as the trailing step of a wrapped-native withdrawal', () => {
+            expect(getYieldFlowSteps('withdraw', 'unwrap', ['action', 'unwrap'])).toEqual({
+                wrap: { state: 'done', indicator: { index: 0, total: 2 } },
+                approve: { state: 'done', indicator: { index: 0, total: 2 } },
+                action: { state: 'done', indicator: { index: 1, total: 2 } },
+                unwrap: { state: 'active', indicator: { index: 2, total: 2 } },
+                complete: { state: 'pending', indicator: { index: 0, total: 2 } },
             });
         });
 
@@ -45,6 +59,7 @@ describe('yieldFlowUtils', () => {
                 wrap: { state: 'done', indicator: { index: 0, total: 3 } },
                 approve: { state: 'active', indicator: { index: 1, total: 3 } },
                 action: { state: 'pending', indicator: { index: 2, total: 3 } },
+                unwrap: { state: 'done', indicator: { index: 0, total: 3 } },
                 complete: { state: 'pending', indicator: { index: 3, total: 3 } },
             });
         });
@@ -54,6 +69,7 @@ describe('yieldFlowUtils', () => {
                 wrap: { state: 'done', indicator: { index: 0, total: 1 } },
                 approve: { state: 'done', indicator: { index: 0, total: 1 } },
                 action: { state: 'active', indicator: { index: 1, total: 1 } },
+                unwrap: { state: 'pending', indicator: { index: 0, total: 1 } },
                 complete: { state: 'pending', indicator: { index: 0, total: 1 } },
             });
         });

--- a/packages/suite/src/components/earn/yield/common/YieldActionStepWarning.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldActionStepWarning.tsx
@@ -5,15 +5,44 @@ type YieldActionStepWarningProps = {
     isInsufficientFunds?: boolean;
     isApprovalInsufficient?: boolean;
     isApproveOverBalance?: boolean;
+    isWrapInsufficient?: boolean;
+    tokenSymbol?: string;
     onModifyApproval?: () => void;
+    onWrapMore?: () => void;
 };
 
 export const YieldActionStepWarning = ({
     isInsufficientFunds = false,
     isApprovalInsufficient = false,
     isApproveOverBalance = false,
+    isWrapInsufficient = false,
+    tokenSymbol,
     onModifyApproval,
+    onWrapMore,
 }: YieldActionStepWarningProps) => {
+    if (isWrapInsufficient) {
+        return (
+            <Banner
+                intent="warning"
+                description={
+                    <Column gap={12}>
+                        <Text>
+                            <Translation
+                                id="TR_EARN_YIELD_WRAP_INSUFFICIENT"
+                                values={{ tokenSymbol }}
+                            />
+                        </Text>
+                        {onWrapMore && (
+                            <Button size="small" intent="warning" onClick={onWrapMore}>
+                                <Translation id="TR_EARN_YIELD_WRAP_MORE" />
+                            </Button>
+                        )}
+                    </Column>
+                }
+            />
+        );
+    }
+
     if (isApproveOverBalance) {
         return (
             <Banner

--- a/packages/suite/src/components/earn/yield/common/YieldFlowCompleteWithdraw.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldFlowCompleteWithdraw.tsx
@@ -1,14 +1,6 @@
-import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
-import { openModal } from '@suite/modal';
-import { useServices } from '@suite-common/dependency-injection';
-import { getNetworkDisplaySymbol, isWrappedNativeToken } from '@suite-common/wallet-config';
 import { type YieldFlowCompleteValue } from '@suite-common/wallet-core';
-import { type Account } from '@suite-common/wallet-types';
-import { Button, Column, Divider, Row, Text } from '@trezor/components';
-import { BigNumber } from '@trezor/utils';
-
-import { useDispatch } from 'src/hooks/suite';
+import { Column, Row, Text } from '@trezor/components';
 
 import { YieldFlowComplete } from './YieldFlowComplete';
 import { YieldFlowTransferRow } from './YieldFlowTransferRow';
@@ -18,58 +10,14 @@ type YieldFlowCompleteWithdrawProps = {
     input: YieldFlowCompleteValue;
     output?: YieldFlowCompleteValue;
     vaultId: string;
-    account?: Account;
 };
 
 export const YieldFlowCompleteWithdraw = ({
     input,
     output,
     vaultId,
-    account,
 }: YieldFlowCompleteWithdrawProps) => {
-    const dispatch = useDispatch();
-    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const receivedValue = output ?? input;
-
-    const showUnwrapOffer =
-        !!account &&
-        isWrappedNativeToken(
-            receivedValue.token.networkSymbol,
-            receivedValue.token.contractAddress,
-        ) &&
-        new BigNumber(receivedValue.amount).gt(0);
-
-    const handleUnwrapOfferClick = () => {
-        if (!account) {
-            return;
-        }
-
-        analytics.report({
-            type: events.yieldInteractionEvent.name,
-            payload: {
-                element: 'unwrap-offer',
-                networkSymbol: account.symbol,
-                vaultId,
-            },
-        });
-        analytics.report({
-            type: events.wethUnwrapEvent.name,
-            payload: {
-                type: 'unwrap-form-modal',
-                action: 'continue',
-                networkSymbol: account.symbol,
-                source: 'withdraw-complete',
-            },
-        });
-
-        dispatch(
-            openModal({
-                type: 'unwrap-weth',
-                account,
-                prefillAmount: receivedValue.amount,
-            }),
-        );
-    };
 
     return (
         <YieldFlowComplete
@@ -110,33 +58,6 @@ export const YieldFlowCompleteWithdraw = ({
                         />
                     </Column>
                 </Row>
-            )}
-
-            {showUnwrapOffer && account && (
-                <>
-                    <Divider color="borderNeutral" margin={0} />
-                    <Column gap={12} padding={{ vertical: 16, horizontal: 20 }}>
-                        <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
-                            <Translation
-                                id="TR_UNWRAP_OFFER_TEXT"
-                                values={{
-                                    symbol: receivedValue.token.symbol,
-                                    nativeSymbol: getNetworkDisplaySymbol(account.symbol),
-                                }}
-                            />
-                        </Text>
-                        <Button
-                            intent="neutral"
-                            priority="secondary"
-                            onClick={handleUnwrapOfferClick}
-                        >
-                            <Translation
-                                id="TR_UNWRAP_TO_NATIVE"
-                                values={{ symbol: getNetworkDisplaySymbol(account.symbol) }}
-                            />
-                        </Button>
-                    </Column>
-                </>
             )}
         </YieldFlowComplete>
     );

--- a/packages/suite/src/components/earn/yield/common/YieldFlowCompleteWithdraw.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldFlowCompleteWithdraw.tsx
@@ -1,6 +1,14 @@
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
+import { openModal } from '@suite/modal';
+import { useServices } from '@suite-common/dependency-injection';
+import { getNetworkDisplaySymbol, isWrappedNativeToken } from '@suite-common/wallet-config';
 import { type YieldFlowCompleteValue } from '@suite-common/wallet-core';
-import { Column, Row, Text } from '@trezor/components';
+import { type Account } from '@suite-common/wallet-types';
+import { Button, Column, Divider, Row, Text } from '@trezor/components';
+import { BigNumber } from '@trezor/utils';
+
+import { useDispatch } from 'src/hooks/suite';
 
 import { YieldFlowComplete } from './YieldFlowComplete';
 import { YieldFlowTransferRow } from './YieldFlowTransferRow';
@@ -10,14 +18,58 @@ type YieldFlowCompleteWithdrawProps = {
     input: YieldFlowCompleteValue;
     output?: YieldFlowCompleteValue;
     vaultId: string;
+    account?: Account;
 };
 
 export const YieldFlowCompleteWithdraw = ({
     input,
     output,
     vaultId,
+    account,
 }: YieldFlowCompleteWithdrawProps) => {
+    const dispatch = useDispatch();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const receivedValue = output ?? input;
+
+    const showUnwrapOffer =
+        !!account &&
+        isWrappedNativeToken(
+            receivedValue.token.networkSymbol,
+            receivedValue.token.contractAddress,
+        ) &&
+        new BigNumber(receivedValue.amount).gt(0);
+
+    const handleUnwrapOfferClick = () => {
+        if (!account) {
+            return;
+        }
+
+        analytics.report({
+            type: events.yieldInteractionEvent.name,
+            payload: {
+                element: 'unwrap-offer',
+                networkSymbol: account.symbol,
+                vaultId,
+            },
+        });
+        analytics.report({
+            type: events.wethUnwrapEvent.name,
+            payload: {
+                type: 'unwrap-form-modal',
+                action: 'continue',
+                networkSymbol: account.symbol,
+                source: 'withdraw-complete',
+            },
+        });
+
+        dispatch(
+            openModal({
+                type: 'unwrap-weth',
+                account,
+                prefillAmount: receivedValue.amount,
+            }),
+        );
+    };
 
     return (
         <YieldFlowComplete
@@ -58,6 +110,33 @@ export const YieldFlowCompleteWithdraw = ({
                         />
                     </Column>
                 </Row>
+            )}
+
+            {showUnwrapOffer && account && (
+                <>
+                    <Divider color="borderNeutral" margin={0} />
+                    <Column gap={12} padding={{ vertical: 16, horizontal: 20 }}>
+                        <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
+                            <Translation
+                                id="TR_UNWRAP_OFFER_TEXT"
+                                values={{
+                                    symbol: receivedValue.token.symbol,
+                                    nativeSymbol: getNetworkDisplaySymbol(account.symbol),
+                                }}
+                            />
+                        </Text>
+                        <Button
+                            intent="neutral"
+                            priority="secondary"
+                            onClick={handleUnwrapOfferClick}
+                        >
+                            <Translation
+                                id="TR_UNWRAP_TO_NATIVE"
+                                values={{ symbol: getNetworkDisplaySymbol(account.symbol) }}
+                            />
+                        </Button>
+                    </Column>
+                </>
             )}
         </YieldFlowComplete>
     );

--- a/packages/suite/src/components/earn/yield/common/YieldFlowStepList.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldFlowStepList.tsx
@@ -6,7 +6,7 @@ import {
     type YieldFlowStepId,
     type YieldFlowType,
 } from '@suite-common/wallet-core';
-import { Column, Row, StepList, Text } from '@trezor/components';
+import { Column, Row, StepList, type StepListItemState, Text } from '@trezor/components';
 
 import { type YieldFlowStepView, getYieldFlowSteps } from '../yieldFlowUtils';
 
@@ -17,6 +17,8 @@ export type YieldFlowStepOf<TFlowType extends YieldFlowType> =
 export type YieldFlowStepDefinition = {
     /** Label on the title row next to the step number. */
     title?: ReactNode;
+    /** Overrides the sequence-derived display state (e.g. the conditional wrap step). */
+    state?: StepListItemState;
     /** Right side of the title row (e.g. a modify action); receives the view for state-dependent actions. */
     rightContent?: (view: YieldFlowStepView) => ReactNode;
     /**
@@ -33,7 +35,10 @@ export type YieldFlowStepDefinition = {
 type YieldFlowStepListProps<TFlowType extends YieldFlowType> = {
     flowType: TFlowType;
     currentStep: YieldFlowStepId;
-    steps: Record<YieldFlowStepOf<TFlowType>, YieldFlowStepDefinition>;
+    steps: Record<YieldFlowStepOf<TFlowType>, YieldFlowStepDefinition> &
+        Partial<Record<YieldFlowStepId, YieldFlowStepDefinition>>;
+    /** Overrides the sequence-derived list, e.g. to stitch in the conditional wrap step. */
+    listSteps?: readonly YieldFlowStepId[];
     /** Renders the steps as an ordered StepList; without it only the current step's content shows. */
     hasStepList?: boolean;
 };
@@ -42,12 +47,15 @@ export const YieldFlowStepList = <TFlowType extends YieldFlowType>({
     flowType,
     currentStep,
     steps,
+    listSteps: listStepsOverride,
     hasStepList = false,
 }: YieldFlowStepListProps<TFlowType>) => {
     // Widened — the prop is keyed by the flow's own steps, but we index it with generic step ids.
     const stepDefinitions: Partial<Record<YieldFlowStepId, YieldFlowStepDefinition>> = steps;
     const sequence: readonly YieldFlowStepId[] = YIELD_FLOW_STEP_SEQUENCES[flowType];
-    const listSteps = sequence.filter(stepId => stepDefinitions[stepId]?.isListItem !== false);
+    const listSteps =
+        listStepsOverride ??
+        sequence.filter(stepId => stepDefinitions[stepId]?.isListItem !== false);
     const views = getYieldFlowSteps(flowType, currentStep, listSteps);
 
     const renderStepContent = (stepId: YieldFlowStepId) => {
@@ -81,7 +89,7 @@ export const YieldFlowStepList = <TFlowType extends YieldFlowType>({
                 return (
                     <StepList.Item
                         key={stepId}
-                        state={view.state}
+                        state={definition?.state ?? view.state}
                         title={
                             <Column gap={8} width="100%">
                                 <Text

--- a/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
@@ -15,6 +15,7 @@ import { Box, Button, Column, IconButton, Row, Text } from '@trezor/components';
 import { CaretLeftIcon, InfoIcon } from '@trezor/icons';
 import { AssetLogo } from '@trezor/product-components';
 
+import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
 import { PageHeader } from 'src/components/suite/layouts/SuiteLayout';
 import { useDispatch } from 'src/hooks/suite';
 import { useLayoutSize } from 'src/hooks/suite/useLayoutSize';
@@ -129,14 +130,28 @@ export const YieldPageHeader = ({
                             >
                                 {vaultName}
                             </Text>
-                            <AccountLabel
-                                account={account}
-                                showAccountTypeBadge
-                                accountTypeBadgeSize="small"
-                                intent="neutral"
-                                priority="secondary"
-                                typographyStyle="body-sm"
-                            />
+                            <Row alignItems="center" gap={4}>
+                                <AccountLabel
+                                    account={account}
+                                    showAccountTypeBadge
+                                    accountTypeBadgeSize="small"
+                                    intent="neutral"
+                                    priority="secondary"
+                                    typographyStyle="body-sm"
+                                />
+                                <Text
+                                    typographyStyle="body-sm"
+                                    intent="neutral"
+                                    priority="secondary"
+                                >
+                                    {'· '}
+                                    <FormattedCryptoAmount
+                                        value={account.formattedBalance}
+                                        symbol={account.symbol}
+                                        isBalance
+                                    />
+                                </Text>
+                            </Row>
                         </Column>
                     </Row>
                 ) : (

--- a/packages/suite/src/components/earn/yield/common/YieldPendingTransaction.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldPendingTransaction.tsx
@@ -16,6 +16,8 @@ const getPendingTransactionLabel = (kind: YieldPendingTransactionState['type']):
     switch (kind) {
         case 'wrap':
             return 'TR_EARN_YIELD_PENDING_WRAP';
+        case 'unwrap':
+            return 'TR_EARN_YIELD_PENDING_UNWRAP';
         case 'approve':
             return 'TR_EXCHANGE_APPROVAL_FORM_CONFIRMING_APPROVAL';
         case 'revoke':

--- a/packages/suite/src/components/earn/yield/common/YieldPendingTransaction.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldPendingTransaction.tsx
@@ -14,6 +14,8 @@ type YieldPendingTransactionProps = {
 
 const getPendingTransactionLabel = (kind: YieldPendingTransactionState['type']): TranslationKey => {
     switch (kind) {
+        case 'wrap':
+            return 'TR_EARN_YIELD_PENDING_WRAP';
         case 'approve':
             return 'TR_EXCHANGE_APPROVAL_FORM_CONFIRMING_APPROVAL';
         case 'revoke':

--- a/packages/suite/src/components/earn/yield/common/YieldReceivingCard.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldReceivingCard.tsx
@@ -1,0 +1,37 @@
+import { Translation } from '@suite/intl';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { Card, Row, Text } from '@trezor/components';
+import { AssetLogo } from '@trezor/product-components';
+
+import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
+
+type YieldReceivingCardProps = {
+    token: {
+        networkSymbol: NetworkSymbol;
+        symbol: string;
+        contractAddress?: string | null;
+    };
+    amount: string;
+};
+
+/** "Receiving" summary row styled identically to YieldApprovedAmountCard. */
+export const YieldReceivingCard = ({ token, amount }: YieldReceivingCardProps) => (
+    <Card type="contrast" paddingType="small">
+        <Row justifyContent="space-between" alignItems="center" width="100%">
+            <Text typographyStyle="body-md">
+                <Translation id="TR_EARN_YIELD_RECEIVING" />
+            </Text>
+            <Row alignItems="center" gap={8}>
+                <AssetLogo
+                    size={20}
+                    symbol={token.networkSymbol}
+                    contractAddress={token.contractAddress ?? null}
+                    placeholder={token.symbol}
+                    showNetworkIcon
+                    isBordered={false}
+                />
+                <FormattedCryptoAmount value={amount} symbol={token.symbol} isBalance />
+            </Row>
+        </Row>
+    </Card>
+);

--- a/packages/suite/src/components/earn/yield/common/YieldTokenValue.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldTokenValue.tsx
@@ -1,7 +1,6 @@
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { Row, Text } from '@trezor/components';
 import { AssetLogo } from '@trezor/product-components';
-import { BigNumber } from '@trezor/utils';
 
 import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
 
@@ -16,22 +15,18 @@ type YieldTokenValueProps = {
     amount: string;
 };
 
-export const YieldTokenValue = ({ token, amount }: YieldTokenValueProps) => {
-    const roundedAmount = new BigNumber(amount).decimalPlaces(2, BigNumber.ROUND_DOWN).toFixed();
-
-    return (
-        <Row alignItems="center" gap={8}>
-            <AssetLogo
-                size={24}
-                symbol={token.networkSymbol}
-                contractAddress={token.contractAddress}
-                placeholder={token.symbol}
-                showNetworkIcon
-                isBordered={false}
-            />
-            <Text typographyStyle="body-md-strong">
-                <FormattedCryptoAmount value={roundedAmount} symbol={token.symbol} />
-            </Text>
-        </Row>
-    );
-};
+export const YieldTokenValue = ({ token, amount }: YieldTokenValueProps) => (
+    <Row alignItems="center" gap={8}>
+        <AssetLogo
+            size={24}
+            symbol={token.networkSymbol}
+            contractAddress={token.contractAddress}
+            placeholder={token.symbol}
+            showNetworkIcon
+            isBordered={false}
+        />
+        <Text typographyStyle="body-md-strong">
+            <FormattedCryptoAmount value={amount} symbol={token.symbol} isBalance />
+        </Text>
+    </Row>
+);

--- a/packages/suite/src/components/earn/yield/common/YieldUnwrapStep.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldUnwrapStep.tsx
@@ -1,0 +1,78 @@
+import { Translation } from '@suite/intl';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import type { YieldPendingTransactionState } from '@suite-common/wallet-core';
+import { Button, Column, Text } from '@trezor/components';
+
+import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
+
+import { YieldPendingTransaction } from './YieldPendingTransaction';
+import { YieldReceivingCard } from './YieldReceivingCard';
+
+export type YieldUnwrapStepProps = {
+    networkSymbol: NetworkSymbol;
+    tokenSymbol: string;
+    nativeSymbol: string;
+    unwrapAmount: string;
+    isLoading?: boolean;
+    pendingTransaction?: YieldPendingTransactionState;
+    onSubmit: () => void;
+    onPendingTxClick: (txid: string) => void;
+};
+
+export const YieldUnwrapStep = ({
+    networkSymbol,
+    tokenSymbol,
+    nativeSymbol,
+    unwrapAmount,
+    isLoading = false,
+    pendingTransaction,
+    onSubmit,
+    onPendingTxClick,
+}: YieldUnwrapStepProps) => (
+    <Column gap={16}>
+        <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
+            <Translation
+                id="TR_EARN_YIELD_UNWRAP_STEP_DESCRIPTION"
+                values={{
+                    amount: (
+                        <FormattedCryptoAmount
+                            value={unwrapAmount}
+                            symbol={tokenSymbol}
+                            isBalance
+                        />
+                    ),
+                    nativeSymbol,
+                    tokenSymbol,
+                }}
+            />
+        </Text>
+
+        {!pendingTransaction && (
+            <YieldReceivingCard
+                token={{
+                    symbol: nativeSymbol,
+                    networkSymbol,
+                    contractAddress: null,
+                }}
+                amount={unwrapAmount}
+            />
+        )}
+
+        <Button
+            size="large"
+            width="100%"
+            onClick={onSubmit}
+            isDisabled={isLoading || !!pendingTransaction}
+            isLoading={isLoading}
+        >
+            <Translation id="TR_EARN_YIELD_UNWRAP_BUTTON" values={{ nativeSymbol, tokenSymbol }} />
+        </Button>
+
+        {pendingTransaction && (
+            <YieldPendingTransaction
+                pendingTransaction={pendingTransaction}
+                onTxClick={onPendingTxClick}
+            />
+        )}
+    </Column>
+);

--- a/packages/suite/src/components/earn/yield/common/YieldWrapStep.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldWrapStep.tsx
@@ -6,12 +6,12 @@ import type {
     YieldFlowDisplayToken,
     YieldPendingTransactionState,
 } from '@suite-common/wallet-core';
-import { Banner, Button, Card, Column, Row, Text } from '@trezor/components';
+import { Banner, Button, Column, Text } from '@trezor/components';
 import { InfoIcon } from '@trezor/icons';
 
 import { YieldAmountCard } from './YieldAmountCard';
 import { YieldPendingTransaction } from './YieldPendingTransaction';
-import { YieldTokenValue } from './YieldTokenValue';
+import { YieldReceivingCard } from './YieldReceivingCard';
 
 export type YieldWrapStepProps = {
     token: YieldFlowDisplayToken;
@@ -78,28 +78,7 @@ export const YieldWrapStep = ({
             />
         )}
 
-        {!pendingTransaction && (
-            <Card paddingType="none">
-                <Row
-                    justifyContent="space-between"
-                    alignItems="center"
-                    gap={16}
-                    padding={{ vertical: 16, horizontal: 20 }}
-                >
-                    <Text typographyStyle="body-md" intent="neutral" priority="secondary">
-                        <Translation id="TR_EARN_YIELD_WRAP_RECEIVING" />
-                    </Text>
-                    <YieldTokenValue
-                        token={{
-                            symbol: token.symbol,
-                            networkSymbol: token.networkSymbol,
-                            contractAddress: token.contractAddress ?? null,
-                        }}
-                        amount={wrapAmount}
-                    />
-                </Row>
-            </Card>
-        )}
+        {!pendingTransaction && <YieldReceivingCard token={token} amount={wrapAmount} />}
 
         <Button
             size="large"

--- a/packages/suite/src/components/earn/yield/common/YieldWrapStep.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldWrapStep.tsx
@@ -1,0 +1,121 @@
+import type { ReactNode } from 'react';
+
+import { Translation } from '@suite/intl';
+import { WETH_WRAP_GAS_RESERVE } from '@suite-common/wallet-constants';
+import type {
+    YieldFlowDisplayToken,
+    YieldPendingTransactionState,
+} from '@suite-common/wallet-core';
+import { Banner, Button, Card, Column, Row, Text } from '@trezor/components';
+import { InfoIcon } from '@trezor/icons';
+
+import { YieldAmountCard } from './YieldAmountCard';
+import { YieldPendingTransaction } from './YieldPendingTransaction';
+import { YieldTokenValue } from './YieldTokenValue';
+
+export type YieldWrapStepProps = {
+    token: YieldFlowDisplayToken;
+    nativeSymbol: string;
+    nativeBalanceValue: ReactNode;
+    wrapAmount: string;
+    showReserveNotice?: boolean;
+    isDisabled?: boolean;
+    isLoading?: boolean;
+    warning?: ReactNode;
+    pendingTransaction?: YieldPendingTransactionState;
+    onMaxClick?: () => void;
+    onSubmit: () => void;
+    onPendingTxClick: (txid: string) => void;
+};
+
+export const YieldWrapStep = ({
+    token,
+    nativeSymbol,
+    nativeBalanceValue,
+    wrapAmount,
+    showReserveNotice = false,
+    isDisabled = false,
+    isLoading = false,
+    warning,
+    pendingTransaction,
+    onMaxClick,
+    onSubmit,
+    onPendingTxClick,
+}: YieldWrapStepProps) => (
+    <Column gap={16}>
+        <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
+            <Translation id="TR_EARN_YIELD_WRAP_STEP_DESCRIPTION" values={{ nativeSymbol }} />
+        </Text>
+
+        <YieldAmountCard
+            tokenSymbol={nativeSymbol}
+            decimals={token.decimals}
+            summary={{
+                labelTranslationId: 'TR_BALANCE',
+                value: nativeBalanceValue,
+                onMaxClick: pendingTransaction ? undefined : onMaxClick,
+            }}
+            heading={{
+                amountLabelTranslationId: 'TR_EARN_YIELD_AMOUNT_TO_WRAP',
+            }}
+            warning={warning}
+            isDisabled={!!pendingTransaction}
+        />
+
+        {showReserveNotice && !pendingTransaction && (
+            <Banner
+                icon={InfoIcon}
+                intent="info"
+                description={
+                    <Translation
+                        id="TR_EARN_YIELD_WRAP_RESERVE_KEPT"
+                        values={{
+                            amount: WETH_WRAP_GAS_RESERVE.toString(),
+                            networkDisplaySymbol: nativeSymbol,
+                        }}
+                    />
+                }
+            />
+        )}
+
+        {!pendingTransaction && (
+            <Card paddingType="none">
+                <Row
+                    justifyContent="space-between"
+                    alignItems="center"
+                    gap={16}
+                    padding={{ vertical: 16, horizontal: 20 }}
+                >
+                    <Text typographyStyle="body-md" intent="neutral" priority="secondary">
+                        <Translation id="TR_EARN_YIELD_WRAP_RECEIVING" />
+                    </Text>
+                    <YieldTokenValue
+                        token={{
+                            symbol: token.symbol,
+                            networkSymbol: token.networkSymbol,
+                            contractAddress: token.contractAddress ?? null,
+                        }}
+                        amount={wrapAmount}
+                    />
+                </Row>
+            </Card>
+        )}
+
+        <Button
+            size="large"
+            width="100%"
+            onClick={onSubmit}
+            isDisabled={isDisabled || !!pendingTransaction}
+            isLoading={isLoading}
+        >
+            <Translation id="TR_EARN_YIELD_WRAP_BUTTON" values={{ nativeSymbol }} />
+        </Button>
+
+        {pendingTransaction && (
+            <YieldPendingTransaction
+                pendingTransaction={pendingTransaction}
+                onTxClick={onPendingTxClick}
+            />
+        )}
+    </Column>
+);

--- a/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
+++ b/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
@@ -1,8 +1,9 @@
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
+import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { splitYieldPendingTransaction } from '@suite-common/wallet-core';
-import { Banner, Button, Column, Text } from '@trezor/components';
+import { Banner, Button, Column, type StepListItemState, Switch, Text } from '@trezor/components';
 
 import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
 
@@ -14,7 +15,12 @@ import { YieldApproveStep } from '../common/YieldApproveStep';
 import { YieldApprovedAmountCard } from '../common/YieldApprovedAmountCard';
 import { YieldFlowCompleteDeposit } from '../common/YieldFlowCompleteDeposit';
 import { YieldFlowStepList } from '../common/YieldFlowStepList';
+import { YieldWrapStep } from '../common/YieldWrapStep';
 import { getApyBreakdown } from '../yieldFlowUtils';
+
+// Wrapped-native deposits gain a leading wrap step that is not part of the deposit
+// sequence — it is stitched into the rendered list explicitly.
+const WRAP_FLOW_LIST_STEPS = ['wrap', 'approve', 'action'] as const;
 
 export const YieldDepositForm = () => {
     const { analytics } = useServices(selectDesktopAnalyticsDep);
@@ -41,8 +47,19 @@ export const YieldDepositForm = () => {
         isApprovalInsufficient,
         isSubmittingApprove,
         isSubmittingAction,
+        isWrapFlow,
+        isWrapInsufficient,
+        isWrapReserveKept,
+        isWrapConfirmed,
+        nativeBalance,
+        liveAmount,
+        isSubmittingWrap,
         setAmountInput,
         submitApprovalAction,
+        submitWrap,
+        enableWrapStep,
+        disableWrapStep,
+        goToWrapStep,
         submitAction,
         revokeAllowance,
         enterModifyApproval,
@@ -53,8 +70,27 @@ export const YieldDepositForm = () => {
         flow,
     } = useYieldDepositContext();
 
-    const { approvalPendingTransaction, actionPendingTransaction: depositPendingTransaction } =
-        splitYieldPendingTransaction(pendingTransaction, 'deposit');
+    const {
+        approvalPendingTransaction,
+        actionPendingTransaction: depositPendingTransaction,
+        wrapPendingTransaction,
+    } = splitYieldPendingTransaction(pendingTransaction, 'deposit');
+
+    const nativeSymbol = getNetworkDisplaySymbol(account.symbol);
+    const isWrapStepActive = flow.currentStep === 'wrap';
+    // The wrap step stays visible as step 1 even when disabled: active while editing, a green
+    // check once a wrap confirmed, otherwise a dimmed (pending) placeholder.
+    const getWrapStepState = (): StepListItemState => {
+        if (isWrapStepActive) {
+            return 'active';
+        }
+        if (isWrapConfirmed) {
+            return 'done';
+        }
+
+        return 'pending';
+    };
+    const wrapStepState = getWrapStepState();
 
     const handleOnApprovalSubmit = () => {
         analytics.report({
@@ -96,6 +132,28 @@ export const YieldDepositForm = () => {
         });
 
         enterModifyApproval();
+    };
+
+    const handleOnWrap = () => {
+        analytics.report({
+            type: events.yieldDepositEvent.name,
+            payload: {
+                type: 'wrap',
+                action: 'continue',
+                networkSymbol: token.networkSymbol,
+                vaultId: vault.id,
+            },
+        });
+
+        submitWrap();
+    };
+
+    const handleWrapToggle = (isEnabled: boolean) => {
+        if (isEnabled) {
+            enableWrapStep();
+        } else {
+            disableWrapStep();
+        }
     };
 
     const handleOnDeposit = () => {
@@ -140,6 +198,103 @@ export const YieldDepositForm = () => {
         retryInitAllowance();
     };
 
+    const modifyButton = (
+        <Button size="small" intent="neutral" priority="secondary" onClick={handleOnModify}>
+            <Translation id="TR_MODIFY" />
+        </Button>
+    );
+
+    const renderApproveStep = () => (
+        <YieldApproveStep
+            token={token}
+            summaryValue={<FormattedCryptoAmount value={maxAmount} symbol={token.symbol} />}
+            approvedAmount={allowanceAmount || undefined}
+            isApprovedAmountLoading={allowanceStatus === 'loading'}
+            hasApprovedAmountError={allowanceStatus === 'error'}
+            approvalAction={approvalAction}
+            canRevokeAllowance={canRevokeAllowance}
+            warning={
+                !isAmountInvalidDecimals && (isWrapInsufficient || isAmountTooHigh) ? (
+                    <YieldActionStepWarning
+                        isWrapInsufficient={isWrapInsufficient}
+                        tokenSymbol={token.symbol}
+                        onWrapMore={goToWrapStep}
+                        isApproveOverBalance={isAmountTooHigh}
+                    />
+                ) : undefined
+            }
+            isDisabled={
+                isAmountEmpty ||
+                isAmountInvalidDecimals ||
+                isWrapInsufficient ||
+                isSubmittingApprove ||
+                !!approvalPendingTransaction
+            }
+            isLoading={isSubmittingApprove}
+            pendingApproveTransaction={approvalPendingTransaction}
+            onMaxClick={handleMaxClick}
+            onApprovalSubmit={handleOnApprovalSubmit}
+            onRevoke={handleOnRevoke}
+            onPendingTxClick={openPendingTransaction}
+        />
+    );
+
+    // The approved-amount card only belongs to steps that already passed approval, never
+    // while the wrap step (step 1) is still active.
+    const renderApproveInactive = (state: StepListItemState) =>
+        state === 'done' ? (
+            <YieldApprovedAmountCard
+                token={token}
+                amount={allowanceAmount || '0'}
+                isLoading={allowanceStatus === 'loading'}
+                hasError={allowanceStatus === 'error'}
+            />
+        ) : null;
+
+    const renderActionStep = () => (
+        <YieldActionStep
+            flowType="deposit"
+            token={token}
+            summaryValue={<FormattedCryptoAmount value={maxAmount} symbol={token.symbol} />}
+            warning={
+                !isAmountInvalidDecimals ? (
+                    <YieldActionStepWarning
+                        isWrapInsufficient={isWrapInsufficient}
+                        tokenSymbol={token.symbol}
+                        onWrapMore={goToWrapStep}
+                        isInsufficientFunds={isAmountTooHigh}
+                        isApprovalInsufficient={isApprovalInsufficient}
+                        onModifyApproval={handleOnModify}
+                    />
+                ) : undefined
+            }
+            isDisabled={
+                isAmountEmpty ||
+                isAmountTooHigh ||
+                isAmountInvalidDecimals ||
+                isWrapInsufficient ||
+                isApprovalInsufficient ||
+                isSubmittingAction ||
+                !!depositPendingTransaction
+            }
+            isPending={isSubmittingAction}
+            pendingTransaction={depositPendingTransaction}
+            onMaxClick={handleMaxClick}
+            onSubmit={handleOnDeposit}
+            onPendingTxClick={openPendingTransaction}
+        />
+    );
+
+    const renderComplete = () => (
+        <YieldFlowCompleteDeposit
+            apy={apy}
+            vault={vault}
+            networkSymbol={account.symbol}
+            input={{ token, amount: completedAmount }}
+            output={{ token: receiptToken, amount: completedReceiptAmount }}
+        />
+    );
+
     return (
         <>
             <Column width="100%" alignItems="center">
@@ -178,118 +333,75 @@ export const YieldDepositForm = () => {
                         flowType="deposit"
                         currentStep={flow.currentStep}
                         hasStepList
+                        listSteps={isWrapFlow ? WRAP_FLOW_LIST_STEPS : undefined}
                         steps={{
+                            ...(isWrapFlow && {
+                                wrap: {
+                                    title: (
+                                        <Translation
+                                            id="TR_EARN_YIELD_WRAP_STEP_TITLE"
+                                            values={{ nativeSymbol, tokenSymbol: token.symbol }}
+                                        />
+                                    ),
+                                    state: wrapStepState,
+                                    rightContent: () =>
+                                        wrapStepState === 'done' ? undefined : (
+                                            <Switch
+                                                isChecked={isWrapStepActive}
+                                                isDisabled={
+                                                    isSubmittingWrap || !!wrapPendingTransaction
+                                                }
+                                                onChange={handleWrapToggle}
+                                            />
+                                        ),
+                                    content: () => (
+                                        <YieldWrapStep
+                                            token={token}
+                                            nativeSymbol={nativeSymbol}
+                                            nativeBalanceValue={
+                                                <FormattedCryptoAmount
+                                                    value={nativeBalance}
+                                                    symbol={nativeSymbol}
+                                                />
+                                            }
+                                            wrapAmount={liveAmount || '0'}
+                                            showReserveNotice={isWrapReserveKept}
+                                            warning={
+                                                !isAmountInvalidDecimals && isAmountTooHigh ? (
+                                                    <YieldActionStepWarning
+                                                        isInsufficientFunds={isAmountTooHigh}
+                                                    />
+                                                ) : undefined
+                                            }
+                                            isDisabled={
+                                                isAmountEmpty ||
+                                                isAmountTooHigh ||
+                                                isAmountInvalidDecimals ||
+                                                isSubmittingWrap
+                                            }
+                                            isLoading={isSubmittingWrap}
+                                            pendingTransaction={wrapPendingTransaction}
+                                            onMaxClick={handleMaxClick}
+                                            onSubmit={handleOnWrap}
+                                            onPendingTxClick={openPendingTransaction}
+                                        />
+                                    ),
+                                },
+                            }),
                             approve: {
                                 title: <Translation id="TR_EARN_YIELD_SELECT_AMOUNT_AND_APPROVE" />,
                                 rightContent: view =>
-                                    view.state === 'done' && (
-                                        <Button
-                                            size="small"
-                                            intent="neutral"
-                                            priority="secondary"
-                                            onClick={handleOnModify}
-                                        >
-                                            <Translation id="TR_MODIFY" />
-                                        </Button>
-                                    ),
-                                content: () => (
-                                    <YieldApproveStep
-                                        token={token}
-                                        summaryValue={
-                                            <FormattedCryptoAmount
-                                                value={maxAmount}
-                                                symbol={token.symbol}
-                                            />
-                                        }
-                                        approvedAmount={allowanceAmount || undefined}
-                                        isApprovedAmountLoading={allowanceStatus === 'loading'}
-                                        hasApprovedAmountError={allowanceStatus === 'error'}
-                                        approvalAction={approvalAction}
-                                        canRevokeAllowance={canRevokeAllowance}
-                                        warning={
-                                            !isAmountInvalidDecimals && isAmountTooHigh ? (
-                                                <YieldActionStepWarning
-                                                    isApproveOverBalance={isAmountTooHigh}
-                                                />
-                                            ) : undefined
-                                        }
-                                        isDisabled={
-                                            isAmountEmpty ||
-                                            isAmountInvalidDecimals ||
-                                            isSubmittingApprove ||
-                                            !!approvalPendingTransaction
-                                        }
-                                        isLoading={isSubmittingApprove}
-                                        pendingApproveTransaction={approvalPendingTransaction}
-                                        onMaxClick={handleMaxClick}
-                                        onApprovalSubmit={handleOnApprovalSubmit}
-                                        onRevoke={handleOnRevoke}
-                                        onPendingTxClick={openPendingTransaction}
-                                    />
-                                ),
-                                inactiveContent: () => (
-                                    <YieldApprovedAmountCard
-                                        token={token}
-                                        amount={allowanceAmount || '0'}
-                                        isLoading={allowanceStatus === 'loading'}
-                                        hasError={allowanceStatus === 'error'}
-                                    />
-                                ),
+                                    view.state === 'done' ? modifyButton : undefined,
+                                content: renderApproveStep,
+                                inactiveContent: view => renderApproveInactive(view.state),
                             },
                             action: {
                                 title: <Translation id="TR_EARN_YIELD_DEPOSIT" />,
-                                content: () => (
-                                    <YieldActionStep
-                                        flowType="deposit"
-                                        token={token}
-                                        summaryValue={
-                                            <FormattedCryptoAmount
-                                                value={maxAmount}
-                                                symbol={token.symbol}
-                                            />
-                                        }
-                                        warning={
-                                            !isAmountInvalidDecimals ? (
-                                                <YieldActionStepWarning
-                                                    isInsufficientFunds={isAmountTooHigh}
-                                                    isApprovalInsufficient={isApprovalInsufficient}
-                                                    onModifyApproval={handleOnModify}
-                                                />
-                                            ) : undefined
-                                        }
-                                        isDisabled={
-                                            isAmountEmpty ||
-                                            isAmountTooHigh ||
-                                            isAmountInvalidDecimals ||
-                                            isApprovalInsufficient ||
-                                            isSubmittingAction ||
-                                            !!depositPendingTransaction
-                                        }
-                                        isPending={isSubmittingAction}
-                                        pendingTransaction={depositPendingTransaction}
-                                        onMaxClick={handleMaxClick}
-                                        onSubmit={handleOnDeposit}
-                                        onPendingTxClick={openPendingTransaction}
-                                    />
-                                ),
+                                content: renderActionStep,
                             },
                             complete: {
                                 isListItem: false,
-                                content: () => (
-                                    <YieldFlowCompleteDeposit
-                                        apy={apy}
-                                        vault={vault}
-                                        networkSymbol={account.symbol}
-                                        input={{
-                                            token,
-                                            amount: completedAmount,
-                                        }}
-                                        output={{
-                                            token: receiptToken,
-                                            amount: completedReceiptAmount,
-                                        }}
-                                    />
-                                ),
+                                content: renderComplete,
                             },
                         }}
                     />

--- a/packages/suite/src/components/earn/yield/hooks/useResolvedYieldFlowData.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useResolvedYieldFlowData.ts
@@ -2,13 +2,14 @@ import { useMemo } from 'react';
 
 import { type EarnParams } from '@suite/router';
 import { type TokenDtoV2, type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbol, isWrappedNativeToken } from '@suite-common/wallet-config';
 import {
     type YieldFlowDisplayToken,
     type YieldFlowToken,
     doTokensMatch,
     getConvertedOutputTokenBalanceToInputTokenAmount,
     getStablecoinYieldFlowKey,
+    getYieldDepositableBalance,
 } from '@suite-common/wallet-core';
 import type { Account, TokenInfoBranded } from '@suite-common/wallet-types';
 import { getApyPercent, getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils';
@@ -52,6 +53,10 @@ type UseResolvedYieldFlowDataResult = {
     depositedAmount: string;
     depositedSharesAmount: string;
     flowKey: string;
+    isWrappedNativeVaultToken: boolean;
+    nativeFormattedBalance: string;
+    /** Token balance plus, for wrapped-native vaults, the wrappable native balance minus a gas reserve. */
+    depositableBalance: string;
 };
 
 type UseResolvedYieldFlowDataProps = {
@@ -144,6 +149,15 @@ export const useResolvedYieldFlowData = ({
 
     const apy = vault.rewardRate.total != null ? getApyPercent(vault.rewardRate.total) : null;
 
+    const isWrappedNativeVaultToken = isWrappedNativeToken(account.symbol, resolvedContractAddress);
+    const nativeFormattedBalance = account.formattedBalance;
+    const depositableBalance = getYieldDepositableBalance({
+        networkSymbol: account.symbol,
+        nativeFormattedBalance,
+        vaultTokenAddress: resolvedContractAddress,
+        matchedTokenBalance: matchedToken?.balance,
+    });
+
     return {
         account,
         token,
@@ -152,5 +166,8 @@ export const useResolvedYieldFlowData = ({
         depositedAmount,
         depositedSharesAmount,
         flowKey,
+        isWrappedNativeVaultToken,
+        nativeFormattedBalance,
+        depositableBalance,
     };
 };

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -35,6 +35,7 @@ import { BigNumber } from '@trezor/utils';
 import { setConnectionModal, setConnectionMode } from 'src/actions/device/deviceSlice';
 import {
     submitYieldDepositThunk,
+    submitYieldUnwrapThunk,
     submitYieldWithdrawThunk,
     submitYieldWrapThunk,
 } from 'src/actions/wallet/stablecoin-yield';
@@ -98,12 +99,18 @@ export type UseYieldFlowResult = {
     isWrapReserveKept: boolean;
     nativeBalance: string;
     isSubmittingWrap: boolean;
+    isUnwrapFlow: boolean;
+    isUnwrapEnabled: boolean;
+    isSubmittingUnwrap: boolean;
+    unwrappedAmount: string | null;
     setAmountInput: (amount: string) => void;
     submitApprovalAction: () => void;
     submitWrap: () => void;
     enableWrapStep: () => void;
     disableWrapStep: () => void;
     goToWrapStep: () => void;
+    setUnwrapEnabled: (isEnabled: boolean) => void;
+    submitUnwrap: (unwrapAmount: string) => void;
     submitAction: () => void;
     revokeAllowance: () => void;
     enterModifyApproval: () => void;
@@ -161,6 +168,9 @@ export const useYieldFlow = ({
 
     const isWrapFlow = flowType === 'deposit' && isWrappedNativeVaultToken;
     const isWrapFlowRef = useCurrentRef(isWrapFlow);
+
+    const isUnwrapFlow = isYieldWithdrawFlow(flowType) && isWrappedNativeVaultToken;
+    const isUnwrapFlowRef = useCurrentRef(isUnwrapFlow);
 
     const wethBalance = token?.balance ?? '0';
     // Native ETH wrappable after keeping a reserve for the wrap/approve/deposit fees.
@@ -225,6 +235,14 @@ export const useYieldFlow = ({
             dispatch(stablecoinYieldActions.enterWrapStep({ flowType, flowKey }));
         }
 
+        // Wrapped-native withdrawals receive the native coin by default — the chained
+        // unwrap step can be opted out via the "Receive as ETH" toggle.
+        if (isUnwrapFlowRef.current) {
+            dispatch(
+                stablecoinYieldActions.setUnwrapEnabled({ flowType, flowKey, isEnabled: true }),
+            );
+        }
+
         // Wrap OFF by default lands on the approve step prefilled with the held WETH balance.
         methodsRef.current.reset({
             amountInput: isWrapFlowSession && !startsAtWrapStep ? wethBalanceRef.current : '',
@@ -239,6 +257,7 @@ export const useYieldFlow = ({
         dispatch,
         methodsRef,
         isWrapFlowRef,
+        isUnwrapFlowRef,
         shouldDefaultWrapOnRef,
         wethBalanceRef,
     ]);
@@ -609,6 +628,55 @@ export const useYieldFlow = ({
         openDeviceConnectionModal,
     ]);
 
+    const setUnwrapEnabled = useCallback(
+        (isEnabled: boolean) => {
+            dispatch(stablecoinYieldActions.setUnwrapEnabled({ flowType, flowKey, isEnabled }));
+        },
+        [dispatch, flowType, flowKey],
+    );
+
+    const submitUnwrap = useCallback(
+        (unwrapAmount: string) => {
+            if (!isYieldWithdrawFlow(flowType) || !token || !receiptToken) {
+                dispatch(
+                    stablecoinYieldActions.setError({
+                        flowType,
+                        flowKey,
+                        error: 'TR_EARN_YIELD_ERROR_GENERIC',
+                    }),
+                );
+
+                return;
+            }
+
+            if (!isDeviceConnected) {
+                openDeviceConnectionModal();
+
+                return;
+            }
+
+            void dispatch(
+                submitYieldUnwrapThunk({
+                    flowKey,
+                    flowType,
+                    flowData: { account, vault, token, receiptToken },
+                    unwrapAmount,
+                }),
+            );
+        },
+        [
+            account,
+            flowKey,
+            flowType,
+            receiptToken,
+            dispatch,
+            token,
+            vault,
+            isDeviceConnected,
+            openDeviceConnectionModal,
+        ],
+    );
+
     const submitAction = useCallback(async () => {
         if (!isDeviceConnected) {
             openDeviceConnectionModal();
@@ -760,12 +828,18 @@ export const useYieldFlow = ({
         isWrapConfirmed,
         nativeBalance,
         isSubmittingWrap: session.wrap.isSubmitting,
+        isUnwrapFlow,
+        isUnwrapEnabled: session.unwrap.isEnabled,
+        isSubmittingUnwrap: session.unwrap.isSubmitting,
+        unwrappedAmount: session.unwrap.unwrappedAmount,
         setAmountInput,
         submitApprovalAction,
         submitWrap,
         enableWrapStep,
         disableWrapStep,
         goToWrapStep,
+        setUnwrapEnabled,
+        submitUnwrap,
         submitAction,
         revokeAllowance,
         enterModifyApproval,

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -8,6 +8,8 @@ import { openModal } from '@suite/modal';
 import { type EarnParams } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
+import { WRAPPED_NATIVE_TOKEN_DECIMALS } from '@suite-common/wallet-config';
+import { WETH_WRAP_GAS_RESERVE } from '@suite-common/wallet-constants';
 import {
     type YieldAllowanceStatus,
     type YieldApproveModalState,
@@ -28,11 +30,13 @@ import {
 } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { useCurrentRef } from '@trezor/react-utils';
+import { BigNumber } from '@trezor/utils';
 
 import { setConnectionModal, setConnectionMode } from 'src/actions/device/deviceSlice';
 import {
     submitYieldDepositThunk,
     submitYieldWithdrawThunk,
+    submitYieldWrapThunk,
 } from 'src/actions/wallet/stablecoin-yield';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
@@ -88,8 +92,18 @@ export type UseYieldFlowResult = {
     isApprovalInsufficient: boolean;
     isSubmittingApprove: boolean;
     isSubmittingAction: boolean;
+    isWrapFlow: boolean;
+    isWrapInsufficient: boolean;
+    isWrapConfirmed: boolean;
+    isWrapReserveKept: boolean;
+    nativeBalance: string;
+    isSubmittingWrap: boolean;
     setAmountInput: (amount: string) => void;
     submitApprovalAction: () => void;
+    submitWrap: () => void;
+    enableWrapStep: () => void;
+    disableWrapStep: () => void;
+    goToWrapStep: () => void;
     submitAction: () => void;
     revokeAllowance: () => void;
     enterModifyApproval: () => void;
@@ -129,12 +143,37 @@ export const useYieldFlow = ({
     const methodsRef = useCurrentRef(methods);
     const initAllowancePromiseRef = useRef<{ abort: () => void } | null>(null);
 
-    const { token, receiptToken, apy, depositedAmount, depositedSharesAmount, flowKey } =
-        useResolvedYieldFlowData({
-            account,
-            routeParams,
-            vault,
-        });
+    const {
+        token,
+        receiptToken,
+        apy,
+        depositedAmount,
+        depositedSharesAmount,
+        flowKey,
+        isWrappedNativeVaultToken,
+        nativeFormattedBalance: nativeBalance,
+        depositableBalance,
+    } = useResolvedYieldFlowData({
+        account,
+        routeParams,
+        vault,
+    });
+
+    const isWrapFlow = flowType === 'deposit' && isWrappedNativeVaultToken;
+    const isWrapFlowRef = useCurrentRef(isWrapFlow);
+
+    const wethBalance = token?.balance ?? '0';
+    // Native ETH wrappable after keeping a reserve for the wrap/approve/deposit fees.
+    const wrapMaxAmount = BigNumber.max(
+        new BigNumber(nativeBalance || '0').minus(WETH_WRAP_GAS_RESERVE),
+        0,
+    ).toString();
+
+    // Wrap starts ON only when there is no WETH to deposit yet; a held WETH balance means
+    // the user can approve straight away.
+    const shouldDefaultWrapOn = !isAmountGreaterThan({ amount: wethBalance, threshold: '0' });
+    const wethBalanceRef = useCurrentRef(wethBalance);
+    const shouldDefaultWrapOnRef = useCurrentRef(shouldDefaultWrapOn);
     const allowanceFlowDataRef = useCurrentRef({
         account,
         vault,
@@ -151,7 +190,12 @@ export const useYieldFlow = ({
 
     const getMaxAmount = () => {
         if (flowType === 'deposit') {
-            return token?.balance ?? '';
+            if (!isWrapFlow) {
+                return token?.balance ?? '';
+            }
+
+            // Step 1 wraps native ETH (capped by the fee reserve); steps 2–3 deposit WETH.
+            return session.step === 'wrap' ? wrapMaxAmount : wethBalance;
         }
         if (isSharesInput) {
             return depositedSharesAmount;
@@ -174,12 +218,30 @@ export const useYieldFlow = ({
         dispatch(stablecoinYieldActions.initSession({ flowType, flowKey }));
         dispatch(stablecoinYieldActions.resetSession({ flowType, flowKey }));
 
-        methodsRef.current.reset({ amountInput: '' });
+        const isWrapFlowSession = flowType === 'deposit' && isWrapFlowRef.current;
+        const startsAtWrapStep = isWrapFlowSession && shouldDefaultWrapOnRef.current;
+
+        if (startsAtWrapStep) {
+            dispatch(stablecoinYieldActions.enterWrapStep({ flowType, flowKey }));
+        }
+
+        // Wrap OFF by default lands on the approve step prefilled with the held WETH balance.
+        methodsRef.current.reset({
+            amountInput: isWrapFlowSession && !startsAtWrapStep ? wethBalanceRef.current : '',
+        });
 
         return () => {
             dispatch(stablecoinYieldActions.disposeSession({ flowType, flowKey }));
         };
-    }, [flowKey, flowType, dispatch, methodsRef]);
+    }, [
+        flowKey,
+        flowType,
+        dispatch,
+        methodsRef,
+        isWrapFlowRef,
+        shouldDefaultWrapOnRef,
+        wethBalanceRef,
+    ]);
 
     const { allowanceStatus } = session.approval;
 
@@ -196,9 +258,14 @@ export const useYieldFlow = ({
             return;
         }
 
-        const { account, vault: currentVault, token, receiptToken } = allowanceFlowDataRef.current;
+        const {
+            account: currentAccount,
+            vault: currentVault,
+            token: currentToken,
+            receiptToken: currentReceiptToken,
+        } = allowanceFlowDataRef.current;
 
-        if (!token || !receiptToken || !currentVault) {
+        if (!currentToken || !currentReceiptToken || !currentVault) {
             return;
         }
 
@@ -206,7 +273,12 @@ export const useYieldFlow = ({
             initYieldAllowanceThunk({
                 flowKey,
                 flowType,
-                flowData: { account, vault: currentVault, token, receiptToken },
+                flowData: {
+                    account: currentAccount,
+                    vault: currentVault,
+                    token: currentToken,
+                    receiptToken: currentReceiptToken,
+                },
             }),
         );
 
@@ -218,7 +290,7 @@ export const useYieldFlow = ({
                     type: events.yieldInteractionEvent.name,
                     payload: {
                         element: 'allowance-error-banner',
-                        networkSymbol: token.networkSymbol,
+                        networkSymbol: currentToken.networkSymbol,
                         vaultId: currentVault.id,
                     },
                 });
@@ -252,6 +324,15 @@ export const useYieldFlow = ({
         const nextStep = session.step;
 
         if (prevStep !== null && prevStep !== nextStep) {
+            if (prevStep === 'wrap' && nextStep === 'approve') {
+                // Prefer the total the user committed to before wrapping (held WETH +
+                // wrapped amount) — the refreshed token balance may lag behind the wrap
+                // and would otherwise present a stale or unintended deposit amount.
+                methodsRef.current.reset({
+                    amountInput: session.action.amount ?? maxAmount,
+                });
+            }
+
             if (prevStep === 'approve' && nextStep === 'action') {
                 const actionAmount = session.action.amount ?? '';
                 const cappedAmount = isAmountGreaterThan({
@@ -313,6 +394,35 @@ export const useYieldFlow = ({
     const enterModifyApproval = useCallback(() => {
         dispatch(stablecoinYieldActions.enterModifyMode({ flowType, flowKey }));
     }, [dispatch, flowType, flowKey]);
+
+    const enableWrapStep = useCallback(() => {
+        dispatch(stablecoinYieldActions.enterWrapStep({ flowType, flowKey }));
+        methodsRef.current.reset({ amountInput: '' });
+    }, [dispatch, flowType, flowKey, methodsRef]);
+
+    const disableWrapStep = useCallback(() => {
+        dispatch(
+            stablecoinYieldActions.skipWrapStep({
+                flowType,
+                flowKey,
+                amount: wethBalanceRef.current,
+            }),
+        );
+        dispatch(stablecoinYieldActions.invalidateAllowance({ flowType, flowKey }));
+    }, [dispatch, flowType, flowKey, wethBalanceRef]);
+
+    const goToWrapStep = useCallback(() => {
+        const currentAmount = methodsRef.current.getValues('amountInput');
+        const shortfall = BigNumber.max(
+            new BigNumber(currentAmount || '0').minus(wethBalanceRef.current),
+            0,
+        )
+            .decimalPlaces(WRAPPED_NATIVE_TOKEN_DECIMALS, BigNumber.ROUND_UP)
+            .toString();
+
+        dispatch(stablecoinYieldActions.enterWrapStep({ flowType, flowKey }));
+        methodsRef.current.setValue('amountInput', shortfall);
+    }, [dispatch, flowType, flowKey, methodsRef, wethBalanceRef]);
 
     const setAmountInput = useCallback(
         (amount: string) => {
@@ -454,6 +564,51 @@ export const useYieldFlow = ({
         await submitApprove();
     }, [approvalAction, revokeAllowance, submitApprove]);
 
+    const submitWrap = useCallback(() => {
+        if (!token || !receiptToken) {
+            dispatch(
+                stablecoinYieldActions.setError({
+                    flowType,
+                    flowKey,
+                    error: 'TR_EARN_YIELD_ERROR_GENERIC',
+                }),
+            );
+
+            return;
+        }
+
+        if (!isDeviceConnected) {
+            openDeviceConnectionModal();
+
+            return;
+        }
+
+        const wrapAmount = methodsRef.current.getValues('amountInput');
+
+        void dispatch(
+            submitYieldWrapThunk({
+                flowKey,
+                flowData: { account, vault, token, receiptToken },
+                wrapAmount,
+                totalDepositAmount: new BigNumber(wrapAmount || '0')
+                    .plus(wethBalanceRef.current)
+                    .toString(),
+            }),
+        );
+    }, [
+        account,
+        flowKey,
+        flowType,
+        receiptToken,
+        dispatch,
+        token,
+        vault,
+        methodsRef,
+        wethBalanceRef,
+        isDeviceConnected,
+        openDeviceConnectionModal,
+    ]);
+
     const submitAction = useCallback(async () => {
         if (!isDeviceConnected) {
             openDeviceConnectionModal();
@@ -531,11 +686,31 @@ export const useYieldFlow = ({
         [dispatch, flowKey, flowType],
     );
 
+    // Past the wrap step (or with wrap OFF) the deposit amount can exceed the held WETH,
+    // which means the user needs to wrap more before approving.
+    const isWrapInsufficient =
+        isWrapFlow &&
+        session.step !== 'wrap' &&
+        isAmountGreaterThan({ amount: liveAmount, threshold: wethBalance });
+    const isWrapConfirmed = session.wrap.wrappedAmount !== null;
+
     const isAmountEmpty =
         !liveAmount || !isAmountGreaterThan({ amount: liveAmount, threshold: '0' });
     const allowanceAmount = session.approval.allowanceAmount ?? '0';
     const canRevokeAllowance = isAmountGreaterThan({ amount: allowanceAmount, threshold: '0' });
-    const isAmountTooHigh = isAmountGreaterThan({ amount: liveAmount, threshold: maxAmount });
+    // On the wrap step the cap keeps the gas reserve behind — wrapping the full native
+    // balance would leave nothing for the wrap fee itself. Past the wrap step the cap is
+    // the total depositable balance so amounts above the WETH balance surface "wrap
+    // more", not "too high".
+    const wrapFlowCap = session.step === 'wrap' ? wrapMaxAmount : depositableBalance;
+    const amountCap = isWrapFlow ? wrapFlowCap : maxAmount;
+    const isAmountTooHigh = isAmountGreaterThan({ amount: liveAmount, threshold: amountCap });
+    // The wrap Max keeps a fee reserve behind — surface that whenever the input sits at it.
+    const isWrapReserveKept =
+        isWrapFlow &&
+        session.step === 'wrap' &&
+        new BigNumber(wrapMaxAmount).gt(0) &&
+        liveAmount === wrapMaxAmount;
     const isAmountInvalidDecimals = !!methods.formState.errors.amountInput;
     const isApprovalInsufficient =
         !session.approval.isModifyMode &&
@@ -579,8 +754,18 @@ export const useYieldFlow = ({
             session.approval.allowanceStatus === 'loading' ||
             session.approval.modalState !== null,
         isSubmittingAction: session.action.isSubmitting,
+        isWrapFlow,
+        isWrapInsufficient,
+        isWrapReserveKept,
+        isWrapConfirmed,
+        nativeBalance,
+        isSubmittingWrap: session.wrap.isSubmitting,
         setAmountInput,
         submitApprovalAction,
+        submitWrap,
+        enableWrapStep,
+        disableWrapStep,
+        goToWrapStep,
         submitAction,
         revokeAllowance,
         enterModifyApproval,

--- a/packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts
@@ -36,7 +36,10 @@ const getPollIntervalMs = (blockTime: number | undefined): number => {
 };
 
 type ResolutionEventType =
-    | { type: 'deposit'; successType: 'approve-success' | 'revoke-success' | 'success' }
+    | {
+          type: 'deposit';
+          successType: 'approve-success' | 'revoke-success' | 'wrap-success' | 'success';
+      }
     | { type: 'withdraw'; operation: YieldWithdrawFlowType; successType: 'success' }
     | { type: 'claim'; successType: 'success' };
 
@@ -45,6 +48,8 @@ const getResolutionEventType = (
     flowType: YieldFlowType,
 ): ResolutionEventType | null => {
     switch (pendingTxType) {
+        case 'wrap':
+            return { type: 'deposit', successType: 'wrap-success' };
         case 'approve':
             return { type: 'deposit', successType: 'approve-success' };
         case 'revoke':
@@ -240,6 +245,21 @@ export const useYieldPendingTransactionTracking = ({
         if (resolution) {
             reportResolution(analytics, resolution, 'success', context);
             pendingStartRef.current = null;
+        }
+
+        if (pendingTransaction.type === 'wrap') {
+            // The confirming account update already refreshed the WETH balance,
+            // so allowance init in the approve step runs against fresh data.
+            dispatch(
+                stablecoinYieldActions.completeWrap({
+                    flowType,
+                    flowKey,
+                    wrappedAmount: pendingTransaction.amount,
+                }),
+            );
+            dispatch(stablecoinYieldActions.invalidateAllowance({ flowType, flowKey }));
+
+            return;
         }
 
         if (pendingTransaction.type === 'revoke') {

--- a/packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts
@@ -40,7 +40,11 @@ type ResolutionEventType =
           type: 'deposit';
           successType: 'approve-success' | 'revoke-success' | 'wrap-success' | 'success';
       }
-    | { type: 'withdraw'; operation: YieldWithdrawFlowType; successType: 'success' }
+    | {
+          type: 'withdraw';
+          operation: YieldWithdrawFlowType;
+          successType: 'success' | 'unwrap-success';
+      }
     | { type: 'claim'; successType: 'success' };
 
 const getResolutionEventType = (
@@ -50,6 +54,10 @@ const getResolutionEventType = (
     switch (pendingTxType) {
         case 'wrap':
             return { type: 'deposit', successType: 'wrap-success' };
+        case 'unwrap':
+            return flowType === 'withdraw' || flowType === 'redeem'
+                ? { type: 'withdraw', operation: flowType, successType: 'unwrap-success' }
+                : null;
         case 'approve':
             return { type: 'deposit', successType: 'approve-success' };
         case 'revoke':
@@ -258,6 +266,18 @@ export const useYieldPendingTransactionTracking = ({
                 }),
             );
             dispatch(stablecoinYieldActions.invalidateAllowance({ flowType, flowKey }));
+
+            return;
+        }
+
+        if (pendingTransaction.type === 'unwrap') {
+            dispatch(
+                stablecoinYieldActions.completeUnwrap({
+                    flowType,
+                    flowKey,
+                    unwrappedAmount: pendingTransaction.amount,
+                }),
+            );
 
             return;
         }

--- a/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
+++ b/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
@@ -19,6 +19,7 @@ export const YieldWithdrawForm = () => {
     const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     const {
+        account,
         vault,
         token,
         receiptToken,
@@ -187,6 +188,7 @@ export const YieldWithdrawForm = () => {
                                     input={completedInput}
                                     output={completedOutput}
                                     vaultId={vault.id}
+                                    account={account}
                                 />
                             ),
                         },

--- a/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
+++ b/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
@@ -3,8 +3,15 @@ import { useEffect, useRef } from 'react';
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
-import { splitYieldPendingTransaction } from '@suite-common/wallet-core';
-import { Banner, Column, Text } from '@trezor/components';
+import {
+    WRAPPED_NATIVE_TOKEN_DECIMALS,
+    getNetworkDisplaySymbol,
+} from '@suite-common/wallet-config';
+import {
+    type YieldFlowCompleteValue,
+    splitYieldPendingTransaction,
+} from '@suite-common/wallet-core';
+import { Banner, Column, Switch, Text } from '@trezor/components';
 
 import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
 
@@ -13,13 +20,17 @@ import { YieldActionStep } from '../common/YieldActionStep';
 import { YieldActionStepWarning } from '../common/YieldActionStepWarning';
 import { YieldFlowCompleteWithdraw } from '../common/YieldFlowCompleteWithdraw';
 import { YieldFlowStepList } from '../common/YieldFlowStepList';
+import { YieldUnwrapStep } from '../common/YieldUnwrapStep';
 import { getApyBreakdown } from '../yieldFlowUtils';
+
+// Wrapped-native withdrawals gain a trailing unwrap step that is not part of the
+// withdraw sequence — it is stitched into the rendered list explicitly.
+const UNWRAP_FLOW_LIST_STEPS = ['action', 'unwrap'] as const;
 
 export const YieldWithdrawForm = () => {
     const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     const {
-        account,
         vault,
         token,
         receiptToken,
@@ -36,18 +47,38 @@ export const YieldWithdrawForm = () => {
         flowType,
         completedInput,
         completedOutput,
+        isUnwrapFlow,
+        isUnwrapEnabled,
+        isSubmittingUnwrap,
+        unwrappedAmount,
         setAmountInput,
+        setUnwrapEnabled,
+        submitUnwrap,
         toggleWithdrawFlowType,
         submitAction,
         openPendingTransaction,
         flow,
     } = useYieldWithdrawContext();
 
-    const { actionPendingTransaction: withdrawPendingTransaction } = splitYieldPendingTransaction(
-        pendingTransaction,
-        flowType,
-    );
+    const { actionPendingTransaction: withdrawPendingTransaction, unwrapPendingTransaction } =
+        splitYieldPendingTransaction(pendingTransaction, flowType);
     const withdrawInputUnit = flowType === 'redeem' ? 'shares' : 'asset';
+
+    const nativeSymbol = getNetworkDisplaySymbol(token.networkSymbol);
+    // The withdrawn wrapped-native amount the unwrap step converts 1:1.
+    const receivedTokenAmount = completedOutput?.amount ?? completedInput.amount;
+    // After an unwrap, the complete screen reports the received value in the native coin.
+    const unwrappedOutput: YieldFlowCompleteValue | undefined = unwrappedAmount
+        ? {
+              token: {
+                  networkSymbol: token.networkSymbol,
+                  symbol: nativeSymbol,
+                  decimals: WRAPPED_NATIVE_TOKEN_DECIMALS,
+                  contractAddress: null,
+              },
+              amount: unwrappedAmount,
+          }
+        : undefined;
 
     const handleOnWithdraw = () => {
         const apyBreakdown = getApyBreakdown(vault.rewardRate?.components);
@@ -64,6 +95,35 @@ export const YieldWithdrawForm = () => {
         });
 
         submitAction();
+    };
+
+    const handleUnwrapToggle = (isEnabled: boolean) => {
+        analytics.report({
+            type: events.yieldInteractionEvent.name,
+            payload: {
+                element: 'receive-as-native-toggle',
+                value: isEnabled ? 'on' : 'off',
+                networkSymbol: token.networkSymbol,
+                vaultId: vault.id,
+            },
+        });
+
+        setUnwrapEnabled(isEnabled);
+    };
+
+    const handleOnUnwrap = () => {
+        analytics.report({
+            type: events.yieldWithdrawEvent.name,
+            payload: {
+                type: 'unwrap',
+                operation: flowType,
+                action: 'continue',
+                networkSymbol: token.networkSymbol,
+                vaultId: vault.id,
+            },
+        });
+
+        submitUnwrap(receivedTokenAmount);
     };
 
     const handleToggleWithdrawInputUnit = () => {
@@ -117,6 +177,47 @@ export const YieldWithdrawForm = () => {
         setAmountInput(maxAmount);
     };
 
+    const renderActionStep = () => (
+        <YieldActionStep
+            flowType={flowType}
+            token={flowType === 'redeem' ? receiptToken : token}
+            summaryValue={<FormattedCryptoAmount value={maxAmount} symbol={inputTokenSymbol} />}
+            warning={
+                !isAmountInvalidDecimals && isAmountTooHigh ? (
+                    <YieldActionStepWarning isInsufficientFunds={isAmountTooHigh} />
+                ) : undefined
+            }
+            isDisabled={
+                isAmountEmpty ||
+                isAmountTooHigh ||
+                isAmountInvalidDecimals ||
+                isSubmittingAction ||
+                !!withdrawPendingTransaction
+            }
+            isPending={isSubmittingAction}
+            pendingTransaction={withdrawPendingTransaction}
+            unitToggle={
+                canToggleWithdrawUnit
+                    ? {
+                          otherTokenSymbol: otherUnitTokenSymbol,
+                          onClick: handleToggleWithdrawInputUnit,
+                      }
+                    : undefined
+            }
+            onMaxClick={handleMaxClick}
+            onSubmit={handleOnWithdraw}
+            onPendingTxClick={openPendingTransaction}
+        />
+    );
+
+    const renderComplete = () => (
+        <YieldFlowCompleteWithdraw
+            input={completedInput}
+            output={unwrappedOutput ?? completedOutput}
+            vaultId={vault.id}
+        />
+    );
+
     return (
         <Column width="100%" alignItems="center">
             <Column gap={24} width="100%" maxWidth={500}>
@@ -138,59 +239,47 @@ export const YieldWithdrawForm = () => {
                 <YieldFlowStepList
                     flowType={flowType}
                     currentStep={flow.currentStep}
+                    hasStepList={isUnwrapFlow}
+                    listSteps={isUnwrapFlow ? UNWRAP_FLOW_LIST_STEPS : undefined}
                     steps={{
                         action: {
                             title: <Translation id="TR_EARN_YIELD_WITHDRAW" />,
-                            content: () => (
-                                <YieldActionStep
-                                    flowType={flowType}
-                                    token={flowType === 'redeem' ? receiptToken : token}
-                                    summaryValue={
-                                        <FormattedCryptoAmount
-                                            value={maxAmount}
-                                            symbol={inputTokenSymbol}
-                                        />
-                                    }
-                                    warning={
-                                        !isAmountInvalidDecimals && isAmountTooHigh ? (
-                                            <YieldActionStepWarning
-                                                isInsufficientFunds={isAmountTooHigh}
-                                            />
-                                        ) : undefined
-                                    }
-                                    isDisabled={
-                                        isAmountEmpty ||
-                                        isAmountTooHigh ||
-                                        isAmountInvalidDecimals ||
-                                        isSubmittingAction ||
-                                        !!withdrawPendingTransaction
-                                    }
-                                    isPending={isSubmittingAction}
-                                    pendingTransaction={withdrawPendingTransaction}
-                                    unitToggle={
-                                        canToggleWithdrawUnit
-                                            ? {
-                                                  otherTokenSymbol: otherUnitTokenSymbol,
-                                                  onClick: handleToggleWithdrawInputUnit,
-                                              }
-                                            : undefined
-                                    }
-                                    onMaxClick={handleMaxClick}
-                                    onSubmit={handleOnWithdraw}
-                                    onPendingTxClick={openPendingTransaction}
-                                />
-                            ),
+                            content: renderActionStep,
                         },
+                        ...(isUnwrapFlow && {
+                            unwrap: {
+                                title: (
+                                    <Translation
+                                        id="TR_EARN_YIELD_RECEIVE_AS_NATIVE"
+                                        values={{ nativeSymbol }}
+                                    />
+                                ),
+                                rightContent: () => (
+                                    <Switch
+                                        isChecked={isUnwrapEnabled}
+                                        isDisabled={
+                                            isSubmittingUnwrap || !!unwrapPendingTransaction
+                                        }
+                                        onChange={handleUnwrapToggle}
+                                    />
+                                ),
+                                content: () => (
+                                    <YieldUnwrapStep
+                                        networkSymbol={token.networkSymbol}
+                                        tokenSymbol={token.symbol}
+                                        nativeSymbol={nativeSymbol}
+                                        unwrapAmount={receivedTokenAmount}
+                                        isLoading={isSubmittingUnwrap}
+                                        pendingTransaction={unwrapPendingTransaction}
+                                        onSubmit={handleOnUnwrap}
+                                        onPendingTxClick={openPendingTransaction}
+                                    />
+                                ),
+                            },
+                        }),
                         complete: {
                             isListItem: false,
-                            content: () => (
-                                <YieldFlowCompleteWithdraw
-                                    input={completedInput}
-                                    output={completedOutput}
-                                    vaultId={vault.id}
-                                    account={account}
-                                />
-                            ),
+                            content: renderComplete,
                         },
                     }}
                 />

--- a/packages/suite/src/components/earn/yield/yieldFlowUtils.ts
+++ b/packages/suite/src/components/earn/yield/yieldFlowUtils.ts
@@ -76,9 +76,13 @@ export const getYieldFlowSteps = (
 ): Record<YieldFlowStepId, YieldFlowStepView> => {
     // Both annotations widen the per-flow tuples (and the filter's inferred type predicate)
     // so indexOf below accepts any step id.
-    const sequence: readonly YieldFlowStepId[] = YIELD_FLOW_STEP_SEQUENCES[flowType];
+    const baseSequence: readonly YieldFlowStepId[] = YIELD_FLOW_STEP_SEQUENCES[flowType];
+    // 'wrap' is a conditional deposit-only step that precedes the base sequence; it is not
+    // part of YIELD_FLOW_STEP_SEQUENCES, so it is stitched in here for state/indicator maths.
+    const sequence: readonly YieldFlowStepId[] =
+        flowType === 'deposit' ? ['wrap', ...baseSequence] : baseSequence;
     const effectiveListSteps: readonly YieldFlowStepId[] =
-        listSteps ?? sequence.filter(stepId => stepId !== 'complete');
+        listSteps ?? baseSequence.filter(stepId => stepId !== 'complete');
     const currentStepIndex = sequence.indexOf(currentStep);
 
     const getStepState = (stepIndex: number): StepListItemState => {
@@ -107,6 +111,7 @@ export const getYieldFlowSteps = (
     });
 
     return {
+        wrap: getStepView('wrap'),
         approve: getStepView('approve'),
         action: getStepView('action'),
         complete: getStepView('complete'),

--- a/packages/suite/src/components/earn/yield/yieldFlowUtils.ts
+++ b/packages/suite/src/components/earn/yield/yieldFlowUtils.ts
@@ -77,10 +77,20 @@ export const getYieldFlowSteps = (
     // Both annotations widen the per-flow tuples (and the filter's inferred type predicate)
     // so indexOf below accepts any step id.
     const baseSequence: readonly YieldFlowStepId[] = YIELD_FLOW_STEP_SEQUENCES[flowType];
-    // 'wrap' is a conditional deposit-only step that precedes the base sequence; it is not
-    // part of YIELD_FLOW_STEP_SEQUENCES, so it is stitched in here for state/indicator maths.
-    const sequence: readonly YieldFlowStepId[] =
-        flowType === 'deposit' ? ['wrap', ...baseSequence] : baseSequence;
+    // 'wrap' and 'unwrap' are conditional steps that are not part of
+    // YIELD_FLOW_STEP_SEQUENCES; they are stitched in here for state/indicator maths —
+    // wrap precedes the deposit sequence, unwrap slots in before a withdrawal completes.
+    const getStitchedSequence = (): readonly YieldFlowStepId[] => {
+        if (flowType === 'deposit') {
+            return ['wrap', ...baseSequence];
+        }
+        if (flowType === 'withdraw' || flowType === 'redeem') {
+            return ['action', 'unwrap', 'complete'];
+        }
+
+        return baseSequence;
+    };
+    const sequence = getStitchedSequence();
     const effectiveListSteps: readonly YieldFlowStepId[] =
         listSteps ?? baseSequence.filter(stepId => stepId !== 'complete');
     const currentStepIndex = sequence.indexOf(currentStep);
@@ -114,6 +124,7 @@ export const getYieldFlowSteps = (
         wrap: getStepView('wrap'),
         approve: getStepView('approve'),
         action: getStepView('action'),
+        unwrap: getStepView('unwrap'),
         complete: getStepView('complete'),
     };
 };

--- a/packages/suite/src/components/suite/UnwrapTxAmount.tsx
+++ b/packages/suite/src/components/suite/UnwrapTxAmount.tsx
@@ -1,0 +1,32 @@
+import { type WalletAccountTransaction } from '@suite-common/wallet-types';
+import {
+    asAmountSubunit,
+    getUnwrapAmountByEthereumDataHex,
+    subunitsToUnits,
+} from '@suite-common/wallet-utils';
+import { BigNumber } from '@trezor/utils';
+
+import { FormattedCryptoAmount } from './FormattedCryptoAmount';
+
+interface UnwrapTxAmountProps {
+    transaction: WalletAccountTransaction;
+}
+
+export const UnwrapTxAmount = ({ transaction }: UnwrapTxAmountProps) => {
+    const unwrapAmount = getUnwrapAmountByEthereumDataHex(transaction.ethereumSpecific?.data);
+
+    if (!unwrapAmount) return null;
+
+    return (
+        <>
+            {' '}
+            <FormattedCryptoAmount
+                value={subunitsToUnits({
+                    value: asAmountSubunit(new BigNumber(unwrapAmount)),
+                    symbol: transaction.symbol,
+                })}
+                symbol={transaction.symbol}
+            />
+        </>
+    );
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnwrapWethModal/UnwrapWethModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnwrapWethModal/UnwrapWethModal.tsx
@@ -121,7 +121,10 @@ export const UnwrapWethModal = ({ account, prefillAmount, onCancel }: UnwrapWeth
                         isDeviceCompromised
                     }
                 >
-                    <Translation id="TR_UNWRAP_TO_NATIVE" values={{ symbol: nativeSymbol }} />
+                    <Translation
+                        id="TR_EARN_YIELD_UNWRAP_BUTTON"
+                        values={{ nativeSymbol, tokenSymbol: wethSymbol }}
+                    />
                 </Button>
             }
         >

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnwrapWethModal/UnwrapWethModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnwrapWethModal/UnwrapWethModal.tsx
@@ -1,0 +1,169 @@
+import { FormProvider, useForm } from 'react-hook-form';
+
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
+import { selectIsDeviceCompromised } from '@suite/authenticity-checks';
+import { useDevice } from '@suite/device';
+import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
+import {
+    WRAPPED_NATIVE_TOKEN_DECIMALS,
+    getNetworkDisplaySymbol,
+    isWrappedNativeToken,
+} from '@suite-common/wallet-config';
+import { WETH_WRAP_GAS_RESERVE } from '@suite-common/wallet-constants';
+import { type YieldFlowFormValues } from '@suite-common/wallet-core';
+import { type Account } from '@suite-common/wallet-types';
+import { Banner, Button, Column, Modal } from '@trezor/components';
+import { InfoIcon } from '@trezor/icons';
+import { BigNumber } from '@trezor/utils';
+
+import { setConnectionModal, setConnectionMode } from 'src/actions/device/deviceSlice';
+import { submitWethUnwrapThunk } from 'src/actions/wallet/weth';
+import { YieldAmountCard } from 'src/components/earn/yield/common/YieldAmountCard';
+import { isAmountGreaterThan } from 'src/components/earn/yield/yieldFlowUtils';
+import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+
+type UnwrapWethModalProps = {
+    account: Account;
+    prefillAmount?: string;
+    onCancel: () => void;
+};
+
+export const UnwrapWethModal = ({ account, prefillAmount, onCancel }: UnwrapWethModalProps) => {
+    const dispatch = useDispatch();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
+    const { device } = useDevice();
+    const isDeviceCompromised = useSelector(selectIsDeviceCompromised);
+
+    const wethToken = account.tokens?.find(token =>
+        isWrappedNativeToken(account.symbol, token.contract),
+    );
+    const wethBalance = wethToken?.balance ?? '0';
+    const wethSymbol = wethToken?.symbol ?? 'WETH';
+    const nativeSymbol = getNetworkDisplaySymbol(account.symbol);
+    const nativeBalance = account.formattedBalance;
+
+    const methods = useForm<YieldFlowFormValues>({
+        mode: 'onChange',
+        defaultValues: {
+            amountInput: prefillAmount ? BigNumber.min(prefillAmount, wethBalance).toString() : '',
+        },
+    });
+
+    const liveAmount = methods.watch('amountInput');
+    const isAmountEmpty =
+        !liveAmount || !isAmountGreaterThan({ amount: liveAmount, threshold: '0' });
+    const isAmountTooHigh = isAmountGreaterThan({ amount: liveAmount, threshold: wethBalance });
+    const isAmountInvalidDecimals = !!methods.formState.errors.amountInput;
+    const isLowOnNativeForFee = new BigNumber(nativeBalance || '0').lt(WETH_WRAP_GAS_RESERVE);
+    const hasNoNativeForFee = new BigNumber(nativeBalance || '0').lte(0);
+
+    const isDeviceConnected = !!device?.connected && !!device?.available;
+
+    const handleCancel = () => {
+        analytics.report({
+            type: events.wethUnwrapEvent.name,
+            payload: {
+                type: 'unwrap-form-modal',
+                action: 'cancel',
+                networkSymbol: account.symbol,
+            },
+        });
+
+        onCancel();
+    };
+
+    const handleMaxClick = () => {
+        methods.setValue('amountInput', wethBalance, { shouldValidate: true });
+    };
+
+    const handleSubmit = () => {
+        if (!isDeviceConnected) {
+            if (device?.descriptor?.apiType === 'bluetooth') {
+                dispatch(setConnectionMode('bluetooth'));
+            }
+            dispatch(setConnectionModal(true));
+
+            return;
+        }
+
+        const amount = methods.getValues('amountInput');
+
+        // The deferred simulation/review modals replace this one, so close it
+        // right away and let the thunk drive the rest of the flow.
+        onCancel();
+
+        void dispatch(submitWethUnwrapThunk({ account, amount }));
+    };
+
+    return (
+        <Modal
+            width={480}
+            heading={<Translation id="TR_UNWRAP_WETH_HEADING" values={{ symbol: wethSymbol }} />}
+            description={
+                <Translation
+                    id="TR_UNWRAP_WETH_DESCRIPTION"
+                    values={{ symbol: wethSymbol, nativeSymbol }}
+                />
+            }
+            onCancel={handleCancel}
+            bottomContent={
+                <Button
+                    size="large"
+                    width="100%"
+                    onClick={handleSubmit}
+                    isDisabled={
+                        isAmountEmpty ||
+                        isAmountTooHigh ||
+                        isAmountInvalidDecimals ||
+                        hasNoNativeForFee ||
+                        isDeviceCompromised
+                    }
+                >
+                    <Translation id="TR_UNWRAP_TO_NATIVE" values={{ symbol: nativeSymbol }} />
+                </Button>
+            }
+        >
+            <FormProvider {...methods}>
+                <Column gap={16}>
+                    <YieldAmountCard
+                        tokenSymbol={wethSymbol}
+                        decimals={WRAPPED_NATIVE_TOKEN_DECIMALS}
+                        summary={{
+                            labelTranslationId: 'TR_BALANCE',
+                            value: (
+                                <FormattedCryptoAmount value={wethBalance} symbol={wethSymbol} />
+                            ),
+                            onMaxClick: handleMaxClick,
+                        }}
+                        heading={{
+                            amountLabelTranslationId: 'TR_UNWRAP_AMOUNT',
+                        }}
+                        warning={
+                            !isAmountInvalidDecimals && isAmountTooHigh ? (
+                                <Banner
+                                    intent="warning"
+                                    description={<Translation id="AMOUNT_IS_NOT_ENOUGH" />}
+                                />
+                            ) : undefined
+                        }
+                    />
+
+                    {isLowOnNativeForFee && (
+                        <Banner
+                            icon={InfoIcon}
+                            intent="warning"
+                            description={
+                                <Translation
+                                    id="TR_UNWRAP_LOW_ETH_FOR_FEE"
+                                    values={{ symbol: nativeSymbol }}
+                                />
+                            }
+                        />
+                    )}
+                </Column>
+            </FormProvider>
+        </Modal>
+    );
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
@@ -26,11 +26,9 @@ import { AddTokenModal } from './AddTokenModal';
 import type { ReduxModalProps } from '../ReduxModalProps';
 import { AdvancedCoinSettingsModal } from './AdvancedCoinSettingsModal/AdvancedCoinSettingsModal';
 import { ApplicationLogModal } from './ApplicationLogModal';
-import { BackgroundGalleryModal } from './BackgroundGalleryModal';
-import { PinInvalidModal } from '../DeviceContextModal/PinInvalidModal';
-import { TransactionReviewModal } from '../TransactionReviewModal/TransactionReviewModal';
 import { UnhideTokenModal } from '../UnhideTokenModal';
 import { AutoStartBeforeQuitModal } from './AutoStartBeforeQuitModal';
+import { BackgroundGalleryModal } from './BackgroundGalleryModal';
 import { CancelCoinjoinModal } from './CancelCoinjoinModal';
 import { CoinjoinSuccessModal } from './CoinjoinSuccessModal';
 import { ConfirmUnverifiedAddressModal } from './ConfirmUnverifiedAddressModal';
@@ -54,8 +52,11 @@ import { RequestEnableTorModal } from './RequestEnableTorModal';
 import { SafetyChecksModal } from './SafetyChecksModal';
 import { StakeChangeDelegateModal } from './StakeChangeDelegateModal/StakeChangeDelegateModal';
 import { TorLoadingModal } from './TorLoadingModal';
+import { PinInvalidModal } from '../DeviceContextModal/PinInvalidModal';
+import { TransactionReviewModal } from '../TransactionReviewModal/TransactionReviewModal';
 import { TxDetailModal } from './TxDetailModal/TxDetailModal';
 import { UnecoCoinjoinModal } from './UnecoCoinjoinModal';
+import { UnwrapWethModal } from './UnwrapWethModal/UnwrapWethModal';
 import { WalletConnectProposalModal } from './WalletConnectProposalModal';
 import { WalletConnectSwitchAccountModal } from './WalletConnectSwitchAccountModal';
 import { WipeDeviceSuccessModal } from './WipeDeviceSuccessModal';
@@ -165,6 +166,14 @@ export const UserContextModal = ({ payload }: ReduxModalProps<typeof MODAL_CONTE
             return <UnstakeModal onCancel={onCancel} account={payload.account} />;
         case 'claim':
             return <EarnClaimModal onCancel={onCancel} account={payload.account} />;
+        case 'unwrap-weth':
+            return (
+                <UnwrapWethModal
+                    onCancel={onCancel}
+                    account={payload.account}
+                    prefillAmount={payload.prefillAmount}
+                />
+            );
         case 'change-delegate':
             return <StakeChangeDelegateModal onCancel={onCancel} />;
         case 'copy-address':

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
@@ -638,6 +638,20 @@ export const NotificationRenderer = ({
                 />
             );
 
+        case 'tx-yield-unwrap':
+            return (
+                <TransactionRenderer
+                    render={render}
+                    notification={notification}
+                    icon="arrowDown"
+                    variant="success"
+                    message="TOAST_TX_YIELD_UNWRAP"
+                    messageValues={{
+                        account: notification.descriptor,
+                    }}
+                />
+            );
+
         case 'tx-yield-withdraw':
             return (
                 <TransactionRenderer

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
@@ -624,6 +624,20 @@ export const NotificationRenderer = ({
                 />
             );
 
+        case 'tx-yield-wrap':
+            return (
+                <TransactionRenderer
+                    render={render}
+                    notification={notification}
+                    icon="arrowUp"
+                    variant="success"
+                    message="TOAST_TX_YIELD_WRAP"
+                    messageValues={{
+                        account: notification.descriptor,
+                    }}
+                />
+            );
+
         case 'tx-yield-withdraw':
             return (
                 <TransactionRenderer

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionHeader.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionHeader.tsx
@@ -1,6 +1,10 @@
 import { Translation, useTranslation } from '@suite/intl';
 import { redactNumericalSubstring, useDiscreetMode } from '@suite-common/discreet-mode';
-import { getNetworkDisplaySymbol, isNetworkSymbol } from '@suite-common/wallet-config';
+import {
+    getNetworkDisplaySymbol,
+    getWrappedNativeSymbol,
+    isNetworkSymbol,
+} from '@suite-common/wallet-config';
 import { type TronTxContractType } from '@suite-common/wallet-constants';
 import { type StakeType } from '@suite-common/wallet-types';
 import {
@@ -8,11 +12,14 @@ import {
     isCardanoStakingTx,
     isSupportedEthStakingNetworkSymbol,
     isSupportedSolStakingNetworkSymbol,
+    isUnwrapNativeTx,
+    isWrapNativeTx,
 } from '@suite-common/wallet-utils';
 import { type AccountTransaction } from '@trezor/connect';
 import { BigNumber } from '@trezor/utils';
 
 import { UnstakingTxAmount } from 'src/components/suite/UnstakingTxAmount';
+import { UnwrapTxAmount } from 'src/components/suite/UnwrapTxAmount';
 import { type WalletAccountTransaction } from 'src/types/wallet';
 import { BlurUrls } from 'src/views/wallet/tokens/common/BlurUrls';
 
@@ -126,6 +133,28 @@ export const TransactionHeader = ({ transaction, isPending }: TransactionHeaderP
 
     if (isPending && (transaction.ethereumSpecific || transaction.cardanoSpecific)) {
         return <Translation id="TR_UNCONFIRMED_TX_LONG" />;
+    }
+
+    const wrappedNativeSymbol = getWrappedNativeSymbol(transaction.symbol);
+    if (
+        wrappedNativeSymbol &&
+        transaction.type !== 'failed' &&
+        (isWrapNativeTx(transaction) || isUnwrapNativeTx(transaction))
+    ) {
+        const isWrap = isWrapNativeTx(transaction);
+        const displaySymbol = getNetworkDisplaySymbol(transaction.symbol);
+
+        return (
+            <>
+                <BlurUrls
+                    text={translationString(isWrap ? 'TR_TX_WRAP_NATIVE' : 'TR_TX_UNWRAP_NATIVE', {
+                        fromSymbol: isWrap ? displaySymbol : wrappedNativeSymbol,
+                        toSymbol: isWrap ? wrappedNativeSymbol : displaySymbol,
+                    })}
+                />
+                {!isWrap && <UnwrapTxAmount transaction={transaction} />}
+            </>
+        );
     }
 
     if (

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakingBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakingBanner.tsx
@@ -3,11 +3,17 @@ import { useMemo } from 'react';
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { selectFlags, setFlag } from '@suite/flags';
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { goto, selectRouter } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
+import { type YieldDtoV2, useAllYieldOpportunities } from '@suite-common/earn-stablecoin-api';
 import { useFormatters } from '@suite-common/formatters';
 import { getNetworkAdjustedStakingBalance } from '@suite-common/staking';
-import { type NetworkType, getDisplaySymbol } from '@suite-common/wallet-config';
+import {
+    type NetworkType,
+    getDisplaySymbol,
+    getNetworkByYieldXyzId,
+    isWrappedNativeToken,
+} from '@suite-common/wallet-config';
 import { selectAccountIsStakingActive } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import {
@@ -16,18 +22,22 @@ import {
     getStakingLimitsByNetworkSymbol,
     isSupportedStakingNetworkSymbol,
 } from '@suite-common/wallet-utils';
-import { Banner } from '@trezor/components';
+import { Banner, Row } from '@trezor/components';
 import { PiggyBankIcon, XIcon } from '@trezor/icons';
 import { exhaustive } from '@trezor/type-utils';
 import { BigNumber } from '@trezor/utils';
 
+import { EarnStakingVsYieldHint } from 'src/components/earn/dashboard/common/EarnStakingVsYieldHint';
 import { formatApyValue } from 'src/components/earn/utils/earnApyUtils';
 import { useStakingRate } from 'src/hooks/earn/useStakingRate';
 import { useDispatch, useSelector } from 'src/hooks/suite';
+import { useMessageSystemYield } from 'src/hooks/suite/useMessageSystemYield';
 
 type StakingBannerProps = {
     account: Account;
 };
+
+const emptyVaults: YieldDtoV2[] = [];
 
 export const StakingBanner = ({ account }: StakingBannerProps) => {
     const { analytics } = useServices(selectDesktopAnalyticsDep);
@@ -35,16 +45,40 @@ export const StakingBanner = ({ account }: StakingBannerProps) => {
     const { CryptoAmountFormatter } = useFormatters();
     const {
         stakeEthBannerClosed,
+        earnEthBannerClosed,
         stakeSolBannerClosed,
         stakeCardanoBannerClosed,
         stakeTronBannerClosed,
     } = useSelector(selectFlags);
-    const { route } = useSelector(state => state.router);
+    const { route } = useSelector(selectRouter);
     const { rate } = useStakingRate({ symbol: account.symbol, accountKey: account.key });
     const isStakingActive = useSelector(state => selectAccountIsStakingActive(state, account.key));
 
+    const yieldDepositMessageSystem = useMessageSystemYield('deposit');
+    const isYieldOptionRelevant =
+        account.networkType === 'ethereum' && !yieldDepositMessageSystem.isDisabled;
+    const {
+        data: availableVaults,
+        isSuccess: hasLoadedVaults,
+        isError: hasVaultsError,
+    } = useAllYieldOpportunities({ enabled: isYieldOptionRelevant });
+
     const displaySymbol = getDisplaySymbol(account.symbol);
     const stakingData = getStakingDataForNetwork(account);
+
+    // The native coin can also earn yield via a wrapped-native vault — promote both options.
+    const hasYieldOption =
+        isYieldOptionRelevant &&
+        (availableVaults ?? emptyVaults).some(
+            vault =>
+                !vault.metadata.underMaintenance &&
+                !vault.metadata.deprecated &&
+                getNetworkByYieldXyzId(vault.network)?.symbol === account.symbol &&
+                isWrappedNativeToken(account.symbol, vault.token.address),
+        );
+    // Hold rendering until the vaults query settles so the banner variant does not
+    // flash from staking-only to staking+yield underneath the user.
+    const isYieldOptionResolving = isYieldOptionRelevant && !hasLoadedVaults && !hasVaultsError;
 
     const accountBalance = account.formattedBalance;
     const stakingBalance = stakingData?.depositedBalance ?? '0';
@@ -98,6 +132,20 @@ export const StakingBanner = ({ account }: StakingBannerProps) => {
         });
     };
 
+    const closeEarnBanner = () => {
+        dispatch(setFlag({ key: 'earnEthBannerClosed', value: true }));
+
+        analytics.report({
+            type: events.yieldNavigateEvent.name,
+            payload: {
+                action: 'cancel',
+                from: 'account-banner',
+                to: 'earn-dashboard',
+                networkSymbol: account.symbol,
+            },
+        });
+    };
+
     const goToStakingTab = () => {
         dispatch(goto({ routeName: 'wallet-staking', preserveParams: true }));
 
@@ -106,6 +154,20 @@ export const StakingBanner = ({ account }: StakingBannerProps) => {
             payload: {
                 action: 'navigate',
                 from: 'account/banner',
+                networkSymbol: account.symbol,
+            },
+        });
+    };
+
+    const goToEarnDashboard = () => {
+        dispatch(goto({ routeName: 'suite-earn' }));
+
+        analytics.report({
+            type: events.yieldNavigateEvent.name,
+            payload: {
+                action: 'continue',
+                from: 'account-banner',
+                to: 'earn-dashboard',
                 networkSymbol: account.symbol,
             },
         });
@@ -135,13 +197,53 @@ export const StakingBanner = ({ account }: StakingBannerProps) => {
 
     const stakingLimits = getStakingLimitsByNetworkSymbol(account.symbol);
 
-    if (
-        route?.name !== 'wallet-index' ||
-        isStakingBannerClosed(account.networkType) ||
-        !account ||
-        isStakingActive ||
-        !stakingLimits
-    ) {
+    if (route?.name !== 'wallet-index' || !account || isYieldOptionResolving) {
+        return null;
+    }
+
+    // The earn promo has its own dismissal flag and is shown even to users who
+    // already stake or closed the staking banner before the promo existed.
+    if (hasYieldOption) {
+        if (earnEthBannerClosed) {
+            return null;
+        }
+
+        return (
+            <Banner
+                icon={PiggyBankIcon}
+                isIconCentered
+                intent="brand"
+                title={
+                    <Translation id="TR_STAKING_BANNER_ETH_EARN_TITLE" values={{ displaySymbol }} />
+                }
+                description={
+                    <Row gap={8} alignItems="center" flexWrap="wrap">
+                        <Translation
+                            id="TR_STAKING_BANNER_ETH_EARN_TEXT"
+                            values={{ displaySymbol }}
+                        />
+                        <EarnStakingVsYieldHint />
+                    </Row>
+                }
+                rightContent={
+                    <>
+                        <Banner.Button onClick={goToEarnDashboard}>
+                            <Translation id="TR_STAKING_BANNER_ETH_EARN_BUTTON" />
+                        </Banner.Button>
+                        <Banner.IconButton
+                            intent="neutral"
+                            priority="secondary"
+                            icon={XIcon}
+                            onClick={closeEarnBanner}
+                            tooltip={{ content: <Translation id="TR_DISMISS" /> }}
+                        />
+                    </>
+                }
+            />
+        );
+    }
+
+    if (isStakingBannerClosed(account.networkType) || isStakingActive || !stakingLimits) {
         return null;
     }
 

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
@@ -27,7 +27,7 @@ import {
     toTokenCryptoId,
     tradingActions,
 } from '@suite-common/trading';
-import { type Explorer, type Network } from '@suite-common/wallet-config';
+import { type Explorer, type Network, isWrappedNativeToken } from '@suite-common/wallet-config';
 import { selectExplorer, sendFormActions } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import {
@@ -50,6 +50,7 @@ import {
     ArrowDownIcon,
     ArrowUpIcon,
     ArrowUpRightIcon,
+    ArrowsDownUpIcon,
     CurrencyCircleDollarIcon,
     EyeIcon,
     EyeSlashIcon,
@@ -145,7 +146,7 @@ const TokenRowBasicActions = ({
         if (!availableVault) return;
 
         const yieldId = availableVault.id;
-        const contractAddress = availableVault.token.address;
+        const vaultTokenAddress = availableVault.token.address;
 
         analytics.report({
             type: events.yieldNavigateEvent.name,
@@ -164,7 +165,7 @@ const TokenRowBasicActions = ({
                 params: getEarnRouteParams({
                     account,
                     yieldId,
-                    contractAddress,
+                    contractAddress: vaultTokenAddress,
                 }),
             }),
         );
@@ -174,7 +175,7 @@ const TokenRowBasicActions = ({
         if (!availableVault) return;
 
         const yieldId = availableVault.id;
-        const contractAddress = availableVault.token.address;
+        const vaultTokenAddress = availableVault.token.address;
 
         analytics.report({
             type: events.yieldNavigateEvent.name,
@@ -193,13 +194,16 @@ const TokenRowBasicActions = ({
                 params: getEarnRouteParams({
                     account,
                     yieldId,
-                    contractAddress,
+                    contractAddress: vaultTokenAddress,
                 }),
             }),
         );
     };
 
-    const onTradeButtonClick = (type: TradingType, ...[payload]: Parameters<typeof goto>) => {
+    const onTradeButtonClick = (
+        tradingType: TradingType,
+        ...[payload]: Parameters<typeof goto>
+    ) => {
         dispatch(
             tradingActions.setTradingFromPrefilledAccount(
                 getTradingPrefilledFromAccountData(account, tokenCryptoId),
@@ -212,7 +216,7 @@ const TokenRowBasicActions = ({
             type: events.tradeNavigateEvent.name,
             payload: {
                 action: 'navigate',
-                type,
+                type: tradingType,
                 from: 'account/tokens',
                 networkSymbol: account.symbol,
                 contractAddress: token.contract,
@@ -303,10 +307,26 @@ const TokenRowBasicActions = ({
         setShowDeactivateModal(true);
     };
 
+    const isWrappedNative = isWrappedNativeToken(account.symbol, token.contract);
+
+    const onUnwrapButtonClick = () => {
+        analytics.report({
+            type: events.wethUnwrapEvent.name,
+            payload: {
+                type: 'unwrap-form-modal',
+                action: 'continue',
+                networkSymbol: account.symbol,
+                source: 'tokens-table',
+            },
+        });
+
+        dispatch(openModal({ type: 'unwrap-weth', account }));
+    };
+
     const TokenAddressItem = ({
         label,
         address,
-        type,
+        type: addressType,
     }: {
         label: ReactNode;
         address: string;
@@ -322,7 +342,7 @@ const TokenRowBasicActions = ({
                     onCopy={() => {
                         dispatch(
                             shouldShowCopyAddressModal
-                                ? showCopyAddressModal(address, type)
+                                ? showCopyAddressModal(address, addressType)
                                 : copyAddressToClipboard(address),
                         );
                     }}
@@ -413,6 +433,13 @@ const TokenRowBasicActions = ({
                             (tokenStatusType === TokenManagementAction.HIDE
                                 ? !isBelowTablet
                                 : true),
+                    },
+                    {
+                        label: <Translation id="TR_UNWRAP_TOKEN" />,
+                        icon: ArrowsDownUpIcon,
+                        onClick: onUnwrapButtonClick,
+                        isDisabled: token.balance === '0',
+                        isHidden: !isWrappedNative || !!isUnverifiedTable,
                     },
                     {
                         label: <Translation id="TR_EARN_YIELD_DEPOSIT" />,

--- a/suite-common/calldata/src/builder/evm/weth/deposit.ts
+++ b/suite-common/calldata/src/builder/evm/weth/deposit.ts
@@ -1,0 +1,9 @@
+import { EVM_ABI } from '../../../constants/evm';
+import { createEvmEncoder } from '../../../encoder/evm';
+import { createBuilder } from '../../createBuilder';
+
+// The wrapped amount is carried in the transaction value, not in calldata.
+export const buildWethDeposit = createBuilder({
+    params: {},
+    encode: createEvmEncoder(EVM_ABI.weth.deposit),
+});

--- a/suite-common/calldata/src/builder/evm/weth/withdraw.ts
+++ b/suite-common/calldata/src/builder/evm/weth/withdraw.ts
@@ -1,0 +1,24 @@
+import { type BigNumber } from '@trezor/utils';
+
+import { EVM_ABI } from '../../../constants/evm';
+import { createEvmEncoder } from '../../../encoder/evm';
+import { createPolicy } from '../../../policy/createPolicy';
+import { validateUint256 } from '../../../validation/shared/uint256';
+import { createBuilder } from '../../createBuilder';
+import { createParam } from '../../createParam';
+
+type WethWithdrawContext = {
+    balance?: bigint;
+};
+
+const wadParam = createParam<BigNumber, bigint, WethWithdrawContext>({
+    validate: validateUint256,
+    policy: createPolicy({ ZERO_AMOUNT: 'error', INSUFFICIENT_BALANCE: 'error' }),
+});
+
+export const buildWethWithdraw = createBuilder({
+    params: {
+        wad: wadParam,
+    },
+    encode: createEvmEncoder(EVM_ABI.weth.withdraw),
+});

--- a/suite-common/calldata/src/calldata.ts
+++ b/suite-common/calldata/src/calldata.ts
@@ -7,6 +7,8 @@ import { buildStake } from './builder/evm/everstake/stake';
 import { buildUnstake } from './builder/evm/everstake/unstake';
 import { buildRedeem } from './builder/evm/redeem';
 import { buildTransfer } from './builder/evm/transfer';
+import { buildWethDeposit } from './builder/evm/weth/deposit';
+import { buildWethWithdraw } from './builder/evm/weth/withdraw';
 import { buildWithdraw } from './builder/evm/withdraw';
 import { buildTrc20Transfer } from './builder/tron/trc20/transfer';
 import { EVM_ABI } from './constants/evm';
@@ -49,6 +51,16 @@ export const Calldata = {
             stake: { encode: buildStake },
             unstake: { encode: buildUnstake },
             claimWithdrawRequest: { encode: buildClaimWithdrawRequest },
+        },
+        weth: {
+            deposit: {
+                encode: buildWethDeposit,
+                decode: createEvmDecoder(EVM_ABI.weth.deposit),
+            },
+            withdraw: {
+                encode: buildWethWithdraw,
+                decode: createEvmDecoder(EVM_ABI.weth.withdraw),
+            },
         },
     },
     tron: {

--- a/suite-common/calldata/src/constants/evm.ts
+++ b/suite-common/calldata/src/constants/evm.ts
@@ -25,4 +25,8 @@ export const EVM_ABI = {
         ]),
         claimWithdrawRequest: parseAbi(['function claimWithdrawRequest()']),
     },
+    weth: {
+        deposit: parseAbi(['function deposit() payable']),
+        withdraw: parseAbi(['function withdraw(uint256 wad)']),
+    },
 } as const;

--- a/suite-common/calldata/src/decoder/evm.ts
+++ b/suite-common/calldata/src/decoder/evm.ts
@@ -41,7 +41,8 @@ export const createEvmDecoder = <const T extends Abi>(abi: T): Decoder<T> => {
         ) as `0x${string}`;
         try {
             const { args } = decodeFunctionData({ abi, data: normalized });
-            const values = (args as readonly unknown[]).map((v, i) => {
+            // viem returns `args: undefined` for zero-input functions (e.g. `deposit()`).
+            const values = ((args ?? []) as readonly unknown[]).map((v, i) => {
                 const { inputs } = fn;
                 // @ts-expect-error: noUncheckedIndexedAccess
                 const inputIndexed: AbiFunction['inputs'][number] = inputs[i];

--- a/suite-common/calldata/src/tests/builder/evm/weth/deposit.test.ts
+++ b/suite-common/calldata/src/tests/builder/evm/weth/deposit.test.ts
@@ -1,0 +1,12 @@
+import { buildWethDeposit } from '../../../../builder/evm/weth/deposit';
+
+describe('buildWethDeposit', () => {
+    it('encodes deposit selector with no args', () => {
+        const result = buildWethDeposit({});
+
+        expect(result.isValid).toBe(true);
+        expect(result.data).toBe('0xd0e30db0');
+        expect(result.errors).toEqual([]);
+        expect(result.warnings).toEqual([]);
+    });
+});

--- a/suite-common/calldata/src/tests/builder/evm/weth/withdraw.test.ts
+++ b/suite-common/calldata/src/tests/builder/evm/weth/withdraw.test.ts
@@ -1,0 +1,58 @@
+import { BigNumber } from '@trezor/utils';
+
+import { buildWethWithdraw } from '../../../../builder/evm/weth/withdraw';
+import { Calldata } from '../../../../calldata';
+
+describe('buildWethWithdraw', () => {
+    it('encodes valid withdraw calldata', () => {
+        const result = buildWethWithdraw({ wad: new BigNumber('1000000000000000000') });
+
+        expect(result.isValid).toBe(true);
+        expect(result.data).toBe(
+            '0x2e1a7d4d0000000000000000000000000000000000000000000000000de0b6b3a7640000',
+        );
+        expect(result.errors).toEqual([]);
+        expect(result.warnings).toEqual([]);
+    });
+
+    it('decodes encoded calldata back to the wad amount', () => {
+        const result = buildWethWithdraw({ wad: new BigNumber('1507906') });
+
+        expect(result.data).not.toBe(null);
+        expect(Calldata.evm.weth.withdraw.decode(result.data ?? undefined)).toEqual({
+            wad: 1_507_906n,
+        });
+    });
+
+    it('returns error for zero wad', () => {
+        const result = buildWethWithdraw({ wad: new BigNumber('0') });
+
+        expect(result.isValid).toBe(false);
+        expect(result.data).toBe(null);
+        expect(result.errors).toEqual([{ code: 'ZERO_AMOUNT', path: 'wad', severity: 'error' }]);
+        expect(result.warnings).toEqual([]);
+    });
+
+    it('returns error when wad exceeds the balance', () => {
+        const result = buildWethWithdraw(
+            { wad: new BigNumber('1000000000000000001') },
+            { balance: 1_000_000_000_000_000_000n },
+        );
+
+        expect(result.isValid).toBe(false);
+        expect(result.data).toBe(null);
+        expect(result.errors).toEqual([
+            { code: 'INSUFFICIENT_BALANCE', path: 'wad', severity: 'error' },
+        ]);
+    });
+
+    it('encodes when wad is within the balance', () => {
+        const result = buildWethWithdraw(
+            { wad: new BigNumber('1000000000000000000') },
+            { balance: 1_000_000_000_000_000_000n },
+        );
+
+        expect(result.isValid).toBe(true);
+        expect(result.errors).toEqual([]);
+    });
+});

--- a/suite-common/calldata/src/tests/decoder/evm.test.ts
+++ b/suite-common/calldata/src/tests/decoder/evm.test.ts
@@ -56,6 +56,12 @@ describe('createEvmDecoder', () => {
         });
     });
 
+    it('decodes zero-input functions to an empty object', () => {
+        const depositDecode = createEvmDecoder(EVM_ABI.weth.deposit);
+        // `deposit()` calldata is just the 4-byte selector, no arguments.
+        expect(depositDecode('0xd0e30db0')).toEqual({});
+    });
+
     it('lowercases addresses inside address[] params', () => {
         const arrayDecode = createEvmDecoder(EVM_ABI.distributor.claim);
         const calldata = buildClaim(

--- a/suite-common/calldata/src/verifier.ts
+++ b/suite-common/calldata/src/verifier.ts
@@ -20,5 +20,9 @@ export const Verifier = {
             unstake: createVerifier({ abi: EVM_ABI.everstake.unstake }),
             claimWithdrawRequest: createVerifier({ abi: EVM_ABI.everstake.claimWithdrawRequest }),
         },
+        weth: {
+            deposit: createVerifier({ abi: EVM_ABI.weth.deposit }),
+            withdraw: createVerifier({ abi: EVM_ABI.weth.withdraw }),
+        },
     },
 } as const;

--- a/suite-common/earn-stablecoin/src/tx-simulation/__tests__/debugWrap.test.ts
+++ b/suite-common/earn-stablecoin/src/tx-simulation/__tests__/debugWrap.test.ts
@@ -1,0 +1,29 @@
+import { composeStablecoinYieldTxSimulationAction } from '../txSimulationAction';
+
+it('debug wrap', () => {
+    const result = composeStablecoinYieldTxSimulationAction(
+        {
+            flow: 'wrap',
+            account: {
+                key: 'eth-account-key',
+                networkType: 'ethereum',
+                symbol: 'eth',
+                descriptor: '0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3',
+                path: "m/44'/60'/0'/0/0",
+            },
+            unsignedTx: JSON.stringify({
+                from: '0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3',
+                to: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+                data: '0xd0e30db0',
+                value: '0x2386f26fc10000',
+                chainId: 1,
+                gasLimit: '0xea60',
+                maxFeePerGas: '0x77359400',
+                maxPriorityFeePerGas: '0x3b9aca00',
+                nonce: '0x7',
+            }),
+        },
+        'trezor-suite-native://stablecoin-yield',
+    );
+    expect(result).not.toBeNull();
+});

--- a/suite-common/earn-stablecoin/src/tx-simulation/__tests__/txSimulationAction.test.ts
+++ b/suite-common/earn-stablecoin/src/tx-simulation/__tests__/txSimulationAction.test.ts
@@ -119,4 +119,109 @@ describe('composeStablecoinYieldTxSimulationAction', () => {
             ),
         ).toBeNull();
     });
+
+    const WETH_MAINNET = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+
+    const wethUnsignedTx = (overrides: Record<string, unknown> = {}) =>
+        JSON.stringify({
+            from: account.descriptor,
+            to: WETH_MAINNET,
+            data: '0xd0e30db0',
+            value: '0x2386f26fc10000',
+            chainId: 1,
+            gasLimit: '0xea60',
+            maxFeePerGas: '0x77359400',
+            maxPriorityFeePerGas: '0x3b9aca00',
+            nonce: '0x7',
+            ...overrides,
+        });
+
+    it('accepts a wrap transaction targeting the canonical WETH contract', () => {
+        const result = composeStablecoinYieldTxSimulationAction(
+            { flow: 'wrap', account, unsignedTx: wethUnsignedTx() },
+            sourceOrigin,
+        );
+
+        expect(result?.action.payload.transaction.to).toBe(WETH_MAINNET);
+    });
+
+    it('rejects a wrap transaction targeting a different contract', () => {
+        expect(
+            composeStablecoinYieldTxSimulationAction(
+                {
+                    flow: 'wrap',
+                    account,
+                    unsignedTx: wethUnsignedTx({
+                        to: '0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae',
+                    }),
+                },
+                sourceOrigin,
+            ),
+        ).toBeNull();
+    });
+
+    it('rejects a wrap transaction with a mismatched chainId', () => {
+        expect(
+            composeStablecoinYieldTxSimulationAction(
+                { flow: 'wrap', account, unsignedTx: wethUnsignedTx({ chainId: 137 }) },
+                sourceOrigin,
+            ),
+        ).toBeNull();
+    });
+
+    it('rejects a wrap transaction without a value', () => {
+        expect(
+            composeStablecoinYieldTxSimulationAction(
+                { flow: 'wrap', account, unsignedTx: wethUnsignedTx({ value: '0x0' }) },
+                sourceOrigin,
+            ),
+        ).toBeNull();
+    });
+
+    it('accepts an unwrap transaction calling withdraw without a value', () => {
+        const result = composeStablecoinYieldTxSimulationAction(
+            {
+                flow: 'unwrap',
+                account,
+                unsignedTx: wethUnsignedTx({
+                    data: `0x2e1a7d4d${'de0b6b3a7640000'.padStart(64, '0')}`,
+                    value: '0x0',
+                }),
+            },
+            sourceOrigin,
+        );
+
+        expect(result?.action.payload.transaction.to).toBe(WETH_MAINNET);
+    });
+
+    it('rejects an unwrap transaction carrying a value', () => {
+        expect(
+            composeStablecoinYieldTxSimulationAction(
+                {
+                    flow: 'unwrap',
+                    account,
+                    unsignedTx: wethUnsignedTx({
+                        data: `0x2e1a7d4d${'de0b6b3a7640000'.padStart(64, '0')}`,
+                    }),
+                },
+                sourceOrigin,
+            ),
+        ).toBeNull();
+    });
+
+    it('rejects an unwrap transaction withdrawing a zero amount', () => {
+        expect(
+            composeStablecoinYieldTxSimulationAction(
+                {
+                    flow: 'unwrap',
+                    account,
+                    unsignedTx: wethUnsignedTx({
+                        data: `0x2e1a7d4d${'0'.repeat(64)}`,
+                        value: '0x0',
+                    }),
+                },
+                sourceOrigin,
+            ),
+        ).toBeNull();
+    });
 });

--- a/suite-common/earn-stablecoin/src/tx-simulation/txSimulationAction.ts
+++ b/suite-common/earn-stablecoin/src/tx-simulation/txSimulationAction.ts
@@ -4,6 +4,7 @@ import { UnsignedEvmTransactionForSigningSchema } from '@suite-common/earn-stabl
 import { evmHexString } from '@suite-common/schemas/src/evm';
 import {
     getNetwork,
+    getWrappedNativeAddress,
     networkSymbolCollection,
     networksCollection,
 } from '@suite-common/wallet-config';
@@ -28,7 +29,13 @@ const claimUnsignedTxBase = {
 
 const stablecoinYieldTxSimulationParams = z.discriminatedUnion('flow', [
     z.strictObject({
-        flow: z.union([z.literal('deposit'), z.literal('withdraw'), z.literal('redeem')]),
+        flow: z.union([
+            z.literal('deposit'),
+            z.literal('withdraw'),
+            z.literal('redeem'),
+            z.literal('wrap'),
+            z.literal('unwrap'),
+        ]),
         account: partialAccount,
         unsignedTx: z.string(),
     }),
@@ -51,13 +58,75 @@ const stablecoinYieldTxSimulationParams = z.discriminatedUnion('flow', [
 
 export type StablecoinYieldTxSimulationParams = z.infer<typeof stablecoinYieldTxSimulationParams>;
 
+const WETH_DEPOSIT_CALLDATA = '0xd0e30db0';
+const WETH_WITHDRAW_SELECTOR = '0x2e1a7d4d';
+const WETH_WITHDRAW_CALLDATA_LENGTH = 74;
+
+function assertWethUnsignedTx({
+    flow,
+    account,
+    to,
+    data,
+    value,
+    chainId,
+}: {
+    flow: 'wrap' | 'unwrap';
+    account: StablecoinYieldTxSimulationParams['account'];
+    to: string;
+    data: string;
+    value: string;
+    chainId: number;
+}) {
+    const wethAddress = getWrappedNativeAddress(account.symbol);
+
+    if (!wethAddress || to.toLowerCase() !== wethAddress) {
+        throw new Error(
+            `WETH ${flow} transaction must target the canonical wrapped-native contract.`,
+        );
+    }
+
+    const network = getNetwork(account.symbol);
+
+    if (chainId !== network.chainId) {
+        throw new Error(
+            `WETH ${flow} transaction chainId ${chainId} does not match account network chainId ${network.chainId}.`,
+        );
+    }
+
+    const calldata = data.toLowerCase();
+
+    if (flow === 'wrap') {
+        if (calldata !== WETH_DEPOSIT_CALLDATA) {
+            throw new Error('WETH wrap transaction must call deposit().');
+        }
+        if (BigInt(value) === 0n) {
+            throw new Error('WETH wrap transaction must carry a non-zero value.');
+        }
+    } else {
+        if (
+            !calldata.startsWith(WETH_WITHDRAW_SELECTOR) ||
+            calldata.length !== WETH_WITHDRAW_CALLDATA_LENGTH
+        ) {
+            throw new Error('WETH unwrap transaction must call withdraw(wad).');
+        }
+        if (BigInt(`0x${calldata.slice(WETH_WITHDRAW_SELECTOR.length)}`) === 0n) {
+            throw new Error('WETH unwrap transaction must withdraw a non-zero amount.');
+        }
+        if (BigInt(value) !== 0n) {
+            throw new Error('WETH unwrap transaction must not carry a value.');
+        }
+    }
+}
+
 function composeUnsignedEvmTx(
     params: StablecoinYieldTxSimulationParams,
 ): EthereumSignTransaction['transaction'] {
     switch (params.flow) {
         case 'deposit':
         case 'redeem':
-        case 'withdraw': {
+        case 'withdraw':
+        case 'wrap':
+        case 'unwrap': {
             const {
                 to,
                 value = '0x0',
@@ -68,6 +137,17 @@ function composeUnsignedEvmTx(
                 maxPriorityFeePerGas = '0x0',
                 nonce,
             } = UnsignedEvmTransactionForSigningSchema.parse(JSON.parse(params.unsignedTx));
+
+            if (params.flow === 'wrap' || params.flow === 'unwrap') {
+                assertWethUnsignedTx({
+                    flow: params.flow,
+                    account: params.account,
+                    to,
+                    data,
+                    value,
+                    chainId,
+                });
+            }
 
             return {
                 to,

--- a/suite-common/suite-types/src/modal.ts
+++ b/suite-common/suite-types/src/modal.ts
@@ -190,6 +190,11 @@ export type UserContextPayload =
           account: Account;
       }
     | {
+          type: 'unwrap-weth';
+          account: Account;
+          prefillAmount?: string;
+      }
+    | {
           type: 'earn-provider-consent';
           flow: EarnFlow;
           provider: EarnProvider;

--- a/suite-common/toast-notifications/src/types.ts
+++ b/suite-common/toast-notifications/src/types.ts
@@ -73,6 +73,10 @@ type YieldDepositTransactionNotification = {
     type: 'tx-yield-deposit';
 } & BaseTransactionNotificationPayload;
 
+type YieldWrapTransactionNotification = {
+    type: 'tx-yield-wrap';
+} & BaseTransactionNotificationPayload;
+
 type YieldWithdrawTransactionNotification = {
     type: 'tx-yield-withdraw';
 } & BaseTransactionNotificationPayload;
@@ -205,6 +209,7 @@ export type ToastPayload<TranslationKey extends UnknownTranslationKey = UnknownT
     | UnstakedTransactionNotification
     | ClaimedTransactionNotification
     | YieldDepositTransactionNotification
+    | YieldWrapTransactionNotification
     | YieldWithdrawTransactionNotification
     | YieldClaimTransactionNotification
     | {

--- a/suite-common/toast-notifications/src/types.ts
+++ b/suite-common/toast-notifications/src/types.ts
@@ -77,6 +77,10 @@ type YieldWrapTransactionNotification = {
     type: 'tx-yield-wrap';
 } & BaseTransactionNotificationPayload;
 
+type YieldUnwrapTransactionNotification = {
+    type: 'tx-yield-unwrap';
+} & BaseTransactionNotificationPayload;
+
 type YieldWithdrawTransactionNotification = {
     type: 'tx-yield-withdraw';
 } & BaseTransactionNotificationPayload;
@@ -210,6 +214,7 @@ export type ToastPayload<TranslationKey extends UnknownTranslationKey = UnknownT
     | ClaimedTransactionNotification
     | YieldDepositTransactionNotification
     | YieldWrapTransactionNotification
+    | YieldUnwrapTransactionNotification
     | YieldWithdrawTransactionNotification
     | YieldClaimTransactionNotification
     | {

--- a/suite-common/wallet-config/src/__tests__/wrappedNativeToken.test.ts
+++ b/suite-common/wallet-config/src/__tests__/wrappedNativeToken.test.ts
@@ -1,0 +1,36 @@
+import { getWrappedNativeAddress, isWrappedNativeToken } from '../wrappedNativeToken';
+
+const WETH_ADDRESS = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
+const WETH_ADDRESS_CHECKSUMMED = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+
+describe('getWrappedNativeAddress', () => {
+    it('returns the WETH address for eth', () => {
+        expect(getWrappedNativeAddress('eth')).toBe(WETH_ADDRESS);
+    });
+
+    it('returns undefined for networks without a wrapped native token', () => {
+        expect(getWrappedNativeAddress('btc')).toBeUndefined();
+    });
+});
+
+describe('isWrappedNativeToken', () => {
+    it('matches the canonical WETH address regardless of case', () => {
+        expect(isWrappedNativeToken('eth', WETH_ADDRESS)).toBe(true);
+        expect(isWrappedNativeToken('eth', WETH_ADDRESS_CHECKSUMMED)).toBe(true);
+    });
+
+    it('does not match a different address', () => {
+        expect(isWrappedNativeToken('eth', '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48')).toBe(
+            false,
+        );
+    });
+
+    it('does not match on networks without a wrapped native token', () => {
+        expect(isWrappedNativeToken('btc', WETH_ADDRESS)).toBe(false);
+    });
+
+    it('does not match a missing address', () => {
+        expect(isWrappedNativeToken('eth', null)).toBe(false);
+        expect(isWrappedNativeToken('eth', undefined)).toBe(false);
+    });
+});

--- a/suite-common/wallet-config/src/index.ts
+++ b/suite-common/wallet-config/src/index.ts
@@ -6,3 +6,4 @@ export * from './stakingProviders';
 export * from './types';
 export * from './utils';
 export * from './getExplorerUrls';
+export * from './wrappedNativeToken';

--- a/suite-common/wallet-config/src/wrappedNativeToken.ts
+++ b/suite-common/wallet-config/src/wrappedNativeToken.ts
@@ -9,8 +9,15 @@ const WRAPPED_NATIVE_TOKEN_CONTRACT: Partial<Record<NetworkSymbol, `0x${string}`
 // metadata coming from a remote API or account token info.
 export const WRAPPED_NATIVE_TOKEN_DECIMALS = 18;
 
+const WRAPPED_NATIVE_TOKEN_SYMBOL: Partial<Record<NetworkSymbol, string>> = {
+    eth: 'WETH',
+};
+
 export const getWrappedNativeAddress = (networkSymbol: NetworkSymbol) =>
     WRAPPED_NATIVE_TOKEN_CONTRACT[networkSymbol];
+
+export const getWrappedNativeSymbol = (networkSymbol: NetworkSymbol) =>
+    WRAPPED_NATIVE_TOKEN_SYMBOL[networkSymbol];
 
 export const isWrappedNativeToken = (
     networkSymbol: NetworkSymbol,

--- a/suite-common/wallet-config/src/wrappedNativeToken.ts
+++ b/suite-common/wallet-config/src/wrappedNativeToken.ts
@@ -1,0 +1,20 @@
+import { type NetworkSymbol } from './types';
+
+// Keys must be stored lowercase — isWrappedNativeToken compares lowercased addresses.
+const WRAPPED_NATIVE_TOKEN_CONTRACT: Partial<Record<NetworkSymbol, `0x${string}`>> = {
+    eth: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+};
+
+// Pinned so value-carrying wrap/unwrap conversions never scale by token
+// metadata coming from a remote API or account token info.
+export const WRAPPED_NATIVE_TOKEN_DECIMALS = 18;
+
+export const getWrappedNativeAddress = (networkSymbol: NetworkSymbol) =>
+    WRAPPED_NATIVE_TOKEN_CONTRACT[networkSymbol];
+
+export const isWrappedNativeToken = (
+    networkSymbol: NetworkSymbol,
+    contractAddress?: string | null,
+): boolean =>
+    !!contractAddress &&
+    WRAPPED_NATIVE_TOKEN_CONTRACT[networkSymbol] === contractAddress.toLowerCase();

--- a/suite-common/wallet-constants/src/earnConstants.ts
+++ b/suite-common/wallet-constants/src/earnConstants.ts
@@ -1,0 +1,10 @@
+import { BigNumber } from '@trezor/utils';
+
+// Native balance kept aside when wrapping so the wrap + approve + deposit fees
+// stay covered (~200k gas total, with headroom for fee spikes). Caps both the
+// Max suggestion and the wrap amount validation.
+export const WETH_WRAP_GAS_RESERVE = new BigNumber(0.001);
+
+// WETH deposit() consumes ~45k gas; the generic contract-call backup of 250k
+// would over-reserve the fee and could make a max-amount wrap fail.
+export const WETH_DEPOSIT_BACKUP_GAS_LIMIT = '60000';

--- a/suite-common/wallet-constants/src/index.ts
+++ b/suite-common/wallet-constants/src/index.ts
@@ -1,5 +1,6 @@
 export * from './formDraft';
 export * from './sendForm';
+export * from './earnConstants';
 export * from './ethereumStakingConstants';
 export * from './tronStakingConstants';
 export * from './cardanoConstants';

--- a/suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldReducer.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldReducer.test.ts
@@ -310,4 +310,180 @@ describe('stablecoinYieldReducer', () => {
             expect(getSession(state, 'deposit')?.action.pendingTransaction?.txid).toBe('0xdef');
         });
     });
+
+    describe('unwrap step', () => {
+        it('initializes the withdraw session with the unwrap sub-state', () => {
+            const state = initSession('withdraw');
+
+            expect(getSession(state, 'withdraw')?.unwrap).toEqual({
+                isEnabled: false,
+                isSubmitting: false,
+                isPending: false,
+                unwrappedAmount: null,
+            });
+        });
+
+        it.each(['withdraw', 'redeem'] as const)(
+            'chains the unwrap step in when %s completes with unwrap enabled',
+            flowType => {
+                let state = stablecoinYieldReducer(
+                    initSession(flowType),
+                    stablecoinYieldActions.setUnwrapEnabled({
+                        flowType,
+                        flowKey: FLOW_KEY,
+                        isEnabled: true,
+                    }),
+                );
+
+                state = stablecoinYieldReducer(
+                    state,
+                    stablecoinYieldActions.completeAction({
+                        flowType,
+                        flowKey: FLOW_KEY,
+                        amount: '1.2',
+                    }),
+                );
+
+                expect(getSession(state, flowType)?.step).toBe('unwrap');
+                expect(getSession(state, flowType)?.result.completedAmount).toBe('1.2');
+            },
+        );
+
+        it('completes withdraw without the unwrap step when unwrap is disabled', () => {
+            const state = stablecoinYieldReducer(
+                initSession('withdraw'),
+                stablecoinYieldActions.completeAction({
+                    flowType: 'withdraw',
+                    flowKey: FLOW_KEY,
+                    amount: '1.2',
+                }),
+            );
+
+            expect(getSession(state, 'withdraw')?.step).toBe('complete');
+        });
+
+        it('does not chain the unwrap step into deposit completion', () => {
+            let state = stablecoinYieldReducer(
+                initSession('deposit'),
+                stablecoinYieldActions.setUnwrapEnabled({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                    isEnabled: true,
+                }),
+            );
+
+            state = stablecoinYieldReducer(
+                state,
+                stablecoinYieldActions.completeAction({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                    amount: '100',
+                }),
+            );
+
+            expect(getSession(state, 'deposit')?.step).toBe('complete');
+        });
+
+        it('skips the active unwrap step when the toggle is turned off', () => {
+            let state = stablecoinYieldReducer(
+                initSession('withdraw'),
+                stablecoinYieldActions.setUnwrapEnabled({
+                    flowType: 'withdraw',
+                    flowKey: FLOW_KEY,
+                    isEnabled: true,
+                }),
+            );
+            state = stablecoinYieldReducer(
+                state,
+                stablecoinYieldActions.completeAction({
+                    flowType: 'withdraw',
+                    flowKey: FLOW_KEY,
+                    amount: '1.2',
+                }),
+            );
+            state = stablecoinYieldReducer(
+                state,
+                stablecoinYieldActions.setUnwrapEnabled({
+                    flowType: 'withdraw',
+                    flowKey: FLOW_KEY,
+                    isEnabled: false,
+                }),
+            );
+
+            expect(getSession(state, 'withdraw')?.step).toBe('complete');
+            expect(getSession(state, 'withdraw')?.unwrap.unwrappedAmount).toBe(null);
+        });
+
+        it('starts and finishes submitting the unwrap', () => {
+            let state = stablecoinYieldReducer(
+                initSession('withdraw'),
+                stablecoinYieldActions.startSubmittingUnwrap({
+                    flowType: 'withdraw',
+                    flowKey: FLOW_KEY,
+                }),
+            );
+
+            expect(getSession(state, 'withdraw')?.unwrap.isSubmitting).toBe(true);
+            expect(getSession(state, 'withdraw')?.error).toBe(null);
+
+            state = stablecoinYieldReducer(
+                state,
+                stablecoinYieldActions.finishSubmittingUnwrap({
+                    flowType: 'withdraw',
+                    flowKey: FLOW_KEY,
+                }),
+            );
+
+            expect(getSession(state, 'withdraw')?.unwrap.isSubmitting).toBe(false);
+        });
+
+        it('tracks the pending unwrap transaction and completes to the final step', () => {
+            let state = stablecoinYieldReducer(
+                initSession('withdraw'),
+                stablecoinYieldActions.setPendingTx({
+                    flowType: 'withdraw',
+                    flowKey: FLOW_KEY,
+                    tx: { type: 'unwrap', txid: '0xabc', amount: '1.2' },
+                }),
+            );
+
+            expect(getSession(state, 'withdraw')?.unwrap.isPending).toBe(true);
+
+            state = stablecoinYieldReducer(
+                state,
+                stablecoinYieldActions.completeUnwrap({
+                    flowType: 'withdraw',
+                    flowKey: FLOW_KEY,
+                    unwrappedAmount: '1.2',
+                }),
+            );
+
+            expect(getSession(state, 'withdraw')?.step).toBe('complete');
+            expect(getSession(state, 'withdraw')?.unwrap.isPending).toBe(false);
+            expect(getSession(state, 'withdraw')?.unwrap.unwrappedAmount).toBe('1.2');
+            expect(getSession(state, 'withdraw')?.action.pendingTransaction).toBe(null);
+        });
+
+        it('clears the pending unwrap flag when the transaction fails', () => {
+            let state = stablecoinYieldReducer(
+                initSession('withdraw'),
+                stablecoinYieldActions.setPendingTx({
+                    flowType: 'withdraw',
+                    flowKey: FLOW_KEY,
+                    tx: { type: 'unwrap', txid: '0xabc', amount: '1.2' },
+                }),
+            );
+
+            state = stablecoinYieldReducer(
+                state,
+                stablecoinYieldActions.transactionFailed({
+                    flowType: 'withdraw',
+                    flowKey: FLOW_KEY,
+                }),
+            );
+
+            expect(getSession(state, 'withdraw')?.unwrap.isPending).toBe(false);
+            expect(getSession(state, 'withdraw')?.action.pendingTransaction).toBe(null);
+        });
+    });
 });

--- a/suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldReducer.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldReducer.test.ts
@@ -1,3 +1,6 @@
+import { type AccountKey } from '@suite-common/wallet-types';
+
+import { transactionsActions } from '../../transactions/transactionsActions';
 import {
     type StablecoinYieldState,
     getStablecoinYieldSessionKey,
@@ -125,6 +128,186 @@ describe('stablecoinYieldReducer', () => {
             );
 
             expect(getSession(state, 'deposit')?.step).toBe('approve');
+        });
+    });
+
+    describe('wrap step', () => {
+        it('initializes the deposit session with the wrap sub-state', () => {
+            const state = initSession('deposit');
+
+            expect(getSession(state, 'deposit')?.wrap).toEqual({
+                isSubmitting: false,
+                isPending: false,
+                wrappedAmount: null,
+            });
+        });
+
+        it('enters the wrap step', () => {
+            const state = stablecoinYieldReducer(
+                initSession('deposit'),
+                stablecoinYieldActions.enterWrapStep({ flowType: 'deposit', flowKey: FLOW_KEY }),
+            );
+
+            expect(getSession(state, 'deposit')?.step).toBe('wrap');
+        });
+
+        it('starts and finishes submitting the wrap with the total amount', () => {
+            let state = stablecoinYieldReducer(
+                initSession('deposit'),
+                stablecoinYieldActions.startSubmittingWrap({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                    amount: '2',
+                }),
+            );
+
+            expect(getSession(state, 'deposit')?.wrap.isSubmitting).toBe(true);
+            expect(getSession(state, 'deposit')?.action.amount).toBe('2');
+            expect(getSession(state, 'deposit')?.error).toBe(null);
+
+            state = stablecoinYieldReducer(
+                state,
+                stablecoinYieldActions.finishSubmittingWrap({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                }),
+            );
+
+            expect(getSession(state, 'deposit')?.wrap.isSubmitting).toBe(false);
+        });
+
+        it('skips the wrap step and stores the action amount', () => {
+            let state = stablecoinYieldReducer(
+                initSession('deposit'),
+                stablecoinYieldActions.enterWrapStep({ flowType: 'deposit', flowKey: FLOW_KEY }),
+            );
+
+            state = stablecoinYieldReducer(
+                state,
+                stablecoinYieldActions.skipWrapStep({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                    amount: '1.5',
+                }),
+            );
+
+            expect(getSession(state, 'deposit')?.step).toBe('approve');
+            expect(getSession(state, 'deposit')?.action.amount).toBe('1.5');
+            expect(getSession(state, 'deposit')?.wrap.wrappedAmount).toBe(null);
+        });
+
+        it('keeps a previously recorded wrap when the step is later skipped', () => {
+            let state = stablecoinYieldReducer(
+                initSession('deposit'),
+                stablecoinYieldActions.completeWrap({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                    wrappedAmount: '1',
+                }),
+            );
+
+            state = stablecoinYieldReducer(
+                state,
+                stablecoinYieldActions.skipWrapStep({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                    amount: '0.5',
+                }),
+            );
+
+            expect(getSession(state, 'deposit')?.wrap.wrappedAmount).toBe('1');
+        });
+
+        it('completes the wrap and moves to the approve step', () => {
+            let state = stablecoinYieldReducer(
+                initSession('deposit'),
+                stablecoinYieldActions.enterWrapStep({ flowType: 'deposit', flowKey: FLOW_KEY }),
+            );
+
+            state = stablecoinYieldReducer(
+                state,
+                stablecoinYieldActions.setPendingTx({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                    tx: { type: 'wrap', txid: '0xabc', amount: '0.5' },
+                }),
+            );
+
+            expect(getSession(state, 'deposit')?.wrap.isPending).toBe(true);
+
+            state = stablecoinYieldReducer(
+                state,
+                stablecoinYieldActions.completeWrap({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                    wrappedAmount: '0.5',
+                }),
+            );
+
+            expect(getSession(state, 'deposit')?.step).toBe('approve');
+            expect(getSession(state, 'deposit')?.wrap.isPending).toBe(false);
+            expect(getSession(state, 'deposit')?.wrap.wrappedAmount).toBe('0.5');
+            expect(getSession(state, 'deposit')?.action.pendingTransaction).toBe(null);
+        });
+
+        it('does not skip the approval step while the wrap step is active', () => {
+            let state = stablecoinYieldReducer(
+                initSession('deposit'),
+                stablecoinYieldActions.enterWrapStep({ flowType: 'deposit', flowKey: FLOW_KEY }),
+            );
+
+            state = stablecoinYieldReducer(
+                state,
+                stablecoinYieldActions.skipApprovalStep({ flowType: 'deposit', flowKey: FLOW_KEY }),
+            );
+
+            expect(getSession(state, 'deposit')?.step).toBe('wrap');
+        });
+
+        it('clears the pending wrap flag when the transaction fails', () => {
+            let state = stablecoinYieldReducer(
+                initSession('deposit'),
+                stablecoinYieldActions.setPendingTx({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                    tx: { type: 'wrap', txid: '0xabc', amount: '0.5' },
+                }),
+            );
+
+            state = stablecoinYieldReducer(
+                state,
+                stablecoinYieldActions.transactionFailed({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                }),
+            );
+
+            expect(getSession(state, 'deposit')?.wrap.isPending).toBe(false);
+            expect(getSession(state, 'deposit')?.action.pendingTransaction).toBe(null);
+        });
+
+        it('rewrites a replaced wrap pending txid', () => {
+            let state = stablecoinYieldReducer(
+                initSession('deposit'),
+                stablecoinYieldActions.setPendingTx({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                    tx: { type: 'wrap', txid: '0xabc', amount: '0.5' },
+                }),
+            );
+
+            state = stablecoinYieldReducer(
+                state,
+                transactionsActions.replaceTransaction({
+                    key: 'account-key' as AccountKey,
+                    txid: '0xabc',
+                    tx: { txid: '0xdef' } as Parameters<
+                        typeof transactionsActions.replaceTransaction
+                    >[0]['tx'],
+                }),
+            );
+
+            expect(getSession(state, 'deposit')?.action.pendingTransaction?.txid).toBe('0xdef');
         });
     });
 });

--- a/suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldUtils.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldUtils.test.ts
@@ -207,6 +207,17 @@ describe('stablecoinYieldUtils', () => {
                 wrapPendingTransaction: undefined,
             });
         });
+
+        it('classifies an unwrap tx as the unwrap tx', () => {
+            const unwrapTx = mockPendingTx('unwrap');
+
+            expect(splitYieldPendingTransaction(unwrapTx, 'withdraw')).toEqual({
+                approvalPendingTransaction: undefined,
+                actionPendingTransaction: undefined,
+                wrapPendingTransaction: undefined,
+                unwrapPendingTransaction: unwrapTx,
+            });
+        });
     });
 
     describe('buildYieldDepositCalldata', () => {

--- a/suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldUtils.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldUtils.test.ts
@@ -6,7 +6,9 @@ import {
     buildYieldDepositCalldata,
     buildYieldUnsignedTransaction,
     buildYieldWithdrawCalldata,
+    buildYieldWrapTransactionData,
     getNextYieldFlowStep,
+    getYieldDepositableBalance,
     splitYieldPendingTransaction,
 } from '../stablecoinYieldUtils';
 
@@ -88,6 +90,29 @@ describe('stablecoinYieldUtils', () => {
         });
     });
 
+    describe('buildYieldWrapTransactionData', () => {
+        it('builds the WETH deposit selector and the wrapped amount as value', () => {
+            expect(
+                buildYieldWrapTransactionData({
+                    wrapAmount: '1.5',
+                    decimals: 18,
+                }),
+            ).toEqual({
+                data: '0xd0e30db0',
+                value: '0x14d1120d7b160000',
+            });
+        });
+
+        it('throws for a zero wrap amount', () => {
+            expect(() =>
+                buildYieldWrapTransactionData({
+                    wrapAmount: '0',
+                    decimals: 18,
+                }),
+            ).toThrow();
+        });
+    });
+
     describe('getNextYieldFlowStep', () => {
         it('advances deposit through approve → action → complete', () => {
             expect(getNextYieldFlowStep('deposit', 'approve')).toBe('action');
@@ -162,6 +187,26 @@ describe('stablecoinYieldUtils', () => {
                 actionPendingTransaction: undefined,
             });
         });
+
+        it('classifies a wrap tx as the wrap tx', () => {
+            const wrapTx = mockPendingTx('wrap');
+
+            expect(splitYieldPendingTransaction(wrapTx, 'deposit')).toEqual({
+                approvalPendingTransaction: undefined,
+                actionPendingTransaction: undefined,
+                wrapPendingTransaction: wrapTx,
+            });
+        });
+
+        it('does not mark an approval as a wrap transaction', () => {
+            const approveTx = mockPendingTx('approve');
+
+            expect(splitYieldPendingTransaction(approveTx, 'deposit')).toEqual({
+                approvalPendingTransaction: approveTx,
+                actionPendingTransaction: undefined,
+                wrapPendingTransaction: undefined,
+            });
+        });
     });
 
     describe('buildYieldDepositCalldata', () => {
@@ -200,6 +245,20 @@ describe('stablecoinYieldUtils', () => {
             nonce: 7,
             to: VAULT_ADDRESS,
         };
+
+        it('passes a custom value through', () => {
+            expect(
+                buildYieldUnsignedTransaction({
+                    ...commonParams,
+                    feeLevel: {
+                        feePerUnit: '5',
+                    },
+                    value: '0x14d1120d7b160000',
+                }),
+            ).toMatchObject({
+                value: '0x14d1120d7b160000',
+            });
+        });
 
         it('builds legacy fee fields', () => {
             expect(
@@ -263,6 +322,77 @@ describe('stablecoinYieldUtils', () => {
             maxFeePerGas: '0x165a0bc00',
             maxPriorityFeePerGas: '0x3b9aca00',
             type: 'eip1559',
+        });
+    });
+
+    describe('getYieldDepositableBalance', () => {
+        const WETH_ADDRESS = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+        const USDC_ADDRESS = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+
+        it('returns only the matched token balance for a non-wrapped-native vault', () => {
+            expect(
+                getYieldDepositableBalance({
+                    networkSymbol: 'eth',
+                    nativeFormattedBalance: '5',
+                    vaultTokenAddress: USDC_ADDRESS,
+                    matchedTokenBalance: '100',
+                }),
+            ).toBe('100');
+        });
+
+        it('returns zero for a non-wrapped-native vault without a matched token', () => {
+            expect(
+                getYieldDepositableBalance({
+                    networkSymbol: 'eth',
+                    nativeFormattedBalance: '5',
+                    vaultTokenAddress: USDC_ADDRESS,
+                    matchedTokenBalance: null,
+                }),
+            ).toBe('0');
+        });
+
+        it('adds the native balance minus the gas reserve for a wrapped-native vault', () => {
+            expect(
+                getYieldDepositableBalance({
+                    networkSymbol: 'eth',
+                    nativeFormattedBalance: '0.2',
+                    vaultTokenAddress: WETH_ADDRESS,
+                    matchedTokenBalance: '1.5',
+                }),
+            ).toBe('1.699');
+        });
+
+        it('ignores native balance below the gas reserve', () => {
+            expect(
+                getYieldDepositableBalance({
+                    networkSymbol: 'eth',
+                    nativeFormattedBalance: '0.0005',
+                    vaultTokenAddress: WETH_ADDRESS,
+                    matchedTokenBalance: '1',
+                }),
+            ).toBe('1');
+        });
+
+        it('returns the spendable native balance when no token is matched', () => {
+            expect(
+                getYieldDepositableBalance({
+                    networkSymbol: 'eth',
+                    nativeFormattedBalance: '1',
+                    vaultTokenAddress: WETH_ADDRESS,
+                    matchedTokenBalance: undefined,
+                }),
+            ).toBe('0.999');
+        });
+
+        it('returns zero when there is no balance at all', () => {
+            expect(
+                getYieldDepositableBalance({
+                    networkSymbol: 'eth',
+                    nativeFormattedBalance: '0',
+                    vaultTokenAddress: WETH_ADDRESS,
+                    matchedTokenBalance: undefined,
+                }),
+            ).toBe('0');
         });
     });
 });

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
@@ -73,6 +73,12 @@ export type StablecoinYieldTxReviewState = {
 export type StablecoinYieldSessionState = {
     step: YieldFlowStepId;
     error: StablecoinYieldTranslationKey | null;
+    wrap: {
+        isSubmitting: boolean;
+        isPending: boolean;
+        /** Amount of native coin actually wrapped (display units); null = wrap skipped or not run. */
+        wrappedAmount: string | null;
+    };
     approval: {
         allowanceAmount: string | null;
         modalState: YieldApproveModalState | null;
@@ -113,6 +119,11 @@ type StablecoinYieldSessionActionPayload = {
 export const initialStablecoinYieldSessionState: StablecoinYieldSessionState = {
     step: 'approve',
     error: null,
+    wrap: {
+        isSubmitting: false,
+        isPending: false,
+        wrappedAmount: null,
+    },
     approval: {
         allowanceAmount: null,
         modalState: null,
@@ -156,6 +167,7 @@ const createInitialStablecoinYieldSessionState = (
 ): StablecoinYieldSessionState => ({
     ...initialStablecoinYieldSessionState,
     step: YIELD_FLOW_STEP_SEQUENCES[flowType][0],
+    wrap: { ...initialStablecoinYieldSessionState.wrap },
     approval: { ...initialStablecoinYieldSessionState.approval },
     action: { ...initialStablecoinYieldSessionState.action },
     result: {
@@ -318,6 +330,49 @@ export const stablecoinYieldSlice = createSlice({
                 session.step = 'approve';
             });
         },
+        enterWrapStep(state, action: PayloadAction<StablecoinYieldSessionActionPayload>) {
+            withSession(state, action.payload, session => {
+                session.step = 'wrap';
+            });
+        },
+        startSubmittingWrap(
+            state,
+            action: PayloadAction<StablecoinYieldSessionActionPayload & { amount: string }>,
+        ) {
+            withSession(state, action.payload, session => {
+                session.wrap.isSubmitting = true;
+                // The total deposit amount the user confirmed, not just the wrapped part.
+                session.action.amount = action.payload.amount;
+                session.error = null;
+            });
+        },
+        finishSubmittingWrap(state, action: PayloadAction<StablecoinYieldSessionActionPayload>) {
+            withSession(state, action.payload, session => {
+                session.wrap.isSubmitting = false;
+            });
+        },
+        skipWrapStep(
+            state,
+            action: PayloadAction<StablecoinYieldSessionActionPayload & { amount: string }>,
+        ) {
+            withSession(state, action.payload, session => {
+                session.action.amount = action.payload.amount;
+                // A wrap recorded earlier in this session stays recorded — only
+                // completeWrap writes a non-null wrappedAmount.
+                session.step = 'approve';
+            });
+        },
+        completeWrap(
+            state,
+            action: PayloadAction<StablecoinYieldSessionActionPayload & { wrappedAmount: string }>,
+        ) {
+            withSession(state, action.payload, session => {
+                session.wrap.isPending = false;
+                session.wrap.wrappedAmount = action.payload.wrappedAmount;
+                session.action.pendingTransaction = null;
+                session.step = 'approve';
+            });
+        },
         completeApproval(
             state,
             action: PayloadAction<
@@ -338,7 +393,10 @@ export const stablecoinYieldSlice = createSlice({
         },
         skipApprovalStep(state, action: PayloadAction<StablecoinYieldSessionActionPayload>) {
             withSession(state, action.payload, session => {
-                session.step = getNextYieldFlowStep(action.payload.flowType, 'approve');
+                // Guarded so the allowance auto-skip cannot jump over an active wrap step.
+                if (session.step === 'approve') {
+                    session.step = getNextYieldFlowStep(action.payload.flowType, 'approve');
+                }
             });
         },
         revokeSuccess(state, action: PayloadAction<StablecoinYieldSessionActionPayload>) {
@@ -407,6 +465,7 @@ export const stablecoinYieldSlice = createSlice({
                 session.action.pendingTransaction = action.payload.tx;
                 session.action.pendingReceiptAmount =
                     action.payload.receiptAmount ?? session.action.pendingReceiptAmount;
+                session.wrap.isPending = action.payload.tx.type === 'wrap';
             });
         },
         completeAction(
@@ -433,6 +492,7 @@ export const stablecoinYieldSlice = createSlice({
         transactionFailed(state, action: PayloadAction<StablecoinYieldSessionActionPayload>) {
             withSession(state, action.payload, session => {
                 session.action.pendingTransaction = null;
+                session.wrap.isPending = false;
                 session.error = 'TR_EARN_YIELD_ERROR_TRANSACTION_FAILED';
             });
         },

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
@@ -19,7 +19,7 @@ import {
     type YieldPendingTransactionState,
     type YieldPositionFlowType,
 } from './stablecoinYieldTypes';
-import { getNextYieldFlowStep } from './stablecoinYieldUtils';
+import { getNextYieldFlowStep, isYieldWithdrawFlow } from './stablecoinYieldUtils';
 import { transactionsActions } from '../transactions/transactionsActions';
 
 // Message ids must exist in the desktop `suite/intl` messages — the desktop app renders
@@ -79,6 +79,14 @@ export type StablecoinYieldSessionState = {
         /** Amount of native coin actually wrapped (display units); null = wrap skipped or not run. */
         wrappedAmount: string | null;
     };
+    unwrap: {
+        /** "Receive as ETH" — chain an unwrap step after a wrapped-native withdrawal. */
+        isEnabled: boolean;
+        isSubmitting: boolean;
+        isPending: boolean;
+        /** Amount actually unwrapped (display units); null = unwrap skipped or not run. */
+        unwrappedAmount: string | null;
+    };
     approval: {
         allowanceAmount: string | null;
         modalState: YieldApproveModalState | null;
@@ -124,6 +132,12 @@ export const initialStablecoinYieldSessionState: StablecoinYieldSessionState = {
         isPending: false,
         wrappedAmount: null,
     },
+    unwrap: {
+        isEnabled: false,
+        isSubmitting: false,
+        isPending: false,
+        unwrappedAmount: null,
+    },
     approval: {
         allowanceAmount: null,
         modalState: null,
@@ -168,6 +182,7 @@ const createInitialStablecoinYieldSessionState = (
     ...initialStablecoinYieldSessionState,
     step: YIELD_FLOW_STEP_SEQUENCES[flowType][0],
     wrap: { ...initialStablecoinYieldSessionState.wrap },
+    unwrap: { ...initialStablecoinYieldSessionState.unwrap },
     approval: { ...initialStablecoinYieldSessionState.approval },
     action: { ...initialStablecoinYieldSessionState.action },
     result: {
@@ -373,6 +388,43 @@ export const stablecoinYieldSlice = createSlice({
                 session.step = 'approve';
             });
         },
+        setUnwrapEnabled(
+            state,
+            action: PayloadAction<StablecoinYieldSessionActionPayload & { isEnabled: boolean }>,
+        ) {
+            withSession(state, action.payload, session => {
+                session.unwrap.isEnabled = action.payload.isEnabled;
+                // Turning the toggle off on the unwrap step skips it — the withdrawal
+                // is already complete at that point.
+                if (!action.payload.isEnabled && session.step === 'unwrap') {
+                    session.step = 'complete';
+                }
+            });
+        },
+        startSubmittingUnwrap(state, action: PayloadAction<StablecoinYieldSessionActionPayload>) {
+            withSession(state, action.payload, session => {
+                session.unwrap.isSubmitting = true;
+                session.error = null;
+            });
+        },
+        finishSubmittingUnwrap(state, action: PayloadAction<StablecoinYieldSessionActionPayload>) {
+            withSession(state, action.payload, session => {
+                session.unwrap.isSubmitting = false;
+            });
+        },
+        completeUnwrap(
+            state,
+            action: PayloadAction<
+                StablecoinYieldSessionActionPayload & { unwrappedAmount: string }
+            >,
+        ) {
+            withSession(state, action.payload, session => {
+                session.unwrap.isPending = false;
+                session.unwrap.unwrappedAmount = action.payload.unwrappedAmount;
+                session.action.pendingTransaction = null;
+                session.step = 'complete';
+            });
+        },
         completeApproval(
             state,
             action: PayloadAction<
@@ -466,6 +518,7 @@ export const stablecoinYieldSlice = createSlice({
                 session.action.pendingReceiptAmount =
                     action.payload.receiptAmount ?? session.action.pendingReceiptAmount;
                 session.wrap.isPending = action.payload.tx.type === 'wrap';
+                session.unwrap.isPending = action.payload.tx.type === 'unwrap';
             });
         },
         completeAction(
@@ -486,13 +539,19 @@ export const stablecoinYieldSlice = createSlice({
 
                 session.action.pendingTransaction = null;
                 session.action.review = null;
-                session.step = getNextYieldFlowStep(action.payload.flowType, 'action');
+                // A wrapped-native withdrawal with "Receive as ETH" on chains the unwrap
+                // step in before completion.
+                session.step =
+                    isYieldWithdrawFlow(action.payload.flowType) && session.unwrap.isEnabled
+                        ? 'unwrap'
+                        : getNextYieldFlowStep(action.payload.flowType, 'action');
             });
         },
         transactionFailed(state, action: PayloadAction<StablecoinYieldSessionActionPayload>) {
             withSession(state, action.payload, session => {
                 session.action.pendingTransaction = null;
                 session.wrap.isPending = false;
+                session.unwrap.isPending = false;
                 session.error = 'TR_EARN_YIELD_ERROR_TRANSACTION_FAILED';
             });
         },

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldTypes.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldTypes.ts
@@ -4,7 +4,7 @@ import type { NetworkSymbol } from '@suite-common/wallet-config';
 import type { Account } from '@suite-common/wallet-types';
 
 export const YIELD_FLOW_TYPES = ['deposit', 'withdraw', 'redeem', 'claim'] as const;
-export const YIELD_FLOW_STEPS = ['wrap', 'approve', 'action', 'complete'] as const;
+export const YIELD_FLOW_STEPS = ['wrap', 'approve', 'action', 'unwrap', 'complete'] as const;
 
 export type YieldFlowType = (typeof YIELD_FLOW_TYPES)[number];
 export type YieldPositionFlowType = Exclude<YieldFlowType, 'claim'>;
@@ -68,7 +68,7 @@ export type YieldApproveModalState = {
 };
 
 export type YieldPendingTransactionState = {
-    type: 'wrap' | 'approve' | 'revoke' | 'deposit' | 'withdraw' | 'redeem' | 'claim';
+    type: 'wrap' | 'approve' | 'revoke' | 'deposit' | 'withdraw' | 'redeem' | 'claim' | 'unwrap';
     txid: string;
     amount: string;
     fee?: string;

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldTypes.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldTypes.ts
@@ -4,7 +4,7 @@ import type { NetworkSymbol } from '@suite-common/wallet-config';
 import type { Account } from '@suite-common/wallet-types';
 
 export const YIELD_FLOW_TYPES = ['deposit', 'withdraw', 'redeem', 'claim'] as const;
-export const YIELD_FLOW_STEPS = ['approve', 'action', 'complete'] as const;
+export const YIELD_FLOW_STEPS = ['wrap', 'approve', 'action', 'complete'] as const;
 
 export type YieldFlowType = (typeof YIELD_FLOW_TYPES)[number];
 export type YieldPositionFlowType = Exclude<YieldFlowType, 'claim'>;
@@ -68,7 +68,7 @@ export type YieldApproveModalState = {
 };
 
 export type YieldPendingTransactionState = {
-    type: 'approve' | 'revoke' | 'deposit' | 'withdraw' | 'redeem' | 'claim';
+    type: 'wrap' | 'approve' | 'revoke' | 'deposit' | 'withdraw' | 'redeem' | 'claim';
     txid: string;
     amount: string;
     fee?: string;

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
@@ -366,6 +366,8 @@ export const splitYieldPendingTransaction = (
             pendingTransaction?.type === actionKind ? pendingTransaction : undefined,
         wrapPendingTransaction:
             pendingTransaction?.type === 'wrap' ? pendingTransaction : undefined,
+        unwrapPendingTransaction:
+            pendingTransaction?.type === 'unwrap' ? pendingTransaction : undefined,
     };
 };
 

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
@@ -1,6 +1,7 @@
 import { Calldata, type EvmAddress } from '@suite-common/calldata';
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
-import type { NetworkSymbol } from '@suite-common/wallet-config';
+import { type NetworkSymbol, isWrappedNativeToken } from '@suite-common/wallet-config';
+import { WETH_WRAP_GAS_RESERVE } from '@suite-common/wallet-constants';
 import { type AccountKey, type EvmSelectedFee } from '@suite-common/wallet-types';
 import {
     asAmountUnit,
@@ -94,11 +95,49 @@ type BuildYieldUnsignedTransactionParams = {
     gasLimit: string;
     nonce: number;
     to: string;
+    value?: string;
+};
+
+type BuildYieldWrapTransactionDataParams = {
+    wrapAmount: string;
+    decimals: number;
 };
 
 type BuildEvmFeeFieldsParams = {
     feeLevel: EvmFeeLevel;
     gasLimit: string;
+};
+
+type GetYieldDepositableBalanceParams = {
+    networkSymbol: NetworkSymbol;
+    /** Native coin balance in display units — account.formattedBalance, NOT account.balance (wei). */
+    nativeFormattedBalance: string;
+    vaultTokenAddress?: string | null;
+    matchedTokenBalance?: string | null;
+};
+
+/**
+ * Balance available for a yield deposit. For wrapped-native vaults (WETH) the
+ * native balance can be wrapped, so it counts in after a gas reserve is kept.
+ */
+export const getYieldDepositableBalance = ({
+    networkSymbol,
+    nativeFormattedBalance,
+    vaultTokenAddress,
+    matchedTokenBalance,
+}: GetYieldDepositableBalanceParams): string => {
+    const tokenBalance = matchedTokenBalance ?? '0';
+
+    if (!isWrappedNativeToken(networkSymbol, vaultTokenAddress)) {
+        return tokenBalance;
+    }
+
+    const spendableNativeBalance = BigNumber.max(
+        0,
+        new BigNumber(nativeFormattedBalance || '0').minus(WETH_WRAP_GAS_RESERVE),
+    );
+
+    return new BigNumber(tokenBalance).plus(spendableNativeBalance).toString();
 };
 
 export const getStablecoinYieldFlowKey = ({
@@ -207,6 +246,38 @@ export const buildYieldDepositCalldata = ({
     return builderResult.data;
 };
 
+/**
+ * Calldata and value for wrapping the native coin via WETH deposit(). The
+ * wrapped amount travels in the transaction value, the calldata is only the
+ * function selector.
+ */
+export const buildYieldWrapTransactionData = ({
+    wrapAmount,
+    decimals,
+}: BuildYieldWrapTransactionDataParams) => {
+    const wrapAmountSubunits = unitsToSubunits({
+        value: asAmountUnit(new BigNumber(wrapAmount)),
+        decimals,
+    });
+
+    if (wrapAmountSubunits.lte(0)) {
+        throw new Error('Wrap amount must be greater than zero.');
+    }
+
+    const builderResult = Calldata.evm.weth.deposit.encode({});
+
+    if (!builderResult.isValid || !builderResult.data) {
+        const issues = builderResult.errors.map(issue => issue.code).join(', ');
+
+        throw new Error(`Failed to encode wrap calldata${issues ? `: ${issues}` : '.'}`);
+    }
+
+    return {
+        data: builderResult.data,
+        value: fromIntegerString(wrapAmountSubunits.toFixed(0)).toHex(),
+    };
+};
+
 export const buildEvmFeeFields = ({ feeLevel, gasLimit }: BuildEvmFeeFieldsParams) => {
     const commonFields = {
         gasLimit: fromIntegerString(gasLimit).toHex(),
@@ -254,13 +325,14 @@ export const buildYieldUnsignedTransaction = ({
     gasLimit,
     nonce,
     to,
+    value,
 }: BuildYieldUnsignedTransactionParams) => {
     const feeFields = buildEvmFeeFields({ feeLevel, gasLimit });
     const commonFields = {
         from,
         to,
         data,
-        value: '0x0',
+        value: value ?? '0x0',
         nonce,
         chainId,
         gasLimit: feeFields.gasLimit,
@@ -292,6 +364,8 @@ export const splitYieldPendingTransaction = (
         approvalPendingTransaction: isApprovalPending ? pendingTransaction : undefined,
         actionPendingTransaction:
             pendingTransaction?.type === actionKind ? pendingTransaction : undefined,
+        wrapPendingTransaction:
+            pendingTransaction?.type === 'wrap' ? pendingTransaction : undefined,
     };
 };
 

--- a/suite-common/wallet-utils/src/__tests__/wrappedNativeTokenUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/wrappedNativeTokenUtils.test.ts
@@ -1,0 +1,87 @@
+import { type WalletAccountTransaction } from '@suite-common/wallet-types';
+
+import {
+    getUnwrapAmountByEthereumDataHex,
+    isUnwrapNativeTx,
+    isWrapNativeTx,
+} from '../wrappedNativeTokenUtils';
+
+const WETH_ADDRESS_CHECKSUMMED = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+const UNWRAP_DATA = `0x2e1a7d4d${'de0b6b3a7640000'.padStart(64, '0')}`;
+
+const mockTx = ({
+    symbol = 'eth',
+    methodId,
+    to = WETH_ADDRESS_CHECKSUMMED,
+    data,
+}: {
+    symbol?: string;
+    methodId: string;
+    to?: string;
+    data?: string;
+}) =>
+    ({
+        symbol,
+        targets: [{ addresses: [to] }],
+        ethereumSpecific: { parsedData: { methodId }, data },
+    }) as unknown as WalletAccountTransaction;
+
+describe('isWrapNativeTx', () => {
+    it('detects a WETH deposit() to the canonical contract regardless of case', () => {
+        expect(isWrapNativeTx(mockTx({ methodId: '0xD0E30DB0' }))).toBe(true);
+    });
+
+    it('rejects the deposit selector sent to a different contract', () => {
+        expect(
+            isWrapNativeTx(
+                mockTx({
+                    methodId: '0xd0e30db0',
+                    to: '0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae',
+                }),
+            ),
+        ).toBe(false);
+    });
+
+    it('rejects networks without a wrapped native token', () => {
+        expect(isWrapNativeTx(mockTx({ symbol: 'pol', methodId: '0xd0e30db0' }))).toBe(false);
+    });
+
+    it('rejects other methods on the WETH contract', () => {
+        expect(isWrapNativeTx(mockTx({ methodId: '0xa9059cbb' }))).toBe(false);
+    });
+});
+
+describe('isUnwrapNativeTx', () => {
+    it('detects a WETH withdraw(wad) to the canonical contract', () => {
+        expect(isUnwrapNativeTx(mockTx({ methodId: '0x2e1a7d4d' }))).toBe(true);
+    });
+
+    it('rejects the withdraw selector sent to a different contract', () => {
+        expect(
+            isUnwrapNativeTx(
+                mockTx({
+                    methodId: '0x2e1a7d4d',
+                    to: '0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae',
+                }),
+            ),
+        ).toBe(false);
+    });
+});
+
+describe('getUnwrapAmountByEthereumDataHex', () => {
+    it('decodes the wad argument in wei', () => {
+        expect(getUnwrapAmountByEthereumDataHex(UNWRAP_DATA)).toBe('1000000000000000000');
+    });
+
+    it('returns null for a different method', () => {
+        expect(getUnwrapAmountByEthereumDataHex('0xd0e30db0')).toBeNull();
+    });
+
+    it('returns null for truncated calldata', () => {
+        expect(getUnwrapAmountByEthereumDataHex('0x2e1a7d4d00ff')).toBeNull();
+    });
+
+    it('returns null for missing calldata', () => {
+        expect(getUnwrapAmountByEthereumDataHex(undefined)).toBeNull();
+    });
+});

--- a/suite-common/wallet-utils/src/index.ts
+++ b/suite-common/wallet-utils/src/index.ts
@@ -38,3 +38,4 @@ export * from './feeUnitUtils';
 export * from './stellarTokens';
 export * from './tronUtils';
 export * from './tronStakingUtils';
+export * from './wrappedNativeTokenUtils';

--- a/suite-common/wallet-utils/src/wrappedNativeTokenUtils.ts
+++ b/suite-common/wallet-utils/src/wrappedNativeTokenUtils.ts
@@ -1,0 +1,43 @@
+import { getWrappedNativeAddress } from '@suite-common/wallet-config';
+import { type WalletAccountTransaction } from '@suite-common/wallet-types';
+
+import { fromHex } from './ethConverter';
+import { getSignatureByEthereumDataHex } from './ethereumStakingUtils';
+
+// WETH9 deposit() / withdraw(uint256 wad) selectors.
+const WRAP_SIGNATURE = '0xd0e30db0';
+const UNWRAP_SIGNATURE = '0x2e1a7d4d';
+
+const targetsWrappedNativeContract = (transaction: WalletAccountTransaction) => {
+    const wrappedNativeAddress = getWrappedNativeAddress(transaction.symbol);
+    const targetAddress = transaction.targets?.[0]?.addresses?.[0];
+
+    return (
+        !!wrappedNativeAddress &&
+        !!targetAddress &&
+        targetAddress.toLowerCase() === wrappedNativeAddress
+    );
+};
+
+export const isWrapNativeTx = (transaction: WalletAccountTransaction) =>
+    transaction.ethereumSpecific?.parsedData?.methodId?.toLowerCase() === WRAP_SIGNATURE &&
+    targetsWrappedNativeContract(transaction);
+
+export const isUnwrapNativeTx = (transaction: WalletAccountTransaction) =>
+    transaction.ethereumSpecific?.parsedData?.methodId?.toLowerCase() === UNWRAP_SIGNATURE &&
+    targetsWrappedNativeContract(transaction);
+
+/** Unwrapped amount (wei) decoded from withdraw(wad) calldata. */
+export const getUnwrapAmountByEthereumDataHex = (dataHex?: string) => {
+    if (!dataHex) return null;
+
+    const data = dataHex.startsWith('0x') ? dataHex.slice(2) : dataHex;
+
+    if (getSignatureByEthereumDataHex(data) !== UNWRAP_SIGNATURE) return null;
+
+    const dataBuffer = Buffer.from(data, 'hex');
+
+    if (dataBuffer.length < 36) return null;
+
+    return fromHex(`0x${dataBuffer.subarray(4, 36).toString('hex')}`).toIntegerString();
+};

--- a/suite/analytics/src/constants.ts
+++ b/suite/analytics/src/constants.ts
@@ -113,6 +113,7 @@ export enum EventType {
     YieldDeposit = 'yield/deposit',
     YieldWithdraw = 'yield/withdraw',
     YieldClaim = 'yield/claim',
+    YieldWethUnwrap = 'yield/weth-unwrap',
     // eslint-disable-next-line local-rules/analytics-event-name
     SuiteReady = 'suite-ready',
     // eslint-disable-next-line local-rules/analytics-event-name

--- a/suite/analytics/src/events/index.ts
+++ b/suite/analytics/src/events/index.ts
@@ -93,6 +93,7 @@ export { yieldNavigateEvent } from './yieldNavigateEvent';
 export { yieldDepositEvent } from './yieldDepositEvent';
 export { yieldWithdrawEvent } from './yieldWithdrawEvent';
 export { yieldClaimEvent } from './yieldClaimEvent';
+export { wethUnwrapEvent } from './wethUnwrapEvent';
 export { suiteReadyEvent } from './suiteReadyEvent';
 export { switchDeviceEjectEvent } from './switchDeviceEjectEvent';
 export { switchDeviceForgetEvent } from './switchDeviceForgetEvent';

--- a/suite/analytics/src/events/wethUnwrapEvent.ts
+++ b/suite/analytics/src/events/wethUnwrapEvent.ts
@@ -1,0 +1,38 @@
+import type { AttributeDef, EventDef } from '@suite-common/analytics';
+
+import { EventType } from '../constants';
+
+type Attributes = {
+    action: AttributeDef<'continue' | 'cancel'>;
+    type: AttributeDef<'unwrap-form-modal' | 'tx-simulation-modal' | 'unwrap' | 'error'>;
+    networkSymbol?: AttributeDef<string>;
+    source?: AttributeDef<'tokens-table' | 'withdraw-complete'>;
+    errorMessage?: AttributeDef<string>;
+};
+
+export const wethUnwrapEvent: EventDef<Attributes, EventType.YieldWethUnwrap> = {
+    name: EventType.YieldWethUnwrap,
+    descriptionTrigger: 'fired on WETH unwrap actions (modal open/cancel, submit, errors)',
+    changelog: [{ version: '26.7.0', notes: 'added' }],
+
+    attributes: {
+        action: {
+            changelog: [{ version: '26.7.0', notes: 'added' }],
+        },
+        type: {
+            description:
+                '`unwrap-form-modal` = unwrap modal opened or cancelled, `tx-simulation-modal` = simulation accepted/cancelled, `unwrap` = transaction submitted, `error` = submit failed',
+            changelog: [{ version: '26.7.0', notes: 'added' }],
+        },
+        networkSymbol: {
+            changelog: [{ version: '26.7.0', notes: 'added' }],
+        },
+        source: {
+            description: 'Entry point of the unwrap flow',
+            changelog: [{ version: '26.7.0', notes: 'added' }],
+        },
+        errorMessage: {
+            changelog: [{ version: '26.7.0', notes: 'added' }],
+        },
+    },
+};

--- a/suite/analytics/src/events/yieldDepositEvent.ts
+++ b/suite/analytics/src/events/yieldDepositEvent.ts
@@ -14,6 +14,8 @@ type Attributes = {
         | 'revoke-success'
         | 'modify-allowance'
         | 'deposit'
+        | 'wrap'
+        | 'wrap-success'
         | 'tx-simulation-modal'
         | 'success'
         | 'error'
@@ -46,6 +48,10 @@ export const yieldDepositEvent: EventDef<Attributes, EventType.YieldDeposit> = {
                 {
                     version: '26.5.2',
                     notes: 'added `approve-success`, `revoke-success`, `leftPending`, `tx-simulation-modal`, `firmware-upgrade-needed-modal` values',
+                },
+                {
+                    version: '26.7.0',
+                    notes: 'added `wrap`, `wrap-success` values for the ETH wrap step',
                 },
             ],
         },

--- a/suite/analytics/src/events/yieldInteractionEvent.ts
+++ b/suite/analytics/src/events/yieldInteractionEvent.ts
@@ -17,6 +17,7 @@ type Attributes = {
         | 'allowance-error-banner'
         | 'allowance-retry'
         | 'unwrap-offer'
+        | 'receive-as-native-toggle'
         | 'staking-vs-yield-tooltip'
     >;
     value?: AttributeDef<string>;
@@ -37,7 +38,7 @@ export const yieldInteractionEvent: EventDef<Attributes, EventType.YieldInteract
                 { version: '26.5.2', notes: 'added' },
                 {
                     version: '26.7.0',
-                    notes: 'added `unwrap-offer`, `staking-vs-yield-tooltip` values',
+                    notes: 'added `unwrap-offer`, `receive-as-native-toggle`, `staking-vs-yield-tooltip` values',
                 },
             ],
         },

--- a/suite/analytics/src/events/yieldInteractionEvent.ts
+++ b/suite/analytics/src/events/yieldInteractionEvent.ts
@@ -16,6 +16,8 @@ type Attributes = {
         | 'insufficient-funds-banner'
         | 'allowance-error-banner'
         | 'allowance-retry'
+        | 'unwrap-offer'
+        | 'staking-vs-yield-tooltip'
     >;
     value?: AttributeDef<string>;
     networkSymbol?: AttributeDef<string>;
@@ -31,7 +33,13 @@ export const yieldInteractionEvent: EventDef<Attributes, EventType.YieldInteract
     attributes: {
         element: {
             description: 'Which UI element the user interacted with',
-            changelog: [{ version: '26.5.2', notes: 'added' }],
+            changelog: [
+                { version: '26.5.2', notes: 'added' },
+                {
+                    version: '26.7.0',
+                    notes: 'added `unwrap-offer`, `staking-vs-yield-tooltip` values',
+                },
+            ],
         },
         value: {
             description:

--- a/suite/analytics/src/events/yieldNavigateEvent.ts
+++ b/suite/analytics/src/events/yieldNavigateEvent.ts
@@ -7,6 +7,7 @@ type Attributes = {
     action: AttributeDef<EarnModalAction>;
     from: AttributeDef<
         | 'earn-dashboard'
+        | 'account-banner'
         | 'account-defi-tokens'
         | 'deposit-in-a-nutshell-modal'
         | 'deposit-legal-modal'
@@ -38,7 +39,10 @@ export const yieldNavigateEvent: EventDef<Attributes, EventType.YieldNavigate> =
             changelog: [{ version: '26.5.0', notes: 'added' }],
         },
         from: {
-            changelog: [{ version: '26.5.0', notes: 'added' }],
+            changelog: [
+                { version: '26.5.0', notes: 'added' },
+                { version: '26.7.0', notes: 'added `account-banner` value for the earn promo' },
+            ],
         },
         to: {
             changelog: [{ version: '26.5.0', notes: 'added' }],

--- a/suite/analytics/src/events/yieldWithdrawEvent.ts
+++ b/suite/analytics/src/events/yieldWithdrawEvent.ts
@@ -7,6 +7,8 @@ type Attributes = {
     action: AttributeDef<EarnModalAction>;
     type: AttributeDef<
         | 'withdraw'
+        | 'unwrap'
+        | 'unwrap-success'
         | 'tx-simulation-modal'
         | 'success'
         | 'error'
@@ -36,6 +38,10 @@ export const yieldWithdrawEvent: EventDef<Attributes, EventType.YieldWithdraw> =
                 {
                     version: '26.5.2',
                     notes: 'added `leftPending`, `tx-simulation-modal`, `firmware-upgrade-needed-modal` values',
+                },
+                {
+                    version: '26.7.0',
+                    notes: 'added `unwrap`, `unwrap-success` values for the chained WETH unwrap step',
                 },
             ],
         },

--- a/suite/flags/src/flagsSlice.ts
+++ b/suite/flags/src/flagsSlice.ts
@@ -18,6 +18,7 @@ export type FlagsState = {
     showSettingsDesktopAppPromoBanner: boolean;
     activateAssetsBannerClosed: boolean;
     stakeEthBannerClosed: boolean;
+    earnEthBannerClosed: boolean;
     stakeSolBannerClosed: boolean;
     stakeCardanoBannerClosed: boolean;
     stakeTronBannerClosed: boolean;
@@ -51,6 +52,7 @@ export const flagsInitialState: FlagsState = {
     showSettingsDesktopAppPromoBanner: true,
     activateAssetsBannerClosed: false,
     stakeEthBannerClosed: false,
+    earnEthBannerClosed: false,
     stakeSolBannerClosed: false,
     stakeCardanoBannerClosed: false,
     stakeTronBannerClosed: false,

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -11042,6 +11042,11 @@ export const messages = defineMessages({
         id: 'TR_EARN_DEPOSITING_IN_A_NUTSHELL',
         defaultMessage: 'How stablecoin yield works',
     },
+    TR_EARN_YIELD_NUTSHELL_DEPOSIT_EITHER: {
+        id: 'TR_EARN_YIELD_NUTSHELL_DEPOSIT_EITHER',
+        defaultMessage:
+            'You can deposit {nativeSymbol} or {supplySymbol} — {nativeSymbol} is wrapped to {supplySymbol} automatically, 1:1.',
+    },
     TR_EARN_YIELD_NUTSHELL_DEPOSITED_AMOUNT: {
         id: 'TR_EARN_YIELD_NUTSHELL_DEPOSITED_AMOUNT',
         defaultMessage:

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10177,10 +10177,10 @@ export const messages = defineMessages({
     TR_EARN_YIELD_WRAP_STEP_DESCRIPTION: {
         id: 'TR_EARN_YIELD_WRAP_STEP_DESCRIPTION',
         defaultMessage:
-            "Wrap the {nativeSymbol} you want to deposit — it's 1:1, and you can unwrap anytime.",
+            "Wrap the {nativeSymbol} you want to deposit — it's 1:1, and you can unwrap anytime during the withdraw process or from the Tokens tab.",
     },
-    TR_EARN_YIELD_WRAP_RECEIVING: {
-        id: 'TR_EARN_YIELD_WRAP_RECEIVING',
+    TR_EARN_YIELD_RECEIVING: {
+        id: 'TR_EARN_YIELD_RECEIVING',
         defaultMessage: 'Receiving',
     },
     TR_EARN_YIELD_WRAP_MORE: {
@@ -10190,6 +10190,23 @@ export const messages = defineMessages({
     TR_EARN_YIELD_PENDING_WRAP: {
         id: 'TR_EARN_YIELD_PENDING_WRAP',
         defaultMessage: 'Confirming wrap...',
+    },
+    TR_EARN_YIELD_PENDING_UNWRAP: {
+        id: 'TR_EARN_YIELD_PENDING_UNWRAP',
+        defaultMessage: 'Confirming unwrap...',
+    },
+    TR_EARN_YIELD_RECEIVE_AS_NATIVE: {
+        id: 'TR_EARN_YIELD_RECEIVE_AS_NATIVE',
+        defaultMessage: 'Receive as {nativeSymbol}',
+    },
+    TR_EARN_YIELD_UNWRAP_STEP_DESCRIPTION: {
+        id: 'TR_EARN_YIELD_UNWRAP_STEP_DESCRIPTION',
+        defaultMessage:
+            'Confirm to unwrap your withdrawn {amount} and receive {nativeSymbol}. You can also keep {tokenSymbol} and unwrap anytime later from the Tokens tab.',
+    },
+    TR_EARN_YIELD_UNWRAP_BUTTON: {
+        id: 'TR_EARN_YIELD_UNWRAP_BUTTON',
+        defaultMessage: 'Unwrap {nativeSymbol} from {tokenSymbol}',
     },
     TR_UNWRAP_TOKEN: {
         id: 'TR_UNWRAP_TOKEN',
@@ -10201,24 +10218,15 @@ export const messages = defineMessages({
     },
     TR_UNWRAP_WETH_DESCRIPTION: {
         id: 'TR_UNWRAP_WETH_DESCRIPTION',
-        defaultMessage:
-            '{symbol} converts back to {nativeSymbol} 1:1. A network fee paid in {nativeSymbol} applies.',
+        defaultMessage: '{symbol} converts back to {nativeSymbol} 1:1.',
     },
     TR_UNWRAP_AMOUNT: {
         id: 'TR_UNWRAP_AMOUNT',
         defaultMessage: 'Amount to unwrap',
     },
-    TR_UNWRAP_TO_NATIVE: {
-        id: 'TR_UNWRAP_TO_NATIVE',
-        defaultMessage: 'Unwrap to {symbol}',
-    },
     TR_UNWRAP_LOW_ETH_FOR_FEE: {
         id: 'TR_UNWRAP_LOW_ETH_FOR_FEE',
         defaultMessage: 'You need a small amount of {symbol} to pay the network fee.',
-    },
-    TR_UNWRAP_OFFER_TEXT: {
-        id: 'TR_UNWRAP_OFFER_TEXT',
-        defaultMessage: 'You received {symbol}. You can unwrap it to {nativeSymbol} anytime.',
     },
     TR_EARN_YIELD_NUTSHELL_WRAP: {
         id: 'TR_EARN_YIELD_NUTSHELL_WRAP',
@@ -11564,6 +11572,10 @@ export const messages = defineMessages({
     TOAST_TX_YIELD_WRAP: {
         id: 'TOAST_TX_YIELD_WRAP',
         defaultMessage: 'Wrap transaction from {account} has been broadcast',
+    },
+    TOAST_TX_YIELD_UNWRAP: {
+        id: 'TOAST_TX_YIELD_UNWRAP',
+        defaultMessage: 'Unwrap transaction from {account} has been broadcast',
     },
     TOAST_TX_YIELD_WITHDRAW: {
         id: 'TOAST_TX_YIELD_WITHDRAW',

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -3593,6 +3593,10 @@ export const messages = defineMessages({
         defaultMessage: '{count, plural, =0 {Fee} =1 {Fee} other {{count}× Fees}}',
         id: 'TR_TX_FEE_COUNT',
     },
+    TR_TX_FEE_COUNT_UP_TO: {
+        defaultMessage: '{count, plural, =1 {Up to 1× Fee} other {Up to {count}× Fees}}',
+        id: 'TR_TX_FEE_COUNT_UP_TO',
+    },
     TR_TX_FEE_INCLUDING_RENT: {
         defaultMessage: 'Network fee (including rent)',
         id: 'TR_TX_FEE_INCLUDING_RENT',
@@ -9784,11 +9788,11 @@ export const messages = defineMessages({
     },
     TR_PROMO_BANNER_DASHBOARD_STABLECOIN_YIELD_TITLE: {
         id: 'TR_PROMO_BANNER_DASHBOARD_STABLECOIN_YIELD_TITLE',
-        defaultMessage: 'Earn on your stablecoins',
+        defaultMessage: 'Earn on your stablecoins and ETH',
     },
     TR_PROMO_BANNER_DASHBOARD_STABLECOIN_YIELD_DESCRIPTION: {
         id: 'TR_PROMO_BANNER_DASHBOARD_STABLECOIN_YIELD_DESCRIPTION',
-        defaultMessage: 'Earn yield on USDC and USDT with Trezor-grade security.',
+        defaultMessage: 'Earn yield on USDC, USDT, and ETH with Trezor-grade security.',
     },
     TR_PROMO_BANNER_DASHBOARD_STABLECOIN_YIELD_BUTTON: {
         id: 'TR_PROMO_BANNER_DASHBOARD_STABLECOIN_YIELD_BUTTON',
@@ -10140,6 +10144,112 @@ export const messages = defineMessages({
     TR_EARN_STABLECOIN_YIELD_TITLE: {
         id: 'TR_EARN_STABLECOIN_YIELD_TITLE',
         defaultMessage: 'Stablecoin yield',
+    },
+    TR_EARN_YIELD_WRAP_STEP_TITLE: {
+        id: 'TR_EARN_YIELD_WRAP_STEP_TITLE',
+        defaultMessage: 'Wrap {nativeSymbol} to {tokenSymbol}',
+    },
+    TR_EARN_YIELD_WRAP_BUTTON: {
+        id: 'TR_EARN_YIELD_WRAP_BUTTON',
+        defaultMessage: 'Wrap {nativeSymbol}',
+    },
+    TR_EARN_YIELD_WRAP_INSUFFICIENT: {
+        id: 'TR_EARN_YIELD_WRAP_INSUFFICIENT',
+        defaultMessage: 'Amount exceeds your {tokenSymbol} balance.',
+    },
+    TR_EARN_YIELD_WRAP_RESERVE_KEPT: {
+        id: 'TR_EARN_YIELD_WRAP_RESERVE_KEPT',
+        defaultMessage:
+            "We've left {amount} {networkDisplaySymbol} in your account so you can pay for transaction fees.",
+    },
+    TR_EARN_YIELD_AMOUNT_TO_WRAP: {
+        id: 'TR_EARN_YIELD_AMOUNT_TO_WRAP',
+        defaultMessage: 'Amount to wrap',
+    },
+    TR_EARN_YIELD_WRAP_STEP_DESCRIPTION: {
+        id: 'TR_EARN_YIELD_WRAP_STEP_DESCRIPTION',
+        defaultMessage:
+            "Wrap the {nativeSymbol} you want to deposit — it's 1:1, and you can unwrap anytime.",
+    },
+    TR_EARN_YIELD_WRAP_RECEIVING: {
+        id: 'TR_EARN_YIELD_WRAP_RECEIVING',
+        defaultMessage: 'Receiving',
+    },
+    TR_EARN_YIELD_WRAP_MORE: {
+        id: 'TR_EARN_YIELD_WRAP_MORE',
+        defaultMessage: 'Wrap more',
+    },
+    TR_EARN_YIELD_PENDING_WRAP: {
+        id: 'TR_EARN_YIELD_PENDING_WRAP',
+        defaultMessage: 'Confirming wrap...',
+    },
+    TR_UNWRAP_TOKEN: {
+        id: 'TR_UNWRAP_TOKEN',
+        defaultMessage: 'Unwrap',
+    },
+    TR_UNWRAP_WETH_HEADING: {
+        id: 'TR_UNWRAP_WETH_HEADING',
+        defaultMessage: 'Unwrap {symbol}',
+    },
+    TR_UNWRAP_WETH_DESCRIPTION: {
+        id: 'TR_UNWRAP_WETH_DESCRIPTION',
+        defaultMessage:
+            '{symbol} converts back to {nativeSymbol} 1:1. A network fee paid in {nativeSymbol} applies.',
+    },
+    TR_UNWRAP_AMOUNT: {
+        id: 'TR_UNWRAP_AMOUNT',
+        defaultMessage: 'Amount to unwrap',
+    },
+    TR_UNWRAP_TO_NATIVE: {
+        id: 'TR_UNWRAP_TO_NATIVE',
+        defaultMessage: 'Unwrap to {symbol}',
+    },
+    TR_UNWRAP_LOW_ETH_FOR_FEE: {
+        id: 'TR_UNWRAP_LOW_ETH_FOR_FEE',
+        defaultMessage: 'You need a small amount of {symbol} to pay the network fee.',
+    },
+    TR_UNWRAP_OFFER_TEXT: {
+        id: 'TR_UNWRAP_OFFER_TEXT',
+        defaultMessage: 'You received {symbol}. You can unwrap it to {nativeSymbol} anytime.',
+    },
+    TR_EARN_YIELD_NUTSHELL_WRAP: {
+        id: 'TR_EARN_YIELD_NUTSHELL_WRAP',
+        defaultMessage: 'Wrap {nativeSymbol} to {supplySymbol}',
+    },
+    TR_EARN_YIELD_NUTSHELL_WRAP_SUB: {
+        id: 'TR_EARN_YIELD_NUTSHELL_WRAP_SUB',
+        defaultMessage:
+            "Only needed when you don't hold enough {supplySymbol} — converts {nativeSymbol} 1:1.",
+    },
+    TR_EARN_YIELD_NUTSHELL_UNWRAP_HINT: {
+        id: 'TR_EARN_YIELD_NUTSHELL_UNWRAP_HINT',
+        defaultMessage: 'Unwrap {supplySymbol} back to {nativeSymbol} anytime',
+    },
+    TR_EARN_YIELD_NUTSHELL_UNWRAP_HINT_SUB: {
+        id: 'TR_EARN_YIELD_NUTSHELL_UNWRAP_HINT_SUB',
+        defaultMessage: 'Optional separate transaction with a network fee.',
+    },
+    TR_EARN_STAKING_VS_YIELD_TITLE: {
+        id: 'TR_EARN_STAKING_VS_YIELD_TITLE',
+        defaultMessage: 'Staking vs. yield',
+    },
+    TR_EARN_STAKING_VS_YIELD_DESCRIPTION: {
+        id: 'TR_EARN_STAKING_VS_YIELD_DESCRIPTION',
+        defaultMessage:
+            'Staking locks your ETH to help secure the network and may involve waiting periods. Yield wraps ETH to WETH and lends it through a vault — withdrawals are instant and rates are variable. Each carries different risks.',
+    },
+    TR_STAKING_BANNER_ETH_EARN_TITLE: {
+        id: 'TR_STAKING_BANNER_ETH_EARN_TITLE',
+        defaultMessage: 'Earn on your {displaySymbol}: stake it or earn yield',
+    },
+    TR_STAKING_BANNER_ETH_EARN_TEXT: {
+        id: 'TR_STAKING_BANNER_ETH_EARN_TEXT',
+        defaultMessage:
+            'Stake {displaySymbol} for network rewards, or deposit it in a yield vault — your choice.',
+    },
+    TR_STAKING_BANNER_ETH_EARN_BUTTON: {
+        id: 'TR_STAKING_BANNER_ETH_EARN_BUTTON',
+        defaultMessage: 'Explore earning options',
     },
     TR_EARN_YIELD_PENDING_DEPOSIT: {
         id: 'TR_EARN_YIELD_PENDING_DEPOSIT',
@@ -11437,6 +11547,10 @@ export const messages = defineMessages({
     TOAST_TX_YIELD_DEPOSIT: {
         id: 'TOAST_TX_YIELD_DEPOSIT',
         defaultMessage: 'Deposit transaction from {account} has been broadcast',
+    },
+    TOAST_TX_YIELD_WRAP: {
+        id: 'TOAST_TX_YIELD_WRAP',
+        defaultMessage: 'Wrap transaction from {account} has been broadcast',
     },
     TOAST_TX_YIELD_WITHDRAW: {
         id: 'TOAST_TX_YIELD_WITHDRAW',

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -3645,6 +3645,14 @@ export const messages = defineMessages({
         defaultMessage: 'Swap from {fromSymbol} to {toSymbol}',
         id: 'TR_SWAP_TRANSACTION',
     },
+    TR_TX_WRAP_NATIVE: {
+        defaultMessage: 'Wrapped {fromSymbol} to {toSymbol}',
+        id: 'TR_TX_WRAP_NATIVE',
+    },
+    TR_TX_UNWRAP_NATIVE: {
+        defaultMessage: 'Unwrapped {fromSymbol} to {toSymbol}',
+        id: 'TR_TX_UNWRAP_NATIVE',
+    },
     TR_UNKNOWN_ERROR_SEE_CONSOLE: {
         defaultMessage: 'Unknown error. See console logs for details.',
         id: 'TR_UNKNOWN_ERROR_SEE_CONSOLE',


### PR DESCRIPTION
> [!WARNING]
> **NOT READY FOR REVIEW** — exploration PR of what we need for WETH Vault support

> [!TIP]
> Can be tested on https://dev.suite.sldev.cz/suite-web/feat/introduce-weth-flow/web

## Description

Adds a WETH flow to the ETH yield vault so native ETH can earn yield:

1. Wrap ETH → WETH inside the vault deposit flow 

<img width="568" height="738" alt="Screenshot 2026-07-10 at 20 35 47" src="https://github.com/user-attachments/assets/3d8b68db-cec2-426d-b02b-999df82be73c" />
<img width="565" height="636" alt="Screenshot 2026-07-10 at 20 37 21" src="https://github.com/user-attachments/assets/10877b21-1bfa-4206-b913-86e15e24fd34" />

2. Unwrap WETH → ETH inside the vault withdraw flow 

<img width="575" height="627" alt="Screenshot 2026-07-10 at 20 38 10" src="https://github.com/user-attachments/assets/77934dab-d6d5-4997-b4cc-c50756a9ca2b" />
<img width="587" height="494" alt="Screenshot 2026-07-10 at 20 38 32" src="https://github.com/user-attachments/assets/80310f52-65db-4b45-9703-d3cd0f42f671" />
<img width="574" height="571" alt="Screenshot 2026-07-10 at 20 41 30" src="https://github.com/user-attachments/assets/9118723f-64ed-495b-8bb6-9f941a4f3194" />


2. Unwrap WETH → ETH in Tokens
- tokens table "Unwrap" action

<img width="970" height="381" alt="Screenshot 2026-07-10 at 14 02 20" src="https://github.com/user-attachments/assets/d660fbc0-f777-42ca-9914-5251881c1ecf" />
<img width="450"  alt="Screenshot 2026-07-10 at 20 45 29" src="https://github.com/user-attachments/assets/14071c0a-1160-4447-9d7a-6d5693cd590b" />


4. Earn in nutshell modal
<img width="400" alt="Screenshot 2026-07-10 at 20 33 27" src="https://github.com/user-attachments/assets/80e07f1c-c759-4b97-9f30-4a9e6022d7db" />
<img width="400"  alt="Screenshot 2026-07-10 at 20 33 30" src="https://github.com/user-attachments/assets/c99dd34c-460a-4843-9bc8-f0d28b18f5ae" />
<img width="400"  alt="Screenshot 2026-07-10 at 20 33 36" src="https://github.com/user-attachments/assets/d435e48e-9f0d-4731-b6bc-3b3f18111214" />

5. Earn dashboard
- Dashboard vault rows count both ETH and WETH into the depositable balance for wrapped-native vaults

<img width="1102" height="375" alt="Screenshot 2026-07-10 at 16 31 46" src="https://github.com/user-attachments/assets/1aff733a-f564-4b95-9190-44709943e717" />


6. Promo
- StakingBanner earn variant: ETH accounts with a matching WETH vault get "earn" messaging → Earn dashboard

<img width="663" height="400" alt="Screenshot 2026-07-10 at 15 40 19" src="https://github.com/user-attachments/assets/0d181f18-4020-4870-8734-e2467b55f970" />
<img width="678" height="181" alt="Screenshot 2026-07-10 at 20 42 23" src="https://github.com/user-attachments/assets/af132d9c-c734-40a5-8b6e-c5c3a70faf09" />


## Related Issue

Resolve #28554

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/introduce-weth-flow&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/introduce-weth-flow&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/introduce-weth-flow&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-10T19:21:17.862Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-10T19:22:51.851Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/introduce-weth-flow/web/](https://dev.suite.sldev.cz/suite-web/feat/introduce-weth-flow/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

