### PR TITLE
test(agent): adds agent timeouts and better constrain

### DIFF
--- a/packages/e2e-utils/src/fixBot/ANALYSIS_AGENT.md
+++ b/packages/e2e-utils/src/fixBot/ANALYSIS_AGENT.md
@@ -164,8 +164,8 @@ Route each cluster by the **first** rule that applies:
    overlapping spec path — a failure may be specific to a platform or device group (e.g. `T1B1`):
     - **Confident match → skipped**, reusing the entry's `reason`.
     - **Unsure → treat as new** — skip this rule, continue to rules 2–4.
-2. **Fixable** inside `suite/e2e/` and/or by adding `data-testid` attributes in product source →
-   **fix_task**.
+2. **Fixable** — the **entire** remedy fits inside `suite/e2e/` and/or adding `data-testid`
+   attributes in product source → **fix_task**.
 3. **Needs a product-logic change** → **skipped**, `reason: "PRODUCT_BUG"`.
 4. **Needs an infra/environment change** → **skipped**, `reason: "INFRASTRUCTURE"`.
 

--- a/packages/e2e-utils/src/fixBot/FIX_AGENT.md
+++ b/packages/e2e-utils/src/fixBot/FIX_AGENT.md
@@ -23,10 +23,14 @@ Your fix task is embedded at the bottom of this prompt. Read it before doing any
 
 ## Fix Constraints
 
-Allowed changes are:
+Your change surface is exactly two things — nothing else, no exceptions:
 
-- Any file inside `suite/e2e/`
-- `data-testid` attributes in product source files. No other product code changes!
+1. Any file inside `suite/e2e/`.
+2. Adding a `data-testid` attribute in a product source file.
+
+Everything else in product code is off-limits.
+This holds even when a product change is the only way to make a test pass — in that case the
+failure is not yours to fix (see Step 2, "Bail when it is not yours to fix").
 
 ## Environment
 
@@ -64,6 +68,12 @@ Then read the source files mentioned in the analysis — spec files, page object
 analysis with your own product-code analysis and the preflight results (Step 2)** before
 deciding the fix.
 
+The test name and each `test.step()` label are the specification of intended behavior — read
+them as the source of truth for what the test verifies. A correct fix restores the test's
+ability to exercise that behavior; it repairs what drifted (locators, waits, selectors, flow),
+never the test's design or what it asserts. If the only way to green is to weaken an assertion
+or change what the test checks, the failure is not yours to fix — bail as in Step 2.
+
 ---
 
 ## Step 2 — Pre-flight
@@ -91,7 +101,7 @@ Non-zero = failing — read the trace before deciding anything further (see belo
 find suite/e2e/test-results -name 'trace.zip' -newer /tmp/preflight-marker
 ```
 
-Unzip and read the last 10 screenshots (closest to the failure):
+Unzip and read the screenshot closest to the failure:
 
 ```bash
 unzip -q <path/to/trace.zip> -d /tmp/trace-preflight/
@@ -107,9 +117,11 @@ infrastructure or environment error, return the result (Step 4) with `result: "f
 `iterations: 0`, and stop. Do not enter the fix loop.
 
 **Bail when it is not yours to fix.** If at preflight — or during any later iteration — your
-analysis concludes the root cause is a **product bug** (logic/behavior/markup must change, not
-just a `data-testid`) do not continue in the fix loop. Instead, return the result (Step 4) with
-`result: "fail"`, the iteration count reached, and explain the reclassification in the
+analysis concludes the root cause is a **product bug** (product logic, behavior, or markup must
+change, not just a `data-testid`), you are NOT ALLOWED to fix. Do not edit product code to make the
+test pass, even when you are confident in the fix and still have iteration budget left — a passing
+test is never justification for stepping outside the change surface. Return the result (Step 4)
+with `result: "fail"`, the iteration count reached, and explain the reclassification in the
 `pr-description.md`.
 
 ---
@@ -131,11 +143,12 @@ current one. Add a new `data-testid` only if the element genuinely has none.
 
 **2. Run all validations that are still failing:**
 
+Run each failing validation separately so you get one trace per spec.
+Select config by platform:
+
 ```bash
 touch /tmp/iter-<N>-marker
 
-# Run each failing validation separately so you get one trace per spec.
-# Select config by platform:
 (cd suite/e2e && yarn xvfb-maybe -- playwright test \
   --config=./playwright-config/playwright-<web|desktop>.config.ts \
   --project=<group> \
@@ -187,11 +200,10 @@ Emit only the JSON object as your final answer, with no surrounding prose or cod
   "iterations": <number of fix iterations performed, 0 if none needed>,
   "passed": ["<platform>/<group>/<spec>"],
   "failed": ["<platform>/<group>/<spec>"],
-  "prTitle": "<string up to 100 chars>"
+  "prTitle": "Nightly fix <YY-MM-DD> - <description of committed fix, up to 80 chars>"
 }
 ```
 
-`prTitle` must be the full PR title including the `Nightly fix <YY-MM-DD> - ` prefix. Base it on the fix you just made.
 `pass` — all validations pass after fixes.
 `partial` — at least one passes, at least one fails.
 `fail` — zero validations pass after fixes.

--- a/packages/e2e-utils/src/fixBot/analyze.ts
+++ b/packages/e2e-utils/src/fixBot/analyze.ts
@@ -7,6 +7,9 @@ import { error, log } from '../logger';
 import { loadLedger, processAgentOutput, runClaude } from './common';
 import { AnalysisReportJsonSchema, AnalysisReportSchema } from './schemas';
 
+const MAX_BUDGET_USD = '10';
+const TIMEOUT_MS = 45 * 60 * 1000;
+
 function buildLedgerPromptSection(ledgerPath: string): string {
     const ledger = loadLedger(ledgerPath);
 
@@ -56,16 +59,24 @@ function main(): void {
             '--mcp-config',
             join(botDir, 'mcp.json'),
             '--strict-mcp-config',
+            '--max-budget-usd',
+            MAX_BUDGET_USD,
         ],
         input: analysisPromptWithLedger,
         tmpPrefix: 'claude-analyze',
+        timeoutMs: TIMEOUT_MS,
     });
 
     const { model } = JSON.parse(readFileSync(join(botDir, 'settings.json'), 'utf-8'));
     const agentResult = processAgentOutput(claudeOutput, 'nightlyAnalyzer', model);
 
     if (spawnError) {
-        error(`Failed to run claude: ${spawnError.message}`);
+        const timedOut = (spawnError as NodeJS.ErrnoException).code === 'ETIMEDOUT';
+        error(
+            timedOut
+                ? `Analysis agent exceeded the ${TIMEOUT_MS / 60000}-minute timeout and was killed; no report produced.`
+                : `Failed to run claude: ${spawnError.message}`,
+        );
         process.exit(1);
     }
 

--- a/packages/e2e-utils/src/fixBot/common.ts
+++ b/packages/e2e-utils/src/fixBot/common.ts
@@ -67,8 +67,9 @@ export function runClaude(opts: {
     args: string[];
     input: string;
     tmpPrefix: string;
+    timeoutMs?: number;
 }): ClaudeRunResult {
-    const { root, args, input, tmpPrefix } = opts;
+    const { root, args, input, tmpPrefix, timeoutMs } = opts;
 
     const env = { ...process.env };
     // Prevents an internal Claude Code setting from accidentally being inherited
@@ -82,6 +83,8 @@ export function runClaude(opts: {
         cwd: root,
         env,
         stdio: ['pipe', stdoutFd, 'inherit'],
+        timeout: timeoutMs,
+        killSignal: 'SIGTERM',
     });
 
     closeSync(stdoutFd);

--- a/packages/e2e-utils/src/fixBot/fix.ts
+++ b/packages/e2e-utils/src/fixBot/fix.ts
@@ -7,6 +7,9 @@ import { error, log } from '../logger';
 import { processAgentOutput, runClaude } from './common';
 import { AnalysisReportSchema, FixResultJsonSchema, FixResultSchema } from './schemas';
 
+const MAX_BUDGET_USD = '10';
+const TIMEOUT_MS = 60 * 60 * 1000;
+
 function main(): void {
     const reportPath = process.env.REPORT_PATH;
     const taskId = process.env.TASK_ID;
@@ -54,16 +57,24 @@ function main(): void {
             JSON.stringify(FixResultJsonSchema),
             '--settings',
             join(fixAgentDir, 'settings.json'),
+            '--max-budget-usd',
+            MAX_BUDGET_USD,
         ],
         input: prompt,
         tmpPrefix: `claude-fix-${task.id}`,
+        timeoutMs: TIMEOUT_MS,
     });
 
     const { model } = JSON.parse(readFileSync(join(fixAgentDir, 'settings.json'), 'utf-8'));
     const agentResult = processAgentOutput(output, 'nightlyFixer', model);
 
     if (spawnError) {
-        error(`Failed to run claude: ${spawnError.message}`);
+        const timedOut = (spawnError as NodeJS.ErrnoException).code === 'ETIMEDOUT';
+        error(
+            timedOut
+                ? `Fix agent exceeded the ${TIMEOUT_MS / 60000}-minute timeout and was killed; no result produced.`
+                : `Failed to run claude: ${spawnError.message}`,
+        );
         process.exit(1);
     }
 

--- a/packages/e2e-utils/src/fixBot/notify.ts
+++ b/packages/e2e-utils/src/fixBot/notify.ts
@@ -91,6 +91,10 @@ function buildMessage(
                 const prPart = prUrl ? `<${prUrl}|PR link>` : 'no PR';
                 lines.push(`    ${task.id} · ${prPart} · ${iterStr} · ${countStr} · ${costPart}`);
             }
+
+            if (summary.error) {
+                lines.push(`    ⚠️ publish failed: ${summary.error.split('\n')[0]}`);
+            }
         }
     }
 
@@ -102,8 +106,7 @@ function buildMessage(
         for (const skip of report.skipped) {
             lines.push('');
             lines.push(`⛔ *${skip.reason}* — ${skip.rootCause}`);
-            const testRef = formatTestRef(skip.validations);
-            if (testRef) lines.push(testRef);
+            lines.push(formatTestRef(skip.validations));
         }
     }
 

--- a/packages/e2e-utils/src/fixBot/publish.ts
+++ b/packages/e2e-utils/src/fixBot/publish.ts
@@ -8,13 +8,8 @@ import { type FixResult, FixResultSchema, type SlackFixSummary } from './schemas
 const BASE_BRANCH = 'develop';
 const GIT_REMOTE = 'origin';
 const QA_PROJECT_NUMBER = 78; // QA and Test Automation
-
-const ICONS: Record<FixResult['result'], string> = {
-    pass: '✅',
-    partial: '⚠️',
-    fail: '❌',
-    not_duplicated: '🔵',
-};
+const PUSH_ATTEMPTS = 3;
+const PUSH_RETRY_DELAY_S = 5;
 
 function writeSummary(root: string, summary: SlackFixSummary): void {
     writeFileSync(
@@ -32,6 +27,123 @@ function readCostUsd(): number | null {
         return typeof usage.total_cost_usd === 'number' ? usage.total_cost_usd : null;
     } catch {
         return null;
+    }
+}
+
+function getErrorText(err: unknown): string {
+    const stderr = (err as { stderr?: unknown })?.stderr;
+    let detail = '';
+    if (typeof stderr === 'string') {
+        detail = stderr.trim();
+    } else if (Buffer.isBuffer(stderr)) {
+        detail = stderr.toString('utf-8').trim();
+    }
+
+    if (detail) return detail;
+
+    return err instanceof Error ? err.message : String(err);
+}
+
+function sleepSync(ms: number): void {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function shouldPublish(result: FixResult['result']): boolean {
+    return result === 'pass' || result === 'partial';
+}
+
+function pushBranchWithRetry(branch: string): void {
+    log(`  → Pushing ${branch} to ${GIT_REMOTE}...`);
+    let lastError = '';
+    for (let attempt = 1; attempt <= PUSH_ATTEMPTS; attempt++) {
+        try {
+            execFileSync('git', ['push', '--', GIT_REMOTE, branch], { encoding: 'utf-8' });
+
+            return;
+        } catch (err) {
+            lastError = getErrorText(err);
+            sleepSync(PUSH_RETRY_DELAY_S * 1000);
+        }
+    }
+    throw new Error(`git push failed after ${PUSH_ATTEMPTS} attempts: ${lastError}`);
+}
+
+function buildPrArgs(
+    branch: string,
+    root: string,
+    fixResult: FixResult,
+    costUsd: number | null,
+): string[] {
+    const args = [
+        'pr',
+        'create',
+        '--title',
+        fixResult.prTitle,
+        '--head',
+        branch,
+        '--base',
+        BASE_BRANCH,
+    ];
+    const prDescriptionFile = join(root, 'pr-description.md');
+
+    if (existsSync(prDescriptionFile)) {
+        if (costUsd !== null) {
+            appendFileSync(prDescriptionFile, `\n\n### Agent cost\n~$${costUsd.toFixed(2)}\n`);
+        }
+        args.push('--body-file', prDescriptionFile);
+    } else {
+        args.push(
+            '--body',
+            [
+                '## Nightly fix',
+                'PR description file not found.',
+                '',
+                '```json',
+                JSON.stringify({ results: fixResult }, null, 2),
+                '```',
+            ].join('\n'),
+        );
+    }
+
+    return args;
+}
+
+function createPr(args: string[]): string {
+    const url = execFileSync('gh', args, { encoding: 'utf-8' }).trim();
+    log(`PR: ${url}`);
+
+    return url;
+}
+
+function assignToProject(prUrl: string): void {
+    const args = [
+        'project',
+        'item-add',
+        String(QA_PROJECT_NUMBER),
+        '--owner',
+        'trezor',
+        '--url',
+        prUrl,
+    ];
+    execFileSync('gh', args, { encoding: 'utf-8' });
+    log(`Assigned PR to QA and Test Automation project (#${QA_PROJECT_NUMBER})`);
+}
+
+function runPublish(
+    branch: string,
+    root: string,
+    fixResult: FixResult,
+    summary: SlackFixSummary,
+): void {
+    try {
+        pushBranchWithRetry(branch);
+        const prArgs = buildPrArgs(branch, root, fixResult, summary.costUsd);
+        summary.prUrl = createPr(prArgs);
+        assignToProject(summary.prUrl);
+    } catch (err) {
+        summary.error = getErrorText(err);
+        error(`Publish failed: ${summary.error}`);
+        process.exitCode = 1;
     }
 }
 
@@ -55,75 +167,23 @@ function publishPR(): void {
         return;
     }
 
-    const { result, passed, failed, iterations, prTitle, taskId } = FixResultSchema.parse(
-        JSON.parse(readFileSync(resultFile, 'utf-8')),
-    );
-    const costUsd = readCostUsd();
+    const fixResult = FixResultSchema.parse(JSON.parse(readFileSync(resultFile, 'utf-8')));
+    const summary: SlackFixSummary = {
+        ...fixResult,
+        prUrl: null,
+        costUsd: readCostUsd(),
+        error: null,
+    };
 
-    log(
-        `Result: ${ICONS[result] ?? '?'} ${result}  passed=${passed.length}  failed=${failed.length}  iterations=${iterations}`,
-    );
+    log(`Raw result summary: \n\n${JSON.stringify(summary, null, 2)}`);
 
-    if (result === 'fail' || result === 'not_duplicated') {
-        log(
-            result === 'fail'
-                ? '  → No branch pushed (zero validations pass).'
-                : '  → No branch pushed (failure not reproduced in pre-flight).',
-        );
-        writeSummary(root, {
-            taskId,
-            result,
-            passed,
-            failed,
-            iterations,
-            prTitle,
-            prUrl: null,
-            costUsd,
-        });
-
-        return;
+    if (shouldPublish(fixResult.result)) {
+        runPublish(branch, root, fixResult, summary);
+    } else {
+        log('Fix bot failed to apply fix or issue was not duplicated → No branch pushed.');
     }
 
-    log(`  → Pushing ${branch} to ${GIT_REMOTE}...`);
-    // TODO: add --force-with-lease to handle retries when branch was already pushed in a previous run
-    execFileSync('git', ['push', '--', GIT_REMOTE, branch], { stdio: 'inherit' });
-
-    const prDescriptionFile = join(root, 'pr-description.md');
-    const prArgs = ['pr', 'create', '--title', prTitle, '--head', branch, '--base', BASE_BRANCH];
-
-    if (existsSync(prDescriptionFile)) {
-        if (costUsd !== null) {
-            appendFileSync(prDescriptionFile, `\n\n### Agent cost\n~$${costUsd.toFixed(2)}\n`);
-        }
-        prArgs.push('--body-file', prDescriptionFile);
-    }
-
-    // TODO: if 'gh pr create' errors because a PR for this branch already exists, catch it
-    // and print the existing PR URL instead (e.g. via `gh pr list --head <branch> --json url`)
-    const prUrl = execFileSync('gh', prArgs, { encoding: 'utf-8' }).trim();
-    log(`PR: ${prUrl}`);
-
-    try {
-        execFileSync(
-            'gh',
-            ['project', 'item-add', String(QA_PROJECT_NUMBER), '--owner', 'trezor', '--url', prUrl],
-            { stdio: 'inherit' },
-        );
-        log(`Assigned PR to QA and Test Automation project (#${QA_PROJECT_NUMBER})`);
-    } catch (err) {
-        error(`Failed to assign PR to QA and Test Automation project: ${err}`);
-    }
-
-    writeSummary(root, {
-        taskId,
-        result,
-        passed,
-        failed,
-        iterations,
-        prTitle,
-        prUrl,
-        costUsd,
-    });
+    writeSummary(root, summary);
 }
 
 publishPR();

--- a/packages/e2e-utils/src/fixBot/schemas.ts
+++ b/packages/e2e-utils/src/fixBot/schemas.ts
@@ -70,8 +70,9 @@ export const ClaudeResultSchema = z.object({
 });
 
 export const SlackFixSummarySchema = FixResultSchema.extend({
-    prUrl: z.string().nullable(),
-    costUsd: z.number().nullable(),
+    prUrl: z.string().nullable().default(null),
+    costUsd: z.number().nullable().default(null),
+    error: z.string().nullable().default(null),
 });
 
 // ── Cross-run ledger ─────────────────────────────────────────────────────────


### PR DESCRIPTION
This PR addresses few smaller things:
- improve constrain on where agent can do the fix -> we had one [PR](https://github.com/trezor/trezor-suite/pull/28580) where it probably correctly fixed a product bug
- improve guidance how to fix a test. In past there was one run where it changed the flow of the test. So we give instruction that test name and test.steps are test guidelance that have to be respected
- we have on stuck run for 1h 50m. -> timeout and price roof 
- error handling of publish.ts

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All changed files are within the `packages/e2e-utils/src/fixBot/` directory, which contains tooling for analyzing, fixing, notifying, and publishing related to a "fixBot" — an internal CI/CD helper utility. None of the 69 candidate E2E tests reference or exercise fixBot functionality; they test user-facing Suite features (onboarding, wallet, trading, staking, metadata, etc.). The fixBot code is infrastructure/tooling that operates outside the runtime paths exercised by any of these E2E tests. No tests are recommended.

<details><summary><b>Changed files (6)</b></summary>

- `packages/e2e-utils/src/fixBot/analyze.ts`
- `packages/e2e-utils/src/fixBot/common.ts`
- `packages/e2e-utils/src/fixBot/fix.ts`
- `packages/e2e-utils/src/fixBot/notify.ts`
- `packages/e2e-utils/src/fixBot/publish.ts`
- `packages/e2e-utils/src/fixBot/schemas.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (6)**
- `packages/e2e-utils/src/fixBot/analyze.ts`
- `packages/e2e-utils/src/fixBot/common.ts`
- `packages/e2e-utils/src/fixBot/fix.ts`
- `packages/e2e-utils/src/fixBot/notify.ts`
- `packages/e2e-utils/src/fixBot/publish.ts`
- `packages/e2e-utils/src/fixBot/schemas.ts`

_Updated: 2026-06-11T18:04:45.270Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/nightly-fix-agent-timeouts/web/](https://dev.suite.sldev.cz/suite-web/nightly-fix-agent-timeouts/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=nightly-fix-agent-timeouts&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=nightly-fix-agent-timeouts&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase numbering > hidden wallet numbering | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-11T18:09:58.721Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-11T18:08:44.697Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->