### PR TITLE
feat(trading): merge trade history

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsList.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsList.tsx
@@ -1,59 +1,24 @@
-import { useMemo } from 'react';
-
-import styled from 'styled-components';
-
 import { Translation } from '@suite/intl';
 import {
-    selectTradingActiveSection,
+    selectDeviceTradingTradesOrderedByDate,
     selectTradingBuyProviders,
     selectTradingExchangeInfo,
     selectTradingSellInfo,
-    selectTradingTradesForSelectedDevice,
 } from '@suite-common/trading';
-import { H3, Paragraph, variables } from '@trezor/components';
-import { spacingsPx, typography } from '@trezor/theme';
+import { Box, Column, H3, Paragraph, Text } from '@trezor/components';
+import { exhaustive } from '@trezor/type-utils';
 
 import { useSelector } from 'src/hooks/suite';
 import { TradingTransactionExchange } from 'src/views/wallet/trading/common/TradingTransactions/TradingTransactionExchange';
 import { TradingTransactionBuy } from 'src/views/wallet/trading/common/TradingTransactions/TradingTransactionsBuy';
 import { TradingTransactionSell } from 'src/views/wallet/trading/common/TradingTransactions/TradingTransactionsSell';
 
-const Wrapper = styled.div`
-    padding: ${spacingsPx.zero} ${spacingsPx.lg};
-
-    ${variables.SCREEN_QUERY.BELOW_DESKTOP} {
-        padding: 0;
-    }
-`;
-
-const Header = styled.div`
-    padding-bottom: ${spacingsPx.xxl};
-`;
-
-const TransactionCount = styled.div`
-    margin-top: ${spacingsPx.xxxs};
-    ${typography['body-sm']}
-    color: ${({ theme }) => theme.contentSecondary};
-`;
-
 export const TradingTransactionsList = () => {
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
     const buyProviders = useSelector(selectTradingBuyProviders);
     const exchangeProviders = useSelector(selectTradingExchangeInfo)?.providerInfos;
     const sellProviders = useSelector(selectTradingSellInfo)?.providerInfos;
-    const activeSection = useSelector(selectTradingActiveSection);
-    const isBuyAndSell = activeSection !== 'exchange';
-    const trades = useSelector(selectTradingTradesForSelectedDevice);
-    const sortedTrades = useMemo(
-        () =>
-            [...trades].sort((a, b) => {
-                if (a.date > b.date) return -1;
-                if (a.date < b.date) return 1;
-
-                return 0;
-            }),
-        [trades],
-    );
+    const trades = useSelector(selectDeviceTradingTradesOrderedByDate);
 
     if (selectedAccount.status !== 'loaded') {
         return null;
@@ -61,86 +26,83 @@ export const TradingTransactionsList = () => {
 
     const { account } = selectedAccount;
 
-    const buyTransactions = sortedTrades.filter(tx => tx.tradeType === 'buy');
-    const exchangeTransactions = sortedTrades.filter(tx => tx.tradeType === 'exchange');
-    const sellTransactions = sortedTrades.filter(tx => tx.tradeType === 'sell');
-    const buyAndSellTransactionLength = buyTransactions.length + sellTransactions.length;
-    const isEmpty =
-        (isBuyAndSell && buyAndSellTransactionLength === 0) ||
-        (!isBuyAndSell && exchangeTransactions.length === 0);
+    const buyTransactions = trades.filter(tx => tx.tradeType === 'buy');
+    const exchangeTransactions = trades.filter(tx => tx.tradeType === 'exchange');
+    const sellTransactions = trades.filter(tx => tx.tradeType === 'sell');
+    const isEmpty = trades.length === 0;
 
     return (
-        <Wrapper data-testid="@trading/transactions/list">
-            {isEmpty && (
-                <Paragraph
-                    data-testid="@trading/transactions/no-transaction"
-                    align="center"
-                    intent="neutral"
-                    priority="secondary"
-                >
-                    <Translation id="TR_BUY_NOT_TRANSACTIONS" />
-                </Paragraph>
-            )}
-            {!isEmpty && (
-                <>
-                    <Header>
-                        <H3 data-testid="@trading/transactions/heading">
-                            <Translation id="TR_TRADING_LAST_TRANSACTIONS" />
-                        </H3>
-                        <TransactionCount data-testid="@trading/transactions/count">
-                            {isBuyAndSell ? (
+        <Column alignItems="center">
+            <Box data-testid="@trading/transactions/list" maxWidth={800}>
+                {isEmpty && (
+                    <Paragraph
+                        data-testid="@trading/transactions/no-transaction"
+                        align="center"
+                        intent="neutral"
+                        priority="secondary"
+                    >
+                        <Translation id="TR_BUY_NOT_TRANSACTIONS" />
+                    </Paragraph>
+                )}
+                {!isEmpty && (
+                    <>
+                        <Column margin={{ bottom: 32 }}>
+                            <H3 data-testid="@trading/transactions/heading">
+                                <Translation id="TR_TRADING_LAST_TRANSACTIONS" />
+                            </H3>
+                            <Text
+                                typographyStyle="body-sm"
+                                color="contentSecondary"
+                                data-testid="@trading/transactions/count"
+                            >
                                 <Translation
-                                    id="TR_TRADING_BUY_AND_SELL_COUNTER"
+                                    id="TR_TRADING_TRADE_HISTORY_COUNTER"
                                     values={{
                                         totalBuys: buyTransactions.length,
                                         totalSells: sellTransactions.length,
-                                    }}
-                                />
-                            ) : (
-                                <Translation
-                                    id="TR_TRADING_SWAP_COUNTER"
-                                    values={{
                                         totalSwaps: exchangeTransactions.length,
                                     }}
                                 />
-                            )}
-                        </TransactionCount>
-                    </Header>
-                    {sortedTrades.map(trade => {
-                        if (isBuyAndSell && trade.tradeType === 'buy') {
-                            return (
-                                <TradingTransactionBuy
-                                    account={account}
-                                    key={`${trade.tradeType}-${trade.key}`}
-                                    trade={trade}
-                                    providers={buyProviders}
-                                />
-                            );
-                        }
-                        if (isBuyAndSell && trade.tradeType === 'sell') {
-                            return (
-                                <TradingTransactionSell
-                                    account={account}
-                                    key={`${trade.tradeType}-${trade.key}`}
-                                    trade={trade}
-                                    providers={sellProviders}
-                                />
-                            );
-                        }
+                            </Text>
+                        </Column>
+                        {trades.map(trade => {
+                            const key = `${trade.tradeType}-${trade.key}`;
 
-                        if (!isBuyAndSell && trade.tradeType === 'exchange') {
-                            return (
-                                <TradingTransactionExchange
-                                    account={account}
-                                    key={`${trade.tradeType}-${trade.key}`}
-                                    trade={trade}
-                                    providers={exchangeProviders}
-                                />
-                            );
-                        }
-                    })}
-                </>
-            )}
-        </Wrapper>
+                            switch (trade.tradeType) {
+                                case 'buy':
+                                    return (
+                                        <TradingTransactionBuy
+                                            account={account}
+                                            key={key}
+                                            trade={trade}
+                                            providers={buyProviders}
+                                        />
+                                    );
+                                case 'sell':
+                                    return (
+                                        <TradingTransactionSell
+                                            account={account}
+                                            key={key}
+                                            trade={trade}
+                                            providers={sellProviders}
+                                        />
+                                    );
+                                case 'exchange':
+                                    return (
+                                        <TradingTransactionExchange
+                                            account={account}
+                                            key={key}
+                                            trade={trade}
+                                            providers={exchangeProviders}
+                                        />
+                                    );
+                                default:
+                                    return exhaustive(trade);
+                            }
+                        })}
+                    </>
+                )}
+            </Box>
+        </Column>
     );
 };

--- a/suite/e2e/tests/trading/swap-history.test.ts
+++ b/suite/e2e/tests/trading/swap-history.test.ts
@@ -62,8 +62,8 @@ test.describe('Trading - Swap history', { tag: ['@webOnly', '@T3T1', '@T3W1'] },
             } as const;
 
             await expect(tradingPage.transactions.count).toHaveTranslation(
-                'TR_TRADING_SWAP_COUNTER',
-                { values: { totalSwaps: SEEDED_TRADES.length } },
+                'TR_TRADING_TRADE_HISTORY_COUNTER',
+                { values: { totalBuys: 0, totalSells: 0, totalSwaps: SEEDED_TRADES.length } },
             );
 
             for (const trade of SEEDED_TRADES) {

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -979,16 +979,6 @@ export const messages = defineMessages({
         defaultMessage: 'Trade history',
         id: 'TR_TRADING_LAST_TRANSACTIONS',
     },
-    TR_TRADING_BUY_AND_SELL_COUNTER: {
-        defaultMessage:
-            '{totalBuys, plural, =0 {{totalBuys} buys} one {{totalBuys} buy} other {{totalBuys} buys} } • {totalSells, plural, =0 {{totalSells} sells} one {{totalSells} sell} other {{totalSells} sells} }',
-        id: 'TR_TRADING_BUY_AND_SELL_COUNTER',
-    },
-    TR_TRADING_SWAP_COUNTER: {
-        defaultMessage:
-            '{totalSwaps, plural, =0 {{totalSwaps} swaps} one {{totalSwaps} swap} other {{totalSwaps} swaps} }',
-        id: 'TR_TRADING_SWAP_COUNTER',
-    },
     TR_TRADING_PAYMENT_METHOD: {
         defaultMessage: 'Payment method',
         id: 'TR_TRADING_PAYMENT_METHOD',
@@ -1113,6 +1103,11 @@ export const messages = defineMessages({
     TR_TRADING_TRADE_FEE: {
         defaultMessage: 'Trade fee',
         id: 'TR_TRADING_TRADE_FEE',
+    },
+    TR_TRADING_TRADE_HISTORY_COUNTER: {
+        defaultMessage:
+            '{totalBuys, plural, =0 {{totalBuys} buys} one {{totalBuys} buy} other {{totalBuys} buys} } • {totalSells, plural, =0 {{totalSells} sells} one {{totalSells} sell} other {{totalSells} sells} } • {totalSwaps, plural, =0 {{totalSwaps} swaps} one {{totalSwaps} swap} other {{totalSwaps} swaps} }',
+        id: 'TR_TRADING_TRADE_HISTORY_COUNTER',
     },
     TR_TRADING_POPULAR_CURRENCIES: {
         defaultMessage: 'Popular currencies',


### PR DESCRIPTION
## Description

- Merge buy, sell, and swap records into one Trade history list.
- Use the device-wide trading history sorted by date across all trade types.
- Replace separate history counters with one subheadline showing swaps, buys, and sells.
- Keep the existing buy, sell, and swap transaction rows in the merged list.
- Show the empty state only when the combined trade history is empty.

## Notes for QA

- In the Trading history on desktop, load an account with buy, sell, and swap records, and verify they appear in one list ordered by date with a `X swaps • Y buys • Z sells` subheadline.
- Switch between Buy, Sell, and Swap in Trading, and verify the same merged history remains visible instead of separate history sections.
- Open an account with no trading records, and verify the empty Trade history state is still shown.

## Related Issue

Resolve #28182

## Screenshots:

N/A

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changeset modifies the TradingTransactionsList component (swap/trading transaction history UI), the swap-history E2E test itself, and the global messages.ts translations file. The highest risk is in the swap history display — the test file was directly changed and exercises the modified component. Medium risk extends to other swap and trading flows that render transaction detail status pages using translation keys from messages.ts. Since messages.ts is a broad global file, only tests with specific trading-related translation assertions are included.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsList.tsx`
- `suite/e2e/tests/trading/swap-history.test.ts`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/trading/swap-history.test.ts` — This test file itself was directly modified in the changeset. It also directly exercises TradingTransactionsList.tsx, which is the other main changed source file — the test verifies swap/exchange order history display including trade rows, status, amounts, provider names, dates, counters, and detail navigation. Changes to messages.ts (translation keys like TR_TRADING_LAST_TRANSACTIONS, TR_TRADING_SWAP_COUNTER, etc.) are also asserted here.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/trading/swap-coins.test.ts` — This test exercises the full swap flow including transaction detail status pages that render through TradingTransactions components. It asserts on translation keys (TR_EXCHANGE_DETAIL_SUCCESS_TITLE, TR_EXCHANGE_FLOAT) from messages.ts and verifies swap transaction confirmation and status progression, which are closely related to the transaction list view.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — This swap test verifies transaction detail status (TR_EXCHANGE_DETAIL_SUCCESS_TITLE) and confirmation details after a swap, exercising the trading transaction display path. Changes to TradingTransactionsList or related translation keys could affect the transaction detail rendering.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Similar to other swap tests, this verifies transaction detail status and confirmation after a token-to-coin swap, using translation keys from messages.ts and rendering through trading transaction components.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — This test covers token-to-token swaps and verifies transaction detail status using TR_EXCHANGE_DETAIL_SUCCESS_TITLE and TR_EXCHANGE_FLOAT translations. The transaction detail view likely renders through the TradingTransactions component hierarchy.
- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — The buy flow includes a transaction detail page showing status updates (TR_BUY_DETAIL_WAITING_FOR_USER_TITLE, TR_BUY_DETAIL_SUCCESS_TITLE) that may render through TradingTransactions components. Changes to messages.ts translation keys used in these views could cause regressions.
- `suite/e2e/tests/trading/sell-solana.test.ts` — This sell test verifies transaction detail status progression (TR_SELL_DETAIL_SENDING_TRANSACTION, TR_TRADING_DETAIL_PROCESSING) and a trading transactions menu, which are likely rendered by TradingTransactionsList. Translation key changes in messages.ts could affect these assertions.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — This test navigates across Buy, Sell, and Swap forms and verifies correct cryptocurrency display. While it doesn't directly test transaction lists, changes to the trading module's shared components or translation keys could affect navigation behavior.

</details>

_Updated: 2026-06-12T10:01:57.792Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=lukas.werner/feat-trading-merge-history-28182&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=lukas.werner/feat-trading-merge-history-28182&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-12T10:06:24.459Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-12T10:05:41.888Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/lukas.werner/feat-trading-merge-history-28182/web/](https://dev.suite.sldev.cz/suite-web/lukas.werner/feat-trading-merge-history-28182/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->