### PR TITLE
fix(suite): sort zero-balance and hidden tokens alphabetically

### DIFF
--- a/packages/suite/src/views/wallet/tokens/coins/CoinsTable.tsx
+++ b/packages/suite/src/views/wallet/tokens/coins/CoinsTable.tsx
@@ -4,7 +4,7 @@ import { Translation } from '@suite/intl';
 import { TokenManagementAction, selectCoinDefinitions } from '@suite-common/token-definitions';
 import { selectBaseCurrency, selectCurrentFiatRates } from '@suite-common/wallet-core';
 import { type SelectedAccountLoaded } from '@suite-common/wallet-types';
-import { isErc4626, isTestnet } from '@suite-common/wallet-utils';
+import { isErc4626, isTestnet, sortTokensByName } from '@suite-common/wallet-utils';
 
 import { useSelector } from 'src/hooks/suite';
 import {
@@ -42,16 +42,17 @@ export const CoinsTable = ({ selectedAccount, searchQuery }: CoinsTableProps) =>
         return tokensWithRates.sort(sortTokensWithRates);
     }, [account.tokens, account.symbol, baseCurrencyCode, fiatRates]);
 
-    const tokens = useMemo(
-        () =>
-            getTokens({
-                tokens: enhancedTokens,
-                symbol: account.symbol,
-                tokenDefinitions: coinDefinitions,
-                searchQuery,
-            }),
-        [enhancedTokens, account.symbol, coinDefinitions, searchQuery],
-    );
+    const tokens = useMemo(() => {
+        const groupedTokens = getTokens({
+            tokens: enhancedTokens,
+            symbol: account.symbol,
+            tokenDefinitions: coinDefinitions,
+            searchQuery,
+        });
+        groupedTokens.shownWithoutBalance.sort(sortTokensByName);
+
+        return groupedTokens;
+    }, [enhancedTokens, account.symbol, coinDefinitions, searchQuery]);
 
     const hiddenTokensCount =
         tokens.unverifiedWithBalance.length +

--- a/packages/suite/src/views/wallet/tokens/defi/DefiTokensTable.tsx
+++ b/packages/suite/src/views/wallet/tokens/defi/DefiTokensTable.tsx
@@ -5,7 +5,7 @@ import { useAllYieldOpportunities } from '@suite-common/earn-stablecoin-api';
 import { TokenManagementAction, selectCoinDefinitions } from '@suite-common/token-definitions';
 import { selectBaseCurrency, selectCurrentFiatRates } from '@suite-common/wallet-core';
 import { type SelectedAccountLoaded } from '@suite-common/wallet-types';
-import { isErc4626 } from '@suite-common/wallet-utils';
+import { isErc4626, sortTokensByName } from '@suite-common/wallet-utils';
 import { Banner, Column } from '@trezor/components';
 
 import { useSelector } from 'src/hooks/suite';
@@ -45,16 +45,17 @@ export const DefiTokensTable = ({ selectedAccount, searchQuery }: DefiTokensTabl
         return tokensWithRates.sort(sortTokensWithRates);
     }, [account.tokens, account.symbol, baseCurrencyCode, fiatRates]);
 
-    const tokens = useMemo(
-        () =>
-            getTokens({
-                tokens: enhancedTokens,
-                symbol: account.symbol,
-                tokenDefinitions: coinDefinitions,
-                searchQuery,
-            }),
-        [enhancedTokens, account.symbol, coinDefinitions, searchQuery],
-    );
+    const tokens = useMemo(() => {
+        const groupedTokens = getTokens({
+            tokens: enhancedTokens,
+            symbol: account.symbol,
+            tokenDefinitions: coinDefinitions,
+            searchQuery,
+        });
+        groupedTokens.shownWithoutBalance.sort(sortTokensByName);
+
+        return groupedTokens;
+    }, [enhancedTokens, account.symbol, coinDefinitions, searchQuery]);
 
     const hasShownTokens =
         tokens.shownWithBalance.length > 0 || tokens.shownWithoutBalance.length > 0;

--- a/packages/suite/src/views/wallet/tokens/hidden-tokens/HiddenTokensTable.tsx
+++ b/packages/suite/src/views/wallet/tokens/hidden-tokens/HiddenTokensTable.tsx
@@ -1,7 +1,7 @@
 import { Translation } from '@suite/intl';
 import { TokenManagementAction, selectCoinDefinitions } from '@suite-common/token-definitions';
 import { type SelectedAccountLoaded } from '@suite-common/wallet-types';
-import { isTestnet } from '@suite-common/wallet-utils';
+import { isTestnet, sortTokensByName } from '@suite-common/wallet-utils';
 import { Banner, Column, H3 } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
@@ -21,11 +21,7 @@ export const HiddenTokensTable = ({ selectedAccount, searchQuery }: HiddenTokens
 
     const coinDefinitions = useSelector(state => selectCoinDefinitions(state, account.symbol));
 
-    const sortedTokens = account.tokens
-        ? [...account.tokens].sort(
-              (a, b) => parseInt(b?.balance || '0') - parseInt(a?.balance || '0'),
-          )
-        : [];
+    const sortedTokens = account.tokens?.toSorted(sortTokensByName) ?? [];
 
     const filteredTokens = getTokens({
         tokens: sortedTokens,

--- a/suite-common/wallet-utils/src/__tests__/tokenUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/tokenUtils.test.ts
@@ -1,5 +1,9 @@
 import { getContractAddressForNetworkSymbolFixtures } from '../__fixtures__/tokenUtils';
-import { getAssetLogoContractAddresses, getContractAddressForNetworkSymbol } from '../tokenUtils';
+import {
+    getAssetLogoContractAddresses,
+    getContractAddressForNetworkSymbol,
+    sortTokensByName,
+} from '../tokenUtils';
 
 describe('getContractAddressForNetworkSymbol', () => {
     getContractAddressForNetworkSymbolFixtures.forEach(
@@ -35,6 +39,34 @@ describe('getAssetLogoContractAddresses', () => {
         const contract = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
         await expect(getAssetLogoContractAddresses('eth', contract)).resolves.toEqual([
             contract.toLowerCase(),
+        ]);
+    });
+});
+
+describe('sortTokensByName', () => {
+    it('sorts tokens alphabetically by name regardless of case', () => {
+        const tokens = [
+            { name: 'Tether USD' },
+            { name: 'chainlink' },
+            { name: 'Aave' },
+            { name: 'USD Coin' },
+        ];
+
+        expect([...tokens].sort(sortTokensByName).map(token => token.name)).toEqual([
+            'Aave',
+            'chainlink',
+            'Tether USD',
+            'USD Coin',
+        ]);
+    });
+
+    it('places tokens without a name first', () => {
+        const tokens = [{ name: 'Aave' }, { name: undefined }, { name: 'chainlink' }];
+
+        expect([...tokens].sort(sortTokensByName).map(token => token.name)).toEqual([
+            undefined,
+            'Aave',
+            'chainlink',
         ]);
     });
 });

--- a/suite-common/wallet-utils/src/tokenUtils.ts
+++ b/suite-common/wallet-utils/src/tokenUtils.ts
@@ -136,3 +136,6 @@ export const shouldUppercaseTokenSymbol = (token: TokenInfo) =>
     token.standard ? !PRESERVE_TOKEN_SYMBOL_CASE_STANDARDS.has(token.standard) : true;
 
 export const isErc4626 = (token: TokenInfo) => !!token.protocols?.includes('erc4626');
+
+export const sortTokensByName = (a: Pick<TokenInfo, 'name'>, b: Pick<TokenInfo, 'name'>) =>
+    (a.name ?? '').localeCompare(b.name ?? '');

--- a/suite-native/accounts/src/selectors.ts
+++ b/suite-native/accounts/src/selectors.ts
@@ -50,6 +50,7 @@ import {
     isCardanoStakingActive,
     isErc4626,
     isStakingSymbol,
+    sortTokensByName,
     toFiatCurrency,
 } from '@suite-common/wallet-utils';
 import { type CombinedLabelingState, selectIsLabellingAllowed } from '@suite-native/labeling';
@@ -320,9 +321,7 @@ export const getAccountListSections = (
             sections.push({
                 type: 'zeroBalance',
                 account,
-                tokens: [...zeroBalanceTokens].sort((a, b) =>
-                    (a.name ?? '').localeCompare(b.name ?? ''),
-                ),
+                tokens: [...zeroBalanceTokens].sort(sortTokensByName),
             });
         }
     }


### PR DESCRIPTION
Zero-balance tokens and the hidden tokens section are now sorted alphabetically by token name in desktop Suite, using a comparator shared with mobile via @suite-common/wallet-utils.

Resolves #26836

<img width="767" height="776" alt="Screenshot 2026-06-20 at 9 43 46" src="https://github.com/user-attachments/assets/5b136dcc-5a02-43a1-b76c-10cd3df34b7c" />
<img width="680" height="658" alt="Screenshot 2026-06-20 at 9 43 35" src="https://github.com/user-attachments/assets/c81938dd-c105-4ca2-a3a8-c0672afa9de8" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes primarily affect token-related UI components (CoinsTable, DefiTokensTable, HiddenTokensTable) and the core token utility library (tokenUtils.ts). Since tokenUtils.ts is a broadly imported utility (121 tests), most tests are only transitively dependent and unlikely to be affected. The highest risk is in tests that directly navigate token views or perform token-specific trading operations. The native mobile selector change (suite-native) and the unit test file have no E2E coverage.

<details><summary><b>Changed files (6)</b></summary>

- `packages/suite/src/views/wallet/tokens/coins/CoinsTable.tsx`
- `packages/suite/src/views/wallet/tokens/defi/DefiTokensTable.tsx`
- `packages/suite/src/views/wallet/tokens/hidden-tokens/HiddenTokensTable.tsx`
- `suite-common/wallet-utils/src/__tests__/tokenUtils.test.ts`
- `suite-common/wallet-utils/src/tokenUtils.ts`
- `suite-native/accounts/src/selectors.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — This test navigates to token-level pages (TrueUSD, USDC under Ethereum) and opens trading forms for specific tokens. Changes to CoinsTable.tsx and HiddenTokensTable.tsx directly affect the token views that this test navigates through, and tokenUtils.ts changes could affect how tokens are resolved/displayed in these navigation flows.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — This test verifies asset display in grid and table views after enabling networks like ETH. Token utility changes (tokenUtils.ts) could affect how token/asset contents are verified and displayed in the assets section, particularly the verifyAssetContents assertions.
- `suite/e2e/tests/trading-live/live-swap-coin-to-token.test.ts` — This test performs a live swap involving token handling (SOL to USDC). It is statically mapped to both CoinsTable.tsx and HiddenTokensTable.tsx, and the swap flow involves token resolution logic that tokenUtils.ts provides. Changes to token display or utility functions could affect how tokens are presented in the swap form.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — This test sells an ERC-20 token (USDC) which requires navigating to token-level views and interacting with token data. tokenUtils.ts changes could affect how the token is identified, displayed, or selected in the sell trading flow.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trading/buy-solana-token.test.ts` — This test buys a Solana SPL token (Jupiter/JUP) by filtering by network and searching by name. Token utility changes could affect how SPL tokens are resolved or displayed in the asset picker, though the impact is indirect.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — This test swaps between SPL tokens (USDT to USDC) on Solana. Token utility changes in tokenUtils.ts could affect how these tokens are identified or displayed in the swap form and confirmation views.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/suite/src/views/wallet/tokens/defi/DefiTokensTable.tsx`
- `suite-common/wallet-utils/src/__tests__/tokenUtils.test.ts`
- `suite-native/accounts/src/selectors.ts`

_Updated: 2026-06-20T09:49:02.229Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/sort-zero-balance-hidden-tokens-alphabetically&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/sort-zero-balance-hidden-tokens-alphabetically&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/sort-zero-balance-hidden-tokens-alphabetically&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy BTC > Buy Bitcoin from best offer | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-20T09:54:21.059Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-20T09:52:36.309Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/sort-zero-balance-hidden-tokens-alphabetically/web/](https://dev.suite.sldev.cz/suite-web/fix/sort-zero-balance-hidden-tokens-alphabetically/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->