### PR TITLE
chore(firmware): remove unused INVALID_HASH_ERROR constant

### DIFF
--- a/suite-common/firmware/src/firmwareThunks.ts
+++ b/suite-common/firmware/src/firmwareThunks.ts
@@ -8,8 +8,6 @@ import { FIRMWARE_MODULE_PREFIX, firmwareActions } from './firmwareActions';
 import { selectFirmware } from './firmwareReducer';
 import { getBinFilesBaseUrlThunk } from './getBinFilesBaseUrlThunk';
 
-export const INVALID_HASH_ERROR = 'Invalid hash';
-
 export type FirmwareUpdateProps = {
     firmwareType?: FirmwareType;
     binary?: ArrayBuffer;


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into small isolated PRs for easy, low-risk review.

Remove the unused INVALID_HASH_ERROR constant from @suite-common/firmware.

The full staging branch is green; CI verifies this subset independently.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to suite-common/firmware/src/firmwareThunks.ts, which is the core module handling firmware-related async operations (installation, checks, updates). While this file is transitively imported by 121 tests (nearly all E2E tests), most of those tests only touch firmware logic incidentally during onboarding setup. The highest-risk tests are the custom firmware installation test and firmware check test, which directly exercise firmware thunk logic. Medium-priority tests cover onboarding flows where firmware steps are explicitly traversed, and device settings where the firmware update modal is tested. The vast majority of tests that statically reference this file do so only through shared onboarding infrastructure and can be safely omitted.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/firmware/src/firmwareThunks.ts`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/firmware/custom-firmware.test.ts` — This test directly exercises firmware installation functionality through the Settings > Device tab. The changed file firmwareThunks.ts contains the core firmware installation logic (thunks), and this test verifies the end-to-end custom firmware installation flow including the reconnect device prompt afterward.
- `suite/e2e/tests/onboarding/firmware-check.test.ts` — This test directly validates firmware readiness detection during onboarding, calling expectFirmwareToBeReady and disableNecessaryFirmwareChecks. Changes to firmwareThunks.ts could alter how firmware status is determined and reported during the onboarding flow.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts` — This test goes through the full onboarding flow including the firmware setup step (onboardingPage.firmware), wallet creation with Shamir backup, and PIN setup. Firmware thunks are exercised during the firmware continuation step of onboarding.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts` — This test exercises the full T3T1 onboarding flow including firmware installation step, authenticity check, and wallet creation. The firmware continuation step directly invokes firmware thunks logic.
- `suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts` — This test covers T1B1 onboarding with firmware checks disabled and wallet creation. The firmware step is explicitly passed through, and changes to firmware thunks could affect how firmware readiness is evaluated for T1B1 devices.
- `suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts` — This test validates entropy check failure handling during wallet creation, which involves the firmware/onboarding flow. The test explicitly proceeds through analytics, firmware checks, and wallet creation steps where firmware thunks are invoked.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-success.test.ts` — This test covers the full T2T1 recovery onboarding flow including firmware continuation. Changes to firmware thunks could affect the firmware check/continuation step that gates access to the recovery flow.
- `suite/e2e/tests/settings/t2t1-device-settings.test.ts` — This test opens the firmware update modal from device settings and verifies it can be opened and closed. The firmware update modal likely invokes firmware thunks to check firmware status and initiate updates.

</details>

_Updated: 2026-06-17T09:54:54.457Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-firmware&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-firmware&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-firmware&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-17T10:00:00.853Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-17T09:58:05.200Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-firmware/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-firmware/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- BLAME-AUTHORS -->
**Author(s) of the removed code** (via `git blame`): @tomasklim — please confirm this code is genuinely dead and safe to delete, and not intentional preparation. 🙏