### PR TITLE
chore(suite-native): unexport intra-file AlertType

### DIFF
--- a/suite-native/alerts/src/alertsAtoms.ts
+++ b/suite-native/alerts/src/alertsAtoms.ts
@@ -6,7 +6,7 @@ import { type ButtonColorProps, type PictogramVariant } from '@suite-native/atom
 import { type IconName } from '@suite-native/icons';
 import { type NativeSpacing } from '@trezor/theme';
 
-export type AlertType =
+type AlertType =
     | 'autoEject'
     | 'bluetoothAdapter'
     | 'bluetoothPairing'


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into small isolated PRs for easy, low-risk review.

Unexport the intra-file AlertType union in @suite-native/alerts.

The full staging branch is green; CI verifies this subset independently.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-native-alerts&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->