### PR TITLE
fix(suite): include existing account in selectedAccount on discovery error

### DIFF
--- a/packages/suite/src/actions/wallet/__fixtures__/selectedAccountActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/selectedAccountActions.ts
@@ -1,3 +1,33 @@
+import { routerLocationChange } from '@suite/router';
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+import { type StaticSessionId } from '@trezor/connect';
+
+const DEVICE_STATE: StaticSessionId = '1stTestnetAddress@device_id:0';
+const DEVICE_PATH = '1';
+
+const device = {
+    path: DEVICE_PATH,
+    state: { staticSessionId: DEVICE_STATE },
+};
+
+const walletParams = {
+    symbol: 'btc',
+    accountIndex: 0,
+    accountType: 'normal',
+};
+
+const btcAccount = mockWalletAccount({
+    symbol: 'btc',
+    visible: false,
+    deviceState: DEVICE_STATE,
+});
+
+const btcFailedAccount = {
+    ...mockWalletAccount({ symbol: 'btc', deviceState: DEVICE_STATE }),
+    failed: true,
+    error: 'discovery error',
+};
+
 export default [
     {
         description: 'Action ignored',
@@ -5,6 +35,79 @@ export default [
         action: {
             location: '/foo',
         },
-        result: undefined,
+        result: {
+            status: 'none',
+        },
+    },
+    {
+        description: 'Discovery failed, requested account exists in wallet.accounts',
+        initialState: {
+            device: { selectedDevice: device },
+            router: { app: 'wallet', params: walletParams },
+            wallet: {
+                accounts: [btcAccount],
+                settings: { enabledNetworks: ['btc'] },
+                discovery: { [DEVICE_PATH]: { status: 'failed' } },
+            },
+        },
+        action: {
+            type: routerLocationChange.type,
+        },
+        result: {
+            status: 'exception',
+            loader: 'discovery-error',
+            account: { key: btcAccount.key },
+            network: { symbol: 'btc' },
+            params: walletParams,
+        },
+    },
+    {
+        description: 'Discovery failed for the requested account, failed account is included',
+        initialState: {
+            device: { selectedDevice: device },
+            router: { app: 'wallet', params: walletParams },
+            wallet: {
+                accounts: [btcFailedAccount],
+                settings: { enabledNetworks: ['btc'] },
+                discovery: { [DEVICE_PATH]: { status: 'failed' } },
+            },
+        },
+        action: {
+            type: routerLocationChange.type,
+        },
+        result: {
+            status: 'exception',
+            loader: 'account-not-loaded',
+            account: { key: btcFailedAccount.key },
+            network: { symbol: 'btc' },
+            params: walletParams,
+        },
+    },
+    {
+        description: 'Discovery failed, requested account does not exist',
+        initialState: {
+            device: { selectedDevice: device },
+            router: { app: 'wallet', params: walletParams },
+            wallet: {
+                accounts: [
+                    mockWalletAccount({
+                        symbol: 'ltc',
+                        deviceState: DEVICE_STATE,
+                    }),
+                ],
+                settings: { enabledNetworks: ['btc', 'ltc'] },
+                discovery: { [DEVICE_PATH]: { status: 'failed' } },
+            },
+        },
+        action: {
+            type: routerLocationChange.type,
+        },
+        result: {
+            status: 'exception',
+            loader: 'discovery-error',
+            account: undefined,
+            network: { symbol: 'btc' },
+            params: walletParams,
+        },
     },
 ] as const;

--- a/packages/suite/src/actions/wallet/__tests__/selectedAccountActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/selectedAccountActions.test.ts
@@ -5,8 +5,24 @@ import { configureStore } from 'src/support/tests/configureStore';
 import fixtures from '../__fixtures__/selectedAccountActions';
 import { syncSelectedAccount } from '../selectedAccountActions';
 
-const getInitialState = (_settings?: any) => ({
+const getInitialState = (initialState: any = {}) => ({
+    suite: {},
+    device: {
+        selectedDevice: undefined,
+        ...initialState.device,
+    },
+    router: {
+        app: 'wallet',
+        route: { name: 'wallet-index' },
+        params: undefined,
+        ...initialState.router,
+    },
     wallet: {
+        accounts: [],
+        settings: { enabledNetworks: [] },
+        discovery: {},
+        accountSearch: { coinFilter: [] },
+        ...initialState.wallet,
         selectedAccount: {
             ...selectedAccountReducer(undefined, { type: 'foo' } as any),
         },
@@ -33,12 +49,8 @@ describe('selectedAccount Actions', () => {
         it(f.description, () => {
             const state = getInitialState(f.initialState);
             const store = initStore(state);
-            const selectedAccountState = store.dispatch(syncSelectedAccount(f.action as any));
-            if (f.result) {
-                expect(selectedAccountState).toMatchObject(f.result as any);
-            } else {
-                expect(selectedAccountState).toBe(undefined);
-            }
+            store.dispatch(syncSelectedAccount(f.action as any));
+            expect(store.getState().wallet.selectedAccount).toMatchObject(f.result as any);
         });
     });
 });

--- a/packages/suite/src/actions/wallet/selectedAccountActions.ts
+++ b/packages/suite/src/actions/wallet/selectedAccountActions.ts
@@ -90,6 +90,7 @@ export const getAccountState = (state: AppState): SelectedAccountStatus => {
         return {
             status: 'exception',
             loader: 'account-not-loaded',
+            account: matchedFailed,
             network,
             params,
         };
@@ -112,6 +113,7 @@ export const getAccountState = (state: AppState): SelectedAccountStatus => {
                 return {
                     status: 'exception',
                     loader: 'account-not-loaded',
+                    account,
                     network,
                     params,
                 };
@@ -135,6 +137,7 @@ export const getAccountState = (state: AppState): SelectedAccountStatus => {
         return {
             status: 'exception',
             loader: 'discovery-error',
+            account: account ?? undefined,
             network,
             params,
         };

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/PageName.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/PageName.tsx
@@ -7,7 +7,6 @@ import {
     selectSuiteRouterHistoryDep,
 } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
-import { selectDeviceAccountForNetworkSymbolAndAccountTypeWithIndex } from '@suite-common/wallet-core';
 
 import { useSelector } from 'src/hooks/suite';
 
@@ -25,16 +24,6 @@ export const PageName = () => {
     );
     const selectedAccount = useSelector(selectSelectedAccount);
     const isAccountTabPage = isAccountTabRoute(currentRoute);
-    const { params } = useSelector(state => state.wallet.selectedAccount);
-
-    const fallbackAccount = useSelector(state =>
-        selectDeviceAccountForNetworkSymbolAndAccountTypeWithIndex(
-            state,
-            params?.symbol,
-            params?.accountType,
-            params?.accountIndex,
-        ),
-    );
 
     // TODO: does not work properly with foreground apps, e.g. FW update,
     // as the `route` does not indicate the current page
@@ -57,10 +46,6 @@ export const PageName = () => {
 
     if (selectedAccount) {
         return <AccountSubpageName key={selectedAccount.key} selectedAccount={selectedAccount} />;
-    }
-
-    if (fallbackAccount) {
-        return <AccountName key={fallbackAccount.key} selectedAccount={fallbackAccount} />;
     }
 
     return (

--- a/packages/suite/src/views/wallet/details/index.tsx
+++ b/packages/suite/src/views/wallet/details/index.tsx
@@ -7,7 +7,6 @@ import { useDevice } from '@suite/device';
 import { LearnMoreButton } from '@suite/external-links';
 import { Translation, type TranslationKey } from '@suite/intl';
 import { useReceiveDisabled } from '@suite/receive';
-import { selectDeviceAccountForNetworkSymbolAndAccountTypeWithIndex } from '@suite-common/wallet-core';
 import { getAccountTypeTech } from '@suite-common/wallet-utils';
 import { Button, Card, Column, InfoItem, Paragraph } from '@trezor/components';
 import { typography } from '@trezor/theme';
@@ -68,15 +67,6 @@ const DetailsRow = ({ title, description, learnMoreUrl, children }: DetailsRowPr
 const Details = () => {
     const { device, isLocked } = useDevice();
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
-    const { params } = selectedAccount;
-    const fallbackAccount = useSelector(state =>
-        selectDeviceAccountForNetworkSymbolAndAccountTypeWithIndex(
-            state,
-            params?.symbol,
-            params?.accountType,
-            params?.accountIndex,
-        ),
-    );
     const { isReceiveDisabled, ReceiveDisabledWrapper } = useReceiveDisabled();
 
     const dispatch = useDispatch();
@@ -84,15 +74,15 @@ const Details = () => {
     if (
         !device ||
         (selectedAccount.status !== 'loaded' && selectedAccount.status !== 'exception') ||
-        fallbackAccount == null
+        selectedAccount.account == null
     ) {
         return <WalletLayout title="TR_ACCOUNT_DETAILS_HEADER" account={selectedAccount} />;
     }
 
-    const account = selectedAccount.account ?? fallbackAccount;
+    const { account } = selectedAccount;
 
     const locked = isLocked(true);
-    const disabled = locked || isReceiveDisabled || !selectedAccount.account;
+    const disabled = locked || isReceiveDisabled || selectedAccount.status !== 'loaded';
 
     const accountTypeTech = getAccountTypeTech(account.path);
 

--- a/suite-common/wallet-types/src/selectedAccount.ts
+++ b/suite-common/wallet-types/src/selectedAccount.ts
@@ -28,15 +28,28 @@ export interface SelectedAccountLoaded {
 export type SelectedAccountException =
     | {
           status: 'exception';
-          loader: 'discovery-error' | 'discovery-empty'; // No network enabled in settings
+          loader: 'discovery-error'; // Account discovery failed
+          account?: Account;
+          network?: Network;
+          params?: WalletParams;
+      }
+    | {
+          status: 'exception';
+          loader: 'discovery-empty'; // No network enabled in settings
           account?: undefined;
           network?: Network;
           params?: WalletParams;
       }
     | {
           status: 'exception';
+          loader: 'account-not-loaded'; // Account discovery failed
+          account: Account;
+          network: Network;
+          params: WalletParams;
+      }
+    | {
+          status: 'exception';
           loader:
-              | 'account-not-loaded' // Account discovery failed
               | 'account-not-enabled' // Requested account network is not enabled in settings
               | 'account-not-exists'; // Requested account network is not listed in `networks` (@suite-common/wallet-config)
           account?: undefined;


### PR DESCRIPTION
## Description

When discovery fails, `selectedAccount.account` now carries the account already present in `wallet.accounts` instead of being `undefined`, for **both** failure branches in `getAccountState`:
- `account-not-loaded` — a `failed` account matching the requested params (the root cause from #24389's workaround); it now attaches the matched failed account.
- `discovery-error` — uses the account already resolved by `getSelectedAccount` (dropping the positional `selectDeviceAccountForNetworkSymbolAndAccountTypeWithIndex` fallback).

Because `selectedAccount.account` is now populated on discovery failure, the `fallbackAccount` workaround introduced in #24389 is removed from `PageName.tsx` and the account details view — they read `selectedAccount.account` directly. The shared selector stays (still used by suite-native).

Resolves #24479

<img width="1950" height="932" alt="Screenshot 2026-06-21 at 19 33 16" src="https://github.com/user-attachments/assets/c0c07489-69a9-4cf2-b941-e05bbf19cbde" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes center on wallet account selection logic (selectedAccountActions.ts), the selectedAccount type definition, the wallet details view, and the PageName header component. The highest risk is in the wallet details view, which is directly tested by only 2 tests (cardano and public-keys). The selectedAccountActions and PageName changes map to 121 tests each, indicating they are broadly shared infrastructure — most of those tests are unlikely to be specifically affected. The recommended strategy focuses on the 2 directly-affected detail view tests at high priority, plus a small set of wallet tests at medium priority that exercise core account selection and display flows where regressions would be most visible.

<details><summary><b>Changed files (6)</b></summary>

- `packages/suite/src/actions/wallet/__fixtures__/selectedAccountActions.ts`
- `packages/suite/src/actions/wallet/__tests__/selectedAccountActions.test.ts`
- `packages/suite/src/actions/wallet/selectedAccountActions.ts`
- `packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/PageName.tsx`
- `packages/suite/src/views/wallet/details/index.tsx`
- `suite-common/wallet-types/src/selectedAccount.ts`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/wallet/cardano.test.ts` — Directly exercises the wallet details view (packages/suite/src/views/wallet/details/index.tsx) by opening a Cardano account and navigating to account details tab to view account type description, derivation path, and xpub. Changes to the details view could break assertions on TR_ACCOUNT_TYPE_NORMAL_CARDANO_DESC, TR_ACCOUNT_DETAILS_PATH_DESC, and TR_ACCOUNT_DETAILS_XPUB.
- `suite/e2e/tests/wallet/public-keys.test.ts` — Directly exercises the wallet details view by navigating to account details tab and showing/confirming public keys for BTC, LTC, and ADA. Changes to the details view or selectedAccount types could break the public key display and verification flow.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/wallet/discovery.test.ts` — Discovery activates multiple coins and verifies account balances are visible, which exercises selectedAccountActions when accounts are selected. Changes to selectedAccountActions or the selectedAccount type could cause accounts to fail to load or display properly after discovery.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — Tests account balance display after receiving BTC on regtest, which depends on selectedAccountActions for resolving and displaying the selected account's balance. Changes to account selection logic could break balance rendering.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — Tests adding different account types (normal, taproot, segwit, legacy) and verifying they appear correctly. The selectedAccountActions and selectedAccount type changes could affect how newly added accounts are selected and displayed.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — Tests ejecting a wallet and discovering/adding a standard wallet, then verifying account balance visibility. This exercises the selectedAccountActions flow when switching between wallets and selecting discovered accounts.
- `suite/e2e/tests/wallet/transactions.test.ts` — Opens a BTC account and interacts with transaction overview including graph range filters and transaction search. The PageName component change could affect the page header display, and selectedAccountActions changes could affect account loading.
- `suite/e2e/tests/wallet/receive.test.ts` — Tests receiving on multiple coin types (BTC, ETH, SOL, TRX) which requires selecting and displaying each account. selectedAccountActions changes could break account selection before the receive flow starts.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/actions/wallet/__fixtures__/selectedAccountActions.ts`
- `packages/suite/src/actions/wallet/__tests__/selectedAccountActions.test.ts`

_Updated: 2026-06-25T10:55:01.975Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/selected-account-discovery-error-account/web/](https://dev.suite.sldev.cz/suite-web/fix/selected-account-discovery-error-account/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/selected-account-discovery-error-account&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/selected-account-discovery-error-account&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/selected-account-discovery-error-account&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-25T10:58:03.008Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-25T10:59:40.397Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->
