### PR TITLE
fix(suite): log device-setup events without analytics consent

### DIFF
--- a/packages/suite/src/actions/onboarding/onboardingActions.ts
+++ b/packages/suite/src/actions/onboarding/onboardingActions.ts
@@ -153,18 +153,31 @@ const goToSuite = () => (dispatch: Dispatch, getState: GetState, extra: ExtraDep
 
     dispatch(startDiscoveryThunk({ device }));
     const reportAnalytics = () => {
-        const payload = {
-            ...onboardingAnalytics,
-            duration: Date.now() - onboardingAnalytics.startTime!,
+        const { analytics } = extra.services;
+        const { startTime, ...onboardingAttributes } = onboardingAnalytics;
+        const fullPayload = {
+            ...onboardingAttributes,
+            duration: Date.now() - startTime!,
             device: device.features.internal_model,
             unitPackaging: device.features.unit_packaging ?? 0,
         };
-        delete payload.startTime;
 
-        asTypedDesktopAnalytics(extra.services.analytics).report({
-            type: events.deviceSetupCompletedEvent.name,
-            payload,
-        });
+        const hasConsent = analytics.isEnabled();
+        const payload = hasConsent
+            ? fullPayload
+            : {
+                  duration: fullPayload.duration,
+                  device: fullPayload.device,
+                  unitPackaging: fullPayload.unitPackaging,
+              };
+
+        asTypedDesktopAnalytics(analytics).report(
+            {
+                type: events.deviceSetupCompletedEvent.name,
+                payload,
+            },
+            { force: true },
+        );
     };
     reportAnalytics();
 };

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceInitialize.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceInitialize.tsx
@@ -33,12 +33,15 @@ export const DeviceInitialize = () => {
 
         const device = selectSelectedDevice(getState());
 
-        analytics.report({
-            type: events.deviceSetupStartedEvent.name,
-            payload: {
-                deviceModel: device?.features?.internal_model || DeviceModelInternal.UNKNOWN,
+        analytics.report(
+            {
+                type: events.deviceSetupStartedEvent.name,
+                payload: {
+                    deviceModel: device?.features?.internal_model || DeviceModelInternal.UNKNOWN,
+                },
             },
-        });
+            { force: true },
+        );
         dispatch(goto({ routeName: 'onboarding-index' }));
     };
 

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceNoFirmware.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceNoFirmware.tsx
@@ -21,12 +21,15 @@ export const DeviceNoFirmware = () => {
         e.stopPropagation();
         const device = selectSelectedDevice(getState());
 
-        analytics.report({
-            type: events.deviceSetupStartedEvent.name,
-            payload: {
-                deviceModel: device?.features?.internal_model || DeviceModelInternal.UNKNOWN,
+        analytics.report(
+            {
+                type: events.deviceSetupStartedEvent.name,
+                payload: {
+                    deviceModel: device?.features?.internal_model || DeviceModelInternal.UNKNOWN,
+                },
             },
-        });
+            { force: true },
+        );
         dispatch(goto({ routeName: 'onboarding-index' }));
     };
 

--- a/packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/SecurityCheck.tsx
+++ b/packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/SecurityCheck.tsx
@@ -155,12 +155,15 @@ const SecurityCheckContent = ({
 
     const handleSetupButtonClick = () => {
         dispatch(deviceActions.setManualDeviceCheckSuccess({ deviceId }));
-        analytics.report({
-            type: events.deviceSetupStartedEvent.name,
-            payload: {
-                deviceModel,
+        analytics.report(
+            {
+                type: events.deviceSetupStartedEvent.name,
+                payload: {
+                    deviceModel,
+                },
             },
-        });
+            { force: true },
+        );
 
         if (isRecoveryInProgress) {
             rerun();


### PR DESCRIPTION

## Description

device-setup-started was reported through the consent-gated analytics, so it was dropped whenever the user did not grant analytics consent (consent is resolved before the event fires, so there is no queue window). device-setup- completed only kept landing without consent because it used to go through the removed legacyAnalytics service.

Report both events as exceptions with { force: true } so they are logged regardless of consent. For device-setup-completed, without consent we send a limited payload (duration, device, unitPackaging only) and drop the behavioral attributes (seed, seedType, recoveryType, backup, pin, firmware, ...).

<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

## Notes for QA

This fixes the fact that we do not have the ending event tracked due to lacking consnete due to the fact the first event is lgged before user gives consent.

## Related Issue

Resolve  https://github.com/trezor/trezor-suite/issues/24542

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes target core onboarding infrastructure: the onboarding actions state machine (onboardingActions.ts), the device authenticity/security check step (SecurityCheck.tsx), and two prerequisite guide components shown when a device needs initialization or firmware (DeviceInitialize.tsx, DeviceNoFirmware.tsx). All four files map to 121 tests due to broad transitive imports, but only onboarding-specific tests are meaningfully affected. The highest risk is in wallet creation and recovery flows that directly exercise these components. The recommended strategy prioritizes onboarding create-wallet and recovery tests across device models, plus the initial-run persistence test and firmware check test.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite/src/actions/onboarding/onboardingActions.ts`
- `packages/suite/src/components/suite/PrerequisitesGuide/DeviceInitialize.tsx`
- `packages/suite/src/components/suite/PrerequisitesGuide/DeviceNoFirmware.tsx`
- `packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/SecurityCheck.tsx`

</details>

**Recommended tests (15)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts` — This test exercises the full onboarding flow including the device authenticity check (SecurityCheck.tsx) and wallet creation. Changes to SecurityCheck.tsx and onboardingActions.ts directly affect this flow.
- `suite/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts` — This test covers wallet creation on T2T1 including analytics consent, firmware steps, and backup — all orchestrated by onboardingActions. It also passes through the authenticity check step affected by SecurityCheck.tsx changes.
- `suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts` — This test directly exercises the onboarding wallet creation flow including backup confirmation and seed type selection, which are controlled by onboardingActions. The SecurityCheck/backup components are part of this flow.
- `suite/e2e/tests/onboarding/firmware-check.test.ts` — This test validates firmware readiness detection during onboarding across multiple device models. DeviceNoFirmware.tsx is the prerequisite guide component shown when firmware is missing, and onboardingActions manages the firmware check flow.
- `suite/e2e/tests/suite/initial-run.test.ts` — This test validates the initial run/onboarding persistence across reloads, including analytics consent, complete onboarding button, and THP pairing — all managed by onboardingActions. It directly tests the onboarding flow state machine.
- `suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts` — Tests wallet creation on T1B1 including seed backup and PIN setup — core onboarding actions. Changes to onboardingActions.ts could affect the create wallet button, backup flow, and final button behavior.

</details>

<details><summary>🟡 <b>Medium priority (8)</b></summary>

- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-success.test.ts` — Tests the recovery wallet flow during onboarding, which uses onboardingActions for firmware continuation, recovery initiation, PIN skip, and final completion. A regression in onboarding state transitions would break this.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-fail.test.ts` — Tests device disconnection during recovery and retry flow, both managed by onboardingActions. Changes to the onboarding action state machine could affect reconnection and retry behavior.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts` — Tests recovery mode persistence across page reloads and device reconnects during onboarding. The onboardingActions module manages the recovery state that must persist, making this sensitive to changes.
- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-success.test.ts` — Tests T1B1 recovery flow through onboarding including firmware step, mnemonic input, and PIN skip — all orchestrated by onboardingActions.
- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-advanced.test.ts` — Tests advanced recovery mode and device disconnection handling during T1B1 onboarding recovery flow, which relies on onboardingActions for retry and recovery state management.
- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-fail.test.ts` — Tests device disconnection and retry during T1B1 recovery, exercising onboardingActions' retryRecoveryButton and recovery flow state transitions.
- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — Tests analytics consent dialog during onboarding and completing onboarding flow. Changes to onboardingActions affect the consent step and the completeOnboarding action.
- `suite/e2e/tests/firmware/custom-firmware.test.ts` — Tests custom firmware installation after onboarding completion. DeviceNoFirmware.tsx is the prerequisite component shown when no firmware is present, and onboarding must complete before reaching device settings.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/suite/guide.test.ts` — One test case opens the guide panel during onboarding with a device connected, passing through firmware checks and THP pairing. Changes to onboarding components could affect the guide's availability during onboarding.

</details>

_Updated: 2026-06-10T13:11:46.264Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=24542-devicesetup-followup&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=24542-devicesetup-followup&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/24542-devicesetup-followup/web/](https://dev.suite.sldev.cz/suite-web/24542-devicesetup-followup/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add account types ada | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-10T13:14:12.491Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-10T13:15:38.414Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->