### PR TITLE
fix(suite): strip BCH address prefix from all display contexts

### DIFF
--- a/suite/address/src/Address.tsx
+++ b/suite/address/src/Address.tsx
@@ -88,11 +88,12 @@ export const Address = ({
     const isChunkedSettings = useSelector(selectAddressDisplayType);
     const isAddressChunked = isChunked ?? isChunkedSettings === 'chunked';
 
-    const formattedValue = AddressFormatter.format(value, {
+    const addressWithoutPrefix = clearAddressPrefix(value);
+    const formattedValue = AddressFormatter.format(addressWithoutPrefix, {
         format: isTruncated ? 'long' : 'full',
         isChunked: isAddressChunked,
     });
-    const formattedValueFull = AddressFormatter.format(clearAddressPrefix(value), {
+    const formattedValueFull = AddressFormatter.format(addressWithoutPrefix, {
         format: 'full',
         isChunked: isAddressChunked,
     });


### PR DESCRIPTION
## Description

Addresses in Receive, Trade and transaction detail were showing the bitcoincash: prefix while the device shows addresses without it.

clearAddressPrefix was previously applied only when computing formattedValueFull (tooltip/device-rendered path). Extracting a shared addressWithoutPrefix variable makes both formattedValue and formattedValueFull consistent, fixing the display across all components that use the Address component.
<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

On desktop tested all places referenced in the GH issue

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/28351

## Screenshots:

<details><summary>Screens</summary>
<p>
<img width="1634" height="1020" alt="Screenshot 2026-06-12 at 17 01 27" src="https://github.com/user-attachments/assets/869e3d2f-fc8b-4d99-9ba7-d0f48cb04f13" />



<img width="922" height="620" alt="Screenshot 2026-06-12 at 17 01 43" src="https://github.com/user-attachments/assets/1863d260-dd3d-413f-969a-6040027b7107" />
ssets/11837643-da29-4840-b812-bd5432462979" />
<img width="1298" height="887" alt="Screenshot 2026-06-12 at 17 02 11" src="https://github.com/user-attachments/assets/e7d9899d-d3b4-45e5-8bdc-7a0f8d67a35d" />
<img width="1208" height="1084" alt="Screenshot 2026-06-12 at 17 02 42" src="https://github.com/user-attachments/assets/3dd9f8be-796f-49b2-8c5d-5b69901a1930" />

</p>
</details> 

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change to suite/address/src/Address.tsx affects an address rendering component with no static test coverage mapping available. Based on LLM analysis, the highest-risk tests are those that directly verify address display, formatting, and interaction in receive flows. The recommended strategy focuses on receive-related tests across different coin types and wallet configurations, as these most directly exercise address rendering. Trading/send tests that show addresses on device prompts are lower risk since those typically use separate formatting utilities.

<details><summary><b>Changed files (1)</b></summary>

- `suite/address/src/Address.tsx`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/wallet/receive.test.ts` — The Address.tsx component is most likely used to render/format addresses in the receive flow. This test explicitly verifies address display, copying, and format validation for multiple coin types (BTC, ETH, SOL, TRX), making it the most direct consumer of an Address component.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test verifies the global receive flow including address reveal, display, device-matching, and copy functionality. It checks that addresses are correctly rendered in the UI and match device output, directly exercising address rendering components.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts` — This test verifies Cardano address display formatting (cardanoTetragrams), address reveal, and copy functionality for passphrase-protected wallets. The Address component likely handles Cardano-specific address rendering.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — This test verifies that revealed receive addresses are correctly formatted and displayed (formatAddress utility), and that previously revealed addresses remain visible in the address table after device reconnection.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — This test verifies receive address derivation and display for multiple passphrase wallets, checking that formatted addresses match expected values. Address rendering is central to its assertions.
- `suite/e2e/tests/wallet/cardano.test.ts` — This test verifies Cardano-specific address display including cardanoTetragrams formatting on device and formatted address in the UI. The Address component likely handles this specialized rendering.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/metadata/legacy/address-metadata.test.ts` — This test adds and edits labels on receive addresses. While primarily testing labeling, the address display component is part of the UI flow where labels are attached, so changes to Address.tsx could affect the label attachment point.

</details>

_Updated: 2026-06-12T15:09:07.458Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/bch-address-prefix/web/](https://dev.suite.sldev.cz/suite-web/fix/bch-address-prefix/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/bch-address-prefix&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/bch-address-prefix&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-12T15:14:11.779Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-12T15:13:06.402Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->