### PR TITLE
fix(suite): show canonical vault name in yield deposit and withdraw header

### DIFF
--- a/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
@@ -39,7 +39,7 @@ export const YieldPageHeader = ({
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { translationString } = useTranslation();
     const { isBelowMobile } = useLayoutSize();
-    const vaultName = vault?.outputToken?.name;
+    const vaultName = vault?.metadata.name;
     const networkSymbol = account?.symbol;
     const isHowItWorksVisible = !isInvalid;
 


### PR DESCRIPTION
The yield deposit and withdraw page header showed the vault output token name, which lacks the trailing Vault and so did not match the name the device displays during signing. It now uses the canonical vault name from the earn API, which is guaranteed to match the firmware label exactly and is already used by the transaction review modal, approve modal, and the mobile deposit flow.

Resolves #28350

<img width="755" height="844" alt="Screenshot 2026-06-13 at 9 46 19" src="https://github.com/user-attachments/assets/9d6051d7-4241-46cd-8e54-e148793acc9b" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to YieldPageHeader.tsx, a UI component in the earn/yield common directory. This component is rendered on staking/yield pages across ETH, SOL, and ADA networks. Despite the static mapping showing 121 tests (due to broad transitive imports), only staking-related tests actually render the yield page where this header component appears. The recommended strategy focuses on ETH staking tests as highest priority (most direct consumers of yield UI), with SOL and ADA staking tests as medium priority for cross-network validation. All other mapped tests (analytics, backup, browser, metadata, trading, etc.) are unrelated to the yield page rendering path and are omitted.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — YieldPageHeader.tsx is a component in the earn/yield UI path. The ETH initial stake test exercises the full staking flow including the staking dashboard and form, which directly renders yield/earn page components including headers. A regression in the header would be visible here.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — The stake-more test navigates to the ETH staking tab and interacts with staking dashboard and form UI, which renders yield page components. YieldPageHeader is part of the earn/yield common components directly used in these views.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — The ETH unstake test covers the unstaking and claiming flows on the staking tab, which renders earn/yield UI components. YieldPageHeader would be displayed on these yield pages, making this a direct consumer of the changed component.
- `suite/e2e/tests/staking/staking-form.test.ts` — This test validates the ETH staking form including balance display, input validation, and percentage buttons on the staking/yield page. YieldPageHeader is a common component in the yield page layout that would render alongside this form.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — SOL initial staking uses the same earn/yield page infrastructure as ETH staking. YieldPageHeader likely renders on SOL staking pages as well, making this a secondary validation of the component across a different network.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — SOL unstake and claim flows render earn/yield UI pages where YieldPageHeader is used. This provides cross-network coverage for the changed header component.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — SOL stake-more flow navigates to the staking dashboard and form, which share the earn/yield page layout including YieldPageHeader. Ensures the header renders correctly for SOL staking.
- `suite/e2e/tests/staking/sol/rewards.test.ts` — SOL rewards test verifies the staking dashboard display including amounts and reward lists on the yield page. YieldPageHeader is part of this page layout.
- `suite/e2e/tests/staking/ada/stake.test.ts` — Cardano staking navigates to the staking tab which may render earn/yield components. While ADA staking has some distinct UI, the earn page header is a shared common component.
- `suite/e2e/tests/staking/ada/claim.test.ts` — ADA claim rewards flow uses the staking tab UI which shares earn/yield page infrastructure where YieldPageHeader renders.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — ADA unstake flow operates on the staking tab that renders earn/yield page components including YieldPageHeader.

</details>

_Updated: 2026-06-12T15:47:45.187Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/vault-name-deposit-flow&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/vault-name-deposit-flow&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-12T15:52:33.920Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-12T15:51:17.496Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/vault-name-deposit-flow/web/](https://dev.suite.sldev.cz/suite-web/fix/vault-name-deposit-flow/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->