### PR TITLE
chore(suite): remove unused labeling option types and map

### DIFF
--- a/suite/labeling/src/LabelingSettings.tsx
+++ b/suite/labeling/src/LabelingSettings.tsx
@@ -36,21 +36,18 @@ import { LabelingSwitchToLegacyModal } from './LabelingSwitchToLegacyModal';
 
 export type LabelingSelectValue = 'off' | 'suite-sync' | 'legacy';
 
-export type LabelingOption<T> = { label: T; value: LabelingSelectValue };
-export type LabelingOptionTranslated = LabelingOption<TranslationKey>;
+type LabelingOption<T> = { label: T; value: LabelingSelectValue };
+type LabelingOptionTranslated = LabelingOption<TranslationKey>;
 
-export const LABELING_SELECT_OPTIONS_MAP: Record<
-    LabelingSelectValue,
-    LabelingOption<TranslationKey>
-> = {
+const LABELING_SELECT_OPTIONS_MAP: Record<LabelingSelectValue, LabelingOption<TranslationKey>> = {
     off: { label: 'TR_LABELING_OFF', value: 'off' },
     'suite-sync': { label: 'TR_LABELING_SECURE_SYNC', value: 'suite-sync' },
     legacy: { label: 'TR_LABELING_LEGACY', value: 'legacy' },
 };
 
-export const LABELING_LEGACY_OPTION_LABEL = 'TR_LABELING_ON';
+const LABELING_LEGACY_OPTION_LABEL = 'TR_LABELING_ON';
 
-export const LABELING_SELECT_OPTIONS = typedObjectValues(LABELING_SELECT_OPTIONS_MAP);
+const LABELING_SELECT_OPTIONS = typedObjectValues(LABELING_SELECT_OPTIONS_MAP);
 
 type LabelingTranslatedOption = LabelingOption<string> & {
     tooltipContent?: ReactNode;


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into small isolated PRs for easy, low-risk review.

Remove unused LabelingProps, LabelingOption(Translated) types and LABELING_SELECT_OPTIONS_MAP in suite/labeling.

The full staging branch is green; CI verifies this subset independently.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change to suite/labeling/src/LabelingSettings.tsx directly affects the labeling/metadata settings UI component in Trezor Suite. This component controls enabling/disabling labeling, selecting metadata providers (Dropbox, Google, local file, Suite Sync), and managing provider connections. The highest risk is in tests that directly manipulate labeling settings (lifecycle, switching providers, remembered device). All metadata/labeling tests have medium-to-high relevance since they depend on this settings component for initial setup. No static coverage mapping was available, so all recommendations are inferred from test behavior analysis.

<details><summary><b>Changed files (1)</b></summary>

- `suite/labeling/src/LabelingSettings.tsx`

</details>

**Recommended tests (16)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/metadata/legacy/metadata-lifecycle.test.ts` — This test exercises the full lifecycle of metadata labeling settings — enabling, disabling, toggling, and re-enabling labeling from application settings. LabelingSettings.tsx is the settings component that controls this flow, including the metadataSelectInput dropdown showing 'TR_LABELING_OFF' and 'TR_LABELING_LEGACY' states.
- `suite/e2e/tests/metadata/legacy/remembered-device.test.ts` — This test directly interacts with the labeling settings UI — disconnecting/reconnecting the metadata provider via settings, disabling metadata entirely, and re-enabling it. These are all operations controlled by the LabelingSettings component (@settings/metadata/disconnect-provider-button, connect-provider-button).
- `suite/e2e/tests/metadata/legacy/switching-providers.test.ts` — This test exercises switching metadata providers (Dropbox to Google) through application settings, including the disconnect-provider-button and connect-provider-button UI elements, and the metadata provider modal — all part of the LabelingSettings component's responsibility.

</details>

<details><summary>🟡 <b>Medium priority (13)</b></summary>

- `suite/e2e/tests/metadata/legacy/dropbox-api-errors.test.ts` — This test interacts with the metadata provider selection in application settings (metadataSelectInput dropdown) which is rendered by LabelingSettings.tsx. Changes to the settings component could affect how the legacy metadata provider option is selected and initialized.
- `suite/e2e/tests/metadata/legacy/google-api-errors.test.ts` — This test selects the 'legacy' metadata provider option from application settings via the metadataSelectInput dropdown, which is part of the LabelingSettings component. Changes could affect provider selection flow.
- `suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts` — This test enables legacy local labeling and then switches to Suite Sync, exercising the labeling settings component's ability to handle provider transitions. The enableLegacyLabeling and enableSuiteSync flows go through LabelingSettings.
- `suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts` — This test enables legacy Dropbox labeling via settings and later switches to Suite Sync, which involves the LabelingSettings component for provider management and migration.
- `suite/e2e/tests/metadata/legacy/account-metadata.test.ts` — This test enables legacy labeling with Dropbox provider through the settings UI (enableLegacyLabeling), which is controlled by LabelingSettings.tsx. A regression in the settings component could prevent labeling from being enabled.
- `suite/e2e/tests/metadata/legacy/address-metadata.test.ts` — This test enables legacy labeling with Google provider through settings, relying on the LabelingSettings component to initiate the provider connection flow.
- `suite/e2e/tests/metadata/legacy/interval-fetching.test.ts` — This test enables legacy labeling through the settings UI for both Google and Dropbox providers, which depends on the LabelingSettings component rendering correctly.
- `suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — This test enables legacy Dropbox labeling via settings before testing output labeling functionality. The enableLegacyLabeling flow goes through the LabelingSettings component.
- `suite/e2e/tests/metadata/legacy/wallet-metadata.test.ts` — This test enables legacy labeling with Dropbox provider via settings before testing wallet label management. The initial labeling setup depends on LabelingSettings.tsx.
- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — This test enables Suite Sync through the metadata settings flow. If LabelingSettings.tsx controls or renders the Suite Sync enablement UI, changes could affect the sync setup path.
- `suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — This test initiates Suite Sync setup through the metadata settings, which likely involves the LabelingSettings component for provider configuration.
- `suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts` — This test enables Suite Sync through metadata settings before testing label removal. The setup depends on the LabelingSettings component functioning correctly.
- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — This test exercises Suite Sync enablement and the Suite Sync banner across multiple wallets, which involves labeling settings state management that LabelingSettings.tsx likely controls.

</details>

_Updated: 2026-06-17T09:39:37.824Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-suite-labeling/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-suite-labeling/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-suite-labeling&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-suite-labeling&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-suite-labeling&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-17T09:44:30.686Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-17T09:43:12.671Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- BLAME-AUTHORS -->
**Author(s) of the removed code** (via `git blame`): @peter-sanderson — please confirm this code is genuinely dead and safe to delete, and not intentional preparation. 🙏