### PR TITLE
fix(suite): disable labeling for phishing transactions

### DIFF
--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
@@ -204,7 +204,7 @@ export const TransactionTarget = ({
             addressLabel={
                 <Labeling
                     deviceStaticSessionId={transaction.deviceState}
-                    isDisabled={isActionDisabled}
+                    isDisabled={isActionDisabled || isPhishingTransaction}
                     displayValue={label}
                     placeholder={translationString('TR_LABELING_OUTPUT_LABEL')}
                     payload={{


### PR DESCRIPTION
Phishing-flagged transactions no longer show the output labeling affordance (hover background and pen icon), so fake transactions do not look actionable. All target, token transfer, and internal transfer rows are covered since they all render through TransactionTarget.

I think it makes sense to mark phishing address as phishing but it should probably be doable in inputs&outputs, not in tx list

Resolves #27479

<img width="454" height="331" alt="Screenshot 2026-06-12 at 9 26 40" src="https://github.com/user-attachments/assets/da57dcd0-fd82-4578-9ab8-05aa0b6a50be" />

When I mark it safe, it works again
<img width="406" height="161" alt="Screenshot 2026-06-12 at 9 26 49" src="https://github.com/user-attachments/assets/09b3d807-1137-4f9e-8acb-1a0e9b261b47" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to TransactionTarget.tsx, a component within the TransactionItem that renders transaction target addresses, amounts, and labels in wallet transaction lists. This is a UI rendering component with focused scope — the primary risk is visual/functional regressions in how transactions are displayed. The highest priority tests are those that directly inspect transaction list contents (addresses, labels, OP_RETURN targets). Despite the file mapping to 121 tests via static analysis, most of those tests never interact with the transaction list view, so only a small targeted set is recommended.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/transactions.test.ts` — TransactionTarget is a core sub-component of TransactionItem, which renders transaction targets (addresses/amounts) in the transaction list. This test directly exercises the transaction list view, searches by transaction address, and verifies transaction items are displayed — all of which render TransactionTarget components.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/wallet/export-transactions.test.ts` — This test opens wallet accounts and interacts with transaction history views (including exporting transactions). The TransactionTarget component renders within the transaction list that this test exercises, and changes to how targets display could affect the transaction view from which exports are triggered.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test verifies that after sending a transaction with OP_RETURN, the pending transaction list shows 'OP_RETURN (meow)' as a target address. TransactionTarget is the component responsible for rendering those target addresses/labels in the transaction list, making this a direct functional dependency.
- `suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — This test labels transaction outputs and verifies labels appear correctly on transaction targets. TransactionTarget renders the output labels within the transaction list view, so changes to this component could directly affect how output labels are displayed.
- `suite/e2e/tests/wallet/pagination.test.ts` — This test navigates paginated transaction lists and asserts on specific transaction addresses displayed on each page. TransactionTarget renders these addresses within transaction items, so changes could affect address display across paginated views.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — TransactionTarget may render balance/amount values that are masked by discreet mode. If the component changes how amounts are rendered, it could affect the discreet mode hiding/revealing behavior for transaction-level values.

</details>

_Updated: 2026-06-12T06:46:42.216Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/disable-labeling-for-phishing-transactions/web/](https://dev.suite.sldev.cz/suite-web/fix/disable-labeling-for-phishing-transactions/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/disable-labeling-for-phishing-transactions&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/disable-labeling-for-phishing-transactions&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-12T06:51:26.894Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-12T06:50:21.328Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->