### PR TITLE
chore(suite): remove dead router anchor and search-string helpers

### DIFF
--- a/suite-native/trading-residence/src/components/CountrySheet/CountrySheet.tsx
+++ b/suite-native/trading-residence/src/components/CountrySheet/CountrySheet.tsx
@@ -9,7 +9,7 @@ import { BottomSheetSectionList, SearchableSheetHeader } from '@suite-native/tra
 import { CountryListEmptyComponent } from './CountryListEmptyComponent';
 import { CountryListItem } from './CountryListItem';
 
-export type CountrySheetProps = {
+type CountrySheetProps = {
     isVisible: boolean;
     onClose: () => void;
     onCountrySelect: (symbol: TradingCountryOption) => void;

--- a/suite-native/trading-residence/src/components/CountrySheet/CountrySubdivisionPicker.tsx
+++ b/suite-native/trading-residence/src/components/CountrySheet/CountrySubdivisionPicker.tsx
@@ -13,7 +13,7 @@ import { useCountrySubdivisionPickerControls } from './CountrySubdivisionPickerC
 import { CountrySubdivisionSheet } from './CountrySubdivisionSheet';
 import { type TradingLocationFormValues } from '../../types/tradingLocationForm';
 
-export type CountrySubdivisionPickerProps = {
+type CountrySubdivisionPickerProps = {
     testID: string;
     noBottomBorder?: boolean;
 };

--- a/suite-native/trading-residence/src/components/CountrySheet/CountrySubdivisionSheet.tsx
+++ b/suite-native/trading-residence/src/components/CountrySheet/CountrySubdivisionSheet.tsx
@@ -15,7 +15,7 @@ import {
 
 import { CountrySubdivisionListItem } from './CountrySubdivisionListItem';
 
-export type CountrySubdivisionSheetProps = {
+type CountrySubdivisionSheetProps = {
     countryCode: string | undefined;
     isVisible: boolean;
     onClose: () => void;

--- a/suite-native/trading-residence/src/components/LocationForm.tsx
+++ b/suite-native/trading-residence/src/components/LocationForm.tsx
@@ -4,7 +4,7 @@ import { Form } from '@suite-native/forms';
 
 import { useLocationForm } from '../hooks/useLocationForm';
 
-export type LocationFormProps = {
+type LocationFormProps = {
     children: ReactNode;
 };
 

--- a/suite-native/trading-residence/src/components/ResidenceCheckAwareAnimatedBox.tsx
+++ b/suite-native/trading-residence/src/components/ResidenceCheckAwareAnimatedBox.tsx
@@ -5,7 +5,7 @@ import { AnimatedBox, type BoxProps } from '@suite-native/atoms';
 import { selectIsTradingResidenceCheckEnabled } from '@suite-native/trading-state';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
-export type ResidenceCheckAwareAnimatedBoxProps = Omit<BoxProps, 'style'>;
+type ResidenceCheckAwareAnimatedBoxProps = Omit<BoxProps, 'style'>;
 
 const pickerStyle = prepareNativeStyle<{ hasBorder: boolean }>(
     ({ borders, colors }, { hasBorder }) => ({

--- a/suite-native/trading-residence/src/components/TradingLocationPickers.tsx
+++ b/suite-native/trading-residence/src/components/TradingLocationPickers.tsx
@@ -6,7 +6,7 @@ import { CountryOfResidencePicker } from './CountrySheet/CountryOfResidencePicke
 import { CountrySubdivisionPicker } from './CountrySheet/CountrySubdivisionPicker';
 import { type TradingLocationFormValues } from '../types/tradingLocationForm';
 
-export type TradingLocationPickersProps = {
+type TradingLocationPickersProps = {
     context: CountryChangeContext;
     testID: string;
     hasCountrySubdivisionBottomBorder?: boolean;

--- a/suite/router/src/Anchor.tsx
+++ b/suite/router/src/Anchor.tsx
@@ -2,7 +2,7 @@ import { type ReactNode, type RefObject } from 'react';
 
 import { useAnchor } from './useAnchor';
 
-export type AnchorRenderProps = {
+type AnchorRenderProps = {
     anchorId: string;
     anchorRef: RefObject<HTMLDivElement | null>;
     shouldHighlight: boolean;

--- a/suite/router/src/anchorUtils.ts
+++ b/suite/router/src/anchorUtils.ts
@@ -2,7 +2,7 @@ import type { WalletAccountTransaction } from '@suite-common/wallet-types';
 
 import { AccountTransactionBaseAnchor, type AnchorType } from './anchors';
 
-export const getTxIdFromAnchor = (anchor?: string): string => anchor?.split('/').pop() || '';
+const getTxIdFromAnchor = (anchor?: string): string => anchor?.split('/').pop() || '';
 
 export const getTxAnchor = (txId?: string): AnchorType | undefined =>
     txId ? `${AccountTransactionBaseAnchor}/${txId}` : undefined;

--- a/suite/router/src/router.ts
+++ b/suite/router/src/router.ts
@@ -16,8 +16,8 @@ import {
 } from './routes';
 
 export type PathString = `/${string}`; // in format `/alpha/beta/gamma`
-export type SearchString = '' | `?${string}`; // in format `?alpha=beta&gamma=delta`
-export type HashString = '' | `#${string}`; // in format `#/alpha/beta/gamma`
+type SearchString = '' | `?${string}`; // in format `?alpha=beta&gamma=delta`
+type HashString = '' | `#${string}`; // in format `#/alpha/beta/gamma`
 
 // NOTE: this is basically a bit stricter Path from history package (file://./../../../node_modules/history/index.d.ts),
 // but it is satisfied by window.location as well

--- a/suite/router/src/routerParams.ts
+++ b/suite/router/src/routerParams.ts
@@ -21,7 +21,7 @@ const accountTypes = [
     'ledger',
 ] as const satisfies readonly AccountType[];
 
-export const earnParamsSchema = yup.object({
+const earnParamsSchema = yup.object({
     symbol: yup.mixed<NetworkSymbol>().required(),
     accountIndex: yup.number().required(),
     accountType: yup.mixed<AccountType>().oneOf(accountTypes).required(),
@@ -39,7 +39,7 @@ export function parseEarnParams(params: unknown): EarnParams | undefined {
     }
 }
 
-export const dashboardParamsSchema = yup.object({
+const dashboardParamsSchema = yup.object({
     networkSymbol: yup.mixed<NetworkSymbol>().notRequired(),
     modal: yup.mixed<NonNullable<GlobalSendReceiveType>>().oneOf(['send', 'receive']).required(),
 });

--- a/suite/router/src/routerReducer.ts
+++ b/suite/router/src/routerReducer.ts
@@ -20,7 +20,7 @@ const ACCOUNT_TABS = [
     'wallet-staking',
 ];
 
-export const ROUTER_PREFIX = 'router';
+const ROUTER_PREFIX = 'router';
 
 export type RouterState = RouterPath & {
     loaded: boolean;
@@ -60,7 +60,7 @@ const initialState: RouterState = {
     },
 };
 
-export const routerSlice = createSlice({
+const routerSlice = createSlice({
     name: ROUTER_PREFIX,
     initialState: initialState as RouterState,
     reducers: {

--- a/suite/router/src/scrollContext.ts
+++ b/suite/router/src/scrollContext.ts
@@ -1,6 +1,6 @@
 import { type RefObject, createContext } from 'react';
 
-export type ScrollContextPayload = {
+type ScrollContextPayload = {
     scrollRef: RefObject<HTMLDivElement | null>;
     topOffset: number;
 };

--- a/suite/router/src/suiteRouterHistory.ts
+++ b/suite/router/src/suiteRouterHistory.ts
@@ -4,7 +4,7 @@ import type { CommonServices } from '@suite-common/redux-utils';
 
 import type { RouterPath } from './router';
 
-export type LocationPushState = Record<string, unknown>;
+type LocationPushState = Record<string, unknown>;
 
 // This is a Listener from history package
 type Listener = (_: { location: RouterPath; action: 'PUSH' | 'POP' | 'REPLACE' }) => void;


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into small isolated PRs for easy, low-risk review.

Remove dead AnchorRenderProps, getTxIdFromAnchor and the unused SearchString/HashString template-literal types.

The full staging branch is green (type-check + lint + format + depcheck); CI verifies this subset independently.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set touches two distinct areas: suite-native trading residence components (country/location pickers) and the suite web router infrastructure. The native trading components have no direct E2E test coverage since they target the mobile app. The router changes (router.ts, routerReducer.ts, routerParams.ts, suiteRouterHistory.ts, Anchor.tsx, anchorUtils.ts, scrollContext.ts) are higher risk as they affect all navigation in the web Suite app. The check-links test is the most critical as it validates every route. Trading navigation and DB migration tests provide additional confidence that routing works correctly across key user flows.

<details><summary><b>Changed files (13)</b></summary>

- `suite-native/trading-residence/src/components/CountrySheet/CountrySheet.tsx`
- `suite-native/trading-residence/src/components/CountrySheet/CountrySubdivisionPicker.tsx`
- `suite-native/trading-residence/src/components/CountrySheet/CountrySubdivisionSheet.tsx`
- `suite-native/trading-residence/src/components/LocationForm.tsx`
- `suite-native/trading-residence/src/components/ResidenceCheckAwareAnimatedBox.tsx`
- `suite-native/trading-residence/src/components/TradingLocationPickers.tsx`
- `suite/router/src/Anchor.tsx`
- `suite/router/src/anchorUtils.ts`
- `suite/router/src/router.ts`
- `suite/router/src/routerParams.ts`
- `suite/router/src/routerReducer.ts`
- `suite/router/src/scrollContext.ts`
- `suite/router/src/suiteRouterHistory.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test validates every route defined in the router config and checks that pages load correctly. Changes to suite/router/src/router.ts, routerParams.ts, and routerReducer.ts directly affect route definitions and resolution, which this test comprehensively verifies.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — This test exercises navigation across multiple trading entry points (Buy, Sell, Swap from dashboard, accounts, tokens, global header). Router changes to router.ts, routerReducer.ts, and suiteRouterHistory.ts could break navigation flows and route matching for trading pages.
- `suite/e2e/tests/suite/db-migration.test.ts` — Database migration tests navigate between Suite versions and multiple routes. Changes to router internals (suiteRouterHistory.ts, routerReducer.ts) could affect how routes are resolved after migration, especially when restoring remembered wallet state and navigating to accounts/send forms.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — This test includes country/location selector assertions (verifying country value does not show 'Worldwide'), which relates to the TradingLocationPickers and CountrySheet components changed in suite-native. While these are native components, the sell-inputs test validates country selection behavior in the web trading flow that may share logic.
- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — This test navigates directly to /accounts during onboarding and verifies routing behavior. Changes to router.ts, routerReducer.ts, and suiteRouterHistory.ts could affect how direct URL navigation works during the onboarding flow, especially route guards and redirects.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — The analytics events test captures routerLocationChangeEvent which is directly tied to router state changes. Modifications to routerReducer.ts could affect what data is included in router-related analytics events.
- `suite/e2e/tests/trading/remembered-wallet-loading.test.ts` — This test loads a remembered wallet from IndexedDB and navigates to specific accounts. Router changes (suiteRouterHistory.ts, routerReducer.ts) could affect route restoration from persisted state when no device is connected.

</details>

⚠️ **Changes with no test coverage (9)**
- `suite-native/trading-residence/src/components/CountrySheet/CountrySheet.tsx`
- `suite-native/trading-residence/src/components/CountrySheet/CountrySubdivisionPicker.tsx`
- `suite-native/trading-residence/src/components/CountrySheet/CountrySubdivisionSheet.tsx`
- `suite-native/trading-residence/src/components/LocationForm.tsx`
- `suite-native/trading-residence/src/components/ResidenceCheckAwareAnimatedBox.tsx`
- `suite-native/trading-residence/src/components/TradingLocationPickers.tsx`
- `suite/router/src/Anchor.tsx`
- `suite/router/src/anchorUtils.ts`
- `suite/router/src/scrollContext.ts`

_Updated: 2026-06-11T13:51:12.362Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-suite-router/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-suite-router/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-suite-router&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-suite-router&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-suite-router&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-11T13:54:06.088Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-11T13:56:17.606Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->