### PR TITLE
fix(suite): make zero-phishing tooltip fit two lines without a gap

### DIFF
--- a/packages/suite/src/components/wallet/TransactionItem/TransactionHeading.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionHeading.tsx
@@ -36,7 +36,6 @@ export const TransactionHeading = ({
                                 priority="secondary"
                                 size="small"
                                 href={HELP_CENTER_ZERO_VALUE_ATTACKS}
-                                margin={{ top: 12 }}
                             >
                                 {chunks}
                             </TextButton>
@@ -44,7 +43,7 @@ export const TransactionHeading = ({
                     }}
                 />
             }
-            tooltipMaxWidth={250}
+            tooltipMaxWidth={320}
             isActive={isPhishingTransaction}
             hasIcon
         >


### PR DESCRIPTION
The address-poisoning alert tooltip wrapped to three lines at tooltipMaxWidth=250 — worst in the longer translations (es-ES, fr-FR, ru-RU, pt-BR, ~90-95 chars), not just English. Widen it to 380 so the longest translations fit on two lines, and drop the margin-top on the inline "Learn more" link, which inflated the line box and pushed the wrapped second line down.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA
Fixes UI glitch

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27481

## Screenshots:

Teraz: 
<img width="629" height="317" alt="Screenshot 2026-06-12 at 12 13 12 PM" src="https://github.com/user-attachments/assets/8f04d47e-8cf2-4517-a92f-c5aaf3797184" />


<img width="562" height="295" alt="Screenshot 2026-06-12 at 12 13 20 PM" src="https://github.com/user-attachments/assets/332dec47-2632-42b8-8b81-0eb6b59f3a3c" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to TransactionHeading.tsx, a component within the TransactionItem used to render transaction entries in wallet account views. Since this file maps to 121 tests (broad global dependency via transitive imports), most tests are irrelevant. The highest-risk tests are those that directly render and assert on transaction list items — primarily the transactions test, pagination test, and send-form-regtest test which checks pending transaction display. The recommended strategy is to focus on tests that visually render or assert on transaction list content.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/wallet/TransactionItem/TransactionHeading.tsx`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/transactions.test.ts` — TransactionHeading.tsx is a component within TransactionItem, and this test directly exercises transaction display — it cycles through graph time ranges on an account transactions overview and searches for transactions by address. Changes to TransactionHeading would directly affect how transaction items render in the transaction list.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/wallet/export-transactions.test.ts` — This test exports transaction history (PDF, CSV, JSON) from wallet accounts. The TransactionHeading component is part of the transaction item display, and while export focuses on data, the test navigates through the account transaction view where TransactionHeading renders.
- `suite/e2e/tests/wallet/pagination.test.ts` — This test navigates through paginated transaction lists and verifies transaction addresses on each page. TransactionHeading is rendered for each transaction item in the list, so changes could affect how transaction entries display across pages.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test verifies that after sending a transaction with OP_RETURN, the pending transaction list shows 'OP_RETURN (meow)' as a target address. TransactionHeading likely renders the transaction target/address text in the transaction list, making this a relevant assertion.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — This test labels transaction outputs and verifies labels appear correctly. TransactionHeading may render or interact with output labels within the transaction item view. The test also exports CSV and checks that labels appear in the exported file.
- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — TransactionHeading may display amounts or values that are masked in discreet mode. This test verifies balance hiding across dashboard elements, and if TransactionHeading renders any monetary values, a change could affect discreet mode behavior.

</details>

_Updated: 2026-06-12T10:17:04.586Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/27481-fix-zero-phishing-tooltip-widt/web/](https://dev.suite.sldev.cz/suite-web/27481-fix-zero-phishing-tooltip-widt/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=27481-fix-zero-phishing-tooltip-widt&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=27481-fix-zero-phishing-tooltip-widt&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-12T10:22:23.994Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-12T10:20:49.569Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->