### PR TITLE
fix(trading): show swap from balance helper

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
@@ -127,7 +127,6 @@ export const TradingExchangeFormInputs = () => {
                         inputBottomText={
                             <AssetPickerInputBalance
                                 name={TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT}
-                                showOnlyAmount
                             />
                         }
                         includedCryptoIds={exchangeSellSupportedCryptoIds}


### PR DESCRIPTION
## Description

- Show the full balance helper under the Swap `FROM` asset field.

## Notes for QA

- Verify that balance is there

## Related Issue

Resolve #27961

## Screenshots:

<img width="721" height="351" alt="image" src="https://github.com/user-attachments/assets/858d4494-2ae4-4407-8d1f-75b2e172fd69" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is to TradingExchangeFormInputs.tsx, a shared component used across all trading swap form tests. Since it maps to 10 tests (broad dependency), we apply extra scrutiny. The mocked swap tests that directly fill in the form with various asset combinations (coin-to-token, coins, token-to-coin, tokens, disabled network) are the most relevant at medium priority since they exercise the form input component's core selection logic. The live swap tests are omitted as they duplicate the same form interaction patterns but run against live services with longer execution times. Fee-focused and navigation tests are lower priority as they only tangentially exercise the changed component.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx`

</details>

**Recommended tests (8)**

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — This test fills in the swap form with sell/buy asset selection, which directly exercises the TradingExchangeFormInputs component. It covers coin-to-token asset selection, a core use case of the exchange form inputs.
- `suite/e2e/tests/trading/swap-coins.test.ts` — This test fills in the swap form with coin-to-coin asset selection (SOL→BTC), exercising the TradingExchangeFormInputs component with a different asset pairing than coin-to-token, providing complementary coverage.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — This test exercises the swap form inputs with a token (USDT) as the sell asset and a coin (BTC) as the buy asset, covering the reverse direction of token/coin selection in TradingExchangeFormInputs.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — This test fills the swap form with both sell and buy assets being SPL tokens (USDT→USDC), testing token-to-token selection in TradingExchangeFormInputs, a distinct combination from the other swap tests.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — This test specifically validates that the swap form allows selecting a buy asset from a disabled network, directly testing edge-case behavior in TradingExchangeFormInputs asset selection.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — This test verifies that Buy/Sell/Swap forms open with the correct cryptocurrency pre-selected, which involves TradingExchangeFormInputs rendering the correct asset. However, it focuses more on navigation routing than form input interaction.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — This test interacts with the swap form inputs to set up a BTC→ETH swap before testing custom fee settings. The primary focus is on fee configuration, but it does exercise the form inputs for asset selection.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Similar to the Bitcoin fees test, this exercises the swap form inputs for ETH→BTC selection but primarily tests Ethereum custom fee parameters. Only indirectly affected by changes to TradingExchangeFormInputs.

</details>

_Updated: 2026-06-12T06:18:38.875Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=lukas.werner/fix-trading-swap-from-balance-label-27961&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=lukas.werner/fix-trading-swap-from-balance-label-27961&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/lukas.werner/fix-trading-swap-from-balance-label-27961/web/](https://dev.suite.sldev.cz/suite-web/lukas.werner/fix-trading-swap-from-balance-label-27961/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-12T06:23:22.170Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-12T06:22:52.514Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->