### PR TITLE
feat(suite-native): yield deposit fee selector

### DIFF
--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
@@ -184,7 +184,7 @@ export const buildYieldDepositCalldata = ({
     return builderResult.data;
 };
 
-const buildEvmFeeFields = ({ feeLevel, gasLimit }: BuildEvmFeeFieldsParams) => {
+export const buildEvmFeeFields = ({ feeLevel, gasLimit }: BuildEvmFeeFieldsParams) => {
     const commonFields = {
         gasLimit: fromIntegerString(gasLimit).toHex(),
     };

--- a/suite-native/module-earn/src/__tests__/yieldDepositFeeUtils.test.ts
+++ b/suite-native/module-earn/src/__tests__/yieldDepositFeeUtils.test.ts
@@ -1,4 +1,13 @@
-import { buildYieldDepositFeePreview } from '../yieldDepositFeeUtils';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { type FeeInfo, type FormState } from '@suite-common/wallet-types';
+
+import {
+    buildYieldDepositFeeDraftState,
+    buildYieldDepositFeeFormDraft,
+    buildYieldDepositFeeLevels,
+    buildYieldDepositFeePreview,
+    buildYieldDepositSelectedFeeUnsignedTransaction,
+} from '../yieldDepositFeeUtils';
 
 const baseUnsignedTransaction = {
     from: '0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3',
@@ -8,6 +17,69 @@ const baseUnsignedTransaction = {
     gasLimit: '0x5208',
     nonce: 1,
     value: '0x0',
+};
+
+const buildFormDraft = (overrides: Partial<FormState>): FormState => ({
+    outputs: [],
+    selectedFee: 'normal',
+    feePerUnit: '1',
+    feeLimit: '21000',
+    options: [],
+    isCoinControlEnabled: false,
+    hasCoinControlBeenOpened: false,
+    selectedUtxos: [],
+    ...overrides,
+});
+
+const legacyFeeInfo: FeeInfo = {
+    blockHeight: 0,
+    blockTime: 0,
+    minFee: 1,
+    maxFee: 100,
+    minPriorityFee: 0,
+    levels: [
+        {
+            label: 'normal',
+            feePerUnit: '1',
+            blocks: 2,
+        },
+        {
+            label: 'high',
+            feePerUnit: '2',
+            blocks: 1,
+        },
+    ],
+};
+
+const eip1559FeeInfo: FeeInfo = {
+    blockHeight: 0,
+    blockTime: 0,
+    minFee: 1,
+    maxFee: 100,
+    minPriorityFee: 0,
+    levels: [
+        {
+            label: 'normal',
+            feePerUnit: '1',
+            blocks: 2,
+            baseFeePerGas: '0.5',
+            maxFeePerGas: '1',
+            maxPriorityFeePerGas: '0.5',
+        },
+        {
+            label: 'high',
+            feePerUnit: '2',
+            blocks: 1,
+            baseFeePerGas: '1',
+            maxFeePerGas: '2',
+            maxPriorityFeePerGas: '1',
+        },
+        {
+            label: 'custom',
+            feePerUnit: '3',
+            blocks: 0,
+        },
+    ],
 };
 
 describe('buildYieldDepositFeePreview', () => {
@@ -53,5 +125,247 @@ describe('buildYieldDepositFeePreview', () => {
 
     it('returns null when the backend transaction has no fee fields', () => {
         expect(buildYieldDepositFeePreview(JSON.stringify(baseUnsignedTransaction))).toBeNull();
+    });
+});
+
+describe('buildYieldDepositFeeLevels', () => {
+    it('derives EIP-1559 fee levels from the base deposit transaction', () => {
+        const result = buildYieldDepositFeeLevels({
+            amount: '1.25',
+            feeInfo: eip1559FeeInfo,
+            gasLimit: '21000',
+            symbol: 'eth' as NetworkSymbol,
+            token: {
+                contractAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+                decimals: 6,
+                symbol: 'USDC',
+            },
+            unsignedTransaction: JSON.stringify({
+                ...baseUnsignedTransaction,
+                type: 2,
+                maxFeePerGas: '0x3b9aca00',
+                maxPriorityFeePerGas: '0x1dcd6500',
+            }),
+        });
+
+        expect(result.normal).toMatchObject({
+            type: 'final',
+            fee: '21000000000000',
+            feePerByte: '1',
+            feeLimit: '21000',
+            maxFeePerGas: '1',
+            maxPriorityFeePerGas: '0.5',
+            outputs: [
+                {
+                    address: baseUnsignedTransaction.to,
+                    amount: '1250000',
+                },
+            ],
+        });
+        expect(result.high).toMatchObject({
+            type: 'final',
+            fee: '42000000000000',
+            feePerByte: '2',
+            feeLimit: '21000',
+            maxFeePerGas: '2',
+            maxPriorityFeePerGas: '1',
+        });
+        expect(result.custom).toBeUndefined();
+    });
+});
+
+describe('buildYieldDepositSelectedFeeUnsignedTransaction', () => {
+    it('updates legacy fee fields without changing non-fee transaction fields', () => {
+        const result = buildYieldDepositSelectedFeeUnsignedTransaction({
+            feeInfo: legacyFeeInfo,
+            currentFormDraft: buildFormDraft({ selectedFee: 'high' }),
+            unsignedTransaction: JSON.stringify({
+                ...baseUnsignedTransaction,
+                gasPrice: '0x3b9aca00',
+                baseFeePerGas: '0x0',
+            }),
+        });
+
+        expect(result ? JSON.parse(result) : null).toEqual({
+            ...baseUnsignedTransaction,
+            gasLimit: '0x5208',
+            gasPrice: '0x77359400',
+        });
+    });
+
+    it('rebuilds a custom EIP-1559 fee and removes legacy fee fields', () => {
+        const result = buildYieldDepositSelectedFeeUnsignedTransaction({
+            feeInfo: eip1559FeeInfo,
+            currentFormDraft: buildFormDraft({
+                selectedFee: 'custom',
+                feePerUnit: '7',
+                feeLimit: '30000',
+                maxFeePerGas: '8',
+                maxPriorityFeePerGas: '2',
+            }),
+            unsignedTransaction: JSON.stringify({
+                ...baseUnsignedTransaction,
+                gasPrice: '0x3b9aca00',
+            }),
+        });
+        const parsedResult = result ? JSON.parse(result) : null;
+
+        expect(parsedResult).toEqual({
+            ...baseUnsignedTransaction,
+            type: 2,
+            gasLimit: '0x7530',
+            maxFeePerGas: '0x1dcd65000',
+            maxPriorityFeePerGas: '0x77359400',
+        });
+        expect(parsedResult).not.toHaveProperty('gasPrice');
+        expect(parsedResult).not.toHaveProperty('baseFeePerGas');
+    });
+
+    it('falls back from incomplete custom fee to normal and removes EIP-1559 fee fields', () => {
+        const result = buildYieldDepositSelectedFeeUnsignedTransaction({
+            feeInfo: legacyFeeInfo,
+            currentFormDraft: buildFormDraft({
+                selectedFee: 'custom',
+                feePerUnit: '7',
+                feeLimit: '',
+            }),
+            unsignedTransaction: JSON.stringify({
+                ...baseUnsignedTransaction,
+                type: 2,
+                gasLimit: '0x7530',
+                maxFeePerGas: '0x1dcd65000',
+                maxPriorityFeePerGas: '0x77359400',
+            }),
+        });
+        const parsedResult = result ? JSON.parse(result) : null;
+
+        expect(parsedResult).toEqual({
+            ...baseUnsignedTransaction,
+            gasLimit: '0x7530',
+            gasPrice: '0x3b9aca00',
+        });
+        expect(parsedResult).not.toHaveProperty('type');
+        expect(parsedResult).not.toHaveProperty('maxFeePerGas');
+        expect(parsedResult).not.toHaveProperty('maxPriorityFeePerGas');
+    });
+
+    it('falls back from partial EIP-1559 custom fee to normal EIP-1559 fee', () => {
+        const result = buildYieldDepositSelectedFeeUnsignedTransaction({
+            feeInfo: eip1559FeeInfo,
+            currentFormDraft: buildFormDraft({
+                selectedFee: 'custom',
+                feePerUnit: '7',
+                feeLimit: '30000',
+                maxFeePerGas: '8',
+            }),
+            unsignedTransaction: JSON.stringify({
+                ...baseUnsignedTransaction,
+                type: 2,
+                maxFeePerGas: '0x1dcd65000',
+                maxPriorityFeePerGas: '0x77359400',
+            }),
+        });
+        const parsedResult = result ? JSON.parse(result) : null;
+
+        expect(parsedResult).toEqual({
+            ...baseUnsignedTransaction,
+            type: 2,
+            gasLimit: '0x5208',
+            maxFeePerGas: '0x3b9aca00',
+            maxPriorityFeePerGas: '0x1dcd6500',
+        });
+        expect(parsedResult).not.toHaveProperty('gasPrice');
+    });
+
+    it('returns null for unsupported unsigned transaction payload', () => {
+        expect(
+            buildYieldDepositSelectedFeeUnsignedTransaction({
+                feeInfo: legacyFeeInfo,
+                unsignedTransaction: 'not-json',
+            }),
+        ).toBeNull();
+    });
+});
+
+describe('buildYieldDepositFeeFormDraft', () => {
+    const formState: FormState = {
+        outputs: [],
+        selectedFee: 'normal',
+        feePerUnit: '1',
+        feeLimit: '21000',
+        maxFeePerGas: '1',
+        maxPriorityFeePerGas: '0.5',
+        options: [],
+        isCoinControlEnabled: false,
+        hasCoinControlBeenOpened: false,
+        selectedUtxos: [],
+    };
+
+    it('preserves existing custom EIP-1559 fee fields', () => {
+        const currentFormDraft: FormState = {
+            outputs: [],
+            selectedFee: 'custom',
+            feePerUnit: '7',
+            feeLimit: '30000',
+            maxFeePerGas: '8',
+            maxPriorityFeePerGas: '2',
+            options: [],
+            isCoinControlEnabled: false,
+            hasCoinControlBeenOpened: false,
+            selectedUtxos: [],
+        };
+
+        expect(
+            buildYieldDepositFeeFormDraft({
+                currentFormDraft,
+                formState,
+                selectedFee: 'custom',
+            }),
+        ).toMatchObject({
+            selectedFee: 'custom',
+            feePerUnit: '7',
+            feeLimit: '30000',
+            maxFeePerGas: '8',
+            maxPriorityFeePerGas: '2',
+        });
+    });
+});
+
+describe('buildYieldDepositFeeDraftState', () => {
+    it('adds a custom fee level when the custom fee draft is complete', () => {
+        const result = buildYieldDepositFeeDraftState({
+            amount: '1.25',
+            currentFormDraft: buildFormDraft({
+                selectedFee: 'custom',
+                feePerUnit: '7',
+                feeLimit: '30000',
+                maxFeePerGas: '8',
+                maxPriorityFeePerGas: '2',
+            }),
+            feeInfo: eip1559FeeInfo,
+            gasLimit: '21000',
+            symbol: 'eth' as NetworkSymbol,
+            token: {
+                contractAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+                decimals: 6,
+                symbol: 'USDC',
+            },
+            unsignedTransaction: JSON.stringify({
+                ...baseUnsignedTransaction,
+                type: 2,
+                maxFeePerGas: '0x3b9aca00',
+                maxPriorityFeePerGas: '0x1dcd6500',
+            }),
+        });
+
+        expect(result?.formDraft.selectedFee).toBe('custom');
+        expect(result?.feeLevels.custom).toMatchObject({
+            type: 'final',
+            fee: '240000000000000',
+            feeLimit: '30000',
+            feePerByte: '8',
+            maxFeePerGas: '8',
+            maxPriorityFeePerGas: '2',
+        });
     });
 });

--- a/suite-native/module-earn/src/hooks/__tests__/useYieldDepositSubmit.test.ts
+++ b/suite-native/module-earn/src/hooks/__tests__/useYieldDepositSubmit.test.ts
@@ -1,0 +1,76 @@
+import { act, renderHookWithBasicProvider } from '@suite-native/test-utils';
+
+import { useShowYieldAlert } from '../useShowYieldAlert';
+import { type PreparedYieldDepositAction } from '../useYieldDepositFees';
+import { useYieldDepositSubmit } from '../useYieldDepositSubmit';
+
+jest.mock('../useShowYieldAlert');
+
+const mockUseShowYieldAlert = jest.mocked(useShowYieldAlert);
+
+const preparedAction: PreparedYieldDepositAction = {
+    amount: '1',
+    feePreview: {
+        type: 'final',
+        fee: '21000',
+        feePerByte: '1',
+        feeLimit: '21000',
+        totalSpent: '21000',
+        bytes: 0,
+        inputs: [],
+        outputs: [],
+        outputsPermutation: [],
+    },
+    receiptAmount: '0.99',
+    unsignedTransaction: '{"gasPrice":"0x1"}',
+};
+
+describe('useYieldDepositSubmit', () => {
+    const showYieldAlert = jest.fn();
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockUseShowYieldAlert.mockReturnValue(showYieldAlert);
+    });
+
+    it('continues with the current prepared action', () => {
+        const onActionReady = jest.fn();
+        const { result } = renderHookWithBasicProvider(() =>
+            useYieldDepositSubmit({
+                amount: '1',
+                onActionReady,
+                preparedAction,
+            }),
+        );
+
+        act(() => result.current.handleSubmitDeposit());
+
+        expect(onActionReady).toHaveBeenCalledWith(preparedAction);
+        expect(showYieldAlert).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        ['missing', null],
+        ['stale', { ...preparedAction, amount: '2' }],
+    ] satisfies [string, PreparedYieldDepositAction | null][])(
+        'shows an alert when the prepared action is %s',
+        (_caseName, submitPreparedAction) => {
+            const onActionReady = jest.fn();
+            const { result } = renderHookWithBasicProvider(() =>
+                useYieldDepositSubmit({
+                    amount: '1',
+                    onActionReady,
+                    preparedAction: submitPreparedAction,
+                }),
+            );
+
+            act(() => result.current.handleSubmitDeposit());
+
+            expect(onActionReady).not.toHaveBeenCalled();
+            expect(showYieldAlert).toHaveBeenCalledWith({
+                title: 'earn.yieldDepositFlowScreen.alerts.depositUnavailable.title',
+                description: 'earn.yieldDepositFlowScreen.alerts.depositUnavailable.description',
+            });
+        },
+    );
+});

--- a/suite-native/module-earn/src/hooks/useYieldDepositFees.ts
+++ b/suite-native/module-earn/src/hooks/useYieldDepositFees.ts
@@ -1,12 +1,38 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
-import { composeYieldDepositTransactionThunk } from '@suite-common/wallet-core';
-import { type PrecomposedTransactionFinal } from '@suite-common/wallet-types';
+import {
+    type FeesRootState,
+    type FormDraftRootState,
+    composeYieldDepositTransactionThunk,
+    formDraftActions,
+    selectConvertedNetworkFeeInfo,
+    selectFormDraft,
+} from '@suite-common/wallet-core';
+import {
+    type FeeInfo,
+    type FeeLevelLabel,
+    type FormState,
+    type GeneralPrecomposedLevels,
+    type PrecomposedTransactionFinal,
+    isFinalPrecomposedTransaction,
+} from '@suite-common/wallet-types';
+import {
+    type NativeSendRootState,
+    getFeeAvailability,
+    selectFeeLevels,
+    transactionManagementActions,
+} from '@suite-native/transaction-management';
 import { useDebounce } from '@trezor/react-utils';
+import { deepEqual } from '@trezor/utils';
 
+import { updateEarnSelectedFeeLevelThunk } from './useComposeEarnFees';
 import { type ResolvedYieldFlowData } from './useResolvedYieldFlowData';
-import { buildYieldDepositFeePreview } from '../yieldDepositFeeUtils';
+import { getYieldDepositFormDraftKey } from '../utils/yieldDepositUtils';
+import {
+    buildYieldDepositFeeDraftState,
+    buildYieldDepositFeePreview,
+} from '../yieldDepositFeeUtils';
 
 export type PreparedYieldDepositAction = {
     amount: string;
@@ -20,6 +46,29 @@ type UseYieldDepositFeesParams = Pick<ResolvedYieldFlowData, 'flowData' | 'flowK
     isEnabled: boolean;
 };
 
+type BaseYieldDepositActionContext = {
+    amount: string;
+    baseFeePreview: PrecomposedTransactionFinal;
+    receiptAmount: string;
+    symbol: NonNullable<ResolvedYieldFlowData['flowData']>['account']['symbol'];
+    token: NonNullable<ResolvedYieldFlowData['flowData']>['token'];
+    unsignedTransaction: string;
+};
+
+type ComposeDepositBaseActionParams = {
+    amount: string;
+    flowData: NonNullable<ResolvedYieldFlowData['flowData']>;
+};
+
+const getYieldDepositFeeInfoRevision = (feeInfo: FeeInfo | null | undefined) =>
+    feeInfo?.levels
+        .map(({ baseFeePerGas, blocks, feePerUnit, label, maxFeePerGas, maxPriorityFeePerGas }) =>
+            [label, feePerUnit, blocks, maxFeePerGas, maxPriorityFeePerGas, baseFeePerGas].join(
+                ':',
+            ),
+        )
+        .join('|') ?? '';
+
 export const useYieldDepositFees = ({
     amount,
     flowData,
@@ -29,28 +78,67 @@ export const useYieldDepositFees = ({
     const dispatch = useDispatch();
     const debounce = useDebounce();
     const requestIdRef = useRef(0);
-    const [preparedAction, setPreparedAction] = useState<PreparedYieldDepositAction | null>(null);
+    const [baseActionContext, setBaseActionContext] =
+        useState<BaseYieldDepositActionContext | null>(null);
     const [isPreparingDepositFee, setIsPreparingDepositFee] = useState(false);
 
-    const clearDepositFeeState = useCallback(() => {
-        setPreparedAction(null);
-        setIsPreparingDepositFee(false);
-    }, []);
+    const formDraftKey = useMemo(
+        () => (flowKey ? getYieldDepositFormDraftKey(flowKey) : ''),
+        [flowKey],
+    );
+    const formDraft = useSelector((state: FormDraftRootState) =>
+        formDraftKey ? selectFormDraft<FormState>(state, formDraftKey) : undefined,
+    );
+    const feeInfo = useSelector((state: FeesRootState) =>
+        selectConvertedNetworkFeeInfo(state, flowData?.account.symbol),
+    );
+    const feeLevels = useSelector((state: NativeSendRootState) => selectFeeLevels(state));
 
-    const prepareDepositFeeParams = useMemo(() => {
-        if (!isEnabled || !amount || !flowData || !flowKey) {
+    const feeLevelsRef = useRef(feeLevels);
+    feeLevelsRef.current = feeLevels;
+    const storedDepositFeeLevelsRef = useRef<GeneralPrecomposedLevels | null>(null);
+    const feeInfoRef = useRef(feeInfo);
+    feeInfoRef.current = feeInfo;
+    const feeInfoRevision = useMemo(() => getYieldDepositFeeInfoRevision(feeInfo), [feeInfo]);
+
+    const clearDepositFeeLevels = useCallback(() => {
+        if (
+            storedDepositFeeLevelsRef.current &&
+            feeLevelsRef.current === storedDepositFeeLevelsRef.current
+        ) {
+            dispatch(transactionManagementActions.clearFeeLevels());
+        }
+
+        storedDepositFeeLevelsRef.current = null;
+    }, [dispatch]);
+
+    const clearDepositFeeStore = useCallback(() => {
+        clearDepositFeeLevels();
+
+        if (formDraftKey) {
+            dispatch(formDraftActions.removeDraft({ key: formDraftKey }));
+        }
+    }, [clearDepositFeeLevels, dispatch, formDraftKey]);
+
+    const clearDepositFeeState = useCallback(() => {
+        setBaseActionContext(null);
+        setIsPreparingDepositFee(false);
+        clearDepositFeeStore();
+    }, [clearDepositFeeStore]);
+
+    const hasInvalidDepositContext = !amount || !flowData || !flowKey || !formDraftKey;
+
+    const composeDepositBaseActionParams = useMemo((): ComposeDepositBaseActionParams | null => {
+        if (hasInvalidDepositContext || !isEnabled) {
             return null;
         }
 
         return { amount, flowData };
-    }, [amount, flowData, flowKey, isEnabled]);
+    }, [amount, flowData, hasInvalidDepositContext, isEnabled]);
 
-    const prepareDepositFee = useCallback(
+    const prepareDepositBaseAction = useCallback(
         async (
-            {
-                amount: preparedAmount,
-                flowData: preparedFlowData,
-            }: NonNullable<typeof prepareDepositFeeParams>,
+            { amount: preparedAmount, flowData: preparedFlowData }: ComposeDepositBaseActionParams,
             requestId: number,
         ) => {
             try {
@@ -71,18 +159,20 @@ export const useYieldDepositFees = ({
                     return;
                 }
 
-                const feePreview = buildYieldDepositFeePreview(result.unsignedTransaction);
+                const baseFeePreview = buildYieldDepositFeePreview(result.unsignedTransaction);
 
-                if (!feePreview) {
+                if (!baseFeePreview) {
                     clearDepositFeeState();
 
                     return;
                 }
 
-                setPreparedAction({
+                setBaseActionContext({
                     amount: preparedAmount,
-                    feePreview,
+                    baseFeePreview,
                     receiptAmount: result.receiptAmount,
+                    symbol: preparedFlowData.account.symbol,
+                    token: preparedFlowData.token,
                     unsignedTransaction: result.unsignedTransaction,
                 });
                 setIsPreparingDepositFee(false);
@@ -95,24 +185,160 @@ export const useYieldDepositFees = ({
         [clearDepositFeeState, dispatch],
     );
 
-    useEffect(() => {
-        const requestId = requestIdRef.current + 1;
-        requestIdRef.current = requestId;
+    const depositFeeDraftState = useMemo(() => {
+        const currentFeeInfo = feeInfoRef.current;
 
-        if (!prepareDepositFeeParams) {
-            clearDepositFeeState();
+        if (
+            !baseActionContext ||
+            !feeInfoRevision ||
+            !currentFeeInfo ||
+            !baseActionContext.baseFeePreview.feeLimit
+        ) {
+            return null;
+        }
+
+        return buildYieldDepositFeeDraftState({
+            currentFormDraft: formDraft,
+            amount: baseActionContext.amount,
+            feeInfo: currentFeeInfo,
+            gasLimit: baseActionContext.baseFeePreview.feeLimit,
+            symbol: baseActionContext.symbol,
+            token: baseActionContext.token,
+            unsignedTransaction: baseActionContext.unsignedTransaction,
+        });
+    }, [baseActionContext, feeInfoRevision, formDraft]);
+
+    const preparedAction = useMemo((): PreparedYieldDepositAction | null => {
+        if (!baseActionContext) {
+            return null;
+        }
+
+        if (!depositFeeDraftState && (feeInfo || formDraft)) {
+            return null;
+        }
+
+        const unsignedTransaction =
+            depositFeeDraftState?.selectedFeeUnsignedTransaction ??
+            baseActionContext.unsignedTransaction;
+        const feePreview =
+            unsignedTransaction === baseActionContext.unsignedTransaction
+                ? baseActionContext.baseFeePreview
+                : buildYieldDepositFeePreview(unsignedTransaction);
+
+        if (!feePreview) {
+            return null;
+        }
+
+        return {
+            amount: baseActionContext.amount,
+            feePreview,
+            receiptAmount: baseActionContext.receiptAmount,
+            unsignedTransaction,
+        };
+    }, [baseActionContext, depositFeeDraftState, feeInfo, formDraft]);
+
+    useEffect(() => {
+        if (!baseActionContext) {
+            return;
+        }
+
+        if (!depositFeeDraftState) {
+            clearDepositFeeLevels();
 
             return;
         }
 
-        setPreparedAction(null);
+        if (
+            feeLevelsRef.current !== storedDepositFeeLevelsRef.current ||
+            !deepEqual(storedDepositFeeLevelsRef.current, depositFeeDraftState.feeLevels)
+        ) {
+            dispatch(
+                transactionManagementActions.storeFeeLevels({
+                    feeLevels: depositFeeDraftState.feeLevels,
+                }),
+            );
+            storedDepositFeeLevelsRef.current = depositFeeDraftState.feeLevels;
+        }
+
+        if (formDraftKey && !deepEqual(formDraft, depositFeeDraftState.formDraft)) {
+            dispatch(
+                formDraftActions.storeDraft({
+                    key: formDraftKey,
+                    formDraft: depositFeeDraftState.formDraft,
+                }),
+            );
+        }
+    }, [
+        baseActionContext,
+        clearDepositFeeLevels,
+        depositFeeDraftState,
+        dispatch,
+        formDraft,
+        formDraftKey,
+    ]);
+
+    const selectedFee: FeeLevelLabel =
+        depositFeeDraftState?.formDraft.selectedFee ?? formDraft?.selectedFee ?? 'normal';
+    const localFeeLevels = depositFeeDraftState?.feeLevels ?? {};
+    const selectedFeeLevel = localFeeLevels[selectedFee];
+    const fee = isFinalPrecomposedTransaction(selectedFeeLevel) ? selectedFeeLevel.fee : null;
+    const feeAvailability = getFeeAvailability({
+        fee,
+        feeLevels: localFeeLevels,
+        selectedFee,
+        isLoading: isPreparingDepositFee,
+    });
+    const isFeeUnavailable =
+        (!!baseActionContext && !depositFeeDraftState && !isPreparingDepositFee) ||
+        feeAvailability.isFeeUnavailable;
+    const isCurrentDepositFeePreparing = !!composeDepositBaseActionParams && isPreparingDepositFee;
+    const isDepositFeeReady = isEnabled && preparedAction?.amount === amount && !isFeeUnavailable;
+
+    useEffect(() => {
+        const requestId = requestIdRef.current + 1;
+        requestIdRef.current = requestId;
+
+        if (!composeDepositBaseActionParams) {
+            setBaseActionContext(null);
+            setIsPreparingDepositFee(false);
+
+            if (hasInvalidDepositContext) {
+                clearDepositFeeStore();
+            }
+
+            return;
+        }
+
+        setBaseActionContext(null);
         setIsPreparingDepositFee(true);
-        void debounce(() => void prepareDepositFee(prepareDepositFeeParams, requestId));
-    }, [clearDepositFeeState, debounce, prepareDepositFee, prepareDepositFeeParams]);
+        void debounce(
+            () => void prepareDepositBaseAction(composeDepositBaseActionParams, requestId),
+        );
+    }, [
+        clearDepositFeeStore,
+        composeDepositBaseActionParams,
+        debounce,
+        hasInvalidDepositContext,
+        prepareDepositBaseAction,
+    ]);
+
+    useEffect(
+        () => () => {
+            requestIdRef.current += 1;
+            clearDepositFeeStore();
+        },
+        [clearDepositFeeStore],
+    );
 
     return {
         feePreview: preparedAction?.feePreview ?? null,
-        isPreparingDepositFee: !!prepareDepositFeeParams && isPreparingDepositFee,
+        formDraft,
+        formDraftKey,
+        isDepositFeeReady,
+        isFeeUnavailable,
+        isPreparingDepositFee: isCurrentDepositFeePreparing,
         preparedAction,
+        selectedFee,
+        updateFeeLevelThunk: updateEarnSelectedFeeLevelThunk,
     };
 };

--- a/suite-native/module-earn/src/hooks/useYieldDepositSubmit.ts
+++ b/suite-native/module-earn/src/hooks/useYieldDepositSubmit.ts
@@ -1,16 +1,9 @@
 import { useCallback } from 'react';
-import { useDispatch } from 'react-redux';
 
-import { isFulfilled } from '@reduxjs/toolkit';
-
-import { prepareYieldDepositThunk } from '@suite-common/wallet-core';
-
-import { type ResolvedYieldFlowData } from './useResolvedYieldFlowData';
 import { useShowYieldAlert } from './useShowYieldAlert';
 import { type PreparedYieldDepositAction } from './useYieldDepositFees';
-import { buildYieldDepositFeePreview } from '../yieldDepositFeeUtils';
 
-type UseYieldDepositSubmitParams = Pick<ResolvedYieldFlowData, 'flowData' | 'flowKey'> & {
+type UseYieldDepositSubmitParams = {
     amount: string | undefined;
     onActionReady: (preparedAction: PreparedYieldDepositAction) => void;
     preparedAction: PreparedYieldDepositAction | null;
@@ -18,34 +11,13 @@ type UseYieldDepositSubmitParams = Pick<ResolvedYieldFlowData, 'flowData' | 'flo
 
 export const useYieldDepositSubmit = ({
     amount,
-    flowData,
-    flowKey,
     onActionReady,
     preparedAction,
 }: UseYieldDepositSubmitParams) => {
-    const dispatch = useDispatch();
     const showYieldAlert = useShowYieldAlert();
 
-    const handleSubmitDeposit = useCallback(async () => {
-        if (!amount || !flowData || !flowKey) {
-            return;
-        }
-
-        if (preparedAction?.amount === amount) {
-            onActionReady(preparedAction);
-
-            return;
-        }
-
-        const response = await dispatch(
-            prepareYieldDepositThunk({
-                amount,
-                flowData,
-                flowKey,
-            }),
-        );
-
-        if (!isFulfilled(response) || response.payload.type === 'error') {
+    const handleSubmitDeposit = useCallback(() => {
+        if (!preparedAction || preparedAction.amount !== amount) {
             showYieldAlert({
                 title: 'earn.yieldDepositFlowScreen.alerts.depositUnavailable.title',
                 description: 'earn.yieldDepositFlowScreen.alerts.depositUnavailable.description',
@@ -54,29 +26,8 @@ export const useYieldDepositSubmit = ({
             return;
         }
 
-        if (response.payload.type === 'action-ready') {
-            const feePreview = buildYieldDepositFeePreview(response.payload.unsignedTransaction);
-
-            if (!feePreview) {
-                showYieldAlert({
-                    title: 'earn.yieldDepositFlowScreen.alerts.depositUnavailable.title',
-                    description:
-                        'earn.yieldDepositFlowScreen.alerts.depositUnavailable.description',
-                });
-
-                return;
-            }
-
-            onActionReady({
-                amount,
-                feePreview,
-                receiptAmount: response.payload.receiptAmount,
-                unsignedTransaction: response.payload.unsignedTransaction,
-            });
-
-            return;
-        }
-    }, [amount, dispatch, flowData, flowKey, onActionReady, preparedAction, showYieldAlert]);
+        onActionReady(preparedAction);
+    }, [amount, onActionReady, preparedAction, showYieldAlert]);
 
     return { handleSubmitDeposit };
 };

--- a/suite-native/module-earn/src/screens/YieldDepositScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldDepositScreen.tsx
@@ -3,7 +3,7 @@ import { useDispatch } from 'react-redux';
 
 import { type RouteProp, useIsFocused, useNavigation, useRoute } from '@react-navigation/native';
 
-import { getNetwork, getNetworkType } from '@suite-common/wallet-config';
+import { getNetwork } from '@suite-common/wallet-config';
 import { stablecoinYieldActions } from '@suite-common/wallet-core';
 import { Box, FullAlertBox, VStack, useBottomSheetModal } from '@suite-native/atoms';
 import { Form } from '@suite-native/forms';
@@ -15,7 +15,7 @@ import {
     YieldStackRoutes,
     useNavigateToInitialScreen,
 } from '@suite-native/navigation';
-import { FeeSummaryCard } from '@suite-native/transaction-management';
+import { FeeSelector } from '@suite-native/transaction-management';
 import { BigNumber } from '@trezor/utils';
 
 import { YieldDepositAmountInputCard } from '../components/YieldDepositAmountInputCard';
@@ -128,7 +128,6 @@ export const YieldDepositScreen = () => {
         !isDepositPending &&
         !isActionSubmitting;
     const canPrepareDepositFee = canContinueDepositFlow && !isApprovalInsufficient;
-    const isSubmitDisabled = !canContinueDepositFlow || isApprovalInsufficient;
 
     const depositFee = useYieldDepositFees({
         amount: amountValue,
@@ -136,6 +135,9 @@ export const YieldDepositScreen = () => {
         flowKey,
         isEnabled: canPrepareDepositFee,
     });
+    const isSubmitDisabled =
+        !canContinueDepositFlow || isApprovalInsufficient || !depositFee.isDepositFeeReady;
+
     useShowYieldTransactionFailureAlert({
         error: session?.error,
         flowKey,
@@ -210,8 +212,6 @@ export const YieldDepositScreen = () => {
     ]);
     const { handleSubmitDeposit } = useYieldDepositSubmit({
         amount: amountValue,
-        flowData,
-        flowKey,
         onActionReady: handleActionReady,
         preparedAction: depositFee.preparedAction,
     });
@@ -221,7 +221,7 @@ export const YieldDepositScreen = () => {
             return;
         }
 
-        void handleSubmitDeposit();
+        handleSubmitDeposit();
     }, [handleSubmitDeposit, isSubmitDisabled]);
 
     const handleCloseInfoBottomSheet = useCallback(() => {
@@ -242,8 +242,8 @@ export const YieldDepositScreen = () => {
         return null;
     }
 
-    const networkType = getNetworkType(account.symbol);
     const accountLabel = account.accountLabel ?? getNetwork(account.symbol).name;
+    const shouldShowDepositFee = isValid && !!amountValue && !isApprovalInsufficient;
 
     return (
         <Screen
@@ -311,14 +311,16 @@ export const YieldDepositScreen = () => {
                         </Box>
                     )}
 
-                    {isValid && !!amountValue && !isApprovalInsufficient && (
+                    {shouldShowDepositFee && (
                         <Box paddingHorizontal="sp16">
-                            <FeeSummaryCard
-                                fee={depositFee.feePreview?.fee ?? null}
-                                symbol={account.symbol}
-                                networkType={networkType}
-                                areFeesLoading={depositFee.isPreparingDepositFee}
-                                testID="@earn/yield-deposit-fee-preview-card"
+                            <FeeSelector
+                                accountKey={account.key}
+                                tokenContract={route.params.tokenContract}
+                                updateThunk={depositFee.updateFeeLevelThunk}
+                                selectedFee={depositFee.selectedFee}
+                                selectedFeePerUnit={depositFee.formDraft?.feePerUnit}
+                                formDraft={depositFee.formDraft}
+                                formDraftKey={depositFee.formDraftKey}
                             />
                         </Box>
                     )}

--- a/suite-native/module-earn/src/utils/yieldDepositUtils.ts
+++ b/suite-native/module-earn/src/utils/yieldDepositUtils.ts
@@ -1,0 +1,4 @@
+import { EARN_MODULE_PREFIX } from '../constants';
+
+export const getYieldDepositFormDraftKey = (flowKey: string) =>
+    `${EARN_MODULE_PREFIX}/yield-deposit/${flowKey}`;

--- a/suite-native/module-earn/src/yieldDepositFeeUtils.ts
+++ b/suite-native/module-earn/src/yieldDepositFeeUtils.ts
@@ -1,10 +1,56 @@
+import { buildStablecoinYieldTransactionReview } from '@suite-common/earn-stablecoin/src/signing';
 import { parseUnsignedEvmTransactionForSigning } from '@suite-common/earn-stablecoin-api';
-import { type PrecomposedTransactionFinal } from '@suite-common/wallet-types';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { buildEvmFeeFields, buildEvmSelectedFee } from '@suite-common/wallet-core';
+import {
+    type FeeInfo,
+    type FeeLevelLabel,
+    type FormState,
+    type PrecomposedLevels,
+    type PrecomposedTransactionFinal,
+} from '@suite-common/wallet-types';
 import { calculateTotalGasCost, fromHex } from '@suite-common/wallet-utils';
 
 type ParsedUnsignedEvmTransaction = NonNullable<
     ReturnType<typeof parseUnsignedEvmTransactionForSigning>
 >;
+
+type YieldDepositFeeToken = {
+    contractAddress?: string | null;
+    decimals: number;
+    symbol: string;
+};
+
+type BuildYieldDepositFeeLevelsParams = {
+    amount: string;
+    feeInfo: FeeInfo;
+    gasLimit: string;
+    symbol: NetworkSymbol;
+    token: YieldDepositFeeToken;
+    unsignedTransaction: string;
+};
+
+type BuildYieldDepositFeeFormDraftParams = {
+    currentFormDraft?: FormState;
+    formState: FormState;
+    selectedFee: FeeLevelLabel;
+};
+
+type BuildYieldDepositFeeDraftStateParams = BuildYieldDepositFeeLevelsParams & {
+    currentFormDraft?: FormState;
+};
+
+type BuildYieldDepositSelectedFeeUnsignedTransactionParams = {
+    currentFormDraft?: FormState;
+    feeInfo: FeeInfo;
+    unsignedTransaction: string;
+};
+
+type BuildYieldDepositFeeDraftStateResult = {
+    feeLevels: PrecomposedLevels;
+    formDraft: FormState;
+    selectedFeeUnsignedTransaction: string;
+};
 
 const buildPrecomposedTransaction = (
     tx: ParsedUnsignedEvmTransaction,
@@ -43,6 +89,91 @@ const buildPrecomposedTransaction = (
     };
 };
 
+const parseRawUnsignedEvmTransaction = (unsignedTransaction: string) => {
+    const parsedTransaction = parseUnsignedEvmTransactionForSigning(unsignedTransaction);
+
+    if (!parsedTransaction) {
+        return null;
+    }
+
+    const rawTransaction = JSON.parse(unsignedTransaction) as Record<string, unknown>;
+
+    return { parsedTransaction, rawTransaction };
+};
+
+const isYieldDepositEip1559FeeInfo = (feeInfo: FeeInfo) =>
+    feeInfo.levels.some(feeLevel => feeLevel.maxFeePerGas && feeLevel.maxPriorityFeePerGas);
+
+const getYieldDepositFeeState = (
+    currentFormDraft: FormState | undefined,
+    isEip1559Fee: boolean,
+) => {
+    const hasCompleteCustomFee =
+        currentFormDraft?.selectedFee === 'custom' &&
+        !!currentFormDraft.feePerUnit &&
+        !!currentFormDraft.feeLimit;
+    const hasCompleteEip1559CustomFee =
+        !!currentFormDraft?.maxFeePerGas && !!currentFormDraft.maxPriorityFeePerGas;
+
+    if (hasCompleteCustomFee && (!isEip1559Fee || hasCompleteEip1559CustomFee)) {
+        const customFee = {
+            feeLimit: currentFormDraft.feeLimit,
+            feePerUnit: currentFormDraft.feePerUnit,
+            ...(isEip1559Fee && currentFormDraft.maxFeePerGas
+                ? { maxFeePerGas: currentFormDraft.maxFeePerGas }
+                : {}),
+            ...(isEip1559Fee && currentFormDraft.maxPriorityFeePerGas
+                ? { maxPriorityFeePerGas: currentFormDraft.maxPriorityFeePerGas }
+                : {}),
+        };
+
+        return {
+            customFee,
+            selectedFee: 'custom' as const,
+        };
+    }
+
+    return {
+        customFee: undefined,
+        selectedFee:
+            currentFormDraft?.selectedFee === 'custom'
+                ? ('normal' as const)
+                : (currentFormDraft?.selectedFee ?? 'normal'),
+    };
+};
+
+const getYieldDepositFeeLevel = (feeInfo: FeeInfo, selectedFee: FeeLevelLabel) =>
+    feeInfo.levels.find(level => level.label === selectedFee) ??
+    feeInfo.levels.find(level => level.label === 'normal');
+
+const buildUnsignedTransactionWithFeeFields = (
+    rawTransaction: Record<string, unknown>,
+    feeFields: ReturnType<typeof buildEvmFeeFields>,
+) => {
+    const transaction = { ...rawTransaction };
+    delete transaction.gasPrice;
+    delete transaction.maxFeePerGas;
+    delete transaction.maxPriorityFeePerGas;
+    delete transaction.baseFeePerGas;
+    delete transaction.type;
+
+    if ('maxFeePerGas' in feeFields && 'maxPriorityFeePerGas' in feeFields) {
+        return {
+            ...transaction,
+            type: 2,
+            gasLimit: feeFields.gasLimit,
+            maxFeePerGas: feeFields.maxFeePerGas,
+            maxPriorityFeePerGas: feeFields.maxPriorityFeePerGas,
+        };
+    }
+
+    return {
+        ...transaction,
+        gasLimit: feeFields.gasLimit,
+        gasPrice: feeFields.gasPrice,
+    };
+};
+
 export const buildYieldDepositFeePreview = (
     unsignedTransaction: string,
 ): PrecomposedTransactionFinal | null => {
@@ -53,4 +184,141 @@ export const buildYieldDepositFeePreview = (
     }
 
     return buildPrecomposedTransaction(tx);
+};
+
+export const buildYieldDepositFeeLevels = ({
+    amount,
+    feeInfo,
+    gasLimit,
+    symbol,
+    token,
+    unsignedTransaction,
+}: BuildYieldDepositFeeLevelsParams): PrecomposedLevels =>
+    Object.fromEntries(
+        feeInfo.levels
+            .filter(feeLevel => feeLevel.label !== 'custom')
+            .map(feeLevel => {
+                const { precomposedTransaction } = buildStablecoinYieldTransactionReview({
+                    amount,
+                    selectedFee: buildEvmSelectedFee({ feeLevel, gasLimit }),
+                    symbol,
+                    token,
+                    unsignedTransaction,
+                });
+
+                return [feeLevel.label, precomposedTransaction];
+            }),
+    );
+
+export const buildYieldDepositSelectedFeeUnsignedTransaction = ({
+    currentFormDraft,
+    feeInfo,
+    unsignedTransaction,
+}: BuildYieldDepositSelectedFeeUnsignedTransactionParams): string | null => {
+    const parsedUnsignedTransaction = parseRawUnsignedEvmTransaction(unsignedTransaction);
+
+    if (!parsedUnsignedTransaction) {
+        return null;
+    }
+
+    const { parsedTransaction, rawTransaction } = parsedUnsignedTransaction;
+    const isEip1559Fee =
+        isYieldDepositEip1559FeeInfo(feeInfo) ||
+        !!(parsedTransaction.maxFeePerGas && parsedTransaction.maxPriorityFeePerGas);
+    const { customFee, selectedFee } = getYieldDepositFeeState(currentFormDraft, isEip1559Fee);
+    const gasLimit = fromHex(parsedTransaction.gasLimit).toBigNumber().toFixed(0);
+    const feeLevel = customFee ? customFee : getYieldDepositFeeLevel(feeInfo, selectedFee);
+
+    if (!feeLevel) {
+        return null;
+    }
+
+    const feeFields = buildEvmFeeFields({
+        feeLevel,
+        gasLimit: customFee?.feeLimit ?? gasLimit,
+    });
+
+    return JSON.stringify(buildUnsignedTransactionWithFeeFields(rawTransaction, feeFields));
+};
+
+export const buildYieldDepositFeeFormDraft = ({
+    currentFormDraft,
+    formState,
+    selectedFee,
+}: BuildYieldDepositFeeFormDraftParams): FormState => {
+    const shouldPreserveCustomFeeFields =
+        selectedFee === 'custom' && !!currentFormDraft?.feePerUnit && !!currentFormDraft.feeLimit;
+    const feeFields = shouldPreserveCustomFeeFields ? currentFormDraft : formState;
+
+    return {
+        ...formState,
+        selectedFee,
+        feePerUnit: feeFields.feePerUnit,
+        feeLimit: feeFields.feeLimit,
+        maxFeePerGas: feeFields.maxFeePerGas,
+        maxPriorityFeePerGas: feeFields.maxPriorityFeePerGas,
+    };
+};
+
+export const buildYieldDepositFeeDraftState = ({
+    currentFormDraft,
+    ...feeLevelParams
+}: BuildYieldDepositFeeDraftStateParams): BuildYieldDepositFeeDraftStateResult | null => {
+    try {
+        const feeLevels = buildYieldDepositFeeLevels(feeLevelParams);
+        const { selectedFee } = getYieldDepositFeeState(
+            currentFormDraft,
+            isYieldDepositEip1559FeeInfo(feeLevelParams.feeInfo),
+        );
+        const feeLevel = getYieldDepositFeeLevel(feeLevelParams.feeInfo, selectedFee);
+
+        if (!feeLevel) {
+            return null;
+        }
+
+        const selectedFeeUnsignedTransaction = buildYieldDepositSelectedFeeUnsignedTransaction({
+            currentFormDraft,
+            feeInfo: feeLevelParams.feeInfo,
+            unsignedTransaction: feeLevelParams.unsignedTransaction,
+        });
+
+        if (!selectedFeeUnsignedTransaction) {
+            return null;
+        }
+
+        const selectedFeePreview = buildYieldDepositFeePreview(selectedFeeUnsignedTransaction);
+
+        if (!selectedFeePreview) {
+            return null;
+        }
+
+        const { formState } = buildStablecoinYieldTransactionReview({
+            amount: feeLevelParams.amount,
+            selectedFee: buildEvmSelectedFee({
+                feeLevel,
+                gasLimit: feeLevelParams.gasLimit,
+            }),
+            symbol: feeLevelParams.symbol,
+            token: feeLevelParams.token,
+            unsignedTransaction: feeLevelParams.unsignedTransaction,
+        });
+
+        return {
+            feeLevels:
+                selectedFee === 'custom'
+                    ? {
+                          ...feeLevels,
+                          custom: selectedFeePreview,
+                      }
+                    : feeLevels,
+            formDraft: buildYieldDepositFeeFormDraft({
+                currentFormDraft,
+                formState,
+                selectedFee,
+            }),
+            selectedFeeUnsignedTransaction,
+        };
+    } catch {
+        return null;
+    }
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- allow modify yield deposit fee 

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/28523

## Screenshots:

https://github.com/user-attachments/assets/4cd917ab-7b78-44ff-825d-30ffe4517193


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/yield-deposit-fee-selector&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/yield-deposit-fee-selector&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/yield-deposit-fee-selector&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/native/yield-deposit-fee-selector/web/](https://dev.suite.sldev.cz/suite-web/feat/native/yield-deposit-fee-selector/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-16T10:17:47.656Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-16T10:16:33.419Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->