### PR TITLE
chore(suite-native): remove unused trading fixture quotes and states

### DIFF
--- a/suite-native/trading-fixtures/src/__fixtures__/buyQuotes.ts
+++ b/suite-native/trading-fixtures/src/__fixtures__/buyQuotes.ts
@@ -72,7 +72,7 @@ export const mercuryoCreditCardBuyQuote: BuyTrade = {
     paymentId: 'e709df77-ee9e-4d12-98c2-84004a19c546',
 };
 
-export const mercuryoGooglePayBuyQuote: BuyTrade = {
+const mercuryoGooglePayBuyQuote: BuyTrade = {
     fiatStringAmount: '10',
     fiatCurrency: 'EUR',
     receiveCurrency: 'bitcoin' as CryptoId,

--- a/suite-native/trading-fixtures/src/__fixtures__/exchangeQuotes.ts
+++ b/suite-native/trading-fixtures/src/__fixtures__/exchangeQuotes.ts
@@ -61,7 +61,7 @@ export const invityDexQuote: ExchangeTrade = {
     sendStringAmount: '100',
 };
 
-export const mercuryoDexQuote: ExchangeTrade = {
+const mercuryoDexQuote: ExchangeTrade = {
     exchange: 'mercuryo',
     fee: 'UNKNOWN',
     max: 'NONE',

--- a/suite-native/trading-fixtures/src/__fixtures__/tradingState.ts
+++ b/suite-native/trading-fixtures/src/__fixtures__/tradingState.ts
@@ -25,7 +25,7 @@ import { platforms } from './platforms';
 import { sellBanxa, sellCexdirect, sellInvity, sellMercuryo, sellMoonpay } from './sellProviders';
 import { sellQuotes } from './sellQuotes';
 
-export const getInitializedBuyState = () =>
+const getInitializedBuyState = () =>
     ({
         ...tradingInitialState.buy,
         quotesRequest: undefined,
@@ -65,7 +65,7 @@ export const getInitializedBuyState = () =>
         },
     }) as TradingBuyState;
 
-export const getInitializedExchangeState = () =>
+const getInitializedExchangeState = () =>
     ({
         ...tradingInitialState.exchange,
         exchangeInfo: {
@@ -96,7 +96,7 @@ export const getInitializedExchangeState = () =>
         },
     }) as TradingExchangeState;
 
-export const getInitializedSellState = () =>
+const getInitializedSellState = () =>
     ({
         ...tradingInitialState.sell,
         sellInfo: {


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into small isolated PRs for easy, low-risk review.

Remove unused fixture quotes and initialized-state helpers (mercuryoGooglePayBuyQuote, mercuryoDexQuote, residenceCheckEnabledState, getInitializedBuyState/ExchangeState/SellState).

The full staging branch is green (type-check + lint + format + depcheck); CI verifies this subset independently.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-native-trading-fixtures&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->