### PR TITLE
ci: replace SFW with PMG

### DIFF
--- a/.github/actions/minimal-yarn-install/action.yml
+++ b/.github/actions/minimal-yarn-install/action.yml
@@ -29,14 +29,12 @@ runs:
       run: |
         echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
 
-    - name: Install Socket Firewall
-      uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+    - name: Install SafeDep PMG
+      uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
       continue-on-error: true
       with:
-        mode: firewall-free
-        job-summary: errors
-        firewall-version: 1.11.0
+        version: v0.19.1
 
     - name: Install dependencies using Yarn
       shell: bash
-      run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn --immutable
+      run: yarn --immutable

--- a/.github/actions/post-quarantine-list/action.yml
+++ b/.github/actions/post-quarantine-list/action.yml
@@ -15,6 +15,11 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Install SafeDep PMG
+      uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
+      continue-on-error: true
+      with:
+        version: v0.19.1
     - name: Fetch quarantined tests
       shell: bash
       env:
@@ -25,6 +30,7 @@ runs:
           PROJECT_ARGS+=(--project "${{ inputs.project_name }}")
         fi
         # npx used because `yarn` does not run in this action; the pinned version may be updated if it changes in root package.json
+        npm i -g tsx@4.21.0
         npx tsx@4.21.0 \
           "${{ github.workspace }}/packages/e2e-utils/src/quarantineBot/index.ts" \
           --list "${PROJECT_ARGS[@]}" > "${{ runner.temp }}/quarantine.json"

--- a/.github/actions/release-connect-npm/action.yml
+++ b/.github/actions/release-connect-npm/action.yml
@@ -56,17 +56,15 @@ runs:
         node-version-file: ".nvmrc"
         cache: yarn
 
-    - name: Install Socket Firewall
-      uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+    - name: Install SafeDep PMG
+      uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
       continue-on-error: true
       with:
-        mode: firewall-free
-        job-summary: errors
-        firewall-version: 1.11.0
+        version: v0.19.1
 
     - name: Install dependencies
       shell: bash
-      run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable
+      run: yarn install --immutable
 
     - name: Check version
       shell: bash

--- a/.github/actions/release-connect/action.yml
+++ b/.github/actions/release-connect/action.yml
@@ -63,18 +63,16 @@ runs:
         node-version-file: ".nvmrc"
         cache: yarn
 
-    - name: Install Socket Firewall
-      uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+    - name: Install SafeDep PMG
+      uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
       continue-on-error: true
       with:
-        mode: firewall-free
-        job-summary: errors
-        firewall-version: 1.11.0
+        version: v0.19.1
 
     - name: Install dependencies
       shell: bash
       run: |
-        $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable # focus install is not used here to make sure that all global patches are applied for the release.
+        yarn install --immutable # focus install is not used here to make sure that all global patches are applied for the release.
 
     - name: Build connect-explorer-theme
       shell: bash

--- a/.github/workflows/bot-crowdin-sync.yml
+++ b/.github/workflows/bot-crowdin-sync.yml
@@ -37,15 +37,13 @@ jobs:
       - name: Set current timestamp as env variable
         run: echo "NOW=$(date +'%s')" >> $GITHUB_ENV
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+          version: v0.19.1
       - name: Install dependencies
-        run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn install
+        run: yarn install
 
       - name: Set source branch
         run: echo "SOURCE_BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV

--- a/.github/workflows/build-analytics-docs.yml
+++ b/.github/workflows/build-analytics-docs.yml
@@ -36,17 +36,15 @@ jobs:
           node-version-file: ".nvmrc"
           cache: yarn
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+          version: v0.19.1
       - name: Install dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @trezor/analytics-docs
+          yarn workspaces focus @trezor/analytics-docs
 
       - name: Build analytics-docs
         env:

--- a/.github/workflows/build-desktop-apps.yml
+++ b/.github/workflows/build-desktop-apps.yml
@@ -41,16 +41,14 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: ".nvmrc"
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+          version: v0.19.1
       - name: Install deps and build libs
         run: |
-          $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable
+          yarn install --immutable
           yarn message-system-sign-config
           yarn workspace @trezor/suite-data build:lib
           yarn workspace @trezor/transport-bridge build:lib
@@ -95,16 +93,10 @@ jobs:
           key: renderer-bundle-${{ github.sha }}
           fail-on-cache-miss: true
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
-        continue-on-error: true
-        with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+      # safedep/pmg not available on macOS (that's ok, it already guards the `build-and-cache-renderer` job)
       - name: Install deps and build libs
         run: |
-          $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable
+          yarn install --immutable
           yarn message-system-sign-config
           yarn workspace @trezor/suite-data build:lib
           yarn workspace @trezor/transport-bridge build:lib
@@ -157,16 +149,14 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+          version: v0.19.1
       - name: Install deps and build libs
         run: |
-          $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable
+          yarn install --immutable
           yarn message-system-sign-config
 
       - name: Build libs

--- a/.github/workflows/build-llm-test-analysis-nightly.yml
+++ b/.github/workflows/build-llm-test-analysis-nightly.yml
@@ -49,16 +49,14 @@ jobs:
           path: node_modules
           key: node_modules-e2e-utils-${{ hashFiles('yarn.lock') }}
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+          version: v0.19.1
       - name: Install dependencies
         shell: bash
-        run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @trezor/e2e-utils
+        run: yarn workspaces focus @trezor/e2e-utils
 
       - name: Delete existing LLM analysis cache from S3 (no_cache)
         if: ${{ inputs.no_cache }}

--- a/.github/workflows/build-node-bridge.yml
+++ b/.github/workflows/build-node-bridge.yml
@@ -31,16 +31,14 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+          version: v0.19.1
       - name: Install deps and build libs
         run: |
-          $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable
+          yarn install --immutable
 
       - name: Build bin.js file
         run: |

--- a/.github/workflows/build-storybook-native.yml
+++ b/.github/workflows/build-storybook-native.yml
@@ -44,17 +44,15 @@ jobs:
           path: node_modules
           key: node_modules/${{ github.ref }}/${{github.run_id}}
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+          version: v0.19.1
       - name: Install Yarn dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          $(command -v sfw > /dev/null && echo sfw --verbose) yarn install
+          yarn install
 
       - name: Build storybook
         working-directory: ./suite-native/storybook

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -31,18 +31,16 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: yarn
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+          version: v0.19.1
       - name: Install dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @trezor/components
-          $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @trezor/product-components
+          yarn workspaces focus @trezor/components
+          yarn workspaces focus @trezor/product-components
 
       - name: Build storybook
         env:

--- a/.github/workflows/build-suite-desktop-e2e.yml
+++ b/.github/workflows/build-suite-desktop-e2e.yml
@@ -26,16 +26,14 @@ jobs:
           path: node_modules
           key: node_modules-suite-desktop-e2e-${{ hashFiles('yarn.lock') }}
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+          version: v0.19.1
       - name: Install dependencies
         shell: bash
-        run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @trezor/suite-desktop @trezor/suite-desktop-core @trezor/suite-build @trezor/suite @trezor/suite-data @trezor/transport-bridge @suite-common/message-system @trezor/suite-desktop-ui
+        run: yarn workspaces focus @trezor/suite-desktop @trezor/suite-desktop-core @trezor/suite-build @trezor/suite @trezor/suite-data @trezor/transport-bridge @suite-common/message-system @trezor/suite-desktop-ui
 
       - name: Build libs
         shell: bash

--- a/.github/workflows/build-suite-native-adhoc.yml
+++ b/.github/workflows/build-suite-native-adhoc.yml
@@ -38,16 +38,14 @@ jobs:
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN_DEVELOP }}
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+          version: v0.19.1
       - name: Install libs
         run: |
-          $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @suite-native/app
+          yarn workspaces focus @suite-native/app
       - name: Trigger adhoc build Android
         working-directory: suite-native/app
         if: ${{ github.event.inputs.PLATFORM == 'android' || github.event.inputs.PLATFORM == 'all' }}

--- a/.github/workflows/build-suite-native-preview.yml
+++ b/.github/workflows/build-suite-native-preview.yml
@@ -48,16 +48,14 @@ jobs:
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN_DEVELOP }}
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+          version: v0.19.1
       - name: Install libs
         run: |
-          $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @suite-native/app
+          yarn workspaces focus @suite-native/app
 
       - name: Check runtimeVersion builds
         run: |

--- a/.github/workflows/build-suite-web-e2e.yml
+++ b/.github/workflows/build-suite-web-e2e.yml
@@ -47,13 +47,11 @@ jobs:
           path: node_modules
           key: node_modules-suite-web-e2e-${{ hashFiles('yarn.lock') }}
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+          version: v0.19.1
       - name: Disable Yarn hardened mode
         shell: bash
         run: |
@@ -61,7 +59,7 @@ jobs:
 
       - name: Install dependencies
         shell: bash
-        run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @trezor/suite-web @trezor/suite-data @trezor/suite-build
+        run: yarn workspaces focus @trezor/suite-web @trezor/suite-data @trezor/suite-build
 
       - name: Build Suite Web
         shell: bash

--- a/.github/workflows/build-suite-web.yml
+++ b/.github/workflows/build-suite-web.yml
@@ -57,17 +57,15 @@ jobs:
           node-version-file: ".nvmrc"
           cache: yarn
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+          version: v0.19.1
       - name: Install dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @trezor/suite-web @trezor/suite-data @trezor/suite-build
+          yarn workspaces focus @trezor/suite-web @trezor/suite-data @trezor/suite-build
 
       - name: Build suite-web
         env:

--- a/.github/workflows/check-code-validation.yml
+++ b/.github/workflows/check-code-validation.yml
@@ -24,13 +24,11 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: ".nvmrc"
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+          version: v0.19.1
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
@@ -44,7 +42,7 @@ jobs:
       # We can skip the build for all dependencies, even for those whitelisted, because this process is used only to validate the yarn.lock file and populate the cache.
       - name: Install deps
         run: |
-          $(command -v sfw > /dev/null && echo sfw --verbose) yarn --immutable --mode=skip-build
+          yarn --immutable --mode=skip-build
 
   type-check:
     name: Type Checking
@@ -114,6 +112,7 @@ jobs:
       - name: "Minimal yarn install"
         uses: ./.github/actions/minimal-yarn-install
       - name: Check for new Circular Imports
+        # safedep/pmg covers also the `npx` running inside the shell script
         run: ./scripts/circular-dependencies/check-circular-dependencies.sh
 
   unit-tests-suite:
@@ -172,15 +171,13 @@ jobs:
         run: yarn verify-project-references
       - name: Detect unused dependencies
         run: yarn depcheck
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+          version: v0.19.1
       - name: Yarn Dedupe check
-        run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn dedupe --check
+        run: yarn dedupe --check
       - name: Check dependency domain lists
         run: ./scripts/ci/list-missing-dependencies.sh
       - name: Verify Workspace Resolutions

--- a/.github/workflows/check-test-health-nightly.yml
+++ b/.github/workflows/check-test-health-nightly.yml
@@ -35,16 +35,14 @@ jobs:
           path: node_modules
           key: node_modules-e2e-utils-${{ hashFiles('yarn.lock') }}
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+          version: v0.19.1
       - name: Install dependencies
         shell: bash
-        run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @trezor/e2e-utils
+        run: yarn workspaces focus @trezor/e2e-utils
 
       - name: Check test health and manage quarantine
         env:

--- a/.github/workflows/check-test-health.yml
+++ b/.github/workflows/check-test-health.yml
@@ -47,16 +47,14 @@ jobs:
           path: node_modules
           key: node_modules-e2e-utils-${{ hashFiles('yarn.lock') }}
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+          version: v0.19.1
       - name: Install dependencies
         shell: bash
-        run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @trezor/e2e-utils
+        run: yarn workspaces focus @trezor/e2e-utils
 
       - name: Check test health and manage quarantine
         env:

--- a/.github/workflows/chore-purge-android-e2e-build.yml
+++ b/.github/workflows/chore-purge-android-e2e-build.yml
@@ -33,17 +33,15 @@ jobs:
           path: node_modules
           key: node_modules/${{ github.ref }}/${{github.run_id}}
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+          version: v0.19.1
       - name: Install Yarn dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          $(command -v sfw > /dev/null && echo sfw --verbose) yarn install
+          yarn install
 
       - name: Prebuild native expo project
         working-directory: ./suite-native/app

--- a/.github/workflows/release-connect-bump-versions.yml
+++ b/.github/workflows/release-connect-bump-versions.yml
@@ -43,15 +43,13 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+          version: v0.19.1
       - name: Install dependencies
-        run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn install
+        run: yarn install
 
       # The script connect-bump-versions.ts needs to build packages so dependencies are required.
       - name: Build dependencies

--- a/.github/workflows/release-connect-npm.yml
+++ b/.github/workflows/release-connect-npm.yml
@@ -56,15 +56,13 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+          version: v0.19.1
       - name: Install dependencies
-        run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn install
+        run: yarn install
 
       - name: Get packages that need release
         id: set-packages-need-release

--- a/.github/workflows/release-suite-coin-icons.yml
+++ b/.github/workflows/release-suite-coin-icons.yml
@@ -27,16 +27,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+          version: v0.19.1
       - name: Download crypto icons
         run: |
-          $(command -v sfw > /dev/null && echo sfw --verbose) yarn install
+          yarn install
           cd suite-common/icons
           yarn download-crypto-icons
 

--- a/.github/workflows/release-suite-definitions.yml
+++ b/.github/workflows/release-suite-definitions.yml
@@ -37,17 +37,15 @@ jobs:
           role-to-assume: ${{ github.event.inputs.environment == 'develop-definitions' && 'arn:aws:iam::538326561891:role/gh_actions_suite_develop_definitions' || 'arn:aws:iam::538326561891:role/gh_actions_suite_production_definitions' }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+          version: v0.19.1
       - name: Build and sign ${{ github.event.inputs.environment }} token-definitions
         if: ${{ github.event.inputs.environment == 'develop-definitions' && github.ref == 'refs/heads/develop' }}
         run: |
-          $(command -v sfw > /dev/null && echo sfw --verbose) yarn install
+          yarn install
           cd suite-common/token-definitions
 
           yarn nfts simple ethereum polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche
@@ -60,7 +58,7 @@ jobs:
           IS_CODESIGN_BUILD: "true"
           JWS_PRIVATE_KEY_ENV: ${{ secrets.JWS_PRIVATE_KEY_ENV }}
         run: |
-          $(command -v sfw > /dev/null && echo sfw --verbose) yarn install
+          yarn install
           cd suite-common/token-definitions
 
           yarn nfts simple ethereum polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche

--- a/.github/workflows/release-suite-desktop-web-staging.yml
+++ b/.github/workflows/release-suite-desktop-web-staging.yml
@@ -62,16 +62,10 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
-        continue-on-error: true
-        with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+      # safedep/pmg not available on macOS (that's ok, PMG must be run on PR workflows but here it's optional)
       - name: Install deps and build libs
         run: |
-          $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable
+          yarn install --immutable
           yarn message-system-sign-config
           yarn workspace @trezor/suite-data build:lib
           yarn workspace @trezor/transport-bridge build:lib
@@ -191,17 +185,11 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: yarn
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
-        continue-on-error: true
-        with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+      # safedep/pmg not available on macOS (that's ok, PMG must be run on PR workflows but here it's optional)
       - name: Install dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable # focus install is not used here to make sure that all global patches are applied for the release.
+          yarn install --immutable # focus install is not used here to make sure that all global patches are applied for the release.
 
       - name: Build suite-web
         env:
@@ -251,16 +239,10 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
-        continue-on-error: true
-        with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+      # safedep/pmg not available on macOS (that's ok, PMG must be run on PR workflows but here it's optional)
       - name: Install deps and build libs
         run: |
-          $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable
+          yarn install --immutable
           yarn message-system-sign-config
           yarn workspace @trezor/suite-data build:lib
           yarn workspace @trezor/transport-bridge build:lib

--- a/.github/workflows/release-suite-message-system-config.yml
+++ b/.github/workflows/release-suite-message-system-config.yml
@@ -31,19 +31,17 @@ jobs:
           role-to-assume: ${{ env.ROLE_TO_ASSUME  }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+          version: v0.19.1
       - name: Build and sign ${{ env.RELEASE_ENV }} message-system config file
         env:
           IS_CODESIGN_BUILD: ${{ env.RELEASE_ENV == 'production' && 'true' || 'false' }}
           JWS_PRIVATE_KEY_ENV: ${{ secrets.JWS_PRIVATE_KEY_ENV }}
         run: |
-          $(command -v sfw > /dev/null && echo sfw --verbose) yarn install
+          yarn install
           yarn message-system-sign-config
 
       - name: Upload ${{ env.RELEASE_ENV }}  message-system config file

--- a/.github/workflows/release-suite-native-develop.yml
+++ b/.github/workflows/release-suite-native-develop.yml
@@ -33,16 +33,14 @@ jobs:
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+          version: v0.19.1
       - name: Install libs
         run: |
-          $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @suite-native/app
+          yarn workspaces focus @suite-native/app
       - name: Build on EAS Android
         run: eas build
           --platform android

--- a/.github/workflows/release-suite-native-production.yml
+++ b/.github/workflows/release-suite-native-production.yml
@@ -40,16 +40,14 @@ jobs:
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+          version: v0.19.1
       - name: Install libs
         run: |
-          $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @suite-native/app
+          yarn workspaces focus @suite-native/app
       - name: Build on EAS iOS
         run: eas build
           --platform ios
@@ -76,16 +74,14 @@ jobs:
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+          version: v0.19.1
       - name: Install libs
         run: |
-          $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @suite-native/app
+          yarn workspaces focus @suite-native/app
       - name: Build on EAS Android
         run: eas build
           --platform android
@@ -118,16 +114,14 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::538326561891:role/gh_actions_mobile_prod_deploy
           aws-region: eu-central-1
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+          version: v0.19.1
       - name: Install libs
         run: |
-          $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @suite-native/app
+          yarn workspaces focus @suite-native/app
 
       - name: Get Suite version
         id: get_version

--- a/.github/workflows/template-connect-test-params.yml
+++ b/.github/workflows/template-connect-test-params.yml
@@ -63,21 +63,19 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: yarn
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+          version: v0.19.1
       - run: echo "FOCUS_WORKSPACES=@trezor/connect" >> "$GITHUB_ENV"
       - if: ${{ inputs.testEnv == 'web' }}
         run: echo "FOCUS_WORKSPACES=$FOCUS_WORKSPACES @trezor/connect-web" >> "$GITHUB_ENV"
       - if: ${{ inputs.transport && contains(inputs.transport, 'local-suite') }}
         run: echo "FOCUS_WORKSPACES=$FOCUS_WORKSPACES @trezor/transport-bridge" >> "$GITHUB_ENV"
-      - run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus $FOCUS_WORKSPACES
+      - run: yarn workspaces focus $FOCUS_WORKSPACES
       - if: ${{ inputs.transport && contains(inputs.transport, 'local-suite') }}
-        run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspace @trezor/transport-bridge build:node:bin
+        run: yarn workspace @trezor/transport-bridge build:node:bin
       - name: Install Playwright chromium
         if: ${{ inputs.testEnv == 'web' }}
         run: yarn workspace @trezor/connect-web exec playwright install --with-deps chromium

--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -74,19 +74,17 @@ jobs:
             suite-native/app/node_modules
           key: node_modules-native-full-${{ hashFiles('yarn.lock') }}
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+          version: v0.19.1
       - name: Disable Yarn hardened mode
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
 
       - name: Install Yarn dependencies
-        run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable
+        run: yarn install --immutable
 
       # Detox runtime may indirectly import the built config, and that would crash if message-system is not built
       - name: Sign message system config

--- a/.github/workflows/template-suite-native-prepare-test-app-android.yml
+++ b/.github/workflows/template-suite-native-prepare-test-app-android.yml
@@ -47,19 +47,17 @@ jobs:
             suite-native/app/node_modules
           key: node_modules-native-full-${{ hashFiles('yarn.lock') }}
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+          version: v0.19.1
       - name: Disable Yarn hardened mode
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
 
       - name: Install Yarn dependencies
-        run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable
+        run: yarn install --immutable
 
       - name: Setup Java
         uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5

--- a/.github/workflows/template-suite-run-e2e.yml
+++ b/.github/workflows/template-suite-run-e2e.yml
@@ -145,17 +145,15 @@ jobs:
           rm -rf ${{ github.workspace }}/packages/connect-explorer/build-webextension
           mv ${{ github.workspace }}/artifact-download ${{ github.workspace }}/packages/connect-explorer/build-webextension
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+          version: v0.19.1
       - name: Install PW Dependencies
         shell: bash
         run: |
-          $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @trezor/suite-e2e
+          yarn workspaces focus @trezor/suite-e2e
 
       - name: Install Playwright Browsers
         if: inputs.target == 'web' && steps.playwright-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/test-blockchain-link.yml
+++ b/.github/workflows/test-blockchain-link.yml
@@ -33,15 +33,13 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+          version: v0.19.1
       - name: Install dependencies
-        run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn --immutable
+        run: yarn --immutable
 
       - name: Build dependencies
         run: yarn build:libs

--- a/.github/workflows/test-connect-misc.yml
+++ b/.github/workflows/test-connect-misc.yml
@@ -71,15 +71,13 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+          version: v0.19.1
       - name: Install dependencies
-        run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn install
+        run: yarn install
 
       - name: Pack packages
         run: yarn tsx ./scripts/ci/pack-packages.ts
@@ -108,12 +106,10 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
-      - run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable
+          version: v0.19.1
+      - run: yarn install --immutable
       - run: yarn workspace @trezor/protobuf update:protobuf

--- a/.github/workflows/test-misc.yml
+++ b/.github/workflows/test-misc.yml
@@ -39,15 +39,15 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
-      - run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable
-      - run: ./scripts/circular-dependencies/check-circular-dependencies.sh
+          version: v0.19.1
+      - run: yarn install --immutable
+      - name: Check for Circular Imports
+        # safedep/pmg covers also the `npx` running inside the shell script
+        run: ./scripts/circular-dependencies/check-circular-dependencies.sh
 
   test-unit:
     runs-on: ubuntu-latest
@@ -63,14 +63,12 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
-      - run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable
+          version: v0.19.1
+      - run: yarn install --immutable
       - run: yarn message-system-sign-config
       - name: Unit Tests - Suite, Connect, Common
         run: yarn test:unit:all --exclude='@suite-native/*' -- --silent
@@ -93,14 +91,12 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
-      - run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable
+          version: v0.19.1
+      - run: yarn install --immutable
       - name: Fuzz Tests - Transport sessions lock
         run: yarn workspace @trezor/transport-common test:fuzz
 
@@ -116,7 +112,7 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
-      # sfw not working on windows runners
+      # safedep/pmg not available on Windows (that's ok, PMG must be run on PR workflows but here it's optional)
       - run: yarn install --immutable
       - run: yarn workspace @trezor/node-utils test:unit
 
@@ -132,14 +128,12 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
-      - run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable
+          version: v0.19.1
+      - run: yarn install --immutable
       - run: yarn generate-package @trezor/meow-package
       - run: rm -rf packages/meow-package
 
@@ -154,12 +148,10 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
-      - run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable
+          version: v0.19.1
+      - run: yarn install --immutable
       - run: yarn tsx ./packages/components/scripts/test-img-paths-exist.ts

--- a/.github/workflows/test-request-manager.yml
+++ b/.github/workflows/test-request-manager.yml
@@ -32,12 +32,10 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
-      - run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable
+          version: v0.19.1
+      - run: yarn install --immutable
       - run: yarn workspace @trezor/request-manager ${{ env.TEST_SCRIPT }}

--- a/.github/workflows/test-suite-manual-release.yml
+++ b/.github/workflows/test-suite-manual-release.yml
@@ -46,18 +46,16 @@ jobs:
         run: |
           echo "release_build=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}-${GITHUB_SHA:0:7}" >> $GITHUB_ENV
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+          version: v0.19.1
       - name: Install PW Dependencies
         shell: bash
         run: |
           echo "Installing Playwright dependencies"
-          $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @trezor/suite-e2e
+          yarn workspaces focus @trezor/suite-e2e
           # Playwright runtime may indirectly import the built config, and that would crash if message-system is not built
           yarn message-system-sign-config
 

--- a/.github/workflows/test-suite-native-e2e-ios.yml
+++ b/.github/workflows/test-suite-native-e2e-ios.yml
@@ -52,19 +52,13 @@ jobs:
             suite-native/app/node_modules
           key: node_modules-native-full-${{ hashFiles('yarn.lock') }}
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
-        continue-on-error: true
-        with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+      # safedep/pmg not available on macOS (that's ok, PMG must be run on PR workflows but here it's optional)
       - name: Disable Yarn hardened mode
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
 
       - name: Install Yarn dependencies
-        run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable
+        run: yarn install --immutable
 
       - name: Use latest stable Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
@@ -133,19 +127,13 @@ jobs:
             suite-native/app/node_modules
           key: node_modules-native-full-${{ hashFiles('yarn.lock') }}
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
-        continue-on-error: true
-        with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+      # safedep/pmg not available on macOS (that's ok, PMG must be run on PR workflows but here it's optional)
       - name: Disable Yarn hardened mode
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
 
       - name: Install Yarn dependencies
-        run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable
+        run: yarn install --immutable
 
       # Detox runtime may indirectly import the built config, and that would crash if message-system is not built
       - name: Sign message system config

--- a/.github/workflows/test-suite-native-e2e-manual-reporter.yml
+++ b/.github/workflows/test-suite-native-e2e-manual-reporter.yml
@@ -43,17 +43,15 @@ jobs:
           path: node_modules
           key: node_modules/${{ github.ref }}/${{github.run_id}}
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+          version: v0.19.1
       - name: Install Yarn dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          $(command -v sfw > /dev/null && echo sfw --verbose) yarn install
+          yarn install
 
       - name: Extract Release Build
         id: extract_branch

--- a/.github/workflows/test-suite-web-desktop-e2e-nightly.yml
+++ b/.github/workflows/test-suite-web-desktop-e2e-nightly.yml
@@ -138,16 +138,14 @@ jobs:
           node-version-file: ".nvmrc"
           cache: yarn
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+          version: v0.19.1
 
       - name: Install dependencies
-        run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @trezor/e2e-utils
+        run: yarn workspaces focus @trezor/e2e-utils
 
       - name: Download per-test coverage map artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/.github/workflows/test-transport.yml
+++ b/.github/workflows/test-transport.yml
@@ -40,16 +40,14 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+          version: v0.19.1
       - name: Install dependencies
         run: |
-          $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @trezor/transport-test
+          yarn workspaces focus @trezor/transport-test
 
       - name: Setup containers
         run: |
@@ -84,17 +82,15 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+          version: v0.19.1
       - name: Install dependencies
         shell: bash
         run: |
-          $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @trezor/transport -A
+          yarn workspaces focus @trezor/transport -A
 
       - name: Build transport tester
         run: |

--- a/.github/workflows/test-trezor-user-env-link-e2e.yml
+++ b/.github/workflows/test-trezor-user-env-link-e2e.yml
@@ -32,17 +32,15 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: yarn
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
+          version: v0.19.1
       - name: Install dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          $(command -v sfw > /dev/null && echo sfw --verbose) yarn workspaces focus @trezor/trezor-user-env-link
+          yarn workspaces focus @trezor/trezor-user-env-link
 
       - name: Run e2e tests
         run: |

--- a/.github/workflows/test-urls.yml
+++ b/.github/workflows/test-urls.yml
@@ -23,12 +23,10 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
-      - name: Install Socket Firewall
-        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      - name: Install SafeDep PMG
+        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
         continue-on-error: true
         with:
-          mode: firewall-free
-          job-summary: errors
-          firewall-version: 1.11.0
-      - run: $(command -v sfw > /dev/null && echo sfw --verbose) yarn install --immutable
+          version: v0.19.1
+      - run: yarn install --immutable
       - run: yarn workspace @trezor/urls test:e2e

--- a/packages/request-manager/tests/interceptor-whitelist.test.ts
+++ b/packages/request-manager/tests/interceptor-whitelist.test.ts
@@ -12,7 +12,12 @@ const NOT_WHITELISTED_DOMAIN = 'not-white-listed-but-does-not-exists.com';
 // The specific DNS error code (ENOTFOUND, EBUSY, etc.) is irrelevant.
 // what matters is that the error is not "Request blocked, not whitelisted domain: ...".
 const OK_ERROR_SHORT = new RegExp(`getaddrinfo E\\w+ ${WHITELISTED_DOMAIN}`);
-const OK_ERROR_HTTPS = OK_ERROR_SHORT;
+
+// Needed if your environment uses a local HTTPS proxy (e.g. PMG by SafeDep)
+const LOCALHOST_DOMAINS = ['localhost', '127.0.0.1'];
+const OK_ERROR_WITH_PROXY = new RegExp(`Failed to establish tunnel to ${WHITELISTED_DOMAIN}`);
+
+const OK_ERROR_HTTPS = new RegExp(`${OK_ERROR_SHORT.source}|${OK_ERROR_WITH_PROXY.source}`);
 
 const createWebSocket = (url: string) =>
     new Promise<void>((resolve, reject) => {
@@ -60,7 +65,7 @@ describe('Interceptor', () => {
     const torSettings = { running: false };
 
     const interceptorOptions: InterceptorOptions = {
-        getWhitelistedDomains: () => [WHITELISTED_DOMAIN],
+        getWhitelistedDomains: () => [...LOCALHOST_DOMAINS, WHITELISTED_DOMAIN],
         handler: () => {},
         getTorSettings: () => torSettings,
     };

--- a/scripts/circular-dependencies/check-circular-dependencies.sh
+++ b/scripts/circular-dependencies/check-circular-dependencies.sh
@@ -7,6 +7,7 @@ export LC_ALL=C  # force `sort` to work the same way (ASCII order)
 SNAPSHOT_FILE="scripts/circular-dependencies/madge-snapshot.txt"
 TMP_FILE="$(mktemp)"
 
+npm i -g madge@8.0.0
 # Run madge, allow it to fail. `npx` is used because `yarn` may not be installed when running this script.
 if ! npx madge@8.0.0 --circular --extensions ts,tsx --exclude "node_modules|lib|libDev" packages suite suite-native suite-common | tail -n +2 | sed 's/^[0-9][0-9]*) *//' | sort > "$TMP_FILE"; then
   echo "⚠️ madge exited with non-zero status, continuing to compare results..."


### PR DESCRIPTION
## Description

Replace SFW (https://github.com/trezor/trezor-suite/pull/27771) by PMG in every CI action

Reasons:
1. SFW is closed source binary.
2. SFW install action does not even verify checksums on the binaries

While PMG is
- fully open source with permissible license
- also fully supports yarn
- available both for local development and for CI
  - I tested it thoroughly locally, it did not cause me any problems with any flows (unlike SFW, which I had to run only on install commands to prevent interference)

One drawback is, that the github action to install PMG is not available on Windows or macOS runners. If we really needed it though, we can setup PMG by ourselves in the script.

## Notes for QA

No new CI crashes – already checked the workflows that run automatically, but some continuous vigilance needed for workflows invoked at will, e.g.  release-cycle workflows. 

If it crashes either in install step, or because of some weird network error, this PR is likely culprit. 

## Related Issue

Followup to https://github.com/trezor/trezor-suite/issues/27696

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=ci/pmg-instead-of-sfw&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=ci/pmg-instead-of-sfw&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=ci/pmg-instead-of-sfw&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/ci/pmg-instead-of-sfw/web/](https://dev.suite.sldev.cz/suite-web/ci/pmg-instead-of-sfw/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-01T07:58:09.715Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-07-01T07:56:14.030Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->