### PR TITLE
fix(suite): show neutral 0% and loading skeleton in TrendTicker

### DIFF
--- a/packages/suite/src/components/suite/Ticker/TrendTicker.tsx
+++ b/packages/suite/src/components/suite/Ticker/TrendTicker.tsx
@@ -5,21 +5,20 @@ import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { selectBaseCurrency, selectFiatRatesByFiatRateKey } from '@suite-common/wallet-core';
 import { type TokenAddress } from '@suite-common/wallet-types';
 import { getFiatRateKey, localizePercentage } from '@suite-common/wallet-utils';
-import { Icon } from '@trezor/components';
-import { spacingsPx, typography } from '@trezor/theme';
+import { Icon, type IconName, SkeletonRectangle } from '@trezor/components';
+import { type Color, spacingsPx, typography } from '@trezor/theme';
 
 import { BaseCurrencyValue } from 'src/components/suite/BaseCurrencyValue';
-import { useSelector } from 'src/hooks/suite';
+import { useLoadingSkeleton, useSelector } from 'src/hooks/suite';
 
 import { NoRatesTooltip } from './NoRatesTooltip';
 
-const PercentageWrapper = styled.div<{ $isRateGoingUp: boolean }>`
+const PercentageWrapper = styled.div<{ $color: Color }>`
     ${typography['body-sm-strong']}
     gap: ${spacingsPx.xxs};
     display: flex;
     align-items: center;
-    color: ${({ theme, $isRateGoingUp }) =>
-        $isRateGoingUp ? theme.contentBrand : theme.contentCritical};
+    color: ${({ theme, $color }) => theme[$color]};
 `;
 
 const Empty = styled.div`
@@ -27,7 +26,27 @@ const Empty = styled.div`
     color: ${({ theme }) => theme.contentSecondary};
 `;
 
+type Trend = 'up' | 'down' | 'stable';
+
+const trendStyles: Record<Trend, { icon?: IconName; color: Color }> = {
+    up: { icon: 'trendUp', color: 'contentBrand' },
+    down: { icon: 'trendDown', color: 'contentCritical' },
+    stable: { color: 'contentSecondary' },
+};
+
 const calculatePercentageDifference = (a: number, b: number) => (a - b) / b;
+
+// localizePercentage renders 1 decimal place, so a change below this rounds to ±0.0% and should
+// be shown as neutral rather than as a tiny up/down move.
+const NEUTRAL_TREND_THRESHOLD = 0.0005;
+
+const getTrend = (percentageChange: number): Trend => {
+    if (Math.abs(percentageChange) < NEUTRAL_TREND_THRESHOLD) return 'stable';
+    if (percentageChange > 0) return 'up';
+    if (percentageChange < 0) return 'down';
+
+    return 'stable';
+};
 
 interface TickerProps {
     symbol: NetworkSymbol;
@@ -42,6 +61,7 @@ export const TrendTicker = ({
     noEmptyStateTooltip,
     showLoadingSkeleton = true,
 }: TickerProps) => {
+    const { shouldAnimate } = useLoadingSkeleton();
     const locale = useSelector(selectLanguage);
     const baseCurrencyCode = useSelector(selectBaseCurrency);
     const fiatRateKey = getFiatRateKey(symbol, baseCurrencyCode, contractAddress);
@@ -50,28 +70,43 @@ export const TrendTicker = ({
     );
     const currentRate = useSelector(state => selectFiatRatesByFiatRateKey(state, fiatRateKey));
 
-    const isSuccessfullyFetched =
-        lastWeekRate?.lastTickerTimestamp && currentRate?.lastTickerTimestamp;
+    const hasRateError =
+        !!currentRate?.error ||
+        !!lastWeekRate?.error ||
+        // temp fix to avoid showing 0% 7d change
+        currentRate?.lastTickerTimestamp === lastWeekRate?.lastTickerTimestamp;
 
-    // TODO: create selectIsRateGoingUp selector when wallet.settings is moved to suite-common
-    const isRateGoingUp = isSuccessfullyFetched ? currentRate.rate! >= lastWeekRate.rate! : false;
+    // lastTickerTimestamp is set even on failed attempts, so check the rate values and error state.
+    const isSuccessfullyFetched =
+        currentRate?.rate != null && lastWeekRate?.rate != null && !hasRateError;
+    // Show the skeleton only while a rate is actually being fetched; an unavailable rate falls through
+    // to the empty state instead. Rendered here (not via BaseCurrencyValue, whose skeleton is gated by
+    // isTokenKnown and never shows for native coins).
+    const isFetching = !!currentRate?.isLoading || !!lastWeekRate?.isLoading;
+    if (showLoadingSkeleton && isFetching) {
+        return <SkeletonRectangle animate={shouldAnimate} />;
+    }
+
     const percentageChange = isSuccessfullyFetched
         ? calculatePercentageDifference(currentRate.rate!, lastWeekRate.rate!)
         : 0;
+    const trend = getTrend(percentageChange);
+    const { icon, color } = trendStyles[trend];
+    // A change that rounds to ±0.0% is shown as a neutral "≈0%" instead of e.g. "-0.0%".
+    const formattedChange =
+        trend === 'stable'
+            ? '≈0%'
+            : localizePercentage({ valueInFraction: percentageChange, locale });
 
     const emptyStateComponent = noEmptyStateTooltip ? <Empty>—</Empty> : <NoRatesTooltip />;
 
     return (
-        <BaseCurrencyValue amount="1" symbol={symbol} showLoadingSkeleton={showLoadingSkeleton}>
+        <BaseCurrencyValue amount="1" symbol={symbol} showLoadingSkeleton={false}>
             {({ rate, timestamp }) =>
-                rate && timestamp && percentageChange ? (
-                    <PercentageWrapper $isRateGoingUp={isRateGoingUp}>
-                        <Icon
-                            name={isRateGoingUp ? 'trendUp' : 'trendDown'}
-                            color={isRateGoingUp ? 'contentBrand' : 'contentCritical'}
-                            size={16}
-                        />
-                        {localizePercentage({ valueInFraction: percentageChange, locale })}
+                rate && timestamp && isSuccessfullyFetched ? (
+                    <PercentageWrapper $color={color}>
+                        {icon !== undefined && <Icon name={icon} color={color} size={16} />}
+                        {formattedChange}
                     </PercentageWrapper>
                 ) : (
                     emptyStateComponent


### PR DESCRIPTION
TrendTicker now renders a neutral 0% change instead of an empty dash when the rate is unchanged week over week, and shows the loading skeleton while the last week rate is still being fetched, not only the current one.

BaseCurrencyValue loading skeleton cannot be used as it is made for loading fiat rates.

There is also this `currentRate?.lastTickerTimestamp === lastWeekRate?.lastTickerTimestamp;` which fixes when Blockbook returns exactly same rate and lastTickerTimestamp for rate in history and in present. Reported in backend channel.

Resolves #16127

<img width="1138" height="1083" alt="Screenshot 2026-06-21 at 18 35 28" src="https://github.com/user-attachments/assets/dc1322ca-9205-44cb-8b35-b488f86cbb90" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to TrendTicker.tsx, a UI component that displays price trend information. Since it maps to 121 tests via static coverage, it is clearly a widely-imported shared component. The risk is primarily visual/rendering — a broken TrendTicker could cause layout issues or crashes on pages where it renders (dashboard assets, account views). The recommended strategy focuses on the dashboard assets test (where trend tickers are most prominently displayed) and a few tests that exercise balance/price display areas where this component is most likely visible.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/suite/Ticker/TrendTicker.tsx`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — TrendTicker is a price trend indicator component likely rendered in the Assets section of the dashboard. This test verifies asset contents in both grid and table views, which would display ticker/trend information for each asset.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — TrendTicker displays price/value information on the dashboard that may be affected by discreet mode (hiding balances). This test verifies that fiat amounts including asset card and row values are properly hidden/revealed, which could include trend ticker values.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — TrendTicker likely renders alongside coin balance displays. This test verifies balance display and formatting including ellipsis truncation, which exercises the same UI area where TrendTicker would be rendered.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/wallet/transactions.test.ts` — The transactions overview page includes account-level graph and summary views where TrendTicker may render price trend data. A rendering error in TrendTicker could break the account transactions page layout.

</details>

_Updated: 2026-06-21T17:16:09.332Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trend-ticker-stable-rate-and-loading&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trend-ticker-stable-rate-and-loading&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy BTC > Buy Bitcoin from best offer | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-21T16:42:20.420Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-21T17:19:30.207Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/trend-ticker-stable-rate-and-loading/web/](https://dev.suite.sldev.cz/suite-web/fix/trend-ticker-stable-rate-and-loading/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->