### PR TITLE
feat(suite): Add snap animation for collapsed sidebar

### DIFF
--- a/packages/components/src/components/ResizableBox/ResizableBox.tsx
+++ b/packages/components/src/components/ResizableBox/ResizableBox.tsx
@@ -61,11 +61,15 @@ type ResizersProps = TransientProps<AllowedResizableBoxFrameProps> &
         $minHeight?: number;
         $maxHeight?: number;
         $isResizing?: boolean;
+        $isSnapping?: boolean;
     };
 
 const MINIMAL_BOX_SIZE = 1;
 const REACTIVE_AREA_WIDTH = 16;
 const BORDER_WIDTH = 4;
+// Short transition used when the size "snaps" across a disabled interval, so the
+// jump between the interval edges animates smoothly instead of changing abruptly.
+const SNAP_TRANSITION_DURATION = 100;
 
 type ResizePointerEvent = MouseEvent | TouchEvent;
 
@@ -94,6 +98,13 @@ const Resizers = styled.div<ResizersProps>`
         css`
             user-select: none;
             cursor: ${$isResizing ? 'ns-resize' : 'auto'};
+        `}
+    ${({ $isSnapping }) =>
+        $isSnapping &&
+        css`
+            transition:
+                width ${SNAP_TRANSITION_DURATION}ms ease,
+                height ${SNAP_TRANSITION_DURATION}ms ease;
         `}
 
     ${withFrameProps}
@@ -225,13 +236,14 @@ type ResizeState = {
     height: number;
     isResizing: boolean;
     isHovering: boolean;
+    isSnapping: boolean;
     direction: Direction | null;
 };
 
 type ResizeAction =
     | { type: 'SET_POSITION'; x: number; y: number }
-    | { type: 'SET_WIDTH'; width: number }
-    | { type: 'SET_HEIGHT'; height: number }
+    | { type: 'SET_WIDTH'; width: number; snapping?: boolean }
+    | { type: 'SET_HEIGHT'; height: number; snapping?: boolean }
     | { type: 'START_RESIZE'; direction: Direction }
     | { type: 'STOP_RESIZE' }
     | { type: 'MOUSE_OVER'; direction: Direction }
@@ -242,9 +254,9 @@ const resizeReducer = (state: ResizeState, action: ResizeAction): ResizeState =>
         case 'SET_POSITION':
             return { ...state, x: action.x, y: action.y };
         case 'SET_WIDTH':
-            return { ...state, width: action.width };
+            return { ...state, width: action.width, isSnapping: action.snapping ?? false };
         case 'SET_HEIGHT':
-            return { ...state, height: action.height };
+            return { ...state, height: action.height, isSnapping: action.snapping ?? false };
         case 'START_RESIZE':
             return {
                 ...state,
@@ -253,7 +265,7 @@ const resizeReducer = (state: ResizeState, action: ResizeAction): ResizeState =>
                 direction: action.direction,
             };
         case 'STOP_RESIZE':
-            return { ...state, isResizing: false };
+            return { ...state, isResizing: false, isSnapping: false };
         case 'MOUSE_OVER':
             return {
                 ...state,
@@ -308,11 +320,19 @@ export const ResizableBox = ({
         height: height || minHeight,
         isResizing: false,
         isHovering: false,
+        isSnapping: false,
         direction: null,
     };
 
     const [state, dispatch] = useReducer(resizeReducer, initialState);
-    const { width: widthState, height: heightState, isResizing, isHovering, direction } = state;
+    const {
+        width: widthState,
+        height: heightState,
+        isResizing,
+        isHovering,
+        isSnapping,
+        direction,
+    } = state;
 
     const effectiveWidth = typeof forcedWidth === 'number' ? forcedWidth : widthState;
 
@@ -352,41 +372,41 @@ export const ResizableBox = ({
                 let nextHeight = heightState;
 
                 if (direction === 'top') {
-                    const diff = anchor.bottom - mouseY;
-                    let result = ensureMinimalSize(diff);
-                    result = calculateDisabledInterval(result, disabledHeightInterval);
+                    const diff = ensureMinimalSize(anchor.bottom - mouseY);
+                    const snapping = !!isInDisabledInterval(diff, disabledHeightInterval);
+                    const result = calculateDisabledInterval(diff, disabledHeightInterval);
                     nextHeight =
                         result > originalHeight
                             ? getMaxResult(maxHeight, result)
                             : getMinResult(minHeight, result);
-                    dispatch({ type: 'SET_HEIGHT', height: nextHeight });
+                    dispatch({ type: 'SET_HEIGHT', height: nextHeight, snapping });
                 } else if (direction === 'bottom') {
-                    const diff = mouseY - anchor.y;
-                    let result = ensureMinimalSize(diff);
-                    result = calculateDisabledInterval(result, disabledHeightInterval);
+                    const diff = ensureMinimalSize(mouseY - anchor.y);
+                    const snapping = !!isInDisabledInterval(diff, disabledHeightInterval);
+                    const result = calculateDisabledInterval(diff, disabledHeightInterval);
                     nextHeight =
                         result > originalHeight
                             ? getMaxResult(maxHeight, result)
                             : getMinResult(minHeight, result);
-                    dispatch({ type: 'SET_HEIGHT', height: nextHeight });
+                    dispatch({ type: 'SET_HEIGHT', height: nextHeight, snapping });
                 } else if (direction === 'left') {
-                    const diff = anchor.right - mouseX;
-                    let result = ensureMinimalSize(diff);
-                    result = calculateDisabledInterval(result, disabledWidthInterval);
+                    const diff = ensureMinimalSize(anchor.right - mouseX);
+                    const snapping = !!isInDisabledInterval(diff, disabledWidthInterval);
+                    const result = calculateDisabledInterval(diff, disabledWidthInterval);
                     nextWidth =
                         result > originalWidth
                             ? getMaxResult(maxWidth, result)
                             : getMinResult(minWidth, result);
-                    dispatch({ type: 'SET_WIDTH', width: nextWidth });
+                    dispatch({ type: 'SET_WIDTH', width: nextWidth, snapping });
                 } else if (direction === 'right') {
-                    const diff = mouseX - anchor.x;
-                    let result = ensureMinimalSize(diff);
-                    result = calculateDisabledInterval(result, disabledWidthInterval);
+                    const diff = ensureMinimalSize(mouseX - anchor.x);
+                    const snapping = !!isInDisabledInterval(diff, disabledWidthInterval);
+                    const result = calculateDisabledInterval(diff, disabledWidthInterval);
                     nextWidth =
                         result > originalWidth
                             ? getMaxResult(maxWidth, result)
                             : getMinResult(minWidth, result);
-                    dispatch({ type: 'SET_WIDTH', width: nextWidth });
+                    dispatch({ type: 'SET_WIDTH', width: nextWidth, snapping });
                 }
 
                 onWidthResizeMove?.(nextWidth);
@@ -508,6 +528,7 @@ export const ResizableBox = ({
             ref={resizableBoxRef}
             $highlightDirection={highlightDirection}
             $isResizing={isResizing}
+            $isSnapping={isSnapping}
             $zIndex={zIndex}
             {...frameProps}
         >


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/28615

## Screenshots:



https://github.com/user-attachments/assets/c6ceb70a-5d72-4b2c-a58d-4ef884c3cc03


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is `packages/components/src/components/ResizableBox/ResizableBox.tsx`, a generic UI component that maps to all 121 E2E tests via transitive imports. This is a classic broad shared component — it is likely used as a layout primitive across the application. None of the 121 analyzed E2E tests mention ResizableBox in their behaviors, entry points, assertions, or source hints, meaning none of them specifically exercise ResizableBox functionality. Without evidence that any particular test's code path is meaningfully affected by changes to this component, recommending E2E tests would be speculative and wasteful. Unit or integration tests for the ResizableBox component itself (not present in this E2E suite) would be the appropriate verification. If visual regression or layout-sensitive tests exist outside this E2E suite, those would be more relevant.

<details><summary><b>Changed files (1)</b></summary>

- `packages/components/src/components/ResizableBox/ResizableBox.tsx`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/components/src/components/ResizableBox/ResizableBox.tsx`

_Updated: 2026-06-12T15:39:16.551Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=snap-animation-for-collapsed-sidebar&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=snap-animation-for-collapsed-sidebar&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-12T15:45:03.905Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-12T15:43:26.997Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/snap-animation-for-collapsed-sidebar/web/](https://dev.suite.sldev.cz/suite-web/snap-animation-for-collapsed-sidebar/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->