### PR TITLE
fix(suite): truncate long token names in tokens table to prevent row overflow

### DIFF
--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
@@ -10,7 +10,14 @@ import {
 import { getUnusedAddressFromAccount } from '@suite-common/trading';
 import { type Network } from '@suite-common/wallet-config';
 import { type Account, type TokenAddress } from '@suite-common/wallet-types';
-import { Column, Row, Table, Text } from '@trezor/components';
+import {
+    Column,
+    Row,
+    TOOLTIP_DELAY_LONG,
+    Table,
+    Text,
+    TruncateWithTooltip,
+} from '@trezor/components';
 import { AssetLogo } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 
@@ -73,7 +80,11 @@ export const TokenRow = ({
                             size={24}
                             shouldTryToFetch={isTokenKnown}
                         />
-                        {isTokenKnown ? token.name : <BlurUrls text={token.name} />}
+                        <Text as="div" textWrap="nowrap" maxWidth={180}>
+                            <TruncateWithTooltip delayShow={TOOLTIP_DELAY_LONG}>
+                                {isTokenKnown ? token.name : <BlurUrls text={token.name} />}
+                            </TruncateWithTooltip>
+                        </Text>
                     </Row>
                 </Table.Cell>
 


### PR DESCRIPTION
Long token names (typically on spam tokens in the hidden tokens section) expanded the first column of the tokens table, breaking the alignment of the values column and pushing the actions out of view. The name is now capped and truncated with an ellipsis, with the full name shown in a tooltip.


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to TokenRow.tsx, a UI component within the tokens table view. The primary risk is around token display and navigation from token rows to trading forms. The trading/navigation test is more directly relevant since it explicitly tests navigation from specific token pages (which render TokenRow) to trading forms. The live-swap test has a weaker connection, primarily through token balance display during teardown logic.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx`

</details>

**Recommended tests (2)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — TokenRow.tsx is part of the tokens table UI, and this test navigates to token-level pages (TrueUSD, USDC under Ethereum) to open trading forms. Changes to TokenRow could affect how token entries render or how navigation links/buttons within token rows function, potentially breaking the token-specific trading navigation paths.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/trading-live/live-swap-coin-to-token.test.ts` — This test swaps SOL to USDC and involves token balance retrieval (walletPage token balance check for teardown). TokenRow changes could affect how token balances are displayed or interacted with, but the core swap flow primarily operates through the trading/swap form rather than the tokens table directly.

</details>

_Updated: 2026-06-21T19:00:39.429Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/tokens-hidden-row-overflow&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/tokens-hidden-row-overflow&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy BTC > Buy Bitcoin from best offer | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-21T19:06:19.968Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-21T19:04:27.171Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/tokens-hidden-row-overflow/web/](https://dev.suite.sldev.cz/suite-web/fix/tokens-hidden-row-overflow/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->