### PR TITLE
chore(suite): remove dead receive types and unexport receiveSlice

### DIFF
--- a/suite/receive/src/receiveReducer.ts
+++ b/suite/receive/src/receiveReducer.ts
@@ -89,7 +89,7 @@ const markAddressUnverified = (draft: ReceiveAccountState, path: string, address
     draft.currentFreshAddress = undefined;
 };
 
-export const receiveSlice = createSlice({
+const receiveSlice = createSlice({
     name: 'receive',
     initialState: receiveInitialState,
     reducers: {


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into small isolated PRs for easy, low-risk review.

Remove unused receive state types and unexport intra-file ReceiveState and receiveSlice in suite/receive.

The full staging branch is green; CI verifies this subset independently.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change to suite/receive/src/receiveReducer.ts affects the core state management for the wallet receive flow. This is a focused change with clear impact on address reveal, receive modal behavior, and address caching. The highest risk is in the direct receive flows (wallet/receive, global-receive-send), with secondary risk in passphrase-related receive flows that test address state across wallet switching and reconnection scenarios. No static coverage mapping was available, so all recommendations are inferred from LLM analysis of test behaviors.

<details><summary><b>Changed files (1)</b></summary>

- `suite/receive/src/receiveReducer.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/wallet/receive.test.ts` — The receiveReducer directly manages state for the wallet receive flow. This test exercises the full receive flow for multiple coins (BTC, ETH, SOL, TRX) including revealing addresses, copying to clipboard, and device confirmation — all of which depend on receive state management.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test covers the global receive flow including opening the receive form, revealing addresses, verifying them on the device, and copying them. The receiveReducer manages the state for address reveal and receive modal behavior that this test directly exercises.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — This test heavily exercises the receive address reveal flow including post-reconnection passphrase re-entry for address reveal. The receiveReducer likely manages the address reveal state and caching behavior tested here.
- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts` — This test exercises Cardano receive address reveal with passphrase protection, including device confirmation and copy-address flows. Changes to the receiveReducer could affect how revealed addresses and their state are managed for passphrase wallets.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — Tests reveal-address flow across multiple passphrase wallets, verifying address caching and display after switching wallets. The receiveReducer manages per-wallet receive address state that this test validates.
- `suite/e2e/tests/wallet/cardano.test.ts` — This test covers the Cardano receive flow including address reveal, device confirmation, and copy address — all of which depend on the receiveReducer's state management for receive addresses.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/trading/remembered-wallet-loading.test.ts` — This test opens the receive form on a remembered wallet without a device connected. The receiveReducer state restoration from IndexedDB is exercised here, though the test primarily validates loading rather than full receive flow.

</details>

_Updated: 2026-06-15T09:53:16.208Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-suite-receive&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-suite-receive&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-15T09:59:34.122Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-15T09:56:43.804Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-suite-receive/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-suite-receive/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->