### PR TITLE
fix(suite): add tooltips to DeFi tokens table CTA buttons

### DIFF
--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
@@ -503,8 +503,11 @@ const TokenRowBasicActions = ({
                                     isDisabled={isSupplyButtonDisabled}
                                     onClick={navigateToYieldSupply}
                                     tooltip={{
-                                        content: <Translation id="TR_DEFI_NO_VAULT_TOOLTIP" />,
-                                        isActive: isSupplyButtonDisabled,
+                                        content: isSupplyButtonDisabled ? (
+                                            <Translation id="TR_DEFI_NO_VAULT_TOOLTIP" />
+                                        ) : (
+                                            <Translation id="TR_EARN_YIELD_SUPPLY" />
+                                        ),
                                     }}
                                 />
 
@@ -513,8 +516,11 @@ const TokenRowBasicActions = ({
                                     isDisabled={isWithdrawButtonDisabled}
                                     onClick={navigateToYieldWithdraw}
                                     tooltip={{
-                                        content: <Translation id="TR_DEFI_NO_VAULT_TOOLTIP" />,
-                                        isActive: isWithdrawButtonDisabled,
+                                        content: isWithdrawButtonDisabled ? (
+                                            <Translation id="TR_DEFI_NO_VAULT_TOOLTIP" />
+                                        ) : (
+                                            <Translation id="TR_EARN_YIELD_WITHDRAW" />
+                                        ),
                                     }}
                                 />
                             </ButtonGroup>


### PR DESCRIPTION
The deposit and withdraw CTA icon buttons in the DeFi tokens table now show a tooltip on hover, matching the tokens tab behavior. When the action is unavailable the tooltip explains that no vault was found.

Resolves #28337

<img width="1186" height="265" alt="Screenshot 2026-06-12 at 8 59 52" src="https://github.com/user-attachments/assets/811e4019-9364-4df3-be6d-3b05ab4c713d" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to TokenRowActions.tsx, a component in the wallet tokens table that likely renders action buttons (buy, sell, swap, receive, etc.) for individual token rows. There is no static test coverage mapping for this file, so all recommendations are inferred from LLM analysis of test behaviors. The primary risk is that token-level trading entry points (buy/sell/swap from a specific token) could break. Tests that navigate to trading flows from token rows are the most relevant. The overall risk is moderate since this is a UI action component in a specific view.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx`

</details>

**Recommended tests (6)**

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — TokenRowActions.tsx likely contains action buttons (buy, sell, swap) rendered in token rows. The navigation test verifies that navigating to Buy/Sell/Swap forms from specific tokens (e.g., TrueUSD, USDC on Ethereum) works correctly, which directly exercises token-level trading action entry points that would be rendered by TokenRowActions.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — This test sells an ERC-20 token (USDC) through the trading/sell flow, which is likely initiated via token row actions in the tokens table. TokenRowActions.tsx would render the sell action button for tokens, making this a plausible regression path.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — This test buys a Solana SPL token (Jupiter/JUP) which may be initiated from token row actions. TokenRowActions likely provides buy/trade entry points for individual tokens displayed in the tokens table.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — This test swaps between SPL tokens (USDT to USDC) on Solana. Token swap actions could be triggered from TokenRowActions in the token table, making changes to this component relevant to the swap-from-token flow.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Swapping a token (USDT on Solana) to a coin (BTC) may originate from token row actions. The test exercises the token-level swap entry point which TokenRowActions could provide.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — While this test swaps a coin to a token (SOL to USDC), the receive side involves tokens. TokenRowActions changes could indirectly affect token-related UI paths in the swap flow.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx`

_Updated: 2026-06-12T06:53:54.670Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/defi-cta-tooltips/web/](https://dev.suite.sldev.cz/suite-web/fix/defi-cta-tooltips/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/defi-cta-tooltips&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/defi-cta-tooltips&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-12T06:58:31.546Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-12T06:57:33.673Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->