### PR TITLE
fix(suite): add OP_RETURN output below recipient instead of replacing it

### DIFF
--- a/packages/suite/src/hooks/wallet/useSendFormOutputs.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormOutputs.ts
@@ -55,22 +55,7 @@ export const useSendFormOutputs = ({
     );
 
     const addOpReturn = () => {
-        // const outputs = getValues('outputs');
-        const values = getValues();
-        const outputsDirty = values.outputs.some(
-            output => output.address.length > 0 || output.amount.length > 0,
-        );
-        if (outputsDirty) {
-            outputsFieldArray.append({ ...DEFAULT_OPRETURN });
-        } else {
-            reset(
-                {
-                    ...values,
-                    outputs: [DEFAULT_OPRETURN],
-                },
-                { keepErrors: true },
-            );
-        }
+        outputsFieldArray.append({ ...DEFAULT_OPRETURN });
     };
 
     const removeOpReturn = (index: number) => {


### PR DESCRIPTION
Enabling Attach message on a pristine Bitcoin send form "replaced" the recipient output, so the OP_RETURN card appeared in place of the address and amount inputs as if it covered them. The OP_RETURN output is now always appended as a separate card below the recipient inputs, matching the Locktime behavior. 

User can always close the recipient part and send only OP_RETURN. This makes the UX less confusing.

Resolves #23166

https://github.com/user-attachments/assets/32c46158-911e-4026-8d93-8575d396ca72

<img width="1156" height="364" alt="Screenshot 2026-06-19 at 9 59 08" src="https://github.com/user-attachments/assets/cb699589-2844-4150-8021-565fcc5bacee" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is to useSendFormOutputs.ts, a hook managing send form output state (addresses, amounts, adding/removing outputs). Despite mapping to 121 tests via static analysis (indicating it's bundled broadly), the actual risk is concentrated in tests that directly exercise send form functionality: filling addresses/amounts, managing multiple outputs, CSV import, send-max, and transaction composition. The highest priority tests are those that directly manipulate send form outputs (send-form-regtest, send-sol, send-eth, send-doge, send-form-ltc, import-btc-csv). Medium priority covers trading sell/swap flows and staking forms that compose transactions through shared send infrastructure.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/hooks/wallet/useSendFormOutputs.ts`

</details>

**Recommended tests (14)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test directly exercises the Bitcoin send form with multiple outputs (adding/removing outputs), OP_RETURN data outputs, locktime options, and unit switching — all of which rely on the useSendFormOutputs hook for managing output state in the send form.
- `suite/e2e/tests/wallet/send-sol.test.ts` — This test exercises the Solana send form including Send Max calculation, filling recipient address and amount, and reviewing the transaction — directly using the send form output management provided by useSendFormOutputs.
- `suite/e2e/tests/wallet/send-eth.test.ts` — This test fills in the Ethereum send form with recipient address, amount, and custom gas fees, then reviews the transaction on device — directly exercising the send form output fields managed by useSendFormOutputs.
- `suite/e2e/tests/wallet/send-doge.test.ts` — This test fills in a DOGE send form with a recipient address and large amount via broadcast mode, validating error handling for invalid amounts — directly exercising the send form output management from useSendFormOutputs.
- `suite/e2e/tests/wallet/import-btc-csv.test.ts` — This test imports a CSV file to populate multiple send form outputs with addresses and amounts, directly testing the output management logic (multiple outputs creation) in useSendFormOutputs.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — This test exercises the LTC send form in broadcast mode with a MimbleWimble peg-out transaction, filling recipient address and setting max amount — directly using send form output fields managed by useSendFormOutputs.

</details>

<details><summary>🟡 <b>Medium priority (8)</b></summary>

- `suite/e2e/tests/wallet/global-receive-send.test.ts` — The global send flow opens a send form for a selected account and verifies correct account labeling on the send form header. While it doesn't deeply test output fields, it exercises the send form initialization path that depends on useSendFormOutputs.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — This test validates sell form input behavior including decimal limits, insufficient funds errors, and percentage/max buttons for BTC and SOL — the sell form likely shares output management infrastructure with useSendFormOutputs for composing transactions.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — The sell BTC flow initiates a send transaction with device confirmation showing address, amount, and fee — the send portion of the sell flow uses the same send form output composition that useSendFormOutputs manages.
- `suite/e2e/tests/trading/sell-solana.test.ts` — The sell SOL flow sends crypto to a provider address with device confirmation of amount and fee, exercising the send form output composition path that depends on useSendFormOutputs.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — ETH staking involves composing a staking transaction with specific amounts and fees, which uses the send form infrastructure including output management from useSendFormOutputs.
- `suite/e2e/tests/staking/staking-form.test.ts` — This test validates the staking form's input validation (minimum amounts, decimal limits, insufficient funds, percentage buttons, max button, crypto/fiat switching) which shares send form output composition infrastructure with useSendFormOutputs.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — This test verifies custom BTC fee settings in a swap flow, checking that composedTransactionInfo is populated correctly — the transaction composition relies on send form output management from useSendFormOutputs.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — This test verifies custom Ethereum fee parameters (gas limit, max fee, priority fee) in a swap flow with composedTransactionInfo validation — the transaction composition path uses useSendFormOutputs.

</details>

_Updated: 2026-06-12T08:29:39.323Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/op-return-overlay-23166&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/op-return-overlay-23166&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-12T08:33:58.936Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-12T08:32:13.649Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/op-return-overlay-23166/web/](https://dev.suite.sldev.cz/suite-web/fix/op-return-overlay-23166/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->