### PR TITLE
fix(ci): always run yarn install in native e2e jobs to repair node_modules cache

### DIFF
--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -87,7 +87,10 @@ jobs:
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
 
       - name: Install Yarn dependencies
-        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        # Always run install, even on a node_modules cache hit. The cached tree can be missing
+        # platform binaries that are not reliably captured (e.g. tsx's nested @esbuild/linux-x64),
+        # and skipping install left node_modules incomplete, breaking `yarn sign-config`. With a
+        # warm cache the node-modules linker reconciles quickly and re-fetches anything missing.
         run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn install
 
       # Detox runtime may indirectly import the built config, and that would crash if message-system is not built

--- a/.github/workflows/template-suite-native-prepare-test-app-android.yml
+++ b/.github/workflows/template-suite-native-prepare-test-app-android.yml
@@ -60,7 +60,10 @@ jobs:
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
 
       - name: Install Yarn dependencies
-        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        # Always run install, even on a node_modules cache hit. The cached tree can be missing
+        # platform binaries that are not reliably captured (e.g. tsx's nested @esbuild/linux-x64),
+        # and skipping install left node_modules incomplete, breaking `yarn sign-config`. With a
+        # warm cache the node-modules linker reconciles quickly and re-fetches anything missing.
         run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn install
 
       - name: Setup Java

--- a/.github/workflows/test-suite-native-e2e-ios.yml
+++ b/.github/workflows/test-suite-native-e2e-ios.yml
@@ -65,7 +65,10 @@ jobs:
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
 
       - name: Install Yarn dependencies
-        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        # Always run install, even on a node_modules cache hit. The cached tree can be missing
+        # platform binaries that are not reliably captured (e.g. tsx's nested @esbuild/linux-x64),
+        # and skipping install left node_modules incomplete, breaking `yarn sign-config`. With a
+        # warm cache the node-modules linker reconciles quickly and re-fetches anything missing.
         run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn install
 
       - name: Use latest stable Xcode
@@ -148,7 +151,10 @@ jobs:
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
 
       - name: Install Yarn dependencies
-        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        # Always run install, even on a node_modules cache hit. The cached tree can be missing
+        # platform binaries that are not reliably captured (e.g. tsx's nested @esbuild/linux-x64),
+        # and skipping install left node_modules incomplete, breaking `yarn sign-config`. With a
+        # warm cache the node-modules linker reconciles quickly and re-fetches anything missing.
         run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn install
 
       # Detox runtime may indirectly import the built config, and that would crash if message-system is not built


### PR DESCRIPTION
## Problem

The `prepare_android_test_app` job (and the other native e2e jobs) started failing across many unrelated PRs with:

```
Error: The package "@esbuild/linux-x64" could not be found, and is needed by esbuild.
  at .../node_modules/tsx/node_modules/esbuild/lib/main.js
```

It fails in the `yarn sign-config` step, which runs through `tsx` (and `tsx` ships its own nested `esbuild`).

## Root cause

#28478 (commit 6d04b07, cc @HajekOndrej) added `if: steps.node-modules-cache.outputs.cache-hit != 'true'` to the install step so `yarn install` is skipped on a node_modules cache hit. The cached `node_modules-native-full-<yarn.lock hash>` archive does not reliably contain platform binaries such as tsx's nested `@esbuild/linux-x64`. Previously the always-running `yarn install` reconciled that gap; once it is skipped, `node_modules` stays incomplete and `tsx` crashes at runtime. Because the cache key is only the yarn.lock hash, the incomplete cache is shared across every PR on the same lockfile, so a plain re-run cannot recover.

## Fix

Run `yarn install` unconditionally again in the native e2e jobs that share this cache and run `yarn sign-config`:

- `template-suite-native-prepare-test-app-android.yml` (the failing job)
- `template-suite-native-e2e-android.yml`
- `test-suite-native-e2e-ios.yml` (both jobs)

The cache restore still warms the install, so the node-modules linker reconciles the restored tree and re-fetches anything missing in a few seconds — this is exactly how the runs that got a cache miss already pass.

## Notes

- Not verified by a real CI run yet; the reasoning matches what distinguishes the one green run (cache miss → full install) from the red ones.
- #28478 applied the same skip-on-cache-hit pattern to ~11 workflows. The non-native ones (desktop/web/llm/health) use a different cache key and likely do not hit the tsx/esbuild path, so they are left out of scope here, but worth watching.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/fix-ci-job-failure&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/fix-ci-job-failure&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/fix-ci-job-failure&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-11T09:43:12.250Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-11T09:41:34.609Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/fix-ci-job-failure/web/](https://dev.suite.sldev.cz/suite-web/mroz22/fix-ci-job-failure/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->