### PR TITLE
fix(suite-native): move account type badge next to account name

### DIFF
--- a/suite-native/accounts/src/components/AccountsList/AccountsListItem.tsx
+++ b/suite-native/accounts/src/components/AccountsList/AccountsListItem.tsx
@@ -160,9 +160,13 @@ export const AccountsListItem = ({
             disabled={disabled}
             icon={icon}
             title={title}
+            titleBadge={
+                formattedAccountType ? (
+                    <Badge label={formattedAccountType} size="small" />
+                ) : undefined
+            }
             badges={
                 <>
-                    {formattedAccountType && <Badge label={formattedAccountType} size="small" />}
                     {shouldShowStakingBadge && (
                         <StakingBadge networkSymbol={account.symbol} account={account} />
                     )}

--- a/suite-native/accounts/src/components/AccountsList/AccountsListItemBase.tsx
+++ b/suite-native/accounts/src/components/AccountsList/AccountsListItemBase.tsx
@@ -7,6 +7,7 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 type AccountListItemBaseProps = {
     icon: React.ReactNode;
     title: React.ReactNode;
+    titleBadge?: React.ReactNode;
     secondaryTitle?: React.ReactNode;
     mainValue: React.ReactNode;
     secondaryValue: React.ReactNode;
@@ -75,6 +76,10 @@ const accountDescriptionStyle = prepareNativeStyle(_ => ({
     flexShrink: 1,
 }));
 
+const titleStyle = prepareNativeStyle(_ => ({
+    flexShrink: 1,
+}));
+
 const valuesContainerStyle = prepareNativeStyle(utils => ({
     maxWidth: '40%',
     flexShrink: 0,
@@ -89,6 +94,7 @@ const valuesContainerStyle = prepareNativeStyle(utils => ({
 export const AccountsListItemBase = ({
     icon,
     title,
+    titleBadge,
     secondaryTitle,
     badges,
     mainValue,
@@ -118,9 +124,17 @@ export const AccountsListItemBase = ({
             <Box flexDirection="row" alignItems="center" flex={1}>
                 <Box marginRight="sp16">{icon}</Box>
                 <Box style={applyStyle(accountDescriptionStyle)}>
-                    <Text numberOfLines={1} ellipsizeMode="tail" testID="@accountList/item/title">
-                        {title}
-                    </Text>
+                    <HStack spacing="sp4" alignItems="center">
+                        <Text
+                            numberOfLines={1}
+                            ellipsizeMode="tail"
+                            style={applyStyle(titleStyle)}
+                            testID="@accountList/item/title"
+                        >
+                            {title}
+                        </Text>
+                        {titleBadge}
+                    </HStack>
                     {secondaryTitle}
                     <HStack spacing="sp4" alignItems="center">
                         {badges}

--- a/suite-native/module-earn/src/components/ChooseAccountItem.tsx
+++ b/suite-native/module-earn/src/components/ChooseAccountItem.tsx
@@ -42,8 +42,10 @@ export const ChooseAccountItem = ({
             onPress={handlePress}
             icon={<CryptoIcon symbol={account.symbol} />}
             title={<AccountLabel account={account} />}
-            badges={
-                formattedAccountType ? <Badge label={formattedAccountType} size="small" /> : null
+            titleBadge={
+                formattedAccountType ? (
+                    <Badge label={formattedAccountType} size="small" />
+                ) : undefined
             }
             mainValue={
                 <CryptoAmountFormatter


### PR DESCRIPTION
Moves the account type badge (e.g. Legacy) from the badge row under the asset/network name to sit inline next to the account name, matching the placement used on desktop. Applied in the shared accounts list item and the earn account select sheet.


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/mobile-account-type-badge-placement&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->