### PR TITLE
chore(suite): remove dead metadata labeling and password helpers

### DIFF
--- a/suite/metadata/src/metadataLabelingActions.ts
+++ b/suite/metadata/src/metadataLabelingActions.ts
@@ -36,7 +36,7 @@ import {
 } from './metadataReducer';
 import * as metadataUtils from './metadataUtils';
 
-export const getLabelableEntities =
+const getLabelableEntities =
     (deviceState: StaticSessionId) => (_dispatch: Dispatch, getState: () => MetadataRootState) =>
         selectLabelableEntities(getState(), deviceState);
 

--- a/suite/metadata/src/metadataLabelingConstants.ts
+++ b/suite/metadata/src/metadataLabelingConstants.ts
@@ -8,10 +8,9 @@ import { type TrezorConnect } from '@trezor/connect';
 export const FORMAT_VERSION = '1.0.0';
 
 // @trezor/connect params
-export const ENABLE_LABELING_PATH = "m/10015'/0'";
-export const ENABLE_LABELING_KEY = 'Enable labeling?';
-export const ENABLE_LABELING_VALUE =
-    'fedcba98765432100123456789abcdeffedcba98765432100123456789abcdef';
+const ENABLE_LABELING_PATH = "m/10015'/0'";
+const ENABLE_LABELING_KEY = 'Enable labeling?';
+const ENABLE_LABELING_VALUE = 'fedcba98765432100123456789abcdeffedcba98765432100123456789abcdef';
 export const FETCH_INTERVAL = 60_000;
 
 export const ENCRYPTION_VERSION: MetadataEncryptionVersion = 1;

--- a/suite/metadata/src/metadataPasswordsActions.ts
+++ b/suite/metadata/src/metadataPasswordsActions.ts
@@ -19,7 +19,7 @@ import { type MetadataRootState, selectSelectedProviderForPasswords } from './me
 import * as metadataUtils from './metadataUtils';
 import { type FetchIntervalTrackingId } from './metadataUtils';
 
-export const fetchPasswords =
+const fetchPasswords =
     (keys: LabelableEntityKeys) =>
     async (dispatch: Dispatch, _getState: () => MetadataRootState) => {
         const provider = dispatch(

--- a/suite/metadata/src/metadataProviderConstants.ts
+++ b/suite/metadata/src/metadataProviderConstants.ts
@@ -1,6 +1,6 @@
 export const AUTH_WINDOW_TITLE = 'AuthPopup';
-export const AUTH_WINDOW_WIDTH = 600;
-export const AUTH_WINDOW_HEIGHT = 720;
+const AUTH_WINDOW_WIDTH = 600;
+const AUTH_WINDOW_HEIGHT = 720;
 export const AUTH_WINDOW_PROPS = `width=${AUTH_WINDOW_WIDTH},height=${AUTH_WINDOW_HEIGHT},dialog=yes,dependent=yes,scrollbars=yes,location=yes`;
 
 // used for desktop app when auth-server is running - generate testing credentials for development

--- a/suite/metadata/src/metadataProviderThunks.ts
+++ b/suite/metadata/src/metadataProviderThunks.ts
@@ -27,7 +27,7 @@ import { FileSystemProvider } from './providers/FileSystemProvider';
 import { GoogleProvider } from './providers/GoogleProvider';
 import { InMemoryTestProvider } from './providers/InMemoryTestProvider';
 
-export type ProviderInstance =
+type ProviderInstance =
     | DropboxProvider
     | GoogleProvider
     | FileSystemProvider
@@ -222,7 +222,7 @@ export const initProvider = () => (dispatch: Dispatch) => {
     return decision.promise;
 };
 
-export const selectProvider =
+const selectProvider =
     ({ dataType, clientId }: { dataType: DataType; clientId: string }) =>
     (dispatch: Dispatch) => {
         dispatch({

--- a/suite/metadata/src/moveLabelsForRbfOldMetadataThunk.ts
+++ b/suite/metadata/src/moveLabelsForRbfOldMetadataThunk.ts
@@ -12,7 +12,7 @@ import * as METADATA from './metadataConstants';
 import * as metadataLabelingActions from './metadataLabelingActions';
 import { selectLabelingDataForAccount } from './metadataReducer';
 
-export type DeleteAllOutputLabelsParams = {
+type DeleteAllOutputLabelsParams = {
     labels: AccountLabels['outputLabels']['labels'];
     dispatch: Dispatch;
     accountKey: AccountKey;
@@ -21,7 +21,7 @@ export type DeleteAllOutputLabelsParams = {
     txid: string;
 };
 
-export const deleteDanglingLabels = async ({
+const deleteDanglingLabels = async ({
     labels,
     dispatch,
     accountKey,
@@ -54,7 +54,7 @@ type MoveLabelToNewTransactionParams = {
     networkSymbol: NetworkSymbol;
 };
 
-export const copyLabelToNewTransaction = async ({
+const copyLabelToNewTransaction = async ({
     accountOutputLabels,
     dispatch,
     accountKey,
@@ -80,7 +80,7 @@ export const copyLabelToNewTransaction = async ({
     }
 };
 
-export type MoveLabelsForRbfOldMetadataThunkParams = {
+type MoveLabelsForRbfOldMetadataThunkParams = {
     accountKey: AccountKey;
     data: RbfLabelsToBeUpdated[keyof RbfLabelsToBeUpdated];
     newTxid: string;

--- a/suite/metadata/src/oauth.ts
+++ b/suite/metadata/src/oauth.ts
@@ -45,7 +45,7 @@ const oauthResponseMessage = z
         }),
     );
 
-export type OAuthResponseMessage = z.infer<typeof oauthResponseMessage>;
+type OAuthResponseMessage = z.infer<typeof oauthResponseMessage>;
 
 const oauthResult = oauthResponseMessage.transform(value => {
     const searchOrHash = 'search' in value ? value.search : value.hash;


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into small isolated PRs for easy, low-risk review.

Remove unused getLabelableEntities, fetchPasswords, ProviderInstance and the ENABLE_LABELING_*/AUTH_WINDOW_* constants.

The full staging branch is green (type-check + lint + format + depcheck); CI verifies this subset independently.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All 7 changed files are in the suite/metadata/src module, covering labeling actions, provider thunks, OAuth, provider constants, labeling constants, passwords actions, and RBF label movement. This is a core metadata/labeling infrastructure change that affects all legacy metadata tests (Dropbox, Google, local file providers) and has indirect impact on Suite Sync labeling. The legacy metadata tests are highest priority since they directly exercise the changed provider integration, OAuth, label CRUD, and error handling paths. Suite Sync tests are medium priority as they share the labeling action infrastructure. The metadataPasswordsActions.ts file has no dedicated E2E test coverage.

<details><summary><b>Changed files (7)</b></summary>

- `suite/metadata/src/metadataLabelingActions.ts`
- `suite/metadata/src/metadataLabelingConstants.ts`
- `suite/metadata/src/metadataPasswordsActions.ts`
- `suite/metadata/src/metadataProviderConstants.ts`
- `suite/metadata/src/metadataProviderThunks.ts`
- `suite/metadata/src/moveLabelsForRbfOldMetadataThunk.ts`
- `suite/metadata/src/oauth.ts`

</details>

**Recommended tests (16)**

<details><summary>🔴 <b>High priority (12)</b></summary>

- `suite/e2e/tests/metadata/legacy/account-metadata.test.ts` — Directly exercises legacy labeling with Dropbox provider, editing/saving account labels, and metadata label persistence — all of which flow through metadataLabelingActions, metadataProviderThunks, and metadataProviderConstants.
- `suite/e2e/tests/metadata/legacy/address-metadata.test.ts` — Tests adding and editing address labels via the Google metadata provider, directly exercising metadataLabelingActions for address label CRUD and metadataProviderThunks for Google provider initialization and OAuth.
- `suite/e2e/tests/metadata/legacy/dropbox-api-errors.test.ts` — Tests error handling for Dropbox metadata provider (malformed tokens, rate-limit retries, corrupted metadata files), directly exercising metadataProviderThunks error paths and OAuth token handling.
- `suite/e2e/tests/metadata/legacy/google-api-errors.test.ts` — Tests Google API 401 error handling during metadata provider connection with retry logic, directly exercising metadataProviderThunks and oauth.ts for Google provider authentication error paths.
- `suite/e2e/tests/metadata/legacy/interval-fetching.test.ts` — Tests automatic metadata label refresh using FETCH_INTERVAL from metadataLabelingConstants. Changes to the fetch interval constant or polling logic would directly affect this test's timing-sensitive assertions.
- `suite/e2e/tests/metadata/legacy/metadata-lifecycle.test.ts` — Tests the full lifecycle of metadata labeling — enable, use, switch wallets, disable, forget device, re-enable — exercising metadataLabelingActions, metadataProviderThunks, and provider constants extensively.
- `suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — Tests output/transaction label CRUD operations and CSV export with labels, directly exercising metadataLabelingActions for output label management and moveLabelsForRbfOldMetadataThunk for RBF-related label handling.
- `suite/e2e/tests/metadata/legacy/remembered-device.test.ts` — Tests metadata provider connect/disconnect/reconnect flows and label persistence on remembered devices, directly exercising metadataProviderThunks for provider lifecycle management and metadataLabelingActions for label editing.
- `suite/e2e/tests/metadata/legacy/switching-providers.test.ts` — Tests switching between Dropbox and Google metadata providers, directly exercising metadataProviderThunks for provider initialization/disconnection, oauth.ts for provider authentication, and metadataProviderConstants for provider type handling.
- `suite/e2e/tests/metadata/legacy/wallet-metadata.test.ts` — Tests wallet-level label management (add, edit, persist across reloads) via Dropbox provider, directly exercising metadataLabelingActions for wallet labels and metadataProviderThunks for provider sync.
- `suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts` — Tests migration from legacy Dropbox labels to Suite Sync, exercising metadataLabelingActions for legacy label creation and metadataProviderThunks for provider switching during migration.
- `suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts` — Tests migration of local file labels (account, output, address) to Suite Sync, directly exercising metadataLabelingActions for label creation and the migration logic that depends on metadataProviderThunks.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — Tests creating account, wallet, address, and output labels via Suite Sync. While Suite Sync uses a different provider path, the labeling actions in metadataLabelingActions are shared infrastructure for label CRUD operations.
- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — Tests Suite Sync labeling across multiple wallets including passphrase wallets. The labeling flow shares metadataLabelingActions for label change operations even though the provider is Evolu rather than Dropbox/Google.
- `suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts` — Tests removing labels via Suite Sync and verifying null values sync to Evolu. Label removal flows through metadataLabelingActions which is directly changed.
- `suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — Tests syncing labels from the Evolu relay server. While primarily Suite Sync focused, the metadata setup and provider initialization flows depend on metadataProviderThunks and metadataLabelingActions.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/metadata/src/metadataPasswordsActions.ts`

_Updated: 2026-06-11T13:51:43.358Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-suite-metadata/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-suite-metadata/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-suite-metadata&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-suite-metadata&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-11T13:54:57.007Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-11T13:56:10.584Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->