### PR TITLE
refactor(suite): manage send form prefill in TokenSelect as local state

### DIFF
--- a/packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx
@@ -40,11 +40,13 @@ export const TokenSelect = ({ outputId }: TokenSelectProps) => {
 
     const dispatch = useDispatch();
 
+    const sendFormPrefill = useSelector(state => state.suite.prefillFields.sendForm);
+
     const [isTokensModalActive, setIsTokensModalActive] = useState(false);
+    const [prefillContractAddress, setPrefillContractAddress] = useState(sendFormPrefill);
 
     const explorer = useSelector(state => selectExplorer(state, account.symbol)) as Explorer;
     const shouldShowCopyAddressModal = useSelector(selectIsCopyAddressModalShown);
-    const sendFormPrefillContractAddress = useSelector(state => state.suite.prefillFields.sendForm);
 
     const tokenInputName = `outputs.${outputId}.token` as const;
     const tokenContractAddress = watch(tokenInputName);
@@ -73,18 +75,16 @@ export const TokenSelect = ({ outputId }: TokenSelectProps) => {
     }, [account, outputId, tokenWatch, setAmount, getValues, isSetMaxActive]);
 
     useEffect(() => {
-        if (sendFormPrefillContractAddress) {
-            setValue(tokenInputName, sendFormPrefillContractAddress, {
+        if (prefillContractAddress) {
+            setValue(tokenInputName, prefillContractAddress, {
                 shouldValidate: true,
                 shouldDirty: true,
             });
             setDraftSaveRequest(true);
-
-            return () => {
-                dispatch(setSendFormPrefill({ contractAddress: undefined }));
-            };
+            setPrefillContractAddress(undefined);
+            dispatch(setSendFormPrefill({ contractAddress: undefined }));
         }
-    }, [sendFormPrefillContractAddress, setValue, tokenInputName, setDraftSaveRequest, dispatch]);
+    }, [prefillContractAddress, setValue, tokenInputName, setDraftSaveRequest, dispatch]);
 
     const selectedToken = useMemo(
         () => account.tokens?.find(token => token.contract === tokenContractAddress),


### PR DESCRIPTION
TokenSelect now reads the send form prefill from Redux once on mount, keeps it in local state and clears the Redux field immediately after applying it to the token input, instead of clearing it from an effect cleanup on unmount. This guarantees the prefill is applied only once even when TokenSelect remounts, while both prefill writers (token row Send action and the global send modal) keep working since they always set the prefill before the send form mounts.

https://github.com/user-attachments/assets/5f6a5c98-016b-485a-b13d-42e08283658b


Resolves #18641

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to TokenSelect.tsx, a component rendered within the send form's Outputs section. It maps to 9 tests, all of which involve the send form to varying degrees. The highest risk is to tests that actively interact with multiple outputs or token-aware networks (ETH, SOL, regtest). Tests that only tangentially touch the send form (cardano, global-receive-send, without-device) are omitted as their test behaviors don't meaningfully exercise token selection. The recommended strategy is to run the 2 high-priority send form tests plus 4 medium-priority ones covering different networks and send form modes.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test exercises the most comprehensive send form functionality including multiple outputs, OP_RETURN, locktime, and unit switching. TokenSelect is part of the send form's output section, and changes to it could affect output rendering or interaction in any of these scenarios.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Ethereum send form exercises token-aware send functionality where TokenSelect is directly relevant — ETH accounts can have ERC-20 tokens, making the TokenSelect component actively used in the ETH send flow. Changes here could affect token/asset selection behavior.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/wallet/send-sol.test.ts` — Solana supports SPL tokens, so TokenSelect is relevant in the SOL send flow. This test exercises send-max calculation and form submission, which could be affected if TokenSelect changes alter how the selected token/asset is reported to the form state.
- `suite/e2e/tests/wallet/import-btc-csv.test.ts` — CSV import populates multiple send form outputs. TokenSelect is rendered per output in the send form, so changes could affect how imported outputs render or behave when the token selector component is present.
- `suite/e2e/tests/wallet/send-doge.test.ts` — This test opens the DOGE send form and fills in address/amount via broadcast mode. TokenSelect is part of the Outputs component rendered in the send form, so structural changes could affect the send form layout or functionality.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — LTC send form test uses broadcast mode and set-max functionality. TokenSelect is rendered as part of the send form outputs, and changes could affect form rendering or interaction.

</details>

_Updated: 2026-06-21T06:44:22.829Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/token-select-send-form-prefill/web/](https://dev.suite.sldev.cz/suite-web/refactor/token-select-send-form-prefill/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/token-select-send-form-prefill&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/token-select-send-form-prefill&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy BTC > Buy Bitcoin from best offer | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-21T06:49:30.765Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-21T06:48:00.528Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->