### PR TITLE
fix(suite-native): Clean up the search on leaving the page

### DIFF
--- a/suite-native/accounts/src/components/AccountsListWithFilter.tsx
+++ b/suite-native/accounts/src/components/AccountsListWithFilter.tsx
@@ -1,7 +1,8 @@
-import { type ReactNode, useEffect, useRef, useState } from 'react';
+import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import { type BottomSheetModalMethods } from '@gorhom/bottom-sheet/lib/typescript/types';
+import { useNavigation } from '@react-navigation/native';
 
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { Box, Button, VStack } from '@suite-native/atoms';
@@ -38,6 +39,7 @@ export const AccountsListWithFilter = ({
     children,
 }: AccountsListWithFilterProps) => {
     const [searchValue, setSearchValue] = useState('');
+    const [isSearchActive, setIsSearchActive] = useState(false);
     const [filteredNetworks, setFilteredNetworks] = useState<NetworkSymbol[]>(networksFilter);
     const filterBottomSheetRef = useRef<BottomSheetModalMethods>(null);
 
@@ -49,6 +51,35 @@ export const AccountsListWithFilter = ({
     useEffect(() => {
         setFilteredNetworks(networksFilter);
     }, [networksFilter]);
+
+    const navigation = useNavigation();
+
+    // Clear search only when the user actually switches tabs, not when navigating to an
+    // account (which pushes a root-stack screen and blurs the whole tab navigator).
+    // The tab navigator's 'state' event fires on tab switches but NOT on root-stack pushes.
+    useEffect(() => {
+        const tabParent = navigation.getParent();
+        if (!tabParent) return;
+
+        let prevTabIndex = tabParent.getState()?.index;
+
+        const unsubscribe = tabParent.addListener('state', () => {
+            const currentTabIndex = tabParent.getState()?.index;
+            if (currentTabIndex !== prevTabIndex) {
+                prevTabIndex = currentTabIndex;
+                setIsSearchActive(false);
+            }
+        });
+
+        return () => unsubscribe();
+    }, [navigation]);
+
+    const handleSelectAccount: OnSelectAccount = useCallback(
+        params => {
+            onSelectAccount(params);
+        },
+        [onSelectAccount],
+    );
 
     const handleFilterPress = () => {
         filterBottomSheetRef.current?.present();
@@ -67,6 +98,8 @@ export const AccountsListWithFilter = ({
             <SearchableAccountsListHeader
                 title={title}
                 onSearchInputChange={setSearchValue}
+                isSearchActive={isSearchActive}
+                onSearchActiveChange={setIsSearchActive}
                 flowType={flowType}
                 closeActionType={closeActionType}
                 closeAction={closeAction}
@@ -76,7 +109,7 @@ export const AccountsListWithFilter = ({
             {children}
             <VStack spacing="sp16">
                 <AccountsList
-                    onSelectAccount={onSelectAccount}
+                    onSelectAccount={handleSelectAccount}
                     searchValue={searchValue}
                     networkFilter={filteredNetworks}
                     isSendFlow={isSendFlow}

--- a/suite-native/accounts/src/components/AccountsSearchForm.tsx
+++ b/suite-native/accounts/src/components/AccountsSearchForm.tsx
@@ -41,6 +41,13 @@ export const AccountsSearchForm = ({ onPressCancel, onInputChange }: AccountsSea
         };
     }, [inputText, onInputChange]);
 
+    useEffect(
+        () => () => {
+            onInputChange('');
+        },
+        [onInputChange],
+    );
+
     return (
         <Animated.View
             entering={FadeIn.duration(SEARCH_INPUT_ANIMATION_DURATION).delay(

--- a/suite-native/accounts/src/components/SearchableAccountsListHeader.tsx
+++ b/suite-native/accounts/src/components/SearchableAccountsListHeader.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useState } from 'react';
+import { type ReactNode } from 'react';
 import { View } from 'react-native';
 import Animated, {
     type EntryExitAnimationFunction,
@@ -19,6 +19,8 @@ import { FilterCountBadge } from './FilterCountBadge';
 type SearchableAccountsListHeaderProps = {
     title: ReactNode;
     onSearchInputChange: (value: string) => void;
+    isSearchActive: boolean;
+    onSearchActiveChange: (value: boolean) => void;
     flowType?: AddCoinFlowType;
     closeActionType?: CloseActionType;
     closeAction?: () => void;
@@ -37,6 +39,8 @@ const searchFormContainerStyle = prepareNativeStyle(({ spacings }) => ({
 export const SearchableAccountsListHeader = ({
     title,
     onSearchInputChange,
+    isSearchActive,
+    onSearchActiveChange,
     flowType,
     closeActionType,
     closeAction,
@@ -46,10 +50,8 @@ export const SearchableAccountsListHeader = ({
     const isFirstRender = useSharedValue(true);
     const { applyStyle } = useNativeStyles();
 
-    const [isSearchActive, setIsSearchActive] = useState(false);
-
     const handleHideFilter = () => {
-        setIsSearchActive(false);
+        onSearchActiveChange(false);
         onSearchInputChange('');
     };
 
@@ -97,7 +99,7 @@ export const SearchableAccountsListHeader = ({
                             )}
                             <IconButton
                                 iconName="magnifyingGlass"
-                                onPress={() => setIsSearchActive(true)}
+                                onPress={() => onSearchActiveChange(true)}
                                 intent="neutral"
                                 priority="secondary"
                             />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This adjusts controls of search input on the My Assets tab to kindly preserve search string if user navigates inside and reset if exists the stack. 

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

The longest path and desired UX I was thinking of is:

Navigate -> search input -> x2 elements -> detail first element -> back -> search preserved -> navigate to any other screen -> navigate back -> search is cleared

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27848

## Screenshots:

https://github.com/user-attachments/assets/1dd0bf8c-9d51-4b9a-8d45-cbc366c85ceb




<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/search-cleanup&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->