### PR TITLE
fix(suite-native-27373): mobile bottomsheet is unable to close with button

### DIFF
--- a/suite-native/atoms/src/Sheet/BottomSheetFlashList.tsx
+++ b/suite-native/atoms/src/Sheet/BottomSheetFlashList.tsx
@@ -4,13 +4,17 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import {
     BottomSheetBackdrop,
+    type BottomSheetHandleProps,
     BottomSheetModal,
-    type BottomSheetProps,
     useBottomSheetScrollableCreator,
 } from '@gorhom/bottom-sheet';
 import { FlashList, type FlashListProps } from '@shopify/flash-list';
 
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+
+export type BottomSheetFlashListHandleProps = BottomSheetHandleProps & {
+    closeSheet: () => void;
+};
 
 export type BottomSheetFlashListProps<TItem> = {
     isVisible: boolean;
@@ -18,7 +22,7 @@ export type BottomSheetFlashListProps<TItem> = {
     title?: ReactNode;
     subtitle?: ReactNode;
     estimatedListHeight?: number;
-    handleComponent?: BottomSheetProps['handleComponent'];
+    handleComponent?: ((props: BottomSheetFlashListHandleProps) => ReactNode) | null;
     flashListKey?: string;
 } & FlashListProps<TItem>;
 
@@ -63,9 +67,23 @@ export const BottomSheetFlashList = <TItem,>({
         bottomSheetModalRef.current?.dismiss();
     }, []);
 
+    const closeSheet = useCallback(() => {
+        dismissSheet();
+        onClose(false);
+    }, [dismissSheet, onClose]);
+
     const handleDismiss = useCallback(() => {
         onClose(false);
     }, [onClose]);
+
+    const renderHandleComponent = useCallback(
+        (props: BottomSheetHandleProps) =>
+            handleComponent?.({
+                ...props,
+                closeSheet,
+            }) ?? undefined,
+        [closeSheet, handleComponent],
+    );
 
     const maxHeight = Dimensions.get('window').height * 0.9;
     const minHeight = Math.max(Dimensions.get('window').height * 0.4, estimatedListHeight);
@@ -101,7 +119,7 @@ export const BottomSheetFlashList = <TItem,>({
             handleIndicatorStyle={applyStyle(handleStyle)}
             // @ts-expect-error wrong type, doesn't expect children
             containerComponent={WindowOverlay}
-            handleComponent={handleComponent}
+            handleComponent={renderHandleComponent}
             keyboardBlurBehavior="restore"
             keyboardBehavior="fillParent"
         >

--- a/suite-native/atoms/src/Sheet/BottomSheetFlashList.tsx
+++ b/suite-native/atoms/src/Sheet/BottomSheetFlashList.tsx
@@ -12,19 +12,30 @@ import { FlashList, type FlashListProps } from '@shopify/flash-list';
 
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
+type FlashListRenderItem<TItem> = NonNullable<FlashListProps<TItem>['renderItem']>;
+type FlashListRenderItemInfo<TItem> = Parameters<FlashListRenderItem<TItem>>[0];
+
+export type BottomSheetFlashListControls = {
+    closeSheet: (shouldHideKeyboard?: boolean) => void;
+};
+
 export type BottomSheetFlashListHandleProps = BottomSheetHandleProps & {
-    closeSheet: () => void;
+    closeSheet: BottomSheetFlashListControls['closeSheet'];
 };
 
 export type BottomSheetFlashListProps<TItem> = {
     isVisible: boolean;
-    onClose: (isVisible: boolean) => void;
+    onClose: (shouldHideKeyboard?: boolean) => void;
     title?: ReactNode;
     subtitle?: ReactNode;
     estimatedListHeight?: number;
     handleComponent?: ((props: BottomSheetFlashListHandleProps) => ReactNode) | null;
     flashListKey?: string;
-} & FlashListProps<TItem>;
+    renderItem: (
+        info: FlashListRenderItemInfo<TItem>,
+        sheetControls: BottomSheetFlashListControls,
+    ) => ReturnType<FlashListRenderItem<TItem>>;
+} & Omit<FlashListProps<TItem>, 'renderItem'>;
 
 const bottomSheetStyle = prepareNativeStyle(utils => ({
     backgroundColor: utils.colors.surfaceFillPage,
@@ -56,6 +67,7 @@ export const BottomSheetFlashList = <TItem,>({
     estimatedListHeight = 0,
     handleComponent,
     flashListKey,
+    renderItem,
     ...flashListProps
 }: BottomSheetFlashListProps<TItem>) => {
     const { applyStyle } = useNativeStyles();
@@ -67,10 +79,13 @@ export const BottomSheetFlashList = <TItem,>({
         bottomSheetModalRef.current?.dismiss();
     }, []);
 
-    const closeSheet = useCallback(() => {
-        dismissSheet();
-        onClose(false);
-    }, [dismissSheet, onClose]);
+    const closeSheet = useCallback(
+        (shouldHideKeyboard?: boolean) => {
+            dismissSheet();
+            onClose(shouldHideKeyboard);
+        },
+        [dismissSheet, onClose],
+    );
 
     const handleDismiss = useCallback(() => {
         onClose(false);
@@ -83,6 +98,11 @@ export const BottomSheetFlashList = <TItem,>({
                 closeSheet,
             }) ?? undefined,
         [closeSheet, handleComponent],
+    );
+
+    const renderFlashListItem = useCallback(
+        (info: FlashListRenderItemInfo<TItem>) => renderItem(info, { closeSheet }),
+        [renderItem, closeSheet],
     );
 
     const maxHeight = Dimensions.get('window').height * 0.9;
@@ -110,7 +130,7 @@ export const BottomSheetFlashList = <TItem,>({
             backdropComponent={props => (
                 <BottomSheetBackdrop
                     {...props}
-                    onPress={dismissSheet}
+                    onPress={closeSheet}
                     appearsOnIndex={0}
                     disappearsOnIndex={-1}
                 />
@@ -125,6 +145,7 @@ export const BottomSheetFlashList = <TItem,>({
         >
             <FlashList
                 renderScrollComponent={BottomSheetListScrollComponent}
+                renderItem={renderFlashListItem}
                 key={flashListKey}
                 {...flashListProps}
                 contentContainerStyle={applyStyle(sheetContentContainerStyle, {

--- a/suite-native/atoms/src/Sheet/BottomSheetFlashList.tsx
+++ b/suite-native/atoms/src/Sheet/BottomSheetFlashList.tsx
@@ -16,7 +16,7 @@ type FlashListRenderItem<TItem> = NonNullable<FlashListProps<TItem>['renderItem'
 type FlashListRenderItemInfo<TItem> = Parameters<FlashListRenderItem<TItem>>[0];
 
 export type BottomSheetFlashListControls = {
-    closeSheet: (shouldHideKeyboard?: boolean) => void;
+    closeSheet: () => void;
 };
 
 export type BottomSheetFlashListHandleProps = BottomSheetHandleProps & {
@@ -79,14 +79,6 @@ export const BottomSheetFlashList = <TItem,>({
         bottomSheetModalRef.current?.dismiss();
     }, []);
 
-    const closeSheet = useCallback(
-        (shouldHideKeyboard?: boolean) => {
-            dismissSheet();
-            onClose(shouldHideKeyboard);
-        },
-        [dismissSheet, onClose],
-    );
-
     const handleDismiss = useCallback(() => {
         onClose(false);
     }, [onClose]);
@@ -95,14 +87,14 @@ export const BottomSheetFlashList = <TItem,>({
         (props: BottomSheetHandleProps) =>
             handleComponent?.({
                 ...props,
-                closeSheet,
+                closeSheet: dismissSheet,
             }) ?? undefined,
-        [closeSheet, handleComponent],
+        [dismissSheet, handleComponent],
     );
 
     const renderFlashListItem = useCallback(
-        (info: FlashListRenderItemInfo<TItem>) => renderItem(info, { closeSheet }),
-        [renderItem, closeSheet],
+        (info: FlashListRenderItemInfo<TItem>) => renderItem(info, { closeSheet: dismissSheet }),
+        [renderItem, dismissSheet],
     );
 
     const maxHeight = Dimensions.get('window').height * 0.9;
@@ -130,7 +122,7 @@ export const BottomSheetFlashList = <TItem,>({
             backdropComponent={props => (
                 <BottomSheetBackdrop
                     {...props}
-                    onPress={closeSheet}
+                    onPress={dismissSheet}
                     appearsOnIndex={0}
                     disappearsOnIndex={-1}
                 />

--- a/suite-native/atoms/src/Sheet/hooks/useBottomSheetModal.ts
+++ b/suite-native/atoms/src/Sheet/hooks/useBottomSheetModal.ts
@@ -1,26 +1,30 @@
 import { useCallback, useRef } from 'react';
 import { KeyboardController } from 'react-native-keyboard-controller';
 
-import { useBottomSheetModal as useBottomSheetModalContext } from '@gorhom/bottom-sheet';
 import {
     type BottomSheetModal,
     useBottomSheetModal as useGorhomBottomSheetModal,
 } from '@gorhom/bottom-sheet';
 
-export const useBottomSheetModal = () => {
-    const { dismiss } = useGorhomBottomSheetModal();
+type BottomSheetModalProps = {
+    isNestedSheet?: boolean;
+};
+
+export const useBottomSheetModal = ({ isNestedSheet = false }: BottomSheetModalProps = {}) => {
+    const { dismiss, dismissAll } = useGorhomBottomSheetModal();
     const bottomSheetRef = useRef<BottomSheetModal>(null);
-    const { dismissAll } = useBottomSheetModalContext();
 
     const openModal = useCallback(() => {
-        dismissAll();
-        void KeyboardController.dismiss({ animated: false });
-        // When rapidly presenting and dismissing multiple bottom sheets, already dismissed bottom
-        // sheet may reappear because dismiss() is not actually called until the closing animation
-        // finishes & unmounts. Dismissing the last presented bottom sheet prevents this.
-        dismiss();
+        if (!isNestedSheet) {
+            dismissAll();
+            void KeyboardController.dismiss({ animated: false });
+            // When rapidly presenting and dismissing multiple bottom sheets, already dismissed bottom
+            // sheet may reappear because dismiss() is not actually called until the closing animation
+            // finishes & unmounts. Dismissing the last presented bottom sheet prevents this.
+            dismiss();
+        }
         bottomSheetRef.current?.present();
-    }, [dismiss, dismissAll]);
+    }, [dismissAll, dismiss, isNestedSheet]);
 
     const closeModal = useCallback(() => {
         bottomSheetRef.current?.dismiss();

--- a/suite-native/module-trading/src/components/concierge/ConciergeProviderSheet.tsx
+++ b/suite-native/module-trading/src/components/concierge/ConciergeProviderSheet.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { Pressable } from 'react-native';
 
 import { type OtcProviderType } from '@suite-common/trading';
-import { Box, Text } from '@suite-native/atoms';
+import { type BottomSheetFlashListHandleProps, Box, Text } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { BottomSheetSectionList, type SectionListData } from '@suite-native/trading-atoms';
 
@@ -61,9 +61,9 @@ export const ConciergeProviderSheet = ({
             estimatedListHeight={estimatedListHeight}
             isVisible={isVisible}
             onClose={onClose}
-            handleComponent={() => (
+            handleComponent={({ closeSheet }: BottomSheetFlashListHandleProps) => (
                 <SimpleSheetHeader
-                    onClose={onClose}
+                    onClose={closeSheet}
                     title={<Translation id="moduleTrading.tradingScreen.provider" />}
                 />
             )}

--- a/suite-native/module-trading/src/components/general/FiatCurrencySheet/FiatCurrencySheet.tsx
+++ b/suite-native/module-trading/src/components/general/FiatCurrencySheet/FiatCurrencySheet.tsx
@@ -50,11 +50,6 @@ export const FiatCurrencySheet = memo(
             [setFilterValue, translate, searchInputTestId],
         );
 
-        const onFiatSelectCallback = (currency: FiatCurrencyCode) => {
-            onFiatSelect(currency);
-            onClose();
-        };
-
         // re-mount FLashList component when filterValue changes (resets scroll position)
         const flashListKey = 'fiat_currencies_list-' + filterValue;
 
@@ -64,11 +59,14 @@ export const FiatCurrencySheet = memo(
                 onClose={onClose}
                 ListEmptyComponent={<FiatCurrencyListEmptyComponent />}
                 handleComponent={renderHandle}
-                renderItem={({ value, ...rest }) => (
+                renderItem={({ value, ...rest }, _config, { closeSheet }) => (
                     <FiatCurrencyListItem
                         {...rest}
                         value={value}
-                        onPress={() => onFiatSelectCallback(value)}
+                        onPress={() => {
+                            onFiatSelect(value);
+                            closeSheet();
+                        }}
                     />
                 )}
                 data={filteredData}

--- a/suite-native/module-trading/src/components/general/FiatCurrencySheet/FiatCurrencySheet.tsx
+++ b/suite-native/module-trading/src/components/general/FiatCurrencySheet/FiatCurrencySheet.tsx
@@ -2,7 +2,7 @@ import { memo, useCallback } from 'react';
 
 import type { FiatCurrencyCode } from 'invity-api';
 
-import { Divider } from '@suite-native/atoms';
+import { type BottomSheetFlashListHandleProps, Divider } from '@suite-native/atoms';
 import { Translation, useTranslate } from '@suite-native/intl';
 import { BottomSheetSectionList, SearchableSheetHeader } from '@suite-native/trading-atoms';
 import { type FiatCurrencyItem } from '@suite-native/trading-types';
@@ -35,10 +35,10 @@ export const FiatCurrencySheet = memo(
         const { translate } = useTranslate();
 
         const renderHandle = useCallback(
-            () => (
+            ({ closeSheet }: BottomSheetFlashListHandleProps) => (
                 <SearchableSheetHeader
                     key="fiat_currency"
-                    onClose={onClose}
+                    onClose={closeSheet}
                     title={<Translation id="moduleTrading.fiatCurrencySheet.title" />}
                     onFilterChange={setFilterValue}
                     searchInputPlaceholder={translate(
@@ -47,7 +47,7 @@ export const FiatCurrencySheet = memo(
                     searchInputTestId={searchInputTestId}
                 />
             ),
-            [onClose, setFilterValue, translate, searchInputTestId],
+            [setFilterValue, translate, searchInputTestId],
         );
 
         const onFiatSelectCallback = (currency: FiatCurrencyCode) => {

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetSheet.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetSheet.tsx
@@ -42,11 +42,6 @@ const renderItem = (
 
 export const MyAssetSheet = memo(
     ({ tradingType, isVisible, onClose, onAssetSelect, testID }: MyAssetSheetProps) => {
-        const onAssetSelectCallback = (asset: TradeableAsset, account: Account) => {
-            onAssetSelect(asset, account);
-            onClose(false);
-        };
-
         const myAssets = useSelector((state: CombinedSelectorsRootState) =>
             selectAccountsWithTokensToSellSectionCondensedListByTradingType(state, tradingType),
         );
@@ -82,7 +77,12 @@ export const MyAssetSheet = memo(
                 handleComponent={renderHandle}
                 data={filteredSections}
                 keyExtractor={keyExtractor}
-                renderItem={(asset, config) => renderItem(asset, config, onAssetSelectCallback)}
+                renderItem={(asset, config, { closeSheet }) =>
+                    renderItem(asset, config, (selectedAsset: TradeableAsset, account: Account) => {
+                        onAssetSelect(selectedAsset, account);
+                        closeSheet(false);
+                    })
+                }
                 renderSectionHeader={(_label, config) => {
                     const sectionIndex = filteredSections.findIndex(
                         section => section.sectionData.key === config.sectionData.key,

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetSheet.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetSheet.tsx
@@ -80,7 +80,7 @@ export const MyAssetSheet = memo(
                 renderItem={(asset, config, { closeSheet }) =>
                     renderItem(asset, config, (selectedAsset: TradeableAsset, account: Account) => {
                         onAssetSelect(selectedAsset, account);
-                        closeSheet(false);
+                        closeSheet();
                     })
                 }
                 renderSectionHeader={(_label, config) => {

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetSheet.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetSheet.tsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 
 import { type TradingType } from '@suite-common/trading';
 import { type Account } from '@suite-common/wallet-types';
+import { type BottomSheetFlashListHandleProps } from '@suite-native/atoms';
 import { BottomSheetSectionList } from '@suite-native/trading-atoms';
 import {
     type CombinedSelectorsRootState,
@@ -61,16 +62,16 @@ export const MyAssetSheet = memo(
         const headerTestID = testID ? `${testID}/header` : undefined;
 
         const renderHandle = useCallback(
-            () => (
+            ({ closeSheet }: BottomSheetFlashListHandleProps) => (
                 <MyAssetSheetHeader
-                    onClose={onClose}
+                    onClose={closeSheet}
                     onFilterChange={setFilterValue}
                     onSelectedNetworkFilter={setFilterSymbol}
                     availableNetworks={availableNetworks}
                     testID={headerTestID}
                 />
             ),
-            [onClose, setFilterValue, setFilterSymbol, availableNetworks, headerTestID],
+            [setFilterValue, setFilterSymbol, availableNetworks, headerTestID],
         );
 
         return (

--- a/suite-native/module-trading/src/components/general/PaymentMethodSheet/PaymentMethodSheet.tsx
+++ b/suite-native/module-trading/src/components/general/PaymentMethodSheet/PaymentMethodSheet.tsx
@@ -2,7 +2,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import type { BuyTrade, SellFiatTrade } from 'invity-api';
 
-import { BottomSheetFlashList } from '@suite-native/atoms';
+import { BottomSheetFlashList, type BottomSheetFlashListHandleProps } from '@suite-native/atoms';
 
 import {
     ESTIMATED_HEADER_HEIGHT,
@@ -39,24 +39,24 @@ export const PaymentMethodSheet = <T extends BuyTrade | SellFiatTrade>({
 }: PaymentMethodsSheetProps<T>) => {
     const { bottom: insetBottom } = useSafeAreaInsets();
 
-    const onQuoteSelectCallback = (quote: T) => {
-        onQuoteSelect(quote);
-        onClose();
-    };
-
     return (
         <BottomSheetFlashList<T>
             isVisible={isVisible}
             onClose={onClose}
-            renderItem={({ item, index }) => (
+            renderItem={({ item, index }, { closeSheet }) => (
                 <PaymentMethodListItem
                     quote={item}
-                    onPress={() => onQuoteSelectCallback(item)}
+                    onPress={() => {
+                        onQuoteSelect(item);
+                        closeSheet();
+                    }}
                     isFirst={index === 0}
                     isLast={index === quotes.length - 1}
                 />
             )}
-            handleComponent={() => <SimpleSheetHeader onClose={onClose} title={title} />}
+            handleComponent={({ closeSheet }: BottomSheetFlashListHandleProps) => (
+                <SimpleSheetHeader onClose={closeSheet} title={title} />
+            )}
             data={quotes}
             estimatedListHeight={getEstimatedListHeight(quotes.length, insetBottom)}
             keyExtractor={keyExtractor}

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderSheet.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderSheet.tsx
@@ -3,6 +3,7 @@ import {
     type TradingTradeType,
     type TradingType,
 } from '@suite-common/trading';
+import { type BottomSheetFlashListHandleProps } from '@suite-native/atoms';
 import { BottomSheetSectionList } from '@suite-native/trading-atoms';
 import { type QuotesByCategories, type QuotesCategory } from '@suite-native/trading-types';
 import { prepareNativeStyle } from '@trezor/styles-native';
@@ -46,27 +47,25 @@ export const ProviderSheet = <
         shouldShowFilters,
     );
 
-    const onQuoteSelectCallback = (quote: T) => {
-        onQuoteSelect(quote);
-        onClose();
-    };
-
     return (
         <BottomSheetSectionList<T, QuotesCategory>
             isVisible={isVisible}
             onClose={onClose}
-            renderItem={item => (
+            renderItem={(item, _config, { closeSheet }) => (
                 <ProviderListItem
-                    onPress={onQuoteSelectCallback}
+                    onPress={quote => {
+                        onQuoteSelect(quote);
+                        closeSheet();
+                    }}
                     isSelected={item.orderId === selectedQuote?.orderId}
                     quote={item}
                     shouldShowExchangeType={shouldShowExchangeType}
                     tradingType={tradingType}
                 />
             )}
-            handleComponent={() => (
+            handleComponent={({ closeSheet }: BottomSheetFlashListHandleProps) => (
                 <ProviderSheetHandle
-                    onClose={onClose}
+                    onClose={closeSheet}
                     shouldShowFilters={shouldShowFilters}
                     filterItems={filterItems}
                     selectedFilter={selectedFilter}

--- a/suite-native/module-trading/src/components/general/TradeableAssetSheet/TradeableAssetSheet.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetSheet/TradeableAssetSheet.tsx
@@ -45,11 +45,6 @@ export const TradeableAssetSheet = memo(
         flashListKey,
         testID,
     }: TradeableAssetsSheetProps) => {
-        const onAssetSelectCallback = (asset: TradeableAsset) => {
-            onAssetSelect(asset);
-            onClose(hideKeyboardOnAssetSelect);
-        };
-
         const listData = useFavouriteAssetsSectionList(assets);
 
         const headerTestID = testID ? `${testID}/header` : undefined;
@@ -75,7 +70,12 @@ export const TradeableAssetSheet = memo(
                 handleComponent={renderHandle}
                 data={listData}
                 keyExtractor={keyExtractor}
-                renderItem={(item, config) => renderItem(item, config, onAssetSelectCallback)}
+                renderItem={(item, config, { closeSheet }) =>
+                    renderItem(item, config, selectedAsset => {
+                        onAssetSelect(selectedAsset);
+                        closeSheet(hideKeyboardOnAssetSelect);
+                    })
+                }
                 flashListKey={flashListKey}
                 noSingletonSectionHeader
                 testID={testID}

--- a/suite-native/module-trading/src/components/general/TradeableAssetSheet/TradeableAssetSheet.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetSheet/TradeableAssetSheet.tsx
@@ -65,7 +65,7 @@ export const TradeableAssetSheet = memo(
         return (
             <BottomSheetSectionList<TradeableAsset, ListItemExtraData>
                 isVisible={isVisible}
-                onClose={onClose}
+                onClose={() => onClose(hideKeyboardOnAssetSelect)}
                 ListEmptyComponent={<TradeableAssetListEmptyComponent />}
                 handleComponent={renderHandle}
                 data={listData}
@@ -73,7 +73,7 @@ export const TradeableAssetSheet = memo(
                 renderItem={(item, config, { closeSheet }) =>
                     renderItem(item, config, selectedAsset => {
                         onAssetSelect(selectedAsset);
-                        closeSheet(hideKeyboardOnAssetSelect);
+                        closeSheet();
                     })
                 }
                 flashListKey={flashListKey}

--- a/suite-native/module-trading/src/components/general/TradeableAssetSheet/TradeableAssetSheet.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetSheet/TradeableAssetSheet.tsx
@@ -1,6 +1,7 @@
 import { memo, useCallback } from 'react';
 
 import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { type BottomSheetFlashListHandleProps } from '@suite-native/atoms';
 import { BottomSheetSectionList, type ItemRenderConfig } from '@suite-native/trading-atoms';
 import { type TradeableAsset } from '@suite-native/trading-types';
 
@@ -55,15 +56,15 @@ export const TradeableAssetSheet = memo(
 
         // we need to keep stable callback reference, otherwise header will be re-mounted on every keystroke
         const renderHandle = useCallback(
-            () => (
+            ({ closeSheet }: BottomSheetFlashListHandleProps) => (
                 <TradeableAssetSheetHeader
-                    onClose={onClose}
+                    onClose={closeSheet}
                     onFilterChange={onFilterChange}
                     onSelectedNetworkFilter={onSelectedNetworkFilter}
                     testID={headerTestID}
                 />
             ),
-            [onClose, onFilterChange, onSelectedNetworkFilter, headerTestID],
+            [onFilterChange, onSelectedNetworkFilter, headerTestID],
         );
 
         return (

--- a/suite-native/test-utils/src/mocks/expoAndRNMock.jsx
+++ b/suite-native/test-utils/src/mocks/expoAndRNMock.jsx
@@ -426,9 +426,29 @@ jest.mock('@gorhom/bottom-sheet', () => {
     const { ScrollView } = require('react-native');
     const GorhomBottomSheetMock = require('@gorhom/bottom-sheet/mock');
 
+    class BottomSheetModal extends GorhomBottomSheetMock.BottomSheetModal {
+        isPresented = false;
+
+        present(data) {
+            this.isPresented = true;
+            super.present(data);
+        }
+
+        dismiss(...args) {
+            if (!this.isPresented) return;
+
+            this.isPresented = false;
+            super.dismiss(...args);
+            this.props.onDismiss?.();
+        }
+    }
+
     GorhomBottomSheetMock.useBottomSheetScrollableCreator = () => props => (
         <ScrollView {...props} />
     );
 
-    return GorhomBottomSheetMock;
+    return {
+        ...GorhomBottomSheetMock,
+        BottomSheetModal,
+    };
 });

--- a/suite-native/trading-atoms/src/components/BottomSheetSectionList.tsx
+++ b/suite-native/trading-atoms/src/components/BottomSheetSectionList.tsx
@@ -1,7 +1,11 @@
 import { type ReactElement, type ReactNode } from 'react';
 import { Dimensions } from 'react-native';
 
-import { BottomSheetFlashList, type BottomSheetFlashListProps } from '@suite-native/atoms';
+import {
+    BottomSheetFlashList,
+    type BottomSheetFlashListControls,
+    type BottomSheetFlashListProps,
+} from '@suite-native/atoms';
 import { type NativeStyle } from '@trezor/styles-native';
 
 import {
@@ -25,7 +29,11 @@ export type TradingBottomSheetSectionListProps<T, U> = Omit<
     | 'viewabilityConfigCallbackPairs'
 > & {
     data: SectionListData<T, U>;
-    renderItem: (item: T, config: ItemRenderConfig<U>) => ReactElement;
+    renderItem: (
+        item: T,
+        config: ItemRenderConfig<U>,
+        sheetControls: BottomSheetFlashListControls,
+    ) => ReactElement;
     renderSectionHeader?: (label: ReactNode, config: SectionHeaderRenderConfig<U>) => ReactElement;
     keyExtractor: (item: T, sectionData: U) => string;
     noSingletonSectionHeader?: boolean;

--- a/suite-native/trading-atoms/src/hooks/useSectionList.tsx
+++ b/suite-native/trading-atoms/src/hooks/useSectionList.tsx
@@ -1,7 +1,7 @@
 import { type ReactElement, type ReactNode, useMemo } from 'react';
 import { FadeIn, FadeOut } from 'react-native-reanimated';
 
-import { AnimatedBox, Text } from '@suite-native/atoms';
+import { AnimatedBox, type BottomSheetFlashListControls, Text } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 import { exhaustive } from '@trezor/type-utils';
 
@@ -46,7 +46,11 @@ export type ListInternalItemShape<T, U> =
 
 export type UseSectionListProps<T, U> = {
     data: SectionListData<T, U>;
-    renderItem: (item: T, config: ItemRenderConfig<U>) => ReactElement;
+    renderItem: (
+        item: T,
+        config: ItemRenderConfig<U>,
+        sheetControls: BottomSheetFlashListControls,
+    ) => ReactElement;
     renderSectionHeader?: (label: ReactNode, config: SectionHeaderRenderConfig<U>) => ReactElement;
     SectionEmptyComponent?: ReactElement;
     keyExtractor: (item: T, sectionData: U) => string;
@@ -64,13 +68,18 @@ type TransformToInternalFlatListDataProps<T, U> = {
 
 type RenderInternalItemProps<T, U> = {
     item: ListInternalItemShape<T, U>;
-    renderItem: (item: T, config: ItemRenderConfig<U>) => ReactElement;
+    renderItem: (
+        item: T,
+        config: ItemRenderConfig<U>,
+        sheetControls: BottomSheetFlashListControls,
+    ) => ReactElement;
     renderSectionHeader:
         | ((label: ReactNode, config: SectionHeaderRenderConfig<U>) => ReactElement)
         | undefined;
     SectionEmptyComponent: ReactElement | undefined;
     applyStyle: ReturnType<typeof useNativeStyles>['applyStyle'];
     itemStyle?: ReturnType<typeof prepareNativeStyle<ItemRenderConfig<unknown>>>;
+    sheetControls: BottomSheetFlashListControls;
 };
 
 const defaultItemStyle = prepareNativeStyle<ItemRenderConfig<unknown>>(
@@ -179,6 +188,7 @@ const renderInternalItem = <T, U>({
     SectionEmptyComponent,
     applyStyle,
     itemStyle,
+    sheetControls,
 }: RenderInternalItemProps<T, U>): ReactElement => {
     const { type } = item;
 
@@ -210,7 +220,7 @@ const renderInternalItem = <T, U>({
                     exiting={FadeOut}
                     style={applyStyle(itemStyle ?? defaultItemStyle, item.config)}
                 >
-                    {renderItem(item.item, item.config)}
+                    {renderItem(item.item, item.config, sheetControls)}
                 </AnimatedBox>
             );
 
@@ -271,7 +281,10 @@ export const useSectionList = <T, U = undefined>({
         itemsCount,
         keyExtractor: (item: ListInternalItemShape<T, U>) =>
             internalKeyExtractor(item, keyExtractor),
-        renderItem: ({ item }: { item: ListInternalItemShape<T, U> }) =>
+        renderItem: (
+            { item }: { item: ListInternalItemShape<T, U> },
+            sheetControls: BottomSheetFlashListControls = { closeSheet: () => {} },
+        ) =>
             renderInternalItem({
                 item,
                 renderItem,
@@ -279,6 +292,7 @@ export const useSectionList = <T, U = undefined>({
                 SectionEmptyComponent,
                 applyStyle,
                 itemStyle,
+                sheetControls,
             }),
     };
 };

--- a/suite-native/trading-provider-utils/src/components/Footer.tsx
+++ b/suite-native/trading-provider-utils/src/components/Footer.tsx
@@ -60,7 +60,7 @@ const stackStyle = prepareNativeStyle(() => ({
 
 export const Footer = () => {
     const { applyStyle } = useNativeStyles();
-    const { bottomSheetRef, openModal, closeModal } = useBottomSheetModal();
+    const { bottomSheetRef, openModal, closeModal } = useBottomSheetModal({ isNestedSheet: true });
 
     const shouldHideFooter = useSelector(selectIsAmountInputActive);
     const providerInfo = useSelector(selectTradingProviderMetadata);

--- a/suite-native/trading-provider-utils/src/components/HowTradingWorksSheet.tsx
+++ b/suite-native/trading-provider-utils/src/components/HowTradingWorksSheet.tsx
@@ -45,7 +45,6 @@ export const HowTradingWorksSheet = ({ ref, closeModal }: HowTradingWorksSheetPr
         title={
             <Translation id="moduleTrading.tradingScreen.footer.howTradingWorksSheet.sheetTitle" />
         }
-        onClose={closeModal}
     >
         <VStack spacing="sp24">
             <VStack spacing="sp16">
@@ -74,7 +73,6 @@ export const HowTradingWorksSheet = ({ ref, closeModal }: HowTradingWorksSheetPr
                     <Translation id="moduleTrading.tradingScreen.footer.howTradingWorksSheet.item5" />
                 </ListItem>
             </VStack>
-
             <Button onPress={closeModal}>
                 <Translation id="generic.buttons.gotIt" />
             </Button>

--- a/suite-native/trading-residence/src/components/CountrySheet/CountrySheet.tsx
+++ b/suite-native/trading-residence/src/components/CountrySheet/CountrySheet.tsx
@@ -2,7 +2,7 @@ import { memo, useCallback, useMemo } from 'react';
 import { Keyboard } from 'react-native';
 
 import { type TradingCountryOption, useCountryFilteredData } from '@suite-common/trading';
-import { Divider } from '@suite-native/atoms';
+import { type BottomSheetFlashListHandleProps, Divider } from '@suite-native/atoms';
 import { Translation, useTranslate } from '@suite-native/intl';
 import { BottomSheetSectionList, SearchableSheetHeader } from '@suite-native/trading-atoms';
 
@@ -30,9 +30,9 @@ export const CountrySheet = memo(
 
         // we need to keep stable callback reference, otherwise header will be re-mounted on every keystroke
         const renderHandle = useCallback(
-            () => (
+            ({ closeSheet }: BottomSheetFlashListHandleProps) => (
                 <SearchableSheetHeader
-                    onClose={onClose}
+                    onClose={closeSheet}
                     title={<Translation id="tradingResidence.countrySheet.title" />}
                     onFilterChange={setFilterValue}
                     searchInputTestId={searchInputTestId}
@@ -41,7 +41,7 @@ export const CountrySheet = memo(
                     )}
                 />
             ),
-            [onClose, setFilterValue, translate, searchInputTestId],
+            [setFilterValue, translate, searchInputTestId],
         );
 
         const onCountrySelectCallback = (country: TradingCountryOption) => {

--- a/suite-native/trading-residence/src/components/CountrySheet/CountrySheet.tsx
+++ b/suite-native/trading-residence/src/components/CountrySheet/CountrySheet.tsx
@@ -44,12 +44,6 @@ export const CountrySheet = memo(
             [setFilterValue, translate, searchInputTestId],
         );
 
-        const onCountrySelectCallback = (country: TradingCountryOption) => {
-            Keyboard.dismiss();
-            onCountrySelect(country);
-            onClose();
-        };
-
         const listData = useMemo(
             () => [
                 {
@@ -71,8 +65,15 @@ export const CountrySheet = memo(
                 onClose={onClose}
                 ListEmptyComponent={<CountryListEmptyComponent />}
                 handleComponent={renderHandle}
-                renderItem={item => (
-                    <CountryListItem {...item} onPress={() => onCountrySelectCallback(item)} />
+                renderItem={(item, _config, { closeSheet }) => (
+                    <CountryListItem
+                        {...item}
+                        onPress={() => {
+                            Keyboard.dismiss();
+                            onCountrySelect(item);
+                            closeSheet();
+                        }}
+                    />
                 )}
                 data={listData}
                 keyExtractor={keyExtractor}

--- a/suite-native/trading-residence/src/components/CountrySheet/CountrySubdivisionSheet.tsx
+++ b/suite-native/trading-residence/src/components/CountrySheet/CountrySubdivisionSheet.tsx
@@ -58,12 +58,6 @@ export const CountrySubdivisionSheet = memo(
             [setFilterValue, translate, searchInputTestId],
         );
 
-        const onSubdivisionSelectCallback = (subdivision: TradingCountrySubdivisionOption) => {
-            Keyboard.dismiss();
-            onSubdivisionSelect(subdivision);
-            onClose();
-        };
-
         const listData = useMemo(
             () => [
                 {
@@ -93,10 +87,14 @@ export const CountrySubdivisionSheet = memo(
                     />
                 }
                 handleComponent={renderHandle}
-                renderItem={item => (
+                renderItem={(item, _config, { closeSheet }) => (
                     <CountrySubdivisionListItem
                         {...item}
-                        onPress={() => onSubdivisionSelectCallback(item)}
+                        onPress={() => {
+                            Keyboard.dismiss();
+                            onSubdivisionSelect(item);
+                            closeSheet();
+                        }}
                     />
                 )}
                 data={listData}

--- a/suite-native/trading-residence/src/components/CountrySheet/CountrySubdivisionSheet.tsx
+++ b/suite-native/trading-residence/src/components/CountrySheet/CountrySubdivisionSheet.tsx
@@ -5,7 +5,7 @@ import {
     type TradingCountrySubdivisionOption,
     useCountrySubdivisionFilteredData,
 } from '@suite-common/trading';
-import { Divider } from '@suite-native/atoms';
+import { type BottomSheetFlashListHandleProps, Divider } from '@suite-native/atoms';
 import { Translation, useTranslate } from '@suite-native/intl';
 import {
     BottomSheetSectionList,
@@ -44,9 +44,9 @@ export const CountrySubdivisionSheet = memo(
         const bottomSheetTestId = `${testID}/bottom-sheet`;
 
         const renderHandle = useCallback(
-            () => (
+            ({ closeSheet }: BottomSheetFlashListHandleProps) => (
                 <SearchableSheetHeader
-                    onClose={onClose}
+                    onClose={closeSheet}
                     title={<Translation id="tradingResidence.countrySubdivisionSheet.title" />}
                     onFilterChange={setFilterValue}
                     searchInputTestId={searchInputTestId}
@@ -55,7 +55,7 @@ export const CountrySubdivisionSheet = memo(
                     )}
                 />
             ),
-            [onClose, setFilterValue, translate, searchInputTestId],
+            [setFilterValue, translate, searchInputTestId],
         );
 
         const onSubdivisionSelectCallback = (subdivision: TradingCountrySubdivisionOption) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Solves Repro#1 by:
* use imperative close instead of tweaking state
* to have imperative close on item callback, I had to introduce closeSheet in useSectionList 😬 

Solves Repro#2 by:
* add option for nested sheets, to not close all sheets when we are displaying nested sheet from the current sheet


<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/27373

## Screenshots:

https://github.com/user-attachments/assets/8ccc6c95-591b-40c0-a4d9-2940940a0e20

