### PR TITLE
chore(wallet-config): replace hardcoded external backend networks with per-network flag

### DIFF
--- a/packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts
@@ -18,6 +18,7 @@ const DEFAULT_ACCOUNT = {
     networkType: 'bitcoin',
     descriptor: 'xpub',
     key: 'xpub-btc-deviceState',
+    visible: true,
     history: {
         total: 0,
     },
@@ -342,6 +343,28 @@ export const onBlock = analyzeTransactions
             block: BLOCK,
             state: {
                 accounts: [],
+            },
+            result: [blockchainActions.synced.type],
+        },
+        {
+            description: 'external backend network is skipped without a custom backend',
+            block: { coin: { shortcut: 'pol' } },
+            state: {
+                accounts: [{ ...DEFAULT_ACCOUNT, symbol: 'pol', networkType: 'ethereum' }],
+            },
+        },
+        {
+            description: 'external backend network syncs when a custom backend is configured',
+            block: { coin: { shortcut: 'pol' } },
+            state: {
+                accounts: [
+                    { ...DEFAULT_ACCOUNT, symbol: 'pol', networkType: 'ethereum', visible: false },
+                ],
+                blockchain: {
+                    pol: {
+                        backends: { selected: 'blockbook', urls: { blockbook: ['http://url'] } },
+                    },
+                },
             },
             result: [blockchainActions.synced.type],
         },

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/CustomBackends/BackendTypeSelect.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/CustomBackends/BackendTypeSelect.tsx
@@ -40,7 +40,7 @@ const useBackendOptions = (network: Network, isDebugModeActive: boolean) => {
 
     return useMemo(
         () =>
-            ['default', ...network.backendTypes]
+            ['default', ...network.backendOptions.map(option => option.type)]
                 .filter(backend => {
                     switch (backend) {
                         case 'default':

--- a/suite-common/wallet-config/src/__tests__/utils.test.ts
+++ b/suite-common/wallet-config/src/__tests__/utils.test.ts
@@ -1,6 +1,12 @@
 import { networks } from '../networksConfig';
 import { type NetworkSymbol } from '../types';
-import { getMainnets, getTestnets, isAccountBasedNetwork, isAccountOfNetwork } from '../utils';
+import {
+    getMainnets,
+    getTestnets,
+    isAccountBasedNetwork,
+    isAccountOfNetwork,
+    isNetworkUsingExternalBackend,
+} from '../utils';
 
 const { btc: bitcoin, eth: ethereum, test: testnet, regtest } = networks;
 
@@ -72,4 +78,20 @@ describe('isAccountBasedNetwork', () => {
     it('returns throw for unknown network type', () => {
         expect(() => isAccountBasedNetwork('unknown' as NetworkSymbol)).toThrow();
     });
+});
+
+describe(isNetworkUsingExternalBackend.name, () => {
+    it.each<NetworkSymbol>(['bsc', 'pol', 'op', 'arb', 'base', 'avax', 'sol', 'dsol'])(
+        'returns true for %s',
+        symbol => {
+            expect(isNetworkUsingExternalBackend(symbol)).toBe(true);
+        },
+    );
+
+    it.each<NetworkSymbol>(['btc', 'eth', 'trx', 'xlm', 'xrp', 'ada'])(
+        'returns false for %s',
+        symbol => {
+            expect(isNetworkUsingExternalBackend(symbol)).toBe(false);
+        },
+    );
 });

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -15,7 +15,7 @@ export const networks = {
         testnet: false,
         explorer: getExplorerUrls('https://mempool.space', 'bitcoin'),
         features: ['rbf', 'sign-verify', 'amount-unit', 'graph'],
-        backendTypes: ['blockbook', 'electrum'],
+        backendOptions: [{ type: 'blockbook' }, { type: 'electrum' }],
         accountTypes: {
             coinjoin: {
                 accountType: 'coinjoin',
@@ -65,7 +65,7 @@ export const networks = {
             'graph',
             'claim-rewards',
         ],
-        backendTypes: ['blockbook', 'evm-rpc'],
+        backendOptions: [{ type: 'blockbook' }, { type: 'evm-rpc' }],
         accountTypes: {
             ledger: {
                 // ledger (live), #1 acc is same as Trezor, so it is skipped
@@ -106,7 +106,7 @@ export const networks = {
             'eip1559',
             'graph',
         ],
-        backendTypes: ['blockbook', 'evm-rpc'],
+        backendOptions: [{ type: 'blockbook', isExternalBackend: true }, { type: 'evm-rpc' }],
         accountTypes: {
             ledger: {
                 // ledger (live), #1 acc is same as Trezor, so it is skipped
@@ -141,7 +141,7 @@ export const networks = {
             'mev-protection',
             'graph',
         ],
-        backendTypes: ['blockbook', 'evm-rpc'],
+        backendOptions: [{ type: 'blockbook', isExternalBackend: true }, { type: 'evm-rpc' }],
         accountTypes: {
             ledger: {
                 // ledger (live), #1 acc is same as Trezor, so it is skipped
@@ -178,7 +178,7 @@ export const networks = {
             'eip1559',
             'graph',
         ],
-        backendTypes: ['blockbook', 'evm-rpc'],
+        backendOptions: [{ type: 'blockbook', isExternalBackend: true }, { type: 'evm-rpc' }],
         accountTypes: {
             ledger: {
                 // ledger (live), #1 acc is same as Trezor, so it is skipped
@@ -215,7 +215,7 @@ export const networks = {
             'mev-protection',
             'graph',
         ],
-        backendTypes: ['blockbook', 'evm-rpc'],
+        backendOptions: [{ type: 'blockbook', isExternalBackend: true }, { type: 'evm-rpc' }],
         accountTypes: {
             ledger: {
                 // ledger (live), #1 acc is same as Trezor, so it is skipped
@@ -252,7 +252,7 @@ export const networks = {
             'eip1559',
             'graph',
         ],
-        backendTypes: ['blockbook', 'evm-rpc'],
+        backendOptions: [{ type: 'blockbook', isExternalBackend: true }, { type: 'evm-rpc' }],
         accountTypes: {
             ledger: {
                 // ledger (live), #1 acc is same as Trezor, so it is skipped
@@ -288,7 +288,7 @@ export const networks = {
             'eip1559',
             'graph',
         ],
-        backendTypes: ['blockbook', 'evm-rpc'],
+        backendOptions: [{ type: 'blockbook', isExternalBackend: true }, { type: 'evm-rpc' }],
         accountTypes: {
             ledger: {
                 // ledger (live), #1 acc is same as Trezor, so it is skipped
@@ -319,7 +319,7 @@ export const networks = {
             [DeviceModelInternal.T3T1]: '2.0.0',
             [DeviceModelInternal.T3W1]: '2.0.0',
         },
-        backendTypes: ['solana'],
+        backendOptions: [{ type: 'solana', isExternalBackend: true }],
         accountTypes: {
             ledger: {
                 // bip44Change - Ledger Live
@@ -351,7 +351,7 @@ export const networks = {
             [DeviceModelInternal.T3T1]: '2.11.0',
             [DeviceModelInternal.T3W1]: '2.11.0',
         },
-        backendTypes: ['blockbook'],
+        backendOptions: [{ type: 'blockbook' }],
         accountTypes: {
             ledger: {
                 // ledger (live), #1 acc is same as Trezor, so it is skipped
@@ -383,7 +383,7 @@ export const networks = {
             [DeviceModelInternal.T3T1]: '2.0.0',
             [DeviceModelInternal.T3W1]: '2.0.0',
         },
-        backendTypes: ['blockfrost'],
+        backendOptions: [{ type: 'blockfrost' }],
         accountTypes: {
             legacy: {
                 // icarus-trezor derivation, differs from default just for 24 words seed
@@ -413,7 +413,7 @@ export const networks = {
         testnet: false,
         explorer: getExplorerUrls('https://etc.trezor.io', 'ethereum'),
         features: ['sign-verify', 'tokens', 'coin-definitions', 'graph'],
-        backendTypes: ['blockbook', 'evm-rpc'],
+        backendOptions: [{ type: 'blockbook' }, { type: 'evm-rpc' }],
         accountTypes: {},
         coingeckoId: 'ethereum-classic',
         tradeCryptoId: 'ethereum-classic',
@@ -429,7 +429,7 @@ export const networks = {
         testnet: false,
         explorer: getExplorerUrls('https://xrpscan.com', 'ripple'),
         features: [],
-        backendTypes: ['ripple'],
+        backendOptions: [{ type: 'ripple' }],
         accountTypes: {},
         coingeckoId: 'ripple',
         tradeCryptoId: 'ripple',
@@ -445,7 +445,7 @@ export const networks = {
         testnet: false,
         explorer: getExplorerUrls('https://stellar.expert/explorer/public', 'stellar'),
         features: ['tokens', 'coin-definitions'],
-        backendTypes: ['stellar'],
+        backendOptions: [{ type: 'stellar' }],
         accountTypes: {},
         coingeckoId: 'stellar',
         tradeCryptoId: 'stellar',
@@ -462,7 +462,7 @@ export const networks = {
         testnet: false,
         explorer: getExplorerUrls('https://blockchair.com/litecoin', 'bitcoin'),
         features: ['sign-verify', 'graph'],
-        backendTypes: ['blockbook'],
+        backendOptions: [{ type: 'blockbook' }],
         accountTypes: {
             segwit: {
                 accountType: 'segwit',
@@ -488,7 +488,7 @@ export const networks = {
         testnet: false,
         explorer: getExplorerUrls('https://blockchair.com/bitcoin-cash', 'bitcoin'),
         features: ['sign-verify', 'graph'],
-        backendTypes: ['blockbook'],
+        backendOptions: [{ type: 'blockbook' }],
         accountTypes: {},
         coingeckoId: 'bitcoin-cash',
         tradeCryptoId: 'bitcoin-cash',
@@ -504,7 +504,7 @@ export const networks = {
         testnet: false,
         explorer: getExplorerUrls('https://blockchair.com/dogecoin', 'bitcoin'),
         features: ['sign-verify', 'graph'],
-        backendTypes: ['blockbook'],
+        backendOptions: [{ type: 'blockbook' }],
         accountTypes: {},
         coingeckoId: 'dogecoin',
         tradeCryptoId: 'dogecoin',
@@ -521,7 +521,7 @@ export const networks = {
         testnet: false,
         explorer: getExplorerUrls('https://blockchair.com/zcash', 'bitcoin'),
         features: ['sign-verify', 'graph'],
-        backendTypes: ['blockbook'],
+        backendOptions: [{ type: 'blockbook' }],
         accountTypes: {},
         coingeckoId: 'zcash',
         tradeCryptoId: 'zcash',
@@ -538,7 +538,7 @@ export const networks = {
         testnet: true,
         explorer: getExplorerUrls('https://mempool.space/testnet4', 'bitcoin'),
         features: ['rbf', 'sign-verify', 'amount-unit', 'graph'],
-        backendTypes: ['blockbook', 'electrum'],
+        backendOptions: [{ type: 'blockbook' }, { type: 'electrum' }],
         accountTypes: {
             coinjoin: {
                 accountType: 'coinjoin',
@@ -575,7 +575,7 @@ export const networks = {
         testnet: true,
         explorer: getExplorerUrls('http://localhost:19121', 'bitcoin'),
         features: ['rbf', 'sign-verify', 'amount-unit', 'graph'],
-        backendTypes: ['blockbook', 'electrum'],
+        backendOptions: [{ type: 'blockbook' }, { type: 'electrum' }],
         accountTypes: {
             coinjoin: {
                 accountType: 'coinjoin',
@@ -613,7 +613,7 @@ export const networks = {
         testnet: true,
         explorer: getExplorerUrls('https://sepolia.etherscan.io', 'ethereum'),
         features: ['rbf', 'sign-verify', 'tokens', 'nfts', 'eip1559', 'graph'],
-        backendTypes: ['blockbook', 'evm-rpc'],
+        backendOptions: [{ type: 'blockbook' }, { type: 'evm-rpc' }],
         accountTypes: {
             legacy: {
                 accountType: 'legacy',
@@ -636,7 +636,7 @@ export const networks = {
         testnet: true,
         explorer: getExplorerUrls('https://hoodi.etherscan.io/', 'ethereum'),
         features: ['rbf', 'sign-verify', 'tokens', 'staking', 'nfts', 'eip1559', 'graph'],
-        backendTypes: ['blockbook', 'evm-rpc'],
+        backendOptions: [{ type: 'blockbook' }, { type: 'evm-rpc' }],
         accountTypes: {
             legacy: {
                 accountType: 'legacy',
@@ -665,7 +665,7 @@ export const networks = {
             [DeviceModelInternal.T3T1]: '2.0.0',
             [DeviceModelInternal.T3W1]: '2.0.0',
         },
-        backendTypes: ['solana'],
+        backendOptions: [{ type: 'solana', isExternalBackend: true }],
         accountTypes: {},
         coingeckoId: undefined,
         tradeCryptoId: undefined,
@@ -682,7 +682,7 @@ export const networks = {
         testnet: true,
         explorer: getExplorerUrls('https://test.bithomp.com', 'ripple'),
         features: ['tokens'],
-        backendTypes: [],
+        backendOptions: [],
         accountTypes: {},
         coingeckoId: undefined,
         tradeCryptoId: 'test-ripple', // fake, coingecko does not have testnets
@@ -698,7 +698,7 @@ export const networks = {
         testnet: true,
         explorer: getExplorerUrls('https://stellar.expert/explorer/testnet', 'stellar'),
         features: ['tokens'],
-        backendTypes: ['stellar'],
+        backendOptions: [{ type: 'stellar' }],
         accountTypes: {},
         coingeckoId: undefined,
         tradeCryptoId: undefined,
@@ -715,7 +715,7 @@ export const networks = {
         testnet: true,
         features: ['tokens', 'graph', 'nfts'],
         explorer: getExplorerUrls('https://nile.tronscan.org/#', 'tron'),
-        backendTypes: ['blockbook'],
+        backendOptions: [{ type: 'blockbook' }],
         accountTypes: {},
         coingeckoId: undefined,
         tradeCryptoId: 'test-tron',

--- a/suite-common/wallet-config/src/types.ts
+++ b/suite-common/wallet-config/src/types.ts
@@ -64,6 +64,12 @@ export type TrezorConnectBackendType = (typeof TREZOR_CONNECT_BACKENDS)[number];
 type NonStandardBackendType = 'coinjoin';
 export type BackendType = TrezorConnectBackendType | NonStandardBackendType;
 
+export type BackendOption = {
+    type: BackendType;
+    // Backend whose nodes run on third-party infrastructure Trezor pays for, not Trezor's own.
+    isExternalBackend?: boolean;
+};
+
 export type NetworkFeature =
     | 'rbf'
     | 'nfts'
@@ -130,7 +136,7 @@ type NetworkWithSpecificKey<TKey extends NetworkSymbol> = {
     isHidden?: boolean; // not used here, but supported elsewhere
     chainId?: number;
     features: NetworkFeature[];
-    backendTypes: BackendType[];
+    backendOptions: BackendOption[];
     support?: NetworkDeviceSupport;
     isDebugOnlyNetwork?: boolean;
     isExperimentalOnlyNetwork?: boolean;

--- a/suite-common/wallet-config/src/utils.ts
+++ b/suite-common/wallet-config/src/utils.ts
@@ -64,24 +64,11 @@ export const getTestnets = ({
 export const getTestnetSymbols = () => getTestnets({ useTestnetNetworks: true }).map(n => n.symbol);
 
 export const isBlockbookBasedNetwork = (symbol: NetworkSymbol) =>
-    networks[symbol]?.backendTypes.some(backend => backend === 'blockbook');
+    networks[symbol]?.backendOptions.some(option => option.type === 'blockbook');
 
-// TODO: move to networksConfig
-export const externalBackendTypeNetworks: NetworkSymbol[] = [
-    'bsc',
-    'pol',
-    'op',
-    'arb',
-    'base',
-    'avax',
-];
-
-export const isTrezorInfraBasedNetwork = (symbol: NetworkSymbol) =>
-    // https://github.com/trezor/trezor-suite/issues/18843
-    networks[symbol]?.backendTypes.some(
-        backend =>
-            ['blockbook', 'stellar'].includes(backend) &&
-            !externalBackendTypeNetworks.includes(symbol),
+export const isNetworkUsingExternalBackend = (symbol: NetworkSymbol) =>
+    !!networks[symbol]?.backendOptions.some(
+        option => 'isExternalBackend' in option && option.isExternalBackend,
     );
 
 export const getNetworkType = (symbol: NetworkSymbol) => networks[symbol]?.networkType;

--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
@@ -3,10 +3,9 @@ import { createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import {
     type NetworkSymbol,
-    externalBackendTypeNetworks,
     getNetworkOptional,
     isNetworkSymbol,
-    isTrezorInfraBasedNetwork,
+    isNetworkUsingExternalBackend,
 } from '@suite-common/wallet-config';
 import type { Account, CustomBackend } from '@suite-common/wallet-types';
 import {
@@ -32,7 +31,11 @@ import type { TimerId } from '@trezor/type-utils';
 import { arrayDistinct, arrayToDictionary } from '@trezor/utils';
 
 import { BLOCKCHAIN_MODULE_PREFIX, blockchainActions } from './blockchainActions';
-import { selectBlockchainState, selectNetworkBlockchainInfo } from './blockchainReducer';
+import {
+    selectBlockchainState,
+    selectIsCustomBackendConfigured,
+    selectNetworkBlockchainInfo,
+} from './blockchainReducer';
 import { selectAccounts } from '../accounts/accountsSelectors';
 import { fetchAndUpdateAccountThunk, reportWalletBalanceThunk } from '../accounts/accountsThunks';
 import { preloadFeeInfoThunk } from '../fees/feesThunks';
@@ -239,13 +242,12 @@ export const syncAccountsWithBlockchainThunk = createThunk(
         // First clear, to cancel last planned sync
         tryClearTimeout(blockchain[symbol].syncTimeout);
 
-        // Only Trezor infra networks sync, and only when app window is active
+        // Sync only when the app window is active
         const shouldSync = isWindowVisible;
 
         if (shouldSync) {
-            // non-blockbook + networks using external nodes will not update periodically if not visible in UI (sidebar)
             const visibleAccounts = findAccountsByNetwork(symbol, accounts).filter(
-                account => isTrezorInfraBasedNetwork(symbol) || account.visible,
+                account => account.visible,
             );
 
             await Promise.all(
@@ -285,18 +287,21 @@ export const onBlockchainConnectThunk = createThunk(
 
 export const onBlockMinedThunk = createThunk(
     `${BLOCKCHAIN_MODULE_PREFIX}/onBlockMinedThunk`,
-    (block: BlockchainBlock, { dispatch }) => {
+    (block: BlockchainBlock, { dispatch, getState }) => {
         const symbol = block.coin.shortcut.toLowerCase();
-        const network = getNetworkOptional(symbol);
 
         if (!isNetworkSymbol(symbol)) {
             return;
         }
 
-        // Don't sync fast networks because a new block is emitted every few seconds.
-        // Accounts are updated via account subscription or also by the timer in syncAccountsWithBlockchainThunk.
-        // Solana - new block every ~333ms, EVMs 0.3s-3s
-        if (network?.networkType === 'solana' || externalBackendTypeNetworks.includes(symbol)) {
+        // Don't sync fast networks running on our metered external backend because a new block is
+        // emitted every few seconds (Solana ~333ms, EVMs 0.3s-3s); the periodic timer in
+        // syncAccountsWithBlockchainThunk and account subscriptions keep them updated instead.
+        // A custom backend is the user's own infrastructure, so the metered concern no longer applies.
+        if (
+            isNetworkUsingExternalBackend(symbol) &&
+            !selectIsCustomBackendConfigured(getState(), symbol)
+        ) {
             return;
         }
 


### PR DESCRIPTION
Moves the hardcoded `externalBackendTypeNetworks` array from wallet-config utils into `networksConfig` as a per-network `isExternalBackend` flag and updates all consumers.

Review follow-ups (these change runtime behavior, so it is no longer a pure refactor):
- Renamed the flag to `isExternalBackend` and removed the `isTrezorInfraBackend` / `isTrezorBackendUrl` `trezor.io` host-matching workaround (now dead after the change below).
- Flagged Solana (`sol`, `dsol`) as an external backend and renamed the helper `networkUsesExternalBackend` → `isNetworkUsingExternalBackend`.
- `onBlockMinedThunk` now skips per-block sync only for external-backend networks **that are not using a custom backend** (a custom backend is the user's own infrastructure via `selectIsCustomBackendConfigured`, so it syncs normally).
- Hidden (non-visible) accounts are no longer refreshed by the periodic sync timer, even on Trezor infrastructure.

Resolves #16833

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes center around wallet-config (networksConfig, types, utils), the BackendTypeSelect UI component for custom backend configuration, and blockchainThunks for blockchain connectivity. These are broadly imported files (121 tests each), so testing should focus on tests that directly exercise custom backend configuration, network discovery, and coin settings — the features most likely affected. The highest risk is in the BackendTypeSelect component and any changes to network definitions or blockchain connection logic that could break discovery or custom backend setup.

<details><summary><b>Changed files (7)</b></summary>

- `packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/CustomBackends/BackendTypeSelect.tsx`
- `suite-common/wallet-config/src/__tests__/utils.test.ts`
- `suite-common/wallet-config/src/networksConfig.ts`
- `suite-common/wallet-config/src/types.ts`
- `suite-common/wallet-config/src/utils.ts`
- `suite-common/wallet-core/src/blockchain/blockchainThunks.ts`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test directly exercises custom backend configuration for BTC/ETH, including the BackendTypeSelect component that was changed. It tests enabling networks, configuring blockbook backends via advanced settings, and verifying discovery with custom backends — all touching networksConfig, wallet-config utils, blockchainThunks, and the BackendTypeSelect UI component.
- `suite/e2e/tests/settings/coins.test.ts` — This test enables/disables coin networks, activates assets via a modal, configures custom blockbook backends for ETH (including BackendType selection), and verifies custom backend indicators. It directly exercises the BackendTypeSelect component, networksConfig, and wallet-config utilities.
- `suite/e2e/tests/settings/electrum.test.ts` — This test configures a custom Electrum backend for regtest, which directly exercises the BackendTypeSelect component and backend configuration logic in networksConfig and blockchainThunks. It verifies discovery completes with an Electrum backend type.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test configures custom blockbook backends for BTC and LTC and verifies wallet discovery completes successfully. It directly exercises the backend configuration UI (BackendTypeSelect), networksConfig definitions, and blockchainThunks for connecting to custom backends.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/wallet/discovery.test.ts` — This test activates multiple coins (btc, eth, ltc, etc, bch, doge, xrp, zec) and verifies discovery completes after page reload interruption. Changes to networksConfig or blockchainThunks could break discovery for any of these networks.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — This test enables regtest network and verifies account balances update correctly. Changes to networksConfig (network definitions) or blockchainThunks (blockchain connection logic) could affect regtest network behavior and balance fetching.
- `suite/e2e/tests/analytics/events.test.ts` — This test configures custom backends and verifies the SuiteReady analytics event reflects customBackends setting. Changes to networksConfig or BackendTypeSelect could affect how custom backends are reported in analytics.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test uses the regtest network for send form operations. Changes to networksConfig and blockchainThunks could affect regtest network connectivity and transaction submission.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — This test sends Bitcoin transactions on regtest and verifies pending/confirmed transaction states. blockchainThunks handles blockchain event subscriptions that drive transaction status updates.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — This test enables new assets (ETH) via the Activate Assets modal and verifies they appear correctly. Changes to networksConfig could affect which networks are available for activation.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — This test adds different account types for various coins. Changes to networksConfig (network definitions, account types) or wallet-config utils could affect which account types are available.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts`
- `suite-common/wallet-config/src/__tests__/utils.test.ts`

_Updated: 2026-06-21T15:16:52.774Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/wallet-config-external-backend-networks/web/](https://dev.suite.sldev.cz/suite-web/chore/wallet-config-external-backend-networks/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/wallet-config-external-backend-networks&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/wallet-config-external-backend-networks&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/wallet-config-external-backend-networks&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy BTC > Buy Bitcoin from best offer | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-21T15:21:30.096Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-21T15:19:50.697Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

