### PR TITLE
chore(suite): remove dead tor selectors and unexport torSlice

### DIFF
--- a/suite/tor/src/index.ts
+++ b/suite/tor/src/index.ts
@@ -1,9 +1,4 @@
-export { type TorBootstrap, type TorState, TorStatus } from './torSlice';
+export { type TorBootstrap, TorStatus } from './torSlice';
 export { getIsTorDomain, getIsTorEnabled, getIsTorLoading, isOnionUrl } from './torUtils';
-export {
-    selectIsTorEnabled,
-    selectTorBootstrap,
-    selectTorState,
-    selectTorStatus,
-} from './torSelectors';
-export { type TorRootState, torActions, torReducer, torSlice } from './torSlice';
+export { selectIsTorEnabled, selectTorState } from './torSelectors';
+export { type TorRootState, torActions, torReducer } from './torSlice';

--- a/suite/tor/src/torSelectors.ts
+++ b/suite/tor/src/torSelectors.ts
@@ -4,10 +4,6 @@ import { getIsTorEnabled, getIsTorLoading } from './torUtils';
 export const selectIsTorEnabled = (state: TorRootState) =>
     state.tor.torStatus === TorStatus.Enabled || state.tor.torStatus === TorStatus.Slow;
 
-export const selectTorStatus = (state: TorRootState) => state.tor.torStatus;
-
-export const selectTorBootstrap = (state: TorRootState) => state.tor.torBootstrap;
-
 export const selectTorState = (state: TorRootState) => {
     const { torStatus, torBootstrap } = state.tor;
 

--- a/suite/tor/src/torSlice.ts
+++ b/suite/tor/src/torSlice.ts
@@ -15,7 +15,7 @@ export interface TorBootstrap {
     isSlow?: boolean;
 }
 
-export type TorState = {
+type TorState = {
     torStatus: TorStatus;
     torBootstrap: TorBootstrap | null;
 };
@@ -25,7 +25,7 @@ const initialState: TorState = {
     torBootstrap: null,
 };
 
-export const torSlice = createSlice({
+const torSlice = createSlice({
     name: 'tor',
     initialState,
     reducers: {


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into small isolated PRs for easy, low-risk review.

Remove unused selectTorStatus/selectTorBootstrap selectors and unexport intra-file TorState and torSlice in suite/tor.

The full staging branch is green; CI verifies this subset independently.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect the Tor module's Redux slice, selectors, and index export. Tor state is a relatively isolated feature but is read by analytics events (specifically the SuiteReady event's 'tor' field) and potentially by network/connectivity logic. There is no direct static test coverage mapping for these files, so recommendations are inferred from LLM analysis of test behaviors. The highest risk is the analytics events test which explicitly asserts on the tor field value; other tests have indirect exposure through shared Redux state persistence and settings infrastructure.

<details><summary><b>Changed files (3)</b></summary>

- `suite/tor/src/index.ts`
- `suite/tor/src/torSelectors.ts`
- `suite/tor/src/torSlice.ts`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — The SuiteReady analytics event explicitly includes a 'tor' field in its payload, which directly reads from the tor state managed by torSlice/torSelectors. Changes to the tor Redux slice or selectors could alter the value reported in this event, making this the most directly affected test.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/analytics/toggle.test.ts` — This test validates analytics event payloads and session/instance ID management across app reloads and settings changes. The tor state is part of the overall Suite settings persisted in Redux, and changes to the tor slice could affect state persistence or rehydration behavior tested here.
- `suite/e2e/tests/settings/general.test.ts` — The general settings page is where Tor-related UI controls typically live alongside other application settings. Changes to torSlice or torSelectors could affect the settings page rendering or state management that this test exercises when interacting with application settings.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts` — This test exercises offline/disconnected mode behavior including the 'no connection' banner. Tor connectivity state managed by torSlice/torSelectors could interact with network status detection logic, potentially affecting how offline state is determined or displayed.

</details>

⚠️ **Changes with no test coverage (3)**
- `suite/tor/src/index.ts`
- `suite/tor/src/torSelectors.ts`
- `suite/tor/src/torSlice.ts`

_Updated: 2026-06-11T13:54:36.457Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-suite-tor&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-suite-tor&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-11T13:58:25.300Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-11T13:57:44.948Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-suite-tor/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-suite-tor/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->