### PR TITLE
feat(trading): merge trade history

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsList.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsList.tsx
@@ -1,59 +1,24 @@
-import { useMemo } from 'react';
-
-import styled from 'styled-components';
-
 import { Translation } from '@suite/intl';
 import {
-    selectTradingActiveSection,
+    selectDeviceTradingTradesOrderedByDate,
     selectTradingBuyProviders,
     selectTradingExchangeInfo,
     selectTradingSellInfo,
-    selectTradingTradesForSelectedDevice,
 } from '@suite-common/trading';
-import { H3, Paragraph, variables } from '@trezor/components';
-import { spacingsPx, typography } from '@trezor/theme';
+import { Box, Column, H3, Paragraph, Text } from '@trezor/components';
+import { exhaustive } from '@trezor/type-utils';
 
 import { useSelector } from 'src/hooks/suite';
 import { TradingTransactionExchange } from 'src/views/wallet/trading/common/TradingTransactions/TradingTransactionExchange';
 import { TradingTransactionBuy } from 'src/views/wallet/trading/common/TradingTransactions/TradingTransactionsBuy';
 import { TradingTransactionSell } from 'src/views/wallet/trading/common/TradingTransactions/TradingTransactionsSell';
 
-const Wrapper = styled.div`
-    padding: ${spacingsPx.zero} ${spacingsPx.lg};
-
-    ${variables.SCREEN_QUERY.BELOW_DESKTOP} {
-        padding: 0;
-    }
-`;
-
-const Header = styled.div`
-    padding-bottom: ${spacingsPx.xxl};
-`;
-
-const TransactionCount = styled.div`
-    margin-top: ${spacingsPx.xxxs};
-    ${typography['body-sm']}
-    color: ${({ theme }) => theme.contentSecondary};
-`;
-
 export const TradingTransactionsList = () => {
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
     const buyProviders = useSelector(selectTradingBuyProviders);
     const exchangeProviders = useSelector(selectTradingExchangeInfo)?.providerInfos;
     const sellProviders = useSelector(selectTradingSellInfo)?.providerInfos;
-    const activeSection = useSelector(selectTradingActiveSection);
-    const isBuyAndSell = activeSection !== 'exchange';
-    const trades = useSelector(selectTradingTradesForSelectedDevice);
-    const sortedTrades = useMemo(
-        () =>
-            [...trades].sort((a, b) => {
-                if (a.date > b.date) return -1;
-                if (a.date < b.date) return 1;
-
-                return 0;
-            }),
-        [trades],
-    );
+    const trades = useSelector(selectDeviceTradingTradesOrderedByDate);
 
     if (selectedAccount.status !== 'loaded') {
         return null;
@@ -61,86 +26,83 @@ export const TradingTransactionsList = () => {
 
     const { account } = selectedAccount;
 
-    const buyTransactions = sortedTrades.filter(tx => tx.tradeType === 'buy');
-    const exchangeTransactions = sortedTrades.filter(tx => tx.tradeType === 'exchange');
-    const sellTransactions = sortedTrades.filter(tx => tx.tradeType === 'sell');
-    const buyAndSellTransactionLength = buyTransactions.length + sellTransactions.length;
-    const isEmpty =
-        (isBuyAndSell && buyAndSellTransactionLength === 0) ||
-        (!isBuyAndSell && exchangeTransactions.length === 0);
+    const buyTransactions = trades.filter(tx => tx.tradeType === 'buy');
+    const exchangeTransactions = trades.filter(tx => tx.tradeType === 'exchange');
+    const sellTransactions = trades.filter(tx => tx.tradeType === 'sell');
+    const isEmpty = trades.length === 0;
 
     return (
-        <Wrapper data-testid="@trading/transactions/list">
-            {isEmpty && (
-                <Paragraph
-                    data-testid="@trading/transactions/no-transaction"
-                    align="center"
-                    intent="neutral"
-                    priority="secondary"
-                >
-                    <Translation id="TR_BUY_NOT_TRANSACTIONS" />
-                </Paragraph>
-            )}
-            {!isEmpty && (
-                <>
-                    <Header>
-                        <H3 data-testid="@trading/transactions/heading">
-                            <Translation id="TR_TRADING_LAST_TRANSACTIONS" />
-                        </H3>
-                        <TransactionCount data-testid="@trading/transactions/count">
-                            {isBuyAndSell ? (
+        <Column alignItems="center">
+            <Box data-testid="@trading/transactions/list" maxWidth={800}>
+                {isEmpty && (
+                    <Paragraph
+                        data-testid="@trading/transactions/no-transaction"
+                        align="center"
+                        intent="neutral"
+                        priority="secondary"
+                    >
+                        <Translation id="TR_BUY_NOT_TRANSACTIONS" />
+                    </Paragraph>
+                )}
+                {!isEmpty && (
+                    <>
+                        <Column margin={{ bottom: 32 }}>
+                            <H3 data-testid="@trading/transactions/heading">
+                                <Translation id="TR_TRADING_LAST_TRANSACTIONS" />
+                            </H3>
+                            <Text
+                                typographyStyle="body-sm"
+                                color="contentSecondary"
+                                data-testid="@trading/transactions/count"
+                            >
                                 <Translation
-                                    id="TR_TRADING_BUY_AND_SELL_COUNTER"
+                                    id="TR_TRADING_TRADE_HISTORY_COUNTER"
                                     values={{
                                         totalBuys: buyTransactions.length,
                                         totalSells: sellTransactions.length,
-                                    }}
-                                />
-                            ) : (
-                                <Translation
-                                    id="TR_TRADING_SWAP_COUNTER"
-                                    values={{
                                         totalSwaps: exchangeTransactions.length,
                                     }}
                                 />
-                            )}
-                        </TransactionCount>
-                    </Header>
-                    {sortedTrades.map(trade => {
-                        if (isBuyAndSell && trade.tradeType === 'buy') {
-                            return (
-                                <TradingTransactionBuy
-                                    account={account}
-                                    key={`${trade.tradeType}-${trade.key}`}
-                                    trade={trade}
-                                    providers={buyProviders}
-                                />
-                            );
-                        }
-                        if (isBuyAndSell && trade.tradeType === 'sell') {
-                            return (
-                                <TradingTransactionSell
-                                    account={account}
-                                    key={`${trade.tradeType}-${trade.key}`}
-                                    trade={trade}
-                                    providers={sellProviders}
-                                />
-                            );
-                        }
+                            </Text>
+                        </Column>
+                        {trades.map(trade => {
+                            const key = `${trade.tradeType}-${trade.key}`;
 
-                        if (!isBuyAndSell && trade.tradeType === 'exchange') {
-                            return (
-                                <TradingTransactionExchange
-                                    account={account}
-                                    key={`${trade.tradeType}-${trade.key}`}
-                                    trade={trade}
-                                    providers={exchangeProviders}
-                                />
-                            );
-                        }
-                    })}
-                </>
-            )}
-        </Wrapper>
+                            switch (trade.tradeType) {
+                                case 'buy':
+                                    return (
+                                        <TradingTransactionBuy
+                                            account={account}
+                                            key={key}
+                                            trade={trade}
+                                            providers={buyProviders}
+                                        />
+                                    );
+                                case 'sell':
+                                    return (
+                                        <TradingTransactionSell
+                                            account={account}
+                                            key={key}
+                                            trade={trade}
+                                            providers={sellProviders}
+                                        />
+                                    );
+                                case 'exchange':
+                                    return (
+                                        <TradingTransactionExchange
+                                            account={account}
+                                            key={key}
+                                            trade={trade}
+                                            providers={exchangeProviders}
+                                        />
+                                    );
+                                default:
+                                    return exhaustive(trade);
+                            }
+                        })}
+                    </>
+                )}
+            </Box>
+        </Column>
     );
 };

--- a/packages/suite/src/views/wallet/trading/common/TradingTransactions/__tests__/TradingTransactionsList.test.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingTransactions/__tests__/TradingTransactionsList.test.tsx
@@ -1,0 +1,183 @@
+import '@suite-common/test-utils/src/globalOverrides';
+
+import { screen } from '@testing-library/react';
+
+import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
+import { configureMockStore } from '@suite-common/test-utils';
+import { initialState as tradingInitialState } from '@suite-common/trading';
+import {
+    type Account,
+    type SelectedAccountStatus,
+    asAccountDescriptor,
+    createAccountKey,
+} from '@suite-common/wallet-types';
+
+import { initialAppState } from 'src/support/tests/__fixtures__/defaultAppState';
+import { extraDependenciesDesktopMock } from 'src/support/tests/extraDependenciesDesktop.mock';
+import { renderWithProviders } from 'src/support/tests/hooksHelper';
+
+import { TradingTransactionsList } from '../TradingTransactionsList';
+
+jest.mock('@suite-common/tx-simulation', () => ({}));
+
+jest.mock('@suite/intl', () => ({
+    ...jest.requireActual('@suite/intl'),
+    Translation: ({ id, values }: { id: string; values?: Record<string, unknown> }) => (
+        <span data-testid={id}>{values ? JSON.stringify(values) : id}</span>
+    ),
+}));
+
+jest.mock('src/views/wallet/trading/common/TradingTransactions/TradingTransactionsBuy', () => ({
+    TradingTransactionBuy: ({ trade }: { trade: { key?: string } }) => (
+        <div data-testid={`@trading/transactions/buy/${trade.key}`} />
+    ),
+}));
+
+jest.mock('src/views/wallet/trading/common/TradingTransactions/TradingTransactionsSell', () => ({
+    TradingTransactionSell: ({ trade }: { trade: { key?: string } }) => (
+        <div data-testid={`@trading/transactions/sell/${trade.key}`} />
+    ),
+}));
+
+jest.mock('src/views/wallet/trading/common/TradingTransactions/TradingTransactionExchange', () => ({
+    TradingTransactionExchange: ({ trade }: { trade: { key?: string } }) => (
+        <div data-testid={`@trading/transactions/exchange/${trade.key}`} />
+    ),
+}));
+
+const DEVICE_SSID = 'btcAddress@deviceId:0' as const;
+const SELECTED_DEVICE = mockSuiteDevice({
+    connected: true,
+    available: true,
+    state: { staticSessionId: DEVICE_SSID },
+});
+
+const ACCOUNT_KEY = createAccountKey({
+    accountDescriptor: asAccountDescriptor('btcDescriptor'),
+    networkSymbol: 'btc',
+    deviceStaticSessionId: DEVICE_SSID,
+});
+
+const btcAccount = {
+    key: ACCOUNT_KEY,
+    deviceState: DEVICE_SSID,
+    accountType: 'normal',
+    visible: true,
+    empty: false,
+    symbol: 'btc',
+    networkType: 'bitcoin',
+} as unknown as Account;
+
+const BUY_TRADE = {
+    date: '2026-01-02T00:00:00Z',
+    key: 'buy-1',
+    tradeType: 'buy' as const,
+    data: {},
+    selectedAccountKey: ACCOUNT_KEY,
+    receiveAccountKey: ACCOUNT_KEY,
+};
+
+const SELL_TRADE = {
+    date: '2026-01-01T00:00:00Z',
+    key: 'sell-1',
+    tradeType: 'sell' as const,
+    data: {},
+    sendAccountKey: ACCOUNT_KEY,
+};
+
+const EXCHANGE_TRADE = {
+    date: '2026-01-03T00:00:00Z',
+    key: 'exchange-1',
+    tradeType: 'exchange' as const,
+    data: {},
+    sendAccountKey: ACCOUNT_KEY,
+    receiveAccountKey: ACCOUNT_KEY,
+};
+
+type BuildStateParams = {
+    selectedAccountStatus?: SelectedAccountStatus;
+    trades?: (typeof BUY_TRADE | typeof SELL_TRADE | typeof EXCHANGE_TRADE)[];
+};
+
+const buildState = ({
+    selectedAccountStatus = {
+        status: 'loaded',
+        account: btcAccount,
+        network: { symbol: 'btc' } as any,
+        params: {} as any,
+    },
+    trades = [],
+}: BuildStateParams = {}) => ({
+    ...initialAppState,
+    device: {
+        ...initialAppState.device,
+        selectedDevice: SELECTED_DEVICE,
+    },
+    wallet: {
+        ...initialAppState.wallet,
+        accounts: [btcAccount],
+        selectedAccount: selectedAccountStatus,
+        trading: {
+            ...tradingInitialState,
+            trades: trades as any,
+        },
+    } as any,
+});
+
+describe('TradingTransactionsList', () => {
+    it('renders nothing when selectedAccount is not loaded', () => {
+        const store = configureMockStore({
+            preloadedState: buildState({
+                selectedAccountStatus: { status: 'loading', loader: 'account-loading' },
+            }),
+        });
+
+        const { container } = renderWithProviders(
+            store,
+            extraDependenciesDesktopMock.services,
+            <TradingTransactionsList />,
+        );
+
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it('renders empty state when there are no trades', () => {
+        const store = configureMockStore({ preloadedState: buildState({ trades: [] }) });
+
+        renderWithProviders(
+            store,
+            extraDependenciesDesktopMock.services,
+            <TradingTransactionsList />,
+        );
+
+        expect(screen.getByTestId('@trading/transactions/list')).toBeInTheDocument();
+        expect(screen.getByTestId('@trading/transactions/no-transaction')).toBeInTheDocument();
+        expect(screen.queryByTestId('@trading/transactions/heading')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('@trading/transactions/count')).not.toBeInTheDocument();
+    });
+
+    it('renders heading, correct transaction counts, and trade rows when there are trades', () => {
+        const store = configureMockStore({
+            preloadedState: buildState({ trades: [BUY_TRADE, SELL_TRADE, EXCHANGE_TRADE] }),
+        });
+
+        renderWithProviders(
+            store,
+            extraDependenciesDesktopMock.services,
+            <TradingTransactionsList />,
+        );
+
+        expect(screen.getByTestId('@trading/transactions/heading')).toBeInTheDocument();
+        expect(
+            screen.queryByTestId('@trading/transactions/no-transaction'),
+        ).not.toBeInTheDocument();
+
+        expect(screen.getByTestId('TR_TRADING_TRADE_HISTORY_COUNTER')).toHaveTextContent(
+            JSON.stringify({ totalBuys: 1, totalSells: 1, totalSwaps: 1 }),
+        );
+
+        expect(screen.getByTestId('@trading/transactions/buy/buy-1')).toBeInTheDocument();
+        expect(screen.getByTestId('@trading/transactions/sell/sell-1')).toBeInTheDocument();
+        expect(screen.getByTestId('@trading/transactions/exchange/exchange-1')).toBeInTheDocument();
+    });
+});

--- a/suite/e2e/tests/trading/swap-history.test.ts
+++ b/suite/e2e/tests/trading/swap-history.test.ts
@@ -62,8 +62,8 @@ test.describe('Trading - Swap history', { tag: ['@webOnly', '@T3T1', '@T3W1'] },
             } as const;
 
             await expect(tradingPage.transactions.count).toHaveTranslation(
-                'TR_TRADING_SWAP_COUNTER',
-                { values: { totalSwaps: SEEDED_TRADES.length } },
+                'TR_TRADING_TRADE_HISTORY_COUNTER',
+                { values: { totalBuys: 0, totalSells: 0, totalSwaps: SEEDED_TRADES.length } },
             );
 
             for (const trade of SEEDED_TRADES) {

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -979,16 +979,6 @@ export const messages = defineMessages({
         defaultMessage: 'Trade history',
         id: 'TR_TRADING_LAST_TRANSACTIONS',
     },
-    TR_TRADING_BUY_AND_SELL_COUNTER: {
-        defaultMessage:
-            '{totalBuys, plural, =0 {{totalBuys} buys} one {{totalBuys} buy} other {{totalBuys} buys} } • {totalSells, plural, =0 {{totalSells} sells} one {{totalSells} sell} other {{totalSells} sells} }',
-        id: 'TR_TRADING_BUY_AND_SELL_COUNTER',
-    },
-    TR_TRADING_SWAP_COUNTER: {
-        defaultMessage:
-            '{totalSwaps, plural, =0 {{totalSwaps} swaps} one {{totalSwaps} swap} other {{totalSwaps} swaps} }',
-        id: 'TR_TRADING_SWAP_COUNTER',
-    },
     TR_TRADING_PAYMENT_METHOD: {
         defaultMessage: 'Payment method',
         id: 'TR_TRADING_PAYMENT_METHOD',
@@ -1113,6 +1103,11 @@ export const messages = defineMessages({
     TR_TRADING_TRADE_FEE: {
         defaultMessage: 'Trade fee',
         id: 'TR_TRADING_TRADE_FEE',
+    },
+    TR_TRADING_TRADE_HISTORY_COUNTER: {
+        defaultMessage:
+            '{totalBuys, plural, =0 {{totalBuys} buys} one {{totalBuys} buy} other {{totalBuys} buys} } • {totalSells, plural, =0 {{totalSells} sells} one {{totalSells} sell} other {{totalSells} sells} } • {totalSwaps, plural, =0 {{totalSwaps} swaps} one {{totalSwaps} swap} other {{totalSwaps} swaps} }',
+        id: 'TR_TRADING_TRADE_HISTORY_COUNTER',
     },
     TR_TRADING_POPULAR_CURRENCIES: {
         defaultMessage: 'Popular currencies',


### PR DESCRIPTION
## Description

- Merge buy, sell, and swap records into one Trade history list.
- Refactored with `trezor/components`. Maintenance improvemnt

## Notes for QA

- In the Trading history on desktop, load an account with buy, sell, and swap records, and verify they appear in one list ordered by date with a `[n] buys • [n] sells • [n] swaps` subheadline.


## Related Issue

Resolve #28182

## Screenshots:

<img width="1158" height="831" alt="image" src="https://github.com/user-attachments/assets/e8b560de-c471-4908-9588-da60d961ee1c" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes center on the TradingTransactionsList component (both source and unit test), the swap-history E2E test, and the global intl messages file. The highest risk is in the swap-history test which was directly modified and exercises the changed component. Medium risk exists for other trading flow tests (buy, sell, swap) that interact with transaction detail/status views rendered by the same component. The messages.ts change is a broad dependency but only trading-related tests that use specific translation keys from the trading transactions domain are recommended.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsList.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingTransactions/__tests__/TradingTransactionsList.test.tsx`
- `suite/e2e/tests/trading/swap-history.test.ts`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/trading/swap-history.test.ts` — This test file itself was modified as part of the change set. It directly tests the TradingTransactionsList component which was also changed. It verifies swap/exchange order history display, ordering, status rendering, and transaction detail navigation — all behaviors that could be affected by changes to TradingTransactionsList.tsx.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — The buy-bitcoin test navigates through the trading flow and verifies transaction detail pages after completing a trade. The TradingTransactionsList component is part of the trading transactions view, and changes to it or related intl messages could affect how completed buy transactions are displayed.
- `suite/e2e/tests/trading/swap-coins.test.ts` — This test exercises the full swap flow including transaction status progression (SENDING → CONFIRMING → CONVERTING → SUCCESS) and uses translation keys like TR_EXCHANGE_DETAIL_SUCCESS_TITLE that may be defined in messages.ts. Changes to the TradingTransactionsList could affect how swap transaction status and history are rendered.
- `suite/e2e/tests/trading/sell-solana.test.ts` — This sell test verifies transaction detail status updates (TR_SELL_DETAIL_SENDING_TRANSACTION, TR_TRADING_DETAIL_PROCESSING) and navigates through trade confirmation flows. Changes to TradingTransactionsList and intl messages could affect how sell transaction history and statuses are displayed.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — This test navigates through buy/sell/swap forms and verifies correct cryptocurrency pre-selection. While it doesn't directly test transaction lists, it exercises the trading module's navigation which could be affected if TradingTransactionsList changes alter the trading page layout or routing.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/views/wallet/trading/common/TradingTransactions/__tests__/TradingTransactionsList.test.tsx`

_Updated: 2026-06-15T23:24:08.140Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/28182-merge-trade-history&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/28182-merge-trade-history&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-15T23:29:22.147Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-15T23:27:36.949Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/28182-merge-trade-history/web/](https://dev.suite.sldev.cz/suite-web/feat/28182-merge-trade-history/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->