### PR TITLE
refactor(connect-explorer): type coin selector with canonical CoinSymbol

### DIFF
--- a/packages/connect-explorer/src/constants/coins.ts
+++ b/packages/connect-explorer/src/constants/coins.ts
@@ -1,10 +1,18 @@
-export const coinsSelect = [
+import type { CoinSymbol } from '@trezor/connect-common';
+
+type CoinSelectOption = {
+    value: CoinSymbol;
+    label: string;
+    affectedValue: string;
+};
+
+export const coinsSelect: CoinSelectOption[] = [
     { value: 'btc', label: 'Bitcoin', affectedValue: `m/49'/0'/0'` },
     { value: 'test', label: 'Bitcoin Testnet', affectedValue: `m/49'/1'/0'` },
     { value: 'bch', label: 'Bitcoin Cash', affectedValue: `m/44'/145'/0'` },
     { value: 'btg', label: 'Bitcoin Gold', affectedValue: `m/49'/156'/0'` },
     { value: 'ltc', label: 'Litecoin', affectedValue: `m/49'/2'/0'` },
     { value: 'dash', label: 'Dash', affectedValue: `m/44'/5'/0'` },
-    { value: 'zcash', label: 'Zcash', affectedValue: `m/44'/133'/0'` },
+    { value: 'zec', label: 'Zcash', affectedValue: `m/44'/133'/0'` },
     { value: 'doge', label: 'Dogecoin', affectedValue: `m/44'/3'/0'` },
 ];

--- a/packages/connect-explorer/src/data/methods/bitcoin/composeTransaction.ts
+++ b/packages/connect-explorer/src/data/methods/bitcoin/composeTransaction.ts
@@ -1,6 +1,8 @@
+import type { CoinSymbol } from '@trezor/connect-common';
+
 import { select } from './common';
 
-const examples = {
+const examples: Partial<Record<CoinSymbol, Array<{ amount: string; address: string }>>> = {
     btc: [
         {
             amount: '498066',
@@ -37,7 +39,7 @@ const examples = {
             address: 'XdTw4G5AWW4cogGd7ayybyBNDbuB45UpgH',
         },
     ],
-    zcash: [
+    zec: [
         {
             amount: '20000',
             address: 't1Lv2EguMkaZwvtFQW5pmbUsBw59KfTEhf4',
@@ -62,7 +64,7 @@ export default [
                 value: 'test',
                 affect: 'outputs',
                 data: select.map(v => {
-                    const example = examples[v.value as keyof typeof examples];
+                    const example = examples[v.value];
 
                     return {
                         ...v,

--- a/packages/connect-explorer/src/data/methods/bitcoin/signTransaction.multisig.ts
+++ b/packages/connect-explorer/src/data/methods/bitcoin/signTransaction.multisig.ts
@@ -1,3 +1,5 @@
+import type { CoinSymbol } from '@trezor/connect-common';
+
 import { select } from './common';
 
 const name = 'signTransaction';
@@ -38,7 +40,7 @@ const test = {
     ],
 };
 
-const examples = {
+const examples: Partial<Record<CoinSymbol, { inputs: unknown[]; outputs: unknown[] }>> = {
     test,
 };
 
@@ -53,7 +55,7 @@ export default [
                 value: 'test',
                 affect: ['inputs', 'outputs'],
                 data: select.map(v => {
-                    const example = examples[v.value as keyof typeof examples];
+                    const example = examples[v.value];
 
                     return {
                         ...v,

--- a/packages/connect-explorer/src/data/methods/bitcoin/signTransaction.opreturn.ts
+++ b/packages/connect-explorer/src/data/methods/bitcoin/signTransaction.opreturn.ts
@@ -1,3 +1,5 @@
+import type { CoinSymbol } from '@trezor/connect-common';
+
 import { select } from './common';
 
 const name = 'signTransaction';
@@ -38,7 +40,7 @@ const test = {
     ],
 };
 
-const examples = {
+const examples: Partial<Record<CoinSymbol, { inputs: unknown[]; outputs: unknown[] }>> = {
     test,
 };
 
@@ -53,7 +55,7 @@ export default [
                 value: 'test',
                 affect: ['inputs', 'outputs'],
                 data: select.map(v => {
-                    const example = examples[v.value as keyof typeof examples];
+                    const example = examples[v.value];
 
                     return {
                         ...v,

--- a/packages/connect-explorer/src/data/methods/bitcoin/signTransaction.p2sh.ts
+++ b/packages/connect-explorer/src/data/methods/bitcoin/signTransaction.p2sh.ts
@@ -1,3 +1,5 @@
+import type { CoinSymbol } from '@trezor/connect-common';
+
 import { select } from './common';
 
 const name = 'signTransaction';
@@ -37,7 +39,7 @@ const test = {
     ],
 };
 
-const examples = {
+const examples: Partial<Record<CoinSymbol, { inputs: unknown[]; outputs: unknown[] }>> = {
     test,
 };
 
@@ -54,7 +56,7 @@ export default [
                 data: select
                     .filter(c => c.affectedValue.includes('m/49'))
                     .map(v => {
-                        const example = examples[v.value as keyof typeof examples];
+                        const example = examples[v.value];
 
                         return {
                             ...v,

--- a/packages/connect-explorer/src/data/methods/bitcoin/signTransaction.paytoaddress.ts
+++ b/packages/connect-explorer/src/data/methods/bitcoin/signTransaction.paytoaddress.ts
@@ -1,3 +1,5 @@
+import type { CoinSymbol } from '@trezor/connect-common';
+
 import { select } from './common';
 
 const name = 'signTransaction';
@@ -121,7 +123,7 @@ const dash = {
 };
 
 // version 3
-const zcash = {
+const zec = {
     inputs: [
         {
             address_n: [2147483692, 2147483781, 2147483648, 0, 2],
@@ -173,12 +175,12 @@ const doge = {
     ],
 };
 
-const examples = {
+const examples: Partial<Record<CoinSymbol, { inputs: unknown[]; outputs: unknown[] }>> = {
     btc,
     bch,
     test,
     dash,
-    zcash,
+    zec,
     doge,
 };
 
@@ -193,7 +195,7 @@ export default [
                 value: 'btc',
                 affect: ['inputs', 'outputs'],
                 data: select.map(v => {
-                    const example = examples[v.value as keyof typeof examples];
+                    const example = examples[v.value];
 
                     return {
                         ...v,

--- a/packages/connect-explorer/src/data/methods/bitcoin/signTransaction.zcash.ts
+++ b/packages/connect-explorer/src/data/methods/bitcoin/signTransaction.zcash.ts
@@ -8,7 +8,7 @@ export default [
             {
                 name: 'coin',
                 type: 'hidden',
-                value: 'zcash',
+                value: 'zec',
             },
             {
                 name: 'inputs',


### PR DESCRIPTION
## What

Types the Connect Explorer bitcoin coin selector against the canonical `CoinSymbol` from `@trezor/connect-common`:

- `coinsSelect` (`constants/coins.ts`) is now `{ value: CoinSymbol; … }[]`,
- the `composeTransaction` `examples` map is `Partial<Record<CoinSymbol, …>>`, which also lets us drop the `as keyof typeof examples` cast.

## Why

`coinsSelect` is the single source of the bitcoin coin dropdown (re-exported as `select`, consumed by ~12 method definitions + the reducer). Typing it makes connect's canonical coin set the **compile-time source of truth** for the explorer's coin examples: adding a non-canonical symbol, or one connect no longer supports, now fails type-checking in CI.

This surfaced existing drift — `zcash` is not a canonical coin symbol. Connect's shortcut is `zec`; `getCoinInfo` only accepted `zcash` via an incidental `name` match. It's replaced with `zec` in `coinsSelect`, the `composeTransaction` example key, and the hidden coin field of the zcash `signTransaction` example. Both resolve to the same network, so behaviour is unchanged.

## QA notes

Only zcash calls could be affected.

## Series

Follow-up to #28641 (canonical `CoinSymbol` type), mirroring it into Connect Explorer. Part of a small series:

- #28663 — drop dead coin selector from `ethereumVerifyMessage` (dead-code removal)
- this PR — type the bitcoin coin selector with `CoinSymbol`

Downstream, #27539 will type connect's own `coin` API params as `CoinSymbol`.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are entirely within the connect-explorer package — specifically coin constants and Bitcoin signTransaction method data files (paytoaddress, p2sh, multisig, opreturn, zcash) plus composeTransaction. These are data/fixture definitions for the Connect Explorer playground UI, not core connect library code. The risk is low since these changes don't affect the actual TrezorConnect API implementation, only how the Explorer pre-populates example method calls. No E2E tests directly exercise the Connect Explorer's Bitcoin signTransaction or composeTransaction playground pages. The two recommended tests are the closest matches as they involve TrezorConnect Bitcoin operations that share conceptual overlap with the changed data.

<details><summary><b>Changed files (7)</b></summary>

- `packages/connect-explorer/src/constants/coins.ts`
- `packages/connect-explorer/src/data/methods/bitcoin/composeTransaction.ts`
- `packages/connect-explorer/src/data/methods/bitcoin/signTransaction.multisig.ts`
- `packages/connect-explorer/src/data/methods/bitcoin/signTransaction.opreturn.ts`
- `packages/connect-explorer/src/data/methods/bitcoin/signTransaction.p2sh.ts`
- `packages/connect-explorer/src/data/methods/bitcoin/signTransaction.paytoaddress.ts`
- `packages/connect-explorer/src/data/methods/bitcoin/signTransaction.zcash.ts`

</details>

**Recommended tests (2)**

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test exercises TrezorConnect.getAddress through the Connect Explorer web UI, which is the primary consumer of the changed connect-explorer data/constants files. Changes to coins.ts or signTransaction method definitions could affect how the Explorer renders or submits Bitcoin methods.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — This test calls TrezorConnect.signTransaction for BTC with PAYTOADDRESS script type via suite-desktop core mode. The changed file signTransaction.paytoaddress.ts defines the Connect Explorer's data/fixtures for exactly this method, and coins.ts provides coin constants used in transaction signing. While the test calls the API directly rather than through the Explorer UI, the shared signTransaction code path makes this relevant.

</details>

⚠️ **Changes with no test coverage (7)**
- `packages/connect-explorer/src/constants/coins.ts`
- `packages/connect-explorer/src/data/methods/bitcoin/composeTransaction.ts`
- `packages/connect-explorer/src/data/methods/bitcoin/signTransaction.multisig.ts`
- `packages/connect-explorer/src/data/methods/bitcoin/signTransaction.opreturn.ts`
- `packages/connect-explorer/src/data/methods/bitcoin/signTransaction.p2sh.ts`
- `packages/connect-explorer/src/data/methods/bitcoin/signTransaction.paytoaddress.ts`
- `packages/connect-explorer/src/data/methods/bitcoin/signTransaction.zcash.ts`

_Updated: 2026-06-12T07:29:54.534Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/connect-explorer-coinsymbol-typing&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/connect-explorer-coinsymbol-typing&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-12T07:34:12.045Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-12T07:32:48.038Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/connect-explorer-coinsymbol-typing/web/](https://dev.suite.sldev.cz/suite-web/mroz22/connect-explorer-coinsymbol-typing/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->