### PR TITLE
fix(trading): refactored trading header

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingContainer.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingContainer.tsx
@@ -8,7 +8,7 @@ import { spacings } from '@trezor/theme';
 import { useSelector } from 'src/hooks/suite';
 import { DiscoveryWarning } from 'src/views/wallet/staking/components/StakingDashboard/components/DiscoveryWarning';
 import { TradingFooter } from 'src/views/wallet/trading/common/TradingFooter/TradingFooter';
-import { TradingLayoutHeader } from 'src/views/wallet/trading/common/TradingLayout/TradingLayoutHeader';
+import { useTradingPageHeader } from 'src/views/wallet/trading/common/TradingLayout/useTradingPageHeader';
 
 export interface TradingContainerProps {
     SectionComponent: ElementType;
@@ -17,9 +17,10 @@ export interface TradingContainerProps {
 
 export const TradingContainer = ({ SectionComponent, provider }: TradingContainerProps) => {
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
+    useTradingPageHeader();
 
     return (
-        <TradingLayoutHeader>
+        <>
             {isDiscoveryRunning && (
                 <Column margin={{ bottom: spacings.md }}>
                     <DiscoveryWarning />
@@ -27,6 +28,6 @@ export const TradingContainer = ({ SectionComponent, provider }: TradingContaine
             )}
             <SectionComponent />
             <TradingFooter provider={provider} />
-        </TradingLayoutHeader>
+        </>
     );
 };

--- a/packages/suite/src/views/wallet/trading/common/TradingLayout/TradingLayout.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingLayout/TradingLayout.tsx
@@ -9,12 +9,16 @@ import { DiscoveryEmpty } from 'src/components/wallet/WalletLayout/AccountExcept
 import { useSelector } from 'src/hooks/suite';
 import { ConnectDeviceGenericPromo } from 'src/views/wallet/receive/components/ConnectDevicePromo';
 import { TradingLayoutNavigation } from 'src/views/wallet/trading/common/TradingLayout/TradingLayoutNavigation';
+import { useTradingPageHeader } from 'src/views/wallet/trading/common/TradingLayout/useTradingPageHeader';
 
 export const TradingLayout = ({ children }: PropsWithChildren) => {
     const routeName = useSelector(selectRouteName);
     const selectedDevice = useSelector(selectSelectedDevice);
     const hasVisibleAccounts = useSelector(state => selectVisibleDeviceAccounts(state).length > 0);
     const isSelectedDeviceConnected = !!selectedDevice?.connected;
+
+    useTradingPageHeader();
+
     const noVisibleAccountsContent = !isSelectedDeviceConnected ? (
         <ConnectDeviceGenericPromo />
     ) : (

--- a/packages/suite/src/views/wallet/trading/common/TradingLayout/useTradingPageHeader.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingLayout/useTradingPageHeader.tsx
@@ -1,5 +1,3 @@
-import { type PropsWithChildren } from 'react';
-
 import { Translation, type TranslationKey, useTranslation } from '@suite/intl';
 import { type Route, goto, selectRouteName } from '@suite/router';
 import { type TradingType, selectTradingActiveSection } from '@suite-common/trading';
@@ -67,7 +65,7 @@ const TradingPageHeader = ({ fallbackTitle }: TradingPageHeaderProps) => {
     );
 };
 
-export const TradingLayoutHeader = ({ children }: PropsWithChildren) => {
+export const useTradingPageHeader = () => {
     const { translationString } = useTranslation();
     const fallbackTitle: TranslationKey = 'TR_NAV_TRADE';
 
@@ -75,8 +73,4 @@ export const TradingLayoutHeader = ({ children }: PropsWithChildren) => {
     const pageTitle = `Trezor Suite | ${translatedTitle}`;
 
     useLayout(pageTitle, <TradingPageHeader fallbackTitle={fallbackTitle} />);
-
-    if (!children) return null;
-
-    return children;
 };


### PR DESCRIPTION
## Description

- Move the trading page header into `useTradingPageHeader` so it is registered through the shared page layout.
- Keep the trading title visible even when a remembered wallet has no visible accounts.
- Preserve the existing empty-state content for both connected and disconnected devices.
- Reuse the same trading page header for populated trading screens and empty states.

## Notes for QA

- On the Welcome screen, open Swap with a remembered wallet that still has enabled coins and verify the trading title and transactions action are visible above the content.
- Disable all coins in a remembered wallet, open Welcome screen Swap, and verify the trading title stays visible above the empty state.
- Disconnect the selected device on the same trading screen and verify the connect-device promo is shown while the page header stays visible.

## Related Issue

Resolve #28295

## Screenshots:

<img width="1077" height="558" alt="image" src="https://github.com/user-attachments/assets/fd5c882b-6b79-4385-a68c-d5e95c4108c7" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect three files in the trading layout/container infrastructure: TradingContainer.tsx (the wrapper for all trading views), TradingLayout.tsx (the layout component), and useTradingPageHeader.tsx (a hook for page headers). These are shared components used by all trading flows (buy, sell, swap). The risk is moderate — layout/container changes can break rendering across all trading pages. The recommended strategy focuses on testing diverse entry points (navigation test), one representative flow per trading type (buy-bitcoin, sell-inputs, swap-inputs for form interaction), and key end-to-end flows, rather than running all 20+ mapped tests.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/views/wallet/trading/common/TradingContainer.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingLayout/TradingLayout.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingLayout/useTradingPageHeader.tsx`

</details>

**Recommended tests (13)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — This test directly exercises navigating to Buy, Sell, and Swap forms from multiple entry points and verifying the correct form opens with the right cryptocurrency. Changes to TradingContainer, TradingLayout, and useTradingPageHeader directly affect how trading pages render and display their headers, making this the most sensitive test to layout/container changes.
- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — This test exercises the full buy flow including form rendering, quote display, offer selection, and transaction detail — all rendered within TradingContainer and TradingLayout. The useTradingPageHeader hook likely controls the page header visible throughout this flow.
- `suite/e2e/tests/trading/buy-negative.test.ts` — This test validates buy form error states and input validation within the trading layout. It checks form loading state, input interactions, and error display — all dependent on proper TradingContainer and TradingLayout rendering.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — This test validates sell form input behavior including decimal validation, percentage buttons, max calculation, and currency switching — all rendered within the trading layout. It directly exercises form interaction within TradingContainer and TradingLayout.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — This test exercises swap form inputs, asset selection, fraction buttons, and balance validation within the trading page. Though not in the static mapping, it uses tradingPage extensively and the swap form is rendered inside TradingContainer/TradingLayout. Inferred from LLM analysis showing heavy tradingPage usage.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/trading/buy-ethereum.test.ts` — Tests the buy flow for a different asset (ETH) including asset picker and quote display within the trading layout. Provides coverage for a non-BTC buy path through TradingContainer.
- `suite/e2e/tests/trading/sell-solana.test.ts` — This test covers the full sell flow for Solana including form, quotes, confirmation, device prompt, and transaction status — exercising TradingContainer and TradingLayout for a non-EVM chain. Provides cross-network sell coverage.
- `suite/e2e/tests/trading/swap-coins.test.ts` — End-to-end swap flow (SOL→BTC) covering form fill, quotes, device confirmation, toast, and transaction status progression through the trading layout. Validates swap flow rendering within TradingContainer.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests custom Ethereum fee parameters in the swap flow with device prompt verification. The fee display and confirmation modal are rendered within TradingLayout, making it sensitive to layout changes.
- `suite/e2e/tests/trading/swap-history.test.ts` — Tests swap transaction history display and detail views. Though not in the static mapping, the trading transactions page likely uses TradingContainer/TradingLayout for its rendering. Inferred from LLM analysis showing tradingPage component usage.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/trading/buy-solana-token.test.ts` — Tests buying a Solana SPL token with crypto amount mode and asset picker — a specific variant of the buy flow within TradingContainer. Lower priority as buy-bitcoin already covers the primary buy path.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — Full sell BTC flow rendered within TradingContainer. Lower priority since sell-solana and sell-inputs already provide sell coverage, but this adds BTC-specific sell path verification.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Tests BTC-specific custom fee settings in swap flow. Lower priority as swap-fees-ethereum already covers fee customization within the trading layout, but this adds Bitcoin fee rate coverage.

</details>

_Updated: 2026-06-11T10:47:23.483Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trading-empty-state-header-28295&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trading-empty-state-header-28295&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-11T10:51:37.797Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-12T05:53:07.131Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/trading-empty-state-header-28295/web/](https://dev.suite.sldev.cz/suite-web/fix/trading-empty-state-header-28295/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->
