### PR TITLE
chore(suite-native): unexport graph slice and intra-file selectors

### DIFF
--- a/suite-native/graph/src/components/TransactionEventTooltip.tsx
+++ b/suite-native/graph/src/components/TransactionEventTooltip.tsx
@@ -19,8 +19,7 @@ import { type TokensRootState, selectAccountTokenInfo } from '@suite-native/toke
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 import { isNotNullOrUndefined } from '@trezor/utils';
 
-export type TransactionEventTooltipProps =
-    EventTooltipComponentProps<GroupedBalanceMovementEventPayload>;
+type TransactionEventTooltipProps = EventTooltipComponentProps<GroupedBalanceMovementEventPayload>;
 
 type EventTooltipRowProps = {
     title: string;

--- a/suite-native/graph/src/selectors.ts
+++ b/suite-native/graph/src/selectors.ts
@@ -18,7 +18,7 @@ import { tryGetAccountIdentity } from '@suite-common/wallet-utils';
 
 type GraphCommonRootState = DeviceRootState & AccountsRootState & TokenDefinitionsRootState;
 
-export const createMemoizedSelector = createWeakMapSelector.withTypes<GraphCommonRootState>();
+const createMemoizedSelector = createWeakMapSelector.withTypes<GraphCommonRootState>();
 
 export const selectPortfolioGraphAccountItems = (state: GraphCommonRootState): AccountItem[] => {
     const accounts = selectDeviceMainnetAccounts(state);

--- a/suite-native/graph/src/slice.ts
+++ b/suite-native/graph/src/slice.ts
@@ -37,7 +37,7 @@ export const graphPersistTransform = createTransform<GraphState, GraphState>(
     { whitelist: ['graph'] },
 );
 
-export const graphSlice = createSlice({
+const graphSlice = createSlice({
     name: 'graph',
     initialState: graphInitialState,
     reducers: {


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into small isolated PRs for easy, low-risk review.

Unexport intra-file TransactionEventTooltipProps, createMemoizedSelector and the graphSlice object in @suite-native/graph.

The full staging branch is green (type-check + lint + format + depcheck); CI verifies this subset independently.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-native-graph&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->