### PR TITLE
feat(suite): show all network settings unless device has bitcoin-only firmware

### DIFF
--- a/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
@@ -9,7 +9,6 @@ import { selectIsMevProtectionSettingsVisible } from '@suite-common/mev';
 import { getNetwork } from '@suite-common/wallet-config';
 import {
     selectEnabledNetworks,
-    selectIsDustPhishingThresholdSettingsVisible,
     selectIsNetworkReserveSettingsVisible,
 } from '@suite-common/wallet-core';
 import { isDesktop, isLinux, isWeb } from '@trezor/env-utils';
@@ -77,12 +76,6 @@ export const SettingsGeneral = () => {
     const isProviderConnected = useSelector(selectSelectedProviderForLabels);
     const isMevProtectionSettingsVisible = useSelector(selectIsMevProtectionSettingsVisible);
     const isNetworkReserveSettingsVisible = useSelector(selectIsNetworkReserveSettingsVisible);
-    const isDustPhishingThresholdSettingsVisible = useSelector(
-        selectIsDustPhishingThresholdSettingsVisible,
-    );
-
-    const isSecuritySettingsSectionVisible =
-        isMevProtectionSettingsVisible || isDustPhishingThresholdSettingsVisible;
 
     return (
         <SettingsLayout data-testid="@settings/index">
@@ -151,16 +144,14 @@ export const SettingsGeneral = () => {
                 <VersionWithUpdate />
             </SettingsSection>
 
-            {isSecuritySettingsSectionVisible && (
-                <SettingsSection
-                    title={<Translation id="TR_SECURITY" />}
-                    icon="shield"
-                    hasVerticalLayout={hasContentBelowTabletWidth}
-                >
-                    {isMevProtectionSettingsVisible && <MevProtection />}
-                    {isDustPhishingThresholdSettingsVisible && <DustPhishing />}
-                </SettingsSection>
-            )}
+            <SettingsSection
+                title={<Translation id="TR_SECURITY" />}
+                icon="shield"
+                hasVerticalLayout={hasContentBelowTabletWidth}
+            >
+                {isMevProtectionSettingsVisible && <MevProtection />}
+                <DustPhishing />
+            </SettingsSection>
 
             {isNetworkReserveSettingsVisible && (
                 <SettingsSection

--- a/suite-common/mev/jest.config.js
+++ b/suite-common/mev/jest.config.js
@@ -1,0 +1,11 @@
+/**
+ * Jest configuration for web packages.
+ * Keeping this file next to the package.json file instead of providing configuration
+ * with `-c ../../jest.config.base` option in package.json scripts
+ * allows us to run jest tests directly from IDEs.
+ */
+const baseConfig = require('../../jest.config.base.swc');
+
+module.exports = {
+    ...baseConfig,
+};

--- a/suite-common/mev/package.json
+++ b/suite-common/mev/package.json
@@ -8,12 +8,16 @@
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "test:unit": "yarn g:jest",
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
+        "@suite-common/device": "workspace:*",
         "@suite-common/message-system": "workspace:*",
-        "@suite-common/redux-utils": "workspace:*",
-        "@suite-common/wallet-config": "workspace:*",
-        "@suite-common/wallet-core": "workspace:*"
+        "@suite-common/redux-utils": "workspace:*"
+    },
+    "devDependencies": {
+        "@suite-common/suite-types": "workspace:*",
+        "@trezor/device-utils": "workspace:*"
     }
 }

--- a/suite-common/mev/src/__tests__/mevProtectionSettings.test.ts
+++ b/suite-common/mev/src/__tests__/mevProtectionSettings.test.ts
@@ -1,0 +1,26 @@
+import { deviceInitialState } from '@suite-common/device';
+import { messageSystemInitialState } from '@suite-common/message-system';
+import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
+import { FirmwareType } from '@trezor/device-utils';
+
+import { selectIsMevProtectionSettingsVisible } from '../mevProtectionSettings';
+
+describe('selectIsMevProtectionSettingsVisible', () => {
+    const getState = (firmwareType: FirmwareType) => ({
+        device: {
+            ...deviceInitialState,
+            selectedDevice: mockSuiteDevice({ firmwareType }),
+        },
+        messageSystem: messageSystemInitialState,
+    });
+
+    it('returns true for a device with universal firmware', () => {
+        expect(selectIsMevProtectionSettingsVisible(getState(FirmwareType.Universal))).toBe(true);
+    });
+
+    it('returns false for a device with bitcoin-only firmware', () => {
+        expect(selectIsMevProtectionSettingsVisible(getState(FirmwareType.BitcoinOnly))).toBe(
+            false,
+        );
+    });
+});

--- a/suite-common/mev/src/mevProtectionSettings.ts
+++ b/suite-common/mev/src/mevProtectionSettings.ts
@@ -1,28 +1,19 @@
+import { type DeviceRootState, selectHasBitcoinOnlyFirmware } from '@suite-common/device';
 import {
     Feature,
     type MessageSystemRootState,
     selectIsFeatureEnabled,
 } from '@suite-common/message-system';
 import { createWeakMapSelector } from '@suite-common/redux-utils';
-import { networksCollection } from '@suite-common/wallet-config';
-import { type WalletSettingsRootState, selectEnabledNetworks } from '@suite-common/wallet-core';
 
 const createMemoizedSelector = createWeakMapSelector.withTypes<
-    WalletSettingsRootState & MessageSystemRootState
+    DeviceRootState & MessageSystemRootState
 >();
 
 export const selectIsMevProtectionFeatureEnabled = (state: MessageSystemRootState) =>
     selectIsFeatureEnabled(state, Feature.mevProtection, true);
 
-const MEV_PROTECTION_SUPPORTED_NETWORK_SYMBOLS = networksCollection
-    .filter(network => network.features.includes('mev-protection'))
-    .map(network => network.symbol);
-
 export const selectIsMevProtectionSettingsVisible = createMemoizedSelector(
-    [selectIsMevProtectionFeatureEnabled, selectEnabledNetworks],
-    (isFeatureEnabled, enabledNetworks) =>
-        isFeatureEnabled &&
-        enabledNetworks.some(enabledNetwork =>
-            MEV_PROTECTION_SUPPORTED_NETWORK_SYMBOLS.includes(enabledNetwork),
-        ),
+    [selectIsMevProtectionFeatureEnabled, selectHasBitcoinOnlyFirmware],
+    (isFeatureEnabled, hasBitcoinOnlyFirmware) => isFeatureEnabled && !hasBitcoinOnlyFirmware,
 );

--- a/suite-common/mev/tsconfig.json
+++ b/suite-common/mev/tsconfig.json
@@ -2,9 +2,10 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
     "references": [
+        { "path": "../device" },
         { "path": "../message-system" },
         { "path": "../redux-utils" },
-        { "path": "../wallet-config" },
-        { "path": "../wallet-core" }
+        { "path": "../suite-types" },
+        { "path": "../../packages/device-utils" }
     ]
 }

--- a/suite-common/token-definitions/src/phishing/index.ts
+++ b/suite-common/token-definitions/src/phishing/index.ts
@@ -1,5 +1,1 @@
-export {
-    isPhishingTransaction,
-    hasNetworkPotentialFraudTransactions,
-    NETWORKS_WITH_DUST_PHISHING_DETECTION,
-} from './phishing';
+export { isPhishingTransaction, hasNetworkPotentialFraudTransactions } from './phishing';

--- a/suite-common/token-definitions/src/phishing/phishing.ts
+++ b/suite-common/token-definitions/src/phishing/phishing.ts
@@ -56,12 +56,6 @@ const PHISHING_VALIDATORS: NetworkPhishingValidators = new Map([
     ],
 ]);
 
-export const NETWORKS_WITH_DUST_PHISHING_DETECTION = Array.from(PHISHING_VALIDATORS.entries())
-    .filter(([_, validator]) =>
-        validator.getDetectors().some(detector => detector.id === 'DUST_AMOUNT'),
-    )
-    .map(([networkType]) => networkType);
-
 // NOTE: This function determines for which symbols there are filters in the UI to hide/display spam transactions
 // when handling fraud for other symbols, make sure this function is updated!
 export const hasNetworkPotentialFraudTransactions = (symbol: NetworkSymbol) =>

--- a/suite-common/wallet-core/src/settings/walletSettingsReducer.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsReducer.ts
@@ -1,11 +1,11 @@
 import { A } from '@mobily/ts-belt';
 
+import { type DeviceRootState, selectHasBitcoinOnlyFirmware } from '@suite-common/device';
 import {
     createReducerWithExtraDeps,
     createWeakMapSelector,
     returnStableArrayIfEmpty,
 } from '@suite-common/redux-utils';
-import { NETWORKS_WITH_DUST_PHISHING_DETECTION } from '@suite-common/token-definitions';
 import {
     type NetworkSymbol,
     getNetwork,
@@ -166,19 +166,8 @@ export const selectIsNetworkReserveEnabled = (state: WalletSettingsRootState) =>
 export const selectIsMevProtectionEnabled = (state: WalletSettingsRootState) =>
     state.wallet.settings.mevProtection;
 
-export const selectIsNetworkReserveSettingsVisible = createMemoizedSelector(
-    [selectEnabledNetworks],
-    enabledNetworks =>
-        enabledNetworks.some(enabledNetwork => !!getNetwork(enabledNetwork)?.nativeTokenReserve),
-);
-
-export const selectIsDustPhishingThresholdSettingsVisible = createMemoizedSelector(
-    [selectEnabledNetworks],
-    enabledNetworks =>
-        enabledNetworks.some(enabledNetwork =>
-            NETWORKS_WITH_DUST_PHISHING_DETECTION.includes(getNetworkType(enabledNetwork)),
-        ),
-);
+export const selectIsNetworkReserveSettingsVisible = (state: DeviceRootState) =>
+    !selectHasBitcoinOnlyFirmware(state);
 
 export const selectAddressDisplayType = (state: WalletSettingsRootState) =>
     state.wallet.settings.addressDisplayType;

--- a/suite-common/wallet-core/tests/settings/walletSettingsReducer.test.ts
+++ b/suite-common/wallet-core/tests/settings/walletSettingsReducer.test.ts
@@ -1,6 +1,13 @@
+import { deviceInitialState } from '@suite-common/device';
+import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { extraDependenciesCommonMock } from '@suite-common/test-utils';
+import { FirmwareType } from '@trezor/device-utils';
 
-import { initialWalletSettingsState, prepareWalletSettingsReducer } from '../../src';
+import {
+    initialWalletSettingsState,
+    prepareWalletSettingsReducer,
+    selectIsNetworkReserveSettingsVisible,
+} from '../../src';
 import * as walletSettingsActions from '../../src/settings/walletSettingsActions';
 
 const initialState = initialWalletSettingsState;
@@ -49,5 +56,24 @@ describe('settings reducer', () => {
             ...initialState,
             enabledNetworks: ['eth'],
         });
+    });
+});
+
+describe('selectIsNetworkReserveSettingsVisible', () => {
+    const getState = (firmwareType: FirmwareType) => ({
+        device: {
+            ...deviceInitialState,
+            selectedDevice: mockSuiteDevice({ firmwareType }),
+        },
+    });
+
+    it('returns true for a device with universal firmware', () => {
+        expect(selectIsNetworkReserveSettingsVisible(getState(FirmwareType.Universal))).toBe(true);
+    });
+
+    it('returns false for a device with bitcoin-only firmware', () => {
+        expect(selectIsNetworkReserveSettingsVisible(getState(FirmwareType.BitcoinOnly))).toBe(
+            false,
+        );
     });
 });

--- a/suite-native/module-settings/src/screens/SettingsAdvancedScreen.tsx
+++ b/suite-native/module-settings/src/screens/SettingsAdvancedScreen.tsx
@@ -1,10 +1,7 @@
 import { useSelector } from 'react-redux';
 
 import { selectIsMevProtectionSettingsVisible } from '@suite-common/mev';
-import {
-    selectIsDustPhishingThresholdSettingsVisible,
-    selectIsNetworkReserveSettingsVisible,
-} from '@suite-common/wallet-core';
+import { selectIsNetworkReserveSettingsVisible } from '@suite-common/wallet-core';
 import { VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { DynamicScreenHeader, Screen } from '@suite-native/navigation';
@@ -19,9 +16,6 @@ import { ToggleNetworkReserveCheckCard } from '../components/ToggleNetworkReserv
 export const SettingsAdvancedScreen = () => {
     const isMevProtectionSettingsVisible = useSelector(selectIsMevProtectionSettingsVisible);
     const isNetworkReserveSettingsVisible = useSelector(selectIsNetworkReserveSettingsVisible);
-    const isDustPhishingThresholdSettingsVisible = useSelector(
-        selectIsDustPhishingThresholdSettingsVisible,
-    );
 
     return (
         <Screen
@@ -32,7 +26,7 @@ export const SettingsAdvancedScreen = () => {
             <VStack spacing="sp16">
                 <ToggleAddressDisplayCard />
                 {isMevProtectionSettingsVisible && <ToggleMevProtectionCard />}
-                {isDustPhishingThresholdSettingsVisible && <DustPhishingThresholdCard />}
+                <DustPhishingThresholdCard />
                 <ToggleFirmwareAuthenticityCheckCard />
                 <ToggleDeviceAuthenticityCheckCard />
                 {isNetworkReserveSettingsVisible && <ToggleNetworkReserveCheckCard />}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10678,10 +10678,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-common/mev@workspace:suite-common/mev"
   dependencies:
+    "@suite-common/device": "workspace:*"
     "@suite-common/message-system": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
-    "@suite-common/wallet-config": "workspace:*"
-    "@suite-common/wallet-core": "workspace:*"
+    "@suite-common/suite-types": "workspace:*"
+    "@trezor/device-utils": "workspace:*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Dust phishing detection now works on all networks, so its setting is always shown and the enabled-networks gating was removed. MEV protection and network reserve settings are now hidden only when the connected device runs bitcoin-only firmware.

Resolves #28492

<img width="1468" height="750" alt="Screenshot 2026-06-12 at 9 42 05" src="https://github.com/user-attachments/assets/ce8b08b3-6985-480a-a417-61302b725b71" />
<img width="1457" height="742" alt="Screenshot 2026-06-12 at 9 41 54" src="https://github.com/user-attachments/assets/f0bbb844-4233-4b07-80d9-097b696ee84e" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set introduces MEV protection settings (new suite-common/mev package), modifies the wallet settings reducer to support it, updates the SettingsGeneral view (likely adding MEV toggle UI), modifies phishing detection logic, and updates the native settings screen. The highest risk is in the SettingsGeneral.tsx view change which directly affects the general settings page — the general settings test is critical. The walletSettingsReducer and mev module changes are broadly imported but primarily affect settings state shape, making analytics events tests relevant at medium priority. Most of the 121 tests mapped via broad dependencies (walletSettingsReducer, mev, phishing) are only transitively affected and unlikely to regress. The native settings screen change has no E2E coverage in this test suite.

<details><summary><b>Changed files (10)</b></summary>

- `packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx`
- `suite-common/mev/package.json`
- `suite-common/mev/src/__tests__/mevProtectionSettings.test.ts`
- `suite-common/mev/src/mevProtectionSettings.ts`
- `suite-common/mev/tsconfig.json`
- `suite-common/token-definitions/src/phishing/index.ts`
- `suite-common/token-definitions/src/phishing/phishing.ts`
- `suite-common/wallet-core/src/settings/walletSettingsReducer.ts`
- `suite-common/wallet-core/tests/settings/walletSettingsReducer.test.ts`
- `suite-native/module-settings/src/screens/SettingsAdvancedScreen.tsx`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/settings/general.test.ts` — This test directly exercises the SettingsGeneral view, which is one of the changed files. It tests fiat currency changes, theme changes, language changes, and analytics toggles — all rendered by SettingsGeneral.tsx. Any new MEV protection UI added to this view could break existing settings interactions.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — This test validates the SuiteReady analytics event which reports all wallet settings state. Changes to walletSettingsReducer (adding MEV protection state) could affect the shape of settings reported in analytics events, and changes to settings UI could affect the settings flow exercised here.
- `suite/e2e/tests/analytics/toggle.test.ts` — This test interacts with the Settings > Application section (rendered by SettingsGeneral.tsx) to toggle analytics and change fiat currency. Changes to the settings view layout could affect element visibility or interaction order.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/settings/coins.test.ts` — This test navigates through settings pages including the general settings area. While it primarily tests the coins tab, it does interact with the settings navigation which could be affected by SettingsGeneral changes.
- `suite/e2e/tests/suite/db-locale-migration.test.ts` — This test verifies settings persistence across DB migrations and checks the language select component on the settings page. Changes to SettingsGeneral.tsx could affect the layout or rendering of the language selector.

</details>

⚠️ **Changes with no test coverage (8)**
- `suite-common/mev/package.json`
- `suite-common/mev/src/__tests__/mevProtectionSettings.test.ts`
- `suite-common/mev/src/mevProtectionSettings.ts`
- `suite-common/mev/tsconfig.json`
- `suite-common/token-definitions/src/phishing/index.ts`
- `suite-common/token-definitions/src/phishing/phishing.ts`
- `suite-common/wallet-core/tests/settings/walletSettingsReducer.test.ts`
- `suite-native/module-settings/src/screens/SettingsAdvancedScreen.tsx`

_Updated: 2026-06-12T07:02:46.576Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/show-all-network-settings&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/show-all-network-settings&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/show-all-network-settings&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-12T07:07:48.936Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-12T07:06:12.200Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/show-all-network-settings/web/](https://dev.suite.sldev.cz/suite-web/feat/show-all-network-settings/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->