### PR TITLE
feat(suite-native): expose ExperimentWrapper from message-system

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/AfterTradeExperiment.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/AfterTradeExperiment.tsx
@@ -5,10 +5,9 @@ import {
     type SellTradeStatus,
 } from 'invity-api';
 
-import { ExperimentId } from '@suite-common/message-system';
+import { ExperimentId, ExperimentWrapper } from '@suite-common/message-system';
 import { type TradingType } from '@suite-common/trading';
 
-import { ExperimentWrapper } from 'src/components/suite/Experiment/ExperimentWrapper';
 import { type TradingGetCryptoQuoteAmountProps } from 'src/types/trading/trading';
 
 import { TradingDetailFeedback } from './TradingDetailFeedback';

--- a/suite-common/message-system/src/ExperimentWrapper.tsx
+++ b/suite-common/message-system/src/ExperimentWrapper.tsx
@@ -1,6 +1,7 @@
 import { type ReactElement } from 'react';
 
-import { type ExperimentId, useExperiment } from '@suite-common/message-system';
+import { type ExperimentId } from './messageSystemTypes';
+import { useExperiment } from './useExperiment';
 
 interface ExperimentWrapperProps {
     id: ExperimentId;
@@ -20,10 +21,7 @@ export const ExperimentWrapper = ({
     const { experiment, activeExperimentVariant } = useExperiment(id);
     const defaultComponent = components[0];
 
-    const experimentOrVariantNotFound = !experiment || !activeExperimentVariant;
-    const experimentAndComponentsMismatch = experiment?.groups.length !== components.length;
-
-    if (experimentOrVariantNotFound || experimentAndComponentsMismatch) {
+    if (!experiment || !activeExperimentVariant) {
         return defaultComponent?.element ?? null;
     }
 

--- a/suite-common/message-system/src/__fixtures__/createMessageSystemState.ts
+++ b/suite-common/message-system/src/__fixtures__/createMessageSystemState.ts
@@ -1,0 +1,38 @@
+import { messageSystemInitialState } from '../messageSystemReducer';
+import { ExperimentId, type MessageSystemState } from '../messageSystemTypes';
+
+export const experimentGroups = [
+    { variant: 'A', percentage: 50 },
+    { variant: 'B', percentage: 50 },
+];
+
+export const createMessageSystemState = ({
+    groups = experimentGroups,
+    inclusionOverride,
+}: {
+    groups?: typeof experimentGroups;
+    inclusionOverride?: number;
+} = {}) =>
+    ({
+        ...messageSystemInitialState,
+        config: {
+            version: 1,
+            timestamp: '2023-01-01',
+            sequence: 1,
+            actions: [],
+            experiments: [
+                {
+                    conditions: [],
+                    experiment: {
+                        id: ExperimentId.tradingFeedbackForm,
+                        groups,
+                    },
+                },
+            ],
+        },
+        validExperiments: [ExperimentId.tradingFeedbackForm],
+        experimentInclusionOverrides:
+            inclusionOverride !== undefined
+                ? { [ExperimentId.tradingFeedbackForm]: inclusionOverride }
+                : undefined,
+    }) as unknown as MessageSystemState;

--- a/suite-common/message-system/src/__tests__/ExperimentWrapper.test.tsx
+++ b/suite-common/message-system/src/__tests__/ExperimentWrapper.test.tsx
@@ -1,0 +1,86 @@
+import { Provider } from 'react-redux';
+
+import { combineReducers } from '@reduxjs/toolkit';
+
+import {
+    configureMockStore,
+    extraDependenciesCommonMock,
+    render,
+    screen,
+} from '@suite-common/test-utils';
+
+import { ExperimentWrapper } from '../ExperimentWrapper';
+import { createMessageSystemState } from '../__fixtures__/createMessageSystemState';
+import { messageSystemInitialState, prepareMessageSystemReducer } from '../messageSystemReducer';
+import { ExperimentId, type MessageSystemState } from '../messageSystemTypes';
+
+const messageSystemReducer = prepareMessageSystemReducer(extraDependenciesCommonMock);
+
+const createStore = (messageSystem: MessageSystemState) =>
+    configureMockStore({
+        extra: {},
+        reducer: combineReducers({
+            messageSystem: messageSystemReducer,
+            analytics: (state = { instanceId: 'test-instance-id' }) => state,
+        }),
+        preloadedState: { messageSystem } as { messageSystem: MessageSystemState },
+    });
+
+const defaultComponents = [
+    { variant: 'A', element: <div>variant A</div> },
+    { variant: 'B', element: <div>variant B</div> },
+];
+
+const renderWrapper = ({
+    messageSystem = createMessageSystemState(),
+    components = defaultComponents,
+}: {
+    messageSystem?: MessageSystemState;
+    components?: typeof defaultComponents;
+} = {}) =>
+    render(
+        <Provider store={createStore(messageSystem)}>
+            <ExperimentWrapper id={ExperimentId.tradingFeedbackForm} components={components} />
+        </Provider>,
+    );
+
+describe('ExperimentWrapper', () => {
+    it('renders the default (first) component when experiment is not valid', () => {
+        renderWrapper({ messageSystem: messageSystemInitialState });
+
+        expect(screen.getByText('variant A')).toBeDefined();
+    });
+
+    it('renders the component matching the active variant', () => {
+        renderWrapper({ messageSystem: createMessageSystemState({ inclusionOverride: 99 }) });
+
+        expect(screen.getByText('variant B')).toBeDefined();
+    });
+
+    it('renders the matching component when config defines more groups than code', () => {
+        renderWrapper({
+            messageSystem: createMessageSystemState({
+                groups: [
+                    { variant: 'A', percentage: 30 },
+                    { variant: 'B', percentage: 40 },
+                    { variant: 'C', percentage: 30 },
+                ],
+                inclusionOverride: 50,
+            }),
+        });
+
+        expect(screen.getByText('variant B')).toBeDefined();
+    });
+
+    it('renders the default component when active variant has no component', () => {
+        renderWrapper({
+            messageSystem: createMessageSystemState({ inclusionOverride: 99 }),
+            components: [
+                { variant: 'A', element: <div>variant A</div> },
+                { variant: 'C', element: <div>variant C</div> },
+            ],
+        });
+
+        expect(screen.getByText('variant A')).toBeDefined();
+    });
+});

--- a/suite-common/message-system/src/__tests__/useExperiment.test.ts
+++ b/suite-common/message-system/src/__tests__/useExperiment.test.ts
@@ -1,0 +1,118 @@
+import { combineReducers } from '@reduxjs/toolkit';
+
+import {
+    configureMockStore,
+    extraDependenciesCommonMock,
+    renderHookWithStoreProvider,
+} from '@suite-common/test-utils';
+import { getIntegerInRangeFromString } from '@trezor/utils';
+
+jest.mock('@trezor/utils', () => ({
+    ...jest.requireActual('@trezor/utils'),
+    getIntegerInRangeFromString: jest.fn((value: string, range: number) =>
+        jest.requireActual('@trezor/utils').getIntegerInRangeFromString(value, range),
+    ),
+}));
+
+import { createMessageSystemState } from '../__fixtures__/createMessageSystemState';
+import { messageSystemInitialState, prepareMessageSystemReducer } from '../messageSystemReducer';
+import { ExperimentId, type MessageSystemState } from '../messageSystemTypes';
+import { useExperiment } from '../useExperiment';
+
+const messageSystemReducer = prepareMessageSystemReducer(extraDependenciesCommonMock);
+
+const createStore = (
+    overrides: {
+        messageSystem?: MessageSystemState;
+        instanceId?: string | undefined;
+    } = {},
+) => {
+    const messageSystem = overrides.messageSystem ?? createMessageSystemState();
+    // distinguish an explicit `instanceId: undefined` from an absent key
+    const instanceId = 'instanceId' in overrides ? overrides.instanceId : 'test-instance-id';
+
+    return configureMockStore({
+        extra: {},
+        reducer: combineReducers({
+            messageSystem: messageSystemReducer,
+            analytics: (state = { instanceId }) => state,
+        }),
+        preloadedState: { messageSystem } as { messageSystem: MessageSystemState },
+    });
+};
+
+const renderUseExperiment = (store = createStore()) =>
+    renderHookWithStoreProvider(() => useExperiment(ExperimentId.tradingFeedbackForm), { store });
+
+describe('useExperiment', () => {
+    it('returns undefined experiment and variant when experiment is not valid', () => {
+        const store = createStore({ messageSystem: messageSystemInitialState });
+        const { result } = renderUseExperiment(store);
+
+        expect(result.current.experiment).toBeUndefined();
+        expect(result.current.activeExperimentVariant).toBeUndefined();
+    });
+
+    it('returns undefined variant when instanceId is missing', () => {
+        const store = createStore({ instanceId: undefined });
+        const { result } = renderUseExperiment(store);
+
+        expect(result.current.experiment).toBeDefined();
+        expect(result.current.activeExperimentVariant).toBeUndefined();
+    });
+
+    it('assigns the only group when it covers 100 %', () => {
+        const store = createStore({
+            messageSystem: createMessageSystemState({
+                groups: [{ variant: 'A', percentage: 100 }],
+            }),
+        });
+        const { result } = renderUseExperiment(store);
+
+        expect(result.current.activeExperimentVariant?.variant).toBe('A');
+    });
+
+    it.each([
+        { inclusion: 0, expectedVariant: 'A' },
+        { inclusion: 29, expectedVariant: 'A' },
+        { inclusion: 30, expectedVariant: 'B' },
+        { inclusion: 69, expectedVariant: 'B' },
+        { inclusion: 70, expectedVariant: 'C' },
+        { inclusion: 99, expectedVariant: 'C' },
+    ])(
+        'assigns variant $expectedVariant from instanceId when group assignment yields $inclusion',
+        ({ inclusion, expectedVariant }) => {
+            jest.mocked(getIntegerInRangeFromString).mockReturnValueOnce(inclusion);
+
+            const store = createStore({
+                messageSystem: createMessageSystemState({
+                    groups: [
+                        { variant: 'A', percentage: 30 },
+                        { variant: 'B', percentage: 40 },
+                        { variant: 'C', percentage: 30 },
+                    ],
+                }),
+            });
+            const { result } = renderUseExperiment(store);
+
+            expect(result.current.activeExperimentVariant?.variant).toBe(expectedVariant);
+        },
+    );
+
+    it.each([
+        { inclusionOverride: 0, expectedVariant: 'A' },
+        { inclusionOverride: 49, expectedVariant: 'A' },
+        { inclusionOverride: 50, expectedVariant: 'B' },
+        { inclusionOverride: 99, expectedVariant: 'B' },
+    ])(
+        'assigns variant $expectedVariant for inclusion override $inclusionOverride',
+        ({ inclusionOverride, expectedVariant }) => {
+            const store = createStore({
+                messageSystem: createMessageSystemState({ inclusionOverride }),
+            });
+            const { result } = renderUseExperiment(store);
+
+            expect(result.current.activeExperimentVariant?.variant).toBe(expectedVariant);
+        },
+    );
+});

--- a/suite-common/message-system/src/index.ts
+++ b/suite-common/message-system/src/index.ts
@@ -12,6 +12,7 @@ export * from './messageSystemValidation';
 
 export * from './cachedEnvData';
 export * from './experimentUtils';
+export * from './ExperimentWrapper';
 export * from './featureFlagUtils';
 export * from './useExperiment';
 export * from './useMessageSystemStaking';

--- a/suite-native/message-system/src/index.ts
+++ b/suite-native/message-system/src/index.ts
@@ -1,3 +1,5 @@
+export { ExperimentWrapper } from '@suite-common/message-system';
+
 export * from './messageSystemMiddleware';
 export * from './components/ContextMessage';
 export * from './components/MessageSystemBannerRenderer';


### PR DESCRIPTION
## Description

Prepares Experiments (message-system AB testing) for the mobile app:

- Move `ExperimentWrapper` from `packages/suite` to `@suite-common/message-system` (it is pure React with no web-specific dependencies)
- Re-export it from `@suite-native/message-system` so mobile can use it the same way desktop does
- Add unit tests for `ExperimentWrapper` and `useExperiment` (variant assignment via inclusion overrides and mocked group assignment)

Desktop behavior is unchanged; `AfterTradeExperiment` now imports the wrapper from `@suite-common/message-system`.

## Notes for QA

Test that experiments work as before

## Related Issue

Resolve #27723

## Screenshots:

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes center on the ExperimentWrapper component in the message-system package and a new AfterTradeExperiment component in the trading detail view. Most of the message-system changes are to the experiment infrastructure (wrapper, hook, fixtures, index exports) and have dedicated unit tests. The AfterTradeExperiment component is rendered in the post-trade detail screen, so trading tests that verify transaction detail status and confirmation UI are most relevant. Since this is primarily an experiment-gating UI change with limited functional impact on core trading flows, the risk is low-to-moderate. A representative buy test and the most comprehensive swap test provide adequate E2E coverage, with one sell test for additional confidence.

<details><summary><b>Changed files (7)</b></summary>

- `packages/suite/src/views/wallet/trading/common/TradingDetail/AfterTradeExperiment.tsx`
- `suite-common/message-system/src/ExperimentWrapper.tsx`
- `suite-common/message-system/src/__fixtures__/createMessageSystemState.ts`
- `suite-common/message-system/src/__tests__/ExperimentWrapper.test.tsx`
- `suite-common/message-system/src/__tests__/useExperiment.test.ts`
- `suite-common/message-system/src/index.ts`
- `suite-native/message-system/src/index.ts`

</details>

**Recommended tests (3)**

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — This test exercises the full buy trade flow including the transaction detail page where AfterTradeExperiment.tsx is rendered. The component is shown after a trade completes, and this test verifies transaction detail status and confirmation sections that could be affected by the experiment wrapper changes.
- `suite/e2e/tests/trading/swap-coins.test.ts` — This test has the most comprehensive swap flow verification including multiple transaction status transitions (SENDING → CONFIRMING → CONVERTING → SUCCESS) and a provider support banner link check. The AfterTradeExperiment component likely renders in the transaction detail view during these status changes, making this the most thorough swap test for catching regressions.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/trading/sell-solana.test.ts` — This sell flow test verifies transaction detail status progression and provider support link visibility after trade completion, which is the area where AfterTradeExperiment renders. It provides sell-flow coverage complementary to the buy and swap tests above.

</details>

⚠️ **Changes with no test coverage (6)**
- `suite-common/message-system/src/ExperimentWrapper.tsx`
- `suite-common/message-system/src/__fixtures__/createMessageSystemState.ts`
- `suite-common/message-system/src/__tests__/ExperimentWrapper.test.tsx`
- `suite-common/message-system/src/__tests__/useExperiment.test.ts`
- `suite-common/message-system/src/index.ts`
- `suite-native/message-system/src/index.ts`

_Updated: 2026-06-16T13:45:42.674Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/native-experiment-wrapper/web/](https://dev.suite.sldev.cz/suite-web/feat/native-experiment-wrapper/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native-experiment-wrapper&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native-experiment-wrapper&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native-experiment-wrapper&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-16T13:52:12.870Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-16T13:48:46.419Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->