### PR TITLE
chore(staking): unexport internal-only Solana and Ethereum staking helpers

### DIFF
--- a/suite-common/staking/src/actions/solanaStakeFormActions.ts
+++ b/suite-common/staking/src/actions/solanaStakeFormActions.ts
@@ -31,7 +31,7 @@ import { BigNumber } from '@trezor/utils';
 import { calculate, composeStakingTransaction } from './stakeFormActions';
 
 // Rent-aware Solana stake fee calc for `composeStakingTransaction` / `calculate`.
-export const calculateSolanaStakeTransaction = (
+const calculateSolanaStakeTransaction = (
     availableBalance: string,
     output: ExternalOutput,
     feeLevel: FeeLevel,
@@ -72,7 +72,7 @@ export const calculateSolanaStakeTransaction = (
 };
 
 // Merges solanaTxMeta (rent, fee) into each fee level for device review amounts.
-export const applySolanaTxMeta = (
+const applySolanaTxMeta = (
     composed: PrecomposedLevels,
     solanaTxMeta: SolanaTxMeta,
 ): PrecomposedLevels =>
@@ -102,7 +102,7 @@ export const applySolanaTxMeta = (
     );
 
 // Turns a prepared staking transaction into a message and asks the backend to estimate its fee.
-export const estimateSolanaStakeFee = async (
+const estimateSolanaStakeFee = async (
     symbol: NetworkSymbol,
     txData?: PrepareStakeSolTxResponse,
 ): Promise<EstimatedFee> => {

--- a/suite-common/staking/src/utils/ethereumStaking.ts
+++ b/suite-common/staking/src/utils/ethereumStaking.ts
@@ -146,7 +146,7 @@ export const getEthNetworkForWalletSdk = (
     return (symbol && symbol !== 'unknown' ? ethNetworks[symbol] : null) ?? null;
 };
 
-export const getEthNetworkAddresses = (symbol: NetworkSymbol): EthNetworkAddresses | null => {
+const getEthNetworkAddresses = (symbol: NetworkSymbol): EthNetworkAddresses | null => {
     const ethNetwork = getEthNetworkForWalletSdk(symbol);
 
     return ethNetwork ? ETH_NETWORK_ADDRESSES[ethNetwork] : null;
@@ -425,7 +425,7 @@ export const transformTx = (
     return result;
 };
 
-export type PrepareStakeEthTxResponse =
+type PrepareStakeEthTxResponse =
     | {
           success: true;
           tx: EthereumTransaction | EthereumTransactionEIP1559;
@@ -561,7 +561,7 @@ export const prepareClaimEthTx = async ({
     }
 };
 
-export type GetStakeTxGasLimitResponse =
+type GetStakeTxGasLimitResponse =
     | {
           success: true;
           gasLimit: string;


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into small isolated PRs for easy, low-risk review.

Remove unused calculateSolanaStakeTransaction, applySolanaTxMeta, estimateSolanaStakeFee, getEthNetworkForWalletSdk/getEthNetworkAddresses and dead test fixtures.

The full staging branch is green (type-check + lint + format + depcheck); CI verifies this subset independently.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes target two staking-specific files: Solana staking form actions and Ethereum staking utilities. The risk is concentrated in the ETH and SOL staking flows. ethereumStaking.ts maps to 121 tests via static analysis, but this is clearly a broad transitive dependency — only the ETH staking tests and staking form test directly exercise its functionality. solanaStakeFormActions.ts has no static coverage data but is clearly exercised by the SOL staking E2E tests. The recommended strategy is to run all ETH and SOL staking tests at high priority, with SOL rewards at medium, and ADA staking tests at low priority as a safety net.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/staking/src/actions/solanaStakeFormActions.ts`
- `suite-common/staking/src/utils/ethereumStaking.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (7)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Directly exercises Ethereum staking functionality. The changed file ethereumStaking.ts contains utility functions used in ETH staking flows, and this test covers the full initial stake path including form validation, transaction confirmation, and status progression.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Tests the 'stake more' ETH flow which directly uses Ethereum staking utilities for amount calculations, fee display, and staking pool interactions. Changes to ethereumStaking.ts could affect stake-more amount handling and instant staking banner logic.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — Tests ETH unstaking and claiming flows which rely on ethereumStaking.ts utilities for balance calculations (depositedBalance, withdrawTotalAmount, claimableAmount, autocompoundBalance). Changes here could break unstake/claim amount display or transaction construction.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Directly exercises the Solana initial staking flow. The changed file solanaStakeFormActions.ts contains actions that drive the SOL staking form behavior including amount calculation, fee handling, and transaction submission.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — Tests staking additional SOL which uses solanaStakeFormActions for form state management, amount validation, and transaction construction. Changes to these actions could break the stake-more flow.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — Tests SOL unstaking and claiming flows. While solanaStakeFormActions primarily handles staking, unstaking shares common infrastructure and the actions file may contain shared utilities or state that affects unstake behavior.
- `suite/e2e/tests/staking/staking-form.test.ts` — Directly tests the ETH staking form validation (min amount, decimals, insufficient funds, percentage buttons, max button, crypto/fiat switching). ethereumStaking.ts utilities likely power these calculations and validations.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/staking/sol/rewards.test.ts` — Tests SOL staking rewards display which shares staking infrastructure with the changed Solana staking actions. Rewards calculation and display may be indirectly affected by changes to staking form actions.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — ADA staking claim flow is separate from ETH/SOL staking, but the staking module is shared. Changes to ethereumStaking.ts utilities could theoretically affect shared staking infrastructure if common helpers were modified.
- `suite/e2e/tests/staking/ada/stake.test.ts` — ADA staking flow uses the broader staking module. While unlikely to be affected by ETH-specific utility changes, shared staking constants or helpers could create a regression path.

</details>

_Updated: 2026-06-12T06:30:24.264Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-staking/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-staking/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-staking&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-staking&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-staking&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-12T06:33:45.489Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-12T06:35:11.285Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->