### PR TITLE
feat(e2e): Suite native e2e test coverage collector

### DIFF
--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -23,6 +23,11 @@ on:
         required: false
         default: e2e/trezorDetoxRunner/config/runner-android-release.config.js
         type: string
+      enable-coverage:
+        description: "Enable per-test coverage map collection. Requires the android-coverage-build artifact produced by template-suite-native-prepare-test-app-android.yml with enable-coverage: true."
+        required: false
+        default: false
+        type: boolean
     secrets:
       TREZOR_BOT_APP_ID:
         required: true
@@ -123,6 +128,19 @@ jobs:
           name: android-test-build-${{ github.run_id }}
           path: suite-native/app/android/app/build/
 
+      - name: Download Android coverage build artifact
+        if: inputs.enable-coverage
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: android-coverage-build-${{ github.run_id }}
+          path: suite-native/app/android/app/build/outputs/apk/release/
+
+      - name: Replace app APK with instrumented coverage version
+        if: inputs.enable-coverage
+        run: |
+          mv suite-native/app/android/app/build/outputs/apk/release/app-coverage.apk \
+             suite-native/app/android/app/build/outputs/apk/release/app-release.apk
+
       - name: Enable Android emulator KVM optimalization
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
@@ -144,6 +162,8 @@ jobs:
           CURRENTS_CI_BUILD_ID: ${{ inputs.currents_ci_build_id }}
           CURRENTS_TAG: ${{ inputs.currents_tags }}
           COMMIT_INFO_BRANCH: ${{ github.head_ref }}
+          COLLECT_COVERAGE_MAP: ${{ inputs.enable-coverage && 'true' || '' }}
+          COVERAGE_MAP_DIR: ${{ github.workspace }}/suite-native/app/coverage-map
         with:
           api-level: 34
           profile: pixel_6
@@ -199,3 +219,11 @@ jobs:
           name: android-tests-${{ matrix.TEST_GROUP }}
           path: suite-native/app/artifacts
           retention-days: 14
+
+      - name: Upload per-test coverage map
+        if: inputs.enable-coverage && !cancelled()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: coverage-map-native-android-group-${{ matrix.TEST_GROUP }}
+          path: suite-native/app/coverage-map/
+          if-no-files-found: warn

--- a/.github/workflows/template-suite-native-prepare-test-app-android.yml
+++ b/.github/workflows/template-suite-native-prepare-test-app-android.yml
@@ -2,6 +2,12 @@ name: "Android E2E Test Job Template"
 
 on:
   workflow_call:
+    inputs:
+      enable-coverage:
+        description: "Build an instrumented debug APK for coverage collection. Uploads a separate coverage artifact."
+        required: false
+        default: false
+        type: boolean
     secrets:
       SENTRY_AUTH_TOKEN:
         required: true
@@ -171,4 +177,71 @@ jobs:
         with:
           name: android-test-build-${{ github.run_id }}
           path: suite-native/app/android/app/build/
+          retention-days: 1
+
+      # ── Coverage APK (instrumented + debuggable) ──────────────────────────────
+      # Reuses the release APK built above and produces a variant with:
+      #   - JS bundle compiled with INSTRUMENT_CODE=true (populates global.__coverage__)
+      #   - android:debuggable="true" so adb shell run-as works in the test runner
+      - name: Setup Android SDK for coverage APK
+        if: inputs.enable-coverage
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4
+
+      - name: Download Apktool for coverage APK
+        if: inputs.enable-coverage
+        run: |
+          wget -q https://github.com/iBotPeaches/Apktool/releases/download/v2.8.1/apktool_2.8.1.jar -O apktool.jar
+          wget -q https://raw.githubusercontent.com/iBotPeaches/Apktool/master/scripts/linux/apktool -O apktool
+          chmod +x apktool
+          sudo mv apktool.jar /usr/local/bin/apktool.jar
+          sudo mv apktool /usr/local/bin/apktool
+
+      - name: Decompile release APK for coverage
+        if: inputs.enable-coverage
+        working-directory: ./suite-native/app/android/app/build/outputs/apk/release
+        run: apktool d app-release.apk -o unpacked-coverage
+
+      - name: Replace JS bundle with instrumented version
+        if: inputs.enable-coverage
+        working-directory: ./suite-native/app
+        env:
+          INSTRUMENT_CODE: "true"
+          JS_BUNDLE_PATH: ./android/app/build/outputs/apk/release/unpacked-coverage/assets/index.android.bundle
+          ASSETS_DEST_PATH: ./android/app/build/outputs/apk/release/unpacked-coverage/res/
+          ENTRY_FILE_PATH: ./suite-native/app/index.js
+          EXPO_PUBLIC_IS_DETOX_BUILD: true
+          EXPO_PUBLIC_FF_IS_REGTEST_ENABLED: true
+          EXPO_PUBLIC_FF_IS_CONNECT_POPUP_ENABLED: true
+          EXPO_PUBLIC_FF_IS_DEBUG_KEYS_ALLOWED: true
+          EXPO_PUBLIC_ENVIRONMENT: debug
+        run: yarn exec react-native bundle --platform android --dev false --entry-file $ENTRY_FILE_PATH --bundle-output $JS_BUNDLE_PATH --assets-dest $ASSETS_DEST_PATH
+
+      - name: Make coverage APK debuggable
+        if: inputs.enable-coverage
+        working-directory: ./suite-native/app/android/app/build/outputs/apk/release/unpacked-coverage
+        run: |
+          sed -i 's/android:debuggable="false"/android:debuggable="true"/g' AndroidManifest.xml
+          sed -i 's/android:extractNativeLibs="false"/android:extractNativeLibs="true"/g' AndroidManifest.xml
+
+      - name: Repack coverage APK
+        if: inputs.enable-coverage
+        working-directory: ./suite-native/app/android/app/build/outputs/apk/release
+        run: apktool b unpacked-coverage -o app-coverage.apk
+
+      - name: Sign coverage APK
+        if: inputs.enable-coverage
+        working-directory: ./suite-native/app/android/app/build/outputs/apk/release
+        env:
+          KEYSTORE_PATH: ../../../../debug.keystore
+          KEYSTORE_PASSWORD: pass:android
+        run: |
+          $ANDROID_HOME/build-tools/35.0.0/apksigner sign --ks $KEYSTORE_PATH --ks-pass $KEYSTORE_PASSWORD --out app-coverage.apk app-coverage.apk
+          rm -rf unpacked-coverage
+
+      - name: Upload Android coverage build artifact
+        if: inputs.enable-coverage
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: android-coverage-build-${{ github.run_id }}
+          path: suite-native/app/android/app/build/outputs/apk/release/app-coverage.apk
           retention-days: 1

--- a/.github/workflows/test-suite-native-e2e-android-nightly.yml
+++ b/.github/workflows/test-suite-native-e2e-android-nightly.yml
@@ -18,6 +18,8 @@ jobs:
   prepare_android_test_app:
     if: github.repository == 'trezor/trezor-suite'
     uses: ./.github/workflows/template-suite-native-prepare-test-app-android.yml
+    with:
+      enable-coverage: true
     secrets:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
@@ -27,12 +29,72 @@ jobs:
     needs: [prepare_android_test_app]
     with:
       runner_config: e2e/trezorDetoxRunner/config/runner-android-release-nightly.config.js
+      enable-coverage: true
     secrets:
       TREZOR_BOT_APP_ID: ${{ secrets.TREZOR_BOT_APP_ID }}
       TREZOR_BOT_PRIVATE_KEY: ${{ secrets.TREZOR_BOT_PRIVATE_KEY }}
       CURRENTS_RECORD_KEY: ${{ secrets.CURRENTS_RECORD_KEY }}
       CURRENTS_API_KEY: ${{ secrets.CURRENTS_API_KEY }}
       E2E_TEST_PASSPHRASE: ${{ secrets.E2E_TEST_PASSPHRASE }}
+
+  build-and-publish-coverage-map-native-android:
+    if: always() && github.repository == 'trezor/trezor-suite' && needs.run_android_e2e_tests.result != 'skipped'
+    needs: [run_android_e2e_tests]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6
+        with:
+          role-to-assume: "arn:aws:iam::538326561891:role/gh_actions_trezor_suite_dev_deploy"
+          aws-region: "eu-central-1"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: yarn
+
+      - name: Install Socket Firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        continue-on-error: true
+        with:
+          mode: firewall-free
+          job-summary: errors
+          firewall-version: 1.11.0
+
+      - name: Install dependencies
+        run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @trezor/e2e-utils
+
+      - name: Download per-test coverage map artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        continue-on-error: true
+        with:
+          pattern: coverage-map-native-android-group-*
+          merge-multiple: true
+          path: coverage-map/
+
+      - name: Build coverage map index
+        run: |
+          [ -d "$GITHUB_WORKSPACE/coverage-map" ] || { echo "No coverage artifacts downloaded, skipping"; exit 0; }
+          yarn workspace @trezor/e2e-utils build-coverage-map \
+            --input $GITHUB_WORKSPACE/coverage-map \
+            --output $GITHUB_WORKSPACE/coverage-map/index.json
+
+      - name: Upload coverage map to S3
+        run: |
+          [ -f "$GITHUB_WORKSPACE/coverage-map/index.json" ] || { echo "No coverage map built, skipping upload"; exit 0; }
+          aws s3api put-object \
+            --bucket dev.suite.sldev.cz \
+            --key coverage/native-android/index.json \
+            --body coverage-map/index.json \
+            --content-type application/json \
+            --cache-control "no-cache, max-age=0"
 
   notify_scheduled_failure_to_slack:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-suite-web-desktop-e2e-nightly.yml
+++ b/.github/workflows/test-suite-web-desktop-e2e-nightly.yml
@@ -151,6 +151,7 @@ jobs:
 
       - name: Download per-test coverage map artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        continue-on-error: true
         with:
           pattern: coverage-map-group-*
           merge-multiple: true
@@ -158,10 +159,12 @@ jobs:
 
       - name: Build coverage map index
         run: |
-          yarn tsx packages/e2e-utils/src/testCoverage/buildCoverageMap.ts \
-            --input coverage-map \
-            --output coverage-map/index.json
+          [ -d "$GITHUB_WORKSPACE/coverage-map" ] || { echo "No coverage artifacts downloaded, skipping"; exit 0; }
+          yarn workspace @trezor/e2e-utils build-coverage-map \
+            --input $GITHUB_WORKSPACE/coverage-map \
+            --output $GITHUB_WORKSPACE/coverage-map/index.json
 
       - name: Upload coverage map to S3
         run: |
+          [ -f "$GITHUB_WORKSPACE/coverage-map/index.json" ] || { echo "No coverage map built, skipping upload"; exit 0; }
           aws s3api put-object --bucket dev.suite.sldev.cz --key coverage/e2e/index.json --body coverage-map/index.json --content-type application/json --cache-control "no-cache, max-age=0"

--- a/packages/e2e-utils/package.json
+++ b/packages/e2e-utils/package.json
@@ -20,7 +20,8 @@
         "fix-bot:publish": "tsx src/fixBot/publish.ts",
         "fix-bot:notify": "tsx src/fixBot/notify.ts",
         "fix-bot:update-ledger": "tsx src/fixBot/ledger.ts",
-        "gh-pr-stats": "tsx ./src/ghPrStats/index.ts"
+        "gh-pr-stats": "tsx ./src/ghPrStats/index.ts",
+        "build-coverage-map": "tsx ./src/testCoverage/buildCoverageMap.ts"
     },
     "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",
@@ -29,6 +30,7 @@
         "@trezor/utils": "workspace:*",
         "dotenv": "17.2.3",
         "express": "^5.2.1",
+        "tsx": "^4.21.0",
         "ws": "^8.20.0",
         "zod": "4.3.6"
     },
@@ -37,7 +39,6 @@
         "@currents/mcp": "^2.3.2",
         "@currents/playwright": "^2.1.4",
         "@playwright/test": "1.60.0",
-        "@trezor/node-utils": "workspace:*",
-        "tsx": "^4.21.0"
+        "@trezor/node-utils": "workspace:*"
     }
 }

--- a/scripts/list-outdated-dependencies/qa-dependencies.txt
+++ b/scripts/list-outdated-dependencies/qa-dependencies.txt
@@ -32,3 +32,4 @@ react-intl
 ts-jest
 uri-scheme
 xml2js
+babel-plugin-istanbul

--- a/suite-native/app/.depcheckrc.json
+++ b/suite-native/app/.depcheckrc.json
@@ -44,6 +44,7 @@
         "expo-atlas",
         "jest-junit",
         "ts-jest",
-        "uri-scheme"
+        "uri-scheme",
+        "babel-plugin-istanbul"
     ]
 }

--- a/suite-native/app/.detoxrc.js
+++ b/suite-native/app/.detoxrc.js
@@ -28,12 +28,18 @@ module.exports = {
             binaryPath: 'android/app/build/outputs/apk/debug/app-debug.apk',
             build: 'cd android && NODE_ENV=test ./gradlew :app:assembleDebug :app:assembleAndroidTest -DtestBuildType=debug',
             reversePorts: [8081, 21328, 19121],
+            ...(process.env.COLLECT_COVERAGE_MAP
+                ? { launchArgs: { collectCoverageMap: true } }
+                : {}),
         },
         'android.release': {
             type: 'android.apk',
             binaryPath: 'android/app/build/outputs/apk/release/app-release.apk',
             build: 'cd android && NODE_ENV=test ./gradlew :app:assembleRelease :app:assembleAndroidTest -DtestBuildType=release',
             reversePorts: [21328, 19121],
+            ...(process.env.COLLECT_COVERAGE_MAP
+                ? { launchArgs: { collectCoverageMap: true } }
+                : {}),
         },
     },
     devices: {

--- a/suite-native/app/babel.config.js
+++ b/suite-native/app/babel.config.js
@@ -1,5 +1,7 @@
+const path = require('path');
+
 module.exports = function (api) {
-    api.cache(true);
+    api.cache(!process.env.INSTRUMENT_CODE);
 
     return {
         env: {
@@ -10,6 +12,30 @@ module.exports = function (api) {
         presets: [['babel-preset-expo', { unstable_transformImportMeta: true }]],
         plugins: [
             ['@babel/plugin-transform-class-static-block'],
+            ...(process.env.INSTRUMENT_CODE
+                ? [
+                      [
+                          'istanbul',
+                          {
+                              cwd: path.resolve(__dirname, '../../'),
+                              include: [
+                                  'packages/*/src/**/*',
+                                  'suite-common/*/src/**/*',
+                                  'suite-native/*/src/**/*',
+                              ],
+                              exclude: [
+                                  '**/*.test.{ts,tsx,js,jsx}',
+                                  '**/*.spec.{ts,tsx,js,jsx}',
+                                  '**/__tests__/**',
+                                  '**/tests/**',
+                                  '**/test/**',
+                                  '**/e2e/**',
+                              ],
+                              extension: ['.js', '.jsx', '.ts', '.tsx'],
+                          },
+                      ],
+                  ]
+                : []),
             // react-native-reanimated plugin has to be listed last
             ['react-native-worklets/plugin', { globals: ['__scanCodes'] }],
         ],

--- a/suite-native/app/e2e/jest.perTestFile.teardown.ts
+++ b/suite-native/app/e2e/jest.perTestFile.teardown.ts
@@ -1,4 +1,8 @@
+import { expect as jestExpect } from '@jest/globals';
+
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
+
+import { collectCoverageMap } from './support/coverageMapFixture';
 
 const TEARDOWN_TIMEOUT = 30_000;
 
@@ -21,6 +25,13 @@ const teardownPromises = async () => {
         console.error('Error during Detox global teardown:', error);
     }
 };
+
+afterEach(async () => {
+    const { currentTestName, testPath } = jestExpect.getState();
+    if (currentTestName && testPath) {
+        await collectCoverageMap(currentTestName, testPath);
+    }
+});
 
 afterAll(async () => {
     // We don't want timed out global teardown to fail test run.

--- a/suite-native/app/e2e/support/coverageMapFixture.ts
+++ b/suite-native/app/e2e/support/coverageMapFixture.ts
@@ -1,0 +1,106 @@
+import { execSync } from 'child_process';
+import * as fsSync from 'node:fs';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+type IstanbulFileCoverage = {
+    s: Record<string, number>;
+    [key: string]: unknown;
+};
+
+type IstanbulCoverage = Record<string, IstanbulFileCoverage>;
+
+const ANDROID_PKG = 'io.trezor.suite.debug';
+const DEVICE_COVERAGE_PATH = `/data/user/0/${ANDROID_PKG}/files/coverage.json`;
+
+const hasCoverage = (fileCoverage: IstanbulFileCoverage) =>
+    Object.values(fileCoverage.s).some(count => count > 0);
+
+const findRepoRoot = (startDir: string): string => {
+    let dir = startDir;
+    while (dir !== path.dirname(dir)) {
+        if (fsSync.existsSync(path.join(dir, '.git'))) {
+            return dir;
+        }
+        dir = path.dirname(dir);
+    }
+
+    return startDir;
+};
+
+const sanitizeForFilename = (name: string) => name.replace(/[^a-zA-Z0-9-_]/g, '_').slice(0, 100);
+
+const adb = (cmd: string, opts?: { encoding?: BufferEncoding }) =>
+    execSync(`adb shell run-as ${ANDROID_PKG} ${cmd}`, {
+        encoding: opts?.encoding ?? 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+const pollForCoverageFile = async (): Promise<boolean> => {
+    const POLL_INTERVAL_MS = 200;
+    const MAX_ATTEMPTS = 15;
+
+    for (let i = 0; i < MAX_ATTEMPTS; i++) {
+        try {
+            adb(`test -f ${DEVICE_COVERAGE_PATH}`);
+
+            return true;
+        } catch {
+            await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
+        }
+    }
+
+    return false;
+};
+
+export const collectCoverageMap = async (currentTestName: string, testPath: string) => {
+    if (!process.env.COLLECT_COVERAGE_MAP) return;
+
+    // Trigger AppState 'background' event in the app, which causes it to write coverage.json
+    await device.sendToHome();
+
+    const fileFound = await pollForCoverageFile();
+    if (!fileFound) {
+        console.warn(`[coverage] Coverage file not found on device after waiting. Skipping.`);
+
+        return;
+    }
+
+    let coverageJson: string;
+    try {
+        coverageJson = adb(`cat ${DEVICE_COVERAGE_PATH}`);
+    } catch (err) {
+        console.warn(`[coverage] Failed to read coverage file from device: ${err}`);
+
+        return;
+    }
+
+    let coverage: IstanbulCoverage;
+    try {
+        coverage = JSON.parse(coverageJson);
+    } catch (err) {
+        console.warn(`[coverage] Failed to parse coverage JSON (truncated/empty file?): ${err}`);
+
+        return;
+    }
+    const repoRoot = findRepoRoot(process.cwd());
+
+    const coveredFiles = Object.entries(coverage)
+        .filter(([, fileCoverage]) => hasCoverage(fileCoverage))
+        .map(([filePath]) => path.relative(repoRoot, filePath));
+
+    const testId = `${sanitizeForFilename(path.basename(testPath, '.test.ts'))}_${sanitizeForFilename(currentTestName)}`;
+    const outputDir = process.env.COVERAGE_MAP_DIR ?? 'coverage-map';
+    await fs.mkdir(outputDir, { recursive: true });
+
+    const data = {
+        testId,
+        title: currentTestName,
+        titlePath: currentTestName.split(' > '),
+        file: path.relative(repoRoot, testPath),
+        status: 'unknown',
+        coveredFiles,
+    };
+
+    await fs.writeFile(path.join(outputDir, `${testId}.json`), JSON.stringify(data, null, 2));
+};

--- a/suite-native/app/index.js
+++ b/suite-native/app/index.js
@@ -5,6 +5,9 @@ import './reanimatedLoggerFix';
 import { registerRootComponent } from 'expo';
 
 import { App } from './src/App';
+import { initCoverageDump } from './src/coverageDump';
+
+initCoverageDump();
 
 // registerRootComponent calls AppRegistry.registerComponent('main', () => App);
 // It also ensures that whether you load the app in Expo Go or in a native build,

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -197,6 +197,7 @@
         "@types/node": "22.13.10",
         "@types/xml2js": "^0.4.14",
         "babel-jest": "29.7.0",
+        "babel-plugin-istanbul": "7.0.1",
         "babel-plugin-transform-remove-console": "^6.9.4",
         "babel-preset-expo": "~55.0.8",
         "detox": "20.45.1",

--- a/suite-native/app/src/coverageDump.e2e.ts
+++ b/suite-native/app/src/coverageDump.e2e.ts
@@ -1,0 +1,34 @@
+import { AppState } from 'react-native';
+
+import { File, Paths } from 'expo-file-system';
+
+import { launchArguments } from '@suite-native/config';
+
+type IstanbulFileCoverage = {
+    s: Record<string, number>;
+    [key: string]: unknown;
+};
+
+const writeCoverageToFile = () => {
+    const coverage = (global as unknown as { __coverage__?: Record<string, IstanbulFileCoverage> })
+        .__coverage__;
+
+    if (!coverage) return;
+
+    const file = new File(Paths.document, 'coverage.json');
+    file.write(JSON.stringify(coverage));
+};
+
+export const initCoverageDump = () => {
+    if (!launchArguments.collectCoverageMap) return;
+
+    AppState.addEventListener('change', nextState => {
+        if (nextState === 'background' || nextState === 'inactive') {
+            try {
+                writeCoverageToFile();
+            } catch (e) {
+                console.error(e);
+            }
+        }
+    });
+};

--- a/suite-native/app/src/coverageDump.ts
+++ b/suite-native/app/src/coverageDump.ts
@@ -1,0 +1,3 @@
+// Production no-op — coverage dump is only active in instrumented e2e builds.
+// Metro resolves coverageDump.e2e.ts instead of this file when RN_SRC_EXT includes e2e.ts.
+export const initCoverageDump = () => {};

--- a/suite-native/config/src/types.ts
+++ b/suite-native/config/src/types.ts
@@ -17,4 +17,5 @@ export type LaunchArguments = {
     isStablecoinYieldEnabled?: boolean;
     isSolanaStakingEnabled?: boolean;
     isN4W1BackupEnabled?: boolean;
+    collectCoverageMap?: boolean;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -11609,6 +11609,7 @@ __metadata:
     "@whatwg-node/events": "npm:0.1.2"
     abortcontroller-polyfill: "npm:1.7.8"
     babel-jest: "npm:29.7.0"
+    babel-plugin-istanbul: "npm:7.0.1"
     babel-plugin-transform-remove-console: "npm:^6.9.4"
     babel-preset-expo: "npm:~55.0.8"
     browserify-zlib: "npm:^0.2.0"
@@ -20559,6 +20560,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"babel-plugin-istanbul@npm:7.0.1, babel-plugin-istanbul@npm:^7.0.0, babel-plugin-istanbul@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "babel-plugin-istanbul@npm:7.0.1"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.0.0"
+    "@istanbuljs/load-nyc-config": "npm:^1.0.0"
+    "@istanbuljs/schema": "npm:^0.1.3"
+    istanbul-lib-instrument: "npm:^6.0.2"
+    test-exclude: "npm:^6.0.0"
+  checksum: 10/fe9f865f975aaa7a033de9ccb2b63fdcca7817266c5e98d3e02ac7ffd774c695093d215302796cb3770a71ef4574e7a9b298504c3c0c104cf4b48c8eda67b2a6
+  languageName: node
+  linkType: hard
+
 "babel-plugin-istanbul@npm:^6.1.1":
   version: 6.1.1
   resolution: "babel-plugin-istanbul@npm:6.1.1"
@@ -20569,19 +20583,6 @@ __metadata:
     istanbul-lib-instrument: "npm:^5.0.4"
     test-exclude: "npm:^6.0.0"
   checksum: 10/ffd436bb2a77bbe1942a33245d770506ab2262d9c1b3c1f1da7f0592f78ee7445a95bc2efafe619dd9c1b6ee52c10033d6c7d29ddefe6f5383568e60f31dfe8d
-  languageName: node
-  linkType: hard
-
-"babel-plugin-istanbul@npm:^7.0.0, babel-plugin-istanbul@npm:^7.0.1":
-  version: 7.0.1
-  resolution: "babel-plugin-istanbul@npm:7.0.1"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.0.0"
-    "@istanbuljs/load-nyc-config": "npm:^1.0.0"
-    "@istanbuljs/schema": "npm:^0.1.3"
-    istanbul-lib-instrument: "npm:^6.0.2"
-    test-exclude: "npm:^6.0.0"
-  checksum: 10/fe9f865f975aaa7a033de9ccb2b63fdcca7817266c5e98d3e02ac7ffd774c695093d215302796cb3770a71ef4574e7a9b298504c3c0c104cf4b48c8eda67b2a6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All 9 changed files are within the `suite-native/app/` and `suite-native/config/` packages, which are part of the React Native mobile app codebase. The changes involve mobile-specific configuration files (.depcheckrc.json, .detoxrc.js, package.json), mobile E2E test infrastructure (jest teardown, coverage map fixtures, coverage dump modules), the mobile app entry point (index.js), and a shared config types file. None of these files are referenced by or relevant to the Playwright-based desktop/web E2E tests in `suite/e2e/tests/`. The 116 candidate tests all target the desktop Suite application (Electron or web), and there is no plausible code path connecting these mobile-native changes to any of those tests. No Playwright E2E tests need to be run for this change set.

<details><summary><b>Changed files (9)</b></summary>

- `suite-native/app/.depcheckrc.json`
- `suite-native/app/.detoxrc.js`
- `suite-native/app/e2e/jest.perTestFile.teardown.ts`
- `suite-native/app/e2e/support/coverageMapFixture.ts`
- `suite-native/app/index.js`
- `suite-native/app/package.json`
- `suite-native/app/src/coverageDump.e2e.ts`
- `suite-native/app/src/coverageDump.ts`
- `suite-native/config/src/types.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (9)**
- `suite-native/app/.depcheckrc.json`
- `suite-native/app/.detoxrc.js`
- `suite-native/app/e2e/jest.perTestFile.teardown.ts`
- `suite-native/app/e2e/support/coverageMapFixture.ts`
- `suite-native/app/index.js`
- `suite-native/app/package.json`
- `suite-native/app/src/coverageDump.e2e.ts`
- `suite-native/app/src/coverageDump.ts`
- `suite-native/config/src/types.ts`

_Updated: 2026-06-12T06:29:37.022Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat-ci-android-collect-coverage-data&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat-ci-android-collect-coverage-data&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat-ci-android-collect-coverage-data&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "sol staking,unstake and claim on SOL account" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-27T11:51:45.775Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |

</details>

_Updated: 2026-06-27T11:50:22.010Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat-ci-android-collect-coverage-data/web/](https://dev.suite.sldev.cz/suite-web/feat-ci-android-collect-coverage-data/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->