### PR TITLE
fix(e2e): Added guard to prevent passed tests when nothing was resolved

### DIFF
--- a/.github/workflows/template-suite-run-e2e.yml
+++ b/.github/workflows/template-suite-run-e2e.yml
@@ -235,8 +235,30 @@ jobs:
           if [[ -n "${{ inputs.spec-list }}" ]]; then
             # Strip suite/e2e/ prefix (pwc-p CWD is suite/e2e/ via yarn workspace)
             # then convert comma-separated list to space-separated positional args
-            SPEC_ARGS=$(echo "${{ inputs.spec-list }}" | tr ',' '\n' | sed 's|^suite/e2e/||' | tr '\n' ' ')
+            RESOLVED_SPECS=$(echo "${{ inputs.spec-list }}" | tr ',' '\n' | sed 's|^suite/e2e/||')
+            SPEC_ARGS=$(echo "$RESOLVED_SPECS" | tr '\n' ' ')
             echo "Running focused spec list: $SPEC_ARGS"
+
+            # Guard: verify at least one resolved path exists before enabling --pass-with-no-tests.
+            # If every path is missing (deleted, mistyped, or bad normalisation), fail fast
+            # rather than silently running zero tests and exiting 0.
+            FOUND_ANY=0
+            while IFS= read -r spec; do
+              [[ -z "$spec" ]] && continue
+              if [[ -f "suite/e2e/$spec" ]]; then
+                FOUND_ANY=1
+                break
+              fi
+            done <<< "$RESOLVED_SPECS"
+
+            if [[ "$FOUND_ANY" -eq 0 ]]; then
+              echo "ERROR: spec-list was provided but none of the resolved paths exist on disk."
+              echo "  spec-list: ${{ inputs.spec-list }}"
+              echo "  Resolved:  $SPEC_ARGS"
+              echo "Check for deleted files, typos, or normalisation issues in the upstream selector."
+              exit 1
+            fi
+
             # A focused spec list may not match every Playwright project's grep filter,
             # so allow projects that find zero tests to exit cleanly instead of failing.
             PASS_WITH_NO_TESTS="--pass-with-no-tests"

--- a/suite/e2e/playwright-config/playwright-desktop-pr-all.config.ts
+++ b/suite/e2e/playwright-config/playwright-desktop-pr-all.config.ts
@@ -11,8 +11,8 @@ import { PlaywrightTarget } from '../support/testExtends/suiteTestOptions';
 /*
  * Desktop PR All config
  * This config is used when the LLM test selector provides a specific spec list.
- * Unlike playwright-desktop-pr.config.ts, tests are not filtered to smoke-only on T3T1
- * and @nightlyOnly tests are included — the spec list itself scopes the run.
+ * Unlike playwright-desktop-pr.config.ts, tests are not filtered to @webOnly — the spec list
+ * itself scopes the run, so all device models run their full test set.
  */
 const target = PlaywrightTarget.Desktop;
 const definition: PlaywrightProjectDefinition[] = [

--- a/suite/e2e/playwright-config/playwright-web-pr-all.config.ts
+++ b/suite/e2e/playwright-config/playwright-web-pr-all.config.ts
@@ -12,7 +12,7 @@ import { PlaywrightTarget } from '../support/testExtends/suiteTestOptions';
  * Web PR All config
  * This config is used when the LLM test selector provides a specific spec list.
  * Unlike playwright-web-pr.config.ts, tests are not filtered to @webOnly — the spec list
- * itself scopes the run, so all device models run their full (non-nightly) test set.
+ * itself scopes the run, so all device models run their full test set.
  */
 const target = PlaywrightTarget.Web;
 const definition: PlaywrightProjectDefinition[] = [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat-ci-llm-test-runner&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat-ci-llm-test-runner&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-10T17:08:16.521Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add account types ada | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-10T17:06:39.369Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat-ci-llm-test-runner/web/](https://dev.suite.sldev.cz/suite-web/feat-ci-llm-test-runner/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->