### PR TITLE
feat(connect-common): canonical CoinSymbol type for supported coin symbols

### DIFF
--- a/packages/connect-common/src/types/coinInfo.ts
+++ b/packages/connect-common/src/types/coinInfo.ts
@@ -114,3 +114,84 @@ export const MiscNetworkInfo = Type.Intersect([
 
 export type CoinInfo = Static<typeof CoinInfo>;
 export const CoinInfo = Type.Union([BitcoinNetworkInfo, EthereumNetworkInfo, MiscNetworkInfo]);
+
+// Canonical list of supported coin symbols (lowercased coinInfo `shortcut`s), grouped by
+// coinInfo category. Source of truth for the `CoinSymbol` type. The runtime guard
+// (`getCoinInfo`, `enabledNetworksStore`) compares case-insensitively, so values are kept
+// lowercase here. A drift test in @trezor/connect pins this to the @trezor/connect-data coin
+// definitions — adding or removing a coin there without updating this list fails that test.
+export const coinSymbols = [
+    // UTXO coins, handled by the bitcoin methods (getAddress, getPublicKey, signTransaction, ...)
+    'btc',
+    'regtest',
+    'test',
+    'bch',
+    'tbch',
+    'btg',
+    'tbtg',
+    'dash',
+    'tdash',
+    'dcr',
+    'tdcr',
+    'dgb',
+    'doge',
+    'elements',
+    'ftc',
+    'firo',
+    'tfiro',
+    'fjc',
+    'grs',
+    'tgrs',
+    'kmd',
+    'ltc',
+    'tltc',
+    'mona',
+    'nmc',
+    'qtum',
+    'tqtum',
+    'rvn',
+    'trvn',
+    'sys',
+    'xvg',
+    'vtc',
+    'zec',
+    'taz',
+    // EVM coins
+    'eth',
+    'op',
+    'avax',
+    'bsc',
+    'etc',
+    'pol',
+    'base',
+    'thod',
+    'arb',
+    'tsep',
+    // misc coins (cardano, solana, ripple, stellar, tron, monero, tezos, ...)
+    'ada',
+    'bnb',
+    'dsol',
+    'maid',
+    'omni',
+    'sol',
+    'tada',
+    'txrp',
+    'usdt',
+    'xlm',
+    'trx',
+    'ttrx',
+    'txlm',
+    'xmr',
+    'xrp',
+    'xtz',
+] as const;
+
+// A supported coin symbol, e.g. `'btc'` / `'ada'`. See `coinSymbols`.
+export type CoinSymbol = (typeof coinSymbols)[number];
+
+const coinSymbolSet: ReadonlySet<string> = new Set(coinSymbols);
+
+// Runtime validation for `CoinSymbol`, derived from the same `coinSymbols` source as the type.
+// Strict on the canonical lowercase form; callers accepting mixed case should lowercase first
+// (the coin guard in @trezor/connect compares case-insensitively).
+export const isCoinSymbol = (value: string): value is CoinSymbol => coinSymbolSet.has(value);

--- a/packages/connect/src/data/__tests__/coinSymbol.test.ts
+++ b/packages/connect/src/data/__tests__/coinSymbol.test.ts
@@ -1,0 +1,34 @@
+import { type CoinSymbol, coinSymbols, isCoinSymbol } from '@trezor/connect-common';
+
+import { getAllNetworks } from '../coinInfo';
+
+describe('data/coinSymbol', () => {
+    // Guards `coinSymbols` against drift from the @trezor/connect-data coin definitions: it must
+    // equal the set of supported coinInfo shortcuts (lowercased, as the runtime guard compares).
+    // Adding/removing a coin in coins.json/coins-eth.json without updating `coinSymbols` fails here.
+    it('coinSymbols matches the supported coinInfo shortcuts', () => {
+        const fromCoinInfo = new Set(
+            getAllNetworks().map(network => network.shortcut.toLowerCase()),
+        );
+
+        expect(new Set(coinSymbols)).toEqual(fromCoinInfo);
+    });
+
+    it('isCoinSymbol accepts every supported shortcut and narrows to CoinSymbol', () => {
+        getAllNetworks().forEach(network => {
+            const symbol = network.shortcut.toLowerCase();
+            expect(isCoinSymbol(symbol)).toBe(true);
+
+            if (isCoinSymbol(symbol)) {
+                const narrowed: CoinSymbol = symbol;
+                expect(coinSymbols).toContain(narrowed);
+            }
+        });
+    });
+
+    it('isCoinSymbol rejects unknown and non-canonical (uppercase) values', () => {
+        expect(isCoinSymbol('BTC')).toBe(false);
+        expect(isCoinSymbol('not-a-coin')).toBe(false);
+        expect(isCoinSymbol('')).toBe(false);
+    });
+});


### PR DESCRIPTION
## What

Adds, in `@trezor/connect-common`:
- `coinSymbols` — the canonical lowercase list of every supported coin symbol (UTXO, EVM and misc);
- `CoinSymbol` — the literal union derived from it (`(typeof coinSymbols)[number]`);
- `isCoinSymbol` — a runtime type guard backed by the same list.

This is the source of truth for "a supported coin symbol", meant to replace bare `string` coin fields across the public API and to back runtime validation of untrusted input.

## Why

`coin` fields in `@trezor/connect` are currently typed as plain `string`, which gives no autocomplete and no compile-time validation. We can't reuse Suite's `NetworkSymbol` here: `@trezor/connect-common` must not depend on `suite-common`, and `NetworkSymbol` under-covers connect's coin universe (it omits most UTXO altcoins like `dash`, `dcr`, `dgb`, `firo`, `grs`, `kmd`, `nmc`, `qtum`, `rvn`, `vtc`, …). So the strong type has to come from connect's own coin definitions.

## Design

- **Type derived from a runtime value.** `CoinSymbol` is `(typeof coinSymbols)[number]`, so the type and `isCoinSymbol` share one source of truth and cannot diverge.
- **Lowercase canonical form.** The runtime coin guard (`getCoinInfo`, `enabledNetworksStore`) compares case-insensitively and stores lowercased, and every consumer (Suite, e2e fixtures) passes lowercase. `CoinSymbol` and `isCoinSymbol` follow that contract; `isCoinSymbol` is strict on the lowercase form.
- **Covers all 60 supported coins**, including obscure/testnet UTXO coins, so the type never rejects a value the runtime accepts.
- **Drift-guarded.** A test in `@trezor/connect` asserts `coinSymbols` equals the set of `getAllNetworks()` shortcuts (lowercased) and that `isCoinSymbol` accepts every one. Adding or removing a coin in `@trezor/connect-data` without updating the list fails CI — no silent drift, no codegen.

## Follow-up

Prerequisite for the `enabledNetworks` work in #27539, which will type `EnabledNetwork.coin` as `CoinSymbol` (instead of `string`) and can use `isCoinSymbol` for input validation.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are limited to `packages/connect-common/src/types/coinInfo.ts` (a TypeScript type definition file for coin info structures) and `packages/connect/src/data/__tests__/coinSymbol.test.ts` (a unit test for coin symbol data). These are low-level type definitions and unit tests within the `@trezor/connect` package internals. No static coverage mapping exists linking these files to any E2E tests, and the LLM analysis of the 100 candidate E2E tests reveals no test that directly exercises coinInfo type definitions or coin symbol resolution at a level where type-level or unit-test-level changes would cause E2E regressions. The unit test file (`coinSymbol.test.ts`) is self-contained and would be covered by the package's own unit test suite, not by Playwright E2E tests. No E2E tests are recommended for this change.

<details><summary><b>Changed files (2)</b></summary>

- `packages/connect-common/src/types/coinInfo.ts`
- `packages/connect/src/data/__tests__/coinSymbol.test.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (2)**
- `packages/connect-common/src/types/coinInfo.ts`
- `packages/connect/src/data/__tests__/coinSymbol.test.ts`

_Updated: 2026-06-11T09:03:59.151Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/connect-coin-symbol&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/connect-coin-symbol&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-11T09:08:25.831Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-11T09:07:11.948Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/connect-coin-symbol/web/](https://dev.suite.sldev.cz/suite-web/mroz22/connect-coin-symbol/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->