### PR TITLE
fix(suite): render pending transactions outside of paginated history

### DIFF
--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionList.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionList.tsx
@@ -8,7 +8,6 @@ import { getTxsPerPage } from '@suite-common/suite-utils';
 import { advancedSearchTransactions } from '@suite-common/transaction-search';
 import { groupTransactionsByDate, isPending } from '@suite-common/wallet-utils';
 import { Column, SkeletonStack } from '@trezor/components';
-import { arrayPartition } from '@trezor/utils';
 
 import { DashboardSection } from 'src/components/dashboard';
 import { Pagination } from 'src/components/wallet';
@@ -95,9 +94,20 @@ export const TransactionList = ({
         onPageRequested?.(startPage);
     }, [account.descriptor, account.symbol, onPageRequested, startPage]);
 
+    // Pending txs are not part of the paginated history yet and keep their own chronological order, so
+    // they are rendered above the list on every page.
+    const pendingTxs = useMemo(
+        () => searchedTransactions.filter(isPending),
+        [searchedTransactions],
+    );
+
     const isSearching = searchQuery.trim() !== '';
     const defaultTotalItems = customTotalItems ?? account.history.total;
-    const totalItems = isSearching ? searchedTransactions.length : defaultTotalItems;
+    // account.history.total counts confirmed txs only, but pending txs occupy slots in the sliced
+    // array, so include them in the page count to keep the last confirmed tx reachable.
+    const totalItems = isSearching
+        ? searchedTransactions.length
+        : defaultTotalItems + pendingTxs.length;
 
     const onPageSelected = (page: number) => {
         setSelectedPage(page);
@@ -115,13 +125,16 @@ export const TransactionList = ({
     const startIndex = (currentPage - 1) * perPage;
     const stopIndex = startIndex + perPage;
 
+    // searchedTransactions is a sparse array - not-yet-fetched pages are holes - so it has to be sliced
+    // by index before filtering. Filtering first would drop the holes and shift the page offsets.
     const slicedTransactions = useMemo(
         () => searchedTransactions.slice(startIndex, stopIndex),
         [searchedTransactions, startIndex, stopIndex],
     );
 
-    const [pendingTxs, confirmedTxs] = useMemo(
-        () => arrayPartition(slicedTransactions, isPending),
+    // Only confirmed txs are paginated; pending txs are rendered above the list on every page.
+    const confirmedTxs = useMemo(
+        () => slicedTransactions.filter(tx => !isPending(tx)),
         [slicedTransactions],
     );
 

--- a/packages/suite/src/views/wallet/transactions/TransactionList/useFetchTransactions.ts
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/useFetchTransactions.ts
@@ -7,6 +7,7 @@ import {
     fetchTransactionsPageThunk,
     selectAccountTotalTransactions,
     selectAccountTransactionsWithNulls,
+    selectActiveDustPhishingThreshold,
     selectIsLoadingAccountTransactions,
     selectPhishingTransactionsContext,
 } from '@suite-common/wallet-core';
@@ -174,6 +175,7 @@ export const useVisibleTransactions = ({
     const { tokenDefinitions, txsMarkedAsNotScam, historicRates } = useSelector(state =>
         selectPhishingTransactionsContext(state, account.key, account.symbol),
     );
+    const dustThreshold = useSelector(selectActiveDustPhishingThreshold);
 
     const visibleTransactions = useMemo(
         () =>
@@ -185,10 +187,18 @@ export const useVisibleTransactions = ({
                               tokenDefinitions,
                               txsMarkedAsNotScam,
                               historicRates,
+                              dustThreshold,
                           }).isPhishing,
                   )
                 : allTransactions,
-        [enableFiltering, allTransactions, tokenDefinitions, txsMarkedAsNotScam, historicRates],
+        [
+            enableFiltering,
+            allTransactions,
+            tokenDefinitions,
+            txsMarkedAsNotScam,
+            historicRates,
+            dustThreshold,
+        ],
     );
 
     const perPage = getTxsPerPage(account.networkType);

--- a/suite-common/wallet-core/src/phishing/phishingSelectors.ts
+++ b/suite-common/wallet-core/src/phishing/phishingSelectors.ts
@@ -5,3 +5,8 @@ export const selectDustPhishingThreshold = (state: PhishingRootState) =>
 
 export const selectDustPhishingIsEnabled = (state: PhishingRootState) =>
     state.wallet.phishing.dustPhishing.isEnabled;
+
+// The dust threshold that phishing detection should actually use, or undefined when dust phishing is
+// disabled (passing it to isPhishingTransaction is what enables the dust value detector).
+export const selectActiveDustPhishingThreshold = (state: PhishingRootState) =>
+    selectDustPhishingIsEnabled(state) ? selectDustPhishingThreshold(state) : undefined;

--- a/suite-common/wallet-core/src/transactions/transactionsSelectors.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsSelectors.ts
@@ -40,10 +40,7 @@ import {
 import { selectHistoricFiatRates } from '../fiat-rates/fiatRatesSelectors';
 import type { FiatRatesRootState } from '../fiat-rates/fiatRatesTypes';
 import { type PhishingRootState } from '../phishing/phishingReducerTypes';
-import {
-    selectDustPhishingIsEnabled,
-    selectDustPhishingThreshold,
-} from '../phishing/phishingSelectors';
+import { selectActiveDustPhishingThreshold } from '../phishing/phishingSelectors';
 import { isAccountStakingActive } from '../stake/stakeUtils';
 
 const createMemoizedSelector = createWeakMapSelector.withTypes<
@@ -207,9 +204,7 @@ export const selectIsPhishingTransaction = (
     const { tokenDefinitions, txsMarkedAsNotScam, historicRates } =
         selectPhishingTransactionsContext(state, accountKey, transaction.symbol);
 
-    const dustPhishingIsEnabled = selectDustPhishingIsEnabled(state);
-    const dustPhishingThreshold = selectDustPhishingThreshold(state);
-    const dustThreshold = dustPhishingIsEnabled ? dustPhishingThreshold : undefined;
+    const dustThreshold = selectActiveDustPhishingThreshold(state);
 
     return isPhishingTransaction({
         transaction,


### PR DESCRIPTION
Pending transactions are now partitioned from the full transaction list before pagination slicing, so they stay rendered in their own group above the history regardless of the selected page, and only confirmed transactions are paginated.

Phishing filter did not filter anything, should be fixed.

There are definitely more bugs with phishing. 
When phishing filter is disabled, it shows pagination for all txs, but when it is enabled, it probably only use the already fetched txs.

Resolves #8628

unconfirmed are not part of total
<img width="338" height="229" alt="Screenshot 2026-06-21 at 8 21 21" src="https://github.com/user-attachments/assets/7f2022ff-59dd-42c3-a834-710d9cf7fcf3" />


Page 1
<img width="1161" height="598" alt="Screenshot 2026-06-19 at 10 23 34" src="https://github.com/user-attachments/assets/03464f18-b43d-4935-9ad8-c069a0ffe662" />

Page 2
<img width="1163" height="605" alt="Screenshot 2026-06-19 at 10 24 30" src="https://github.com/user-attachments/assets/5f7973b1-12fa-49c6-9f26-e26d4d817933" />

Before phishing there:
<img width="1178" height="988" alt="Screenshot 2026-06-20 at 13 21 42" src="https://github.com/user-attachments/assets/0f3d9e34-4548-42fb-8631-41384e8e1b0f" />

After phishing not there:
<img width="1172" height="1001" alt="Screenshot 2026-06-20 at 13 21 47" src="https://github.com/user-attachments/assets/261456f5-500b-4b26-b3d6-23c0dabff8c2" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes touch the transaction list view component (TransactionList.tsx), its data-fetching hook (useFetchTransactions.ts), transaction selectors (transactionsSelectors.ts), and phishing selectors (phishingSelectors.ts). The highest risk is in tests that directly exercise transaction list rendering, pagination, and search. The phishing and transaction selectors map to 121 tests each, indicating they are broad shared dependencies — only tests with concrete transaction list interactions are recommended. The recommended strategy focuses on the 3 high-priority tests that directly validate transaction list functionality, supplemented by medium-priority tests covering transaction export and output labeling.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite/src/views/wallet/transactions/TransactionList/TransactionList.tsx`
- `packages/suite/src/views/wallet/transactions/TransactionList/useFetchTransactions.ts`
- `suite-common/wallet-core/src/phishing/phishingSelectors.ts`
- `suite-common/wallet-core/src/transactions/transactionsSelectors.ts`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/wallet/transactions.test.ts` — This test directly exercises the transaction list view (cycling graph time ranges, searching transactions by address) which is rendered by TransactionList.tsx and relies on transactionsSelectors.ts for data. Changes to transaction fetching (useFetchTransactions.ts) or transaction selectors could break pagination, search, or display of transactions.
- `suite/e2e/tests/wallet/pagination.test.ts` — Pagination directly tests navigating through paginated transaction pages and verifying correct transaction addresses on each page. This exercises TransactionList.tsx rendering, useFetchTransactions.ts for loading paginated data, and transactionsSelectors.ts for selecting transactions per page.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test verifies pending transactions appear in the transaction list with correct details (e.g., OP_RETURN content), directly exercising TransactionList.tsx rendering and transactionsSelectors.ts for selecting and displaying pending transactions.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/wallet/export-transactions.test.ts` — Exporting transactions in PDF/CSV/JSON formats requires the transaction list to be loaded and rendered correctly. Changes to useFetchTransactions.ts or transactionsSelectors.ts could affect what data is available for export.
- `suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — This test labels transaction outputs and verifies labels in the transaction view, and also exports CSV containing labeled outputs. It directly interacts with the transaction list UI where TransactionList.tsx renders output labels, and the exported CSV depends on transactionsSelectors.ts data.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — This test verifies account balance updates after receiving BTC, which involves transaction discovery and the transaction list. Changes to transactionsSelectors.ts could affect balance calculations derived from transaction data.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — This test creates output labels that appear in the transaction list view. While the primary focus is on Suite Sync label creation, the output label is rendered within TransactionList.tsx, so changes there could affect label display.
- `suite/e2e/tests/wallet/import-btc-csv.test.ts` — Importing CSV data populates send form outputs with metadata labels. While primarily a send form test, the output labels reference metadata components that also appear in the transaction list rendered by TransactionList.tsx.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/wallet-core/src/phishing/phishingSelectors.ts`

_Updated: 2026-06-21T05:11:35.171Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/pending-txs-outside-pagination/web/](https://dev.suite.sldev.cz/suite-web/fix/pending-txs-outside-pagination/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/pending-txs-outside-pagination&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/pending-txs-outside-pagination&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/pending-txs-outside-pagination&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy BTC > Buy Bitcoin from best offer | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-21T05:16:21.301Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-21T05:14:25.474Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->