### PR TITLE
chore(token-definitions): unexport selectors

### DIFF
--- a/suite-common/token-definitions/src/tokenDefinitionsActions.ts
+++ b/suite-common/token-definitions/src/tokenDefinitionsActions.ts
@@ -4,7 +4,7 @@ import { type NetworkSymbol } from '@suite-common/wallet-config';
 
 import { type DefinitionType, type TokenManagementAction } from './tokenDefinitionsTypes';
 
-export const TOKEN_DEFINITIONS_PREFIX = '@common/token-definitions';
+const TOKEN_DEFINITIONS_PREFIX = '@common/token-definitions';
 
 const setTokenStatus = createAction(
     `${TOKEN_DEFINITIONS_PREFIX}/setTokenStatus`,

--- a/suite-common/token-definitions/src/tokenDefinitionsSelectors.ts
+++ b/suite-common/token-definitions/src/tokenDefinitionsSelectors.ts
@@ -24,7 +24,7 @@ export const selectCoinDefinitions = (state: TokenDefinitionsRootState, symbol: 
 export const selectNftDefinitions = (state: TokenDefinitionsRootState, symbol: NetworkSymbol) =>
     state.tokenDefinitions?.[symbol]?.nft;
 
-export const selectCoinDefinition = (
+const selectCoinDefinition = (
     state: TokenDefinitionsRootState,
     symbol: NetworkSymbol,
     contractAddress: TokenAddress,


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into small isolated PRs for easy, low-risk review.

Unexport intra-file TOKEN_DEFINITIONS_PREFIX and selectCoinDefinition.

The full staging branch is green; CI verifies this subset independently.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files (tokenDefinitionsActions.ts and tokenDefinitionsSelectors.ts) are broadly imported across all 121 E2E tests as global dependencies, but their functional impact is concentrated in flows that deal with token/asset discovery, display, and trading. The highest risk areas are asset discovery (where token definitions are fetched and used to classify tokens), dashboard asset display, and trading flows involving specific tokens (SPL tokens, ERC-20 tokens). The recommended strategy focuses on tests that directly exercise token-aware functionality — asset activation, wallet discovery, and token trading — rather than tests that merely transitively import these modules (e.g., backup, onboarding, analytics tests).

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/token-definitions/src/tokenDefinitionsActions.ts`
- `suite-common/token-definitions/src/tokenDefinitionsSelectors.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — Token definitions actions and selectors directly affect how assets are displayed, discovered, and activated. This test exercises enabling new assets (ETH) via the Activate Assets modal, verifying asset contents in grid/table views, and discovery completion — all flows that depend on token definitions for rendering asset information correctly.
- `suite/e2e/tests/wallet/discovery.test.ts` — Token definitions are fetched during wallet discovery to identify and classify tokens across multiple networks. This test activates 8 different coins and verifies discovery completes successfully with visible balances, directly exercising the token definition fetching and selection pipeline.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/trading/buy-solana-token.test.ts` — Buying a Solana SPL token (Jupiter/JUP) requires token definitions to resolve token metadata, display token names, and handle the asset picker filtering by network. Changes to token definition selectors could affect token identification in the trading flow.
- `suite/e2e/tests/trading/navigation.test.ts` — This test navigates to buy/sell/swap forms for specific tokens (TrueUSD, USDC on Ethereum), which requires token definitions to resolve token metadata and display correct token names in the trading forms. Token definition selector changes could affect token identification.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Selling an ERC-20 token (USDC) involves token definition lookups to display the correct token name and symbol in the sell form, quotes, and device prompt. Changes to selectors could affect how token metadata is resolved.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Swapping a Solana USDT token to Bitcoin relies on token definitions to identify SPL tokens, display token metadata, and resolve crypto IDs. Token definition action/selector changes could affect token resolution in the swap flow.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Swapping between two SPL tokens (USDT to USDC) on Solana requires token definitions for both sell and buy assets. This is a token-heavy flow where changes to token definition resolution could cause failures in asset identification.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — This test swaps a token (USDT on Solana) to an asset on a disabled network (XLM), testing that token definitions and provider info are correctly resolved even when the target network is not enabled. Token selector changes could affect this edge case.
- `suite/e2e/tests/settings/coins.test.ts` — This test exercises enabling/disabling networks and activating assets via the Activate Assets modal on the dashboard. Token definitions are involved in determining which assets are available and how they're displayed during activation flows.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — Configuring custom blockbook backends and completing discovery involves token definition fetching as part of the discovery pipeline. While less token-specific than other tests, a regression in token definition actions could prevent discovery from completing.

</details>

_Updated: 2026-06-21T14:54:35.923Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-token-definitions&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-token-definitions&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-token-definitions&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy BTC > Buy Bitcoin from best offer | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-21T14:58:54.675Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-21T14:57:55.103Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-token-definitions/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-token-definitions/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- BLAME-AUTHORS -->
**Author(s) of the removed code** (via `git blame`): @tomasklim — please confirm this code is genuinely dead and safe to delete, and not intentional preparation. 🙏