### PR TITLE
docs: document PMG as recommended tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Welcome to the Trezor Suite repository! This repository contains the source code
     - _Hint: you can have your shell [automatically switch versions](https://github.com/nvm-sh/nvm/blob/master/README.md#calling-nvm-use-automatically-in-a-directory-with-a-nvmrc-file) in each repo_
 - Enable [Yarn](https://yarnpkg.com/getting-started/install) through npm
 - Install [Git LFS](https://git-lfs.github.com/) (For Linux/Ubuntu, [after adding the repository](https://packagecloud.io/github/git-lfs/install) do `sudo apt-get install git-lfs`, more info [here](https://github.com/git-lfs/git-lfs/blob/main/INSTALLING.md))
-- Optional recommended: [setup Socket Firewall](https://docs.trezor.io/trezor-suite/misc/local-development-security.html)
+- Optional recommended: [setup PMG](https://docs.trezor.io/trezor-suite/misc/local-development-security.html)
 
 ### Getting started
 

--- a/docs/misc/local-development-security.md
+++ b/docs/misc/local-development-security.md
@@ -4,61 +4,18 @@ Given the emerging supply chain attacks, it is not enough to rely on CI security
 Those only safeguard CI itself, and prevent merging compromised code to `develop`.
 Additional hardening for local development is highly recommended for developers to work safely with npm packages (adding new npm packages, updating existing ones).
 
-## Socket Firewall Free
+## PMG by SafeDep
 
-`sfw` is a tool that wraps yarn, and scans packages that are being fetched from npm registry for known malicious code. <br />
-Refer to [the official documentation](https://docs.socket.dev/docs/socket-firewall-free) for more details.
+`pmg` is a tool that wraps yarn, and scans packages that are being fetched from npm registry for known malicious code. <br />
+PMG was chosen because it is fully open source, with permissible license, works well with `yarn` and can easily be built from source. <br />
+You can refer to [the official documentation](https://github.com/safedep/pmg) for more details.
 
-⚠️ Keep in mind that SFW is a **closed-source** binary made by Socket Dev,
-and that it [sends telemetry without opt-out](https://docs.socket.dev/docs/socket-firewall-free#telemetry).
-That's why it's only an optional suggestion.
+See their [Quick start README](https://github.com/safedep/pmg#quick-start) for setup instructions.<br />
+Note that building from source is a viable option.
 
-### Setup:
+You can test it by running `yarn add safedep-test-pkg@0.1.3` (PMG blocks the package as if it was malicious).
 
-```bash
-npm i -g sfw
-```
+### Alternatives
 
-Edit `~/.zshrc` or `~/.bashrc`, depending on your shell, and add:
-
-```bash
-unalias yarn 2>/dev/null
-yarn() {
-  local -a positional
-  local arg
-  positional=()
-
-  # get all positional arguments that are not flags or params
-  for arg in "$@"; do
-    case "$arg" in
-      -*) continue ;;
-      *) positional+=("$arg") ;;
-    esac
-  done
-
-  # just `yarn` itself is an alias for `yarn install`, so wrap it with SFW
-  if [ "${#positional[@]}" -eq 0 ]; then
-    sfw yarn "$@"
-    return
-  fi
-
-  # invoking a yarn command that can download packages, so wrap it with SFW
-  for arg in "${positional[@]}"; do
-    case "$arg" in
-      install|add|remove|up|upgrade|upgrade-interactive|dedupe|dlx|create|focus)
-        sfw yarn "$@"
-        return
-        ;;
-    esac
-  done
-
-  # run original yarn command with unchanged process args
-  command yarn "$@"
-}
-```
-
-### Notes
-
-To cover all cases, we need to alias `yarn` broadly, because just `yarn` itself is enough to install new packages (e.g. after modifying package.jsons with `ncu` or by agent).
-But we cannot have each and every yarn script runs through `sfw`, because some scripts crash (e.g. `electron-builder` or `nx`).
-That's why we cannot use simply `alias yarn='sfw yarn'`.
+- [SFW was explored previously](https://github.com/trezor/trezor-suite/blob/abe28a77db45dd843fbc3bf51cb052d53515ab83/docs/misc/local-development-security.md#socket-firewall-free), but rejected due to being closed source and higher setup complexity.
+- [DataDog firewall](https://github.com/DataDog/supply-chain-firewall) was rejected because it doesn't support `yarn`


### PR DESCRIPTION
## Description

Replace SFW (https://github.com/trezor/trezor-suite/pull/27708) by PMG as a **suggestion** for local development.

FYI CI implementation already done in [#28734](https://github.com/trezor/trezor-suite/pull/28734)

### Reasons:
1. SFW is closed source binary, opaque
2. SFW install action is not hardened: it does not even verify checksums on the downloaded binaries

While PMG is
- fully open source with permissible license
  - I confirm that it can be easily built from source
- also fully supports yarn
- available both for local development and for CI
- much simpler to use, see the docs change :slightly_smiling_face: 
- the SafeDep team were quick to resolve several issues I filed there 

### Report:
After using PMG locally for several weeks, I found only one minor problem: fragile test broken by PMG localhost https proxy, but that I easily resolved in 74dab8c7

I have to stress that when I was working with SFW, it did all kinds of troubles when I wrapped `yarn` with it, so I had to do a quite complex setup to have it run only on install commands – just see the insanity that I am replacing in this PR!

## Notes for QA

docs only

## Related Issue

Followup to https://github.com/trezor/trezor-suite/issues/27699