### PR TITLE
fix(suite-native): account name & type-badge presentation in list rows and detail headers

### DIFF
--- a/suite-native/accounts/src/components/AccountsList/AccountsListItem.tsx
+++ b/suite-native/accounts/src/components/AccountsList/AccountsListItem.tsx
@@ -160,9 +160,13 @@ export const AccountsListItem = ({
             disabled={disabled}
             icon={icon}
             title={title}
+            titleBadge={
+                !isNativeCoinOnly && formattedAccountType ? (
+                    <Badge label={formattedAccountType} size="small" />
+                ) : undefined
+            }
             badges={
                 <>
-                    {formattedAccountType && <Badge label={formattedAccountType} size="small" />}
                     {shouldShowStakingBadge && (
                         <StakingBadge networkSymbol={account.symbol} account={account} />
                     )}

--- a/suite-native/accounts/src/components/AccountsList/AccountsListItemBase.tsx
+++ b/suite-native/accounts/src/components/AccountsList/AccountsListItemBase.tsx
@@ -7,6 +7,7 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 type AccountListItemBaseProps = {
     icon: React.ReactNode;
     title: React.ReactNode;
+    titleBadge?: React.ReactNode;
     secondaryTitle?: React.ReactNode;
     mainValue: React.ReactNode;
     secondaryValue: React.ReactNode;
@@ -75,6 +76,10 @@ const accountDescriptionStyle = prepareNativeStyle(_ => ({
     flexShrink: 1,
 }));
 
+const titleStyle = prepareNativeStyle(_ => ({
+    flexShrink: 1,
+}));
+
 const valuesContainerStyle = prepareNativeStyle(utils => ({
     maxWidth: '40%',
     flexShrink: 0,
@@ -89,6 +94,7 @@ const valuesContainerStyle = prepareNativeStyle(utils => ({
 export const AccountsListItemBase = ({
     icon,
     title,
+    titleBadge,
     secondaryTitle,
     badges,
     mainValue,
@@ -118,9 +124,17 @@ export const AccountsListItemBase = ({
             <Box flexDirection="row" alignItems="center" flex={1}>
                 <Box marginRight="sp16">{icon}</Box>
                 <Box style={applyStyle(accountDescriptionStyle)}>
-                    <Text numberOfLines={1} ellipsizeMode="tail" testID="@accountList/item/title">
-                        {title}
-                    </Text>
+                    <HStack spacing="sp4" alignItems="center">
+                        <Text
+                            numberOfLines={1}
+                            ellipsizeMode="tail"
+                            style={applyStyle(titleStyle)}
+                            testID="@accountList/item/title"
+                        >
+                            {title}
+                        </Text>
+                        {titleBadge}
+                    </HStack>
                     {secondaryTitle}
                     <HStack spacing="sp4" alignItems="center">
                         {badges}

--- a/suite-native/module-accounts-management/src/components/AccountAssets/AccountAssetsScreenHeader.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountAssets/AccountAssetsScreenHeader.tsx
@@ -7,7 +7,7 @@ import {
     type NativeAccountsRootState,
     selectAccountFiatBalance,
 } from '@suite-native/accounts';
-import { HStack, Text, VStack } from '@suite-native/atoms';
+import { HStack, VStack } from '@suite-native/atoms';
 import { BaseCurrencyAmountFormatter } from '@suite-native/formatters';
 import { CryptoIcon } from '@suite-native/icons';
 import { ScreenHeader } from '@suite-native/navigation';
@@ -31,9 +31,13 @@ const AccountAssetsScreenHeaderContent = ({ accountKey }: Omit<Props, 'flowType'
         <HStack alignItems="center" spacing="sp8">
             <CryptoIcon symbol={account.symbol} size="small" />
             <VStack spacing={0} alignItems="flex-start">
-                <Text variant="body-md-strong" adjustsFontSizeToFit numberOfLines={1}>
-                    <AccountLabel account={account} />
-                </Text>
+                <AccountLabel
+                    account={account}
+                    variant="body-md-strong"
+                    adjustsFontSizeToFit
+                    numberOfLines={1}
+                    showAccountTypeBadge
+                />
                 <BaseCurrencyAmountFormatter
                     value={fiatBalance}
                     variant="body-sm"

--- a/suite-native/module-accounts-management/src/components/AccountAssets/ActiveTokensTab.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountAssets/ActiveTokensTab.tsx
@@ -77,6 +77,7 @@ export const ActiveTokensTab = ({
                     return (
                         <AccountsListItem
                             {...item}
+                            isNativeCoinOnly
                             hasBackground
                             showDivider
                             onPress={handleSelectAccount}

--- a/suite-native/module-accounts-management/src/components/AccountDetailCryptoValue.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountDetailCryptoValue.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react';
 
-import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { type NetworkSymbol, getDisplaySymbol } from '@suite-common/wallet-config';
 import type { TokenSymbol } from '@suite-common/wallet-types';
 import { HStack } from '@suite-native/atoms';
 import { CryptoAmountFormatter, TokenAmountFormatter } from '@suite-native/formatters';
@@ -18,7 +18,7 @@ export const AccountDetailCryptoValue = memo(
             {tokenSymbol ? (
                 <TokenAmountFormatter
                     value={value}
-                    tokenSymbol={tokenSymbol}
+                    tokenSymbol={getDisplaySymbol(tokenSymbol) as TokenSymbol}
                     adjustsFontSizeToFit
                 />
             ) : (

--- a/suite-native/module-accounts-management/src/components/AccountDetailScreenHeader.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountDetailScreenHeader.tsx
@@ -1,9 +1,10 @@
 import { type RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 
+import { getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { AccountLabel } from '@suite-native/accounts';
-import { HStack, IconButton, Text } from '@suite-native/atoms';
-import { CryptoIcon } from '@suite-native/icons';
+import { HStack, IconButton, Text, VStack } from '@suite-native/atoms';
+import { CryptoIconWithNetwork } from '@suite-native/icons';
 import {
     type AccountsStackParamList,
     type RootStackParamList,
@@ -24,11 +25,21 @@ type AccountDetailNavigationProps = StackToStackCompositeNavigationProps<
 >;
 
 const AccountDetailScreenHeaderContent = ({ account }: AccountDetailScreenHeaderProps) => (
-    <HStack alignItems="center">
-        <CryptoIcon symbol={account.symbol} size="small" />
-        <Text variant="body-md-strong" adjustsFontSizeToFit numberOfLines={1}>
-            <AccountLabel account={account} />
-        </Text>
+    <HStack alignItems="center" flexShrink={1}>
+        <CryptoIconWithNetwork symbol={account.symbol} size="small" />
+        <VStack spacing={0} flexShrink={1}>
+            <Text variant="body-md-strong" numberOfLines={1} ellipsizeMode="tail">
+                {getNetworkDisplaySymbolName(account.symbol)}
+            </Text>
+            <AccountLabel
+                account={account}
+                variant="body-xs"
+                color="contentSecondary"
+                numberOfLines={1}
+                ellipsizeMode="tail"
+                showAccountTypeBadge
+            />
+        </VStack>
     </HStack>
 );
 

--- a/suite-native/module-accounts-management/src/components/TokenAccountDetailScreenHeader.tsx
+++ b/suite-native/module-accounts-management/src/components/TokenAccountDetailScreenHeader.tsx
@@ -5,6 +5,8 @@ import { type RouteProp, useNavigation, useRoute } from '@react-navigation/nativ
 import { type NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 import { type SuiteSyncDataRootState, selectSuiteSyncAccountLabel } from '@suite-common/suite-sync';
+import { type TokenDefinitionsRootState } from '@suite-common/token-definitions';
+import { getDisplaySymbol } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
     type FiatRatesRootState,
@@ -21,7 +23,7 @@ import { type RootStackParamList, RootStackRoutes, ScreenHeader } from '@suite-n
 import { type TokensRootState, selectAccountTokenInfo } from '@suite-native/tokens';
 import { parseStaticSessionId } from '@trezor/device-utils';
 
-import { selectAssetTabOfAccountToken } from '../selectors';
+import { selectAssetTabOfAccountToken, selectIsUnrecognizedToken } from '../selectors';
 import { TokenScreenHeaderSettings } from './TokenScreenHeaderSettings';
 
 type TokenAccountDetailScreenHeaderProps = {
@@ -54,6 +56,10 @@ export const TokenAccountDetailScreenHeader = ({
     const token = useSelector((state: TokensRootState) =>
         selectAccountTokenInfo(state, accountKey, tokenContract),
     );
+    const isUnrecognizedToken = useSelector(
+        (state: TokenDefinitionsRootState & AccountsRootState) =>
+            selectIsUnrecognizedToken(state, accountKey, tokenContract),
+    );
     const route = useRoute<RouteProp<RootStackParamList, RootStackRoutes.AccountDetail>>();
     const { closeActionType } = route.params;
 
@@ -83,19 +89,24 @@ export const TokenAccountDetailScreenHeader = ({
         return null;
     }
 
+    // Unrecognized tokens use their contract/mint address as the name, which is too long
+    // for the header, so shorten it the same way the desktop app does.
+    const tokenName = token?.name ?? '';
+    const displayTokenName = isUnrecognizedToken ? getDisplaySymbol(tokenName) : tokenName;
+
     return (
         <ScreenHeader
             customContent={
-                <Box alignItems="center">
-                    <HStack alignItems="center">
+                <Box alignItems="center" flexShrink={1}>
+                    <HStack alignItems="center" flexShrink={1}>
                         <CryptoIconWithNetwork
                             symbol={symbol}
                             contractAddress={tokenContract}
                             size="small"
                         />
-                        <VStack spacing={0}>
+                        <VStack spacing={0} flexShrink={1}>
                             <Text ellipsizeMode="tail" numberOfLines={1}>
-                                {token?.name}
+                                {displayTokenName}
                             </Text>
 
                             <HStack alignItems="center" spacing="sp4">

--- a/suite-native/module-earn/src/components/ChooseAccountItem.tsx
+++ b/suite-native/module-earn/src/components/ChooseAccountItem.tsx
@@ -42,8 +42,10 @@ export const ChooseAccountItem = ({
             onPress={handlePress}
             icon={<CryptoIcon symbol={account.symbol} />}
             title={<AccountLabel account={account} />}
-            badges={
-                formattedAccountType ? <Badge label={formattedAccountType} size="small" /> : null
+            titleBadge={
+                formattedAccountType ? (
+                    <Badge label={formattedAccountType} size="small" />
+                ) : undefined
             }
             mainValue={
                 <CryptoAmountFormatter

--- a/suite-native/navigation/src/components/ScreenHeaderContent.tsx
+++ b/suite-native/navigation/src/components/ScreenHeaderContent.tsx
@@ -11,7 +11,11 @@ export type ScreenHeaderContentProps = {
 
 export const ScreenHeaderContent = ({ title, customContent }: ScreenHeaderContentProps) => {
     if (customContent) {
-        return <Box alignItems="center">{customContent}</Box>;
+        return (
+            <Box alignItems="center" flexShrink={1}>
+                {customContent}
+            </Box>
+        );
     }
 
     if (title) {


### PR DESCRIPTION
## Description 

Reworks suite-native account name / type-badge presentation across the account list and detail screens:

- long tokens name is now shortened
- account detail now have account type badge in the header and the native token is not account anymore
- in the native token, there is now badge and correct header

Closes #27612
Closes #27979
Closes #28532
Closes https://github.com/trezor/trezor-suite/issues/28866

<img width="438" height="276" alt="Screenshot 2026-06-22 at 7 32 30" src="https://github.com/user-attachments/assets/9487b4d9-9fe6-4f74-9f56-5ce88676e5c0" />
<img width="451" height="373" alt="Screenshot 2026-06-22 at 7 28 43" src="https://github.com/user-attachments/assets/40827a7c-a72d-4046-8881-bd3297631aec" />
<img width="447" height="524" alt="Screenshot 2026-06-22 at 7 52 26" src="https://github.com/user-attachments/assets/9a46d8fe-7cb9-4c25-a8cd-ef590e89a551" />
<img width="436" height="517" alt="Screenshot 2026-06-22 at 7 53 07" src="https://github.com/user-attachments/assets/7e57d9f1-72c0-46cb-99cf-cb58f46aecc6" />
<img width="451" height="401" alt="Screenshot 2026-06-22 at 8 48 27" src="https://github.com/user-attachments/assets/61f3ac71-6662-4594-a6ea-9a57a46ecf4e" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is to a single component (AccountDetails.tsx) in the PageHeader/AccountName hierarchy, which renders account details like account type, derivation path, and xpub on wallet account pages. This file maps to 121 tests via static analysis, indicating it's a broadly shared layout component. The risk is focused on account detail display correctness. The highest-priority tests are those that explicitly interact with account details tab content (cardano.test.ts, public-keys.test.ts). A small set of medium-priority tests cover account page rendering and labeling. Most of the 121 statically-mapped tests only transitively include this component and don't exercise its specific functionality.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountDetails.tsx`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/wallet/cardano.test.ts` — This test explicitly opens account details tab and verifies account type description, derivation path, and xpub — all content rendered by AccountDetails.tsx. Changes to this component directly affect these assertions.
- `suite/e2e/tests/wallet/public-keys.test.ts` — This test navigates to account details tab and verifies the public key (XPUB) display, which is rendered by the AccountDetails component. Any layout or rendering changes would directly break these assertions.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test opens wallet accounts and verifies account page states (empty, discovery error) which may render the AccountDetails/AccountName component in the page header. Changes could affect the account header rendering.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — This test adds various account types (normal, taproot, segwit, legacy) and verifies account labels and counts in the sidebar. The AccountName/AccountDetails component in the page header renders when viewing these accounts.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test verifies account labeling with derivation paths (LABELING_ACCOUNT with networkName and index) for ETH and BTC accounts, which involves the AccountName component hierarchy that AccountDetails.tsx belongs to.
- `suite/e2e/tests/wallet/transactions.test.ts` — This test opens a BTC account and interacts with the account transaction overview page where the AccountDetails component renders in the page header. Graph range selectors and transaction search interact with the account page layout.

</details>

_Updated: 2026-06-21T19:02:04.648Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/account-detail-coin-name-first/web/](https://dev.suite.sldev.cz/suite-web/fix/account-detail-coin-name-first/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/account-detail-coin-name-first&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/account-detail-coin-name-first&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/account-detail-coin-name-first&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy BTC > Buy Bitcoin from best offer | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-21T19:06:41.397Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-21T19:05:21.372Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

