### PR TITLE
Guide fix according to dcq

### DIFF
--- a/packages/suite/src/components/guide/GuideArticle.tsx
+++ b/packages/suite/src/components/guide/GuideArticle.tsx
@@ -23,13 +23,15 @@ export const GuideArticle = () => {
 
     const { markdown, hasError } = useGuideLoadArticle(currentNode, language);
 
+    // Level 2 categories don't have their own view — they render inside the level 1 view.
+    // Always go back to the level 1 ancestor so the user lands on the same screen they came from.
     const parentCategory =
         currentNode && indexNode
             ? (
                   findAncestorNodes(currentNode, indexNode).filter(
                       node => node.type === 'category',
                   ) as GuideCategory[]
-              ).pop()
+              )[0]
             : undefined;
 
     const goBack = () => {

--- a/packages/suite/src/components/guide/GuideCategory.tsx
+++ b/packages/suite/src/components/guide/GuideCategory.tsx
@@ -9,7 +9,6 @@ import {
     GuideContent,
     GuideHeader,
     GuideNode,
-    GuideSectionHeadline,
     GuideViewWrapper,
 } from 'src/components/guide';
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -48,7 +47,6 @@ export const GuideCategory = () => {
             <GuideContent>
                 {pages.length ? (
                     <Section>
-                        <GuideSectionHeadline id="TR_GUIDE_ARTICLES" />
                         <CardList data-testid="@guide/nodes">
                             {pages.map(page => (
                                 <GuideNode key={page.id} node={page} />

--- a/packages/suite/src/components/guide/GuideContent.tsx
+++ b/packages/suite/src/components/guide/GuideContent.tsx
@@ -7,7 +7,7 @@ type GuideContentProps = {
 };
 
 export const GuideContent = ({ children }: GuideContentProps) => (
-    <Box flex="1" padding={{ top: 16, right: 20, left: 20 }}>
+    <Box flex="1" padding={{ top: 8, right: 16, left: 16 }}>
         {children}
     </Box>
 );

--- a/packages/suite/src/components/guide/GuideHeader.tsx
+++ b/packages/suite/src/components/guide/GuideHeader.tsx
@@ -19,7 +19,7 @@ const HeaderWrapper = styled.div<{
 }>`
     display: flex;
     align-items: center;
-    padding: 12px 21px;
+    padding: 12px 16px;
     position: sticky;
     top: 0;
     background-color: inherit;
@@ -88,7 +88,7 @@ export const GuideHeader = ({ back, label }: GuideHeaderProps) => {
 
                     {label && (
                         <Paragraph
-                            typographyStyle="body-sm-strong"
+                            typographyStyle="body-sm"
                             align="center"
                             ellipsisLineCount={2}
                             margin={{ horizontal: 8 }}

--- a/packages/suite/src/components/guide/GuideNode.tsx
+++ b/packages/suite/src/components/guide/GuideNode.tsx
@@ -46,7 +46,11 @@ export const GuideNode = ({ node, description, itemVariant = 'cardList' }: Guide
 
     if (node.type === 'page') {
         return (
-            <CardList.Item onClick={navigateToNode} data-testid={`@guide/node${node.id}`}>
+            <CardList.Item
+                paddingType="medium"
+                onClick={navigateToNode}
+                data-testid={`@guide/node${node.id}`}
+            >
                 <Column
                     flex="1"
                     gap={description ? 4 : 0}
@@ -98,7 +102,11 @@ export const GuideNode = ({ node, description, itemVariant = 'cardList' }: Guide
         }
 
         return (
-            <CardList.Item onClick={navigateToNode} data-testid={`@guide/category${node.id}`}>
+            <CardList.Item
+                paddingType="medium"
+                onClick={navigateToNode}
+                data-testid={`@guide/category${node.id}`}
+            >
                 <Row gap={12} alignItems="center" flex="1" overflow="hidden">
                     {categoryIcon}
                     <Text typographyStyle="body-md" as="div" maxWidth="100%">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Tiny styling according to design critique (DCQ)

https://www.figma.com/design/zNkRwq4NlG3pkAWcI3cUqs/Product-audit?node-id=2774-4445&p=f&t=CZEaGlMv58F283Yk-0

Also fixed bug when you go to category with two sections and go back you saw only one section

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All 5 changed files are Guide panel UI components (GuideArticle, GuideCategory, GuideContent, GuideHeader, GuideNode). While these map to 121 tests via broad static imports, only 3 tests actually interact with the Guide panel directly. The risk is concentrated in guide panel rendering, navigation, article display, and search functionality. The remaining 118 tests merely have the guide components in their dependency tree but never exercise them.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/components/guide/GuideArticle.tsx`
- `packages/suite/src/components/guide/GuideCategory.tsx`
- `packages/suite/src/components/guide/GuideContent.tsx`
- `packages/suite/src/components/guide/GuideHeader.tsx`
- `packages/suite/src/components/guide/GuideNode.tsx`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/suite/guide.test.ts` — This test directly exercises the Guide panel UI including opening/closing, navigating guide content nodes, viewing article details, and searching — all of which are rendered by the changed GuideArticle, GuideCategory, GuideContent, GuideHeader, and GuideNode components.
- `suite/e2e/tests/general/suite-guide.test.ts` — This test opens the Suite Guide panel, searches for a support article by name ('Install firmware'), and verifies the guide label displays the article title — directly exercising GuideContent, GuideNode, GuideArticle, and GuideHeader rendering.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/suite/bug-report-form.test.ts` — This test opens the Guide panel and navigates to Support and Feedback to submit a bug report. The Guide panel navigation uses GuideContent, GuideHeader, and GuideNode components, so changes there could break the navigation flow to the feedback form.

</details>

_Updated: 2026-06-12T15:08:16.972Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=guide-fix-according-to-dcq&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=guide-fix-according-to-dcq&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-12T15:12:53.732Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-12T15:12:04.636Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/guide-fix-according-to-dcq/web/](https://dev.suite.sldev.cz/suite-web/guide-fix-according-to-dcq/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->