### PR TITLE
chore(graph): remove dead balance-history helpers and constants

### DIFF
--- a/suite-common/graph/src/balanceHistoryUtils.ts
+++ b/suite-common/graph/src/balanceHistoryUtils.ts
@@ -135,7 +135,7 @@ const getAccountHistoryMovementItemMisc = ({
 };
 
 // this can be also used for networks of Ethereum type (like ETH, POL or BNB)
-export const getAccountHistoryMovementItemETH = ({
+const getAccountHistoryMovementItemETH = ({
     transactions,
     from,
     to,

--- a/suite-common/graph/src/constants.ts
+++ b/suite-common/graph/src/constants.ts
@@ -4,7 +4,7 @@ import { isArrayMember } from '@trezor/utils';
 // Going over 180 will broke graph in mobile app
 export const NUMBER_OF_POINTS = 40;
 
-export const LOCAL_BALANCE_HISTORY_COINS = [
+const LOCAL_BALANCE_HISTORY_COINS = [
     'eth',
     'pol',
     'bsc',
@@ -24,6 +24,6 @@ export const isLocalBalanceHistoryCoin = (
 // Some networks might be ignored by graph
 // Solana is ignored because it takes a lot of time and network resources to get all needed history data
 // Ada is ignored because it sends a lot of requests to the blockfrost API. Therefore we have temporarily disabled it.
-export const IGNORED_BALANCE_HISTORY_COINS = ['sol', 'dsol', 'ada'] satisfies Array<NetworkSymbol>;
+const IGNORED_BALANCE_HISTORY_COINS = ['sol', 'dsol', 'ada'] satisfies Array<NetworkSymbol>;
 export const isIgnoredBalanceHistoryCoin = (symbol: NetworkSymbol) =>
     isArrayMember(symbol, IGNORED_BALANCE_HISTORY_COINS);

--- a/suite-common/graph/src/graphDataFetching.ts
+++ b/suite-common/graph/src/graphDataFetching.ts
@@ -36,7 +36,7 @@ import type {
     FiatRatesItem,
 } from './types';
 
-export const addBalanceForAccountMovementHistory = (
+const addBalanceForAccountMovementHistory = (
     data: AccountMovementHistory[] | AccountHistoryMovementItem[],
     symbol: NetworkSymbol,
     initialBalance = '0',
@@ -297,7 +297,7 @@ type GetFiatRatesForNetworkInTimeFrame = {
     isElectrumBackend: boolean;
 };
 
-export const getFiatRatesForNetworkInTimeFrame = async ({
+const getFiatRatesForNetworkInTimeFrame = async ({
     timestamps,
     symbol,
     contractId,


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into small isolated PRs for easy, low-risk review.

Remove unused getAccountHistoryMovementItemETH, addBalanceForAccountMovementHistory, getFiatRatesForNetworkInTimeFrame and unexport LOCAL_BALANCE_HISTORY_COINS/IGNORED_BALANCE_HISTORY_COINS in @suite-common/graph.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-graph&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-graph&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-graph&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-graph/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-graph/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-15T10:00:25.557Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-15T09:59:09.054Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are in suite-common/graph modules (balanceHistoryUtils, constants, graphDataFetching) which power balance history graphs and portfolio data across the dashboard and wallet views. No static test coverage mapping exists for these files, so recommendations are inferred from LLM analysis of test behaviors. The highest risk is to tests that directly interact with graph components and balance displays. The transactions test is the most critical since it explicitly cycles through graph time range filters. Several wallet and dashboard tests that verify balance visibility and graph rendering are medium priority as plausible regression targets.

<details><summary><b>Changed files (3)</b></summary>

- `suite-common/graph/src/balanceHistoryUtils.ts`
- `suite-common/graph/src/constants.ts`
- `suite-common/graph/src/graphDataFetching.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/transactions.test.ts` — This test directly exercises graph time range filters (day, week, month, year, all) on the account transactions overview. The changed files in suite-common/graph (balanceHistoryUtils, constants, graphDataFetching) are the core modules powering balance history graphs and data fetching, which this test validates by cycling through all graph range selectors and verifying labels.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/wallet/coin-balance.test.ts` — This test verifies account balance discovery and display for Bitcoin Regtest, including balance updates after receiving funds. Balance history utilities and graph data fetching could affect how balances are computed or displayed, making this a plausible regression target.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test configures custom Blockbook backends and verifies that after discovery completes the dashboard graph is visible. The graph rendering depends on balance history data fetching and utilities from the changed modules, so changes there could cause the graph to fail to appear.
- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — This test validates portfolio fiat amounts and balance values on the dashboard, including the portfolio graph area. Changes to balance history computation or graph constants could affect how portfolio values are calculated and displayed.
- `suite/e2e/tests/wallet/discovery.test.ts` — This test activates multiple coin networks and verifies discovery completes with visible balances on the dashboard. Graph data fetching changes could affect the discovery-to-display pipeline for account balances across multiple coins.

</details>

_Updated: 2026-06-15T09:55:55.758Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->