### PR TITLE
fix(solana): time out hung RPC requests

### DIFF
--- a/coins/coins-solana/src/runtime/api.ts
+++ b/coins/coins-solana/src/runtime/api.ts
@@ -11,6 +11,7 @@ import type { ClusterUrl, RpcTransportFromClusterUrl, RpcTransportMainnet } from
 
 const DEFAULT_MAX_RPS = 4; // Default maximum requests per second
 const DEFAULT_INTERVAL = 1000; // Default interval in milliseconds (1 second)
+const DEFAULT_REQUEST_TIMEOUT = 15_000; // Default per-request timeout in milliseconds
 const THROTTLE_OPTIONS: ThrottledTransportOptions = {
     maxRps: 4,
     interval: 100,
@@ -23,7 +24,12 @@ type QueuedRequest<TClusterUrl extends ClusterUrl, TResponse = unknown> = Readon
     resolve: (value: TResponse | PromiseLike<TResponse>) => void;
 }>;
 
-type ThrottledTransportOptions = { maxRps?: number; interval?: number; debug?: boolean };
+type ThrottledTransportOptions = {
+    maxRps?: number;
+    interval?: number;
+    debug?: boolean;
+    timeout?: number;
+};
 
 /**
  * Throttled RPC transport for Solana.
@@ -40,6 +46,7 @@ const getThrottledTransport = <TClusterUrl extends ClusterUrl>(
         maxRps = DEFAULT_MAX_RPS,
         interval = DEFAULT_INTERVAL,
         debug = false,
+        timeout = DEFAULT_REQUEST_TIMEOUT,
     }: ThrottledTransportOptions = {},
 ): RpcTransportFromClusterUrl<TClusterUrl> => {
     /**
@@ -83,7 +90,13 @@ const getThrottledTransport = <TClusterUrl extends ClusterUrl>(
             /**
              * When a request's slot comes up, delegate it to the underlying transport.
              */
-            originalTransport(request.config).then(request.resolve).catch(request.reject);
+            const timeoutSignal = AbortSignal.timeout(timeout);
+            const signal = request.config.signal
+                ? AbortSignal.any([request.config.signal, timeoutSignal])
+                : timeoutSignal;
+            originalTransport({ ...request.config, signal })
+                .then(request.resolve)
+                .catch(request.reject);
             requestBudgetRemaining--;
             if (pendingQueueRunTimerId === undefined) {
                 if (debug) {
@@ -131,17 +144,17 @@ const getThrottledTransport = <TClusterUrl extends ClusterUrl>(
     return throttledTransport as RpcTransportFromClusterUrl<TClusterUrl>;
 };
 
-export const getApi = (url: string, userAgent: string) => {
+export const getApi = (url: string, userAgent: string, timeout = DEFAULT_REQUEST_TIMEOUT) => {
     const clusterUrl = mainnet(url);
     const transport = createDefaultRpcTransport({
         url: clusterUrl,
         headers: { 'User-Agent': userAgent },
     });
 
-    const throttledTransport = getThrottledTransport(
-        transport,
-        THROTTLE_OPTIONS,
-    ) as RpcTransportMainnet;
+    const throttledTransport = getThrottledTransport(transport, {
+        ...THROTTLE_OPTIONS,
+        timeout,
+    }) as RpcTransportMainnet;
     const throttledRpc = createSolanaRpcFromTransport(throttledTransport);
 
     const api = {


### PR DESCRIPTION
## Account discovery (and other Solana calls) hang forever after laptop sleep / network suspend

If the laptop sleeps (or the network drops) **while discovery is running**, discovery never finishes — the spinner stays forever and **only a page reload recovers it** (Retry doesn't help). Reproduces on standard wallets too, not just passphrase ones.

### Root cause
The hanging promise is a **Solana RPC request**. `@solana/kit`'s default HTTP transport has **no timeout** ([`makeHttpRequest` → `fetch(url, { signal })`](packages/blockchain-link/src/workers/solana/index.ts#L109)), so when the OS suspends network IO on sleep (`net::ERR_NETWORK_IO_SUSPENDED`) the request neither resolves nor rejects.

Most visibly this breaks **account discovery**: `discoverAccounts` awaits all coins via `Promise.all`, so one stuck Solana request leaves the whole bundle unsettled → discovery never reaches a terminal status and there's nothing to retry against. But any Solana caller (balance sync, send, …) can hang the same way. Blockbook (websocket) coins are unaffected because the websocket client already enforces a 20s timeout.

### Fix
Wrap the Solana RPC transport (`coins-solana` `getApi`) so every request aborts after a timeout and **rejects**, while still honouring an `abortSignal` a caller may pass via `.send({ abortSignal })`:

- Solana-only — scoped to the Solana transport, doesn't touch other coins.
- Covers **every** Solana RPC call automatically (the throttled transport already forwards `signal`), not just discovery — no need to thread a signal into each `.send()`.
- Timeout is configurable via `BlockchainSettings.timeout` (mirrors the ripple worker), defaulting to 30s.

Once Solana rejects reliably, discovery gets a normal error → ends `failed` → existing Retry works.

> Supersedes the earlier discovery-level `scheduleAction` wrapper, which was a band-aid: it affected all coins and only covered the discovery path.

Resolves: https://github.com/trezor/trezor-suite/issues/19917

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change to coins/coins-solana/src/runtime/api.ts affects the core Solana RPC/runtime API layer, which underpins all Solana transaction construction, fee estimation, account discovery, and staking operations. The highest risk is in Solana staking (stake/unstake/claim) and SOL send flows, which directly exercise transaction building and RPC calls. Trading tests involving Solana sends (swap, sell) are medium risk as they also construct Solana transactions. No static coverage mapping exists for this file, so all recommendations are inferred from behavioral analysis of each test's Solana dependencies.

<details><summary><b>Changed files (1)</b></summary>

- `coins/coins-solana/src/runtime/api.ts`

</details>

**Recommended tests (13)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — This test exercises the full Solana staking flow including transaction simulation, fee calculation, and on-chain interactions that directly depend on the Solana runtime API layer changed in coins-solana/src/runtime/api.ts.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — Stake-more exercises Solana staking transactions (simulateTransaction, program accounts) which route through the Solana runtime API. Changes to api.ts could break transaction construction, fee retrieval, or RPC calls used in this flow.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — Unstaking and claiming SOL involves Solana RPC interactions (deactivate stake, withdraw) that flow through the runtime API. This test covers unstake + claim transactions which directly exercise the changed Solana API layer.
- `suite/e2e/tests/wallet/send-sol.test.ts` — Sending SOL requires constructing and signing Solana transactions, calculating fees, and interacting with Solana RPC endpoints — all of which are mediated by the runtime API. A regression here would break basic SOL send functionality.

</details>

<details><summary>🟡 <b>Medium priority (8)</b></summary>

- `suite/e2e/tests/staking/sol/rewards.test.ts` — Rewards display depends on fetching Solana staking program accounts and epoch data via RPC calls that may go through the runtime API. Changes could affect how staking balances and rewards are retrieved and displayed.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Selling SOL involves constructing a Solana send transaction (routeSolanaSendRequests) which uses the Solana runtime API for transaction building and fee estimation. Changes could affect the send flow within the sell process.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Swapping SOL to USDC involves sending a Solana transaction to the swap provider, which depends on the Solana runtime API for transaction construction and signing. Changes could affect the swap send flow.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Swapping SOL to BTC sends a Solana transaction that goes through the runtime API. The test verifies transaction details (amount, fee, address) which could be affected by API changes.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Swapping USDT (SPL token on Solana) to BTC requires Solana runtime API calls for token transfer transaction construction. Changes to the API layer could break SPL token send flows.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Swapping between Solana SPL tokens (USDT to USDC) uses Solana runtime API for transaction construction. Token-to-token swaps may exercise different code paths in the API than native SOL sends.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — Buying a Solana SPL token (JUP) involves Solana account and token infrastructure. While primarily a buy flow, the receive account selection and token discovery may depend on the Solana runtime API.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — This test validates SOL balance retrieval and fraction calculations in the sell form. The SOL balance display depends on Solana RPC calls (getBalance) which may route through the changed runtime API.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/wallet/receive.test.ts` — The receive test includes SOL address generation and display. While address derivation is mostly device-side, the Solana account discovery that populates the receive flow may use the runtime API.

</details>

_Updated: 2026-06-22T11:13:38.314Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/19917-restarting-discovery-on-shut/web/](https://dev.suite.sldev.cz/suite-web/19917-restarting-discovery-on-shut/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=19917-restarting-discovery-on-shut&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=19917-restarting-discovery-on-shut&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Trading - Buy BTC > Buy Bitcoin from best offer | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-22T11:18:18.298Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-22T11:17:02.264Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->