### PR TITLE
chore(suite-native): unexport dead intra-file staking selectors

### DIFF
--- a/suite-native/staking/src/cardanoStakingSelectors.ts
+++ b/suite-native/staking/src/cardanoStakingSelectors.ts
@@ -16,7 +16,7 @@ import {
 
 import { type NativeStakingRootState } from './types';
 
-export const createMemoizedSelector = createWeakMapSelector.withTypes<NativeStakingRootState>();
+const createMemoizedSelector = createWeakMapSelector.withTypes<NativeStakingRootState>();
 
 export const selectVisibleDeviceCardanoAccountsWithStakingByNetworkSymbol = createMemoizedSelector(
     [selectDeviceAccounts, (_state, symbol: NetworkSymbol) => symbol],

--- a/suite-native/staking/src/ethereumStakingSelectors.ts
+++ b/suite-native/staking/src/ethereumStakingSelectors.ts
@@ -1,4 +1,4 @@
-import { getDaysToAddToPool, getDaysToAddToPoolInitial } from '@suite-common/staking';
+import { getDaysToAddToPoolInitial } from '@suite-common/staking';
 import { type NetworkSymbol, getNetworkType } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
@@ -139,14 +139,4 @@ export const selectEthereumEntryPeriodInDays = (state: NativeStakingRootState) =
     }
 
     return getDaysToAddToPoolInitial(validatorsQueue);
-};
-
-export const selectEntryPeriodRemainingInDaysByAccountKey = (
-    state: NativeStakingRootState,
-    accountKey: AccountKey,
-) => {
-    const validatorsQueue = selectEthValidatorsQueue(state);
-    const stakeTxs = selectAccountStakeTransactions(state, accountKey);
-
-    return getDaysToAddToPool(stakeTxs, validatorsQueue);
 };

--- a/suite-native/staking/src/selectors.ts
+++ b/suite-native/staking/src/selectors.ts
@@ -23,7 +23,6 @@ import {
     selectVisibleDeviceCardanoAccountsWithStakingByNetworkSymbol,
 } from './cardanoStakingSelectors';
 import {
-    selectEntryPeriodRemainingInDaysByAccountKey,
     selectEthereumAccountHasStaking,
     selectEthereumCanClaimByAccountKey,
     selectEthereumClaimableAmountByAccountKey,
@@ -52,7 +51,7 @@ import { type NativeStakingRootState } from './types';
 // create empty array in advance so it will be always same on shallow comparison
 const EMPTY_ACCOUNT_ARRAY: Account[] = [];
 
-export const selectDeviceAccountsWithStaking = (
+const selectDeviceAccountsWithStaking = (
     state: NativeStakingRootState,
     symbol: NetworkSymbol,
 ): Account[] => {
@@ -367,4 +366,4 @@ export const selectEntryPeriodInDaysBySymbol = (
     }
 };
 
-export { selectEntryPeriodRemainingInDaysByAccountKey, selectUnstakingPeriodInDaysBySymbol };
+export { selectUnstakingPeriodInDaysBySymbol };

--- a/suite-native/staking/src/solanaStakingSelectors.ts
+++ b/suite-native/staking/src/solanaStakingSelectors.ts
@@ -16,7 +16,7 @@ import { BigNumber } from '@trezor/utils';
 
 import { type NativeStakingRootState } from './types';
 
-export const createMemoizedSelector = createWeakMapSelector.withTypes<NativeStakingRootState>();
+const createMemoizedSelector = createWeakMapSelector.withTypes<NativeStakingRootState>();
 
 export const selectVisibleDeviceSolanaAccountsWithStakingByNetworkSymbol = createMemoizedSelector(
     [selectDeviceAccounts, (_state, symbol: NetworkSymbol) => symbol],


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into small isolated PRs for easy, low-risk review.

Unexport intra-file staking selectors and helpers (createMemoizedSelector, selectEntryPeriodRemainingInDaysByAccountKey, selectDeviceAccountsWithStaking and others) in @suite-native/staking.

The full staging branch is green (type-check + lint + format + depcheck); CI verifies this subset independently.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-native-staking&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->