### PR TITLE
chore(suite): remove show more button from transaction targets list

### DIFF
--- a/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from 'react';
+import { memo } from 'react';
 
 import styled from 'styled-components';
 
@@ -34,8 +34,6 @@ const Wrapper = styled.div`
     scroll-margin-top: calc(${SUBPAGE_NAV_HEIGHT} + 115px);
 `;
 
-const DEFAULT_LIMIT = 3;
-
 type OpenModalParams = {
     flow: 'detail' | 'bump-fee' | 'cancel-transaction';
 };
@@ -62,7 +60,6 @@ export const TransactionItem = memo(
         disableBumpFee,
         index,
     }: TransactionItemProps) => {
-        const [limit, setLimit] = useState(0);
         const { shallDisplayBaseCurrency } = useDisplayBaseCurrency(transaction.symbol);
 
         const account = useSelector(selectSelectedAccount) || null;
@@ -80,9 +77,6 @@ export const TransactionItem = memo(
 
         const fee = formatNetworkAmount(transaction.fee, transaction.symbol);
         const showFeeRow = isTxFeePaid(transaction);
-
-        const isExpandable = allOutputs.length - DEFAULT_LIMIT > 0;
-        const toExpand = allOutputs.length - DEFAULT_LIMIT - limit;
 
         const isTxCancellable =
             transaction.type !== 'self' &&
@@ -138,68 +132,44 @@ export const TransactionItem = memo(
                             />
                         }
                         actions={
-                            (isTxBumpable || isExpandable) && (
+                            isTxBumpable && (
                                 <Row gap={12}>
-                                    {isExpandable && (
+                                    <Tooltip
+                                        content={
+                                            <Translation
+                                                id="TR_BUMP_FEE_DISABLED_TOOLTIP"
+                                                values={{
+                                                    a: chunks => (
+                                                        <Link
+                                                            href={
+                                                                HELP_CENTER_REPLACE_BY_FEE_ETHEREUM
+                                                            }
+                                                        >
+                                                            {chunks}
+                                                        </Link>
+                                                    ),
+                                                }}
+                                            />
+                                        }
+                                        isActive={disableBumpFee}
+                                    >
                                         <Button
                                             intent="neutral"
                                             priority="secondary"
-                                            iconRight={toExpand > 0 ? 'caretDown' : 'caretUp'}
-                                            size="small"
+                                            iconLeft="gauge"
                                             onClick={e => {
-                                                setLimit(toExpand > 0 ? limit + 20 : 0);
-                                                e.preventDefault();
+                                                openTxDetailsModal({
+                                                    flow: 'bump-fee',
+                                                });
                                                 e.stopPropagation();
                                             }}
+                                            isDisabled={disableBumpFee}
+                                            data-testid="@transaction-item/bump-fee-button"
+                                            size="medium"
                                         >
-                                            <Translation
-                                                id={
-                                                    toExpand > 0
-                                                        ? 'TR_SHOW_MORE_ADDRESSES'
-                                                        : 'TR_SHOW_LESS'
-                                                }
-                                                values={{ count: toExpand }}
-                                            />
+                                            <Translation id="TR_BUMP_FEE" />
                                         </Button>
-                                    )}
-                                    {isTxBumpable && (
-                                        <Tooltip
-                                            content={
-                                                <Translation
-                                                    id="TR_BUMP_FEE_DISABLED_TOOLTIP"
-                                                    values={{
-                                                        a: chunks => (
-                                                            <Link
-                                                                href={
-                                                                    HELP_CENTER_REPLACE_BY_FEE_ETHEREUM
-                                                                }
-                                                            >
-                                                                {chunks}
-                                                            </Link>
-                                                        ),
-                                                    }}
-                                                />
-                                            }
-                                            isActive={disableBumpFee}
-                                        >
-                                            <Button
-                                                intent="neutral"
-                                                priority="secondary"
-                                                iconLeft="gauge"
-                                                onClick={e => {
-                                                    openTxDetailsModal({
-                                                        flow: 'bump-fee',
-                                                    });
-                                                    e.stopPropagation();
-                                                }}
-                                                isDisabled={disableBumpFee}
-                                                data-testid="@transaction-item/bump-fee-button"
-                                                size="medium"
-                                            >
-                                                <Translation id="TR_BUMP_FEE" />
-                                            </Button>
-                                        </Tooltip>
-                                    )}
+                                    </Tooltip>
                                     {isTxCancellable && (
                                         <Button
                                             intent="neutral"
@@ -226,8 +196,6 @@ export const TransactionItem = memo(
                                 allOutputs={allOutputs}
                                 isActionDisabled={isActionDisabled}
                                 accountKey={accountKey}
-                                limit={limit}
-                                defaultLimit={DEFAULT_LIMIT}
                                 isPhishingTransaction={isPhishingTransaction}
                             />
                         ) : null}

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTargetsList.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTargetsList.tsx
@@ -8,8 +8,6 @@ import { TransactionTarget } from './TransactionTarget';
 type TransactionTargetsListProps = {
     transaction: WalletAccountTransaction;
     allOutputs: Target[];
-    limit: number;
-    defaultLimit: number;
     accountKey: AccountKey;
     isActionDisabled?: boolean;
     isPhishingTransaction?: boolean;
@@ -18,41 +16,20 @@ type TransactionTargetsListProps = {
 export const TransactionTargetsList = ({
     transaction,
     allOutputs,
-    limit,
-    defaultLimit,
     accountKey,
     isActionDisabled,
     isPhishingTransaction,
-}: TransactionTargetsListProps) => {
-    const previewTargets = allOutputs.slice(0, defaultLimit);
-
-    const renderTarget = ({ target, i }: { target: Target; i: number }) => {
-        const commonProps = {
-            ...target,
-            transaction,
-            accountKey,
-            isActionDisabled,
-            isPhishingTransaction,
-        };
-
-        return <TransactionTarget key={i} {...commonProps} />;
-    };
-
-    return (
-        <>
-            {previewTargets.map((target, i) =>
-                renderTarget({
-                    target,
-                    i,
-                }),
-            )}
-            {limit > 0 &&
-                allOutputs.slice(defaultLimit, defaultLimit + limit).map((target, i) =>
-                    renderTarget({
-                        target,
-                        i,
-                    }),
-                )}
-        </>
-    );
-};
+}: TransactionTargetsListProps) => (
+    <>
+        {allOutputs.map((target, i) => (
+            <TransactionTarget
+                key={i}
+                {...target}
+                transaction={transaction}
+                accountKey={accountKey}
+                isActionDisabled={isActionDisabled}
+                isPhishingTransaction={isPhishingTransaction}
+            />
+        ))}
+    </>
+);

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -3588,10 +3588,6 @@ export const messages = defineMessages({
         description: 'Number of words. For example: 12 words',
         id: 'TR_WORDS',
     },
-    TR_SHOW_MORE_ADDRESSES: {
-        defaultMessage: 'Show more ({count})',
-        id: 'TR_SHOW_MORE_ADDRESSES',
-    },
     TR_RESERVE_INFO: {
         defaultMessage:
             '{networkName} addresses require a minimum balance of {minBalance} {displaySymbol} to activate and maintain the account.',


### PR DESCRIPTION
Removes the show more/show less button and the 3-output limit from transaction items in the transaction list, so all targets of a transaction are always rendered. Also removes the now unused TR_SHOW_MORE_ADDRESSES message.

Resolves #28493

Before:
<img width="581" height="520" alt="Screenshot 2026-06-19 at 10 35 25" src="https://github.com/user-attachments/assets/8581b9e4-d353-4fce-b530-5ed2b547a408" />
<img width="421" height="476" alt="Screenshot 2026-06-19 at 10 35 10" src="https://github.com/user-attachments/assets/5fd1e97e-cb37-459c-98d3-b77fb68dd993" />
<img width="1131" height="502" alt="Screenshot 2026-06-19 at 10 34 48" src="https://github.com/user-attachments/assets/57206c07-e45c-4ff2-92bb-f24099085f75" />

Now:
<img width="1167" height="478" alt="Screenshot 2026-06-19 at 10 34 01" src="https://github.com/user-attachments/assets/baea639d-58f9-490b-9d48-1d9089e3c102" />
<img width="1152" height="709" alt="Screenshot 2026-06-19 at 10 33 53" src="https://github.com/user-attachments/assets/17a95bc7-8b7e-4434-9e2d-c82e6f8511b2" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect TransactionItem.tsx and TransactionTargetsList.tsx (core transaction rendering components) and messages.ts (the global i18n messages file). Since both component files map to 121 tests, they are clearly broad dependencies — most tests only transitively import them. The recommended strategy focuses on tests that directly interact with transaction list rendering, transaction labels/outputs, and transaction status displays. messages.ts has no static coverage but is a universal dependency; only tests checking specific transaction-related translation keys are included. The highest risk is in tests that assert on transaction addresses, output labels, and transaction status text.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx`
- `packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTargetsList.tsx`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/wallet/transactions.test.ts` — This test directly exercises the transaction list UI — finding transaction addresses, searching transactions, and cycling through graph ranges on an account page. TransactionItem.tsx and TransactionTargetsList.tsx are core components rendering each transaction row and its targets/addresses, so any change there directly affects what this test validates.
- `suite/e2e/tests/wallet/export-transactions.test.ts` — This test exports transaction history in PDF/CSV/JSON formats from the wallet account view. The transaction list rendered by TransactionItem and TransactionTargetsList is the source data for these exports, so changes to how transaction targets are rendered or structured could affect export correctness.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test verifies that after sending a transaction with OP_RETURN, the pending transaction list shows 'OP_RETURN (meow)' as a target address. This directly exercises TransactionTargetsList rendering of transaction targets in the transaction list view.
- `suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — This test adds, edits, and cancels labels on transaction outputs, and verifies output labels appear in the exported CSV. Transaction output labels are rendered within TransactionItem/TransactionTargetsList components, making this test directly sensitive to changes in these files.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/wallet/pagination.test.ts` — This test navigates paginated transaction lists and checks that transaction addresses are displayed correctly on each page. Transaction addresses are rendered by TransactionTargetsList within TransactionItem, so rendering changes could affect the displayed addresses.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test verifies pending staking transaction display with confirming status and checks transaction status transitions (TR_TX_CONFIRMING, TR_TX_CONFIRMED). These status labels come from messages.ts and are rendered in transaction items, so changes to either could affect this test.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Similar to initial-stake, this test checks pending transaction text visibility and transaction status translations (TR_TX_CONFIRMING, TR_TX_CONFIRMED) which are rendered through TransactionItem and sourced from messages.ts.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — This test verifies pending unstaking transaction visibility with speed-up button and transaction confirmation status, which are rendered within TransactionItem components using translation keys from messages.ts.
- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — This test creates and verifies transaction output labels via Suite Sync. Output labels are rendered within TransactionTargetsList, so changes to how targets are displayed could break label visibility assertions.
- `suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts` — This test removes output labels and verifies the display reverts to truncated address format. The output label rendering is handled by TransactionTargetsList within TransactionItem.
- `suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — This test syncs output labels from the Evolu relay and verifies they display on the account transaction view. Output labels are rendered within TransactionItem/TransactionTargetsList components.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — Discreet mode hides balance values across the dashboard. While TransactionItem may render transaction amounts that get masked, the test primarily focuses on dashboard-level balances rather than individual transaction items.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/intl/src/messages.ts`

_Updated: 2026-06-12T14:41:59.166Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/remove-show-more-tx-targets/web/](https://dev.suite.sldev.cz/suite-web/chore/remove-show-more-tx-targets/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/remove-show-more-tx-targets&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/remove-show-more-tx-targets&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-12T14:46:01.394Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-12T14:44:18.395Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->