### PR TITLE
Refactoring experiment: extract Suite coin control package

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -85,6 +85,7 @@
         "@suite/analytics": "workspace:*",
         "@suite/authenticity-checks": "workspace:*",
         "@suite/backup": "workspace:*",
+        "@suite/coin-control": "workspace:*",
         "@suite/desktop-update": "workspace:*",
         "@suite/device": "workspace:*",
         "@suite/discreet-mode": "workspace:*",

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/CoinControl.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/CoinControl.tsx
@@ -1,52 +1,112 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 
-import styled from 'styled-components';
-
-import { Translation } from '@suite/intl';
+import { CoinControl as SuiteCoinControl } from '@suite/coin-control';
+import type {
+    CoinControlActions,
+    CoinControlRenderers,
+    CoinControlViewModel,
+} from '@suite/coin-control';
+import { useTranslation } from '@suite/intl';
+import { openModal } from '@suite/modal';
 import { getTxsPerPage } from '@suite-common/suite-utils';
-import { filterAndCategorizeUtxos } from '@suite-common/transaction-search';
 import { COMPOSE_ERROR_TYPES } from '@suite-common/wallet-constants';
-import { fetchUtxoTransactionsForAccountThunk } from '@suite-common/wallet-core';
-import { convertAmountUnitsToSubunits, formatNetworkAmount } from '@suite-common/wallet-utils';
 import {
-    Banner,
-    Card,
-    Checkbox,
-    Column,
-    Divider,
-    Icon,
-    Paragraph,
-    Row,
-    Switch,
-    Text,
-} from '@trezor/components';
-import { spacings, spacingsPx } from '@trezor/theme';
+    fetchUtxoTransactionsForAccountThunk,
+    selectAccountTransactions,
+    useDisplayBaseCurrency,
+} from '@suite-common/wallet-core';
+import {
+    convertAmountUnitsToSubunits,
+    formatNetworkAmount,
+    getUtxoOutpoint,
+} from '@suite-common/wallet-utils';
+import { type AccountUtxo } from '@trezor/connect';
+import { BigNumber } from '@trezor/utils';
 
-import { FormattedCryptoAmount } from 'src/components/suite';
-import { Pagination } from 'src/components/wallet';
+import { BaseCurrencyValue, FormattedCryptoAmount } from 'src/components/suite';
+import { Pagination, TransactionTimestamp, UtxoAnonymity } from 'src/components/wallet';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useSendFormContext } from 'src/hooks/wallet';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
-import { selectCurrentTargetAnonymity } from 'src/reducers/wallet/coinjoinReducer';
+import {
+    selectCoinjoinAccountByKey,
+    selectCoinjoinClient,
+    selectCurrentTargetAnonymity,
+} from 'src/reducers/wallet/coinjoinReducer';
 import { selectAccountLabelsForSearch } from 'src/selectors/suite/selectAccountLabelsForSearch';
-
-import { UtxoSearch } from './UtxoSearch';
-import { UtxoSelectionList } from './UtxoSelectionList/UtxoSelectionList';
-import { UtxoSortingSelect } from './UtxoSortingSelect';
-
-const Empty = styled.div`
-    border-bottom: 1px solid ${({ theme }) => theme.borderNeutral};
-    margin-bottom: ${spacingsPx.sm};
-    padding: ${spacingsPx.sm} 0;
-`;
+import { type WalletAccountTransaction } from 'src/types/wallet';
+import { WabiSabiProtocolErrorCode } from 'src/types/wallet/coinjoin';
 
 type CoinControlProps = {
     close: () => void;
 };
 
+type UseCoinjoinUnavailableMessagesParams = {
+    accountUtxos?: AccountUtxo[];
+    accountKey: string;
+};
+
+const useCoinjoinUnavailableMessages = ({
+    accountKey,
+    accountUtxos,
+}: UseCoinjoinUnavailableMessagesParams) => {
+    const coinjoinAccount = useSelector(state => selectCoinjoinAccountByKey(state, accountKey));
+    const coinjoinClient = useSelector(state => selectCoinjoinClient(state, accountKey));
+    const { translationString } = useTranslation();
+
+    return useMemo(() => {
+        const messages: CoinControlViewModel['coinjoinUnavailableMessages'] = {};
+
+        if (!coinjoinClient?.allowedInputAmounts) {
+            return messages;
+        }
+
+        accountUtxos?.forEach(utxo => {
+            const imprisonedUtxo = coinjoinAccount?.prison?.[getUtxoOutpoint(utxo)];
+
+            if (imprisonedUtxo?.errorCode === WabiSabiProtocolErrorCode.InputBanned) {
+                messages[getUtxoOutpoint(utxo)] = translationString(
+                    'TR_UTXO_SHORT_BANNED_IN_COINJOIN',
+                );
+
+                return;
+            }
+
+            if (imprisonedUtxo?.errorCode === WabiSabiProtocolErrorCode.InputLongBanned) {
+                messages[getUtxoOutpoint(utxo)] = translationString(
+                    'TR_UTXO_LONG_BANNED_IN_COINJOIN',
+                );
+
+                return;
+            }
+
+            const amount = new BigNumber(utxo.amount);
+
+            if (amount.lt(coinjoinClient.allowedInputAmounts.min)) {
+                messages[getUtxoOutpoint(utxo)] = translationString(
+                    'TR_AMOUNT_TOO_SMALL_FOR_COINJOIN',
+                );
+
+                return;
+            }
+
+            if (amount.gt(coinjoinClient.allowedInputAmounts.max)) {
+                messages[getUtxoOutpoint(utxo)] = translationString(
+                    'TR_AMOUNT_TOO_BIG_FOR_COINJOIN',
+                );
+            }
+        });
+
+        return messages;
+    }, [
+        accountUtxos,
+        coinjoinAccount?.prison,
+        coinjoinClient?.allowedInputAmounts,
+        translationString,
+    ]);
+};
+
 export const CoinControl = ({ close }: CoinControlProps) => {
-    const [currentPage, setSelectedPage] = useState(1);
-    const [searchQuery, setSearchQuery] = useState('');
     const {
         account,
         formState: { errors },
@@ -56,20 +116,30 @@ export const CoinControl = ({ close }: CoinControlProps) => {
         isLoading,
         utxoSelection: {
             allUtxosSelected,
+            coinjoinRegisteredUtxos,
             composedInputs,
             dustUtxos,
             isCoinControlEnabled,
             lowAnonymityUtxos,
             selectedUtxos,
+            selectUtxoSorting,
             spendableUtxos,
             toggleCheckAllUtxos,
             toggleCoinControl,
+            toggleUtxoSelection,
+            utxoSorting,
         },
     } = useSendFormContext();
     const { outputLabels } = useSelector(state => selectAccountLabelsForSearch(state, account));
     const targetAnonymity = useSelector(selectCurrentTargetAnonymity);
+    const transactions = useSelector(state => selectAccountTransactions(state, account.key));
+    const coinjoinUnavailableMessages = useCoinjoinUnavailableMessages({
+        accountKey: account.key,
+        accountUtxos: account.utxo,
+    });
     const dispatch = useDispatch();
 
+    const { shallDisplayBaseCurrency } = useDisplayBaseCurrency(account.symbol);
     const { shouldSendInSats } = useBitcoinAmountUnit(account.symbol);
 
     const getTotal = (amounts: number[]) =>
@@ -77,19 +147,18 @@ export const CoinControl = ({ close }: CoinControlProps) => {
     const getFormattedAmount = (amount: number) =>
         formatNetworkAmount(amount.toString(), account.symbol);
 
-    // calculate and format amounts
     const inputs = isCoinControlEnabled ? selectedUtxos : composedInputs;
     const totalInputs = getTotal(inputs.map(input => Number(input.amount)));
     const totalOutputs = getTotal(
-        outputs.map((_, i) => Number(getDefaultValue(`outputs.${i}.amount`, ''))),
+        outputs.map((_, index) => Number(getDefaultValue(`outputs.${index}.amount`, ''))),
     );
     const totalOutputsInSats = shouldSendInSats
         ? totalOutputs
         : Number(convertAmountUnitsToSubunits(totalOutputs.toString(), network.decimals));
     const missingToInput = totalOutputsInSats - totalInputs;
-    const isMissingToAmount = missingToInput > 0; // relevant when the amount field is not validated, e.g. there is an error in the address
+    const isMissingToAmount = missingToInput > 0;
     const missingAmountTooBig = missingToInput > Number.MAX_SAFE_INTEGER;
-    const amountHasError = errors.outputs?.some?.(error => error?.amount); // relevant when input is a number, but there is an error, e.g. decimals in sats
+    const amountHasError = errors.outputs?.some?.(error => error?.amount);
     const notEnoughFundsSelectedError = !!errors.outputs?.some?.(
         error => error?.amount?.type === COMPOSE_ERROR_TYPES.COIN_CONTROL,
     );
@@ -100,171 +169,85 @@ export const CoinControl = ({ close }: CoinControlProps) => {
         !(amountHasError && !notEnoughFundsSelectedError) &&
         (isMissingToAmount || notEnoughFundsSelectedError);
     const missingToInputId = isMissingToAmount ? 'TR_MISSING_TO_INPUT' : 'TR_MISSING_TO_FEE';
-    const formattedTotal = getFormattedAmount(totalInputs);
-    const formattedMissing = isMissingVisible ? getFormattedAmount(missingToInput) : ''; // set to empty string when hidden to avoid affecting the layout
+    const formattedMissing = isMissingVisible ? getFormattedAmount(missingToInput) : '';
 
-    // Filter UTXOs based on searchQuery
-    const { filteredUtxos, filteredSpendableUtxos, filteredLowAnonymityUtxos, filteredDustUtxos } =
-        filterAndCategorizeUtxos({
-            searchQuery,
-            utxos: account.utxo || [],
-            spendableUtxos,
-            lowAnonymityUtxos,
-            dustUtxos,
-            outputLabels,
-        });
-
-    // pagination
-    const totalItems = filteredUtxos.length;
-    const utxosPerPage = getTxsPerPage(account.networkType);
-    const showPagination = totalItems > utxosPerPage;
-
-    // UTXOs and categories displayed on page
-    let previousItemsLength = 0;
-    const paginatedCategories = [
-        filteredSpendableUtxos,
-        filteredLowAnonymityUtxos,
-        filteredDustUtxos,
-    ].map(utxoCategory => {
-        const lastIndexOnPage = currentPage * utxosPerPage - previousItemsLength;
-        previousItemsLength += utxoCategory.length;
-
-        // avoid negative values which may cause unintended results
-        return utxoCategory.slice(
-            Math.max(0, lastIndexOnPage - utxosPerPage),
-            Math.max(0, lastIndexOnPage),
-        );
-    });
-    const spendableUtxosOnPage = paginatedCategories[0] ?? [];
-    const lowAnonymityUtxosOnPage = paginatedCategories[1] ?? [];
-    const dustUtxosOnPage = paginatedCategories[2] ?? [];
-    const isCoinjoinAccount = account.accountType === 'coinjoin';
-    const hasEligibleUtxos = spendableUtxos.length + lowAnonymityUtxos.length > 0;
-
-    // fetch all transactions so that we can show a transaction timestamp for each UTXO
-    useEffect(() => {
-        const promise = dispatch(
-            fetchUtxoTransactionsForAccountThunk({
-                accountKey: account.key,
-            }),
-        );
-
-        return () => {
-            promise.abort();
-        };
-    }, [account, dispatch]);
-
-    const missingToInputValues = {
-        amount: <FormattedCryptoAmount value={formattedMissing} symbol={account.symbol} />,
-    };
-
-    const handleAllUtxosSelected = () => {
-        setSearchQuery('');
-        setSelectedPage(1);
-        toggleCheckAllUtxos();
-    };
-
-    return (
-        <Card paddingType="large">
-            <Column gap={16}>
-                <Row justifyContent="space-between">
-                    <Translation id="TR_COIN_CONTROL" />
-                    <Row gap={spacings.md}>
-                        <Switch isChecked={!!isCoinControlEnabled} onChange={toggleCoinControl} />
-                        <Icon size={24} name="caretUp" onClick={close} />
-                    </Row>
-                </Row>
-
-                <Row justifyContent="space-between" margin={{ top: 24 }}>
-                    <Checkbox
-                        isChecked={allUtxosSelected}
-                        isDisabled={!hasEligibleUtxos}
-                        onChange={handleAllUtxosSelected}
-                    >
-                        <Text intent="neutral" priority="secondary">
-                            <Translation id="TR_SELECTED" values={{ amount: inputs.length }} />
-                        </Text>
-                    </Checkbox>
-
-                    <Text intent="neutral" priority="secondary">
-                        <FormattedCryptoAmount value={formattedTotal} symbol={account.symbol} />
-                    </Text>
-                </Row>
-
-                {isMissingVisible && (
-                    <Banner
-                        icon
-                        description={
-                            <Paragraph>
-                                <Translation id={missingToInputId} values={missingToInputValues} />
-                            </Paragraph>
-                        }
-                    />
-                )}
-
-                <Divider margin={0} />
-
-                {hasEligibleUtxos && (
-                    <Row gap={12}>
-                        <UtxoSearch
-                            searchQuery={searchQuery}
-                            setSearch={setSearchQuery}
-                            setSelectedPage={setSelectedPage}
-                        />
-                        <UtxoSortingSelect />
-                    </Row>
-                )}
-                {!!spendableUtxosOnPage.length && (
-                    <UtxoSelectionList
-                        withHeader={isCoinjoinAccount}
-                        heading={<Translation id="TR_PRIVATE" />}
-                        description={
-                            <Translation id="TR_PRIVATE_DESCRIPTION" values={{ targetAnonymity }} />
-                        }
-                        icon="shieldCheck"
-                        iconIntent="brand"
-                        utxos={spendableUtxosOnPage}
-                    />
-                )}
-                {!!lowAnonymityUtxosOnPage.length && (
-                    <UtxoSelectionList
-                        withHeader
-                        heading={<Translation id="TR_NOT_PRIVATE" />}
-                        description={
-                            <Translation
-                                id="TR_NOT_PRIVATE_DESCRIPTION"
-                                values={{ targetAnonymity }}
-                            />
-                        }
-                        icon="shieldWarning"
-                        iconIntent="warning"
-                        utxos={lowAnonymityUtxosOnPage}
-                    />
-                )}
-                {!hasEligibleUtxos && (
-                    <Empty>
-                        <Translation id="TR_NO_SPENDABLE_UTXOS" />
-                    </Empty>
-                )}
-                {!!dustUtxosOnPage.length && (
-                    <UtxoSelectionList
-                        withHeader
-                        heading={<Translation id="TR_DUST" />}
-                        description={<Translation id="TR_DUST_DESCRIPTION" />}
-                        icon="info"
-                        iconIntent="neutral"
-                        utxos={dustUtxosOnPage}
-                    />
-                )}
-                {showPagination && (
-                    <Pagination
-                        currentPage={currentPage}
-                        totalItems={totalItems}
-                        perPage={utxosPerPage}
-                        onPageSelected={setSelectedPage}
-                    />
-                )}
-            </Column>
-        </Card>
+    const fetchUtxoTransactions = useCallback(
+        () =>
+            dispatch(
+                fetchUtxoTransactionsForAccountThunk({
+                    accountKey: account.key,
+                }),
+            ),
+        [account.key, dispatch],
     );
+
+    const onShowTransactionDetail = useCallback(
+        (transaction: WalletAccountTransaction) => {
+            dispatch(
+                openModal({
+                    type: 'transaction-detail',
+                    txid: transaction.txid,
+                    descriptor: transaction.descriptor,
+                    symbol: transaction.symbol,
+                    deviceState: transaction.deviceState,
+                    flow: 'detail',
+                }),
+            );
+        },
+        [dispatch],
+    );
+
+    const viewModel: CoinControlViewModel = {
+        account,
+        allUtxosSelected,
+        coinjoinRegisteredUtxos,
+        coinjoinUnavailableMessages,
+        composedInputs,
+        dustUtxos,
+        isCoinControlEnabled,
+        lowAnonymityUtxos,
+        network,
+        outputLabels,
+        selectedUtxos,
+        spendableUtxos,
+        summary: {
+            inputCount: inputs.length,
+            missingAmount: isMissingVisible
+                ? {
+                      translationId: missingToInputId,
+                      value: formattedMissing,
+                  }
+                : undefined,
+            totalInputAmount: getFormattedAmount(totalInputs),
+        },
+        targetAnonymity,
+        transactions,
+        utxoSorting,
+        utxosPerPage: getTxsPerPage(account.networkType),
+    };
+
+    const actions: CoinControlActions = {
+        close,
+        fetchUtxoTransactions,
+        onShowTransactionDetail,
+        selectUtxoSorting,
+        toggleCheckAllUtxos,
+        toggleCoinControl,
+        toggleUtxoSelection,
+    };
+
+    const renderers: CoinControlRenderers = {
+        renderBaseCurrencyValue: ({ amount, symbol }) =>
+            shallDisplayBaseCurrency ? <BaseCurrencyValue amount={amount} symbol={symbol} /> : null,
+        renderCryptoAmount: ({ symbol, value }) => (
+            <FormattedCryptoAmount value={value} symbol={symbol} />
+        ),
+        renderPagination: props => <Pagination {...props} />,
+        renderTransactionTimestamp: ({ transaction }) => (
+            <TransactionTimestamp showDate transaction={transaction} />
+        ),
+        renderUtxoAnonymity: ({ anonymity }) => <UtxoAnonymity anonymity={anonymity} />,
+    };
+
+    return <SuiteCoinControl actions={actions} renderers={renderers} viewModel={viewModel} />;
 };

--- a/packages/suite/tsconfig.json
+++ b/packages/suite/tsconfig.json
@@ -165,6 +165,7 @@
             "path": "../../suite/authenticity-checks"
         },
         { "path": "../../suite/backup" },
+        { "path": "../../suite/coin-control" },
         { "path": "../../suite/desktop-update" },
         { "path": "../../suite/device" },
         { "path": "../../suite/discreet-mode" },

--- a/suite/coin-control/package.json
+++ b/suite/coin-control/package.json
@@ -1,0 +1,36 @@
+{
+    "name": "@suite/coin-control",
+    "version": "1.0.0",
+    "private": true,
+    "license": "See LICENSE.md in repo root",
+    "sideEffects": false,
+    "main": "src/index",
+    "scripts": {
+        "depcheck": "yarn g:depcheck",
+        "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "type-check": "yarn g:tsc --build"
+    },
+    "dependencies": {
+        "@suite-common/message-system": "workspace:*",
+        "@suite-common/redux-utils": "workspace:*",
+        "@suite-common/suite-sync": "workspace:*",
+        "@suite-common/suite-sync-storage": "workspace:*",
+        "@suite-common/transaction-search": "workspace:*",
+        "@suite-common/wallet-config": "workspace:*",
+        "@suite-common/wallet-types": "workspace:*",
+        "@suite-common/wallet-utils": "workspace:*",
+        "@suite/address": "workspace:*",
+        "@suite/intl": "workspace:*",
+        "@suite/labeling": "workspace:*",
+        "@suite/metadata": "workspace:*",
+        "@trezor/components": "workspace:*",
+        "@trezor/connect": "workspace:*",
+        "@trezor/theme": "workspace:*",
+        "react": "19.2.4",
+        "react-redux": "9.2.0",
+        "styled-components": "^6.3.9"
+    },
+    "devDependencies": {
+        "@types/react": "19.2.14"
+    }
+}

--- a/suite/coin-control/src/CoinControl.tsx
+++ b/suite/coin-control/src/CoinControl.tsx
@@ -1,0 +1,276 @@
+import { useEffect, useState } from 'react';
+
+import styled from 'styled-components';
+
+import { Translation } from '@suite/intl';
+import { filterAndCategorizeUtxos } from '@suite-common/transaction-search';
+import {
+    Banner,
+    Card,
+    Checkbox,
+    Column,
+    Divider,
+    Icon,
+    Paragraph,
+    Row,
+    Switch,
+    Text,
+} from '@trezor/components';
+import { spacings, spacingsPx } from '@trezor/theme';
+
+import { UtxoSearch } from './UtxoSearch';
+import { UtxoSelectionList } from './UtxoSelectionList/UtxoSelectionList';
+import { UtxoSortingSelect } from './UtxoSortingSelect';
+import {
+    type CoinControlActions,
+    type CoinControlRenderers,
+    type CoinControlViewModel,
+} from './types';
+
+const Empty = styled.div`
+    border-bottom: 1px solid ${({ theme }) => theme.borderNeutral};
+    margin-bottom: ${spacingsPx.sm};
+    padding: ${spacingsPx.sm} 0;
+`;
+
+type CoinControlProps = {
+    actions: CoinControlActions;
+    renderers: CoinControlRenderers;
+    viewModel: CoinControlViewModel;
+};
+
+export const CoinControl = ({ actions, renderers, viewModel }: CoinControlProps) => {
+    const [currentPage, setSelectedPage] = useState(1);
+    const [searchQuery, setSearchQuery] = useState('');
+    const {
+        account,
+        allUtxosSelected,
+        coinjoinRegisteredUtxos,
+        coinjoinUnavailableMessages,
+        composedInputs,
+        dustUtxos,
+        isCoinControlEnabled,
+        lowAnonymityUtxos,
+        outputLabels,
+        selectedUtxos,
+        spendableUtxos,
+        summary,
+        targetAnonymity,
+        transactions,
+        utxoSorting,
+        utxosPerPage,
+    } = viewModel;
+
+    const {
+        close,
+        fetchUtxoTransactions,
+        onShowTransactionDetail,
+        selectUtxoSorting,
+        toggleCheckAllUtxos,
+        toggleCoinControl,
+        toggleUtxoSelection,
+    } = actions;
+
+    const { renderCryptoAmount, renderPagination } = renderers;
+
+    const { filteredUtxos, filteredSpendableUtxos, filteredLowAnonymityUtxos, filteredDustUtxos } =
+        filterAndCategorizeUtxos({
+            searchQuery,
+            utxos: account.utxo || [],
+            spendableUtxos,
+            lowAnonymityUtxos,
+            dustUtxos,
+            outputLabels,
+        });
+
+    const totalItems = filteredUtxos.length;
+    const showPagination = totalItems > utxosPerPage;
+
+    let previousItemsLength = 0;
+    const paginatedCategories = [
+        filteredSpendableUtxos,
+        filteredLowAnonymityUtxos,
+        filteredDustUtxos,
+    ].map(utxoCategory => {
+        const lastIndexOnPage = currentPage * utxosPerPage - previousItemsLength;
+        previousItemsLength += utxoCategory.length;
+
+        return utxoCategory.slice(
+            Math.max(0, lastIndexOnPage - utxosPerPage),
+            Math.max(0, lastIndexOnPage),
+        );
+    });
+    const spendableUtxosOnPage = paginatedCategories[0] ?? [];
+    const lowAnonymityUtxosOnPage = paginatedCategories[1] ?? [];
+    const dustUtxosOnPage = paginatedCategories[2] ?? [];
+    const isCoinjoinAccount = account.accountType === 'coinjoin';
+    const hasEligibleUtxos = spendableUtxos.length + lowAnonymityUtxos.length > 0;
+
+    useEffect(() => {
+        const promise = fetchUtxoTransactions();
+
+        return () => {
+            promise.abort();
+        };
+    }, [fetchUtxoTransactions]);
+
+    const missingToInputValues = {
+        amount: summary.missingAmount
+            ? renderCryptoAmount({
+                  value: summary.missingAmount.value,
+                  symbol: account.symbol,
+              })
+            : null,
+    };
+
+    const handleAllUtxosSelected = () => {
+        setSearchQuery('');
+        setSelectedPage(1);
+        toggleCheckAllUtxos();
+    };
+
+    return (
+        <Card paddingType="large">
+            <Column gap={16}>
+                <Row justifyContent="space-between">
+                    <Translation id="TR_COIN_CONTROL" />
+                    <Row gap={spacings.md}>
+                        <Switch isChecked={!!isCoinControlEnabled} onChange={toggleCoinControl} />
+                        <Icon size={24} name="caretUp" onClick={close} />
+                    </Row>
+                </Row>
+
+                <Row justifyContent="space-between" margin={{ top: 24 }}>
+                    <Checkbox
+                        isChecked={allUtxosSelected}
+                        isDisabled={!hasEligibleUtxos}
+                        onChange={handleAllUtxosSelected}
+                    >
+                        <Text intent="neutral" priority="secondary">
+                            <Translation id="TR_SELECTED" values={{ amount: summary.inputCount }} />
+                        </Text>
+                    </Checkbox>
+
+                    <Text intent="neutral" priority="secondary">
+                        {renderCryptoAmount({
+                            value: summary.totalInputAmount,
+                            symbol: account.symbol,
+                        })}
+                    </Text>
+                </Row>
+
+                {summary.missingAmount && (
+                    <Banner
+                        icon
+                        description={
+                            <Paragraph>
+                                <Translation
+                                    id={summary.missingAmount.translationId}
+                                    values={missingToInputValues}
+                                />
+                            </Paragraph>
+                        }
+                    />
+                )}
+
+                <Divider margin={0} />
+
+                {hasEligibleUtxos && (
+                    <Row gap={12}>
+                        <UtxoSearch
+                            searchQuery={searchQuery}
+                            setSearch={setSearchQuery}
+                            setSelectedPage={setSelectedPage}
+                        />
+                        <UtxoSortingSelect
+                            selectUtxoSorting={selectUtxoSorting}
+                            utxoSorting={utxoSorting}
+                        />
+                    </Row>
+                )}
+                {!!spendableUtxosOnPage.length && (
+                    <UtxoSelectionList
+                        account={account}
+                        coinjoinRegisteredUtxos={coinjoinRegisteredUtxos}
+                        coinjoinUnavailableMessages={coinjoinUnavailableMessages}
+                        composedInputs={composedInputs}
+                        description={
+                            <Translation id="TR_PRIVATE_DESCRIPTION" values={{ targetAnonymity }} />
+                        }
+                        heading={<Translation id="TR_PRIVATE" />}
+                        icon="shieldCheck"
+                        iconIntent="brand"
+                        isCoinControlEnabled={isCoinControlEnabled}
+                        onShowTransactionDetail={onShowTransactionDetail}
+                        renderers={renderers}
+                        selectedUtxos={selectedUtxos}
+                        toggleUtxoSelection={toggleUtxoSelection}
+                        transactions={transactions}
+                        utxos={spendableUtxosOnPage}
+                        withHeader={isCoinjoinAccount}
+                    />
+                )}
+                {!!lowAnonymityUtxosOnPage.length && (
+                    <UtxoSelectionList
+                        account={account}
+                        coinjoinRegisteredUtxos={coinjoinRegisteredUtxos}
+                        coinjoinUnavailableMessages={coinjoinUnavailableMessages}
+                        composedInputs={composedInputs}
+                        description={
+                            <Translation
+                                id="TR_NOT_PRIVATE_DESCRIPTION"
+                                values={{ targetAnonymity }}
+                            />
+                        }
+                        heading={<Translation id="TR_NOT_PRIVATE" />}
+                        icon="shieldWarning"
+                        iconIntent="warning"
+                        isCoinControlEnabled={isCoinControlEnabled}
+                        onShowTransactionDetail={onShowTransactionDetail}
+                        renderers={renderers}
+                        selectedUtxos={selectedUtxos}
+                        toggleUtxoSelection={toggleUtxoSelection}
+                        transactions={transactions}
+                        utxos={lowAnonymityUtxosOnPage}
+                        withHeader
+                    />
+                )}
+                {!hasEligibleUtxos && (
+                    <Empty>
+                        <Translation id="TR_NO_SPENDABLE_UTXOS" />
+                    </Empty>
+                )}
+                {!!dustUtxosOnPage.length && (
+                    <UtxoSelectionList
+                        account={account}
+                        coinjoinRegisteredUtxos={coinjoinRegisteredUtxos}
+                        coinjoinUnavailableMessages={coinjoinUnavailableMessages}
+                        composedInputs={composedInputs}
+                        description={<Translation id="TR_DUST_DESCRIPTION" />}
+                        heading={<Translation id="TR_DUST" />}
+                        icon="info"
+                        iconIntent="neutral"
+                        isCoinControlEnabled={isCoinControlEnabled}
+                        onShowTransactionDetail={onShowTransactionDetail}
+                        renderers={renderers}
+                        selectedUtxos={selectedUtxos}
+                        toggleUtxoSelection={toggleUtxoSelection}
+                        transactions={transactions}
+                        utxos={dustUtxosOnPage}
+                        withHeader
+                    />
+                )}
+                {showPagination && (
+                    <>
+                        {renderPagination({
+                            currentPage,
+                            onPageSelected: setSelectedPage,
+                            perPage: utxosPerPage,
+                            totalItems,
+                        })}
+                    </>
+                )}
+            </Column>
+        </Card>
+    );
+};

--- a/suite/coin-control/src/UtxoSearch.tsx
+++ b/suite/coin-control/src/UtxoSearch.tsx
@@ -1,0 +1,59 @@
+import {
+    type ChangeEvent,
+    type Dispatch,
+    type KeyboardEvent,
+    type SetStateAction,
+    useCallback,
+    useRef,
+} from 'react';
+
+import { useTranslation } from '@suite/intl';
+import { Icon, Input, KEYBOARD_CODE } from '@trezor/components';
+
+export type UtxoSearchProps = {
+    searchQuery: string;
+    setSearch: Dispatch<SetStateAction<string>>;
+    setSelectedPage: Dispatch<SetStateAction<number>>;
+};
+
+export const UtxoSearch = ({ searchQuery, setSearch, setSelectedPage }: UtxoSearchProps) => {
+    const inputRef = useRef<HTMLInputElement | null>(null);
+    const { translationString } = useTranslation();
+
+    const onKeyDown = useCallback(
+        (event: KeyboardEvent) => {
+            // Handle ESC (un-focus)
+            if (event.code === KEYBOARD_CODE.ESCAPE && inputRef.current) {
+                setSearch('');
+                inputRef.current.blur();
+            }
+        },
+        [setSearch],
+    );
+
+    const onSearch = useCallback(
+        ({ target }: ChangeEvent<HTMLInputElement>) => {
+            setSearch(target.value);
+            setSelectedPage(1);
+        },
+        [setSearch, setSelectedPage],
+    );
+
+    return (
+        <Input
+            data-testid="@wallet/send/search-icon"
+            innerRef={inputRef}
+            leftContent={
+                <Icon name="magnifyingGlass" size={16} intent="neutral" priority="secondary" />
+            }
+            placeholder={translationString('TR_SEARCH_UTXOS')}
+            onChange={onSearch}
+            onKeyDown={onKeyDown}
+            value={searchQuery}
+            maxLength={512}
+            showClearButton={true}
+            size="small"
+            onClear={() => setSearch('')}
+        />
+    );
+};

--- a/suite/coin-control/src/UtxoSelectionList/UtxoSelection/UtxoSelection.tsx
+++ b/suite/coin-control/src/UtxoSelectionList/UtxoSelection/UtxoSelection.tsx
@@ -1,0 +1,304 @@
+import { type MouseEventHandler, type ReactNode } from 'react';
+import { useSelector } from 'react-redux';
+
+import { Address, type SelectAddressLabelState, selectAddressLabel } from '@suite/address';
+import { Translation, useTranslation } from '@suite/intl';
+import { Labeling } from '@suite/labeling';
+import {
+    type LegacyLabelingVisibleRootState,
+    selectIsLegacyLabelingVisible,
+    selectLabelingDataForSelectedAccount,
+} from '@suite/metadata';
+import { type MessageSystemRootState } from '@suite-common/message-system';
+import { returnStableArrayIfEmpty } from '@suite-common/redux-utils';
+import {
+    type SuiteSyncDataRootState,
+    type WithSuiteSyncAndDeviceState,
+    selectIsSuiteSyncEnabled,
+    selectSuiteSyncOutputLabels,
+} from '@suite-common/suite-sync';
+import { type SuiteSyncOutput } from '@suite-common/suite-sync-storage';
+import { formatNetworkAmount, isSameUtxo } from '@suite-common/wallet-utils';
+import {
+    Checkbox,
+    Column,
+    GhostContainer,
+    Icon,
+    InfoSegments,
+    Row,
+    Spinner,
+    Text,
+    TextButton,
+    Tooltip,
+} from '@trezor/components';
+import { type AccountUtxo, type PROTO } from '@trezor/connect';
+
+import {
+    type CoinControlActions,
+    type CoinControlRenderers,
+    type CoinControlViewModel,
+} from '../../types';
+
+type ResolveUtxoSpendableProps = {
+    coinjoinRegisteredUtxos: AccountUtxo[];
+    utxo: AccountUtxo;
+};
+
+const MINIMAL_COINBASE_CONFIRMATIONS = 100;
+
+const resolveUtxoSpendable = ({
+    coinjoinRegisteredUtxos,
+    utxo,
+}: ResolveUtxoSpendableProps): ReactNode | null => {
+    if (utxo.coinbase === true && utxo.confirmations < MINIMAL_COINBASE_CONFIRMATIONS) {
+        return (
+            <Translation
+                id="TR_UTXO_NOT_MATURED_COINBASE"
+                values={{ confirmations: MINIMAL_COINBASE_CONFIRMATIONS }}
+            />
+        );
+    }
+
+    if (coinjoinRegisteredUtxos.some(registeredUtxo => isSameUtxo(registeredUtxo, utxo))) {
+        return <Translation id="TR_UTXO_REGISTERED_IN_COINJOIN" />;
+    }
+
+    return null;
+};
+
+type UtxoSelectionProps = {
+    account: CoinControlViewModel['account'];
+    coinjoinRegisteredUtxos: AccountUtxo[];
+    coinjoinUnavailableMessage?: ReactNode;
+    composedInputs: PROTO.TxInputType[];
+    isCoinControlEnabled: boolean;
+    onShowTransactionDetail: CoinControlActions['onShowTransactionDetail'];
+    renderers: CoinControlRenderers;
+    selectedUtxos: AccountUtxo[];
+    toggleUtxoSelection: CoinControlActions['toggleUtxoSelection'];
+    transaction?: CoinControlViewModel['transactions'][number];
+    utxo: AccountUtxo;
+};
+
+export const UtxoSelection = ({
+    account,
+    coinjoinRegisteredUtxos,
+    coinjoinUnavailableMessage,
+    composedInputs,
+    isCoinControlEnabled,
+    onShowTransactionDetail,
+    renderers,
+    selectedUtxos,
+    toggleUtxoSelection,
+    transaction,
+    utxo,
+}: UtxoSelectionProps) => {
+    const isSuiteSyncEnabled = useSelector(
+        (state: WithSuiteSyncAndDeviceState & MessageSystemRootState) =>
+            selectIsSuiteSyncEnabled(state),
+    );
+    const isLegacyLabelingVisible = useSelector((state: LegacyLabelingVisibleRootState) =>
+        selectIsLegacyLabelingVisible(state),
+    );
+
+    const { outputLabels } = useSelector(
+        (state: Parameters<typeof selectLabelingDataForSelectedAccount>[0]) =>
+            selectLabelingDataForSelectedAccount(state),
+    );
+    const suiteSyncOutputLabels = useSelector((state: SuiteSyncDataRootState) =>
+        isSuiteSyncEnabled
+            ? selectSuiteSyncOutputLabels(state, account.deviceState)
+            : returnStableArrayIfEmpty<SuiteSyncOutput>(),
+    );
+    const { translationString } = useTranslation();
+
+    const addressLabel = useSelector((state: SelectAddressLabelState) =>
+        selectAddressLabel(state, {
+            address: utxo.address,
+            deviceStaticId: account.deviceState,
+        }),
+    );
+
+    const isPendingTransaction = utxo.confirmations === 0;
+    const isChangeAddress = utxo.path.split('/').at(-2) === '1';
+    const anonymity = account.addresses?.anonymitySet?.[utxo.address];
+
+    const isChecked = isCoinControlEnabled
+        ? selectedUtxos.some(selected => isSameUtxo(selected, utxo))
+        : composedInputs.some(
+              input => input.prev_hash === utxo.txid && input.prev_index === utxo.vout,
+          );
+
+    const unspendableTooltip = resolveUtxoSpendable({ coinjoinRegisteredUtxos, utxo });
+    const isDisabled = unspendableTooltip !== null;
+
+    const handleCheckbox = () => toggleUtxoSelection(utxo);
+    const showTransactionDetail: MouseEventHandler = event => {
+        event.stopPropagation();
+
+        if (transaction) {
+            onShowTransactionDetail(transaction);
+        }
+    };
+
+    const outputLabel =
+        suiteSyncOutputLabels.find(
+            (item: SuiteSyncOutput) =>
+                item.txId === utxo.txid && item.txTargetId === `${utxo.vout}`,
+        )?.label ?? (isLegacyLabelingVisible ? outputLabels?.[utxo.txid]?.[utxo.vout] : undefined);
+
+    const baseCurrencyValue = renderers.renderBaseCurrencyValue({
+        amount: formatNetworkAmount(utxo.amount, account.symbol, false),
+        symbol: account.symbol,
+    });
+
+    return (
+        <GhostContainer onClick={handleCheckbox} padding={12} margin={{ horizontal: -12 }} as="div">
+            <Row gap={24} width="100%">
+                <Tooltip content={unspendableTooltip}>
+                    <Checkbox
+                        isChecked={isChecked}
+                        isDisabled={isDisabled}
+                        onChange={handleCheckbox}
+                        onClick={event => event.stopPropagation()}
+                    />
+                </Tooltip>
+                <Column flex="1" gap={0}>
+                    <Row gap={12} justifyContent="space-between">
+                        <Text typographyStyle="body-md">
+                            <Labeling
+                                deviceStaticSessionId={account.deviceState}
+                                payload={{
+                                    type: 'addressLabel',
+                                    entityKey: account.key,
+                                    defaultValue: utxo.address,
+                                    accountDescriptor: account.descriptor,
+                                    networkSymbol: account.symbol,
+                                }}
+                                displayValue={<Address value={utxo.address} isTruncated />}
+                                placeholder={translationString('TR_LABELING_ADDRESS_LABEL')}
+                                maxWidth={350}
+                                minHeight={28}
+                                gap={6}
+                                leftAddon={
+                                    <>
+                                        {isPendingTransaction && (
+                                            <Tooltip
+                                                content={
+                                                    <Translation id="TR_IN_PENDING_TRANSACTION" />
+                                                }
+                                            >
+                                                <Icon
+                                                    name="clock"
+                                                    intent="neutral"
+                                                    priority="secondary"
+                                                    size={16}
+                                                />
+                                            </Tooltip>
+                                        )}
+                                        {!!coinjoinUnavailableMessage && (
+                                            <Tooltip content={coinjoinUnavailableMessage}>
+                                                <Icon
+                                                    name="xCircle"
+                                                    intent="neutral"
+                                                    priority="secondary"
+                                                    size={16}
+                                                />
+                                            </Tooltip>
+                                        )}
+                                        {isChangeAddress && (
+                                            <Tooltip
+                                                content={
+                                                    <Translation id="TR_CHANGE_ADDRESS_TOOLTIP" />
+                                                }
+                                            >
+                                                <Icon
+                                                    name="change"
+                                                    intent="neutral"
+                                                    priority="secondary"
+                                                    size={16}
+                                                />
+                                            </Tooltip>
+                                        )}
+                                    </>
+                                }
+                            >
+                                {addressLabel}
+                            </Labeling>
+                        </Text>
+                        {renderers.renderCryptoAmount({
+                            value: formatNetworkAmount(utxo.amount, account.symbol),
+                            symbol: account.symbol,
+                        })}
+                    </Row>
+                    <Row justifyContent="space-between" gap={12}>
+                        <InfoSegments
+                            typographyStyle="body-sm"
+                            intent="neutral"
+                            priority="secondary"
+                            gap={6}
+                        >
+                            {transaction ? (
+                                renderers.renderTransactionTimestamp({ transaction })
+                            ) : (
+                                <Tooltip
+                                    cursor="pointer"
+                                    content={<Translation id="TR_LOADING_TRANSACTION_DETAILS" />}
+                                >
+                                    <Spinner size={16} isDisabled={true} />
+                                </Tooltip>
+                            )}
+                            {!!anonymity && renderers.renderUtxoAnonymity({ anonymity })}
+                            {transaction && (
+                                <TextButton
+                                    size="small"
+                                    intent="neutral"
+                                    onClick={showTransactionDetail}
+                                    isUnderlined
+                                >
+                                    <Translation id="TR_DETAIL" />
+                                </TextButton>
+                            )}
+                            <Labeling
+                                deviceStaticSessionId={account.deviceState}
+                                displayValue={<Translation id="TR_LABELING_ADD_LABEL" />}
+                                payload={{
+                                    type: 'outputLabel',
+                                    entityKey: account.key,
+                                    txid: utxo.txid,
+                                    outputIndex: `${utxo.vout}`,
+                                    defaultValue: `${utxo.txid}-${utxo.vout}`,
+                                    networkSymbol: account.symbol,
+                                    accountDescriptor: account.descriptor,
+                                }}
+                                gap={6}
+                                leftAddon={
+                                    <Icon
+                                        name={outputLabel ? 'tagFilled' : 'tag'}
+                                        intent="neutral"
+                                        priority="secondary"
+                                        size={12}
+                                    />
+                                }
+                                placeholder={translationString('TR_LABELING_OUTPUT_LABEL')}
+                                maxWidth={250}
+                            >
+                                {outputLabel}
+                            </Labeling>
+                        </InfoSegments>
+                        {!!baseCurrencyValue && (
+                            <Text
+                                typographyStyle="body-sm"
+                                intent="neutral"
+                                priority="secondary"
+                                as="div"
+                            >
+                                {baseCurrencyValue}
+                            </Text>
+                        )}
+                    </Row>
+                </Column>
+            </Row>
+        </GhostContainer>
+    );
+};

--- a/suite/coin-control/src/UtxoSelectionList/UtxoSelectionList.tsx
+++ b/suite/coin-control/src/UtxoSelectionList/UtxoSelectionList.tsx
@@ -1,0 +1,106 @@
+import { type ReactNode } from 'react';
+
+import styled from 'styled-components';
+
+import { getUtxoOutpoint } from '@suite-common/wallet-utils';
+import {
+    Column,
+    IconCircle,
+    type IconCircleIntent,
+    type IconName,
+    Paragraph,
+} from '@trezor/components';
+import type { AccountUtxo, PROTO } from '@trezor/connect';
+import { negativeSpacings, typography } from '@trezor/theme';
+
+import {
+    type CoinControlActions,
+    type CoinControlRenderers,
+    type CoinControlViewModel,
+} from '../types';
+import { UtxoSelection } from './UtxoSelection/UtxoSelection';
+
+const Header = styled.header`
+    align-items: center;
+    display: flex;
+    ${typography['body-sm']}
+    gap: 16px;
+    margin: 6px 0 12px;
+`;
+
+type UtxoSelectionListProps = {
+    account: CoinControlViewModel['account'];
+    coinjoinRegisteredUtxos: AccountUtxo[];
+    coinjoinUnavailableMessages: CoinControlViewModel['coinjoinUnavailableMessages'];
+    composedInputs: PROTO.TxInputType[];
+    description: ReactNode;
+    heading: ReactNode;
+    icon: IconName;
+    iconIntent?: IconCircleIntent;
+    isCoinControlEnabled: boolean;
+    onShowTransactionDetail: CoinControlActions['onShowTransactionDetail'];
+    renderers: CoinControlRenderers;
+    selectedUtxos: AccountUtxo[];
+    toggleUtxoSelection: CoinControlActions['toggleUtxoSelection'];
+    transactions: CoinControlViewModel['transactions'];
+    utxos: AccountUtxo[];
+    withHeader: boolean;
+};
+
+export const UtxoSelectionList = ({
+    account,
+    coinjoinRegisteredUtxos,
+    coinjoinUnavailableMessages,
+    composedInputs,
+    description,
+    heading,
+    icon,
+    iconIntent = 'neutral',
+    isCoinControlEnabled,
+    onShowTransactionDetail,
+    renderers,
+    selectedUtxos,
+    toggleUtxoSelection,
+    transactions,
+    utxos,
+    withHeader,
+}: UtxoSelectionListProps) => (
+    <Column>
+        {withHeader && (
+            <Header>
+                <IconCircle
+                    name={icon}
+                    size={64}
+                    intent={iconIntent}
+                    margin={{ left: negativeSpacings.xs }}
+                />
+                <div>
+                    <Paragraph typographyStyle="body-md" margin={{ bottom: 4 }}>
+                        {heading}
+                    </Paragraph>
+                    <Paragraph typographyStyle="body-md" intent="neutral" priority="secondary">
+                        {description}
+                    </Paragraph>
+                </div>
+            </Header>
+        )}
+        <Column gap={4}>
+            {utxos.map(utxo => (
+                <UtxoSelection
+                    account={account}
+                    coinjoinRegisteredUtxos={coinjoinRegisteredUtxos}
+                    coinjoinUnavailableMessage={coinjoinUnavailableMessages[getUtxoOutpoint(utxo)]}
+                    composedInputs={composedInputs}
+                    isCoinControlEnabled={isCoinControlEnabled}
+                    key={`${utxo.txid}-${utxo.vout}`}
+                    onShowTransactionDetail={onShowTransactionDetail}
+                    renderers={renderers}
+                    selectedUtxos={selectedUtxos}
+                    toggleUtxoSelection={toggleUtxoSelection}
+                    transaction={transactions.find(transaction => transaction.txid === utxo.txid)}
+                    utxo={utxo}
+                />
+            ))}
+        </Column>
+    </Column>
+);

--- a/suite/coin-control/src/UtxoSortingSelect.tsx
+++ b/suite/coin-control/src/UtxoSortingSelect.tsx
@@ -1,0 +1,34 @@
+import { type ReactNode } from 'react';
+
+import { Translation } from '@suite/intl';
+import { type UtxoSorting } from '@suite-common/wallet-types';
+import { type Option, Select } from '@trezor/components';
+
+const sortingOptions: { value: UtxoSorting; label: ReactNode }[] = [
+    { value: 'newestFirst', label: <Translation id="TR_NEWEST_FIRST" /> },
+    { value: 'oldestFirst', label: <Translation id="TR_OLDEST_FIRST" /> },
+    { value: 'smallestFirst', label: <Translation id="TR_SMALLEST_FIRST" /> },
+    { value: 'largestFirst', label: <Translation id="TR_LARGEST_FIRST" /> },
+];
+
+type UtxoSortingSelectProps = {
+    selectUtxoSorting: (ordering: UtxoSorting) => void;
+    utxoSorting?: UtxoSorting;
+};
+
+export const UtxoSortingSelect = ({ selectUtxoSorting, utxoSorting }: UtxoSortingSelectProps) => {
+    const selectedOption = sortingOptions.find(option => option.value === utxoSorting);
+
+    const handleChange = ({ value }: Option) => selectUtxoSorting(value);
+
+    return (
+        <Select
+            data-testid="@coin-control/utxo-sorting-select"
+            onChange={handleChange}
+            options={sortingOptions}
+            size="small"
+            value={selectedOption}
+            width={240}
+        />
+    );
+};

--- a/suite/coin-control/src/index.ts
+++ b/suite/coin-control/src/index.ts
@@ -1,0 +1,7 @@
+export { CoinControl } from './CoinControl';
+export type {
+    CoinControlActions,
+    CoinControlAmountSummary,
+    CoinControlRenderers,
+    CoinControlViewModel,
+} from './types';

--- a/suite/coin-control/src/types.ts
+++ b/suite/coin-control/src/types.ts
@@ -1,0 +1,62 @@
+import { type ReactNode } from 'react';
+
+import { type SearchOutputLabels } from '@suite-common/transaction-search';
+import { type Network } from '@suite-common/wallet-config';
+import {
+    type Account,
+    type UtxoSorting,
+    type WalletAccountTransaction,
+} from '@suite-common/wallet-types';
+import { type AccountUtxo, type PROTO } from '@trezor/connect';
+
+export type CoinControlAmountSummary = {
+    inputCount: number;
+    missingAmount?: {
+        translationId: 'TR_MISSING_TO_INPUT' | 'TR_MISSING_TO_FEE';
+        value: string;
+    };
+    totalInputAmount: string;
+};
+
+export type CoinControlViewModel = {
+    account: Account;
+    allUtxosSelected: boolean;
+    coinjoinRegisteredUtxos: AccountUtxo[];
+    coinjoinUnavailableMessages: Record<string, ReactNode>;
+    composedInputs: PROTO.TxInputType[];
+    dustUtxos: AccountUtxo[];
+    isCoinControlEnabled: boolean;
+    lowAnonymityUtxos: AccountUtxo[];
+    network: Network;
+    outputLabels: SearchOutputLabels;
+    selectedUtxos: AccountUtxo[];
+    spendableUtxos: AccountUtxo[];
+    summary: CoinControlAmountSummary;
+    targetAnonymity?: number;
+    transactions: WalletAccountTransaction[];
+    utxoSorting?: UtxoSorting;
+    utxosPerPage: number;
+};
+
+export type CoinControlActions = {
+    close: () => void;
+    fetchUtxoTransactions: () => { abort: () => void };
+    onShowTransactionDetail: (transaction: WalletAccountTransaction) => void;
+    selectUtxoSorting: (ordering: UtxoSorting) => void;
+    toggleCheckAllUtxos: () => void;
+    toggleCoinControl: () => void;
+    toggleUtxoSelection: (utxo: AccountUtxo) => void;
+};
+
+export type CoinControlRenderers = {
+    renderBaseCurrencyValue: (params: { amount: string; symbol: Account['symbol'] }) => ReactNode;
+    renderCryptoAmount: (params: { symbol: Account['symbol']; value: string }) => ReactNode;
+    renderPagination: (params: {
+        currentPage: number;
+        onPageSelected: (page: number) => void;
+        perPage: number;
+        totalItems: number;
+    }) => ReactNode;
+    renderTransactionTimestamp: (params: { transaction: WalletAccountTransaction }) => ReactNode;
+    renderUtxoAnonymity: (params: { anonymity: number }) => ReactNode;
+};

--- a/suite/coin-control/styled.d.ts
+++ b/suite/coin-control/styled.d.ts
@@ -1,0 +1,9 @@
+import 'styled-components';
+import { type SuiteThemeColors } from '@trezor/components';
+import { type BoxShadows, type Colors, type ThemeVariant } from '@trezor/theme';
+
+declare module 'styled-components' {
+    export interface DefaultTheme extends SuiteThemeColors, Colors, BoxShadows {
+        variant: ThemeVariant;
+    }
+}

--- a/suite/coin-control/tsconfig.json
+++ b/suite/coin-control/tsconfig.json
@@ -1,0 +1,45 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "plugins": [
+            {
+                "name": "typescript-styled-plugin",
+                "tags": ["styled", "css", "sty"]
+            }
+        ],
+        "outDir": "libDev"
+    },
+    "references": [
+        {
+            "path": "../../suite-common/message-system"
+        },
+        {
+            "path": "../../suite-common/redux-utils"
+        },
+        {
+            "path": "../../suite-common/suite-sync"
+        },
+        {
+            "path": "../../suite-common/suite-sync-storage"
+        },
+        {
+            "path": "../../suite-common/transaction-search"
+        },
+        {
+            "path": "../../suite-common/wallet-config"
+        },
+        {
+            "path": "../../suite-common/wallet-types"
+        },
+        {
+            "path": "../../suite-common/wallet-utils"
+        },
+        { "path": "../address" },
+        { "path": "../intl" },
+        { "path": "../labeling" },
+        { "path": "../metadata" },
+        { "path": "../../packages/components" },
+        { "path": "../../packages/connect" },
+        { "path": "../../packages/theme" }
+    ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -14492,6 +14492,32 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@suite/coin-control@workspace:*, @suite/coin-control@workspace:suite/coin-control":
+  version: 0.0.0-use.local
+  resolution: "@suite/coin-control@workspace:suite/coin-control"
+  dependencies:
+    "@suite-common/message-system": "workspace:*"
+    "@suite-common/redux-utils": "workspace:*"
+    "@suite-common/suite-sync": "workspace:*"
+    "@suite-common/suite-sync-storage": "workspace:*"
+    "@suite-common/transaction-search": "workspace:*"
+    "@suite-common/wallet-config": "workspace:*"
+    "@suite-common/wallet-types": "workspace:*"
+    "@suite-common/wallet-utils": "workspace:*"
+    "@suite/address": "workspace:*"
+    "@suite/intl": "workspace:*"
+    "@suite/labeling": "workspace:*"
+    "@suite/metadata": "workspace:*"
+    "@trezor/components": "workspace:*"
+    "@trezor/connect": "workspace:*"
+    "@trezor/theme": "workspace:*"
+    "@types/react": "npm:19.2.14"
+    react: "npm:19.2.4"
+    react-redux: "npm:9.2.0"
+    styled-components: "npm:^6.3.9"
+  languageName: unknown
+  linkType: soft
+
 "@suite/desktop-update@workspace:*, @suite/desktop-update@workspace:suite/desktop-update":
   version: 0.0.0-use.local
   resolution: "@suite/desktop-update@workspace:suite/desktop-update"
@@ -16629,6 +16655,7 @@ __metadata:
     "@suite/analytics": "workspace:*"
     "@suite/authenticity-checks": "workspace:*"
     "@suite/backup": "workspace:*"
+    "@suite/coin-control": "workspace:*"
     "@suite/desktop-update": "workspace:*"
     "@suite/device": "workspace:*"
     "@suite/discreet-mode": "workspace:*"


### PR DESCRIPTION
## Summary

This is a refactoring experiment for the desktop/web CoinControl implementation.

- adds a new `@suite/coin-control` package for the desktop/web CoinControl UI
- changes the existing Suite CoinControl entrypoint into an adapter that passes a view model, actions, and renderers into the package
- keeps Suite-specific send form state, modal dispatching, formatting, and coinjoin selector wiring outside the package

## Notes

This PR is intentionally opened as a draft because the package boundary is experimental and should be reviewed before building further common/native extraction on top of it.

## Validation

- `yarn workspace @suite/coin-control lint:js`
- `yarn g:eslint packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/CoinControl.tsx`
- `yarn workspace @suite/coin-control depcheck`

Type-check note: `yarn nx run @suite/coin-control:type-check` currently fails before checking this package because `@trezor/connect:type-check` cannot resolve missing `submodules/trezor-common` fixture JSON files in this workspace.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/using-worktree/web/](https://dev.suite.sldev.cz/suite-web/using-worktree/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=using-worktree&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=using-worktree&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-12T10:31:09.787Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-12T10:29:15.701Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->