### PR TITLE
fix(wallet-core): unstable phishing txns selectors

### DIFF
--- a/suite-common/wallet-core/src/transactions/transactionsSelectors.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsSelectors.ts
@@ -50,6 +50,10 @@ const createMemoizedSelector = createWeakMapSelector.withTypes<
     TransactionsRootState & AccountsRootState
 >();
 
+const createPhishingContextMemoizedSelector = createWeakMapSelector.withTypes<
+    TokenDefinitionsRootState & TransactionsRootState & FiatRatesRootState
+>();
+
 export const selectIsLoadingAccountTransactions = (
     state: TransactionsRootState,
     accountKey: AccountKey | null,
@@ -68,6 +72,7 @@ export const selectAreAllTransactionsLoaded = (
     state.wallet.transactions.fetchStatusDetail?.[accountKey]?.areAllTransactionsLoaded;
 
 const EMPTY_STABLE_TRANSACTIONS: WalletAccountTransaction[] = [];
+const EMPTY_STABLE_TXIDS_ARRAY: string[] = [];
 /**
  * The list is not sorted here because it may contain null values as placeholders
  * for transactions that have not been fetched yet. (This affects pagination.)
@@ -170,19 +175,22 @@ export const selectTransactionIsMarkedAsNotScam = (
 export const selectAccountTransactionsMarkedAsNotScam = (
     state: TransactionsRootState,
     accountKey: AccountKey,
-) => state.wallet.transactions.phishing[accountKey] ?? [];
+) => state.wallet.transactions.phishing[accountKey] ?? EMPTY_STABLE_TXIDS_ARRAY;
 
-export const selectPhishingTransactionsContext = (
-    state: TokenDefinitionsRootState & TransactionsRootState & FiatRatesRootState,
-    accountKey: AccountKey,
-    symbol: NetworkSymbol,
-) => {
-    const historicRates = selectHistoricFiatRates(state);
-    const tokenDefinitions = selectNetworkTokenDefinitions(state, symbol);
-    const txsMarkedAsNotScam = selectAccountTransactionsMarkedAsNotScam(state, accountKey);
-
-    return { tokenDefinitions, txsMarkedAsNotScam, historicRates };
-};
+export const selectPhishingTransactionsContext = createPhishingContextMemoizedSelector(
+    [
+        selectHistoricFiatRates,
+        (state: TokenDefinitionsRootState, _accountKey: AccountKey, symbol: NetworkSymbol) =>
+            selectNetworkTokenDefinitions(state, symbol),
+        (state: TransactionsRootState, accountKey: AccountKey, _symbol: NetworkSymbol) =>
+            selectAccountTransactionsMarkedAsNotScam(state, accountKey),
+    ],
+    (historicRates, tokenDefinitions, txsMarkedAsNotScam) => ({
+        tokenDefinitions,
+        txsMarkedAsNotScam,
+        historicRates,
+    }),
+);
 
 export const selectIsPhishingTransaction = (
     state: TokenDefinitionsRootState &


### PR DESCRIPTION
some selectors were not stable


## Notes for QA
phishing txns should work as before


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/unstable-phishing-txn-selector&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/unstable-phishing-txn-selector&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/unstable-phishing-txn-selector&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-10T21:00:59.304Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-10T20:58:33.101Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change to transactionsSelectors.ts affects the Redux selectors that power transaction list rendering, pagination, search, export, and pending transaction display across the wallet UI. Since this file maps to 121 tests (indicating it's a broadly imported module), the recommended strategy focuses on tests that directly exercise transaction-related UI: listing, pagination, searching, exporting, output labeling, and pending transaction status display (including staking flows). Most other tests (analytics, onboarding, backup, browser, metadata, passphrase, trading) use this file only transitively and are unlikely to be affected by selector logic changes.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/wallet-core/src/transactions/transactionsSelectors.ts`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/wallet/transactions.test.ts` — This test directly exercises transaction listing, searching, and filtering on a BTC account. transactionsSelectors.ts provides the selectors that power transaction list rendering, search, and time-range filtering — all of which are explicitly asserted in this test.
- `suite/e2e/tests/wallet/export-transactions.test.ts` — Transaction export (PDF, CSV, JSON) relies on transaction selectors to retrieve the transaction data that gets exported. A regression in transactionsSelectors would cause empty or incorrect exports, which this test directly validates.
- `suite/e2e/tests/wallet/pagination.test.ts` — Pagination of transaction lists depends on transactionsSelectors to slice and serve the correct page of transactions. This test navigates between pages and asserts specific transaction addresses per page, directly exercising selector logic.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/wallet/coin-balance.test.ts` — Account balance display may depend on transaction selectors to compute or verify balances from transaction history. This test asserts balance values change correctly after receiving BTC, which could be affected by transaction selector changes.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test verifies that after sending a transaction, the pending transaction list shows the correct target (including OP_RETURN). The pending transaction list rendering relies on transactionsSelectors to display recently sent transactions.
- `suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — Output labeling requires selecting specific transaction outputs for label attachment, and the exported CSV must contain labeled outputs. Transaction selectors are used to locate and display transaction outputs that can be labeled.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test asserts pending staking transaction visibility, confirming/confirmed status transitions, and transaction text display — all of which depend on transaction selectors to filter and present staking-related transactions.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — Unstake flow verifies pending transaction visibility, speed-up button state, and transaction confirmation status transitions, all of which rely on transaction selectors to display the correct transaction state.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/wallet/discovery.test.ts` — Discovery completion verifies that all activated coins have visible account balances. While balances are not purely transaction-derived, the discovery flow populates transaction state that selectors read, and a broken selector could cause missing balance display.

</details>

_Updated: 2026-06-10T20:58:43.828Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/unstable-phishing-txn-selector/web/](https://dev.suite.sldev.cz/suite-web/fix/unstable-phishing-txn-selector/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->