### PR TITLE
fix(suite): ignore malformed global send/receive router params

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/AssetSearchWithNetworkFilter/hooks/useNetworkFilter.ts
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/AssetSearchWithNetworkFilter/hooks/useNetworkFilter.ts
@@ -2,6 +2,7 @@ import { type RefObject, useEffect, useMemo, useState } from 'react';
 
 import { goto, parseDashboardParams, selectRouterParams } from '@suite/router';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { selectEnabledNetworks } from '@suite-common/wallet-core';
 import { type GlobalSendReceiveType } from '@suite-common/wallet-types';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -21,15 +22,22 @@ export function useNetworkFilter({ listRef, resetSearch, modal }: UseNetworkFilt
     );
 
     const defaultNetwork = useSelector(globalSendReceiveFilters.selectors.selectNetworkSymbol);
+    const enabledNetworks = useSelector(selectEnabledNetworks);
     const [networkFilter, setNetworkFilter] = useState<NetworkSymbol | undefined>(defaultNetwork);
 
     const dispatch = useDispatch();
 
     useEffect(() => {
-        if (networkSymbolUrlParam && defaultNetwork === undefined) {
+        // Only preselect a network from the URL if it is actually enabled, otherwise the list shows
+        // "no accounts" under a filter the user never chose (e.g. send/sol while Solana is disabled).
+        if (
+            networkSymbolUrlParam &&
+            defaultNetwork === undefined &&
+            enabledNetworks.includes(networkSymbolUrlParam)
+        ) {
             setNetworkFilter(networkSymbolUrlParam);
         }
-    }, [networkSymbolUrlParam, defaultNetwork]);
+    }, [networkSymbolUrlParam, defaultNetwork, enabledNetworks]);
 
     useEffect(() => {
         if (networkFilter === defaultNetwork) {

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/hooks/__tests__/useGlobalSendReceiveModal.test.ts
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/hooks/__tests__/useGlobalSendReceiveModal.test.ts
@@ -1,0 +1,28 @@
+import { getDashboardParamModal } from '../useGlobalSendReceiveModal';
+
+describe('getDashboardParamModal', () => {
+    it('returns the modal type for valid params', () => {
+        expect(getDashboardParamModal({ modal: 'send' })).toBe('send');
+        expect(getDashboardParamModal({ modal: 'receive' })).toBe('receive');
+    });
+
+    it('returns null for malformed params without logging', () => {
+        const consoleErrorSpy = jest.spyOn(console, 'error');
+
+        expect(getDashboardParamModal(undefined)).toBeNull();
+        expect(getDashboardParamModal(null)).toBeNull();
+        expect(getDashboardParamModal(true)).toBeNull();
+        expect(getDashboardParamModal('send')).toBeNull();
+        expect(getDashboardParamModal(['send'])).toBeNull();
+        expect(getDashboardParamModal({ cancelable: true })).toBeNull();
+
+        expect(consoleErrorSpy).not.toHaveBeenCalled();
+
+        consoleErrorSpy.mockRestore();
+    });
+
+    it('returns null for invalid modal values', () => {
+        expect(getDashboardParamModal({ modal: 'unknown' })).toBeNull();
+        expect(getDashboardParamModal({ modal: true })).toBeNull();
+    });
+});

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/hooks/useGlobalSendReceiveModal.ts
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/hooks/useGlobalSendReceiveModal.ts
@@ -18,7 +18,14 @@ export const dashboardParamsSchema = yup
     })
     .notRequired();
 
-const getDashboardParamModal = (param: unknown): GlobalSendReceiveType => {
+export const getDashboardParamModal = (param: unknown): GlobalSendReceiveType => {
+    const hasModalParam =
+        typeof param === 'object' && param !== null && !Array.isArray(param) && 'modal' in param;
+
+    if (!hasModalParam) {
+        return null;
+    }
+
     try {
         const parsedParams = dashboardParamsSchema.validateSync(param, {
             abortEarly: false,
@@ -26,11 +33,9 @@ const getDashboardParamModal = (param: unknown): GlobalSendReceiveType => {
         });
 
         return parsedParams?.modal ?? null;
-    } catch (error) {
-        console.error(error);
+    } catch {
+        return null;
     }
-
-    return null;
 };
 
 export function useGlobalSendReceiveModal() {


### PR DESCRIPTION
getDashboardParamModal now checks that router params are a plain object with a modal key before running strict Yup validation, so malformed params (e.g. boolean hash params from /switch-device#/true) are silently ignored instead of logging ValidationError noise to Sentry. Valid { modal: 'send' | 'receive' } params still open the modal, covered by a new unit test.

Resolves #27737

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are focused on the Global Send/Receive modal infrastructure: the useNetworkFilter hook (asset search with network filtering) and useGlobalSendReceiveModal hook (controlling the global send/receive modal behavior). The useGlobalSendReceiveModal.ts file maps to 121 tests but is a layout-level dependency — most tests merely render it transitively without exercising its logic. The highest-risk test is global-receive-send.test.ts which directly tests the filtering, searching, and selecting flows. A few trading navigation tests that use global entry points with asset pickers are medium priority. The unit test file for the hook has no E2E coverage (expected, as it's a unit test itself).

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/AssetSearchWithNetworkFilter/hooks/useNetworkFilter.ts`
- `packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/hooks/__tests__/useGlobalSendReceiveModal.test.ts`
- `packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/hooks/useGlobalSendReceiveModal.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test directly exercises the Global Send/Receive flows including the asset picker with network filtering and search — exactly the functionality implemented by useNetworkFilter.ts and useGlobalSendReceiveModal.ts. It is the only test statically mapped to the useNetworkFilter hook and explicitly tests filtering/selecting assets from the global send/receive menu.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — This test navigates to Buy/Sell/Swap forms from the global header trading buttons, which rely on the global send/receive modal infrastructure. Changes to useGlobalSendReceiveModal could affect how the global trading entry points open and preselect networks.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — This test uses the global trading button and asset picker to search/select Ethereum as a buy asset, which exercises the asset picker filtering logic powered by useNetworkFilter and the global modal hook. A regression in network filtering could prevent asset selection.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/hooks/__tests__/useGlobalSendReceiveModal.test.ts`

_Updated: 2026-06-21T05:11:13.447Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/global-send-receive-malformed-params&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/global-send-receive-malformed-params&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy BTC > Buy Bitcoin from best offer | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-21T05:16:18.137Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-21T05:14:17.822Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/global-send-receive-malformed-params/web/](https://dev.suite.sldev.cz/suite-web/fix/global-send-receive-malformed-params/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->