### PR TITLE
chore(connect): remove deprecated code

### DIFF
--- a/packages/connect/src/api/bitcoin/inputs.ts
+++ b/packages/connect/src/api/bitcoin/inputs.ts
@@ -6,7 +6,6 @@ import type {
     ProtoWithDerivationPath,
 } from '@trezor/connect-common';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
-import type { Transaction as BitcoinJsTransaction } from '@trezor/utxo-lib';
 
 import { convertMultisigPubKey } from '../../utils/hdnodeUtils';
 import {
@@ -57,24 +56,6 @@ export const validateTrezorInputs = (
 
             return input;
         });
-
-// this method exist as a workaround for breaking change described in validateTrezorInputs
-// TODO: it could be removed after another major version release.
-export const enhanceTrezorInputs = (
-    inputs: PROTO.TxInputType[],
-    rawTxs: BitcoinJsTransaction[],
-) => {
-    inputs.forEach(input => {
-        if (!input.amount) {
-            console.warn('TrezorConnect.signTransaction deprecation: missing input amount.');
-            const refTx = rawTxs.find(t => t.getId() === input.prev_hash);
-            const refTxPrevIndex = refTx?.outs[input.prev_index];
-            if (refTxPrevIndex) {
-                input.amount = refTxPrevIndex.value;
-            }
-        }
-    });
-};
 
 /** *****
  * Transform from @trezor/utxo-lib/compose format to Trezor

--- a/packages/connect/src/api/signTransaction.ts
+++ b/packages/connect/src/api/signTransaction.ts
@@ -16,7 +16,6 @@ import {
     createPendingTransaction,
     deriveOutputScript,
     enhanceSignTx,
-    enhanceTrezorInputs,
     getOrigTransactions,
     getReferencedTransactions,
     parseTransactionHexes,
@@ -292,11 +291,7 @@ export default class SignTransaction extends AbstractMethod<'signTransaction', P
             : await blockchain
                   .getTransactionHexes(refTxsIds)
                   .then(parseTransactionHexes(coinInfo.network))
-                  .then(rawTxs => {
-                      enhanceTrezorInputs(this.params.inputs, rawTxs);
-
-                      return transformReferencedTransactions(rawTxs);
-                  });
+                  .then(rawTxs => transformReferencedTransactions(rawTxs));
 
         const origTxs = !origTxsIds.length
             ? []


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

##  🧹🧹🧹🧹🧹🧹

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect two core Bitcoin transaction modules: bitcoin/inputs.ts (input construction/validation) and signTransaction.ts (the transaction signing API). While bitcoin/inputs.ts is transitively imported by 121 tests, only tests that actually sign or compose Bitcoin-like transactions are meaningfully affected. The 5 tests statically mapped to signTransaction.ts are all high priority since they directly exercise BTC/DOGE/LTC transaction signing flows where both changed files are on the critical path. The remaining 116+ tests that only transitively reference bitcoin/inputs.ts (analytics, metadata, onboarding, staking, etc.) do not exercise Bitcoin transaction signing and are safely omitted.

<details><summary><b>Changed files (2)</b></summary>

- `packages/connect/src/api/bitcoin/inputs.ts`
- `packages/connect/src/api/signTransaction.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test directly exercises Bitcoin transaction signing with multiple outputs, locktime, and OP_RETURN — all of which go through signTransaction.ts and rely on bitcoin/inputs.ts for input handling. Changes to input construction or transaction signing logic would directly affect this test's ability to compose and send transactions.
- `suite/e2e/tests/wallet/send-doge.test.ts` — This test validates DOGE transaction signing including amount validation for values exceeding MAX_SAFE_INTEGER. It directly invokes signTransaction and exercises bitcoin input handling for DOGE (a BTC-like coin), making it highly sensitive to changes in both bitcoin/inputs.ts and signTransaction.ts.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — This test sends LTC with a MimbleWimble peg-out originated output, which is a specialized Bitcoin-like input type. Changes to bitcoin/inputs.ts input processing or signTransaction.ts signing flow could break this specific input handling path.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — This test completes a full BTC sell flow including initiating a send transaction and verifying device prompt details (address, amount, fee). It directly exercises signTransaction for BTC and relies on bitcoin/inputs.ts for constructing the transaction inputs.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — This test performs a BTC-to-ETH swap with custom fee settings, verifying that fee rate, total amount, and fee are correctly calculated and displayed on the device. It directly uses signTransaction for BTC and validates the transaction composition that depends on bitcoin/inputs.ts.

</details>

_Updated: 2026-06-15T10:53:46.257Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/connect-deprecated-code&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/connect-deprecated-code&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/connect-deprecated-code&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-15T10:58:16.784Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-15T10:57:12.456Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/connect-deprecated-code/web/](https://dev.suite.sldev.cz/suite-web/chore/connect-deprecated-code/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->