### PR TITLE
fix(suite-desktop): lower EVM gas fee

### DIFF
--- a/packages/connect/src/backend/fees/__tests__/EthereumFeeLevels.test.ts
+++ b/packages/connect/src/backend/fees/__tests__/EthereumFeeLevels.test.ts
@@ -82,8 +82,8 @@ describe('api/ethereum/Fees', () => {
             // @ts-expect-error: indexing with noUncheckedIndexedAccess
             const [level]: [FeeLevel] = levels;
 
-            // 0.1 Gwei → 0.1 × 1e9 = 100 000 000 wei
-            expect(level.feePerUnit).toBe('100000000');
+            // 0.001 Gwei → 0.001 × 1e9 = 1 000 000 wei
+            expect(level.feePerUnit).toBe('1000000');
 
             backend.disconnect();
             spy.mockRestore();
@@ -129,10 +129,10 @@ describe('api/ethereum/Fees', () => {
 
             const levels = await feeLevels.load(backend, ETH_REQUEST);
 
-            // minFee for eth = 0.1 Gwei → 0.1 × 1e9 = 100 000 000 wei
-            // maxFeePerGas must be an integer wei string, never a decimal gwei string like "0.1"
+            // minFee for eth = 0.001 Gwei → 0.001 × 1e9 = 1 000 000 wei
+            // maxFeePerGas must be an integer wei string, never a decimal gwei string like "0.001"
             levels.forEach(level => {
-                expect(Number(level.maxFeePerGas)).toBeGreaterThanOrEqual(100000000);
+                expect(Number(level.maxFeePerGas)).toBeGreaterThanOrEqual(1000000);
                 expect(level.maxFeePerGas).toMatch(/^\d+$/);
             });
 

--- a/packages/connect/src/data/__tests__/defaultFeeLevels.test.ts
+++ b/packages/connect/src/data/__tests__/defaultFeeLevels.test.ts
@@ -3,7 +3,7 @@ import { getEthereumFeeLevels } from '../defaultFeeLevels';
 describe('getEthereumFeeLevels', () => {
     const fixtures = {
         eth: {
-            defaultGas: 15,
+            defaultGas: 3,
             minFee: 0.001,
             maxFee: 10000,
             coinInfo: {
@@ -15,7 +15,7 @@ describe('getEthereumFeeLevels', () => {
                 defaultFees: [
                     {
                         label: 'normal',
-                        feePerUnit: '10000000000', // 10 Gwei * 1e9 = 15000000000 Wei
+                        feePerUnit: '3000000000', // 3 Gwei * 1e9 = 3000000000 Wei
                         feeLimit: '21000',
                         blocks: -1,
                     },
@@ -28,7 +28,7 @@ describe('getEthereumFeeLevels', () => {
         },
         pol: {
             defaultGas: 200,
-            minFee: 0.001,
+            minFee: 0.1,
             maxFee: 10000000,
             coinInfo: {
                 chain: 'pol',
@@ -44,7 +44,7 @@ describe('getEthereumFeeLevels', () => {
                         blocks: -1,
                     },
                 ],
-                minFee: 0.001,
+                minFee: 0.1,
                 maxFee: 10000000,
                 minPriorityFee: 30,
                 dustLimit: -1,

--- a/packages/connect/src/data/__tests__/defaultFeeLevels.test.ts
+++ b/packages/connect/src/data/__tests__/defaultFeeLevels.test.ts
@@ -4,7 +4,7 @@ describe('getEthereumFeeLevels', () => {
     const fixtures = {
         eth: {
             defaultGas: 15,
-            minFee: 0.1,
+            minFee: 0.001,
             maxFee: 10000,
             coinInfo: {
                 chain: 'eth',
@@ -20,7 +20,7 @@ describe('getEthereumFeeLevels', () => {
                         blocks: -1,
                     },
                 ],
-                minFee: 0.1,
+                minFee: 0.001,
                 maxFee: 10000,
                 minPriorityFee: 0,
                 dustLimit: -1,
@@ -28,7 +28,7 @@ describe('getEthereumFeeLevels', () => {
         },
         pol: {
             defaultGas: 200,
-            minFee: 0.1,
+            minFee: 0.001,
             maxFee: 10000000,
             coinInfo: {
                 chain: 'pol',
@@ -44,7 +44,7 @@ describe('getEthereumFeeLevels', () => {
                         blocks: -1,
                     },
                 ],
-                minFee: 0.1,
+                minFee: 0.001,
                 maxFee: 10000000,
                 minPriorityFee: 30,
                 dustLimit: -1,

--- a/packages/connect/src/data/defaultFeeLevels.ts
+++ b/packages/connect/src/data/defaultFeeLevels.ts
@@ -28,9 +28,9 @@ const EVM_GAS_PRICE_PER_CHAIN_IN_GWEI: Record<
     string,
     { min: number; max: number; defaultGas: number; minPriorityFee: number }
 > = {
-    eth: { min: 0.1, max: 10000, defaultGas: 10, minPriorityFee: 0 },
-    pol: { min: 0.1, max: 10000000, defaultGas: 200, minPriorityFee: 30 },
-    bsc: { min: 0.1, max: 100000, defaultGas: 1, minPriorityFee: 0 },
+    eth: { min: 0.001, max: 10000, defaultGas: 10, minPriorityFee: 0 },
+    pol: { min: 0.001, max: 10000000, defaultGas: 200, minPriorityFee: 30 },
+    bsc: { min: 0.001, max: 100000, defaultGas: 1, minPriorityFee: 0 },
     base: { min: 0.0000001, max: 1000, defaultGas: 0.01, minPriorityFee: 0 },
     arb: { min: 0.001, max: 1000, defaultGas: 0.01, minPriorityFee: 0 },
     op: { min: 0.000000001, max: 1000, defaultGas: 0.01, minPriorityFee: 0 },

--- a/packages/connect/src/data/defaultFeeLevels.ts
+++ b/packages/connect/src/data/defaultFeeLevels.ts
@@ -28,8 +28,15 @@ const EVM_GAS_PRICE_PER_CHAIN_IN_GWEI: Record<
     string,
     { min: number; max: number; defaultGas: number; minPriorityFee: number }
 > = {
-    eth: { min: 0.001, max: 10000, defaultGas: 10, minPriorityFee: 0 },
-    pol: { min: 0.001, max: 10000000, defaultGas: 200, minPriorityFee: 30 },
+    // eth defaultGas lowered 10 -> 3 (2026-06-15): post-Fusaka mainnet base fee is
+    // typically ~0.1-0.5 Gwei with a ~0.01-0.1 Gwei tip, so 3 Gwei is a safe fallback
+    // with headroom for spikes (10 Gwei was ~20x typical conditions).
+    eth: { min: 0.001, max: 10000, defaultGas: 3, minPriorityFee: 0 },
+    // pol min kept at 0.1 (NOT lowered to 0.001): Polygon enforces a high priority-fee
+    // floor, so a sub-Gwei total-fee floor is unreachable noise. Per the Polygon gas
+    // station on 2026-06-15, base fee was ~250 Gwei and the safeLow tip ~44 Gwei, so
+    // minPriorityFee: 30 is still valid (conservative) and must not be lowered.
+    pol: { min: 0.1, max: 10000000, defaultGas: 200, minPriorityFee: 30 },
     bsc: { min: 0.001, max: 100000, defaultGas: 1, minPriorityFee: 0 },
     base: { min: 0.0000001, max: 1000, defaultGas: 0.01, minPriorityFee: 0 },
     arb: { min: 0.001, max: 1000, defaultGas: 0.01, minPriorityFee: 0 },

--- a/packages/suite/src/hooks/wallet/useRbfForm.ts
+++ b/packages/suite/src/hooks/wallet/useRbfForm.ts
@@ -91,12 +91,14 @@ const getEthereumFeeInfo = (info: FeeInfo, rbfParams: RbfTransactionParamsEthere
         const highMaxPriorityFeePerGas = highLevel.maxPriorityFeePerGas;
         const newMaxFeePerGas = BigNumber.maximum(currentMaxFee, highMaxFeePerGas ?? 0)
             .multipliedBy(ETH_SPEED_UP_TX_MULTIPLIER)
+            .decimalPlaces(9, BigNumber.ROUND_UP)
             .toString();
         const newMaxPriorityFeePerGas = BigNumber.maximum(
             currentMaxPriorityFee,
             highMaxPriorityFeePerGas ?? 0,
         )
             .multipliedBy(ETH_SPEED_UP_TX_MULTIPLIER)
+            .decimalPlaces(9, BigNumber.ROUND_UP)
             .toString();
 
         return {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

According to the conversation in related issue adjusted default fees for `eth`, `pol` and `bsc`

There also was an issue with decimal places on RBF, also fixed

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

It would worth checking that transaction can be submitted at least once on each chain followed by a successful inclusion. 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26198

## Screenshots:

<img width="783" height="972" alt="Screenshot 2026-06-12 at 11 11 30" src="https://github.com/user-attachments/assets/cdba2efc-e16a-4a3d-828f-436d218c9068" />

<img width="790" height="909" alt="Screenshot 2026-06-12 at 11 11 34" src="https://github.com/user-attachments/assets/f880c10c-36b1-4aaf-b307-1f3fdb597747" />


Side-fix for decimal places on tx bump and adjusting gas
<img width="806" height="929" alt="Screenshot 2026-06-12 at 11 12 59" src="https://github.com/user-attachments/assets/e2908137-3642-4ced-86e5-c3f68726788e" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies Ethereum fee level defaults (defaultFeeLevels.ts), a wallet RBF (Replace-By-Fee) hook (useRbfForm.ts), and their unit tests. The primary risk is that fee calculations for Ethereum/EVM transactions and Bitcoin RBF flows could produce incorrect values, affecting send forms, staking confirmations, and trading flows. Both changed source files map to 121+ tests as broad dependencies, so testing is focused on the tests that specifically verify fee display, custom fee settings, and transaction speed-up (RBF) functionality. The unit test files have no E2E coverage and are expected to run in the unit test pipeline.

<details><summary><b>Changed files (4)</b></summary>

- `packages/connect/src/backend/fees/__tests__/EthereumFeeLevels.test.ts`
- `packages/connect/src/data/__tests__/defaultFeeLevels.test.ts`
- `packages/connect/src/data/defaultFeeLevels.ts`
- `packages/suite/src/hooks/wallet/useRbfForm.ts`

</details>

**Recommended tests (18)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test exercises the full ETH staking flow including transaction confirmation with fee display on the device. Changes to defaultFeeLevels.ts directly affect Ethereum fee calculation, and the test verifies fee amounts shown during staking transactions.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — This test explicitly verifies custom Ethereum fee parameters (gas limit, max fee per gas, max priority fee per gas) through the swap flow and on the hardware device display. Changes to defaultFeeLevels.ts directly affect how Ethereum fee levels are computed and presented.
- `suite/e2e/tests/wallet/send-eth.test.ts` — This test directly verifies Ethereum send form custom fee parameters (gas limit, max fee per gas, max priority fee per gas) on both Suite UI and device emulator. defaultFeeLevels.ts changes directly affect these fee calculations, and useRbfForm.ts is part of the send flow infrastructure.
- `suite/e2e/tests/wallet/send-base.test.ts` — This test verifies custom Ethereum-like fees (gas limit, max fee, priority fee) on the Base EVM L2 network, including device display verification. Changes to defaultFeeLevels.ts affect EVM fee level computation used in this flow.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — This test verifies custom Bitcoin fee rates in the swap flow, checking fee rate display on device. Changes to defaultFeeLevels.ts affect Bitcoin fee level defaults, and useRbfForm.ts is related to Bitcoin transaction fee handling (RBF).
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — This test sends Bitcoin transactions on regtest and exercises the speed-up (RBF) related flow. useRbfForm.ts is the hook that powers RBF functionality, and pending transactions with speed-up options directly exercise this code path.

</details>

<details><summary>🟡 <b>Medium priority (10)</b></summary>

- `suite/e2e/tests/staking/eth/unstake.test.ts` — This test exercises ETH unstaking and claiming transactions with fee verification on device. Changes to defaultFeeLevels.ts could affect the fee amounts displayed during these transaction confirmations.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Tests the stake-more ETH flow which displays transaction fees on device. The pending transaction speed-up button is also tested, which could relate to RBF-like functionality. Fee level changes could affect displayed amounts.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test exercises the Bitcoin send form on regtest including locktime and custom outputs. Both defaultFeeLevels.ts (Bitcoin fee levels) and useRbfForm.ts (RBF for Bitcoin sends) are relevant to this send flow.
- `suite/e2e/tests/wallet/send-doge.test.ts` — This test sends a DOGE transaction and verifies fee display on the device prompt. Changes to defaultFeeLevels.ts could affect fee calculation for DOGE (UTXO-based coin).
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — This test exercises the BTC sell flow including device prompt verification of fee amounts. Bitcoin fee levels from defaultFeeLevels.ts and useRbfForm.ts for BTC transaction handling are both relevant.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Tests ETH sell flow with custom gas fee settings. Changes to Ethereum fee levels in defaultFeeLevels.ts directly affect how gas fees are initialized and displayed.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Tests SOL sell flow with fee verification and transaction speed-up button. defaultFeeLevels.ts changes could affect Solana fee calculation, and the speed-up button behavior relates to transaction replacement logic.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — This test explicitly exercises custom BTC fee rate settings and Max button calculations that subtract fees from balance. Changes to defaultFeeLevels.ts affect the fee values used in these calculations.
- `suite/e2e/tests/wallet/send-sol.test.ts` — Tests Solana send-max flow with fee deduction. Changes to defaultFeeLevels.ts could affect how Solana fees are computed for the max amount calculation.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — Tests LTC send form with broadcast mode. Both defaultFeeLevels.ts (LTC fee levels) and useRbfForm.ts (UTXO-based send form infrastructure) are relevant.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Tests selling an ERC-20 token which involves Ethereum fee calculation. Fee level changes could affect the displayed fee in the device prompt.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Tests SOL staking with fee display on device. Fee level defaults could affect Solana transaction fee presentation, though the connection is less direct than for ETH.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/connect/src/backend/fees/__tests__/EthereumFeeLevels.test.ts`
- `packages/connect/src/data/__tests__/defaultFeeLevels.test.ts`

_Updated: 2026-06-15T11:58:32.347Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/evm-gas-fees&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/evm-gas-fees&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/evm-gas-fees&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-15T12:02:55.416Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-15T12:00:46.093Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/evm-gas-fees/web/](https://dev.suite.sldev.cz/suite-web/fix/evm-gas-fees/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->