### PR TITLE
fix(suite-native): clear and collapse account search when leaving the screen

### DIFF
--- a/suite-native/accounts/src/components/SearchableAccountsListHeader.tsx
+++ b/suite-native/accounts/src/components/SearchableAccountsListHeader.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useState } from 'react';
+import { type ReactNode, useCallback, useState } from 'react';
 import { View } from 'react-native';
 import Animated, {
     type EntryExitAnimationFunction,
@@ -7,6 +7,8 @@ import Animated, {
     withDelay,
     withTiming,
 } from 'react-native-reanimated';
+
+import { useFocusEffect } from '@react-navigation/native';
 
 import { Box, HStack, IconButton, Text } from '@suite-native/atoms';
 import { type AddCoinFlowType, type CloseActionType, GoBackIcon } from '@suite-native/navigation';
@@ -48,10 +50,12 @@ export const SearchableAccountsListHeader = ({
 
     const [isSearchActive, setIsSearchActive] = useState(false);
 
-    const handleHideFilter = () => {
+    const handleHideFilter = useCallback(() => {
         setIsSearchActive(false);
         onSearchInputChange('');
-    };
+    }, [onSearchInputChange]);
+
+    useFocusEffect(useCallback(() => handleHideFilter, [handleHideFilter]));
 
     const enteringFadeInAnimation: EntryExitAnimationFunction = () => {
         'worklet';


### PR DESCRIPTION
The My assets search field kept its value and stayed expanded after navigating away, because the search state is component-local and React Navigation keeps the screen mounted. The search is now cleared and collapsed when the screen loses focus.


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/my-assets-search-reset&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->