### PR TITLE
feat(connect): fetch eth clear-signing display-format definitions

### DIFF
--- a/packages/connect-common/src/data/connectSettings.ts
+++ b/packages/connect-common/src/data/connectSettings.ts
@@ -2,6 +2,8 @@
 
 import { parseThpSettings } from './thpSettings';
 import { VERSION } from './version';
+import { DEFINITIONS_CHANNELS } from '../types/definitions';
+import type { DefinitionsChannel } from '../types/definitions';
 import type { ConnectSettings, LocalFirmwares, Manifest } from '../types/settings';
 
 /*
@@ -88,6 +90,10 @@ export const parseConnectSettings = (input: Partial<ConnectSettings> = {}) => {
 
     if (typeof input.firmwareChannel === 'string') {
         settings.firmwareChannel = input.firmwareChannel;
+    }
+
+    if (DEFINITIONS_CHANNELS.includes(input.definitionsChannel as DefinitionsChannel)) {
+        settings.definitionsChannel = input.definitionsChannel;
     }
 
     if (Array.isArray(input.transports)) {

--- a/packages/connect-common/src/types/definitions.ts
+++ b/packages/connect-common/src/types/definitions.ts
@@ -1,0 +1,4 @@
+// Selects the source from which coin definitions (e.g. Ethereum network, token and clear-signing
+// display-format) are downloaded. Defaults to `production` when unset.
+export const DEFINITIONS_CHANNELS = ['production', 'development', 'local'] as const;
+export type DefinitionsChannel = (typeof DEFINITIONS_CHANNELS)[number];

--- a/packages/connect-common/src/types/index.ts
+++ b/packages/connect-common/src/types/index.ts
@@ -1,6 +1,7 @@
 export * from './api';
 export type * from './account';
 export * from './coinInfo';
+export * from './definitions';
 export * from './device';
 export * from './fees';
 export type * from './firmware';

--- a/packages/connect-common/src/types/settings.ts
+++ b/packages/connect-common/src/types/settings.ts
@@ -8,6 +8,7 @@ import type { PartialRecord } from '@trezor/type-utils';
 import type { Logger } from '@trezor/utils';
 
 import type { CoinSymbol } from './coinInfo';
+import type { DefinitionsChannel } from './definitions';
 import type { FirmwareChannel } from './firmware';
 
 export const Manifest = Type.Object({
@@ -79,6 +80,7 @@ export interface ConnectSettings {
     enableFirmwareHashCheck?: boolean;
     firmwareHashCheckTimeouts?: FirmwareHashCheckTimeouts;
     firmwareChannel?: FirmwareChannel;
+    definitionsChannel?: DefinitionsChannel;
     localFirmwares?: LocalFirmwares;
     thp?: ThpSettings;
     enabledNetworks?: EnabledNetwork[];

--- a/packages/connect/src/api/ethereum/ethereumDefinitions.ts
+++ b/packages/connect/src/api/ethereum/ethereumDefinitions.ts
@@ -1,6 +1,9 @@
 import fetch from 'cross-fetch';
 
-import type { EthereumNetworkInfoDefinitionValues } from '@trezor/connect-common';
+import type {
+    DefinitionsChannel,
+    EthereumNetworkInfoDefinitionValues,
+} from '@trezor/connect-common';
 import type { MessagesSchema } from '@trezor/protobuf';
 import { protobufManager } from '@trezor/protobuf';
 import { trzd } from '@trezor/protocol';
@@ -8,6 +11,7 @@ import type { Static } from '@trezor/schema-utils';
 import { Assert, Type } from '@trezor/schema-utils';
 
 import { ethereumNetworkInfoBase } from '../../data/coinInfo';
+import * as settingsStore from '../../data/settingsStore';
 
 interface GetEthereumDefinitions {
     chainId?: number;
@@ -15,6 +19,19 @@ interface GetEthereumDefinitions {
     contractAddress?: string;
     functionSignature?: string;
 }
+
+const getDefinitionsBaseUrl = (channel: DefinitionsChannel = 'production') => {
+    switch (channel) {
+        case 'production':
+            return 'https://data.trezor.io/firmware/eth-definitions';
+        case 'development':
+            return 'https://data.trezor.io/dev/firmware/dev-definitions/eth';
+        case 'local':
+            return 'http://localhost:3000';
+        default:
+            throw new Error(`Unknown channel: ${channel}`);
+    }
+};
 
 /**
  * For given chainId and optionally contractAddress download ethereum definitions for transaction signing.
@@ -33,10 +50,13 @@ export const getEthereumDefinitions = async ({
         throw new Error('argument chainId or slip44 is required');
     }
 
+    // The channel is a global connect setting; fall back to `production` when settings are not
+    // loaded (e.g. when this helper is exercised outside of a running connect core).
+    const channel = settingsStore.isLoaded() ? settingsStore.get('definitionsChannel') : undefined;
+    const baseUrl = getDefinitionsBaseUrl(channel);
+
     try {
-        const networkDefinitionUrl = `https://data.trezor.io/firmware/eth-definitions/${
-            chainId ? 'chain-id' : 'slip44'
-        }/${chainId ?? slip44}/network.dat`;
+        const networkDefinitionUrl = `${baseUrl}/${chainId ? 'chain-id' : 'slip44'}/${chainId ?? slip44}/network.dat`;
         const networkDefinition = await fetch(networkDefinitionUrl);
         if (networkDefinition.status === 200) {
             definitions.encoded_network = await networkDefinition.arrayBuffer();
@@ -51,9 +71,7 @@ export const getEthereumDefinitions = async ({
         if (contractAddress) {
             // Contract address has to be in lowercase in order to be found in eth-definitions.
             const lowerCaseContractAddress = contractAddress.toLowerCase();
-            const tokenDefinitionUrl = `https://data.trezor.io/firmware/eth-definitions/${
-                chainId ? 'chain-id' : 'slip44'
-            }/${chainId ?? slip44}/token-${lowerCaseContractAddress}.dat`;
+            const tokenDefinitionUrl = `${baseUrl}/${chainId ? 'chain-id' : 'slip44'}/${chainId ?? slip44}/token-${lowerCaseContractAddress}.dat`;
             const tokenDefinition = await fetch(tokenDefinitionUrl);
             if (tokenDefinition.status === 200) {
                 definitions.encoded_token = await tokenDefinition.arrayBuffer();
@@ -72,11 +90,9 @@ export const getEthereumDefinitions = async ({
         if (chainId && contractAddress && functionSignature) {
             const lowerCaseContractAddress = contractAddress.toLowerCase();
             const lowerCaseFunctionSignature = functionSignature.toLowerCase();
-            // TODO: DEV URL, wait for prod URL to be available and update it here before release
-            const displayFormatUrl = `https://data.trezor.io/dev/firmware/dev-definitions/eth/chain-id/${chainId}/display-format/${lowerCaseContractAddress}-${lowerCaseFunctionSignature}.dat`;
+            const displayFormatUrl = `${baseUrl}/chain-id/${chainId}/display-format/${lowerCaseContractAddress}-${lowerCaseFunctionSignature}.dat`;
             const displayFormatDefinition = await fetch(displayFormatUrl);
             if (displayFormatDefinition.status === 200) {
-                // encoded_display_format is a protobuf bytes field represented as a hex string.
                 const encodedDisplayFormat = await displayFormatDefinition.arrayBuffer();
                 definitions.encoded_display_format =
                     Buffer.from(encodedDisplayFormat).toString('hex');

--- a/packages/connect/src/api/ethereum/ethereumDefinitions.ts
+++ b/packages/connect/src/api/ethereum/ethereumDefinitions.ts
@@ -13,6 +13,7 @@ interface GetEthereumDefinitions {
     chainId?: number;
     slip44?: number;
     contractAddress?: string;
+    functionSignature?: string;
 }
 
 /**
@@ -24,6 +25,7 @@ export const getEthereumDefinitions = async ({
     chainId,
     slip44,
     contractAddress,
+    functionSignature,
 }: GetEthereumDefinitions) => {
     const definitions: MessagesSchema.EthereumDefinitions = {};
 
@@ -62,6 +64,29 @@ export const getEthereumDefinitions = async ({
     } catch (err) {
         console.warn(
             `unable to download or parse ${chainId}/${contractAddress} definition. detail: ${err.message}`,
+        );
+    }
+
+    try {
+        // Clear-signing (display-format) definitions
+        if (chainId && contractAddress && functionSignature) {
+            const lowerCaseContractAddress = contractAddress.toLowerCase();
+            const lowerCaseFunctionSignature = functionSignature.toLowerCase();
+            // TODO: DEV URL, wait for prod URL to be available and update it here before release
+            const displayFormatUrl = `https://data.trezor.io/dev/firmware/dev-definitions/eth/chain-id/${chainId}/display-format/${lowerCaseContractAddress}-${lowerCaseFunctionSignature}.dat`;
+            const displayFormatDefinition = await fetch(displayFormatUrl);
+            if (displayFormatDefinition.status === 200) {
+                // encoded_display_format is a protobuf bytes field represented as a hex string.
+                const encodedDisplayFormat = await displayFormatDefinition.arrayBuffer();
+                definitions.encoded_display_format =
+                    Buffer.from(encodedDisplayFormat).toString('hex');
+            } else if (displayFormatDefinition.status !== 404) {
+                throw new Error(`unexpected status: ${displayFormatDefinition.status}`);
+            }
+        }
+    } catch (err) {
+        console.warn(
+            `unable to download or parse ${chainId}/${contractAddress}/${functionSignature} display-format definition. detail: ${err.message}`,
         );
     }
 

--- a/packages/connect/src/api/ethereum/ethereumSignTx.ts
+++ b/packages/connect/src/api/ethereum/ethereumSignTx.ts
@@ -76,7 +76,8 @@ async function processDefinitionRequest(
 ): Promise<TxSignature> {
     const definitions = await getEthereumDefinitions({
         chainId: request.chain_id,
-        contractAddress: request.token_address.toLowerCase(),
+        contractAddress: request.token_address,
+        functionSignature: request.func_sig,
     });
 
     const nextResponse = await typedCall(

--- a/packages/suite/src/views/settings/SettingsDebug/DefinitionsEnvironmentSelect.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/DefinitionsEnvironmentSelect.tsx
@@ -1,0 +1,34 @@
+import { selectDefinitionsChannel, suiteSettingsActions } from '@suite/settings';
+import { type DefinitionsChannel } from '@trezor/connect-common';
+import { isDesktop } from '@trezor/env-utils';
+import { ActionColumn, ActionSelect, SectionItem, TextColumn } from '@trezor/product-components';
+
+import { useDispatch, useSelector } from 'src/hooks/suite';
+
+const options: { label: string; value: DefinitionsChannel }[] = [
+    { label: 'Production', value: 'production' },
+    { label: 'Development', value: 'development' },
+    { label: 'Local', value: 'local' },
+];
+
+export const DefinitionsEnvironmentSelect = () => {
+    const definitionsChannel = useSelector(selectDefinitionsChannel);
+    const dispatch = useDispatch();
+
+    const selectedOption = options.find(o => o.value === definitionsChannel) ?? options[0];
+    const handleChange = (item: { value: DefinitionsChannel }) => {
+        dispatch(suiteSettingsActions.setDebugMode({ definitionsChannel: item.value }));
+    };
+
+    return (
+        <SectionItem>
+            <TextColumn
+                title="Definitions channel"
+                description={`Set the source for Ethereum network, token and clear-signing definitions. ${isDesktop() ? 'Restart' : 'Refresh'} the application to apply changes.`}
+            />
+            <ActionColumn>
+                <ActionSelect onChange={handleChange} value={selectedOption} options={options} />
+            </ActionColumn>
+        </SectionItem>
+    );
+};

--- a/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
@@ -19,6 +19,7 @@ import { CheckFirmwareAuthenticity } from './CheckFirmwareAuthenticity';
 import { ClearDevicePersistentData } from './ClearDevicePersistentData';
 import { CoinjoinApi } from './CoinjoinApi';
 import { ConnectPopup } from './ConnectPopup';
+import { DefinitionsEnvironmentSelect } from './DefinitionsEnvironmentSelect';
 import { DeviceAuthenticity } from './DeviceAuthenticity';
 import { Devkit } from './Devkit';
 import { EarnApi } from './EarnApi';
@@ -152,6 +153,7 @@ export const SettingsDebug = () => {
             </SettingsSection>
             <SettingsSection hasVerticalLayout={hasContentBelowTabletWidth} title="TrezorConnect">
                 <TrezorConnectLogs />
+                <DefinitionsEnvironmentSelect />
                 {isDesktop() && <ConnectPopup />}
             </SettingsSection>
             <SettingsSection

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -134,7 +134,7 @@ export const connectInitThunk = createThunk<void, void, void>(
             ...firmwareHashCheckTimeoutsOverride,
         };
 
-        const { transports, showConnectLogs } = selectDebugSettings(getState());
+        const { transports, showConnectLogs, definitionsChannel } = selectDebugSettings(getState());
         const thp = selectThpSettings(getState());
         // desktop thp appName/hostName enhanced in ./packages/suite-desktop-core/src/modules/trezor-connect.ts
         if (isWeb()) {
@@ -152,6 +152,7 @@ export const connectInitThunk = createThunk<void, void, void>(
                 createLogger,
                 firmwareHashCheckTimeouts,
                 firmwareChannel: getEffectiveFirmwareChannel(getState()),
+                definitionsChannel,
                 // Suite's enabled coins, declared to Connect one-way (Suite is the source of truth).
                 enabledNetworks: selectEnabledNetworks(getState()).map(coin => ({ coin })),
             });

--- a/suite/settings/src/settingsSelectors.ts
+++ b/suite/settings/src/settingsSelectors.ts
@@ -22,6 +22,8 @@ export const selectDebugTransports = (state: SuiteSettingsRootState) =>
     state.suiteSettings.debug.transports;
 export const selectShowConnectLogs = (state: SuiteSettingsRootState) =>
     state.suiteSettings.debug.showConnectLogs;
+export const selectDefinitionsChannel = (state: SuiteSettingsRootState) =>
+    state.suiteSettings.debug.definitionsChannel;
 export const selectInvityServerEnvironment = (state: SuiteSettingsRootState) =>
     state.suiteSettings.debug.invityServerEnvironment;
 export const selectEarnYieldWorkerBaseUrl = (state: SuiteSettingsRootState) =>

--- a/suite/settings/src/settingsSlice.ts
+++ b/suite/settings/src/settingsSlice.ts
@@ -6,7 +6,7 @@ import { type OAuthServerEnvironment } from '@suite-common/metadata-types';
 import { createSliceWithExtraDeps } from '@suite-common/redux-utils';
 import { type Locale } from '@suite-common/suite-types';
 import type { InvityServerEnvironment } from '@suite-common/trading';
-import type { ConnectSettingsTransport } from '@trezor/connect-common';
+import type { ConnectSettingsTransport, DefinitionsChannel } from '@trezor/connect-common';
 import { isWeb } from '@trezor/env-utils';
 import { type SuiteThemeVariant } from '@trezor/suite-desktop-api';
 
@@ -19,6 +19,7 @@ export interface DebugModeOptions {
     transports: Extract<ConnectSettingsTransport, string>[];
     isUnlockedBootloaderAllowed: boolean;
     showConnectLogs: boolean;
+    definitionsChannel?: DefinitionsChannel;
     isN4w1BackupEnabled: boolean;
     showTranslationKeys: boolean;
 }


### PR DESCRIPTION
## Description

Adds support for clear-signing (display-format) Ethereum definitions and makes the definitions source configurable.

- **Fetch display-format definitions:** when the device sends an `EthereumDefinitionRequest` containing a `func_sig`, `processDefinitionRequest` forwards it to `getEthereumDefinitions`, which downloads the contract call's display-format definition and returns it as `encoded_display_format` (a protobuf bytes field, hex-encoded). Download failures are logged and swallowed like the existing network/token fetches, so a missing definition never blocks signing.
- **Configurable channel (connect):** a new `definitionsChannel` connect setting (`production` / `development` / `local`) selects the base URL definitions are fetched from. Defaults to `production` when unset. The generic `DefinitionsChannel` type lives in `connect-common` so other coins can reuse it later.
- **Debug settings switch (suite):** the channel is exposed as a selector in the TrezorConnect debug settings (mirroring the firmware channel switch). The selection is persisted with the other debug options and passed to `TrezorConnect.init` on startup.

## Notes for QA

In **Settings → Debug → TrezorConnect**, set the **Definitions channel** to `Development`, then reload the app. Sign an Ethereum contract-call transaction that triggers a display-format request and confirm the device shows the decoded call details instead of `UNKNOWN`. 

Example transaction (Lido wrap stETH):
```
{
  "nonce": "0x0",
  "gasPrice": "0x14",
  "gasLimit": "0x14",
  "to": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
  "chainId": 1,
  "value": "0x0",
  "data": "0xea598cb00000000000000000000000000000000000000000000000000f865505b33b3bbf"
}
```

For local definitions testing, you can extract them and run a server on http://localhost:3000 using
```
npx serve --cors eth-definitions/
```

Note - if facing issues with `trezor-user-env` not loading latest nightly version, try using URL: 
https://data.trezor.io/dev/firmware/emu-nightly/trezor-emu-core-arm-T3W1-universal

## Related Issue

Related #26041

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies Ethereum transaction signing (ethereumSignTx.ts), Ethereum definitions resolution (ethereumDefinitions.ts), TrezorConnect initialization settings (connectSettings.ts, connectInitThunks.ts), settings UI (SettingsDebug, DefinitionsEnvironmentSelect), and settings state management (settingsSlice, settingsSelectors). The highest risk is in the Ethereum signing and definitions pipeline, which could break ETH/EVM sends, staking, trading, and TrezorConnect API calls. The connect init changes affect all flows but are broad infrastructure — tests should focus on Ethereum-specific paths and TrezorConnect API integration tests. The SettingsDebug/DefinitionsEnvironment UI changes are lower risk but have no direct E2E coverage for the new component.

<details><summary><b>Changed files (11)</b></summary>

- `packages/connect-common/src/data/connectSettings.ts`
- `packages/connect-common/src/types/definitions.ts`
- `packages/connect-common/src/types/index.ts`
- `packages/connect-common/src/types/settings.ts`
- `packages/connect/src/api/ethereum/ethereumDefinitions.ts`
- `packages/connect/src/api/ethereum/ethereumSignTx.ts`
- `packages/suite/src/views/settings/SettingsDebug/DefinitionsEnvironmentSelect.tsx`
- `packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx`
- `suite-common/connect-init/src/connectInitThunks.ts`
- `suite/settings/src/settingsSelectors.ts`
- `suite/settings/src/settingsSlice.ts`

</details>

**Recommended tests (14)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/wallet/send-eth.test.ts` — This test directly exercises Ethereum transaction signing (ethereumSignTx.ts) and fee display, which are core changed files. It also validates gas limit, fee rate, and priority fee on the device prompt — all of which depend on the Ethereum signing pipeline that was modified.
- `suite/e2e/tests/wallet/send-base.test.ts` — Base is an EVM L2 network that uses the same Ethereum signing path (ethereumSignTx.ts) and definitions (ethereumDefinitions.ts). This test validates custom gas fees, device prompt display, and transaction broadcasting — all directly affected by the Ethereum connect changes.
- `suite/e2e/tests/wallet/sign-and-verify-eth.test.ts` — This test signs and verifies Ethereum messages, which uses ethereumDefinitions for token/network resolution. Changes to definitions environment or connect settings could break the signing flow. It directly validates the Ethereum signMessage/verifyMessage path.
- `suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts` — Directly tests TrezorConnect.ethereumSignMessage which relies on the changed ethereumDefinitions and connect init thunks. Changes to connect settings or definitions types could break the signing permission and confirmation flow.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Directly tests TrezorConnect.ethereumSignTransaction which is the exact API modified in ethereumSignTx.ts. Changes to how definitions are fetched or transaction parameters are constructed would cause this test to fail.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Swap with custom Ethereum fees exercises ethereumSignTx.ts for fee calculation and display on both UI and device. The test validates gas limit, max fee per gas, and priority fee which flow through the changed Ethereum signing code.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Sells ETH with custom gas fees, triggering the Ethereum sign transaction flow. Changes to ethereumSignTx.ts or definitions could affect how the transaction is composed and confirmed on the device.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Selling an ERC-20 token (USDC) requires token definitions resolution via ethereumDefinitions.ts and transaction signing via ethereumSignTx.ts. Changes to definitions environment or types could break token recognition.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — ETH staking sends a transaction to the Everstake contract, exercising ethereumSignTx.ts for composing and signing the stake transaction. Changes to definitions or signing could break the staking confirmation flow.
- `suite/e2e/tests/trezor-connect/error.test.ts` — Tests TrezorConnect error handling for ethereumGetAddress with invalid paths. Changes to connect settings, connect init thunks, or definitions types could alter how errors are surfaced in the popup.
- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — Tests TrezorConnect popup flow including getAddress and cardanoGetAddress. Changes to connectSettings.ts and connect init thunks affect how TrezorConnect initializes and opens the popup, which this test validates end-to-end.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Tests TrezorConnect permission granting and remembering, which depends on connect init and settings. Changes to connectSettings or connectInitThunks could affect permission modal behavior.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/staking/eth/unstake.test.ts` — ETH unstaking and claiming exercises ethereumSignTx for contract interactions. While less directly affected than initial staking, changes to definitions resolution could impact unstake/claim transaction construction.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Stake-more flow uses the same Ethereum signing pipeline as initial stake. A regression in ethereumSignTx or definitions could break the additional staking transaction.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/suite/src/views/settings/SettingsDebug/DefinitionsEnvironmentSelect.tsx`
- `suite/settings/src/settingsSelectors.ts`
- `suite/settings/src/settingsSlice.ts`

_Updated: 2026-07-07T14:26:42.432Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=ethereum-clear-signing-definitions&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=ethereum-clear-signing-definitions&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=ethereum-clear-signing-definitions&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-07T14:32:21.439Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-07T14:29:50.609Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/ethereum-clear-signing-definitions/web/](https://dev.suite.sldev.cz/suite-web/ethereum-clear-signing-definitions/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->
