### PR TITLE
fix(utils): detect urls padded with spaces in extractUrlsFromText

### DIFF
--- a/packages/utils/src/extractUrlsFromText.ts
+++ b/packages/utils/src/extractUrlsFromText.ts
@@ -1,5 +1,5 @@
 const URL_REGEX =
-    /\b(?:https?:\/\/|www\.)[a-zA-Z0-9-._~:/?#[\]@!$&'()*+,;=%]+\b|(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?=\b|\s|$|\])/gi;
+    /\b(?:https?:\/\/|www\.)[a-zA-Z0-9-._~:/?#[\]@!$&'()*+,;=%]+\b|(?:[a-zA-Z0-9-]+\s?\.\s?)+[a-zA-Z]{2,}(?=\b|\s|$|\])/gi;
 
 export const extractUrlsFromText = (text: string) => {
     const urls: string[] = [];

--- a/packages/utils/tests/extractUrlsFromText.test.ts
+++ b/packages/utils/tests/extractUrlsFromText.test.ts
@@ -108,6 +108,42 @@ describe('extractUrlsFromText', () => {
         expect(urls).toEqual([]);
     });
 
+    it('should match url with a space before the dot', () => {
+        const text = 'Claim rewards at vanity-eth .net';
+
+        const { textParts, urls } = extractUrlsFromText(text);
+
+        expect(textParts).toEqual(['Claim rewards at ']);
+        expect(urls).toEqual(['vanity-eth .net']);
+    });
+
+    it('should match url with a space after the dot', () => {
+        const text = 'Claim rewards at vanity-eth. net';
+
+        const { textParts, urls } = extractUrlsFromText(text);
+
+        expect(textParts).toEqual(['Claim rewards at ']);
+        expect(urls).toEqual(['vanity-eth. net']);
+    });
+
+    it('should match url with spaces around the dot', () => {
+        const text = 'Claim rewards at vanity-eth . net';
+
+        const { textParts, urls } = extractUrlsFromText(text);
+
+        expect(textParts).toEqual(['Claim rewards at ']);
+        expect(urls).toEqual(['vanity-eth . net']);
+    });
+
+    it('should match url with a non-breaking space before the dot', () => {
+        const text = 'Claim rewards at vanity-eth\u00a0.net';
+
+        const { textParts, urls } = extractUrlsFromText(text);
+
+        expect(textParts).toEqual(['Claim rewards at ']);
+        expect(urls).toEqual(['vanity-eth\u00a0.net']);
+    });
+
     it('should match two urls next to each other', () => {
         const text = 'Visit trezor.io ledger.com';
 


### PR DESCRIPTION
Token and transaction names containing a URL with spaces around the dot (e.g. "vanity-eth .net") were not blurred because the URL detection required the domain to be contiguous.

Resolves #26835

<img width="572" height="649" alt="Screenshot 2026-06-11 at 21 33 05" src="https://github.com/user-attachments/assets/4b7e4eff-e4c6-4d8c-8c8b-12bfd782ac86" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change modifies `extractUrlsFromText`, a broad utility in `@trezor/utils` that is transitively imported by 121 E2E tests. However, only one test — `check-links.test.ts` — has behavior that directly involves URL extraction from page content. The unit test file (`extractUrlsFromText.test.ts`) has no E2E coverage mapping, which is expected since it's a unit test. The risk is low overall since the change is to a utility function with its own unit tests, but the link-checking E2E test should be run as it directly exercises URL extraction behavior in a real app context.

<details><summary><b>Changed files (2)</b></summary>

- `packages/utils/src/extractUrlsFromText.ts`
- `packages/utils/tests/extractUrlsFromText.test.ts`

</details>

**Recommended tests (1)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test validates that all links across the Trezor Suite app are not broken. The changed file `extractUrlsFromText` is a utility for extracting URLs from text, and this test explicitly extracts and validates links from every page. A change to URL extraction logic could directly cause this test to miss broken links or incorrectly parse URLs.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/utils/tests/extractUrlsFromText.test.ts`

_Updated: 2026-06-11T19:11:13.785Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/blur-urls-with-spaces&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/blur-urls-with-spaces&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/blur-urls-with-spaces/web/](https://dev.suite.sldev.cz/suite-web/fix/blur-urls-with-spaces/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase numbering > hidden wallet numbering | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-11T19:16:40.604Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-11T19:15:21.600Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->