### PR TITLE
chore(analytics): unexport intra-file shared event types and helpers

### DIFF
--- a/suite-common/analytics/src/eventDefinition.ts
+++ b/suite-common/analytics/src/eventDefinition.ts
@@ -2,14 +2,14 @@ export type AppVersion = `${number}.${number}.${number}` | '?';
 
 export type AnalyticsPlatform = 'desktop' | 'mobile';
 
-export type BaseData = {
+type BaseData = {
     changelog: Array<{ version: AppVersion; notes: string }>;
     description?: string;
 };
 
-export type AnalyticsBaseAttribute = BaseData;
+type AnalyticsBaseAttribute = BaseData;
 
-export type AnalyticsBaseEvent = BaseData & {
+type AnalyticsBaseEvent = BaseData & {
     name: string;
     descriptionTrigger: string;
     possibleImprovements?: string;

--- a/suite-common/analytics/src/eventNameValidation.ts
+++ b/suite-common/analytics/src/eventNameValidation.ts
@@ -25,8 +25,6 @@ export const ANALYTICS_ALLOWED_DOMAINS = [
     'wallet-connect',
 ] as const;
 
-export type AnalyticsDomain = (typeof ANALYTICS_ALLOWED_DOMAINS)[number];
-
 const ANALYTICS_EVENT_NAME_KEBAB_SEGMENT = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 
 const ALLOWED_DOMAINS_SET = new Set<string>(ANALYTICS_ALLOWED_DOMAINS);
@@ -59,15 +57,4 @@ export function validateAnalyticsEventName(value: string): ValidateEventNameErro
     }
 
     return null;
-}
-
-/**
- * Returns true if the event part (part after domain/) is valid kebab-case.
- * For multi-segment event parts (e.g. "app-log/exported"), each segment is validated.
- */
-export function isValidEventPart(eventPart: string): boolean {
-    if (eventPart.trim() === '') return false;
-    const segments = eventPart.split('/');
-
-    return segments.every(seg => ANALYTICS_EVENT_NAME_KEBAB_SEGMENT.test(seg.trim()));
 }

--- a/suite-common/analytics/src/index.ts
+++ b/suite-common/analytics/src/index.ts
@@ -6,12 +6,8 @@ export type {
     AppVersion,
     AnalyticsPlatform,
 } from './eventDefinition';
-export {
-    ANALYTICS_ALLOWED_DOMAINS,
-    isValidEventPart,
-    validateAnalyticsEventName,
-} from './eventNameValidation';
-export type { AnalyticsDomain, ValidateEventNameError } from './eventNameValidation';
+export { ANALYTICS_ALLOWED_DOMAINS, validateAnalyticsEventName } from './eventNameValidation';
+export type { ValidateEventNameError } from './eventNameValidation';
 
 export * as events from './events';
 export { type DeviceOnboardingStepName } from './events/onboardingStepViewedEvent';


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into small isolated PRs for easy, low-risk review.

Unexport intra-file sharedEvents and its type aliases (AnySharedEventDef, BaseData, AnalyticsBaseAttribute, AnalyticsBaseEvent) in @suite-common/analytics.

The full staging branch is green (type-check + lint + format + depcheck); CI verifies this subset independently.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes target the core analytics event definition module (eventDefinition.ts), event name validation (eventNameValidation.ts), and the barrel export (index.ts) in suite-common/analytics. This is a foundational analytics infrastructure change that could affect any test asserting on analytics event types, payloads, or event names. The highest risk is to tests that directly validate analytics event structures and payloads. The recommended strategy focuses on the dedicated analytics test files first, then tests in other domains that explicitly assert analytics event correctness. The eventNameValidation.ts change may only be exercised at build/unit-test time rather than E2E level.

<details><summary><b>Changed files (3)</b></summary>

- `suite-common/analytics/src/eventDefinition.ts`
- `suite-common/analytics/src/eventNameValidation.ts`
- `suite-common/analytics/src/index.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — This test directly validates analytics event definitions (SuiteReady, DeviceConnect, TransportType, DeviceDisconnect, SettingsAnalytics) and their payload structures. Changes to eventDefinition.ts and the analytics index.ts barrel export would directly affect the event types and constants this test asserts against.
- `suite/e2e/tests/analytics/toggle.test.ts` — This test validates the analytics enable/dispose lifecycle events, session/instance ID management, and that analytics events fire or don't fire based on toggle state. It directly uses analytics event definitions (settingsAnalyticsEvent, suiteReadyEvent, routerLocationChangeEvent, settingsGeneralChangeFiatEvent) that are defined in the changed files.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/analytics/promo-banner-events.test.ts` — Tests the PromoDashboardBanner analytics event type and its payload structure. Changes to event definitions could affect the EventType constants this test uses to validate analytics payloads.
- `suite/e2e/tests/analytics/staking-events.test.ts` — Tests StakingNavigate analytics event firing and payload validation. This directly depends on EventType.StakingNavigate from the analytics event definitions being changed.
- `suite/e2e/tests/analytics/wallet-connect-events.test.ts` — Tests multiple WalletConnect analytics events (WalletConnectInit, WalletConnectPaired, WalletConnectProposal, WalletConnectProposalApproved/Rejected). These EventType constants are imported from @suite-common/analytics which is being changed.
- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — Validates that the menuToggleDiscreetEvent analytics event fires with the correct payload when discreet mode is toggled. This event is defined in the analytics module being changed.
- `suite/e2e/tests/settings/general.test.ts` — Validates multiple analytics events (settingsGeneralChangeFiatEvent, settingsGeneralChangeThemeEvent, settingsGeneralChangeLanguageEvent, settingsAnalyticsEvent) and their payload structures. These events are defined in the changed analytics event definitions.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/backup/t2t1-success.test.ts` — Tests that the createBackup analytics event is tracked with status 'finished'. This event definition comes from the changed analytics module and a change to event structure could break this assertion.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — Validates the selectWalletTypeEvent analytics event with type 'hidden' when a passphrase wallet is selected. This event is defined in the analytics module being changed.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — Validates accountsNewAccountEvent analytics event with symbol, path, and type payload. This event definition originates from the changed analytics module.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/analytics/src/eventNameValidation.ts`

_Updated: 2026-06-16T08:33:00.691Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-analytics&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-analytics&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-analytics&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-16T08:38:22.700Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-16T08:36:38.676Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-analytics/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-analytics/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->