### PR TITLE
fix(suite-native): prevent transaction detail crashes on missing blockTime and onPress

### DIFF
--- a/suite-common/wallet-core/src/fiat-rates/__tests__/fiatRatesSelectors.test.ts
+++ b/suite-common/wallet-core/src/fiat-rates/__tests__/fiatRatesSelectors.test.ts
@@ -2,10 +2,18 @@ import { type DeviceRootState } from '@suite-common/device';
 import { type TrezorDevice } from '@suite-common/suite-types';
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { type TokenDefinitionsRootState } from '@suite-common/token-definitions';
-import { type Account, type TokenAddress } from '@suite-common/wallet-types';
+import {
+    type Account,
+    type CryptoBaseCurrencyPair,
+    type Timestamp,
+    type TokenAddress,
+} from '@suite-common/wallet-types';
 
 import { type AccountsRootState } from '../../accounts/accountsReducer';
-import { selectTickerFromAccounts } from '../fiatRatesSelectors';
+import {
+    selectHistoricFiatRatesByTimestamp,
+    selectTickerFromAccounts,
+} from '../fiatRatesSelectors';
 import { type FiatRatesRootState } from '../fiatRatesTypes';
 
 const STANDARD_WALLET_SSID = 'standardWallet@device_id:0' as const;
@@ -92,5 +100,37 @@ describe('selectTickerFromAccounts', () => {
         expect(result.map(ticker => ticker.symbol)).toContain('xrp');
         expect(tokenIndexes.length).toBeGreaterThan(0);
         expect(Math.max(...nativeIndexes)).toBeLessThan(Math.min(...tokenIndexes));
+    });
+});
+
+describe('selectHistoricFiatRatesByTimestamp', () => {
+    const BTC_USD = 'btc-usd' as CryptoBaseCurrencyPair;
+    const HOUR_ALIGNED_TIMESTAMP = 1639706400 as Timestamp;
+    const HISTORIC_RATE = 48000;
+
+    const historicRatesState = {
+        wallet: {
+            fiat: {
+                historic: { [BTC_USD]: { [HOUR_ALIGNED_TIMESTAMP]: HISTORIC_RATE } },
+            },
+        },
+    } as unknown as FiatRatesRootState;
+
+    it('returns the historic rate for the timestamp rounded to the nearest past hour', () => {
+        const timestampWithinSameHour = (HOUR_ALIGNED_TIMESTAMP + 1800) as Timestamp;
+
+        expect(
+            selectHistoricFiatRatesByTimestamp(
+                historicRatesState,
+                BTC_USD,
+                timestampWithinSameHour,
+            ),
+        ).toBe(HISTORIC_RATE);
+    });
+
+    it('returns undefined for an undefined timestamp (e.g. a pending transaction without blockTime)', () => {
+        expect(
+            selectHistoricFiatRatesByTimestamp(historicRatesState, BTC_USD, undefined),
+        ).toBeUndefined();
     });
 });

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesSelectors.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesSelectors.ts
@@ -41,8 +41,10 @@ export const selectFiatRatesByFiatRateKey = (
 export const selectHistoricFiatRatesByTimestamp = (
     state: FiatRatesRootState,
     fiatRateKey: CryptoBaseCurrencyPair,
-    timestamp: Timestamp,
+    timestamp: Timestamp | undefined,
 ): number | undefined => {
+    if (timestamp === undefined) return undefined;
+
     const roundedTimestamp = roundTimestampToNearestPastHour(timestamp);
 
     return state.wallet.fiat?.['historic']?.[fiatRateKey]?.[roundedTimestamp];

--- a/suite-native/module-transactions/src/components/TransactionDetailListItem.tsx
+++ b/suite-native/module-transactions/src/components/TransactionDetailListItem.tsx
@@ -24,7 +24,7 @@ type TransactionDetailListItemProps = {
     tokenTransfer?: TypedTokenTransfer;
     isFirst?: boolean;
     isLast?: boolean;
-    onPress: () => void;
+    onPress?: () => void;
     isPhishingTransaction: boolean;
 };
 
@@ -51,7 +51,7 @@ export const TransactionDetailListItem = ({
     const navigation = useNavigation<TransactionDetailNavigation>();
 
     const handleNavigation = () => {
-        onPress();
+        onPress?.();
         navigation.navigate(RootStackRoutes.TransactionDetailStack, {
             screen: TransactionDetailStackRoutes.TransactionDetail,
             params: {


### PR DESCRIPTION
## Description

Guards the historic fiat rate lookups against pending transactions without blockTime and makes the transaction detail list item onPress call optional, preventing JSError crashes reported by Sentry.

Resolves #24751

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native-transaction-detail-crashes&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native-transaction-detail-crashes&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native-transaction-detail-crashes&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies fiat rate selectors (a broadly imported utility used by 129+ tests) and a React Native transaction detail component. The fiatRatesSelectors change is covered by its own unit test file. Since fiatRatesSelectors is a global utility, only tests that specifically exercise fiat-to-crypto conversion display, balance rendering, or currency switching are recommended — most of the 129 statically-mapped tests have no direct relationship to fiat rate computation in their assertions. The React Native component (TransactionDetailListItem) has no E2E web test coverage as it's a mobile-only component.

<details><summary><b>Changed files (3)</b></summary>

- `suite-common/wallet-core/src/fiat-rates/__tests__/fiatRatesSelectors.test.ts`
- `suite-common/wallet-core/src/fiat-rates/fiatRatesSelectors.ts`
- `suite-native/module-transactions/src/components/TransactionDetailListItem.tsx`

</details>

**Recommended tests (5)**

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — This test verifies fiat and crypto balance display values ($0.00, $###) across the dashboard, which directly depend on fiat rate selectors to convert crypto balances to fiat amounts. Changes to fiatRatesSelectors could affect how these values are computed and displayed.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — This test verifies account balance display including fiat amounts after receiving BTC on regtest. Fiat rate selectors are used to convert crypto balances to fiat for display, and this test explicitly checks balance values and fiat rendering.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/staking/eth/stake-more.test.ts` — This test verifies staking amounts display including fiat-denominated values and staking form balances like '1,234 ETH'. Fiat rate selectors could affect how these balances are computed when switching between crypto and fiat display modes.
- `suite/e2e/tests/staking/staking-form.test.ts` — This test explicitly tests switching between crypto (ETH) and fiat (USD) input modes with value conversion, which relies on fiat rate selectors. It verifies the fiat ticker displays 'USD' and correct converted values based on a mocked 0.5 conversion ratio.
- `suite/e2e/tests/settings/general.test.ts` — This test verifies changing fiat currency from USD to EUR and seeing updated currency symbols ($0.00 → €0.00) on the dashboard. Fiat rate selectors may be involved in resolving the current fiat rate for display after currency change.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-common/wallet-core/src/fiat-rates/__tests__/fiatRatesSelectors.test.ts`
- `suite-native/module-transactions/src/components/TransactionDetailListItem.tsx`

_Updated: 2026-07-10T08:04:00.382Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/native-transaction-detail-crashes/web/](https://dev.suite.sldev.cz/suite-web/fix/native-transaction-detail-crashes/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-07-10T08:07:10.963Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-10T08:07:37.460Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->