### PR TITLE
chore(suite-utils): remove unused date, device and protocol helpers

### DIFF
--- a/suite-common/suite-utils/src/__tests__/date.test.ts
+++ b/suite-common/suite-utils/src/__tests__/date.test.ts
@@ -1,17 +1,6 @@
-import { formatDuration, formatDurationStrict, parseUTCdatetime } from '../date';
+import { formatDurationStrict, parseUTCdatetime } from '../date';
 
 describe('Date utils', () => {
-    test('format duration', () => {
-        expect(formatDuration(1)).toBe('less than 5 seconds');
-        expect(formatDuration(3600)).toBe('about 1 hour');
-        expect(formatDuration(14400)).toBe('about 4 hours');
-        expect(formatDuration(86400)).toBe('1 day');
-        expect(formatDuration(604800)).toBe('7 days');
-        expect(formatDuration(31556926)).toBe('about 1 year');
-        expect(formatDuration(63671184000)).toBe('over 2017 years'); // jesus was born
-        expect(formatDuration(99999999999)).toBe('almost 3169 years');
-    });
-
     test('format duration strict', () => {
         expect(formatDurationStrict(1)).toBe('1 second');
         expect(formatDurationStrict(3600)).toBe('1 hour');

--- a/suite-common/suite-utils/src/date.ts
+++ b/suite-common/suite-utils/src/date.ts
@@ -6,7 +6,6 @@ import {
     eachMonthOfInterval,
     eachQuarterOfInterval,
     format,
-    formatDistance,
     formatDistanceStrict,
     fromUnixTime,
     getUnixTime,
@@ -14,9 +13,6 @@ import {
     startOfDay,
     startOfMonth,
 } from 'date-fns';
-
-export const formatDuration = (seconds: number) =>
-    formatDistance(0, seconds * 1000, { includeSeconds: true });
 
 export const formatDurationStrict = (seconds: number, locale?: Locale) =>
     formatDistanceStrict(0, seconds * 1000, { locale });

--- a/suite-common/suite-utils/src/device.ts
+++ b/suite-common/suite-utils/src/device.ts
@@ -13,30 +13,28 @@ import { exhaustive } from '@trezor/type-utils';
 import * as URLS from '@trezor/urls';
 import { hasProp, isArrayMember, unique } from '@trezor/utils';
 
-export const deviceStatuses = [
-    'acquired',
-    'unacquired',
-    'unreadable',
-    'disconnected',
-    'unavailable',
-    'bootloader',
-    'initialize',
-    'seedless',
-    'firmware-required',
-    'used-in-other-window',
-    'was-used-in-other-window',
-    'firmware-recommended',
-    'connected',
-    'device-busy',
-    'device-rebooting',
-    'device-bootloader-locked',
-    'device-hard-locked',
-    'device-pin-locked',
-    'device-thp-locked',
-    'firmware-corrupted',
-    'unknown',
-] as const;
-export type DeviceStatus = (typeof deviceStatuses)[number];
+export type DeviceStatus =
+    | 'acquired'
+    | 'unacquired'
+    | 'unreadable'
+    | 'disconnected'
+    | 'unavailable'
+    | 'bootloader'
+    | 'initialize'
+    | 'seedless'
+    | 'firmware-required'
+    | 'used-in-other-window'
+    | 'was-used-in-other-window'
+    | 'firmware-recommended'
+    | 'connected'
+    | 'device-busy'
+    | 'device-rebooting'
+    | 'device-bootloader-locked'
+    | 'device-hard-locked'
+    | 'device-pin-locked'
+    | 'device-thp-locked'
+    | 'firmware-corrupted'
+    | 'unknown';
 
 export const getStatus = (device: TrezorDevice): DeviceStatus => {
     if (!device.connected) {

--- a/suite-common/suite-utils/src/invariant.ts
+++ b/suite-common/suite-utils/src/invariant.ts
@@ -1,6 +1,6 @@
 const isJest = typeof jest !== 'undefined';
 
-export class InvariantError extends Error {
+class InvariantError extends Error {
     constructor(message: string = 'Invariant Violation') {
         super(message);
     }

--- a/suite-common/suite-utils/src/protocol.ts
+++ b/suite-common/suite-utils/src/protocol.ts
@@ -5,10 +5,6 @@ import {
     isNetworkSymbol,
 } from '@suite-common/wallet-config';
 
-export type ProtocolToNetwork = {
-    [P in Protocol]: NetworkSymbol;
-};
-
 export const getNetworkSymbolForProtocol = (protocol: Protocol): NetworkSymbol | undefined => {
     for (const symbolKey in NETWORK_TO_PROTOCOLS) {
         const symbol = symbolKey;

--- a/suite-common/suite-utils/src/userAgent.ts
+++ b/suite-common/suite-utils/src/userAgent.ts
@@ -4,7 +4,7 @@ let userAgentParser: UAParser;
 
 export const getUserAgent = () => window.navigator.userAgent;
 
-export const getUserAgentParser = () => {
+const getUserAgentParser = () => {
     if (!userAgentParser) {
         const ua = getUserAgent();
         userAgentParser = new UAParser(ua);


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into small isolated PRs for easy, low-risk review.

Remove unused formatDuration, getPhysicalDeviceUniqueIds, InvariantError and getUserAgentParser; convert the deviceStatuses const-for-type array into a direct DeviceStatus union.

The full staging branch is green (type-check + lint + format + depcheck); CI verifies this subset independently.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies low-level shared utilities in suite-common/suite-utils (date formatting, device helpers, invariant assertions, protocol parsing, and user agent detection). Since all five source files map to 121+ tests each, they are clearly global utilities and most tests only transitively import them. The highest-risk changes are in userAgent.ts (browser/platform detection directly tested by browser compatibility tests) and date.ts (date formatting used in transaction displays and analytics timestamps). The device.ts, invariant.ts, and protocol.ts changes are lower risk as they are deeply shared infrastructure unlikely to cause E2E-visible regressions without also breaking unit tests. The recommended strategy is to run browser detection tests and date-dependent UI tests, with a few targeted low-priority tests for protocol and device utilities.

<details><summary><b>Changed files (6)</b></summary>

- `suite-common/suite-utils/src/__tests__/date.test.ts`
- `suite-common/suite-utils/src/date.ts`
- `suite-common/suite-utils/src/device.ts`
- `suite-common/suite-utils/src/invariant.ts`
- `suite-common/suite-utils/src/protocol.ts`
- `suite-common/suite-utils/src/userAgent.ts`

</details>

**Recommended tests (8)**

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/browser/safari.test.ts` — Changes to userAgent.ts directly affect browser detection logic. This test validates that Safari is correctly identified as unsupported and that the warning page is displayed, which relies on user agent parsing from the changed file.
- `suite/e2e/tests/browser/firefox.test.ts` — Changes to userAgent.ts affect browser compatibility detection. This test verifies Firefox is recognized as a supported browser without showing an unsupported warning, directly exercising the browser detection path.
- `suite/e2e/tests/browser/ios.test.ts` — Changes to userAgent.ts affect platform/browser detection. This test verifies iOS is correctly detected as unsupported, which directly depends on user agent parsing logic.
- `suite/e2e/tests/wallet/transactions.test.ts` — Changes to date.ts could affect how transaction dates and graph time range labels (day, week, month, year, all) are formatted and displayed. This test cycles through all graph time range filters and verifies label rendering.
- `suite/e2e/tests/settings/autodetect.test.ts` — Changes to userAgent.ts may affect locale/language autodetection from the browser environment. This test verifies Suite adopts the browser's preferred locale and color scheme, which may depend on user agent utilities.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — The SuiteReady analytics event payload includes browserVersion and osVersion which may be derived from userAgent.ts utilities. Changes there could affect the reported values in analytics events.
- `suite/e2e/tests/settings/forget-device.test.ts` — Changes to device.ts could affect device state handling logic used in the forget device flow, particularly around device connection/disconnection state and Bluetooth history detection.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — Changes to protocol.ts could affect URI/protocol parsing used in send forms. This test exercises the send form including address inputs and locktime which may use protocol utilities.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/suite-utils/src/__tests__/date.test.ts`

_Updated: 2026-06-12T06:33:22.865Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-suite-utils/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-suite-utils/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-suite-utils&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-suite-utils&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-suite-utils&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-12T06:36:55.277Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-12T06:38:30.571Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->