### PR TITLE
chore(bluetooth): unexport intra-file WithBluetoothState type

### DIFF
--- a/suite-common/bluetooth/src/index.ts
+++ b/suite-common/bluetooth/src/index.ts
@@ -1,14 +1,11 @@
 export type {
     BluetoothManufacturerData,
-    BluetoothScanStatus,
     BluetoothFilterPolicy,
-    BluetoothAutoConnectPolicy,
     DeviceBluetoothConnectionStatusType,
     ForgetBluetoothDeviceThunkParams,
     BluetoothDeviceCommon,
 } from './types';
 export type { BluetoothState } from './bluetoothReducer';
-export type { WithBluetoothState } from './bluetoothSelectors';
 
 export { BLUETOOTH_PREFIX, bluetoothActions } from './bluetoothActions';
 export { prepareInitialState, prepareBluetoothReducerCreator } from './bluetoothReducer';


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into small isolated PRs for easy, low-risk review.

Unexport the intra-file WithBluetoothState type in @suite-common/bluetooth.

The full staging branch is green; CI verifies this subset independently.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to suite-common/bluetooth/src/index.ts, which has no static test coverage mapping. Among the 95 candidate tests, only the forget-device test explicitly exercises Bluetooth-related functionality (Bluetooth pairing state mocking, unpairing flows, and Bluetooth history detection for TS7 devices). The overall risk is moderate — Bluetooth is a specialized subsystem with limited E2E surface area, but the forget-device test is the most directly relevant test to validate that Bluetooth state management still works correctly after this change.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/bluetooth/src/index.ts`

</details>

**Recommended tests (1)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/settings/forget-device.test.ts` — This test explicitly covers Bluetooth pairing/unpairing logic for TS7 (T3W1) devices, including mockDeviceBluetoothState and completeBluetoothForgetFlow. Changes to suite-common/bluetooth/src/index.ts could directly affect the Bluetooth state management and unpairing behavior tested here.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/bluetooth/src/index.ts`

_Updated: 2026-06-12T05:11:55.740Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-bluetooth&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-bluetooth&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-bluetooth&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase numbering > hidden wallet numbering | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-12T05:17:04.518Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-12T05:15:18.534Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-bluetooth/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-bluetooth/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->