### PR TITLE
chore(intl): remove unused translation strings

### DIFF
--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -1208,10 +1208,6 @@ export const messages = defineMessages({
         defaultMessage: 'Anonymous',
         id: 'TR_TRADING_KYC_ANONYMOUS',
     },
-    TR_TRADING_BUY_AND_SELL: {
-        defaultMessage: 'Buy & sell',
-        id: 'TR_TRADING_BUY_AND_SELL',
-    },
     TR_TRADING_SWAP: {
         defaultMessage: 'Swap',
         id: 'TR_TRADING_SWAP',
@@ -3358,10 +3354,6 @@ export const messages = defineMessages({
     TR_SUITE_SYNC_GET_KEYS: {
         defaultMessage: 'Allow',
         id: 'TR_SUITE_SYNC_GET_KEYS',
-    },
-    TR_SUITE_SYNC_CONNECT_AND_GET_KEYS: {
-        defaultMessage: 'Connect & allow',
-        id: 'TR_SUITE_SYNC_CONNECT_AND_GET_KEYS',
     },
     TR_SUITE_SYNC_FIRMWARE_UPDATE: {
         defaultMessage: 'Update',
@@ -7598,10 +7590,6 @@ export const messages = defineMessages({
         id: 'TR_SUGGESTION',
         defaultMessage: 'Feedback',
     },
-    TR_GUIDE_DASHBOARD: {
-        id: 'TR_GUIDE_DASHBOARD',
-        defaultMessage: 'Dashboard',
-    },
     TR_GUIDE_BUG_LABEL: {
         id: 'TR_GUIDE_BUG_LABEL',
         defaultMessage: 'Is something wrong?',
@@ -7634,10 +7622,6 @@ export const messages = defineMessages({
     TR_GUIDE_FORUM: {
         id: 'TR_GUIDE_FORUM',
         defaultMessage: 'Trezor Forum',
-    },
-    TR_GUIDE_FORUM_LABEL: {
-        id: 'TR_GUIDE_FORUM_LABEL',
-        defaultMessage: 'Connect with the Trezor community',
     },
     TR_GUIDE_SUPPORT_AND_FEEDBACK: {
         id: 'TR_GUIDE_SUPPORT_AND_FEEDBACK',
@@ -9629,10 +9613,6 @@ export const messages = defineMessages({
     TR_EARN_YIELD_APY_TOOLTIP_FOOTER: {
         id: 'TR_EARN_YIELD_APY_TOOLTIP_FOOTER',
         defaultMessage: 'APY can change over time',
-    },
-    TR_EARN_YIELD_AMOUNT_TO_SUPPLY: {
-        id: 'TR_EARN_YIELD_AMOUNT_TO_SUPPLY',
-        defaultMessage: 'Amount to deposit',
     },
     TR_EARN_YIELD_AMOUNT_TO_WITHDRAW: {
         id: 'TR_EARN_YIELD_AMOUNT_TO_WITHDRAW',


### PR DESCRIPTION
## Summary
Removes unused translation strings from `messages.ts` that are no longer referenced in the codebase.

**Keys removed (5):**
- `TR_TRADING_BUY_AND_SELL`
- `TR_SUITE_SYNC_CONNECT_AND_GET_KEYS`
- `TR_GUIDE_DASHBOARD`
- `TR_GUIDE_FORUM_LABEL`
- `TR_EARN_YIELD_AMOUNT_TO_SUPPLY`

Identified by the `translations:list-unused` CI check.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is to suite/intl/src/messages.ts, which is the central internationalization message definitions file. This is a broad global dependency used by virtually every UI component in the application. The risk depends on whether existing message keys were modified (high risk) or new messages were added (low risk). Since we cannot determine the exact nature of the change, we prioritize tests that directly assert on specific translation keys or localized text content. The recommended strategy focuses on tests that perform explicit text comparisons against known translation keys, particularly the settings/autodetect and settings/general tests which most directly exercise locale and message rendering.

<details><summary><b>Changed files (1)</b></summary>

- `suite/intl/src/messages.ts`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/settings/autodetect.test.ts` — This test directly asserts on localized message content (TR_ONBOARDING_DATA_COLLECTION_HEADING) from the intl messages module, comparing heading text against expected default and translated strings. Changes to messages.ts could alter the default message text and break these assertions.
- `suite/e2e/tests/settings/general.test.ts` — This test verifies language changes (English to Spanish) and checks UI text rendering that depends on intl message definitions. It also validates analytics events tied to language settings. Changes to message definitions could break displayed text comparisons.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/settings/forget-device.test.ts` — This test asserts on multiple translation keys (TR_FORGET_DEVICE_MODAL_HEADING, TR_FORGET_DEVICE_MODAL_FINISH_HEADING, TR_FORGET_DEVICE_MODAL_BULLET_FORGET, etc.) to verify modal content. Changes to those message definitions would directly break these assertions.
- `suite/e2e/tests/settings/coins.test.ts` — This test checks translated text on the dashboard empty state (TR_YOUR_WALLET_IS_READY_WHAT, TR_DASHBOARD_ACTIVATE_ASSETS_DESC, TR_DASHBOARD_GET_STARTED). If these message definitions change, the assertions will fail.
- `suite/e2e/tests/staking/staking-form.test.ts` — This test asserts on multiple translation keys for form validation errors (TR_BUY_VALIDATION_ERROR_MINIMUM_CRYPTO, AMOUNT_IS_NOT_IN_RANGE_DECIMALS, AMOUNT_IS_NOT_ENOUGH, AMOUNT_IS_NOT_SET, TR_STAKE_LEFT_AMOUNT_FOR_WITHDRAWAL). Changes to these message definitions would break validation error assertions.
- `suite/e2e/tests/wallet/send-sol.test.ts` — This test verifies device prompt text and translation-based assertions (e.g., TR_GAS_LIMIT equivalent for Solana). Changes to intl messages used in send form UI could affect displayed text in the review modal.
- `suite/e2e/tests/suite/db-locale-migration.test.ts` — This test validates that language preferences (Spanish) persist across database migrations and checks the language select label. Changes to message definitions or locale handling in the intl module could affect the displayed language label.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — This test asserts on translation keys for validation errors (AMOUNT_IS_NOT_IN_RANGE_DECIMALS, AMOUNT_IS_NOT_ENOUGH) and country selector text (TR_TRADING_COUNTRY_WORLD). Changes to these message definitions would break the assertions.

</details>

<details><summary>🟢 <b>Low priority (4)</b></summary>

- `suite/e2e/tests/browser/safari.test.ts` — This test checks ARIA snapshots including text like 'Your browser is not supported' and 'Continue at my own risk' which are likely defined in the intl messages module. Changes to those message strings would break the ARIA snapshot match.
- `suite/e2e/tests/browser/ios.test.ts` — This test checks for a specific heading 'Trezor Suite web doesn't support iOS' and ARIA snapshot content that likely originates from intl message definitions. Changes to those messages could break assertions.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — This test asserts on translation keys TR_PASSPHRASE_MISMATCH, TR_PASSPHRASE_MISMATCH_DESCRIPTION, and TR_PASSPHRASE_WALLET. Changes to these specific message definitions could cause assertion failures.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test asserts on translation keys TR_USE_HERE and TR_CONNECTED for device session status text. If these specific message definitions change, the status text assertions would fail.

</details>

_Updated: 2026-06-12T08:05:42.482Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/remove-unused-strings-20260612/web/](https://dev.suite.sldev.cz/suite-web/chore/remove-unused-strings-20260612/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/remove-unused-strings-20260612&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/remove-unused-strings-20260612&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-12T08:11:01.888Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-12T08:09:28.767Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->