### PR TITLE
fix(blockchain-link): update tokens decimals default

### DIFF
--- a/packages/blockchain-link-utils/src/blockbook.ts
+++ b/packages/blockchain-link-utils/src/blockbook.ts
@@ -24,6 +24,9 @@ import {
     transformTarget,
 } from './utils';
 
+// ERC-20 default when a token does not expose decimals(); avoids breaking amount formatting.
+const DEFAULT_TOKEN_DECIMALS = 18;
+
 export const transformServerInfo = (payload: ServerInfo) => ({
     name: payload.name,
     shortcut: payload.shortcut,
@@ -83,7 +86,7 @@ export const filterTokenTransfers = (
             const tokenTransfer = {
                 ...transfer,
                 type,
-                decimals: transfer.decimals || 0,
+                decimals: transfer.decimals || DEFAULT_TOKEN_DECIMALS,
                 amount: transfer.value || '',
                 standard: transfer.standard,
             };
@@ -359,7 +362,7 @@ export const transformTokenInfo = (
         return arr.concat([
             {
                 ...token,
-                decimals: token.decimals || 0,
+                decimals: token.decimals || DEFAULT_TOKEN_DECIMALS,
                 standard: token.standard,
             },
         ]);

--- a/packages/blockchain-link-utils/src/tests/fixtures/blockbook.ts
+++ b/packages/blockchain-link-utils/src/tests/fixtures/blockbook.ts
@@ -7,7 +7,7 @@ import type { DeepPartial } from '@trezor/type-utils';
 
 const token = {
     amount: '',
-    decimals: 0,
+    decimals: 18,
 };
 
 const tOut = {
@@ -16,7 +16,7 @@ const tOut = {
     symbol: 'TN',
     contract: '0x0',
     amount: '0',
-    decimals: 0,
+    decimals: 18,
     from: undefined,
     to: undefined,
 };

--- a/packages/blockchain-link/tests/unit/fixtures/getAccountInfo-blockbook.ts
+++ b/packages/blockchain-link/tests/unit/fixtures/getAccountInfo-blockbook.ts
@@ -483,7 +483,7 @@ const fixtures: {
                     symbol: 'TKNNME',
                     contract: '0x0',
                     balance: '1',
-                    decimals: 0,
+                    decimals: 18,
                 },
             ],
         },


### PR DESCRIPTION
Updates `decimals` default to `18` https://docs.openzeppelin.com/contracts/5.x/api/token/erc20#ERC20-decimals--

Trezor Suite should not handle edge cases when decimals are not defined. 

Blockbook has some troubles with decimals, it is hacked here https://github.com/trezor/blockbook/blob/cfa737479d1cf6099fb2c663dac437de0eb64f87/configs/contract-fix/ethereum.json#L12. Blockbook new issue https://github.com/trezor/blockbook/issues/1577

// Resolves #14796
Resolves #15187

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are focused on the blockbook utility layer (packages/blockchain-link-utils/src/blockbook.ts) and its associated test fixtures. This file is a broad dependency (mapped to 121 E2E tests), but the actual risk is concentrated in tests that directly exercise blockbook backend connections, wallet discovery, account balance display, and transaction data parsing. The two fixture files have no E2E test coverage since they are unit test fixtures. The recommended strategy prioritizes tests that configure custom blockbook backends, verify discovery and balance correctness, and validate transaction display — these are the most likely to surface regressions from blockbook parsing changes.

<details><summary><b>Changed files (3)</b></summary>

- `packages/blockchain-link-utils/src/blockbook.ts`
- `packages/blockchain-link-utils/src/tests/fixtures/blockbook.ts`
- `packages/blockchain-link/tests/unit/fixtures/getAccountInfo-blockbook.ts`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test directly exercises custom blockbook backend configuration and connection, then verifies account discovery completes correctly. Changes to blockbook.ts in blockchain-link-utils directly affect how blockbook data is parsed and processed, which this test validates end-to-end.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test configures custom Blockbook backends for BTC and LTC and verifies wallet discovery completes successfully with the dashboard graph displayed. The blockbook.ts utility is the core parser for blockbook API responses used during discovery.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — This test verifies account balance display after receiving BTC on regtest, checking that balance values update correctly. The blockbook.ts utility handles parsing account balance data from blockbook backends, so changes could affect displayed balances.
- `suite/e2e/tests/wallet/discovery.test.ts` — This test activates multiple coins (btc, eth, ltc, etc, bch, doge, xrp, zec), triggers discovery with a page reload interruption, and verifies all account balances are visible. Blockbook data parsing is central to the discovery process for these networks.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/wallet/send-doge.test.ts` — This test enables DOGE with a custom blockbook backend mock and validates send form behavior including amount validation. Changes to blockbook parsing could affect how account state and transaction data are processed for DOGE.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — This test configures a custom blockbook backend for LTC and tests sending with a MimbleWimble peg-out transaction output. Blockbook utility changes could affect how LTC transaction data (including MW peg-out UTXOs) is parsed.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test uses regtest (blockbook-backed) to test send form features including multiple outputs, locktime, OP_RETURN, and unit switching. Blockbook parsing changes could affect UTXO selection and transaction composition.
- `suite/e2e/tests/wallet/transactions.test.ts` — This test verifies transaction history display, graph range filtering, and transaction search on a BTC account. Blockbook utility changes directly affect how transaction data is parsed and presented to the user.
- `suite/e2e/tests/wallet/pagination.test.ts` — This test navigates paginated transaction pages on a legacy BTC account verifying correct addresses on each page. Transaction data parsing from blockbook responses is handled by the changed utility.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/wallet/public-keys.test.ts` — This test verifies public key (XPUB) display for BTC, LTC, and ADA accounts after enabling networks. While it touches blockbook-backed discovery, the public key display itself is less likely affected by blockbook parsing changes.
- `suite/e2e/tests/settings/coins.test.ts` — This test includes setting a custom blockbook backend for ETH and activating mainnet/testnet networks. The blockbook backend configuration path exercises blockbook utility code indirectly.
- `suite/e2e/tests/wallet/export-transactions.test.ts` — This test exports transaction history in PDF/CSV/JSON formats for BTC, LTC, ETH, and ADA. Transaction data used for export originates from blockbook parsing, so changes could affect exported content.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/blockchain-link-utils/src/tests/fixtures/blockbook.ts`
- `packages/blockchain-link/tests/unit/fixtures/getAccountInfo-blockbook.ts`

_Updated: 2026-06-21T15:22:06.147Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/token-transfer-optional-decimals&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/token-transfer-optional-decimals&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/token-transfer-optional-decimals&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/token-transfer-optional-decimals/web/](https://dev.suite.sldev.cz/suite-web/fix/token-transfer-optional-decimals/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy BTC > Buy Bitcoin from best offer | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-21T15:26:42.699Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-21T15:25:22.254Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->