### PR TITLE
fix(suite-desktop): exclude hidden tokens from search

### DIFF
--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
@@ -4,8 +4,9 @@ import { selectAccountLabelsLegacy } from '@suite/metadata';
 import { type RouteParams, selectRouterParams } from '@suite/router';
 import { selectSelectedDevice } from '@suite-common/device';
 import { selectAccountsWithSuiteSyncLabel } from '@suite-common/suite-sync';
+import { selectTokenDefinitions } from '@suite-common/token-definitions';
 import { type AccountType } from '@suite-common/wallet-config';
-import { selectAccountsShownTokens, selectAllAccountsToList } from '@suite-common/wallet-core';
+import { getTokens, selectAllAccountsToList } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { accountSearchFn } from '@suite-common/wallet-utils';
 import { Column } from '@trezor/components';
@@ -103,7 +104,7 @@ export const AccountsList = ({
     const { coinFilter, searchString } = useAccountSearch();
     const discoveryStatus = useSelector(selectDiscoveryOverallStatus);
     const discoveryInProgress = discoveryStatus?.status === 'loading';
-    const accountsShownTokens = useSelector(selectAccountsShownTokens);
+    const tokenDefinitions = useSelector(selectTokenDefinitions);
 
     if (!device) {
         return null;
@@ -121,10 +122,16 @@ export const AccountsList = ({
                           : getDefaultAccountLabel(translationString, account)) ??
                       '';
 
+                  const { shownWithBalance } = getTokens({
+                      tokens: account.tokens ?? [],
+                      symbol: account.symbol,
+                      tokenDefinitions: tokenDefinitions[account.symbol]?.coin,
+                  });
+
                   return accountSearchFn(account, searchString, {
                       coinsFilter: coinFilter,
                       accountLabel,
-                      shownTokens: accountsShownTokens[key],
+                      searchableTokens: shownWithBalance,
                   });
               })
             : accounts;

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
@@ -5,7 +5,7 @@ import { type RouteParams, selectRouterParams } from '@suite/router';
 import { selectSelectedDevice } from '@suite-common/device';
 import { selectAccountsWithSuiteSyncLabel } from '@suite-common/suite-sync';
 import { type AccountType } from '@suite-common/wallet-config';
-import { selectAllAccountsToList } from '@suite-common/wallet-core';
+import { selectAccountsShownTokens, selectAllAccountsToList } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { accountSearchFn } from '@suite-common/wallet-utils';
 import { Column } from '@trezor/components';
@@ -103,6 +103,7 @@ export const AccountsList = ({
     const { coinFilter, searchString } = useAccountSearch();
     const discoveryStatus = useSelector(selectDiscoveryOverallStatus);
     const discoveryInProgress = discoveryStatus?.status === 'loading';
+    const accountsShownTokens = useSelector(selectAccountsShownTokens);
 
     if (!device) {
         return null;
@@ -123,6 +124,7 @@ export const AccountsList = ({
                   return accountSearchFn(account, searchString, {
                       coinsFilter: coinFilter,
                       accountLabel,
+                      shownTokens: accountsShownTokens[key],
                   });
               })
             : accounts;

--- a/suite-common/wallet-core/src/tokens/tokenSelectors.ts
+++ b/suite-common/wallet-core/src/tokens/tokenSelectors.ts
@@ -3,17 +3,12 @@ import {
     type TokenDefinitionsRootState,
     selectTokenDefinitions,
 } from '@suite-common/token-definitions';
-import {
-    type AccountKey,
-    type TokenAddress,
-    type TokenInfoBranded,
-} from '@suite-common/wallet-types';
+import { type TokenAddress, type TokenInfoBranded } from '@suite-common/wallet-types';
 import { getFiatRateKey, isErc4626, toFiatCurrency } from '@suite-common/wallet-utils';
-import { type TokenInfo } from '@trezor/blockchain-link-types';
 
 import { type GetTokensOutputType, getTokens } from './tokenUtils';
 import { type AccountsRootState } from '../accounts/accountsReducer';
-import { selectAccountByKey, selectAccounts } from '../accounts/accountsSelectors';
+import { selectAccountByKey } from '../accounts/accountsSelectors';
 import { selectCurrentFiatRates } from '../fiat-rates/fiatRatesSelectors';
 import { type FiatRatesRootState } from '../fiat-rates/fiatRatesTypes';
 import {
@@ -93,28 +88,6 @@ export const selectAccountUnrecognizedTokens = createMemoizedSelector(
 export const selectAccountManuallyHiddenTokensCount = createMemoizedSelector(
     [selectAccountManuallyHiddenTokens],
     (tokens): number => tokens.length,
-);
-
-/**
- * Returns a map of accountKey → shown (non-hidden, non-unverified) tokens for all accounts.
- * Used to exclude spam/junk tokens from account search.
- */
-export const selectAccountsShownTokens = createMemoizedSelector(
-    [selectAccounts, selectTokenDefinitions],
-    (accounts, tokenDefinitions): Record<AccountKey, TokenInfo[]> => {
-        const result: Record<string, TokenInfo[]> = {};
-
-        for (const account of accounts) {
-            const { shownWithBalance, shownWithoutBalance } = getTokens({
-                tokens: account.tokens ?? [],
-                symbol: account.symbol,
-                tokenDefinitions: tokenDefinitions[account.symbol]?.coin,
-            });
-            result[account.key] = [...shownWithBalance, ...shownWithoutBalance];
-        }
-
-        return result as Record<AccountKey, TokenInfo[]>;
-    },
 );
 
 export const selectAccountDefiTokens = createMemoizedSelector(

--- a/suite-common/wallet-core/src/tokens/tokenSelectors.ts
+++ b/suite-common/wallet-core/src/tokens/tokenSelectors.ts
@@ -3,12 +3,17 @@ import {
     type TokenDefinitionsRootState,
     selectTokenDefinitions,
 } from '@suite-common/token-definitions';
-import { type TokenAddress, type TokenInfoBranded } from '@suite-common/wallet-types';
+import {
+    type AccountKey,
+    type TokenAddress,
+    type TokenInfoBranded,
+} from '@suite-common/wallet-types';
 import { getFiatRateKey, isErc4626, toFiatCurrency } from '@suite-common/wallet-utils';
+import { type TokenInfo } from '@trezor/blockchain-link-types';
 
 import { type GetTokensOutputType, getTokens } from './tokenUtils';
 import { type AccountsRootState } from '../accounts/accountsReducer';
-import { selectAccountByKey } from '../accounts/accountsSelectors';
+import { selectAccountByKey, selectAccounts } from '../accounts/accountsSelectors';
 import { selectCurrentFiatRates } from '../fiat-rates/fiatRatesSelectors';
 import { type FiatRatesRootState } from '../fiat-rates/fiatRatesTypes';
 import {
@@ -88,6 +93,28 @@ export const selectAccountUnrecognizedTokens = createMemoizedSelector(
 export const selectAccountManuallyHiddenTokensCount = createMemoizedSelector(
     [selectAccountManuallyHiddenTokens],
     (tokens): number => tokens.length,
+);
+
+/**
+ * Returns a map of accountKey → shown (non-hidden, non-unverified) tokens for all accounts.
+ * Used to exclude spam/junk tokens from account search.
+ */
+export const selectAccountsShownTokens = createMemoizedSelector(
+    [selectAccounts, selectTokenDefinitions],
+    (accounts, tokenDefinitions): Record<AccountKey, TokenInfo[]> => {
+        const result: Record<string, TokenInfo[]> = {};
+
+        for (const account of accounts) {
+            const { shownWithBalance, shownWithoutBalance } = getTokens({
+                tokens: account.tokens ?? [],
+                symbol: account.symbol,
+                tokenDefinitions: tokenDefinitions[account.symbol]?.coin,
+            });
+            result[account.key] = [...shownWithBalance, ...shownWithoutBalance];
+        }
+
+        return result as Record<AccountKey, TokenInfo[]>;
+    },
 );
 
 export const selectAccountDefiTokens = createMemoizedSelector(

--- a/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
@@ -252,7 +252,7 @@ describe('account utils', () => {
         expect(accountSearchFn(ethAcc, 'pepe', { accountLabel: '' })).toBe(false);
     });
 
-    it('accountSearchFn hidden tokens excluded via shownTokens', () => {
+    it('accountSearchFn hidden tokens excluded via searchableTokens', () => {
         const shownToken = mockAccountToken({ balance: '0.000069', name: 'shown' });
         const hiddenToken = mockAccountToken({ balance: '1.0', name: 'hidden-spam' });
         const ethAcc = mockWalletAccount({
@@ -264,13 +264,13 @@ describe('account utils', () => {
         expect(
             accountSearchFn(ethAcc, 'hidden-spam', {
                 accountLabel: '',
-                shownTokens: [shownToken],
+                searchableTokens: [shownToken],
             }),
         ).toBe(false);
         expect(
             accountSearchFn(ethAcc, 'shown', {
                 accountLabel: '',
-                shownTokens: [shownToken],
+                searchableTokens: [shownToken],
             }),
         ).toBe(true);
     });

--- a/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
@@ -239,6 +239,42 @@ describe('account utils', () => {
         expect(accountSearchFn(ethAcc, 'test2', { accountLabel: '' })).toBe(false);
     });
 
+    it('accountSearchFn empty tokens pepe-like', () => {
+        const ethAcc = mockWalletAccount({
+            symbol: 'eth',
+            tokens: [
+                mockAccountToken({ balance: '0.000069', name: 'test' }),
+                mockAccountToken({ balance: '0.0', name: 'pepe' }),
+            ],
+        });
+
+        expect(accountSearchFn(ethAcc, 'test', { accountLabel: '' })).toBe(true);
+        expect(accountSearchFn(ethAcc, 'pepe', { accountLabel: '' })).toBe(false);
+    });
+
+    it('accountSearchFn hidden tokens excluded via shownTokens', () => {
+        const shownToken = mockAccountToken({ balance: '0.000069', name: 'shown' });
+        const hiddenToken = mockAccountToken({ balance: '1.0', name: 'hidden-spam' });
+        const ethAcc = mockWalletAccount({
+            symbol: 'eth',
+            tokens: [shownToken, hiddenToken],
+        });
+
+        expect(accountSearchFn(ethAcc, 'hidden-spam', { accountLabel: '' })).toBe(true);
+        expect(
+            accountSearchFn(ethAcc, 'hidden-spam', {
+                accountLabel: '',
+                shownTokens: [shownToken],
+            }),
+        ).toBe(false);
+        expect(
+            accountSearchFn(ethAcc, 'shown', {
+                accountLabel: '',
+                shownTokens: [shownToken],
+            }),
+        ).toBe(true);
+    });
+
     it('getNetworkAccountFeatures', () => {
         const btcAcc = mockWalletAccount({ symbol: 'btc' });
         const btcTaprootAcc = mockWalletAccount({ symbol: 'btc', accountType: 'taproot' });

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -792,13 +792,13 @@ export type AccountSearchParams = {
      * Pre-filtered list of visible (non-hidden, non-unverified) tokens to search against.
      * When provided, replaces account.tokens so that hidden/spam tokens are excluded from search.
      */
-    shownTokens?: TokenInfo[];
+    searchableTokens?: TokenInfo[];
 };
 
 export const accountSearchFn = (
     account: Account,
     rawSearchString: string | undefined,
-    { coinsFilter, accountLabel, tokensMatch = true, shownTokens }: AccountSearchParams,
+    { coinsFilter, accountLabel, tokensMatch = true, searchableTokens }: AccountSearchParams,
 ) => {
     let coinsFilterArray: NetworkSymbol[] = [];
 
@@ -849,7 +849,8 @@ export const accountSearchFn = (
             field?.toLowerCase().includes(searchString),
         );
 
-    const tokenMatch = tokensMatch && !!(shownTokens ?? account.tokens)?.some(filterTokens);
+    const tokens = searchableTokens ?? account.tokens;
+    const tokenMatch = tokensMatch && !!tokens?.some(filterTokens);
 
     return (
         accountNumberMatch ||

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -787,12 +787,18 @@ export type AccountSearchParams = {
 
     /** Return true if the account has token that match the search string */
     tokensMatch?: boolean;
+
+    /**
+     * Pre-filtered list of visible (non-hidden, non-unverified) tokens to search against.
+     * When provided, replaces account.tokens so that hidden/spam tokens are excluded from search.
+     */
+    shownTokens?: TokenInfo[];
 };
 
 export const accountSearchFn = (
     account: Account,
     rawSearchString: string | undefined,
-    { coinsFilter, accountLabel, tokensMatch = true }: AccountSearchParams,
+    { coinsFilter, accountLabel, tokensMatch = true, shownTokens }: AccountSearchParams,
 ) => {
     let coinsFilterArray: NetworkSymbol[] = [];
 
@@ -838,13 +844,12 @@ export const accountSearchFn = (
 
     // filter tokens by search string and balance greater than zero
     const filterTokens = (token: TokenInfo) =>
-        [token.name, token.symbol, token.contract].some(
-            field =>
-                field?.toLowerCase().includes(searchString) &&
-                new BigNumber(token.balance || '0').gt(0),
+        new BigNumber(token.balance || '0').gt(0) &&
+        [token.name, token.symbol, token.contract].some(field =>
+            field?.toLowerCase().includes(searchString),
         );
 
-    const tokenMatch = tokensMatch && !!account.tokens?.some(filterTokens);
+    const tokenMatch = tokensMatch && !!(shownTokens ?? account.tokens)?.some(filterTokens);
 
     return (
         accountNumberMatch ||


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Creates a map of displayed addresses to use it during search and excludes hidden assets for per token-name search

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/28603

## Screenshots:


after:
<img width="1423" height="931" alt="Screenshot 2026-06-10 at 17 56 44" src="https://github.com/user-attachments/assets/0a7ce050-b6c1-4d1d-88ef-6c7ad8ecf7d8" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect AccountsList.tsx (wallet sidebar account rendering component) and accountUtils.ts (core account utility functions), both of which are broadly imported across 121+ tests. The highest risk is in tests that directly exercise account listing, filtering, searching, grouping, and discovery — these should be prioritized. The unit test file for accountUtils is also changed but has no E2E coverage (it's a unit test itself). The testing strategy focuses on the small set of tests that specifically interact with the accounts menu sidebar behavior rather than running the full 121-test suite.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx`
- `suite-common/wallet-utils/src/__tests__/accountUtils.test.ts`
- `suite-common/wallet-utils/src/accountUtils.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/wallet/account-search.test.ts` — This test directly exercises account search/filtering in the wallet sidebar, which is rendered by AccountsList.tsx. Changes to AccountsList.tsx or accountUtils.ts (which likely handles account filtering logic) could break the search behavior tested here.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — This test adds different account types and verifies account counts in type groups, expands accounts in the sidebar menu, and filters accounts by coin symbol — all directly exercising AccountsList.tsx rendering and accountUtils.ts grouping/counting logic.
- `suite/e2e/tests/wallet/discovery.test.ts` — This test activates multiple coins and verifies that all discovered accounts have visible balances in the wallet page. Account discovery populates the accounts list rendered by AccountsList.tsx, and accountUtils.ts is used for account processing during discovery.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/wallet/pagination.test.ts` — This test uses expandAllAccountsInMenu and navigates to specific legacy accounts, which exercises the AccountsList.tsx component's expand/collapse and account rendering behavior.
- `suite/e2e/tests/metadata/legacy/account-metadata.test.ts` — This test searches/filters accounts by custom metadata labels in the account menu and verifies account button visibility, directly exercising the AccountsList filtering and rendering logic that may be affected by changes to AccountsList.tsx.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — Tests wallet discovery with custom backends and verifies accounts appear correctly. Changes to accountUtils.ts could affect how discovered accounts are processed and displayed in the accounts list.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — Tests discovering and adding a standard wallet with BTC account balance visibility. Account display in the wallet sidebar relies on AccountsList.tsx and accountUtils.ts for rendering discovered accounts.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test adds new accounts and verifies account labeling with derivation paths. The account label display (LABELING_ACCOUNT with networkName and index) likely uses accountUtils.ts for account identification and AccountsList.tsx for rendering.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — This test opens accounts for multiple coins (btc, ltc, eth) and navigates from account-level views to trading forms. Account navigation depends on AccountsList rendering, but the test's primary focus is trading form navigation rather than account list behavior.
- `suite/e2e/tests/staking/sol/rewards.test.ts` — This test verifies staking account balance labels in the wallet sidebar/account list. The staking sub-account rendering in AccountsList.tsx could be affected by changes to how accounts are displayed.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/wallet-utils/src/__tests__/accountUtils.test.ts`

_Updated: 2026-06-20T07:26:37.532Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/exclude-hidden-tokens&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/exclude-hidden-tokens&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/exclude-hidden-tokens&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy BTC > Buy Bitcoin from best offer | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-20T07:31:06.266Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-20T07:30:00.226Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/exclude-hidden-tokens/web/](https://dev.suite.sldev.cz/suite-web/fix/exclude-hidden-tokens/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->