### PR TITLE
fix(product-components): reject second decimal separator in NumberInput

### DIFF
--- a/packages/product-components/src/components/NumberInput/NumberInput.tsx
+++ b/packages/product-components/src/components/NumberInput/NumberInput.tsx
@@ -68,6 +68,27 @@ const cleanValueString = (value: string, locale: string) => {
 
 const DECIMAL_SEPARATORS = [',', '.'];
 
+export const isExtraDecimalSeparator = (
+    enteredCharacter: string,
+    locale: string,
+    {
+        value,
+        selectionStart,
+        selectionEnd,
+    }: Pick<HTMLInputElement, 'value' | 'selectionStart' | 'selectionEnd'>,
+) => {
+    if (!DECIMAL_SEPARATORS.includes(enteredCharacter)) {
+        return false;
+    }
+
+    const { decimalSeparator } = getLocaleSeparators(locale);
+    const valueWithoutSelection =
+        value.substring(0, selectionStart ?? value.length) +
+        value.substring(selectionEnd ?? value.length);
+
+    return valueWithoutSelection.includes(decimalSeparator);
+};
+
 export type NumberInputProps<TFieldValues extends FieldValues> = Omit<
     InputProps,
     'defaultValue' | 'name' | 'onChange'
@@ -141,10 +162,10 @@ export const NumberInput = <TFieldValues extends FieldValues>({
                     (lastSymbol === '0' && rawValue.includes(decimalSeparator)))
             ) {
                 if (lastSymbol !== '0') {
-                    // disallow entering more than one separator
+                    // drop the entered separator when it directly follows another one
                     const secondToLastSymbol = rawValue.at(-2);
                     if (secondToLastSymbol && DECIMAL_SEPARATORS.includes(secondToLastSymbol)) {
-                        return;
+                        rawValue = rawValue.slice(0, -1);
                     }
 
                     // format a decimal separator to a locale-specific one to allow entering either one
@@ -339,17 +360,23 @@ export const NumberInput = <TFieldValues extends FieldValues>({
         [handleCopy, handleChange, inputRef],
     );
 
-    // only allow digits and separators
-    const handleOnBeforeInput = useCallback((e: FormEvent<HTMLInputElement> & { data: string }) => {
-        if (/[\d.,]/g.test(e.data)) {
-            // reset the redo history when a new digit is entered
-            setRedoHistory([]);
+    // only allow digits and separators, reject a second decimal separator
+    const handleOnBeforeInput = useCallback(
+        (e: FormEvent<HTMLInputElement> & { data: string }) => {
+            if (
+                /[\d.,]/g.test(e.data) &&
+                !(inputRef.current && isExtraDecimalSeparator(e.data, locale, inputRef.current))
+            ) {
+                // reset the redo history when a new digit is entered
+                setRedoHistory([]);
 
-            return;
-        }
+                return;
+            }
 
-        e.preventDefault();
-    }, []);
+            e.preventDefault();
+        },
+        [inputRef, locale],
+    );
 
     // checks for separators at pos + cursorCharacterOffset and moves the cursor to pos + cursorPositionOffset
     const handleCursorShift = useCallback(

--- a/packages/product-components/src/index.ts
+++ b/packages/product-components/src/index.ts
@@ -17,7 +17,7 @@ export { AssetShareIndicator } from './components/AssetShareIndicator/AssetShare
 export * from './components/TokenIconSet/TokenIconSet';
 export * from './components/NetworkIconSet/NetworkIconSet';
 export { TokenTabs, type TokenTab } from './components/SelectAssetModal/TokenTabs';
-export { NumberInput } from './components/NumberInput/NumberInput';
+export { NumberInput, isExtraDecimalSeparator } from './components/NumberInput/NumberInput';
 export { InputWithOptions } from './components/InputWithOptions/InputWithOptions';
 export { EditableText, type EditableTextProps } from './components/EditableText/EditableText';
 export * from './components/JsonlReader/JsonlReader';

--- a/packages/suite/src/components/suite/__tests__/NumberInput.test.tsx
+++ b/packages/suite/src/components/suite/__tests__/NumberInput.test.tsx
@@ -8,7 +8,7 @@ import { type Store } from 'redux';
 import { prepareSuiteSettingsReducer, suiteSettingsInitialState } from '@suite/settings';
 import { type Locale } from '@suite-common/suite-types';
 import { configureMockStore } from '@suite-common/test-utils';
-import { NumberInput } from '@trezor/product-components';
+import { NumberInput, isExtraDecimalSeparator } from '@trezor/product-components';
 
 import { extraDependencies } from 'src/support/extraDependencies';
 import { ThemeProvider } from 'src/support/suite/ThemeProvider';
@@ -95,6 +95,10 @@ describe('NumberInput component', () => {
         await testCase(input, '12 34,.67', '1,234.67', '1234.67');
         await testCase(input, '  1234,.67.231', '1,234.67231', '1234.67231');
 
+        await testCase(input, '1.2.3', '1.23', '1.23');
+        await testCase(input, '0.001.1.1', '0.00111', '0.00111');
+        await testCase(input, '0..5', '0.5', '0.5');
+
         await testCase(input, 'a', '', '');
         await testCase(input, '1234adf134', '1,234,134', '1234134');
     });
@@ -119,6 +123,10 @@ describe('NumberInput component', () => {
         await testCase(input, '22 34,.67', '2\u00A0234,67', '1234.67');
         await testCase(input, '  2234,.67.231', '2\u00A0234,67231', '1234.67231');
 
+        await testCase(input, '2,2,3', '2,23', '2.23');
+        await testCase(input, '0,001,1,1', '0,00111', '0.00111');
+        await testCase(input, '0,,5', '0,5', '0.5');
+
         await testCase(input, 'a', '', '');
         await testCase(input, '2234adf134', '2\u00A0234\u00A0134', '2234134');
     });
@@ -141,5 +149,54 @@ describe('NumberInput component', () => {
 
         await testCase(input, 'a', '', '');
         await testCase(input, '3234adf134', '3.234.134', '3234134');
+    });
+
+    test('Formats a pasted value with consecutive decimal separators', async () => {
+        const input = renderInput('en-US');
+
+        await act(async () => {
+            input.focus();
+            await userEvent.paste('0..');
+        });
+        expect(input.value).toBe('0.');
+        expect(onChangeMock).toHaveBeenCalledWith('0');
+    });
+});
+
+describe('isExtraDecimalSeparator', () => {
+    const inputState = (
+        value: string,
+        selectionStart = value.length,
+        selectionEnd = value.length,
+    ) => ({
+        value,
+        selectionStart,
+        selectionEnd,
+    });
+
+    test('rejects a second decimal separator', () => {
+        expect(isExtraDecimalSeparator('.', 'en-US', inputState('0.001'))).toBe(true);
+        expect(isExtraDecimalSeparator(',', 'en-US', inputState('0.001'))).toBe(true);
+        expect(isExtraDecimalSeparator('.', 'en-US', inputState('1,234.'))).toBe(true);
+        expect(isExtraDecimalSeparator(',', 'cs-CZ', inputState('0,001'))).toBe(true);
+        expect(isExtraDecimalSeparator('.', 'cs-CZ', inputState('0,001'))).toBe(true);
+        expect(isExtraDecimalSeparator(',', 'es-ES', inputState('32.345,67'))).toBe(true);
+    });
+
+    test('allows the first decimal separator', () => {
+        expect(isExtraDecimalSeparator('.', 'en-US', inputState(''))).toBe(false);
+        expect(isExtraDecimalSeparator('.', 'en-US', inputState('1,234'))).toBe(false);
+        expect(isExtraDecimalSeparator(',', 'en-US', inputState('1,234'))).toBe(false);
+        expect(isExtraDecimalSeparator(',', 'cs-CZ', inputState('2\u00A0234'))).toBe(false);
+        expect(isExtraDecimalSeparator(',', 'es-ES', inputState('32.345'))).toBe(false);
+    });
+
+    test('allows a separator replacing a selection containing one', () => {
+        expect(isExtraDecimalSeparator('.', 'en-US', inputState('1.5', 0, 3))).toBe(false);
+        expect(isExtraDecimalSeparator('.', 'en-US', inputState('1.5', 1, 2))).toBe(false);
+    });
+
+    test('ignores digits', () => {
+        expect(isExtraDecimalSeparator('5', 'en-US', inputState('0.001'))).toBe(false);
     });
 });


### PR DESCRIPTION
NumberInput now prevents entering a decimal separator when the value already contains one, and normalizes consecutive separators instead of leaving the raw value rendered in the input, so the amount fields in the send and trade forms no longer accept values like 1.2.3 with the EN locale.


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes modify the NumberInput component, its barrel export, and its unit test. NumberInput is a widely-used shared component (mapped to 121+ E2E tests), so the risk is broad but shallow — most tests only transitively import it. The highest risk is in tests that directly exercise numeric input fields with validation, formatting, unit switching, and fraction/max buttons. The recommended strategy focuses on tests that explicitly interact with amount/fee input fields in staking, trading (buy/sell/swap), and send forms, where NumberInput behavior is most directly tested.

<details><summary><b>Changed files (3)</b></summary>

- `packages/product-components/src/components/NumberInput/NumberInput.tsx`
- `packages/product-components/src/index.ts`
- `packages/suite/src/components/suite/__tests__/NumberInput.test.tsx`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/staking/staking-form.test.ts` — This test directly exercises the staking form's crypto/fiat number input fields, including validation (minimum amount, decimal limits, insufficient funds), percentage buttons, max button, and crypto/fiat switching — all of which rely on NumberInput for amount entry and display.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — This test validates sell form number input behavior including decimal digit limits, not-enough-funds errors, percentage/fraction buttons, max amount calculation, and unit switching between BTC/SOL — all directly exercising NumberInput validation and formatting logic.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — This test validates swap form crypto amount input, fraction buttons (25%, 50%, 75%, Max), balance-exceeding validation for both crypto and fiat amounts, and currency ticker display — all directly dependent on NumberInput component behavior.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/trading/buy-negative.test.ts` — Tests buy form input validation including maximum/minimum limit errors and disabled submit button states, which exercise NumberInput's validation and error display paths in the buy context.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — Tests the Bitcoin send form including adding/removing outputs, filling amount fields, switching BTC/satoshi units, and locktime input — multiple NumberInput instances are exercised in the send flow.
- `suite/e2e/tests/wallet/send-sol.test.ts` — Tests the Solana send form's Send Max calculation, amount input field population, and fee display — the send amount input directly uses NumberInput and the max calculation interacts with its value formatting.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Tests Ethereum send form with custom gas fee parameters (gas limit, max fee per gas, max priority fee per gas) which are entered via NumberInput fields, and verifies amount display on the device prompt.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests custom Ethereum fee parameter inputs (gas limit, max fee per gas, max priority fee per gas) in the swap flow, which are NumberInput fields that must correctly accept and pass through numeric values.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Tests custom Bitcoin fee rate input in the swap flow, which uses a NumberInput field for the custom fee rate entry and verifies the calculated fee is displayed correctly.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/components/suite/__tests__/NumberInput.test.tsx`

_Updated: 2026-06-12T08:20:49.827Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/amount-multiple-decimal-separators&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/amount-multiple-decimal-separators&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-12T08:26:02.277Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-12T08:24:21.668Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->