### PR TITLE
fix(suite): show phishing tooltip text based on detection reason

### DIFF
--- a/packages/suite/src/components/wallet/TransactionItem/TransactionHeading.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionHeading.tsx
@@ -1,4 +1,5 @@
 import { Translation } from '@suite/intl';
+import { type PhishingDetectorId } from '@suite-common/token-definitions';
 import { getTxHeaderSymbol, isSupportedEthStakingNetworkSymbol } from '@suite-common/wallet-utils';
 import { Row, TextButton, Tooltip } from '@trezor/components';
 import { HELP_CENTER_ZERO_VALUE_ATTACKS } from '@trezor/urls';
@@ -9,10 +10,28 @@ import { InstantStakeBadge } from './InstantStakeBadge';
 import { TransactionHeader } from './TransactionHeader';
 import { BlurWrapper } from './TransactionItemBlurWrapper';
 
+const getPhishingTooltipTranslationId = (detectorId?: PhishingDetectorId) => {
+    switch (detectorId) {
+        case 'FAKE_TOKEN':
+            return 'TR_PHISHING_TOOLTIP_FAKE_TOKEN';
+        case 'UNKNOWN_TX':
+            return 'TR_PHISHING_TOOLTIP_UNKNOWN_TX';
+        case 'DUST_AMOUNT':
+            return 'TR_PHISHING_TOOLTIP_DUST_AMOUNT';
+        case 'ZERO_AMOUNT':
+            return 'TR_PHISHING_TOOLTIP_ZERO_AMOUNT';
+        case 'TRC10_TRANSFER':
+            return 'TR_PHISHING_TOOLTIP_TRC10_TRANSFER';
+        default:
+            return 'TR_ZERO_PHISHING_TOOLTIP';
+    }
+};
+
 type TransactionHeadingProps = {
     transaction: WalletAccountTransaction;
     isPending: boolean;
     isPhishingTransaction: boolean;
+    phishingDetectorId?: PhishingDetectorId;
     dataTestBase: string;
 };
 
@@ -20,6 +39,7 @@ export const TransactionHeading = ({
     transaction,
     isPending,
     isPhishingTransaction,
+    phishingDetectorId,
     dataTestBase,
 }: TransactionHeadingProps) => {
     const symbol = getTxHeaderSymbol(transaction);
@@ -28,7 +48,7 @@ export const TransactionHeading = ({
         <Tooltip
             content={
                 <Translation
-                    id="TR_ZERO_PHISHING_TOOLTIP"
+                    id={getPhishingTooltipTranslationId(phishingDetectorId)}
                     values={{
                         a: chunks => (
                             <TextButton

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
@@ -108,8 +108,8 @@ export const TransactionItem = memo(
                 }),
             );
         };
-        const { isPhishing: isPhishingTransaction } = useSelector(state =>
-            selectIsPhishingTransaction(state, transaction.txid, accountKey),
+        const { isPhishing: isPhishingTransaction, detectorId: phishingDetectorId } = useSelector(
+            state => selectIsPhishingTransaction(state, transaction.txid, accountKey),
         );
 
         const dataTestBase = `@transaction-item/${index}${
@@ -127,6 +127,7 @@ export const TransactionItem = memo(
                                 transaction={transaction}
                                 isPending={isPending}
                                 isPhishingTransaction={isPhishingTransaction}
+                                phishingDetectorId={phishingDetectorId}
                                 dataTestBase={dataTestBase}
                             />
                         }

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -9246,6 +9246,30 @@ export const messages = defineMessages({
         defaultMessage:
             'Address poisoning alert. This transaction looks suspicious. <a>Learn more</a>',
     },
+    TR_PHISHING_TOOLTIP_FAKE_TOKEN: {
+        id: 'TR_PHISHING_TOOLTIP_FAKE_TOKEN',
+        defaultMessage:
+            'Fake token alert. This transaction includes a token that may impersonate a legitimate one. <a>Learn more</a>',
+    },
+    TR_PHISHING_TOOLTIP_UNKNOWN_TX: {
+        id: 'TR_PHISHING_TOOLTIP_UNKNOWN_TX',
+        defaultMessage:
+            "Suspicious transaction alert. This transaction couldn't be verified. <a>Learn more</a>",
+    },
+    TR_PHISHING_TOOLTIP_DUST_AMOUNT: {
+        id: 'TR_PHISHING_TOOLTIP_DUST_AMOUNT',
+        defaultMessage:
+            'Dust attack alert. This transaction moves a negligible amount, a tactic used in address poisoning. <a>Learn more</a>',
+    },
+    TR_PHISHING_TOOLTIP_ZERO_AMOUNT: {
+        id: 'TR_PHISHING_TOOLTIP_ZERO_AMOUNT',
+        defaultMessage:
+            'Address poisoning alert. This zero-amount transaction looks suspicious. <a>Learn more</a>',
+    },
+    TR_PHISHING_TOOLTIP_TRC10_TRANSFER: {
+        id: 'TR_PHISHING_TOOLTIP_TRC10_TRANSFER',
+        defaultMessage: 'Scam alert. This TRC10 transfer looks suspicious. <a>Learn more</a>',
+    },
     TR_ZERO_PHISHING_BANNER: {
         id: 'TR_ZERO_PHISHING_BANNER',
         defaultMessage:


### PR DESCRIPTION
The question-mark tooltip on phishing-flagged transactions in the transaction list always showed the address poisoning text regardless of why the transaction was flagged. The tooltip now maps the phishing detector id to a reason-specific message, falling back to the original text when no detector id is available.

Resolves #26871

Text are vibecoded but it can be improved by @c4181 in crowdin.

<img width="318" height="239" alt="Screenshot 2026-06-12 at 10 22 32" src="https://github.com/user-attachments/assets/838f278c-5a44-498e-a622-699f8bf0e23c" />
<img width="414" height="240" alt="Screenshot 2026-06-12 at 10 22 20" src="https://github.com/user-attachments/assets/99024ce0-2495-4a32-a939-c185d0ebaed5" />



<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes target TransactionItem and TransactionHeading components (transaction list row rendering) and the intl messages file. Since these components map to 121 tests via static analysis (indicating they are broadly imported), only tests that directly interact with transaction list display, transaction labels, or pending transaction status rendering are recommended. The highest risk is in tests that assert on transaction addresses, labels, status text, and pagination — these directly exercise the changed components. The messages.ts change is a global file with no static coverage data but is exercised transitively by any test using translations; only tests checking specific transaction-related translation keys are included.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/components/wallet/TransactionItem/TransactionHeading.tsx`
- `packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/wallet/transactions.test.ts` — This test directly exercises the transaction list UI, including finding and searching transactions by address. TransactionItem and TransactionHeading are the core components rendered for each transaction row, so changes to these files directly affect this test's assertions about transaction display.
- `suite/e2e/tests/wallet/export-transactions.test.ts` — This test interacts with the transaction list view to export transactions in various formats. TransactionItem is rendered in the account view where exports are triggered, and changes could affect the transaction rendering that precedes export actions.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test asserts that a pending transaction list shows 'OP_RETURN (meow)' as a target address in the transaction list — directly testing TransactionItem rendering of pending transactions after sending.
- `suite/e2e/tests/wallet/pagination.test.ts` — This test navigates paginated transaction lists and asserts on transaction addresses displayed per page. TransactionItem/TransactionHeading are the components rendering these address values, making this a direct test of the changed code.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — This test labels transaction outputs and verifies labels appear in the transaction view and exported CSV. TransactionItem renders output labels, so changes to the component could affect label display and interaction.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test checks pending staking transaction display including confirming status and transaction text visibility. TransactionItem renders these pending transaction rows, so changes could affect the staking transaction status rendering.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — This test verifies pending unstaking transaction visibility and status text (TR_TX_CONFIRMING, TR_TX_CONFIRMED) rendered within TransactionItem. Changes to the component or messages.ts could affect these status labels.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — This test checks pending staking transaction text visibility and transaction confirming/confirmed status display, which are rendered by TransactionItem.
- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — This test creates and verifies output labels on transactions, which are rendered within TransactionItem. Changes to the component could affect how output labels are displayed and interacted with.
- `suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts` — This test removes output labels from transactions and verifies the label reverts to a truncated address format, which is rendered by TransactionItem.
- `suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — This test syncs output labels from the relay and verifies they appear on transaction outputs, which are rendered within TransactionItem.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/intl/src/messages.ts`

_Updated: 2026-06-12T07:56:43.195Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/phishing-tooltip-per-reason&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/phishing-tooltip-per-reason&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-12T08:01:20.919Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-12T08:00:12.341Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/phishing-tooltip-per-reason/web/](https://dev.suite.sldev.cz/suite-web/fix/phishing-tooltip-per-reason/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->