### PR TITLE
fix(suite): exclude hidden tokens from sidebar account search

### DIFF
--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
@@ -4,6 +4,7 @@ import { selectAccountLabelsLegacy } from '@suite/metadata';
 import { type RouteParams, selectRouterParams } from '@suite/router';
 import { selectSelectedDevice } from '@suite-common/device';
 import { selectAccountsWithSuiteSyncLabel } from '@suite-common/suite-sync';
+import { selectTokenDefinitions } from '@suite-common/token-definitions';
 import { type AccountType } from '@suite-common/wallet-config';
 import { selectAllAccountsToList } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
@@ -17,6 +18,7 @@ import { useAccountSearch, useSelector } from 'src/hooks/suite';
 import { useResponsiveContext } from 'src/support/suite/ResponsiveContext';
 import { type AccountItemType } from 'src/types/wallet';
 import { selectDiscoveryOverallStatus } from 'src/utils/wallet/selectDiscoveryOverallStatus';
+import { getTokens } from 'src/utils/wallet/tokenUtils';
 
 import { AccountGroup } from './AccountGroup';
 import { AccountItemSkeleton } from './AccountItemSkeleton';
@@ -89,6 +91,7 @@ export const AccountsList = ({
 
     const coinjoinIsPreloading = useSelector(state => state.wallet.coinjoin.isPreloading);
     const accountLegacyLabels = useSelector(selectAccountLabelsLegacy);
+    const tokenDefinitions = useSelector(selectTokenDefinitions);
 
     const accounts = useSelector(state =>
         selectAccountsWithSuiteSyncLabel(
@@ -120,9 +123,16 @@ export const AccountsList = ({
                           : getDefaultAccountLabel(translationString, account)) ??
                       '';
 
+                  const { shownWithBalance } = getTokens({
+                      tokens: account.tokens,
+                      symbol: account.symbol,
+                      tokenDefinitions: tokenDefinitions[account.symbol]?.coin,
+                  });
+
                   return accountSearchFn(account, searchString, {
                       coinsFilter: coinFilter,
                       accountLabel,
+                      searchableTokens: shownWithBalance,
                   });
               })
             : accounts;

--- a/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
@@ -246,6 +246,33 @@ describe('account utils', () => {
         expect(accountSearchFn(ethAcc, 'test2', { accountLabel: '' })).toBe(false);
     });
 
+    it('accountSearchFn searchableTokens', () => {
+        const shownToken = mockAccountToken({ balance: '1', name: 'shown token' });
+        const hiddenToken = mockAccountToken({
+            balance: '1',
+            name: 'hidden token',
+            contract: '0x' + 'a'.repeat(40),
+        });
+        const ethAcc = mockWalletAccount({
+            symbol: 'eth',
+            tokens: [shownToken, hiddenToken],
+        });
+
+        expect(
+            accountSearchFn(ethAcc, 'shown token', {
+                accountLabel: '',
+                searchableTokens: [shownToken],
+            }),
+        ).toBe(true);
+        expect(
+            accountSearchFn(ethAcc, 'hidden token', {
+                accountLabel: '',
+                searchableTokens: [shownToken],
+            }),
+        ).toBe(false);
+        expect(accountSearchFn(ethAcc, 'hidden token', { accountLabel: '' })).toBe(true);
+    });
+
     it('getNetworkAccountFeatures', () => {
         const btcAcc = mockWalletAccount({ symbol: 'btc' });
         const btcTaprootAcc = mockWalletAccount({ symbol: 'btc', accountType: 'taproot' });

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -803,12 +803,15 @@ export type AccountSearchParams = {
 
     /** Return true if the account has token that match the search string */
     tokensMatch?: boolean;
+
+    /** Tokens to match against instead of all account tokens, e.g. only tokens visible in the UI */
+    searchableTokens?: TokenInfo[];
 };
 
 export const accountSearchFn = (
     account: Account,
     rawSearchString: string | undefined,
-    { coinsFilter, accountLabel, tokensMatch = true }: AccountSearchParams,
+    { coinsFilter, accountLabel, tokensMatch = true, searchableTokens }: AccountSearchParams,
 ) => {
     let coinsFilterArray: NetworkSymbol[] = [];
 
@@ -860,7 +863,7 @@ export const accountSearchFn = (
                 new BigNumber(token.balance || '0').gt(0),
         );
 
-    const tokenMatch = tokensMatch && !!account.tokens?.some(filterTokens);
+    const tokenMatch = tokensMatch && !!(searchableTokens ?? account.tokens)?.some(filterTokens);
 
     return (
         accountNumberMatch ||


### PR DESCRIPTION
Sidebar account search now matches only tokens that are actually shown in the sidebar, using the same getTokens classification (token definitions hide list and user-hidden tokens) as the tokens UI, so hidden tokens no longer produce matches.


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes touch AccountsList.tsx (the sidebar account menu component) and accountUtils.ts (a core wallet utility for account processing/filtering/grouping), both of which are broadly imported across 121 tests. Since these are shared infrastructure files, the testing strategy focuses on tests that directly exercise account listing, searching, filtering, grouping by type, and discovery — the behaviors most likely affected by changes to these files. The unit test file (accountUtils.test.ts) has no E2E coverage but provides its own unit-level regression safety. Risk is moderate: accountUtils.ts is a foundational utility, so regressions could cascade, but the broad usage also means the code paths are well-established.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx`
- `suite-common/wallet-utils/src/__tests__/accountUtils.test.ts`
- `suite-common/wallet-utils/src/accountUtils.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/wallet/account-search.test.ts` — This test directly exercises account search/filtering in the wallet sidebar, which is rendered by AccountsList.tsx. Changes to AccountsList.tsx or accountUtils.ts (which likely provides filtering/sorting logic) could break search filtering of accounts by name.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — This test adds different account types (normal, taproot, segwit, legacy) and verifies account counts in type groups, directly exercising AccountsList rendering and accountUtils grouping/counting logic (getAccountsInTypeGroupCount, getAccountsForCoinInTypeGroupCount).
- `suite/e2e/tests/wallet/discovery.test.ts` — This test activates multiple coins and verifies discovery completes with visible account balances. AccountsList.tsx renders the discovered accounts in the sidebar, and accountUtils.ts provides account processing logic used during and after discovery.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/wallet/pagination.test.ts` — This test uses expandAllAccountsInMenu to access legacy BTC accounts, which exercises the AccountsList component's account expansion and rendering. Changes to how accounts are listed could affect navigation to specific account types.
- `suite/e2e/tests/metadata/legacy/account-metadata.test.ts` — This test searches/filters accounts by metadata label text in the account menu, which directly exercises the AccountsList filtering logic. The accountButton visibility assertions depend on how AccountsList renders and filters accounts.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — Tests custom backend discovery for BTC/LTC accounts. After discovery, accounts appear in the sidebar rendered by AccountsList.tsx. Changes to account listing logic could affect whether discovered accounts are properly displayed.
- `suite/e2e/tests/passphrase/passphrase-numbering.test.ts` — This test verifies wallet numbering/indexing in the device switcher when adding/ejecting passphrase wallets. While primarily about the device switcher, accountUtils.ts may provide wallet indexing utilities that affect numbering logic.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — Tests global receive/send flows that involve adding accounts and filtering by network. The account label display (LABELING_ACCOUNT with networkName and index) likely uses accountUtils for account identification and derivation path mapping.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — This test verifies a staking account item is visible in the left sidebar, which is rendered by AccountsList.tsx. Changes to account listing could affect whether staking sub-accounts appear correctly.
- `suite/e2e/tests/settings/coins.test.ts` — Tests activating networks via the Activate Assets modal and verifying they appear as enabled. The account listing after activation depends on AccountsList rendering, though the primary assertions are on the settings coin toggles.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/wallet-utils/src/__tests__/accountUtils.test.ts`

_Updated: 2026-06-12T15:04:33.607Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/account-search-exclude-hidden-tokens&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/account-search-exclude-hidden-tokens&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/account-search-exclude-hidden-tokens&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-12T15:09:52.514Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-12T15:07:55.360Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/account-search-exclude-hidden-tokens/web/](https://dev.suite.sldev.cz/suite-web/fix/account-search-exclude-hidden-tokens/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->