### PR TITLE
Auto-start signing in native staking review

### DIFF
--- a/suite-native/module-earn/package.json
+++ b/suite-native/module-earn/package.json
@@ -58,6 +58,7 @@
         "@suite-native/settings": "workspace:*",
         "@suite-native/staking": "workspace:*",
         "@suite-native/test-utils": "workspace:*",
+        "@suite-native/test-utils-store": "workspace:*",
         "@suite-native/transaction-management": "workspace:*",
         "@suite-native/transactions": "workspace:*",
         "@suite-native/tx-simulation": "workspace:*",

--- a/suite-native/module-earn/src/components/ClaimTransactionDataReviewStepList.tsx
+++ b/suite-native/module-earn/src/components/ClaimTransactionDataReviewStepList.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { View } from 'react-native';
 import { useSelector } from 'react-redux';
 
@@ -7,8 +6,7 @@ import { type RouteProp, useRoute } from '@react-navigation/native';
 import { getNetworkDecimals } from '@suite-common/wallet-config';
 import { type AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
 import { isSupportedSolStakingNetworkSymbol } from '@suite-common/wallet-utils';
-import { Button, VStack } from '@suite-native/atoms';
-import { Translation } from '@suite-native/intl';
+import { VStack } from '@suite-native/atoms';
 import { type RootStackParamList, type RootStackRoutes } from '@suite-native/navigation';
 import {
     selectClaimableAmountByAccountKey,
@@ -19,7 +17,6 @@ import {
     SlidingFooterOverlay,
     type TransactionReviewOutputsState,
     selectIsTransactionAlreadySigned,
-    selectIsTransactionReviewInProgress,
     selectReviewSummaryOutput,
     useActiveStepOffset,
 } from '@suite-native/transaction-management';
@@ -29,23 +26,13 @@ import { ClaimOutputItem } from './ClaimOutputItem';
 import { ClaimSummaryOutputItem } from './ClaimSummaryOutputItem';
 import { useEarnSelectedPrecomposedTransaction } from '../hooks/useEarnSelectedPrecomposedTransaction';
 
-const NUMBER_OF_STEPS = 2;
-
 type RouteProps = RouteProp<RootStackParamList, RootStackRoutes.ClaimTransactionDataReview>;
 
-type ClaimTransactionDataReviewStepListProps = {
-    onSign: () => Promise<boolean>;
-};
-
-export const ClaimTransactionDataReviewStepList = ({
-    onSign,
-}: ClaimTransactionDataReviewStepListProps) => {
+export const ClaimTransactionDataReviewStepList = () => {
     const route = useRoute<RouteProps>();
     const { accountKey } = route.params;
 
-    const isTransactionReviewInProgress = useSelector((state: TransactionReviewOutputsState) =>
-        selectIsTransactionReviewInProgress(state, 'claim', accountKey),
-    );
+    const isSigned = useSelector(selectIsTransactionAlreadySigned);
 
     const summaryOutput = useSelector((state: TransactionReviewOutputsState) =>
         selectReviewSummaryOutput(state, 'claim', accountKey),
@@ -61,26 +48,12 @@ export const ClaimTransactionDataReviewStepList = ({
 
     const precomposedTransaction = useEarnSelectedPrecomposedTransaction('claim', accountKey);
 
-    const isTransactionAlreadySigned = useSelector(selectIsTransactionAlreadySigned);
+    // The summary card only unlocks once every device output has been confirmed, which is exactly when
+    // selectReviewSummaryOutput exposes a state.
+    const isSummaryActive = !!summaryOutput?.state;
+    const activeStep = isSummaryActive ? 1 : 0;
 
-    const [stepIndex, setStepIndex] = useState(0);
-
-    const { activeStepBottomOffset, handleReadListItemHeight } = useActiveStepOffset(stepIndex);
-
-    const isLastStep = stepIndex === NUMBER_OF_STEPS - 1;
-    const areAllStepsDone = isLastStep || isTransactionReviewInProgress;
-
-    const handleNextStep = async () => {
-        if (stepIndex === NUMBER_OF_STEPS - 2) {
-            const didSign = await onSign();
-
-            if (!didSign) {
-                return;
-            }
-        }
-
-        setStepIndex(prevStepIndex => prevStepIndex + 1);
-    };
+    const { activeStepBottomOffset, handleReadListItemHeight } = useActiveStepOffset(activeStep);
 
     const networkDecimals = accountSymbol ? (getNetworkDecimals(accountSymbol) ?? 18) : 18;
     const isSolanaClaim = !!accountSymbol && isSupportedSolStakingNetworkSymbol(accountSymbol);
@@ -102,7 +75,7 @@ export const ClaimTransactionDataReviewStepList = ({
                 {!!accountSymbol && (
                     <ClaimOutputItem
                         symbol={accountSymbol}
-                        outputState={isTransactionAlreadySigned ? 'success' : 'active'}
+                        outputState={isSigned || isSummaryActive ? 'success' : 'active'}
                         onLayout={event => handleReadListItemHeight(event, 0)}
                     />
                 )}
@@ -112,18 +85,12 @@ export const ClaimTransactionDataReviewStepList = ({
                         accountKey={accountKey}
                         claimableAmountInWei={claimableAmountInWei}
                         fee={summaryOutput?.fee ?? precomposedTransaction?.fee ?? '0'}
-                        outputState={summaryOutput?.state ?? (isLastStep ? 'active' : undefined)}
+                        outputState={summaryOutput?.state}
                         onLayout={event => handleReadListItemHeight(event, 1)}
                     />
                 )}
             </VStack>
-            {!areAllStepsDone && (
-                <SlidingFooterOverlay activeStepOffset={activeStepBottomOffset}>
-                    <Button onPress={handleNextStep} testID="@earn/claim-review-continue">
-                        <Translation id="generic.buttons.next" />
-                    </Button>
-                </SlidingFooterOverlay>
-            )}
+            {!isSigned && <SlidingFooterOverlay activeStepOffset={activeStepBottomOffset} />}
         </View>
     );
 };

--- a/suite-native/module-earn/src/components/EarnTransactionDataReviewStepList.tsx
+++ b/suite-native/module-earn/src/components/EarnTransactionDataReviewStepList.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { View } from 'react-native';
 import { useSelector } from 'react-redux';
 
@@ -9,14 +8,12 @@ import {
     isSupportedSolStakingNetworkSymbol,
     unitsToSubunits,
 } from '@suite-common/wallet-utils';
-import { Button, VStack } from '@suite-native/atoms';
-import { Translation } from '@suite-native/intl';
+import { VStack } from '@suite-native/atoms';
 import {
     LIST_VERTICAL_SPACING,
     SlidingFooterOverlay,
     type TransactionReviewOutputsState,
     selectIsTransactionAlreadySigned,
-    selectIsTransactionReviewInProgress,
     selectReviewSummaryOutput,
     useActiveStepOffset,
 } from '@suite-native/transaction-management';
@@ -26,24 +23,18 @@ import { EarnStakeOutputItem } from './EarnStakeOutputItem';
 import { EarnSummaryOutputItem } from './EarnSummaryOutputItem';
 import { useEarnSelectedPrecomposedTransaction } from '../hooks/useEarnSelectedPrecomposedTransaction';
 
-const NUMBER_OF_STEPS = 2;
-
 type EarnTransactionDataReviewStepListProps = {
     accountKey: AccountKey;
     amount: string;
     accountSymbol: NetworkSymbol;
-    onSign: () => Promise<boolean>;
 };
 
 export const EarnTransactionDataReviewStepList = ({
     accountKey,
     amount,
     accountSymbol,
-    onSign,
 }: EarnTransactionDataReviewStepListProps) => {
-    const isTransactionReviewInProgress = useSelector((state: TransactionReviewOutputsState) =>
-        selectIsTransactionReviewInProgress(state, 'stake', accountKey),
-    );
+    const isSigned = useSelector(selectIsTransactionAlreadySigned);
 
     const summaryOutput = useSelector((state: TransactionReviewOutputsState) =>
         selectReviewSummaryOutput(state, 'stake', accountKey),
@@ -51,26 +42,12 @@ export const EarnTransactionDataReviewStepList = ({
 
     const selectedPrecomposed = useEarnSelectedPrecomposedTransaction('stake', accountKey);
 
-    const isTransactionAlreadySigned = useSelector(selectIsTransactionAlreadySigned);
+    // The Trezor reveals the staking step first, then the summary. The summary card only unlocks once every
+    // device output has been confirmed, which is exactly when selectReviewSummaryOutput exposes a state.
+    const isSummaryActive = !!summaryOutput?.state;
+    const activeStep = isSummaryActive ? 1 : 0;
 
-    const [stepIndex, setStepIndex] = useState(0);
-
-    const { activeStepBottomOffset, handleReadListItemHeight } = useActiveStepOffset(stepIndex);
-
-    const isLastStep = stepIndex === NUMBER_OF_STEPS - 1;
-    const areAllStepsDone = isLastStep || isTransactionReviewInProgress;
-
-    const handleNextStep = async () => {
-        if (stepIndex === NUMBER_OF_STEPS - 2) {
-            const didSign = await onSign();
-
-            if (!didSign) {
-                return;
-            }
-        }
-
-        setStepIndex(prevStepIndex => prevStepIndex + 1);
-    };
+    const { activeStepBottomOffset, handleReadListItemHeight } = useActiveStepOffset(activeStep);
 
     const amountInBaseUnits = unitsToSubunits({
         value: asAmountUnit(new BigNumber(amount)),
@@ -90,7 +67,7 @@ export const EarnTransactionDataReviewStepList = ({
             <VStack spacing={LIST_VERTICAL_SPACING}>
                 <EarnStakeOutputItem
                     symbol={accountSymbol}
-                    outputState={isTransactionAlreadySigned ? 'success' : 'active'}
+                    outputState={isSigned || isSummaryActive ? 'success' : 'active'}
                     onLayout={event => handleReadListItemHeight(event, 0)}
                 />
 
@@ -98,17 +75,11 @@ export const EarnTransactionDataReviewStepList = ({
                     accountKey={accountKey}
                     amount={displayedAmountInBaseUnits}
                     fee={summaryOutput?.fee ?? selectedPrecomposed?.fee ?? '0'}
-                    outputState={summaryOutput?.state ?? (isLastStep ? 'active' : undefined)}
+                    outputState={summaryOutput?.state}
                     onLayout={event => handleReadListItemHeight(event, 1)}
                 />
             </VStack>
-            {!areAllStepsDone && (
-                <SlidingFooterOverlay activeStepOffset={activeStepBottomOffset}>
-                    <Button onPress={handleNextStep} testID="@earn/address-review-continue">
-                        <Translation id="generic.buttons.next" />
-                    </Button>
-                </SlidingFooterOverlay>
-            )}
+            {!isSigned && <SlidingFooterOverlay activeStepOffset={activeStepBottomOffset} />}
         </View>
     );
 };

--- a/suite-native/module-earn/src/components/UnstakeTransactionDataReviewStepList.tsx
+++ b/suite-native/module-earn/src/components/UnstakeTransactionDataReviewStepList.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { View } from 'react-native';
 import { useSelector } from 'react-redux';
 
@@ -6,15 +5,13 @@ import { type RouteProp, useRoute } from '@react-navigation/native';
 
 import { type AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
 import { asAmountUnit, unitsToSubunits } from '@suite-common/wallet-utils';
-import { Button, VStack } from '@suite-native/atoms';
-import { Translation } from '@suite-native/intl';
+import { VStack } from '@suite-native/atoms';
 import { type RootStackParamList, type RootStackRoutes } from '@suite-native/navigation';
 import {
     LIST_VERTICAL_SPACING,
     SlidingFooterOverlay,
     type TransactionReviewOutputsState,
     selectIsTransactionAlreadySigned,
-    selectIsTransactionReviewInProgress,
     selectReviewSummaryOutput,
     useActiveStepOffset,
 } from '@suite-native/transaction-management';
@@ -24,23 +21,13 @@ import { EarnSummaryOutputItem } from './EarnSummaryOutputItem';
 import { UnstakeOutputItem } from './UnstakeOutputItem';
 import { useEarnSelectedPrecomposedTransaction } from '../hooks/useEarnSelectedPrecomposedTransaction';
 
-const NUMBER_OF_STEPS = 2;
-
 type RouteProps = RouteProp<RootStackParamList, RootStackRoutes.UnstakeTransactionDataReview>;
 
-type UnstakeTransactionDataReviewStepListProps = {
-    onSign: () => Promise<boolean>;
-};
-
-export const UnstakeTransactionDataReviewStepList = ({
-    onSign,
-}: UnstakeTransactionDataReviewStepListProps) => {
+export const UnstakeTransactionDataReviewStepList = () => {
     const route = useRoute<RouteProps>();
     const { accountKey, amount } = route.params;
 
-    const isTransactionReviewInProgress = useSelector((state: TransactionReviewOutputsState) =>
-        selectIsTransactionReviewInProgress(state, 'unstake', accountKey),
-    );
+    const isSigned = useSelector(selectIsTransactionAlreadySigned);
 
     const summaryOutput = useSelector((state: TransactionReviewOutputsState) =>
         selectReviewSummaryOutput(state, 'unstake', accountKey),
@@ -48,34 +35,20 @@ export const UnstakeTransactionDataReviewStepList = ({
 
     const selectedPrecomposed = useEarnSelectedPrecomposedTransaction('unstake', accountKey);
 
-    const isTransactionAlreadySigned = useSelector(selectIsTransactionAlreadySigned);
-
     const accountSymbol = useSelector((state: AccountsRootState) =>
         selectAccountNetworkSymbol(state, accountKey),
     );
 
-    const [stepIndex, setStepIndex] = useState(0);
+    // The summary card only unlocks once every device output has been confirmed, which is exactly when
+    // selectReviewSummaryOutput exposes a state.
+    const isSummaryActive = !!summaryOutput?.state;
+    const activeStep = isSummaryActive ? 1 : 0;
 
-    const { activeStepBottomOffset, handleReadListItemHeight } = useActiveStepOffset(stepIndex);
+    const { activeStepBottomOffset, handleReadListItemHeight } = useActiveStepOffset(activeStep);
 
     if (!accountSymbol) {
         return null;
     }
-
-    const isLastStep = stepIndex === NUMBER_OF_STEPS - 1;
-    const areAllStepsDone = isLastStep || isTransactionReviewInProgress;
-
-    const handleNextStep = async () => {
-        if (stepIndex === NUMBER_OF_STEPS - 2) {
-            const didSign = await onSign();
-
-            if (!didSign) {
-                return;
-            }
-        }
-
-        setStepIndex(prevStepIndex => prevStepIndex + 1);
-    };
 
     const amountInBaseUnits = unitsToSubunits({
         value: asAmountUnit(new BigNumber(amount)),
@@ -87,7 +60,7 @@ export const UnstakeTransactionDataReviewStepList = ({
             <VStack spacing={LIST_VERTICAL_SPACING}>
                 <UnstakeOutputItem
                     symbol={accountSymbol}
-                    outputState={isTransactionAlreadySigned ? 'success' : 'active'}
+                    outputState={isSigned || isSummaryActive ? 'success' : 'active'}
                     onLayout={event => handleReadListItemHeight(event, 0)}
                 />
 
@@ -95,17 +68,11 @@ export const UnstakeTransactionDataReviewStepList = ({
                     accountKey={accountKey}
                     amount={amountInBaseUnits}
                     fee={summaryOutput?.fee ?? selectedPrecomposed?.fee ?? '0'}
-                    outputState={summaryOutput?.state ?? (isLastStep ? 'active' : undefined)}
+                    outputState={summaryOutput?.state}
                     onLayout={event => handleReadListItemHeight(event, 1)}
                 />
             </VStack>
-            {!areAllStepsDone && (
-                <SlidingFooterOverlay activeStepOffset={activeStepBottomOffset}>
-                    <Button onPress={handleNextStep} testID="@earn/unstake-review-continue">
-                        <Translation id="generic.buttons.next" />
-                    </Button>
-                </SlidingFooterOverlay>
-            )}
+            {!isSigned && <SlidingFooterOverlay activeStepOffset={activeStepBottomOffset} />}
         </View>
     );
 };

--- a/suite-native/module-earn/src/components/__tests__/ClaimTransactionDataReviewStepList.test.tsx
+++ b/suite-native/module-earn/src/components/__tests__/ClaimTransactionDataReviewStepList.test.tsx
@@ -1,0 +1,122 @@
+import { mockAccountKey } from '@suite-common/wallet-types/mocks';
+import { renderWithStoreProvider } from '@suite-native/test-utils-store';
+import { type ReviewSummaryOutput } from '@suite-native/transaction-management';
+
+import { ClaimTransactionDataReviewStepList } from '../ClaimTransactionDataReviewStepList';
+
+const mockClaimOutputItem = jest.fn();
+const mockClaimSummaryOutputItem = jest.fn();
+
+let mockIsTransactionAlreadySigned: boolean;
+let mockSummaryOutput: ReviewSummaryOutput | null;
+let mockAccountNetworkSymbol: string | null;
+
+const accountKey = mockAccountKey({ symbol: 'eth', descriptor: 'ethAccount' });
+
+jest.mock('@react-navigation/native', () => ({
+    ...jest.requireActual('@react-navigation/native'),
+    useRoute: () => ({ params: { accountKey } }),
+}));
+
+jest.mock('@suite-native/transaction-management', () => ({
+    ...jest.requireActual('@suite-native/transaction-management'),
+    selectIsTransactionAlreadySigned: () => mockIsTransactionAlreadySigned,
+    selectReviewSummaryOutput: () => mockSummaryOutput,
+}));
+
+jest.mock('@suite-common/wallet-core', () => ({
+    ...jest.requireActual('@suite-common/wallet-core'),
+    selectAccountNetworkSymbol: () => mockAccountNetworkSymbol,
+}));
+
+jest.mock('@suite-native/staking', () => ({
+    ...jest.requireActual('@suite-native/staking'),
+    selectClaimableAmountByAccountKey: () => '5',
+}));
+
+jest.mock('../ClaimOutputItem', () => ({
+    ClaimOutputItem: (props: { outputState?: string }) => {
+        mockClaimOutputItem(props);
+
+        return null;
+    },
+}));
+
+jest.mock('../ClaimSummaryOutputItem', () => ({
+    ClaimSummaryOutputItem: (props: { outputState?: string; fee?: string }) => {
+        mockClaimSummaryOutputItem(props);
+
+        return null;
+    },
+}));
+
+jest.mock('../../hooks/useEarnSelectedPrecomposedTransaction', () => ({
+    useEarnSelectedPrecomposedTransaction: () => ({ fee: '21000', totalSpent: '5' }),
+}));
+
+const renderStepList = () => renderWithStoreProvider(<ClaimTransactionDataReviewStepList />);
+
+describe('ClaimTransactionDataReviewStepList', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockIsTransactionAlreadySigned = false;
+        mockSummaryOutput = null;
+        mockAccountNetworkSymbol = 'eth';
+    });
+
+    it('renders the claim and summary cards without a Next button', () => {
+        const { queryByText, queryByTestId } = renderStepList();
+
+        expect(mockClaimOutputItem).toHaveBeenCalledTimes(1);
+        expect(mockClaimSummaryOutputItem).toHaveBeenCalledTimes(1);
+        expect(queryByText('Next')).toBeNull();
+        expect(queryByTestId('@earn/claim-review-continue')).toBeNull();
+    });
+
+    it('keeps the claim step active and the summary hidden until the device confirms the outputs', () => {
+        mockSummaryOutput = null;
+
+        renderStepList();
+
+        expect(mockClaimOutputItem).toHaveBeenCalledWith(
+            expect.objectContaining({ outputState: 'active' }),
+        );
+        expect(mockClaimSummaryOutputItem).toHaveBeenCalledWith(
+            expect.objectContaining({ outputState: undefined }),
+        );
+    });
+
+    it('marks the claim step done and activates the summary once all device outputs are confirmed', () => {
+        mockSummaryOutput = { state: 'active', totalSpent: '5', fee: '21000' };
+
+        renderStepList();
+
+        expect(mockClaimOutputItem).toHaveBeenCalledWith(
+            expect.objectContaining({ outputState: 'success' }),
+        );
+        expect(mockClaimSummaryOutputItem).toHaveBeenCalledWith(
+            expect.objectContaining({ outputState: 'active' }),
+        );
+    });
+
+    it('marks both steps done and hides the sliding footer once the transaction is signed', () => {
+        mockIsTransactionAlreadySigned = true;
+        mockSummaryOutput = { state: 'success', totalSpent: '5', fee: '21000' };
+
+        const { queryByTestId } = renderStepList();
+
+        expect(mockClaimOutputItem).toHaveBeenCalledWith(
+            expect.objectContaining({ outputState: 'success' }),
+        );
+        expect(mockClaimSummaryOutputItem).toHaveBeenCalledWith(
+            expect.objectContaining({ outputState: 'success' }),
+        );
+        expect(queryByTestId('sliding-footer-overlay')).toBeNull();
+    });
+
+    it('shows the sliding footer while the transaction is not signed', () => {
+        const { getByTestId } = renderStepList();
+
+        expect(getByTestId('sliding-footer-overlay')).toBeOnTheScreen();
+    });
+});

--- a/suite-native/module-earn/src/components/__tests__/EarnTransactionDataReviewStepList.test.tsx
+++ b/suite-native/module-earn/src/components/__tests__/EarnTransactionDataReviewStepList.test.tsx
@@ -1,0 +1,112 @@
+import { mockAccountKey } from '@suite-common/wallet-types/mocks';
+import { renderWithStoreProvider } from '@suite-native/test-utils-store';
+import { type ReviewSummaryOutput } from '@suite-native/transaction-management';
+
+import { EarnTransactionDataReviewStepList } from '../EarnTransactionDataReviewStepList';
+
+const mockEarnStakeOutputItem = jest.fn();
+const mockEarnSummaryOutputItem = jest.fn();
+
+let mockIsTransactionAlreadySigned: boolean;
+let mockSummaryOutput: ReviewSummaryOutput | null;
+
+jest.mock('@suite-native/transaction-management', () => ({
+    ...jest.requireActual('@suite-native/transaction-management'),
+    selectIsTransactionAlreadySigned: () => mockIsTransactionAlreadySigned,
+    selectReviewSummaryOutput: () => mockSummaryOutput,
+}));
+
+jest.mock('../EarnStakeOutputItem', () => ({
+    EarnStakeOutputItem: (props: { outputState?: string }) => {
+        mockEarnStakeOutputItem(props);
+
+        return null;
+    },
+}));
+
+jest.mock('../EarnSummaryOutputItem', () => ({
+    EarnSummaryOutputItem: (props: { outputState?: string; fee?: string }) => {
+        mockEarnSummaryOutputItem(props);
+
+        return null;
+    },
+}));
+
+jest.mock('../../hooks/useEarnSelectedPrecomposedTransaction', () => ({
+    useEarnSelectedPrecomposedTransaction: () => ({ fee: '21000' }),
+}));
+
+const accountKey = mockAccountKey({ symbol: 'eth', descriptor: 'ethAccount' });
+
+const renderStepList = () =>
+    renderWithStoreProvider(
+        <EarnTransactionDataReviewStepList
+            accountKey={accountKey}
+            amount="1"
+            accountSymbol="eth"
+        />,
+    );
+
+describe('EarnTransactionDataReviewStepList', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockIsTransactionAlreadySigned = false;
+        mockSummaryOutput = null;
+    });
+
+    it('renders the stake and summary cards without a Next button', () => {
+        const { queryByText, queryByTestId } = renderStepList();
+
+        expect(mockEarnStakeOutputItem).toHaveBeenCalledTimes(1);
+        expect(mockEarnSummaryOutputItem).toHaveBeenCalledTimes(1);
+        expect(queryByText('Next')).toBeNull();
+        expect(queryByTestId('@earn/address-review-continue')).toBeNull();
+    });
+
+    it('keeps the stake step active and the summary hidden until the device confirms the outputs', () => {
+        mockSummaryOutput = null;
+
+        renderStepList();
+
+        expect(mockEarnStakeOutputItem).toHaveBeenCalledWith(
+            expect.objectContaining({ outputState: 'active' }),
+        );
+        expect(mockEarnSummaryOutputItem).toHaveBeenCalledWith(
+            expect.objectContaining({ outputState: undefined }),
+        );
+    });
+
+    it('marks the stake step done and activates the summary once all device outputs are confirmed', () => {
+        mockSummaryOutput = { state: 'active', totalSpent: '1', fee: '21000' };
+
+        renderStepList();
+
+        expect(mockEarnStakeOutputItem).toHaveBeenCalledWith(
+            expect.objectContaining({ outputState: 'success' }),
+        );
+        expect(mockEarnSummaryOutputItem).toHaveBeenCalledWith(
+            expect.objectContaining({ outputState: 'active' }),
+        );
+    });
+
+    it('marks both steps done and hides the sliding footer once the transaction is signed', () => {
+        mockIsTransactionAlreadySigned = true;
+        mockSummaryOutput = { state: 'success', totalSpent: '1', fee: '21000' };
+
+        const { queryByTestId } = renderStepList();
+
+        expect(mockEarnStakeOutputItem).toHaveBeenCalledWith(
+            expect.objectContaining({ outputState: 'success' }),
+        );
+        expect(mockEarnSummaryOutputItem).toHaveBeenCalledWith(
+            expect.objectContaining({ outputState: 'success' }),
+        );
+        expect(queryByTestId('sliding-footer-overlay')).toBeNull();
+    });
+
+    it('shows the sliding footer while the transaction is not signed', () => {
+        const { getByTestId } = renderStepList();
+
+        expect(getByTestId('sliding-footer-overlay')).toBeOnTheScreen();
+    });
+});

--- a/suite-native/module-earn/src/components/__tests__/UnstakeTransactionDataReviewStepList.test.tsx
+++ b/suite-native/module-earn/src/components/__tests__/UnstakeTransactionDataReviewStepList.test.tsx
@@ -1,0 +1,126 @@
+import { mockAccountKey } from '@suite-common/wallet-types/mocks';
+import { renderWithStoreProvider } from '@suite-native/test-utils-store';
+import { type ReviewSummaryOutput } from '@suite-native/transaction-management';
+
+import { UnstakeTransactionDataReviewStepList } from '../UnstakeTransactionDataReviewStepList';
+
+const mockUnstakeOutputItem = jest.fn();
+const mockEarnSummaryOutputItem = jest.fn();
+
+let mockIsTransactionAlreadySigned: boolean;
+let mockSummaryOutput: ReviewSummaryOutput | null;
+let mockAccountNetworkSymbol: string | null;
+
+const accountKey = mockAccountKey({ symbol: 'eth', descriptor: 'ethAccount' });
+
+jest.mock('@react-navigation/native', () => ({
+    ...jest.requireActual('@react-navigation/native'),
+    useRoute: () => ({ params: { accountKey, amount: '1' } }),
+}));
+
+jest.mock('@suite-native/transaction-management', () => ({
+    ...jest.requireActual('@suite-native/transaction-management'),
+    selectIsTransactionAlreadySigned: () => mockIsTransactionAlreadySigned,
+    selectReviewSummaryOutput: () => mockSummaryOutput,
+}));
+
+jest.mock('@suite-common/wallet-core', () => ({
+    ...jest.requireActual('@suite-common/wallet-core'),
+    selectAccountNetworkSymbol: () => mockAccountNetworkSymbol,
+}));
+
+jest.mock('../UnstakeOutputItem', () => ({
+    UnstakeOutputItem: (props: { outputState?: string }) => {
+        mockUnstakeOutputItem(props);
+
+        return null;
+    },
+}));
+
+jest.mock('../EarnSummaryOutputItem', () => ({
+    EarnSummaryOutputItem: (props: { outputState?: string; fee?: string }) => {
+        mockEarnSummaryOutputItem(props);
+
+        return null;
+    },
+}));
+
+jest.mock('../../hooks/useEarnSelectedPrecomposedTransaction', () => ({
+    useEarnSelectedPrecomposedTransaction: () => ({ fee: '21000' }),
+}));
+
+const renderStepList = () => renderWithStoreProvider(<UnstakeTransactionDataReviewStepList />);
+
+describe('UnstakeTransactionDataReviewStepList', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockIsTransactionAlreadySigned = false;
+        mockSummaryOutput = null;
+        mockAccountNetworkSymbol = 'eth';
+    });
+
+    it('renders nothing until the account network symbol is known', () => {
+        mockAccountNetworkSymbol = null;
+
+        renderStepList();
+
+        expect(mockUnstakeOutputItem).not.toHaveBeenCalled();
+        expect(mockEarnSummaryOutputItem).not.toHaveBeenCalled();
+    });
+
+    it('renders the unstake and summary cards without a Next button', () => {
+        const { queryByText, queryByTestId } = renderStepList();
+
+        expect(mockUnstakeOutputItem).toHaveBeenCalledTimes(1);
+        expect(mockEarnSummaryOutputItem).toHaveBeenCalledTimes(1);
+        expect(queryByText('Next')).toBeNull();
+        expect(queryByTestId('@earn/unstake-review-continue')).toBeNull();
+    });
+
+    it('keeps the unstake step active and the summary hidden until the device confirms the outputs', () => {
+        mockSummaryOutput = null;
+
+        renderStepList();
+
+        expect(mockUnstakeOutputItem).toHaveBeenCalledWith(
+            expect.objectContaining({ outputState: 'active' }),
+        );
+        expect(mockEarnSummaryOutputItem).toHaveBeenCalledWith(
+            expect.objectContaining({ outputState: undefined }),
+        );
+    });
+
+    it('marks the unstake step done and activates the summary once all device outputs are confirmed', () => {
+        mockSummaryOutput = { state: 'active', totalSpent: '1', fee: '21000' };
+
+        renderStepList();
+
+        expect(mockUnstakeOutputItem).toHaveBeenCalledWith(
+            expect.objectContaining({ outputState: 'success' }),
+        );
+        expect(mockEarnSummaryOutputItem).toHaveBeenCalledWith(
+            expect.objectContaining({ outputState: 'active' }),
+        );
+    });
+
+    it('marks both steps done and hides the sliding footer once the transaction is signed', () => {
+        mockIsTransactionAlreadySigned = true;
+        mockSummaryOutput = { state: 'success', totalSpent: '1', fee: '21000' };
+
+        const { queryByTestId } = renderStepList();
+
+        expect(mockUnstakeOutputItem).toHaveBeenCalledWith(
+            expect.objectContaining({ outputState: 'success' }),
+        );
+        expect(mockEarnSummaryOutputItem).toHaveBeenCalledWith(
+            expect.objectContaining({ outputState: 'success' }),
+        );
+        expect(queryByTestId('sliding-footer-overlay')).toBeNull();
+    });
+
+    it('shows the sliding footer while the transaction is not signed', () => {
+        const { getByTestId } = renderStepList();
+
+        expect(getByTestId('sliding-footer-overlay')).toBeOnTheScreen();
+    });
+});

--- a/suite-native/module-earn/src/hooks/__tests__/useAutoStartReview.test.tsx
+++ b/suite-native/module-earn/src/hooks/__tests__/useAutoStartReview.test.tsx
@@ -1,0 +1,155 @@
+import { renderHook, waitFor } from '@suite-native/test-utils';
+
+import { type ReviewAutoStartControls, useAutoStartReview } from '../useAutoStartReview';
+
+const mockWaitForDeviceReview = jest.fn();
+
+jest.mock('@suite-native/transaction-management', () => ({
+    useWaitForButtonRequest: jest.fn(() => mockWaitForDeviceReview),
+}));
+
+type Params = {
+    shouldAutoStartReview: boolean;
+    startReview: () => Promise<string>;
+    onDeviceReviewReady: () => void;
+    onReviewSettled: (result: string, controls: ReviewAutoStartControls) => void | Promise<void>;
+};
+
+const buildParams = (overrides: Partial<Params> = {}): Params => ({
+    shouldAutoStartReview: true,
+    startReview: jest.fn().mockResolvedValue('signed'),
+    onDeviceReviewReady: jest.fn(),
+    onReviewSettled: jest.fn(),
+    ...overrides,
+});
+
+describe('useAutoStartReview', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('starts the review once, arms the device-review reveal and forwards the outcome', async () => {
+        const params = buildParams();
+
+        renderHook(() => useAutoStartReview(params));
+
+        await waitFor(() => expect(params.startReview).toHaveBeenCalledTimes(1));
+        expect(mockWaitForDeviceReview).toHaveBeenCalledTimes(1);
+        await waitFor(() =>
+            expect(params.onReviewSettled).toHaveBeenCalledWith('signed', expect.any(Object)),
+        );
+    });
+
+    it('does not start the review while it is not allowed yet', () => {
+        const params = buildParams({ shouldAutoStartReview: false });
+
+        renderHook(() => useAutoStartReview(params));
+
+        expect(params.startReview).not.toHaveBeenCalled();
+        expect(mockWaitForDeviceReview).not.toHaveBeenCalled();
+    });
+
+    it('re-arms and retries the review when the settle handler calls allowRestart', async () => {
+        const startReview = jest
+            .fn()
+            .mockResolvedValueOnce('not-ready')
+            .mockResolvedValue('signed');
+        const onReviewSettled = jest.fn(
+            (result: string, { allowRestart }: ReviewAutoStartControls) => {
+                if (result === 'not-ready') {
+                    allowRestart();
+                }
+            },
+        );
+        const params = buildParams({ startReview, onReviewSettled });
+
+        const { rerender } = renderHook((props: Params) => useAutoStartReview(props), {
+            initialProps: params,
+        });
+
+        await waitFor(() => expect(onReviewSettled).toHaveBeenCalledTimes(1));
+
+        rerender({ ...params, shouldAutoStartReview: false });
+        rerender({ ...params, shouldAutoStartReview: true });
+
+        await waitFor(() => expect(startReview).toHaveBeenCalledTimes(2));
+    });
+
+    it('does not retry once a terminal outcome leaves the started ref set', async () => {
+        const startReview = jest.fn().mockResolvedValue('failed');
+        const params = buildParams({ startReview });
+
+        const { rerender } = renderHook((props: Params) => useAutoStartReview(props), {
+            initialProps: params,
+        });
+
+        await waitFor(() => expect(startReview).toHaveBeenCalledTimes(1));
+
+        rerender({ ...params, shouldAutoStartReview: false });
+        rerender({ ...params, shouldAutoStartReview: true });
+
+        expect(startReview).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-arms so the review can retry after startReview rejects', async () => {
+        const startReview = jest
+            .fn()
+            .mockRejectedValueOnce(new Error('boom'))
+            .mockResolvedValue('signed');
+        const params = buildParams({ startReview });
+
+        const { rerender } = renderHook((props: Params) => useAutoStartReview(props), {
+            initialProps: params,
+        });
+
+        await waitFor(() => expect(startReview).toHaveBeenCalledTimes(1));
+
+        rerender({ ...params, shouldAutoStartReview: false });
+        rerender({ ...params, shouldAutoStartReview: true });
+
+        await waitFor(() => expect(startReview).toHaveBeenCalledTimes(2));
+    });
+
+    it('re-arms when the settle handler rejects', async () => {
+        const onReviewSettled = jest
+            .fn()
+            .mockRejectedValueOnce(new Error('boom'))
+            .mockResolvedValue(undefined);
+        const params = buildParams({ onReviewSettled });
+
+        const { rerender } = renderHook((props: Params) => useAutoStartReview(props), {
+            initialProps: params,
+        });
+
+        await waitFor(() => expect(onReviewSettled).toHaveBeenCalledTimes(1));
+
+        rerender({ ...params, shouldAutoStartReview: false });
+        rerender({ ...params, shouldAutoStartReview: true });
+
+        await waitFor(() => expect(onReviewSettled).toHaveBeenCalledTimes(2));
+    });
+
+    it('does not settle the review after the component unmounts', async () => {
+        let resolveStart: (result: string) => void = () => {};
+        const startReview = jest.fn(
+            () =>
+                new Promise<string>(resolve => {
+                    resolveStart = resolve;
+                }),
+        );
+        const onReviewSettled = jest.fn();
+        const params = buildParams({ startReview, onReviewSettled });
+
+        const { unmount } = renderHook(() => useAutoStartReview(params));
+
+        await waitFor(() => expect(startReview).toHaveBeenCalledTimes(1));
+
+        unmount();
+        resolveStart('signed');
+        await new Promise<void>(resolve => {
+            setTimeout(resolve, 0);
+        });
+
+        expect(onReviewSettled).not.toHaveBeenCalled();
+    });
+});

--- a/suite-native/module-earn/src/hooks/__tests__/useEarnReviewAutoStart.test.tsx
+++ b/suite-native/module-earn/src/hooks/__tests__/useEarnReviewAutoStart.test.tsx
@@ -1,0 +1,82 @@
+import { renderHook, waitFor } from '@suite-native/test-utils';
+
+import { useEarnReviewAutoStart } from '../useEarnReviewAutoStart';
+
+const mockWaitForDeviceReview = jest.fn();
+
+jest.mock('@suite-native/transaction-management', () => ({
+    useWaitForButtonRequest: jest.fn(() => mockWaitForDeviceReview),
+}));
+
+type Params = Parameters<typeof useEarnReviewAutoStart>[0];
+
+const buildParams = (overrides: Partial<Params> = {}): Params => ({
+    handleSign: jest.fn().mockResolvedValue(true),
+    isSigned: false,
+    canStart: true,
+    onDeviceReviewReady: jest.fn(),
+    onSignFailed: jest.fn(),
+    ...overrides,
+});
+
+describe('useEarnReviewAutoStart', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('auto-starts signing and arms the device-review reveal once the review is ready', async () => {
+        const params = buildParams();
+
+        renderHook(() => useEarnReviewAutoStart(params));
+
+        await waitFor(() => expect(params.handleSign).toHaveBeenCalledTimes(1));
+        expect(mockWaitForDeviceReview).toHaveBeenCalledTimes(1);
+        expect(params.onSignFailed).not.toHaveBeenCalled();
+    });
+
+    it('does not start signing when the transaction is already signed', () => {
+        const params = buildParams({ isSigned: true });
+
+        renderHook(() => useEarnReviewAutoStart(params));
+
+        expect(params.handleSign).not.toHaveBeenCalled();
+        expect(mockWaitForDeviceReview).not.toHaveBeenCalled();
+    });
+
+    it('waits until the transaction can be signed before starting', async () => {
+        const params = buildParams({ canStart: false });
+
+        const { rerender } = renderHook((props: Params) => useEarnReviewAutoStart(props), {
+            initialProps: params,
+        });
+
+        expect(params.handleSign).not.toHaveBeenCalled();
+
+        rerender({ ...params, canStart: true });
+
+        await waitFor(() => expect(params.handleSign).toHaveBeenCalledTimes(1));
+    });
+
+    it('calls onSignFailed when the signature is declined', async () => {
+        const params = buildParams({ handleSign: jest.fn().mockResolvedValue(false) });
+
+        renderHook(() => useEarnReviewAutoStart(params));
+
+        await waitFor(() => expect(params.onSignFailed).toHaveBeenCalledTimes(1));
+    });
+
+    it('signs only once and never re-prompts even if the screen re-renders', async () => {
+        const params = buildParams();
+
+        const { rerender } = renderHook((props: Params) => useEarnReviewAutoStart(props), {
+            initialProps: params,
+        });
+
+        await waitFor(() => expect(params.handleSign).toHaveBeenCalledTimes(1));
+
+        rerender({ ...params });
+        rerender({ ...params });
+
+        expect(params.handleSign).toHaveBeenCalledTimes(1);
+    });
+});

--- a/suite-native/module-earn/src/hooks/useAutoStartReview.ts
+++ b/suite-native/module-earn/src/hooks/useAutoStartReview.ts
@@ -1,0 +1,62 @@
+import { useEffect, useRef } from 'react';
+
+import { useWaitForButtonRequest } from '@suite-native/transaction-management';
+
+export type ReviewAutoStartControls = {
+    allowRestart: () => void;
+};
+
+type UseAutoStartReviewParams<TResult> = {
+    shouldAutoStartReview: boolean;
+    startReview: () => Promise<TResult>;
+    onDeviceReviewReady: () => void;
+    onReviewSettled: (result: TResult, controls: ReviewAutoStartControls) => void | Promise<void>;
+};
+
+export const useAutoStartReview = <TResult>({
+    shouldAutoStartReview,
+    startReview,
+    onDeviceReviewReady,
+    onReviewSettled,
+}: UseAutoStartReviewParams<TResult>) => {
+    const hasStartedRef = useRef(false);
+    const isMountedRef = useRef(true);
+    const waitForDeviceReview = useWaitForButtonRequest(onDeviceReviewReady);
+
+    useEffect(() => {
+        isMountedRef.current = true;
+
+        return () => {
+            isMountedRef.current = false;
+        };
+    }, []);
+
+    useEffect(() => {
+        if (!shouldAutoStartReview || hasStartedRef.current) {
+            return;
+        }
+
+        hasStartedRef.current = true;
+        waitForDeviceReview();
+
+        const start = async () => {
+            try {
+                const result = await startReview();
+
+                if (!isMountedRef.current) {
+                    return;
+                }
+
+                await onReviewSettled(result, {
+                    allowRestart: () => {
+                        hasStartedRef.current = false;
+                    },
+                });
+            } catch {
+                hasStartedRef.current = false;
+            }
+        };
+
+        void start();
+    }, [onReviewSettled, shouldAutoStartReview, startReview, waitForDeviceReview]);
+};

--- a/suite-native/module-earn/src/hooks/useEarnReviewAutoStart.ts
+++ b/suite-native/module-earn/src/hooks/useEarnReviewAutoStart.ts
@@ -1,0 +1,35 @@
+import { useCallback } from 'react';
+
+import { useAutoStartReview } from './useAutoStartReview';
+
+type UseEarnReviewAutoStartParams = {
+    handleSign: () => Promise<boolean>;
+    isSigned: boolean;
+    canStart: boolean;
+    onDeviceReviewReady: () => void;
+    onSignFailed: () => void;
+};
+
+export const useEarnReviewAutoStart = ({
+    handleSign,
+    isSigned,
+    canStart,
+    onDeviceReviewReady,
+    onSignFailed,
+}: UseEarnReviewAutoStartParams) => {
+    const onReviewSettled = useCallback(
+        (didSign: boolean) => {
+            if (!didSign) {
+                onSignFailed();
+            }
+        },
+        [onSignFailed],
+    );
+
+    useAutoStartReview({
+        shouldAutoStartReview: canStart && !isSigned,
+        startReview: handleSign,
+        onDeviceReviewReady,
+        onReviewSettled,
+    });
+};

--- a/suite-native/module-earn/src/hooks/useYieldReviewAutoStart.ts
+++ b/suite-native/module-earn/src/hooks/useYieldReviewAutoStart.ts
@@ -1,8 +1,7 @@
-import { useEffect, useRef } from 'react';
-
-import { useWaitForButtonRequest } from '@suite-native/transaction-management';
+import { useCallback } from 'react';
 
 import { type YieldReviewSigningResult } from '../types';
+import { type ReviewAutoStartControls, useAutoStartReview } from './useAutoStartReview';
 
 type UseYieldReviewAutoStartParams = {
     onDeviceReviewReady: () => void;
@@ -19,22 +18,10 @@ export const useYieldReviewAutoStart = ({
     shouldAutoStartReview,
     startReview,
 }: UseYieldReviewAutoStartParams) => {
-    const hasStartedRef = useRef(false);
-    const waitForDeviceReview = useWaitForButtonRequest(onDeviceReviewReady);
-
-    useEffect(() => {
-        if (!shouldAutoStartReview || hasStartedRef.current) {
-            return;
-        }
-
-        hasStartedRef.current = true;
-        waitForDeviceReview();
-
-        const start = async () => {
-            const result = await startReview();
-
+    const onReviewSettled = useCallback(
+        async (result: YieldReviewSigningResult, { allowRestart }: ReviewAutoStartControls) => {
             if (result === 'not-ready') {
-                hasStartedRef.current = false;
+                allowRestart();
 
                 return;
             }
@@ -48,14 +35,14 @@ export const useYieldReviewAutoStart = ({
             if (result === 'failed') {
                 onReviewFailed();
             }
-        };
+        },
+        [onReviewCancelled, onReviewFailed],
+    );
 
-        void start();
-    }, [
-        onReviewCancelled,
-        onReviewFailed,
+    useAutoStartReview({
         shouldAutoStartReview,
         startReview,
-        waitForDeviceReview,
-    ]);
+        onDeviceReviewReady,
+        onReviewSettled,
+    });
 };

--- a/suite-native/module-earn/src/screens/ClaimTransactionDataReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/ClaimTransactionDataReviewScreen.tsx
@@ -16,14 +16,14 @@ import {
     useNavigateToInitialScreen,
 } from '@suite-native/navigation';
 import {
-    type TransactionReviewOutputsState,
     TxValidityTimer,
     selectIsTransactionAlreadySigned,
-    selectIsTransactionReviewInProgress,
     sendArrowsLottie,
 } from '@suite-native/transaction-management';
 
 import { ClaimTransactionDataReviewStepList } from '../components/ClaimTransactionDataReviewStepList';
+import { useEarnReviewAutoStart } from '../hooks/useEarnReviewAutoStart';
+import { useEarnSelectedPrecomposedTransaction } from '../hooks/useEarnSelectedPrecomposedTransaction';
 import { useEarnTxValidityFlow } from '../hooks/useEarnTxValidityFlow';
 import { useHandleOnEarnTransactionReview } from '../hooks/useHandleOnEarnTransactionReview';
 import { useNavigateAfterPushedTransaction } from '../hooks/useNavigateAfterPushedTransaction';
@@ -37,15 +37,13 @@ export const ClaimTransactionDataReviewScreen = ({
     const navigateToInitialScreen = useNavigateToInitialScreen();
     const [isPushing, setIsPushing] = useState(false);
 
-    const isTransactionReviewInProgress = useSelector((state: TransactionReviewOutputsState) =>
-        selectIsTransactionReviewInProgress(state, 'claim', accountKey),
-    );
-
     const isTransactionAlreadySigned = useSelector(selectIsTransactionAlreadySigned);
 
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
     );
+
+    const precomposedTransaction = useEarnSelectedPrecomposedTransaction('claim', accountKey);
 
     const { handleSign, handlePush } = useHandleOnEarnTransactionReview({
         accountKey,
@@ -67,11 +65,13 @@ export const ClaimTransactionDataReviewScreen = ({
     // Once signed, the user reviews the summary and taps "Claim now" to broadcast the transaction.
     const isReadyToClaim = isTransactionAlreadySigned && !!account;
 
-    useEffect(() => {
-        if (isTransactionReviewInProgress) {
-            revealConfirmOnTrezorSheet();
-        }
-    }, [isTransactionReviewInProgress, revealConfirmOnTrezorSheet]);
+    useEarnReviewAutoStart({
+        handleSign,
+        isSigned: isTransactionAlreadySigned,
+        canStart: !!precomposedTransaction,
+        onDeviceReviewReady: revealConfirmOnTrezorSheet,
+        onSignFailed: closeSheet,
+    });
 
     useEffect(() => {
         if (isTransactionAlreadySigned) {
@@ -121,7 +121,7 @@ export const ClaimTransactionDataReviewScreen = ({
                             isRetryDisabled={isRetryDisabled}
                         />
                     )}
-                    <ClaimTransactionDataReviewStepList onSign={handleSign} />
+                    <ClaimTransactionDataReviewStepList />
                 </VStack>
                 {isReadyToClaim && (
                     <Card>

--- a/suite-native/module-earn/src/screens/EarnTransactionDataReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/EarnTransactionDataReviewScreen.tsx
@@ -16,14 +16,14 @@ import {
     useNavigateToInitialScreen,
 } from '@suite-native/navigation';
 import {
-    type TransactionReviewOutputsState,
     TxValidityTimer,
     selectIsTransactionAlreadySigned,
-    selectIsTransactionReviewInProgress,
     sendArrowsLottie,
 } from '@suite-native/transaction-management';
 
 import { EarnTransactionDataReviewStepList } from '../components/EarnTransactionDataReviewStepList';
+import { useEarnReviewAutoStart } from '../hooks/useEarnReviewAutoStart';
+import { useEarnSelectedPrecomposedTransaction } from '../hooks/useEarnSelectedPrecomposedTransaction';
 import { useEarnTxValidityFlow } from '../hooks/useEarnTxValidityFlow';
 import { useHandleOnEarnTransactionReview } from '../hooks/useHandleOnEarnTransactionReview';
 import { useNavigateAfterPushedTransaction } from '../hooks/useNavigateAfterPushedTransaction';
@@ -37,15 +37,13 @@ export const EarnTransactionDataReviewScreen = ({
     const navigateToInitialScreen = useNavigateToInitialScreen();
     const [isPushing, setIsPushing] = useState(false);
 
-    const isTransactionReviewInProgress = useSelector((state: TransactionReviewOutputsState) =>
-        selectIsTransactionReviewInProgress(state, 'stake', accountKey),
-    );
-
     const isTransactionAlreadySigned = useSelector(selectIsTransactionAlreadySigned);
 
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
     );
+
+    const precomposedTransaction = useEarnSelectedPrecomposedTransaction('stake', accountKey);
 
     const { handleSign, handlePush } = useHandleOnEarnTransactionReview({
         accountKey,
@@ -66,11 +64,13 @@ export const EarnTransactionDataReviewScreen = ({
 
     const isReadyToStake = isTransactionAlreadySigned && !!account;
 
-    useEffect(() => {
-        if (isTransactionReviewInProgress) {
-            revealConfirmOnTrezorSheet();
-        }
-    }, [isTransactionReviewInProgress, revealConfirmOnTrezorSheet]);
+    useEarnReviewAutoStart({
+        handleSign,
+        isSigned: isTransactionAlreadySigned,
+        canStart: !!precomposedTransaction,
+        onDeviceReviewReady: revealConfirmOnTrezorSheet,
+        onSignFailed: closeSheet,
+    });
 
     useEffect(() => {
         if (isTransactionAlreadySigned) {
@@ -125,7 +125,6 @@ export const EarnTransactionDataReviewScreen = ({
                             accountKey={accountKey}
                             amount={amount}
                             accountSymbol={account.symbol}
-                            onSign={handleSign}
                         />
                     )}
                 </VStack>

--- a/suite-native/module-earn/src/screens/UnstakeTransactionDataReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/UnstakeTransactionDataReviewScreen.tsx
@@ -22,11 +22,12 @@ import {
     TxValidityTimer,
     selectIsReceiveAddressOutputConfirmed,
     selectIsTransactionAlreadySigned,
-    selectIsTransactionReviewInProgress,
     sendArrowsLottie,
 } from '@suite-native/transaction-management';
 
 import { UnstakeTransactionDataReviewStepList } from '../components/UnstakeTransactionDataReviewStepList';
+import { useEarnReviewAutoStart } from '../hooks/useEarnReviewAutoStart';
+import { useEarnSelectedPrecomposedTransaction } from '../hooks/useEarnSelectedPrecomposedTransaction';
 import { useEarnTxValidityFlow } from '../hooks/useEarnTxValidityFlow';
 import { useHandleOnEarnTransactionReview } from '../hooks/useHandleOnEarnTransactionReview';
 import { useNavigateAfterPushedTransaction } from '../hooks/useNavigateAfterPushedTransaction';
@@ -46,15 +47,13 @@ export const UnstakeTransactionDataReviewScreen = ({
         selectIsReceiveAddressOutputConfirmed(state, 'unstake', accountKey),
     );
 
-    const isTransactionReviewInProgress = useSelector((state: TransactionReviewOutputsState) =>
-        selectIsTransactionReviewInProgress(state, 'unstake', accountKey),
-    );
-
     const isTransactionAlreadySigned = useSelector(selectIsTransactionAlreadySigned);
 
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
     );
+
+    const precomposedTransaction = useEarnSelectedPrecomposedTransaction('unstake', accountKey);
 
     const { handleSign, handlePush } = useHandleOnEarnTransactionReview({
         accountKey,
@@ -75,6 +74,14 @@ export const UnstakeTransactionDataReviewScreen = ({
 
     const isReadyToUnstake = isTransactionAlreadySigned && !!account;
 
+    useEarnReviewAutoStart({
+        handleSign,
+        isSigned: isTransactionAlreadySigned,
+        canStart: !!precomposedTransaction,
+        onDeviceReviewReady: revealConfirmOnTrezorSheet,
+        onSignFailed: closeSheet,
+    });
+
     useFocusEffect(
         useCallback(() => {
             // Solana address outputs would redirect mid-sign, skip until the success card.
@@ -83,12 +90,6 @@ export const UnstakeTransactionDataReviewScreen = ({
             }
         }, [account, accountKey, isAddressConfirmed, navigateToStakingDetail]),
     );
-
-    useEffect(() => {
-        if (isTransactionReviewInProgress) {
-            revealConfirmOnTrezorSheet();
-        }
-    }, [isTransactionReviewInProgress, revealConfirmOnTrezorSheet]);
 
     useEffect(() => {
         if (isTransactionAlreadySigned) {
@@ -138,7 +139,7 @@ export const UnstakeTransactionDataReviewScreen = ({
                             isRetryDisabled={isRetryDisabled}
                         />
                     )}
-                    <UnstakeTransactionDataReviewStepList onSign={handleSign} />
+                    <UnstakeTransactionDataReviewStepList />
                 </VStack>
                 {isReadyToUnstake && (
                     <Card>

--- a/suite-native/module-earn/tsconfig.json
+++ b/suite-native/module-earn/tsconfig.json
@@ -76,6 +76,7 @@
         { "path": "../settings" },
         { "path": "../staking" },
         { "path": "../test-utils" },
+        { "path": "../test-utils-store" },
         { "path": "../transaction-management" },
         { "path": "../transactions" },
         { "path": "../tx-simulation" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -12991,6 +12991,7 @@ __metadata:
     "@suite-native/settings": "workspace:*"
     "@suite-native/staking": "workspace:*"
     "@suite-native/test-utils": "workspace:*"
+    "@suite-native/test-utils-store": "workspace:*"
     "@suite-native/transaction-management": "workspace:*"
     "@suite-native/transactions": "workspace:*"
     "@suite-native/tx-simulation": "workspace:*"


### PR DESCRIPTION
## Description

Reworks the native staking stake, unstake and claim transaction reviews to start the on-device signing automatically instead of gating it behind a manual "Next" button. The "Continue on your Trezor" sheet now appears on the first device button request and the review steps reveal progressively as the device confirms each output, matching the Stablecoin Yield review flow. The shared auto-start logic is extracted into a reusable hook covered by unit tests.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/28522
