### PR TITLE
fix(trading): use revoke calldata for dex fee estimation

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -25,6 +25,7 @@ import {
     type TradingTransactionExchange,
     cryptoIdToNetwork,
     exchangeThunks,
+    getDexEstimationData,
     invityAPI,
     isSendRejectedError,
     isSendingEvmNativeToken,
@@ -601,7 +602,7 @@ export const useTradingExchangeForm = ({
 
         const { dexTx } = quote;
 
-        setValue('transactionData', dexTx.data);
+        setValue('transactionData', getDexEstimationData(quote) ?? '');
         setValue(TRADING_FORM_OUTPUT_ADDRESS, dexTx.to);
         setValue('ethereumAdjustGasLimit', ETHEREUM_ADJUST_GAS_LIMIT);
         // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/suite-common/trading/src/utils/exchange/__tests__/exchangeUtils.test.ts
+++ b/suite-common/trading/src/utils/exchange/__tests__/exchangeUtils.test.ts
@@ -1,10 +1,16 @@
 import { type CryptoId } from 'invity-api';
 
+import { buildApprovalTransactionData } from '@suite-common/wallet-utils';
+
 import {
     getApprovalStatus,
+    getDexEstimationData,
     requiresTokenApproval,
     tokenSupportsIncreasingAllowance,
 } from '../exchangeUtils';
+
+const USDT_CRYPTO_ID = 'ethereum--0xdac17f958d2ee523a2206206994597c13d831ec7' as CryptoId;
+const DAI_CRYPTO_ID = 'ethereum--0x6b175474e89094c44da98b954eedeac495271d0f' as CryptoId;
 
 describe('requiresTokenApproval', () => {
     it('should return false when no quote is provided', () => {
@@ -45,7 +51,7 @@ describe('requiresTokenApproval', () => {
         const quote = {
             orderId: 'test-order',
             isDex: true,
-            send: 'ethereum--0xdac17f958d2ee523a2206206994597c13d831ec7' as CryptoId,
+            send: USDT_CRYPTO_ID,
         };
         const result = requiresTokenApproval(quote);
         expect(result).toBe(true);
@@ -55,7 +61,7 @@ describe('requiresTokenApproval', () => {
         const quote = {
             orderId: 'test-order',
             isDex: true,
-            send: 'ethereum--0xdac17f958d2ee523a2206206994597c13d831ec7' as CryptoId,
+            send: USDT_CRYPTO_ID,
             status: 'SIGN_DATA' as const,
         };
         const result = requiresTokenApproval(quote);
@@ -66,7 +72,7 @@ describe('requiresTokenApproval', () => {
         const quote = {
             orderId: 'test-order',
             isDex: true,
-            send: 'ethereum--0xdac17f958d2ee523a2206206994597c13d831ec7' as CryptoId,
+            send: USDT_CRYPTO_ID,
             status: 'SIGN_DATA' as const,
             signData: {
                 type: 'slip24',
@@ -81,7 +87,7 @@ describe('requiresTokenApproval', () => {
         const quote = {
             orderId: 'test-order',
             isDex: true,
-            send: 'ethereum--0xdac17f958d2ee523a2206206994597c13d831ec7' as CryptoId,
+            send: USDT_CRYPTO_ID,
             status: 'SIGN_DATA' as const,
             signData: {
                 type: 'eip712-typed-data' as const,
@@ -94,8 +100,6 @@ describe('requiresTokenApproval', () => {
 });
 
 describe('getApprovalStatus', () => {
-    const dexTokenSend = 'ethereum--0x6b175474e89094c44da98b954eedeac495271d0f' as CryptoId;
-
     it('should return null when no quote is provided', () => {
         const result = getApprovalStatus(undefined);
         expect(result).toBe(null);
@@ -106,7 +110,7 @@ describe('getApprovalStatus', () => {
             orderId: 'test-order',
             preapprovedStringAmount: '0.001',
             isDex: true,
-            send: dexTokenSend,
+            send: DAI_CRYPTO_ID,
             status: 'CONFIRM' as const,
         };
         const result = getApprovalStatus(quote);
@@ -118,7 +122,7 @@ describe('getApprovalStatus', () => {
             orderId: 'test-order',
             preapprovedStringAmount: '0.001',
             isDex: true,
-            send: dexTokenSend,
+            send: DAI_CRYPTO_ID,
         };
         const result = getApprovalStatus(quote);
         expect(result).toBe('approved');
@@ -129,7 +133,7 @@ describe('getApprovalStatus', () => {
             orderId: 'test-order',
             preapprovedStringAmount: '0.001',
             isDex: true,
-            send: dexTokenSend,
+            send: DAI_CRYPTO_ID,
             status: 'APPROVAL_REQ' as const,
         };
         const result = getApprovalStatus(quote);
@@ -141,7 +145,7 @@ describe('getApprovalStatus', () => {
             orderId: 'test-order',
             preapprovedStringAmount: '0.001',
             isDex: true,
-            send: 'ethereum--0xdac17f958d2ee523a2206206994597c13d831ec7' as CryptoId,
+            send: USDT_CRYPTO_ID,
             status: 'APPROVAL_REQ' as const,
         };
         const result = getApprovalStatus(quote);
@@ -153,7 +157,7 @@ describe('getApprovalStatus', () => {
             orderId: 'test-order',
             preapprovedStringAmount: '0',
             isDex: true,
-            send: dexTokenSend,
+            send: DAI_CRYPTO_ID,
         };
         const result = getApprovalStatus(quote);
         expect(result).toBe('needs_approval');
@@ -164,7 +168,7 @@ describe('getApprovalStatus', () => {
             orderId: 'test-order',
             preapprovedStringAmount: undefined,
             isDex: true,
-            send: 'ethereum--0x6b175474e89094c44da98b954eedeac495271d0f' as CryptoId,
+            send: DAI_CRYPTO_ID,
         };
         const result = getApprovalStatus(quote);
         expect(result).toBe('needs_approval');
@@ -184,7 +188,7 @@ describe('getApprovalStatus', () => {
         const quote = {
             orderId: 'test-order',
             isDex: true,
-            send: dexTokenSend,
+            send: DAI_CRYPTO_ID,
             status: 'SIGN_DATA' as const,
             signData: {
                 type: 'eip712-typed-data' as const,
@@ -199,7 +203,7 @@ describe('getApprovalStatus', () => {
         const quote = {
             orderId: 'test-order',
             isDex: true,
-            send: dexTokenSend,
+            send: DAI_CRYPTO_ID,
             status: 'SIGN_DATA' as const,
             signData: {
                 type: 'slip24',
@@ -214,7 +218,7 @@ describe('getApprovalStatus', () => {
         const quote = {
             orderId: 'test-order',
             isDex: true,
-            send: dexTokenSend,
+            send: DAI_CRYPTO_ID,
             signData: {
                 type: 'eip712-typed-data' as const,
                 data: {},
@@ -255,5 +259,55 @@ describe('tokenSupportsIncreasingAllowance', () => {
     it('should return false for empty string', () => {
         const result = tokenSupportsIncreasingAllowance('');
         expect(result).toBe(false);
+    });
+});
+
+describe('getDexEstimationData', () => {
+    const spender = '0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae';
+    const approveData = buildApprovalTransactionData({ spender, amount: '9475047' });
+
+    const buildDexTx = (data: string) => ({
+        from: '0x9cd02a26cd336d0fe784fb7995f6e5c9e3776258',
+        to: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+        data,
+        value: '0',
+    });
+
+    it('returns a zero-amount revoke calldata for a needs_revoke quote (USDT with existing allowance)', () => {
+        const quote = {
+            orderId: 'test-order',
+            isDex: true,
+            send: USDT_CRYPTO_ID,
+            preapprovedStringAmount: '0.001',
+            status: 'APPROVAL_REQ' as const,
+            dexTx: buildDexTx(approveData),
+        };
+
+        const result = getDexEstimationData(quote);
+        expect(result).toBe(buildApprovalTransactionData({ spender, amount: '0' }));
+        expect(result).not.toBe(approveData);
+    });
+
+    it('returns dexTx.data unchanged for a needs_increase quote (standard token supports increasing)', () => {
+        const quote = {
+            orderId: 'test-order',
+            isDex: true,
+            send: DAI_CRYPTO_ID,
+            preapprovedStringAmount: '0.001',
+            status: 'APPROVAL_REQ' as const,
+            dexTx: buildDexTx(approveData),
+        };
+
+        expect(getDexEstimationData(quote)).toBe(approveData);
+    });
+
+    it('returns undefined when the quote has no dexTx', () => {
+        const quote = {
+            orderId: 'test-order',
+            isDex: true,
+            send: USDT_CRYPTO_ID,
+        };
+
+        expect(getDexEstimationData(quote)).toBeUndefined();
     });
 });

--- a/suite-common/trading/src/utils/exchange/exchangeUtils.ts
+++ b/suite-common/trading/src/utils/exchange/exchangeUtils.ts
@@ -1,7 +1,11 @@
 import type { CryptoId, ExchangeTrade, ExchangeTradeStatus } from 'invity-api';
 
 import { invariant } from '@suite-common/suite-utils';
-import { tokenSupportsIncreasingAllowance } from '@suite-common/wallet-utils';
+import {
+    buildApprovalTransactionData,
+    getErc20ApproveSpender,
+    tokenSupportsIncreasingAllowance,
+} from '@suite-common/wallet-utils';
 
 import { CONTRACT_ADDRESS_FOR_NATIVE_TOKEN } from '../../constants';
 import { type ExchangeInfo } from '../../reducers/exchangeReducer';
@@ -151,6 +155,25 @@ export const getApprovalStatus = (candidateQuote?: ExchangeTrade): ApprovalStatu
     return 'needs_approval';
 };
 
+export const getDexEstimationData = (quote: ExchangeTrade): string | undefined => {
+    if (!quote.dexTx?.data) {
+        return undefined;
+    }
+
+    if (getApprovalStatus(quote) === 'needs_revoke') {
+        const spender = getErc20ApproveSpender(quote.dexTx.data);
+        if (spender) {
+            try {
+                return buildApprovalTransactionData({ spender, amount: '0' });
+            } catch {
+                return quote.dexTx.data;
+            }
+        }
+    }
+
+    return quote.dexTx.data;
+};
+
 export const exchangeUtils = {
     getAmountLimits,
     isQuoteError,
@@ -161,4 +184,5 @@ export const exchangeUtils = {
     hasEip712SignData,
     requiresTokenApproval,
     getApprovalStatus,
+    getDexEstimationData,
 };

--- a/suite-common/wallet-utils/src/ethUtils.ts
+++ b/suite-common/wallet-utils/src/ethUtils.ts
@@ -60,6 +60,9 @@ export const getEvmTransactionTextSignature = (data?: string): EvmTransactionPur
 export const isEvmApprovalTx = (data?: string): boolean =>
     Calldata.evm.erc20.approve.decode(data) !== null;
 
+export const getErc20ApproveSpender = (data?: string): string | undefined =>
+    Calldata.evm.erc20.approve.decode(data)?.spender;
+
 export type EvmApprovalPurpose = Extract<EvmTransactionPurpose, 'approve' | 'revoke'>;
 
 export const isEvmApprovalTxByTextSignature = (


### PR DESCRIPTION
## Description

- Uses revoke calldata for DEX fee estimation when the selected quote requires an allowance revoke first.
- Keeps the original DEX calldata for tokens that support increasing allowance or quotes without DEX calldata.
- Adds exchange utility coverage for revoke estimation data and approve-spender extraction.

## Notes for QA

- Trading > Swap > Ethereum ERC-20 that requires revoke before approve, load quotes and verify the "Fee estimation from network failed. Using backup value." toast is not repeatedly shown.
- Trading > Swap > Ethereum ERC-20 that supports increasing allowance, load quotes and verify the swap flow still estimates fees normally.

## Related Issue

Resolve #18060

## Screenshots:

N/A

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are focused on trading/exchange (swap) functionality: the exchange form hook (`useTradingExchangeForm.ts`), exchange utility functions (`exchangeUtils.ts`), and Ethereum utility functions (`ethUtils.ts`). All three changed source files map to 121 tests via static analysis, indicating they are broadly imported shared modules. The recommended strategy prioritizes swap/exchange E2E tests at high priority since they directly exercise the exchange form and quote processing logic. ETH send tests are medium priority due to `ethUtils.ts` changes potentially affecting fee calculations. The unit test file for exchangeUtils has no E2E coverage mapping but provides its own coverage.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts`
- `suite-common/trading/src/utils/exchange/__tests__/exchangeUtils.test.ts`
- `suite-common/trading/src/utils/exchange/exchangeUtils.ts`
- `suite-common/wallet-utils/src/ethUtils.ts`

</details>

**Recommended tests (14)**

<details><summary>🔴 <b>High priority (7)</b></summary>

- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — This test exercises the full swap flow (SOL to USDC) including filling the swap form, viewing quotes, confirming trades, and verifying transaction details. The changed `exchangeUtils.ts` directly handles exchange/swap quote processing and the `useTradingExchangeForm.ts` hook drives the swap form logic.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Tests SOL-to-BTC swap including quote display, device confirmation, status progression through SENDING→CONFIRMING→CONVERTING→SUCCESS. Directly exercises exchange form logic and exchange utilities for quote processing and trade execution.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Tests token-to-token swap (USDT to USDC on Solana), exercising the swap form, quote selection, and trade confirmation flow that relies on `useTradingExchangeForm` and `exchangeUtils` for quote/trade processing.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Tests swapping a Solana USDT token for Bitcoin, covering the exchange form fill, best offer quote display, trade confirmation, and success status. Directly depends on exchange utilities and the exchange form hook.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Tests BTC-to-ETH swap with custom fee settings, verifying fee display in the confirmation modal and on the device. The swap form and fee handling rely on `useTradingExchangeForm` and exchange utilities.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests ETH-to-BTC swap with custom Ethereum gas fees. The exchange form hook and ethUtils are both exercised here since the test sets custom gas parameters and verifies their display. Changes to `ethUtils.ts` could affect fee calculations.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — Tests swap form input behavior including asset selection, fraction buttons, balance validation, and provider selection. Directly exercises the swap form UI powered by `useTradingExchangeForm` and quote processing from `exchangeUtils`.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — Tests swapping to an asset on a disabled network and verifying provider info display. Exercises the exchange form and quote display path, though with a simpler flow than full swap tests.
- `suite/e2e/tests/trading/swap-history.test.ts` — Tests swap/exchange order history display including trade status, amounts, and provider details. Exchange utilities are used for processing and displaying swap trade data, so changes there could affect history rendering.
- `suite/e2e/tests/trading/navigation.test.ts` — Tests navigation to the Swap form from various entry points and verifies the form opens with correct pre-selected assets. The swap form initialization relies on `useTradingExchangeForm`.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Tests sending ETH with custom gas fee parameters and verifying fee display on device. Changes to `ethUtils.ts` could affect Ethereum fee calculations and formatting used in the send flow.
- `suite/e2e/tests/wallet/send-base.test.ts` — Tests sending on Base (EVM L2) with custom Ethereum fees. Changes to `ethUtils.ts` could affect gas limit, fee rate calculations, and maximum fee display for EVM chains.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — ETH staking involves Ethereum transaction construction where `ethUtils.ts` may be used for fee/amount calculations. The swap exchange utilities are not directly involved, but ETH utility changes could affect staking transaction display.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — ETH unstaking involves Ethereum transaction construction and fee display that may use `ethUtils.ts` functions. A regression in eth utility functions could affect amount/fee formatting.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/trading/src/utils/exchange/__tests__/exchangeUtils.test.ts`

_Updated: 2026-06-15T10:18:31.702Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trading-18060-dex-fee-estimation-fallback&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trading-18060-dex-fee-estimation-fallback&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/trading-18060-dex-fee-estimation-fallback&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-15T10:23:39.324Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-15T10:21:47.114Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/trading-18060-dex-fee-estimation-fallback/web/](https://dev.suite.sldev.cz/suite-web/fix/trading-18060-dex-fee-estimation-fallback/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->