### PR TITLE
Gate Solana staking management behind a feature flag

### DIFF
--- a/suite-native/app/.env.development
+++ b/suite-native/app/.env.development
@@ -15,6 +15,7 @@ EXPO_PUBLIC_ENVIRONMENT=debug
 # EXPO_PUBLIC_FF_IS_CONNECT_POPUP_ENABLED=true
 # EXPO_PUBLIC_FF_IS_TRADING_ENABLED=true
 # EXPO_PUBLIC_FF_IS_WALLET_CONNECT_ENABLED=true
+# EXPO_PUBLIC_FF_IS_SOLANA_STAKING_ENABLED=true
 
 
 ### Possibility to disable device checks, see suite-native/settings/src/settingsSlice.ts

--- a/suite-native/config/src/types.ts
+++ b/suite-native/config/src/types.ts
@@ -15,5 +15,6 @@ export type LaunchArguments = {
     isTradingDebugEnabled?: boolean;
     isN4w1BackupEnabled?: boolean;
     isStablecoinYieldEnabled?: boolean;
+    isSolanaStakingEnabled?: boolean;
     isN4W1BackupEnabled?: boolean;
 };

--- a/suite-native/feature-flags/src/__tests__/featureFlagsSlice.test.ts
+++ b/suite-native/feature-flags/src/__tests__/featureFlagsSlice.test.ts
@@ -23,6 +23,7 @@ describe('featureFlagsSlice', () => {
                 isTradingDebugEnabled: false,
                 isN4w1BackupEnabled: false,
                 isStablecoinYieldEnabled: false,
+                isSolanaStakingEnabled: false,
             });
         });
 
@@ -41,6 +42,7 @@ describe('featureFlagsSlice', () => {
                 isTradingDebugEnabled: false,
                 isN4w1BackupEnabled: false,
                 isStablecoinYieldEnabled: false,
+                isSolanaStakingEnabled: false,
             });
         });
     });

--- a/suite-native/feature-flags/src/featureFlagsSlice.ts
+++ b/suite-native/feature-flags/src/featureFlagsSlice.ts
@@ -10,6 +10,7 @@ export const FeatureFlag = {
     IsTradingResidenceCheckEnabled: 'isTradingResidenceCheckEnabled',
     IsTradingDebugEnabled: 'isTradingDebugEnabled',
     IsStablecoinYieldEnabled: 'isStablecoinYieldEnabled',
+    IsSolanaStakingEnabled: 'isSolanaStakingEnabled',
     IsN4w1BackupEnabled: 'isN4w1BackupEnabled',
 } as const;
 
@@ -36,6 +37,8 @@ export const featureFlagsInitialState: FeatureFlagsState = {
         process.env.EXPO_PUBLIC_FF_IS_TRADING_DEBUG_ENABLED === 'true',
     [FeatureFlag.IsStablecoinYieldEnabled]:
         process.env.EXPO_PUBLIC_FF_IS_STABLECOIN_YIELD_DEBUG_ENABLED === 'true',
+    [FeatureFlag.IsSolanaStakingEnabled]:
+        process.env.EXPO_PUBLIC_FF_IS_SOLANA_STAKING_ENABLED === 'true',
     [FeatureFlag.IsN4w1BackupEnabled]: process.env.EXPO_PUBLIC_FF_IS_N4W1_BACKUP_ENABLED === 'true',
 };
 
@@ -46,6 +49,7 @@ export const featureFlagsPersistedKeys: Array<keyof FeatureFlagsState> = [
     FeatureFlag.IsTradingResidenceCheckEnabled,
     FeatureFlag.IsTradingDebugEnabled,
     FeatureFlag.IsStablecoinYieldEnabled,
+    FeatureFlag.IsSolanaStakingEnabled,
     FeatureFlag.IsN4w1BackupEnabled,
 ];
 

--- a/suite-native/module-dev-utils/src/components/FeatureFlagsCard.tsx
+++ b/suite-native/module-dev-utils/src/components/FeatureFlagsCard.tsx
@@ -14,6 +14,7 @@ const featureFlagsTitleMap = {
     [FeatureFlagEnum.IsTradingResidenceCheckEnabled]: '💰 Trading Residence Check',
     [FeatureFlagEnum.IsTradingDebugEnabled]: '💰 Trading Debug Mode',
     [FeatureFlagEnum.IsStablecoinYieldEnabled]: 'Stablecoin Yield',
+    [FeatureFlagEnum.IsSolanaStakingEnabled]: 'Solana Staking',
     [FeatureFlagEnum.IsN4w1BackupEnabled]: 'N4W1 Backup',
 } as const satisfies Record<FeatureFlagEnum, string>;
 

--- a/suite-native/module-earn/src/components/EarnAccountCard.tsx
+++ b/suite-native/module-earn/src/components/EarnAccountCard.tsx
@@ -2,7 +2,10 @@ import { useSelector } from 'react-redux';
 
 import { selectIsPortfolioTrackerDevice } from '@suite-common/device';
 import { getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
-import { isSupportedStakingNetworkSymbol } from '@suite-common/wallet-utils';
+import {
+    isSupportedSolStakingNetworkSymbol,
+    isSupportedStakingNetworkSymbol,
+} from '@suite-common/wallet-utils';
 import { AccountTypeBadge } from '@suite-native/accounts';
 import { Box, Card, PressableOpacity, Text, VStack } from '@suite-native/atoms';
 import { CryptoIconWithNetwork, Icon } from '@suite-native/icons';
@@ -19,6 +22,7 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 import { CRYPTO_BALANCE_DECIMALS } from '../constants';
 import { EarnClaimAlert } from './EarnClaimAlert';
 import { useMessageSystemStaking } from '../hooks/useMessageSystemStaking';
+import { useSolanaStakingFlag } from '../hooks/useSolanaStakingFlag';
 import { type EarnDepositsCardActiveItem } from '../types';
 
 const itemCardStyle = prepareNativeStyle(utils => ({
@@ -66,7 +70,9 @@ export const EarnAccountCard = ({ item, onPress, onClaimPress }: EarnAccountCard
     const isStakingItem = item.type === 'staking';
     const isStablecoinYieldItem = item.type === 'stablecoin-yield';
     const isSupportedStaking = isStakingItem && isSupportedStakingNetworkSymbol(item.symbol);
+    const isSolStaking = isStakingItem && isSupportedSolStakingNetworkSymbol(item.symbol);
     const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
+    const isSolanaStakingEnabled = useSolanaStakingFlag();
 
     const apy = useStakingSelector(state =>
         isStakingItem
@@ -91,7 +97,10 @@ export const EarnAccountCard = ({ item, onPress, onClaimPress }: EarnAccountCard
 
     const { isClaimingDisabled } = useMessageSystemStaking(isStakingItem ? item.symbol : null);
 
-    const showClaimAlert = canClaim && !isClaimingDisabled && !isPortfolioTrackerDevice;
+    const isSolClaimHidden = isSolStaking && !isSolanaStakingEnabled;
+
+    const showClaimAlert =
+        canClaim && !isClaimingDisabled && !isPortfolioTrackerDevice && !isSolClaimHidden;
 
     const symbol = isStakingItem ? item.symbol : item.networkSymbol;
     const contractAddress = isStablecoinYieldItem ? item.tokenContractAddress : undefined;

--- a/suite-native/module-earn/src/components/EarnActiveItemsBottomSheet.tsx
+++ b/suite-native/module-earn/src/components/EarnActiveItemsBottomSheet.tsx
@@ -14,7 +14,7 @@ import {
 } from '@suite-native/navigation';
 
 import { EarnAccountCard } from './EarnAccountCard';
-import { useStakingDetailNavigation } from '../hooks/useStakingDetailNavigation';
+import { type NavigateToStakingDetail } from '../hooks/useStakingDetailNavigation';
 import { useStakingNavigateAnalytics } from '../hooks/useStakingNavigateAnalytics';
 import { type EarnDepositsCardActiveItem } from '../types';
 
@@ -24,6 +24,7 @@ type EarnActiveItemsBottomSheetProps = {
     ref: BottomSheetModalRef;
     type: EarnDepositsCardActiveItem['type'];
     items: EarnDepositsCardActiveItem[];
+    navigateToStakingDetail: NavigateToStakingDetail;
     onClose: () => void;
 };
 
@@ -31,10 +32,10 @@ export const EarnActiveItemsBottomSheet = ({
     ref,
     type,
     items,
+    navigateToStakingDetail,
     onClose,
 }: EarnActiveItemsBottomSheetProps) => {
     const navigation = useNavigation<NavigationProp>();
-    const { navigateToStakingDetail } = useStakingDetailNavigation();
     const reportStakingNavigate = useStakingNavigateAnalytics();
     const store = useStore<AccountsRootState>();
 
@@ -81,6 +82,7 @@ export const EarnActiveItemsBottomSheet = ({
             if (item.type !== 'staking') return;
 
             onClose();
+
             navigation.navigate(RootStackRoutes.ClaimReview, {
                 accountKey: item.accountKey,
                 symbol: item.symbol,

--- a/suite-native/module-earn/src/components/EarnDepositsCard.tsx
+++ b/suite-native/module-earn/src/components/EarnDepositsCard.tsx
@@ -10,10 +10,11 @@ import { BaseCurrencyAmountFormatter } from '@suite-native/formatters';
 import { Translation } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
-import { useEarnDepositsCardData } from '../hooks/useEarnDepositsCardData';
-import { type StablecoinYieldEarnItem, type StakingEarnItem } from '../types';
 import { EarnActiveItemsBottomSheet } from './EarnActiveItemsBottomSheet';
 import { EarnDepositsCardRow } from './EarnDepositsCardRow';
+import { useEarnDepositsCardData } from '../hooks/useEarnDepositsCardData';
+import { useStakingDetailNavigation } from '../hooks/useStakingDetailNavigation';
+import { type StablecoinYieldEarnItem, type StakingEarnItem } from '../types';
 
 const cardHeaderStyle = prepareNativeStyle(utils => ({
     padding: utils.spacings.sp16,
@@ -35,6 +36,7 @@ export const EarnDepositsCard = ({
         stakingActiveItems,
         stablecoinYieldActiveItems,
     });
+    const { navigateToStakingDetail } = useStakingDetailNavigation();
     const {
         bottomSheetRef: stakingSheetRef,
         closeModal: closeStakingSheet,
@@ -87,12 +89,14 @@ export const EarnDepositsCard = ({
                 ref={stakingSheetRef}
                 type="staking"
                 items={stakingRow?.activeItems ?? []}
+                navigateToStakingDetail={navigateToStakingDetail}
                 onClose={closeStakingSheet}
             />
             <EarnActiveItemsBottomSheet
                 ref={stablecoinYieldSheetRef}
                 type="stablecoin-yield"
                 items={stablecoinYieldRow?.activeItems ?? []}
+                navigateToStakingDetail={navigateToStakingDetail}
                 onClose={closeStablecoinYieldSheet}
             />
         </>

--- a/suite-native/module-earn/src/hooks/__tests__/useStakingDetailNavigation.test.tsx
+++ b/suite-native/module-earn/src/hooks/__tests__/useStakingDetailNavigation.test.tsx
@@ -1,0 +1,60 @@
+import { type AccountKey } from '@suite-common/wallet-types';
+import { RootStackRoutes } from '@suite-native/navigation';
+import { renderHook } from '@suite-native/test-utils';
+
+import { useSolanaStakingFlag } from '../useSolanaStakingFlag';
+import { useStakingDetailNavigation } from '../useStakingDetailNavigation';
+
+const mockNavigate = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+    ...jest.requireActual('@react-navigation/native'),
+    useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+jest.mock('../useSolanaStakingFlag', () => ({
+    useSolanaStakingFlag: jest.fn(),
+}));
+
+const mockUseSolanaStakingFlag = jest.mocked(useSolanaStakingFlag);
+
+const accountKey = 'account-key' as AccountKey;
+
+describe('useStakingDetailNavigation', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('navigates a Solana account to staking management when the feature flag is enabled', () => {
+        mockUseSolanaStakingFlag.mockReturnValue(true);
+
+        const { result } = renderHook(() => useStakingDetailNavigation());
+        result.current.navigateToStakingDetail({ accountKey, symbol: 'sol' });
+
+        expect(mockNavigate).toHaveBeenCalledWith(RootStackRoutes.StakingManagement, {
+            accountKey,
+        });
+    });
+
+    it('falls back to the read-only staking detail page when the Solana flag is disabled', () => {
+        mockUseSolanaStakingFlag.mockReturnValue(false);
+
+        const { result } = renderHook(() => useStakingDetailNavigation());
+        result.current.navigateToStakingDetail({ accountKey, symbol: 'sol' });
+
+        expect(mockNavigate).toHaveBeenCalledWith(RootStackRoutes.StakingDetail, {
+            accountKey,
+        });
+    });
+
+    it('never gates Ethereum staking regardless of the Solana flag', () => {
+        mockUseSolanaStakingFlag.mockReturnValue(false);
+
+        const { result } = renderHook(() => useStakingDetailNavigation());
+        result.current.navigateToStakingDetail({ accountKey, symbol: 'eth' });
+
+        expect(mockNavigate).toHaveBeenCalledWith(RootStackRoutes.StakingManagement, {
+            accountKey,
+        });
+    });
+});

--- a/suite-native/module-earn/src/hooks/useSolanaStakingFlag.ts
+++ b/suite-native/module-earn/src/hooks/useSolanaStakingFlag.ts
@@ -1,0 +1,3 @@
+import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
+
+export const useSolanaStakingFlag = () => useFeatureFlag(FeatureFlag.IsSolanaStakingEnabled);

--- a/suite-native/module-earn/src/hooks/useStakingDetailNavigation.ts
+++ b/suite-native/module-earn/src/hooks/useStakingDetailNavigation.ts
@@ -4,24 +4,38 @@ import { useNavigation } from '@react-navigation/native';
 
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type AccountKey } from '@suite-common/wallet-types';
+import { isSupportedSolStakingNetworkSymbol } from '@suite-common/wallet-utils';
 import {
     type RootStackParamList,
-    type RootStackRoutes,
+    RootStackRoutes,
     type StackNavigationProps,
 } from '@suite-native/navigation';
 
+import { useSolanaStakingFlag } from './useSolanaStakingFlag';
 import { resolveStakingTargetRoute } from '../utils/resolveStakingTargetRoute';
 
 type NavigationProp = StackNavigationProps<RootStackParamList, RootStackRoutes.StakingManagement>;
 
+export type NavigateToStakingDetail = (params: {
+    accountKey: AccountKey;
+    symbol: NetworkSymbol;
+}) => void;
+
 export const useStakingDetailNavigation = () => {
     const navigation = useNavigation<NavigationProp>();
+    const isSolanaStakingEnabled = useSolanaStakingFlag();
 
-    const navigateToStakingDetail = useCallback(
-        ({ accountKey, symbol }: { accountKey: AccountKey; symbol: NetworkSymbol }) => {
+    const navigateToStakingDetail = useCallback<NavigateToStakingDetail>(
+        ({ accountKey, symbol }) => {
+            if (isSupportedSolStakingNetworkSymbol(symbol) && !isSolanaStakingEnabled) {
+                navigation.navigate(RootStackRoutes.StakingDetail, { accountKey });
+
+                return;
+            }
+
             navigation.navigate(resolveStakingTargetRoute(symbol), { accountKey });
         },
-        [navigation],
+        [navigation, isSolanaStakingEnabled],
     );
 
     return { navigateToStakingDetail };

--- a/suite-native/module-earn/src/hooks/useStakingPromoNavigation.ts
+++ b/suite-native/module-earn/src/hooks/useStakingPromoNavigation.ts
@@ -8,6 +8,7 @@ import { selectIsDeviceInViewOnlyMode } from '@suite-common/device';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { selectVisibleDeviceAccounts } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
+import { isSupportedSolStakingNetworkSymbol } from '@suite-common/wallet-utils';
 import { useAccountAlerts } from '@suite-native/accounts';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { useBottomSheetModal } from '@suite-native/atoms';
@@ -20,6 +21,8 @@ import {
 
 import { useEarnPortfolioTrackerGuard } from '../components/EarnPortfolioTrackerGuard';
 import { type StakingEarnItem } from '../types';
+import { useSolanaStakingFlag } from './useSolanaStakingFlag';
+import { useStakingDetailNavigation } from './useStakingDetailNavigation';
 import { useStakingNavigateAnalytics } from './useStakingNavigateAnalytics';
 import { isStakeFlowSupportedSymbol } from '../utils';
 import { navigateByAccountState } from '../utils/navigateByAccountState';
@@ -34,6 +37,8 @@ export const useStakingPromoNavigation = () => {
     const { showViewOnlyAddAccountAlert } = useAccountAlerts();
     const { isPortfolioTrackerDevice, openPortfolioTrackerSheet } = useEarnPortfolioTrackerGuard();
     const { analytics } = useServices(selectNativeAnalyticsDep);
+    const isSolanaStakingEnabled = useSolanaStakingFlag();
+    const { navigateToStakingDetail } = useStakingDetailNavigation();
 
     const reportStakingNavigate = useStakingNavigateAnalytics();
 
@@ -59,14 +64,28 @@ export const useStakingPromoNavigation = () => {
     const chooseAccountSymbolRef = useRef<NetworkSymbol | null>(null);
     const pendingEnableSymbolRef = useRef<NetworkSymbol | null>(null);
 
+    const chooseAccountModeRef = useRef<'stake' | 'detail'>('stake');
+
     const handleAccountSelected = useCallback(
         (account: Account) => {
             chooseAccountContinuedRef.current = true;
             closeChooseAccountModal();
             reportStakingNavigate(account);
+
+            if (chooseAccountModeRef.current === 'detail') {
+                navigateToStakingDetail({ accountKey: account.key, symbol: account.symbol });
+
+                return;
+            }
+
             navigateByAccountState(account, navigation.navigate);
         },
-        [closeChooseAccountModal, navigation.navigate, reportStakingNavigate],
+        [
+            closeChooseAccountModal,
+            navigation.navigate,
+            reportStakingNavigate,
+            navigateToStakingDetail,
+        ],
     );
 
     const handleChooseAccountDismiss = useCallback(() => {
@@ -138,13 +157,22 @@ export const useStakingPromoNavigation = () => {
                 return;
             }
 
+            const accountsForSymbol = accounts.filter(acc => acc.symbol === item.symbol);
+
+            const isSolStakingViewOnly =
+                isSupportedSolStakingNetworkSymbol(item.symbol) && !isSolanaStakingEnabled;
+
+            if (isSolStakingViewOnly && accountsForSymbol.length === 0) {
+                openInfoModal();
+
+                return;
+            }
+
             if (isPortfolioTrackerDevice) {
                 openPortfolioTrackerSheet();
 
                 return;
             }
-
-            const accountsForSymbol = accounts.filter(acc => acc.symbol === item.symbol);
 
             if (accountsForSymbol.length === 0) {
                 setPendingEnableSymbol(item.symbol);
@@ -158,6 +186,13 @@ export const useStakingPromoNavigation = () => {
             const singleAccount = accountsForSymbol[0];
             if (accountsForSymbol.length === 1 && singleAccount) {
                 reportStakingNavigate(singleAccount);
+
+                if (isSolStakingViewOnly) {
+                    navigateToStakingDetail({ accountKey: singleAccount.key, symbol: item.symbol });
+
+                    return;
+                }
+
                 navigateByAccountState(singleAccount, navigation.navigate);
 
                 return;
@@ -166,17 +201,20 @@ export const useStakingPromoNavigation = () => {
             setChosenAccounts(accountsForSymbol);
             chooseAccountSymbolRef.current = item.symbol;
             chooseAccountContinuedRef.current = false;
+            chooseAccountModeRef.current = isSolStakingViewOnly ? 'detail' : 'stake';
             openChooseAccountModal();
         },
         [
             accounts,
             navigation.navigate,
+            isSolanaStakingEnabled,
             isPortfolioTrackerDevice,
             openPortfolioTrackerSheet,
             openInfoModal,
             openChooseAccountModal,
             openEnableNetworkModal,
             reportStakingNavigate,
+            navigateToStakingDetail,
         ],
     );
 


### PR DESCRIPTION
## Description

Introduces an `IsSolanaStakingEnabled` feature flag for the native app and gates the Solana staking management entry points behind it. While the flag is disabled, existing Solana stakes prompt the user to manage their staking in the Trezor Suite desktop app instead of opening the native management flow. Ethereum and Cardano staking are unaffected. The flag can be overridden via env var (`EXPO_PUBLIC_FF_IS_SOLANA_STAKING_ENABLED`), the dev-utils Feature Flags card, and Detox launch arguments.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/28609