### PR TITLE
fix(blockchain-link): scan known Solana token account pubkeys during txid refresh

### DIFF
--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -39,6 +39,9 @@ type SignatureWithSlot = {
     slot: Slot;
 };
 
+// Cap on the number of token account pubkeys scanned for txids to prevent unbounded RPC fanout.
+export const TOKEN_ACCOUNTS_SCAN_LIMIT = 100;
+
 const getAllSignatures = async (
     api: SolanaAPI,
     descriptor: MessageTypes.GetAccountInfo['payload']['descriptor'],
@@ -149,6 +152,24 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
 
     const recognizedAccountsPubkeys = recognisedWithBalance.map(a => a.pubkey);
 
+    const isValidPubkey = (pubkey: string) => {
+        try {
+            address(pubkey);
+
+            return true;
+        } catch {
+            return false;
+        }
+    };
+
+    // Previously known token accounts have to be scanned as well, even when they are currently
+    // drained or unrecognized, otherwise their latest transactions would be missed.
+    const knownAccountsPubkeys = (payload.tokenAccountsPubKeys ?? []).filter(isValidPubkey);
+
+    const accountsPubkeysToScan = Array.from(
+        new Set<string>([...recognizedAccountsPubkeys, ...knownAccountsPubkeys]),
+    ).slice(0, TOKEN_ACCOUNTS_SCAN_LIMIT);
+
     const getAllTxIds = async (tokenAccountPubkeys: string[]) => {
         const sortedTokenAccountPubkeys = [...tokenAccountPubkeys].sort();
 
@@ -197,7 +218,7 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
     }
 
     if (details === 'txids') {
-        const txids = await getAllTxIds(recognizedAccountsPubkeys);
+        const txids = await getAllTxIds(accountsPubkeysToScan);
         const solEpoch = await getEpoch();
 
         const account: AccountInfo = {
@@ -286,7 +307,7 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
         return transactions;
     };
 
-    const allTxIds = await getAllTxIds(recognizedAccountsPubkeys);
+    const allTxIds = await getAllTxIds(accountsPubkeysToScan);
 
     const pageNumber = payload.page ? payload.page - 1 : 0;
     // for the first page of txs, payload.page is undefined, for the second page is 2

--- a/packages/blockchain-link/tests/unit/solanaGetAccountInfo.test.ts
+++ b/packages/blockchain-link/tests/unit/solanaGetAccountInfo.test.ts
@@ -1,0 +1,160 @@
+import { MESSAGES, RESPONSES } from '@trezor/blockchain-link-types';
+import type { Response } from '@trezor/blockchain-link-types';
+import { TOKEN_PROGRAM_PUBLIC_KEY } from '@trezor/coins-solana/constants';
+import type { SolanaAPI } from '@trezor/coins-solana/types';
+
+import SolanaWorker, { TOKEN_ACCOUNTS_SCAN_LIMIT } from '../../src/workers/solana';
+
+const RECOGNIZED_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+
+jest.mock('@trezor/blockchain-link-utils', () => {
+    const actual = jest.requireActual('@trezor/blockchain-link-utils');
+
+    return {
+        ...actual,
+        solanaUtils: {
+            ...actual.solanaUtils,
+            getTokenMetadata: () =>
+                Promise.resolve({
+                    EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v: {
+                        name: 'USD Coin',
+                        symbol: 'USDC',
+                    },
+                }),
+        },
+    };
+});
+
+const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+const encodeBase58 = (bytes: Uint8Array) => {
+    let value = bytes.reduce((acc, byte) => acc * 256n + BigInt(byte), 0n);
+
+    let encoded = '';
+    while (value > 0n) {
+        encoded = BASE58_ALPHABET[Number(value % 58n)] + encoded;
+        value /= 58n;
+    }
+
+    return encoded;
+};
+
+// Produces a deterministic, valid Solana address (base58 of 32 bytes, no leading zero bytes).
+const createPubkey = (index: number) => {
+    const bytes = new Uint8Array(32);
+    bytes[0] = 1;
+    bytes[30] = Math.floor(index / 256);
+    bytes[31] = index % 256;
+
+    return encodeBase58(bytes);
+};
+
+const DESCRIPTOR = createPubkey(1);
+const RECOGNIZED_PUBKEY = createPubkey(2);
+const DRAINED_PUBKEY = createPubkey(3);
+const ZERO_BALANCE_PUBKEY = createPubkey(4);
+const INVALID_PUBKEY = 'not-a-valid-pubkey';
+
+const createTokenAccount = ({ pubkey, amount }: { pubkey: string; amount: string }) => ({
+    pubkey,
+    account: {
+        data: {
+            program: 'spl-token',
+            parsed: {
+                info: {
+                    mint: RECOGNIZED_MINT,
+                    tokenAmount: { amount, decimals: 6 },
+                },
+            },
+        },
+    },
+});
+
+const runGetAccountInfo = async ({
+    tokenAccounts,
+    tokenAccountsPubKeys,
+}: {
+    tokenAccounts: ReturnType<typeof createTokenAccount>[];
+    tokenAccountsPubKeys: string[];
+}) => {
+    const scannedPubkeys: string[] = [];
+
+    const send = <T>(value: T) => ({ send: () => Promise.resolve(value) });
+
+    const api = {
+        rpc: {
+            getAccountInfo: () => send({ value: null }),
+            getTokenAccountsByOwner: (_owner: unknown, filter: { programId: unknown }) =>
+                send({
+                    value:
+                        String(filter.programId) === TOKEN_PROGRAM_PUBLIC_KEY ? tokenAccounts : [],
+                }),
+            getSignaturesForAddress: (pubkey: unknown) => {
+                scannedPubkeys.push(String(pubkey));
+
+                return send([]);
+            },
+            getEpochInfo: () => send({ epoch: 500n }),
+        },
+    } as unknown as SolanaAPI;
+
+    const worker = SolanaWorker();
+    worker.settings = { name: 'Solana', server: ['http://localhost'], debug: false };
+    worker.tryConnect = () => Promise.resolve(api);
+
+    const post = jest.fn();
+    worker.post = post;
+
+    await worker.messageHandler({
+        data: {
+            id: 1,
+            type: MESSAGES.GET_ACCOUNT_INFO,
+            payload: {
+                descriptor: DESCRIPTOR,
+                details: 'txids',
+                tokenAccountsPubKeys,
+            },
+        },
+    });
+
+    const responses: Response[] = post.mock.calls.map(([response]) => response);
+
+    return { scannedPubkeys, responses };
+};
+
+describe('Solana getAccountInfo txid scan', () => {
+    it('scans known token account pubkeys missing from current recognized accounts', async () => {
+        const { scannedPubkeys, responses } = await runGetAccountInfo({
+            tokenAccounts: [
+                createTokenAccount({ pubkey: RECOGNIZED_PUBKEY, amount: '1000' }),
+                createTokenAccount({ pubkey: ZERO_BALANCE_PUBKEY, amount: '0' }),
+            ],
+            tokenAccountsPubKeys: [DRAINED_PUBKEY, RECOGNIZED_PUBKEY, INVALID_PUBKEY],
+        });
+
+        expect(responses).toContainEqual(
+            expect.objectContaining({ id: 1, type: RESPONSES.GET_ACCOUNT_INFO }),
+        );
+        expect(scannedPubkeys).toHaveLength(3);
+        expect(scannedPubkeys).toEqual(
+            expect.arrayContaining([DESCRIPTOR, RECOGNIZED_PUBKEY, DRAINED_PUBKEY]),
+        );
+        expect(scannedPubkeys).not.toContain(ZERO_BALANCE_PUBKEY);
+        expect(scannedPubkeys).not.toContain(INVALID_PUBKEY);
+    });
+
+    it('caps the number of scanned token accounts, keeping recognized ones', async () => {
+        const knownPubkeys = Array.from({ length: TOKEN_ACCOUNTS_SCAN_LIMIT + 50 }, (_, index) =>
+            createPubkey(100 + index),
+        );
+
+        const { scannedPubkeys } = await runGetAccountInfo({
+            tokenAccounts: [createTokenAccount({ pubkey: RECOGNIZED_PUBKEY, amount: '1000' })],
+            tokenAccountsPubKeys: knownPubkeys,
+        });
+
+        expect(scannedPubkeys).toHaveLength(1 + TOKEN_ACCOUNTS_SCAN_LIMIT);
+        expect(scannedPubkeys).toContain(DESCRIPTOR);
+        expect(scannedPubkeys).toContain(RECOGNIZED_PUBKEY);
+    });
+});


### PR DESCRIPTION
The Solana worker now includes previously known token account pubkeys forwarded via getAccountInfo in the account list scanned by getAllTxIds, so drained or currently unrecognized token accounts still participate in txid refresh. The pubkeys are validated, deduplicated against currently discovered token accounts, and capped to prevent unbounded RPC fanout. Unit tests cover the drained-account, invalid-pubkey, dedup, and cap cases.


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes modify the Solana blockchain-link worker (`solana/index.ts`) and its unit test for `getAccountInfo`. Since the worker is the core data layer for all Solana account interactions, the highest risk is to flows that depend heavily on accurate account state: staking (which reads staked/pending/unstaking amounts), SOL send-max (which calculates balance minus fees/reserves), and trading flows that display SOL balances. The unit test file has no E2E coverage (it's a unit test itself). The recommended strategy prioritizes staking and send-sol tests as high priority since they have the most detailed assertions on balance/amount values derived from account info, followed by trading and receive tests at medium/low priority.

<details><summary><b>Changed files (2)</b></summary>

- `packages/blockchain-link/src/workers/solana/index.ts`
- `packages/blockchain-link/tests/unit/solanaGetAccountInfo.test.ts`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — This test exercises the full Solana staking flow including account info retrieval, epoch data, and program accounts — all of which depend on the Solana blockchain-link worker. Changes to `solana/index.ts` (e.g., getAccountInfo logic) could break staking dashboard state detection and balance display.
- `suite/e2e/tests/staking/sol/rewards.test.ts` — This test validates staking rewards display and balance calculations that depend on Solana account info and epoch data fetched through the blockchain-link worker. The changed file directly affects how account data is retrieved and parsed for the staking dashboard.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — Stake-more flow relies on accurate account balance and staking state from the Solana worker. Changes to getAccountInfo could affect available balance calculation and pending/staked amount transitions shown on the dashboard.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — Unstaking and claiming flows depend on accurate account state (staked, unstaking, claimable) derived from Solana account info. The changed worker file directly handles the data pipeline that feeds these dashboard states.
- `suite/e2e/tests/wallet/send-sol.test.ts` — Send-max SOL calculation depends on accurate balance, fee, and reserve amounts retrieved via getAccountInfo in the Solana worker. Changes here could directly break the max sendable amount computation and balance display.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/wallet/receive.test.ts` — The receive test for SOL verifies address generation and display. While it primarily tests address reveal rather than account info, the Solana worker is involved in account discovery which must succeed for the receive flow to work.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Sell-solana flow requires accurate SOL account balances and fee resolution from the Solana worker. Changes to account info retrieval could affect balance display and fee calculations in the sell confirmation flow.
- `suite/e2e/tests/trading/swap-coins.test.ts` — SOL-to-BTC swap requires the Solana worker to provide accurate account data for the swap form (balance, fees). The detailed device prompt assertions on amounts and fees make this sensitive to account info changes.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Sell input validation for SOL tests percentage-based balance calculations (10%, 25%, 50%) that directly depend on the account balance fetched via the Solana worker's getAccountInfo.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — SOL-to-USDC swap uses Solana account data for balance/fee display. While the swap flow is primarily mocked at the Invity API level, the underlying account info from the worker feeds the send form.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — USDT-to-BTC swap on Solana uses the worker for SPL token account info. Token balance retrieval is part of getAccountInfo, making this potentially affected by the change.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — USDT-to-USDC swap on Solana depends on SPL token account data from the worker. Changes to how token accounts are parsed in getAccountInfo could affect token balance display.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/blockchain-link/tests/unit/solanaGetAccountInfo.test.ts`

_Updated: 2026-06-12T08:33:39.144Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/solana-token-account-pubkeys-txid-refresh&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/solana-token-account-pubkeys-txid-refresh&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-12T08:38:19.756Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-12T08:35:22.290Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/solana-token-account-pubkeys-txid-refresh/web/](https://dev.suite.sldev.cz/suite-web/fix/solana-token-account-pubkeys-txid-refresh/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->