### PR TITLE
chore(suite-native): remove dead ScreenFooterGradient and unused nav types

### DIFF
--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -64,7 +64,7 @@ export type DeviceSuspicionCause =
     | 'securitySeal'
     | 'packaging';
 
-export type DeviceCompromisedModalFailedCheck =
+type DeviceCompromisedModalFailedCheck =
     | 'device-id'
     | 'device-invariability'
     | 'device-authenticity'
@@ -91,13 +91,13 @@ export type YieldFlowParams = {
     yieldId?: string;
 };
 
-export type YieldInsufficientBalanceParams = {
+type YieldInsufficientBalanceParams = {
     accountKey: AccountKey;
     tokenContract: TokenAddress;
     yieldId: string;
 };
 
-export type YieldDepositApprovalReviewParams = YieldFlowParams & {
+type YieldDepositApprovalReviewParams = YieldFlowParams & {
     amount: string;
     approvalLimitType: 'per-deposit' | 'unlimited';
 };

--- a/suite-native/navigation/src/types.tsx
+++ b/suite-native/navigation/src/types.tsx
@@ -14,7 +14,6 @@ import { type IconName } from '@suite-native/icons';
 
 import { type AppTabsRoutes } from './routes';
 
-export type TabProps<T extends ParamListBase, K extends keyof T> = BottomTabScreenProps<T, K>;
 export type TabNavigationProp<
     T extends ParamListBase,
     K extends keyof ParamListBase,


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into small isolated PRs for easy, low-risk review.

Delete the unused ScreenFooterGradient component and unexport unused navigation types in @suite-native/navigation.

The full staging branch is green; CI verifies this subset independently.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-native-navigation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->