### PR TITLE
refactor(components): update styling and structure of Banner component

### DIFF
--- a/packages/components/src/components/Banner/Banner.tsx
+++ b/packages/components/src/components/Banner/Banner.tsx
@@ -1,22 +1,63 @@
 import { type ReactNode } from 'react';
 
+import styled from 'styled-components';
+
+import { spacingsPx } from '@trezor/theme';
+
 import { BannerButton } from './BannerButton';
 import { BannerContext } from './BannerContext';
 import { BannerIconButton } from './BannerIconButton';
 import { DEFAULT_INTENT } from './consts';
 import { type BannerIntent } from './types';
-import { mapIntentToBackgroundColor, mapIntentToIcon, mapIntentToIconColor } from './utils';
+import {
+    mapIntentToBackgroundColor,
+    mapIntentToBorderColor,
+    mapIntentToIcon,
+    mapIntentToIconColor,
+} from './utils';
 import {
     type FrameProps,
     type FramePropsKeys,
     pickAndPrepareFrameProps,
 } from '../../utils/frameProps';
 import { Box } from '../Box/Box';
-import { Column, Row } from '../Flex/Flex';
+import { Row } from '../Flex/Flex';
 import { Icon, type IconName } from '../Icon/Icon';
 import { Spinner } from '../loaders/Spinner/Spinner';
 import { H4 } from '../typography/Heading/Heading';
 import { Paragraph } from '../typography/Paragraph/Paragraph';
+
+const CONTAINER_BREAKPOINT = '440px';
+
+const Layout = styled.div`
+    container-type: inline-size;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    align-items: center;
+`;
+
+const IconCell = styled.div`
+    grid-column: 1;
+    grid-row: 1;
+    margin-right: ${spacingsPx.sm};
+`;
+
+const TextCell = styled.div`
+    grid-column: 2;
+`;
+
+const ActionsCell = styled.div<{ $isMultiline: boolean }>`
+    grid-column: 3;
+    grid-row: ${({ $isMultiline }) => ($isMultiline ? '1 / span 2' : '1')};
+    margin-left: ${spacingsPx.sm};
+
+    @container (max-width: ${CONTAINER_BREAKPOINT}) {
+        grid-column: 2;
+        grid-row: auto;
+        margin-left: 0;
+        margin-top: ${spacingsPx.sm};
+    }
+`;
 
 export const allowedBannerFrameProps = [
     'margin',
@@ -52,46 +93,57 @@ export const Banner = ({
         <Box
             as="section"
             backgroundColor={mapIntentToBackgroundColor(intent)}
+            borderColor={mapIntentToBorderColor(intent)}
+            borderWidth={1}
             borderRadius={8}
             data-testid={dataTest}
+            overflow="hidden"
+            padding={{ vertical: 12, horizontal: 16 }}
             {...frameProps}
             width={width}
         >
-            <Row gap={16} padding={{ vertical: 12, horizontal: 20 }}>
-                {isLoading && <Spinner size={20} isDisabled={true} />}
-                {!isLoading && withIcon && (
-                    <Icon
-                        size={20}
-                        name={icon === true ? mapIntentToIcon(intent) : icon}
-                        color={mapIntentToIconColor(intent)}
-                    />
+            <Layout>
+                {(isLoading || withIcon) && (
+                    <IconCell>
+                        {isLoading && <Spinner size={20} isDisabled={true} />}
+                        {!isLoading && withIcon && (
+                            <Icon
+                                size={title ? 20 : 16}
+                                name={icon === true ? mapIntentToIcon(intent) : icon}
+                                color={mapIntentToIconColor(intent)}
+                            />
+                        )}
+                    </IconCell>
                 )}
 
-                <Row flex="1" flexWrap="wrap" gap={12}>
-                    <Column flex="1 1 360px" maxWidth="100%">
-                        {title && (
-                            <H4 typographyStyle="body-md" intent={intent} priority="primary">
-                                {title}
-                            </H4>
-                        )}
-                        {description && (
-                            <Paragraph
-                                typographyStyle="body-sm"
-                                intent={intent}
-                                priority="primary"
-                                textWrap="pretty"
-                            >
-                                {description}
-                            </Paragraph>
-                        )}
-                    </Column>
-                    {rightContent && (
+                {title && (
+                    <TextCell>
+                        <H4 typographyStyle="body-md" intent={intent} priority="primary">
+                            {title}
+                        </H4>
+                    </TextCell>
+                )}
+                {description && (
+                    <TextCell>
+                        <Paragraph
+                            typographyStyle="body-sm"
+                            intent={intent}
+                            priority={title ? 'secondary' : 'primary'}
+                            textWrap="pretty"
+                        >
+                            {description}
+                        </Paragraph>
+                    </TextCell>
+                )}
+
+                {rightContent && (
+                    <ActionsCell $isMultiline={Boolean(title && description)}>
                         <BannerContext.Provider value={{ intent }}>
                             <Row gap={10}>{rightContent}</Row>
                         </BannerContext.Provider>
-                    )}
-                </Row>
-            </Row>
+                    </ActionsCell>
+                )}
+            </Layout>
         </Box>
     );
 };

--- a/packages/components/src/components/Banner/utils.tsx
+++ b/packages/components/src/components/Banner/utils.tsx
@@ -5,11 +5,23 @@ import { type IconName } from '../Icon/Icon';
 
 export const mapIntentToBackgroundColor = (intent: BannerIntent): Color => {
     const colorMap: Record<BannerIntent, Color> = {
-        brand: 'legacyBackgroundPrimarySubtleOnElevation0',
-        info: 'legacyBackgroundAlertBlueSubtleOnElevation0',
-        warning: 'legacyBackgroundAlertYellowSubtleOnElevation0',
-        critical: 'legacyBackgroundAlertRedSubtleOnElevation0',
-        neutral: 'legacyBackgroundNeutralSubtleOnElevation0',
+        brand: 'elementFillBrandSofter',
+        info: 'elementFillInfoSofter',
+        warning: 'elementFillWarningSofter',
+        critical: 'elementFillCriticalSofter',
+        neutral: 'elementFillNeutralSofter',
+    };
+
+    return colorMap[intent];
+};
+
+export const mapIntentToBorderColor = (intent: BannerIntent): Color => {
+    const colorMap: Record<BannerIntent, Color> = {
+        brand: 'elementBorderBrandSofter',
+        info: 'elementBorderInfoSofter',
+        warning: 'elementBorderWarningSofter',
+        critical: 'elementBorderCriticalSofter',
+        neutral: 'elementBorderNeutralSofter',
     };
 
     return colorMap[intent];

--- a/packages/components/src/components/typography/Text/utils.ts
+++ b/packages/components/src/components/typography/Text/utils.ts
@@ -3,18 +3,15 @@ import { type DefaultTheme } from 'styled-components';
 import { type CSSColor, type Color } from '@trezor/theme';
 
 import { type TextIntent, type TextPriority } from './types';
+import { addAlphaToHex } from '../../../utils/utils';
 
-const colorMap: Record<Exclude<TextIntent, 'neutral'>, Color> = {
+const colorMap: Record<TextIntent, Color> = {
     brand: 'contentBrand',
+    neutral: 'contentPrimary',
     info: 'contentInfo',
     warning: 'contentWarning',
     critical: 'contentCritical',
     accentViolet: 'contentAccentViolet',
-};
-
-const neutralColorMap: Record<TextPriority, Color> = {
-    primary: 'contentPrimary',
-    secondary: 'contentSecondary',
 };
 
 export const mapIntentToCSS = (
@@ -27,7 +24,7 @@ export const mapIntentToCSS = (
         return theme.contentDisabled;
     }
 
-    const token = intent === 'neutral' ? neutralColorMap[priority] : colorMap[intent];
+    const token = theme[colorMap[intent]];
 
-    return theme[token];
+    return priority === 'primary' ? token : addAlphaToHex(token, 0.74);
 };

--- a/packages/suite/src/components/earn/dashboard/common/__tests__/EarnDashboardTableHeader.test.tsx
+++ b/packages/suite/src/components/earn/dashboard/common/__tests__/EarnDashboardTableHeader.test.tsx
@@ -2,6 +2,8 @@ import { type ComponentProps } from 'react';
 
 import { render, screen } from '@testing-library/react';
 
+import { ThemeProvider } from 'src/support/suite/ThemeProvider';
+
 import { EarnDashboardTableHeader } from '../EarnDashboardTableHeader';
 
 jest.mock('@suite/intl', () => ({
@@ -14,12 +16,14 @@ const renderHeader = ({
     showRewardsColumns,
 }: Partial<ComponentProps<typeof EarnDashboardTableHeader>> = {}) =>
     render(
-        <table>
-            <EarnDashboardTableHeader
-                accountColumnTranslationId={accountColumnTranslationId}
-                showRewardsColumns={showRewardsColumns}
-            />
-        </table>,
+        <ThemeProvider>
+            <table>
+                <EarnDashboardTableHeader
+                    accountColumnTranslationId={accountColumnTranslationId}
+                    showRewardsColumns={showRewardsColumns}
+                />
+            </table>
+        </ThemeProvider>,
     );
 
 describe('EarnDashboardTableHeader', () => {


### PR DESCRIPTION
## Notes for QA

Updated Banner component design.

## Screenshots:
<img width="680" height="127" alt="image" src="https://github.com/user-attachments/assets/8bf84745-1dfb-421a-bebe-3dde40a59c64" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect three broadly-shared UI components (Banner, Banner utils, and Text utils) that map to 121 tests each, plus a unit test file for an earn dashboard component. Since Banner.tsx and utils.tsx are global components, most tests only transitively import them. The recommended strategy focuses on the small subset of tests that directly exercise banner-specific behaviors (visibility, dismissal, content assertions). The Text/utils.ts change is purely stylistic infrastructure with no test having specific text-utility assertions worth targeting. The EarnDashboardTableHeader unit test has no E2E coverage.

<details><summary><b>Changed files (4)</b></summary>

- `packages/components/src/components/Banner/Banner.tsx`
- `packages/components/src/components/Banner/utils.tsx`
- `packages/components/src/components/typography/Text/utils.ts`
- `packages/suite/src/components/earn/dashboard/common/__tests__/EarnDashboardTableHeader.test.tsx`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/suite/safety-checks-warning.test.ts` — This test explicitly validates a dismissible warning Banner component — checking visibility, CTA button, dismiss button, and hide/show behavior. Changes to Banner.tsx and its utils.tsx directly affect the rendering and behavior of this banner.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/backup/t2t1-fail.test.ts` — This test asserts that a dashboard notification error banner (backup.errorBanner) is visible and contains specific translation text after a backup failure. Changes to Banner component could affect error banner rendering.
- `suite/e2e/tests/analytics/promo-banner-events.test.ts` — This test directly interacts with promo banners on the dashboard (clicking them, verifying they appear). The Banner component changes could affect promo banner rendering and click behavior.
- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — This test checks Suite Sync banner visibility and content (TR_SUITE_SYNC_KEYS_NEEDED_BANNER), verifying it's shown/hidden in various wallet contexts. Banner component changes could affect this banner's rendering.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts` — This test explicitly asserts that a 'no connection' banner is visible throughout the onboarding flow and persists across multiple steps. Banner component changes directly affect this offline disconnection banner.
- `suite/e2e/tests/wallet/without-device.test.ts` — This test checks for a disconnected device banner (@settings/device/disconnected-device-banner) on the device settings page. Banner component changes could affect its rendering.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/staking/eth/stake-more.test.ts` — This test checks an instant staking banner that appears after activation with specific header/paragraph content and a dismiss button. Banner component changes could plausibly affect this staking-specific banner.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/components/earn/dashboard/common/__tests__/EarnDashboardTableHeader.test.tsx`
- `packages/components/src/components/typography/Text/utils.ts`

_Updated: 2026-06-11T08:49:24.527Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/banner-layout&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/banner-layout&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-11T08:53:51.129Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-11T08:52:53.239Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/banner-layout/web/](https://dev.suite.sldev.cz/suite-web/refactor/banner-layout/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->