### PR TITLE
fix(suite-common): handle missing targets in transaction amount search

### DIFF
--- a/suite-common/transaction-search/src/__tests__/getTargetAmounts.test.ts
+++ b/suite-common/transaction-search/src/__tests__/getTargetAmounts.test.ts
@@ -1,0 +1,29 @@
+import { testMocks } from '@suite-common/test-utils';
+import { type WalletAccountTransaction } from '@suite-common/wallet-types';
+
+import { getTargetAmounts } from '../getTargetAmounts';
+
+const { getWalletTransaction } = testMocks;
+
+describe(getTargetAmounts.name, () => {
+    it('returns amounts of transaction targets', () => {
+        const transaction = getWalletTransaction({ type: 'recv' });
+
+        expect(getTargetAmounts(transaction)).toEqual(['0.00001']);
+    });
+
+    it('falls back to the transaction amount when targets are empty', () => {
+        const transaction = getWalletTransaction({ targets: [] });
+
+        expect(getTargetAmounts(transaction)).toEqual(['0.00001']);
+    });
+
+    it('falls back to the transaction amount when targets are missing', () => {
+        const transaction = {
+            ...getWalletTransaction(),
+            targets: undefined,
+        } as unknown as WalletAccountTransaction;
+
+        expect(getTargetAmounts(transaction)).toEqual(['0.00001']);
+    });
+});

--- a/suite-common/transaction-search/src/getTargetAmounts.ts
+++ b/suite-common/transaction-search/src/getTargetAmounts.ts
@@ -1,7 +1,10 @@
 import { type WalletAccountTransaction } from '@suite-common/wallet-types';
 import { formatNetworkAmount, getTargetAmount } from '@suite-common/wallet-utils';
 
-export const getTargetAmounts = (transaction: WalletAccountTransaction) =>
-    transaction.targets.length === 0
+export const getTargetAmounts = (transaction: WalletAccountTransaction) => {
+    const targets = transaction.targets ?? [];
+
+    return targets.length === 0
         ? [formatNetworkAmount(transaction.amount, transaction.symbol)]
-        : transaction.targets.flatMap(target => getTargetAmount(target, transaction) || []);
+        : targets.flatMap(target => getTargetAmount(target, transaction) || []);
+};


### PR DESCRIPTION
Guards transaction amount search against transactions without a targets array and falls back to the top-level transaction amount. The `targets` is marked as required but maybe it sometimes misses.

Resolves #25379

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is scoped to `getTargetAmounts.ts` in the `transaction-search` module and its unit test. While static analysis maps this file to 59+ E2E tests (indicating it's a broadly imported utility), the function specifically deals with extracting/computing target amounts from transactions. The risk is low-to-moderate since the unit test file covers the core logic directly. E2E tests that exercise transaction display, search, and export are the most likely to surface regressions from this change.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/transaction-search/src/__tests__/getTargetAmounts.test.ts`
- `suite-common/transaction-search/src/getTargetAmounts.ts`

</details>

**Recommended tests (4)**

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/wallet/transactions.test.ts` — This test searches for transactions by address and verifies transaction items are visible. The `getTargetAmounts` function likely processes transaction target/output amounts for display in transaction lists, which this test directly exercises when searching and viewing transactions.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — This test verifies pending transaction display including transaction labels like TR_SENDING_SYMBOL and TR_SENT_SYMBOL, and transaction details. `getTargetAmounts` is part of the transaction-search module which likely affects how transaction amounts/targets are computed and displayed in the transaction list.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/wallet/export-transactions.test.ts` — Transaction export (CSV, JSON, PDF) likely relies on transaction target amount data. If `getTargetAmounts` changes how amounts are calculated, exported transaction data could be affected, particularly CSV content which includes amount fields.
- `suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — This test exports a CSV file and verifies output labels with specific addresses and amounts. The `getTargetAmounts` function in the transaction-search module could affect how transaction outputs are resolved, which directly impacts the CSV export assertion checking '1PmVvr5DNVYJygtDT7J312qmxpa5pceu9E,submitted by button'.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/transaction-search/src/__tests__/getTargetAmounts.test.ts`

_Updated: 2026-06-11T19:17:24.803Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/tx-search-missing-targets/web/](https://dev.suite.sldev.cz/suite-web/fix/tx-search-missing-targets/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/tx-search-missing-targets&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/tx-search-missing-targets&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/tx-search-missing-targets&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase numbering > hidden wallet numbering | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-11T19:23:04.264Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-11T19:20:50.068Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->