### PR TITLE
fix: describe XRP fees as burned instead of paid to validators

### DIFF
--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFeesHeader.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFeesHeader.tsx
@@ -28,6 +28,8 @@ export function CollapsibleFeesHeader({
                 return 'TR_STELLAR_FEE_DESC';
             case 'solana':
                 return 'TR_SOL_FEE_DESC';
+            case 'ripple':
+                return 'TR_XRP_FEE_DESC';
             default:
                 return 'TR_TRANSACTION_FEE_DESC';
         }

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -3665,6 +3665,8 @@ export const messages = {
                     tron: 'Network fee',
                 },
                 body: 'Fees are paid directly to validators for processing your transactions.',
+                bodyRipple:
+                    'Fees for processing your transactions are burned (permanently destroyed), not paid to validators.',
             },
             custom: {
                 addButton: 'Add custom fee',

--- a/suite-native/transaction-management/src/components/fees/FeeDescriptionTranslation.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeeDescriptionTranslation.tsx
@@ -1,0 +1,14 @@
+import type { NetworkType } from '@suite-common/wallet-config';
+import { Translation } from '@suite-native/intl';
+
+export type FeeDescriptionTranslationProps = {
+    networkType: NetworkType;
+};
+
+export const FeeDescriptionTranslation = ({ networkType }: FeeDescriptionTranslationProps) => {
+    if (networkType === 'ripple') {
+        return <Translation id="transactionManagement.fees.description.bodyRipple" />;
+    }
+
+    return <Translation id="transactionManagement.fees.description.body" />;
+};

--- a/suite-native/transaction-management/src/components/fees/FeesBottomSheet.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeesBottomSheet.tsx
@@ -20,6 +20,7 @@ import { Form, useFormState } from '@suite-native/forms';
 import { Translation } from '@suite-native/intl';
 
 import { CustomFeeTabContent } from './CustomFee/CustomFeeTabContent';
+import { FeeDescriptionTranslation } from './FeeDescriptionTranslation';
 import { FeeLabelTranslation } from './FeeLabelTranslation';
 import { FeeOptionsList } from './FeeOptionList/FeeOptionsList';
 import { TronFeeLimitContent } from './TronFeeLimitContent';
@@ -141,7 +142,7 @@ export const FeesBottomSheet = ({
             title={
                 <FeeLabelTranslation networkType={networkType} supportsAdjustableFees={isTrc20} />
             }
-            subtitle={<Translation id="transactionManagement.fees.description.body" />}
+            subtitle={<FeeDescriptionTranslation networkType={networkType} />}
             isCloseDisplayed
             bottomSheetCustomProps={{
                 enableDynamicSizing: false,

--- a/suite-native/transaction-management/src/components/fees/FeesContent.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeesContent.tsx
@@ -1,9 +1,9 @@
 import { type NetworkSymbol, type NetworkType } from '@suite-common/wallet-config';
 import { type AccountKey, type FeeLevelLabel, type FormState } from '@suite-common/wallet-types';
 import { Text, VStack } from '@suite-native/atoms';
-import { Translation } from '@suite-native/intl';
 
 import { CustomFee } from './CustomFee/CustomFee';
+import { FeeDescriptionTranslation } from './FeeDescriptionTranslation';
 import { FeeLabelTranslation } from './FeeLabelTranslation';
 import { FeeOptionsList, type FeeOptionsListProps } from './FeeOptionList/FeeOptionsList';
 import { type CustomFeeParams } from '../../hooks';
@@ -37,7 +37,7 @@ export const FeesContent = ({
                 <FeeLabelTranslation networkType={networkType} />
             </Text>
             <Text>
-                <Translation id="transactionManagement.fees.description.body" />
+                <FeeDescriptionTranslation networkType={networkType} />
             </Text>
         </VStack>
         <VStack spacing="sp24">

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10577,6 +10577,11 @@ export const messages = defineMessages({
         defaultMessage:
             "Network fees are payments made to validators for processing transactions. Paying a higher fee can speed up confirmation times. {br}Rent is a charge for storing data on the blockchain. The cost is based on the size of the account's storage.",
     },
+    TR_XRP_FEE_DESC: {
+        id: 'TR_XRP_FEE_DESC',
+        defaultMessage:
+            "The fee you're willing to pay to process the transaction. XRP fees are burned (permanently destroyed), not paid to validators. A higher fee may speed up processing during network congestion.",
+    },
     TR_STELLAR_FEE_DESC: {
         id: 'TR_STELLAR_FEE_DESC',
         defaultMessage:


### PR DESCRIPTION
The fee descriptions in the XRP send forms on desktop and mobile claimed transaction fees are paid to validators, but XRP fees are burned (permanently destroyed). This adds XRP-specific fee description messages on both platforms without changing other networks' wording.

Resolves #26098

<img width="869" height="750" alt="Screenshot 2026-06-19 at 10 09 40" src="https://github.com/user-attachments/assets/eeb36845-a77b-4a69-8133-92dfe59db69b" />

@EuryShadow let me know if other networks are also wrong. Copy can be improved by @c4181 in crowdin


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes primarily affect the CollapsibleFeesHeader component in the web Suite fee UI and intl message definitions across both web and native platforms. The CollapsibleFeesHeader is a broadly-used component (31 tests reference it), so testing is focused on tests that explicitly validate fee display, custom fee configuration, and fee-related translations rather than tests that merely render the component passively. The suite-native changes (FeeDescriptionTranslation, FeesBottomSheet, FeesContent) have no E2E test coverage in this test suite as they target the React Native mobile app. The highest risk is in swap and sell flows where custom fees are explicitly tested and validated.

<details><summary><b>Changed files (6)</b></summary>

- `packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFeesHeader.tsx`
- `suite-native/intl/src/messages.ts`
- `suite-native/transaction-management/src/components/fees/FeeDescriptionTranslation.tsx`
- `suite-native/transaction-management/src/components/fees/FeesBottomSheet.tsx`
- `suite-native/transaction-management/src/components/fees/FeesContent.tsx`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — This test directly exercises custom fee settings during a swap flow, including fee rate display on the device prompt modal. The CollapsibleFeesHeader component is part of the fee UI that this test validates, and intl messages changes could affect fee-related translations shown in the UI.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — This test explicitly validates custom Ethereum fee parameters (gas limit, max fee per gas, max priority fee per gas) in the swap flow, directly exercising the fee UI components including CollapsibleFeesHeader. Any rendering or translation changes would be caught here.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/trading/sell-inputs.test.ts` — This test validates custom fee configuration for BTC sell transactions (switchToCustom, customInput, maxFee) and fraction buttons that depend on fee calculations. The fee UI header component and related translations are directly involved in the sell form's fee section.
- `suite/e2e/tests/trading/sell-solana.test.ts` — This test verifies fee fields (maxFee, maxFeeFiat) visibility and that maximumFeeAmountToBeCalculated is hidden after fee resolution in the sell flow. Changes to CollapsibleFeesHeader could affect how fees are displayed/collapsed in the sell confirmation.
- `suite/e2e/tests/wallet/send-eth.test.ts` — This test fills in the Ethereum send form with custom gas fee parameters and verifies fee display (gas limit, max fee per gas, max priority fee per gas) on both the UI and device. The fee section UI directly uses the CollapsibleFees component and related translations like TR_GAS_LIMIT.
- `suite/e2e/tests/wallet/send-base.test.ts` — This test sets custom Ethereum fees (gas limit, max fee per gas, max priority fee per gas) when sending on the Base network and validates fee display. It directly exercises the fee UI components that include CollapsibleFeesHeader.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — This test validates custom Ethereum fee settings (gas limit, max fee per gas, max priority fee per gas) in the sell flow. The fee section directly uses CollapsibleFees components for rendering fee options.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/staking/staking-form.test.ts` — The staking form test validates fee display (maxFeeWithSymbol) and withdrawal buffer warnings during ETH staking. While the fee section uses CollapsibleFees components, the staking form's fee interaction is less direct than send/swap forms.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test exercises send form options including fee-related UI (locktime toggling via header dropdown) on regtest. While it touches the send form fee area, its primary focus is on outputs and OP_RETURN rather than fee display.

</details>

⚠️ **Changes with no test coverage (4)**
- `suite-native/intl/src/messages.ts`
- `suite-native/transaction-management/src/components/fees/FeeDescriptionTranslation.tsx`
- `suite-native/transaction-management/src/components/fees/FeesBottomSheet.tsx`
- `suite-native/transaction-management/src/components/fees/FeesContent.tsx`

_Updated: 2026-06-19T09:58:14.481Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/xrp-fee-description&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/xrp-fee-description&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/xrp-fee-description&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy BTC > Buy Bitcoin from best offer | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-19T10:03:02.531Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-19T10:01:26.926Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/xrp-fee-description/web/](https://dev.suite.sldev.cz/suite-web/fix/xrp-fee-description/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->