### PR TITLE
chore(suite-native): unexport intra-file icon Props types

### DIFF
--- a/suite-native/icons/src/CryptoIconWithNetwork.tsx
+++ b/suite-native/icons/src/CryptoIconWithNetwork.tsx
@@ -11,7 +11,7 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 import { CryptoIcon, type CryptoIconSize, cryptoIconSizes } from './CryptoIcon';
 import { NetworkIcon, networkIconSizes } from './NetworkIcon';
 
-export interface CryptoIconWithNetworkProps {
+interface CryptoIconWithNetworkProps {
     symbol: NetworkSymbol;
     contractAddress?: TokenAddress;
     size?: CryptoIconSize;

--- a/suite-native/icons/src/NetworkIcon.tsx
+++ b/suite-native/icons/src/NetworkIcon.tsx
@@ -24,7 +24,7 @@ import { type CSSColor } from '@trezor/theme';
 
 import { type CryptoIconSize } from './CryptoIcon';
 
-export interface NetworkIconProps {
+interface NetworkIconProps {
     symbol: NetworkSymbol;
     size?: CryptoIconSize | number;
 }

--- a/suite-native/icons/src/PaymentMethodLogo.tsx
+++ b/suite-native/icons/src/PaymentMethodLogo.tsx
@@ -3,7 +3,7 @@ import { Image } from 'expo-image';
 import { type PaymentMethodLogoName, paymentMethodLogos } from '@suite-common/icons';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
-export type PaymentMethodLogoProps = {
+type PaymentMethodLogoProps = {
     paymentMethodLogoName: PaymentMethodLogoName;
     size?: number;
 };


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into small isolated PRs for easy, low-risk review.

Unexport intra-file CryptoIconWithNetworkProps, NetworkIconProps and PaymentMethodLogoProps in @suite-native/icons.

The full staging branch is green (type-check + lint + format + depcheck); CI verifies this subset independently.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-native-icons&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->