### PR TITLE
chore(suite): unexport intra-file FlagsRootState type

### DIFF
--- a/suite/flags/src/flagsSlice.ts
+++ b/suite/flags/src/flagsSlice.ts
@@ -29,7 +29,7 @@ export interface FlagsState {
     hasSeenDisconnectTooltip: boolean;
 }
 
-export type FlagsRootState = { flags: FlagsState };
+type FlagsRootState = { flags: FlagsState };
 
 export const flagsInitialState: FlagsState = {
     initialRun: true,


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into small isolated PRs for easy, low-risk review.

Unexport the intra-file FlagsRootState type in suite/flags.

The full staging branch is green; CI verifies this subset independently.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file `suite/flags/src/flagsSlice.ts` is a Redux slice for feature flags. No static test coverage mapping exists for this file, and none of the 81 candidate E2E tests reference feature flags functionality in their behaviors, entry points, or source hints. The flagsSlice likely manages feature flag state (e.g., experimental features, early access program toggles) that could indirectly affect UI visibility of certain features, but without knowing the specific nature of the change (e.g., adding a new flag, changing a default value, modifying reducer logic), there is insufficient evidence to confidently link any specific E2E test to this change. If the change modifies default flag values that gate user-visible features, targeted tests for those features should be identified manually.

<details><summary><b>Changed files (1)</b></summary>

- `suite/flags/src/flagsSlice.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `suite/flags/src/flagsSlice.ts`

_Updated: 2026-06-12T05:07:41.102Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-suite-flags/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-suite-flags/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-suite-flags&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-suite-flags&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase numbering > hidden wallet numbering | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-12T05:13:23.130Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-12T05:10:57.721Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->