### PR TITLE
fix(suite): do not show address verification error toast on user cancel

### DIFF
--- a/suite/receive/src/showAddressThunk.ts
+++ b/suite/receive/src/showAddressThunk.ts
@@ -83,8 +83,13 @@ export const showAddressThunk =
             });
         } else {
             dispatch(closeModal());
-            // Special case: device no-backup permissions not granted.
-            if (response.error.code === 'Method_PermissionsNotGranted') return;
+            if (
+                // Special case: device no-backup permissions not granted
+                response.error.code === 'Method_PermissionsNotGranted' ||
+                // User action: address cancelled on device
+                response.error.code === 'Failure_ActionCancelled'
+            )
+                return;
 
             dispatch(
                 notificationsActions.addToast({


### PR DESCRIPTION
Closing the receive address confirmation dialog or cancelling the verification on the device no longer shows the "Address verification error: Canceled" toast.

Resolves #23982

<img width="336" height="230" alt="Screenshot 2026-06-18 at 17 20 53" src="https://github.com/user-attachments/assets/d5ead341-2f45-49df-a8f5-3e2e8f0ae4de" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is to showAddressThunk.ts, which is the core thunk responsible for revealing receive addresses and coordinating device confirmation in Trezor Suite. This is a critical piece of the receive flow. The highest risk is to all tests that exercise the receive address reveal and verification flow across different coin types (BTC, ETH, SOL, TRX, ADA) and wallet configurations (standard, passphrase-protected, reconnected devices). Tests covering passphrase wallets are also high priority since address reveal with passphrases involves additional device interaction steps. Secondary risk extends to metadata/labeling tests that use address reveal as a prerequisite, and TrezorConnect getAddress tests that share address confirmation UI.

<details><summary><b>Changed files (1)</b></summary>

- `suite/receive/src/showAddressThunk.ts`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/wallet/receive.test.ts` — This test directly exercises the receive address flow including revealing addresses and confirming them on device — the core functionality of showAddressThunk. It covers BTC, ETH, SOL, and TRX receive flows, making it the most direct test of the changed code.
- `suite/e2e/tests/wallet/cardano.test.ts` — This test exercises the Cardano receive flow including revealing an address, confirming it on the hardware device, and copying it. showAddressThunk is the thunk responsible for orchestrating address reveal and device confirmation.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test covers the global receive flow where the user reveals an ETH address and verifies it matches on both the Suite UI and the device display. The showAddressThunk is the core mechanism for address reveal and device verification.
- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts` — This test specifically exercises revealing a Cardano receive address with a passphrase-protected wallet, including re-entering the passphrase after device restart. It tests both happy path and wrong-passphrase error handling of the address reveal flow powered by showAddressThunk.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — This test exercises revealing receive addresses before and after device disconnection/reconnection, including passphrase re-confirmation on reconnect. It directly tests showAddressThunk's behavior across device state changes and passphrase caching.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — This test exercises revealing receive addresses across multiple passphrase wallets, verifying addresses on device, and checking that previously revealed addresses persist. The showAddressThunk handles the address reveal and device confirmation flow being tested.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — This test exercises TrezorConnect.getAddress which shares the address verification UI flow (verified badge, error badge on rejection). While it uses TrezorConnect directly rather than showAddressThunk, changes to address confirmation handling could affect both paths.
- `suite/e2e/tests/wallet/without-device.test.ts` — This test verifies that attempting to reveal a receive address when the device is disconnected shows a connection modal. showAddressThunk likely handles this device-not-connected error path.
- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — This test exercises the receive address label flow including revealing an address and changing its label. The address reveal step is powered by showAddressThunk, making it indirectly dependent on this change.
- `suite/e2e/tests/metadata/legacy/address-metadata.test.ts` — This test adds and edits address labels in the receive address view, which involves the address reveal flow. showAddressThunk orchestrates the address display that labels are applied to.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test covers TrezorConnect.getAddress via the web popup flow with address verification on device. While it uses a different entry point than showAddressThunk, shared address confirmation UI components could be affected.

</details>

_Updated: 2026-06-18T15:27:44.749Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/remove-address-verification-cancel-toast&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/remove-address-verification-cancel-toast&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-18T15:33:03.429Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-18T15:31:01.675Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/remove-address-verification-cancel-toast/web/](https://dev.suite.sldev.cz/suite-web/fix/remove-address-verification-cancel-toast/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->