### PR TITLE
Add Solana tx-validity timer to staking review flows

### DIFF
--- a/packages/react-utils/src/hooks/timer/useCountdownTimer.ts
+++ b/packages/react-utils/src/hooks/timer/useCountdownTimer.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { intervalToDuration } from 'date-fns';
 
@@ -11,32 +11,20 @@ export const useCountdownTimer = (
     deadline: number,
     { pastDeadlineLeadMs = 1000, isEnabled = true }: UseCountdownTimerOptions = {},
 ) => {
-    const getDuration = useCallback(
-        (currentTimestamp = Date.now()) =>
-            intervalToDuration({
-                start: currentTimestamp,
-                end: deadline,
-            }),
-        [deadline],
-    );
-
-    const [duration, setDuration] = useState(getDuration);
-    const [isPastDeadline, setIsPastDeadline] = useState(
-        () => deadline <= Date.now() + pastDeadlineLeadMs,
-    );
+    const [now, setNow] = useState(() => Date.now());
 
     useEffect(() => {
-        if (!isEnabled) return;
+        if (!isEnabled) return undefined;
 
-        const interval = setInterval(() => {
-            const now = Date.now();
-            setIsPastDeadline(deadline <= now + pastDeadlineLeadMs);
+        setNow(Date.now());
 
-            setDuration(getDuration(now));
-        }, 300);
+        const interval = setInterval(() => setNow(Date.now()), 300);
 
         return () => clearInterval(interval);
-    }, [isEnabled, deadline, getDuration, pastDeadlineLeadMs]);
+    }, [isEnabled, deadline]);
+
+    const duration = intervalToDuration({ start: now, end: deadline });
+    const isPastDeadline = deadline <= now + pastDeadlineLeadMs;
 
     return {
         duration,

--- a/suite-native/device-mutex/src/requestDeviceAccess.ts
+++ b/suite-native/device-mutex/src/requestDeviceAccess.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'crypto';
 import { activateKeepAwakeAsync, deactivateKeepAwake } from 'expo-keep-awake';
 
 import { deviceAccessMutex } from './DeviceAccessMutex';
@@ -17,7 +16,7 @@ export const requestDeviceAccess = async <TReturnType>(
         : deviceAccessMutex.lock());
     if (!wasLockSuccessful) return DEVICE_ACCESS_ERROR;
 
-    const keepAwakeTag = randomUUID();
+    const keepAwakeTag = crypto.randomUUID();
 
     try {
         activateKeepAwakeAsync(keepAwakeTag); // Prevents screen from sleeping while app interacts with device.

--- a/suite-native/module-earn/src/__tests__/utils.test.ts
+++ b/suite-native/module-earn/src/__tests__/utils.test.ts
@@ -1,0 +1,79 @@
+import { handleEarnReviewError } from '../utils';
+
+const buildHandlers = () => ({
+    navigation: { pop: jest.fn() },
+    showPushTransactionFailedAlert: jest.fn(),
+    showPendingTransactionConflictAlert: jest.fn(),
+    showDeviceDisconnectedAlert: jest.fn(),
+});
+
+const expectNoReaction = (handlers: ReturnType<typeof buildHandlers>) => {
+    expect(handlers.navigation.pop).not.toHaveBeenCalled();
+    expect(handlers.showPushTransactionFailedAlert).not.toHaveBeenCalled();
+    expect(handlers.showPendingTransactionConflictAlert).not.toHaveBeenCalled();
+    expect(handlers.showDeviceDisconnectedAlert).not.toHaveBeenCalled();
+};
+
+describe('handleEarnReviewError', () => {
+    it('ignores a validity-timer timeout so the expired alert keeps the review screen open', () => {
+        const handlers = buildHandlers();
+
+        handleEarnReviewError({
+            payload: {
+                error: 'sign-transaction-timeout',
+                errorCode: 'Method_Cancel',
+                message: 'tx-timeout',
+            },
+            ...handlers,
+        });
+
+        expectNoReaction(handlers);
+    });
+
+    it('ignores a user cancel reported via the tx-cancelled message', () => {
+        const handlers = buildHandlers();
+
+        handleEarnReviewError({
+            payload: { error: 'sign-transaction-failed', message: 'tx-cancelled' },
+            ...handlers,
+        });
+
+        expectNoReaction(handlers);
+    });
+
+    it('pops the review screen when the user cancels on the device', () => {
+        const handlers = buildHandlers();
+
+        handleEarnReviewError({
+            payload: { error: 'sign-transaction-failed', errorCode: 'Method_Cancel' },
+            ...handlers,
+        });
+
+        expect(handlers.navigation.pop).toHaveBeenCalledTimes(1);
+        expect(handlers.showDeviceDisconnectedAlert).not.toHaveBeenCalled();
+    });
+
+    it('shows the push failed alert for a failed broadcast', () => {
+        const handlers = buildHandlers();
+
+        handleEarnReviewError({
+            payload: { error: 'push-transaction-failed' },
+            ...handlers,
+        });
+
+        expect(handlers.showPushTransactionFailedAlert).toHaveBeenCalledTimes(1);
+        expect(handlers.navigation.pop).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the device disconnected alert for unknown errors', () => {
+        const handlers = buildHandlers();
+
+        handleEarnReviewError({
+            payload: { error: 'sign-transaction-failed', message: 'unknown-error' },
+            ...handlers,
+        });
+
+        expect(handlers.showDeviceDisconnectedAlert).toHaveBeenCalledTimes(1);
+        expect(handlers.navigation.pop).not.toHaveBeenCalled();
+    });
+});

--- a/suite-native/module-earn/src/components/ClaimTransactionDataReviewStepList.tsx
+++ b/suite-native/module-earn/src/components/ClaimTransactionDataReviewStepList.tsx
@@ -18,6 +18,7 @@ import {
     LIST_VERTICAL_SPACING,
     SlidingFooterOverlay,
     type TransactionReviewOutputsState,
+    selectIsTransactionAlreadySigned,
     selectIsTransactionReviewInProgress,
     selectReviewSummaryOutput,
     useActiveStepOffset,
@@ -60,6 +61,8 @@ export const ClaimTransactionDataReviewStepList = ({
 
     const precomposedTransaction = useEarnSelectedPrecomposedTransaction('claim', accountKey);
 
+    const isTransactionAlreadySigned = useSelector(selectIsTransactionAlreadySigned);
+
     const [stepIndex, setStepIndex] = useState(0);
 
     const { activeStepBottomOffset, handleReadListItemHeight } = useActiveStepOffset(stepIndex);
@@ -99,7 +102,7 @@ export const ClaimTransactionDataReviewStepList = ({
                 {!!accountSymbol && (
                     <ClaimOutputItem
                         symbol={accountSymbol}
-                        outputState={stepIndex > 0 ? 'success' : 'active'}
+                        outputState={isTransactionAlreadySigned ? 'success' : 'active'}
                         onLayout={event => handleReadListItemHeight(event, 0)}
                     />
                 )}

--- a/suite-native/module-earn/src/components/EarnTransactionDataReviewStepList.tsx
+++ b/suite-native/module-earn/src/components/EarnTransactionDataReviewStepList.tsx
@@ -11,6 +11,7 @@ import {
     LIST_VERTICAL_SPACING,
     SlidingFooterOverlay,
     type TransactionReviewOutputsState,
+    selectIsTransactionAlreadySigned,
     selectIsTransactionReviewInProgress,
     selectReviewSummaryOutput,
     useActiveStepOffset,
@@ -46,6 +47,8 @@ export const EarnTransactionDataReviewStepList = ({
 
     const selectedPrecomposed = useEarnSelectedPrecomposedTransaction('stake', accountKey);
 
+    const isTransactionAlreadySigned = useSelector(selectIsTransactionAlreadySigned);
+
     const [stepIndex, setStepIndex] = useState(0);
 
     const { activeStepBottomOffset, handleReadListItemHeight } = useActiveStepOffset(stepIndex);
@@ -75,7 +78,7 @@ export const EarnTransactionDataReviewStepList = ({
             <VStack spacing={LIST_VERTICAL_SPACING}>
                 <EarnStakeOutputItem
                     symbol={accountSymbol}
-                    outputState={stepIndex > 0 ? 'success' : 'active'}
+                    outputState={isTransactionAlreadySigned ? 'success' : 'active'}
                     onLayout={event => handleReadListItemHeight(event, 0)}
                 />
 

--- a/suite-native/module-earn/src/components/UnstakeTransactionDataReviewStepList.tsx
+++ b/suite-native/module-earn/src/components/UnstakeTransactionDataReviewStepList.tsx
@@ -13,6 +13,7 @@ import {
     LIST_VERTICAL_SPACING,
     SlidingFooterOverlay,
     type TransactionReviewOutputsState,
+    selectIsTransactionAlreadySigned,
     selectIsTransactionReviewInProgress,
     selectReviewSummaryOutput,
     useActiveStepOffset,
@@ -46,6 +47,8 @@ export const UnstakeTransactionDataReviewStepList = ({
     );
 
     const selectedPrecomposed = useEarnSelectedPrecomposedTransaction('unstake', accountKey);
+
+    const isTransactionAlreadySigned = useSelector(selectIsTransactionAlreadySigned);
 
     const accountSymbol = useSelector((state: AccountsRootState) =>
         selectAccountNetworkSymbol(state, accountKey),
@@ -84,7 +87,7 @@ export const UnstakeTransactionDataReviewStepList = ({
             <VStack spacing={LIST_VERTICAL_SPACING}>
                 <UnstakeOutputItem
                     symbol={accountSymbol}
-                    outputState={stepIndex > 0 ? 'success' : 'active'}
+                    outputState={isTransactionAlreadySigned ? 'success' : 'active'}
                     onLayout={event => handleReadListItemHeight(event, 0)}
                 />
 

--- a/suite-native/module-earn/src/hooks/useEarnTxValidityFlow.tsx
+++ b/suite-native/module-earn/src/hooks/useEarnTxValidityFlow.tsx
@@ -1,0 +1,135 @@
+import { useCallback, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { useNavigation } from '@react-navigation/native';
+import { isRejected } from '@reduxjs/toolkit';
+
+import {
+    type AccountsRootState,
+    type SendRootState,
+    selectAccountByKey,
+    selectSendPrecomposedTx,
+    sendFormActions,
+} from '@suite-common/wallet-core';
+import { type AccountKey } from '@suite-common/wallet-types';
+import {
+    type RootStackParamList,
+    type RootStackRoutes,
+    type StackNavigationProps,
+} from '@suite-native/navigation';
+import { signStakeTransactionNativeThunk } from '@suite-native/staking';
+import {
+    selectIsTransactionAlreadySigned,
+    useTxValidityTimer,
+} from '@suite-native/transaction-management';
+import TrezorConnect from '@trezor/connect';
+
+import { type EarnFormDraftPrefix } from '../types';
+import { handleEarnReviewError } from '../utils';
+import { useEarnSelectedPrecomposedTransaction } from './useEarnSelectedPrecomposedTransaction';
+import { useShowDeviceDisconnectedDuringEarnReviewAlert } from './useShowDeviceDisconnectedDuringEarnReviewAlert';
+import { useShowPushTransactionFailedDuringReviewAlert } from './useShowPushTransactionFailedDuringReviewAlert';
+
+type NavigationProps = StackNavigationProps<RootStackParamList, RootStackRoutes>;
+
+type UseEarnTxValidityFlowProps = {
+    accountKey: AccountKey;
+    stakeType: EarnFormDraftPrefix;
+    revealConfirmOnTrezorSheet: () => void;
+    isPushing: boolean;
+};
+
+export const useEarnTxValidityFlow = ({
+    accountKey,
+    stakeType,
+    revealConfirmOnTrezorSheet,
+    isPushing,
+}: UseEarnTxValidityFlowProps) => {
+    const dispatch = useDispatch();
+    const navigation = useNavigation<NavigationProps>();
+
+    const account = useSelector((state: AccountsRootState) =>
+        selectAccountByKey(state, accountKey),
+    );
+    const precomposedTx = useSelector((state: SendRootState) => selectSendPrecomposedTx(state));
+    const isTransactionAlreadySigned = useSelector(selectIsTransactionAlreadySigned);
+    const precomposedTransaction = useEarnSelectedPrecomposedTransaction(stakeType, accountKey);
+
+    const showDeviceDisconnectedAlert = useShowDeviceDisconnectedDuringEarnReviewAlert();
+    const { showPushTransactionFailedAlert, showPendingTransactionConflictAlert } =
+        useShowPushTransactionFailedDuringReviewAlert(stakeType);
+
+    const handleRetry = useCallback(async () => {
+        if (!precomposedTransaction) return;
+
+        const txToRetry = precomposedTransaction;
+
+        TrezorConnect.cancel('tx-timeout');
+        dispatch(sendFormActions.clearSignedTransactionData());
+        revealConfirmOnTrezorSheet();
+
+        const trySign = () =>
+            dispatch(
+                signStakeTransactionNativeThunk({
+                    accountKey,
+                    stakeType,
+                    precomposedTransaction: txToRetry,
+                }),
+            );
+
+        let response = await trySign();
+
+        // Retry once on transient cancel/re-sign errors, not on a bled `tx-timeout`
+        if (isRejected(response)) {
+            const transientErrorCode =
+                response.payload && 'errorCode' in response.payload
+                    ? response.payload.errorCode
+                    : undefined;
+            if (
+                transientErrorCode === 'Device_InvalidState' ||
+                transientErrorCode === 'Method_Interrupted'
+            ) {
+                response = await trySign();
+            }
+        }
+
+        if (!isRejected(response)) return;
+
+        handleEarnReviewError({
+            payload: response.payload,
+            navigation,
+            showPushTransactionFailedAlert,
+            showPendingTransactionConflictAlert,
+            showDeviceDisconnectedAlert,
+        });
+    }, [
+        accountKey,
+        stakeType,
+        precomposedTransaction,
+        dispatch,
+        navigation,
+        revealConfirmOnTrezorSheet,
+        showDeviceDisconnectedAlert,
+        showPendingTransactionConflictAlert,
+        showPushTransactionFailedAlert,
+    ]);
+
+    const handleCancel = useCallback(() => {
+        TrezorConnect.cancel('tx-timeout');
+        navigation.pop();
+    }, [navigation]);
+
+    const [reviewOpenedAt] = useState(() => Date.now());
+    const precomposedTxTimestamp = precomposedTx?.createdTimestamp ?? 0;
+    const isPrecomposedTxFromCurrentReview = precomposedTxTimestamp >= reviewOpenedAt;
+    const createdTimestamp = isPrecomposedTxFromCurrentReview ? precomposedTxTimestamp : 0;
+
+    return useTxValidityTimer({
+        networkType: account?.networkType,
+        createdTimestamp,
+        isBroadcasting: isPushing,
+        isTransactionAlreadySigned,
+        onRetry: handleRetry,
+        onCancel: handleCancel,
+    });
+};

--- a/suite-native/module-earn/src/hooks/useNavigateAfterPushedTransaction.ts
+++ b/suite-native/module-earn/src/hooks/useNavigateAfterPushedTransaction.ts
@@ -12,6 +12,7 @@ import {
     selectAccountNetworkSymbol,
     selectConvertedNetworkFeeInfo,
     selectTransactionByAccountKeyAndTxid,
+    sendFormActions,
 } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
 import {
@@ -106,6 +107,14 @@ export const useNavigateAfterPushedTransaction = ({
             );
         }
     }, [accountKey, isTransactionProcessedByBackend, navigation, networkSymbol, txid]);
+
+    useEffect(() => {
+        if (!txid) return undefined;
+
+        return () => {
+            dispatch(sendFormActions.discardTransaction());
+        };
+    }, [txid, dispatch]);
 
     return { trackPushedTransaction: setTxid };
 };

--- a/suite-native/module-earn/src/screens/ClaimTransactionDataReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/ClaimTransactionDataReviewScreen.tsx
@@ -17,12 +17,14 @@ import {
 } from '@suite-native/navigation';
 import {
     type TransactionReviewOutputsState,
+    TxValidityTimer,
     selectIsTransactionAlreadySigned,
     selectIsTransactionReviewInProgress,
     sendArrowsLottie,
 } from '@suite-native/transaction-management';
 
 import { ClaimTransactionDataReviewStepList } from '../components/ClaimTransactionDataReviewStepList';
+import { useEarnTxValidityFlow } from '../hooks/useEarnTxValidityFlow';
 import { useHandleOnEarnTransactionReview } from '../hooks/useHandleOnEarnTransactionReview';
 import { useNavigateAfterPushedTransaction } from '../hooks/useNavigateAfterPushedTransaction';
 
@@ -51,6 +53,16 @@ export const ClaimTransactionDataReviewScreen = ({
     });
 
     const { trackPushedTransaction } = useNavigateAfterPushedTransaction({ accountKey });
+
+    const { showTimer, secondsLeft, isPastDeadline, isBroadcasting, onRetry, isRetryDisabled } =
+        useEarnTxValidityFlow({
+            accountKey,
+            stakeType: 'claim',
+            revealConfirmOnTrezorSheet,
+            isPushing,
+        });
+
+    const isSolanaAccount = account?.networkType === 'solana';
 
     // Once signed, the user reviews the summary and taps "Claim now" to broadcast the transaction.
     const isReadyToClaim = isTransactionAlreadySigned && !!account;
@@ -100,6 +112,15 @@ export const ClaimTransactionDataReviewScreen = ({
         >
             <VStack flex={1} justifyContent="space-between">
                 <VStack justifyContent="center" spacing="sp24">
+                    {showTimer && (
+                        <TxValidityTimer
+                            secondsLeft={secondsLeft}
+                            isPastDeadline={isPastDeadline}
+                            isBroadcasting={isBroadcasting}
+                            onRetry={onRetry}
+                            isRetryDisabled={isRetryDisabled}
+                        />
+                    )}
                     <ClaimTransactionDataReviewStepList onSign={handleSign} />
                 </VStack>
                 {isReadyToClaim && (
@@ -118,6 +139,7 @@ export const ClaimTransactionDataReviewScreen = ({
                         </VStack>
                         <Button
                             isLoading={isPushing}
+                            isDisabled={isSolanaAccount && isPastDeadline}
                             onPress={handleClaimNow}
                             testID="@earn/claim-now"
                         >

--- a/suite-native/module-earn/src/screens/EarnTransactionDataReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/EarnTransactionDataReviewScreen.tsx
@@ -17,12 +17,14 @@ import {
 } from '@suite-native/navigation';
 import {
     type TransactionReviewOutputsState,
+    TxValidityTimer,
     selectIsTransactionAlreadySigned,
     selectIsTransactionReviewInProgress,
     sendArrowsLottie,
 } from '@suite-native/transaction-management';
 
 import { EarnTransactionDataReviewStepList } from '../components/EarnTransactionDataReviewStepList';
+import { useEarnTxValidityFlow } from '../hooks/useEarnTxValidityFlow';
 import { useHandleOnEarnTransactionReview } from '../hooks/useHandleOnEarnTransactionReview';
 import { useNavigateAfterPushedTransaction } from '../hooks/useNavigateAfterPushedTransaction';
 
@@ -51,6 +53,16 @@ export const EarnTransactionDataReviewScreen = ({
     });
 
     const { trackPushedTransaction } = useNavigateAfterPushedTransaction({ accountKey });
+
+    const { showTimer, secondsLeft, isPastDeadline, isBroadcasting, onRetry, isRetryDisabled } =
+        useEarnTxValidityFlow({
+            accountKey,
+            stakeType: 'stake',
+            revealConfirmOnTrezorSheet,
+            isPushing,
+        });
+
+    const isSolanaAccount = account?.networkType === 'solana';
 
     const isReadyToStake = isTransactionAlreadySigned && !!account;
 
@@ -99,6 +111,15 @@ export const EarnTransactionDataReviewScreen = ({
         >
             <VStack flex={1} justifyContent="space-between">
                 <VStack justifyContent="center" spacing="sp24">
+                    {showTimer && (
+                        <TxValidityTimer
+                            secondsLeft={secondsLeft}
+                            isPastDeadline={isPastDeadline}
+                            isBroadcasting={isBroadcasting}
+                            onRetry={onRetry}
+                            isRetryDisabled={isRetryDisabled}
+                        />
+                    )}
                     {account && (
                         <EarnTransactionDataReviewStepList
                             accountKey={accountKey}
@@ -124,6 +145,7 @@ export const EarnTransactionDataReviewScreen = ({
                         </VStack>
                         <Button
                             isLoading={isPushing}
+                            isDisabled={isSolanaAccount && isPastDeadline}
                             onPress={handleStakeNow}
                             testID="@earn/stake-now"
                         >

--- a/suite-native/module-earn/src/screens/UnstakeTransactionDataReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/UnstakeTransactionDataReviewScreen.tsx
@@ -19,6 +19,7 @@ import {
 } from '@suite-native/navigation';
 import {
     type TransactionReviewOutputsState,
+    TxValidityTimer,
     selectIsReceiveAddressOutputConfirmed,
     selectIsTransactionAlreadySigned,
     selectIsTransactionReviewInProgress,
@@ -26,6 +27,7 @@ import {
 } from '@suite-native/transaction-management';
 
 import { UnstakeTransactionDataReviewStepList } from '../components/UnstakeTransactionDataReviewStepList';
+import { useEarnTxValidityFlow } from '../hooks/useEarnTxValidityFlow';
 import { useHandleOnEarnTransactionReview } from '../hooks/useHandleOnEarnTransactionReview';
 import { useNavigateAfterPushedTransaction } from '../hooks/useNavigateAfterPushedTransaction';
 import { useStakingDetailNavigation } from '../hooks/useStakingDetailNavigation';
@@ -60,6 +62,16 @@ export const UnstakeTransactionDataReviewScreen = ({
     });
 
     const { trackPushedTransaction } = useNavigateAfterPushedTransaction({ accountKey });
+
+    const { showTimer, secondsLeft, isPastDeadline, isBroadcasting, onRetry, isRetryDisabled } =
+        useEarnTxValidityFlow({
+            accountKey,
+            stakeType: 'unstake',
+            revealConfirmOnTrezorSheet,
+            isPushing,
+        });
+
+    const isSolanaAccount = account?.networkType === 'solana';
 
     const isReadyToUnstake = isTransactionAlreadySigned && !!account;
 
@@ -117,6 +129,15 @@ export const UnstakeTransactionDataReviewScreen = ({
         >
             <VStack flex={1} justifyContent="space-between">
                 <VStack justifyContent="center" spacing="sp24">
+                    {showTimer && (
+                        <TxValidityTimer
+                            secondsLeft={secondsLeft}
+                            isPastDeadline={isPastDeadline}
+                            isBroadcasting={isBroadcasting}
+                            onRetry={onRetry}
+                            isRetryDisabled={isRetryDisabled}
+                        />
+                    )}
                     <UnstakeTransactionDataReviewStepList onSign={handleSign} />
                 </VStack>
                 {isReadyToUnstake && (
@@ -135,6 +156,7 @@ export const UnstakeTransactionDataReviewScreen = ({
                         </VStack>
                         <Button
                             isLoading={isPushing}
+                            isDisabled={isSolanaAccount && isPastDeadline}
                             onPress={handleUnstakeNow}
                             testID="@earn/unstake-now"
                         >

--- a/suite-native/module-earn/src/utils.ts
+++ b/suite-native/module-earn/src/utils.ts
@@ -56,6 +56,10 @@ export const handleEarnReviewError = ({
     showPendingTransactionConflictAlert,
     showDeviceDisconnectedAlert,
 }: HandleEarnReviewErrorProps) => {
+    if (payload?.error === 'sign-transaction-timeout') {
+        return;
+    }
+
     if (payload?.message === 'tx-cancelled') {
         return;
     }

--- a/suite-native/staking/src/__tests__/stakeFormSolanaNativeThunks.test.ts
+++ b/suite-native/staking/src/__tests__/stakeFormSolanaNativeThunks.test.ts
@@ -21,6 +21,7 @@ jest.mock('@trezor/connect', () => ({
     ...jest.requireActual('@trezor/connect'),
     default: {
         solanaSignTransaction: jest.fn(),
+        blockchainGetInfo: jest.fn(),
         blockchainEstimateFee: jest.fn().mockResolvedValue({
             success: true,
             payload: { levels: [{ feePerUnit: '100000', feeLimit: '200000', feePerTx: '5000' }] },
@@ -147,6 +148,7 @@ const buildSolanaPrecomposedTransaction = (): PrecomposedTransactionFinal =>
     }) as unknown as PrecomposedTransactionFinal;
 
 const solanaSignTransactionMock = TrezorConnect.solanaSignTransaction as jest.Mock;
+const blockchainGetInfoMock = TrezorConnect.blockchainGetInfo as jest.Mock;
 
 const dispatchCompose = async (
     store: ReturnType<typeof buildStore>,
@@ -177,6 +179,12 @@ beforeEach(() => {
         payload: { signature: 'ed25519signature' },
     });
     solanaTxShim.addSignature.mockClear();
+
+    blockchainGetInfoMock.mockReset();
+    blockchainGetInfoMock.mockResolvedValue({
+        success: false,
+        payload: { error: 'backend not connected' },
+    });
 
     prepareStakeSolTxMock.mockReset();
     prepareStakeSolTxMock.mockResolvedValue({
@@ -310,6 +318,21 @@ describe('signSolanaStakingTransactionNativeThunk', () => {
         );
     });
 
+    it('stamps createdTimestamp on the stored precomposed transaction (powers the validity timer)', async () => {
+        const store = buildStore();
+
+        const result = await dispatchSign(store, {
+            accountKey: SOL_ACCOUNT_KEY,
+            stakeType: 'stake',
+            precomposedTransaction: buildSolanaPrecomposedTransaction(),
+        });
+
+        expect(result).toEqual({ ok: true });
+        expect(store.getState().wallet.send.precomposedTx?.createdTimestamp).toEqual(
+            expect.any(Number),
+        );
+    });
+
     it('rejects when the blockchain backend URL cannot be resolved', async () => {
         const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
         const store = buildStore({ blockchain: { dsol: { url: 'http://localhost:8899' } } });
@@ -327,8 +350,28 @@ describe('signSolanaStakingTransactionNativeThunk', () => {
                 message: 'Blockchain backend URL not found for sol.',
             },
         });
+        expect(blockchainGetInfoMock).toHaveBeenCalledWith({ coin: 'sol' });
         expect(solanaSignTransactionMock).not.toHaveBeenCalled();
         errorSpy.mockRestore();
+    });
+
+    it('falls back to an on-demand backend connection when the redux url is missing', async () => {
+        blockchainGetInfoMock.mockResolvedValue({
+            success: true,
+            payload: { url: 'http://localhost:8899' },
+        });
+        const store = buildStore({ blockchain: { dsol: { url: 'http://localhost:8899' } } });
+
+        const result = await dispatchSign(store, {
+            accountKey: SOL_ACCOUNT_KEY,
+            stakeType: 'unstake',
+            precomposedTransaction: buildSolanaPrecomposedTransaction(),
+        });
+
+        expect(result).toEqual({ ok: true });
+        expect(blockchainGetInfoMock).toHaveBeenCalledWith({ coin: 'sol' });
+        expect(prepareUnstakeSolTxMock).toHaveBeenCalledTimes(1);
+        expect(solanaSignTransactionMock).toHaveBeenCalledTimes(1);
     });
 
     it('rejects (without logging) when the user cancels on the device', async () => {
@@ -346,6 +389,29 @@ describe('signSolanaStakingTransactionNativeThunk', () => {
 
         expect(result.ok).toBe(false);
         expect((result as { error: { message: string } }).error.message).toBe('tx-cancelled');
+    });
+
+    it('rejects with sign-transaction-timeout when the validity timer cancels the sign', async () => {
+        solanaSignTransactionMock.mockResolvedValue({
+            success: false,
+            error: { code: 'Method_Cancel', message: 'tx-timeout' },
+        });
+        const store = buildStore();
+
+        const result = await dispatchSign(store, {
+            accountKey: SOL_ACCOUNT_KEY,
+            stakeType: 'stake',
+            precomposedTransaction: buildSolanaPrecomposedTransaction(),
+        });
+
+        expect(result).toEqual({
+            ok: false,
+            error: {
+                error: 'sign-transaction-timeout',
+                errorCode: 'Method_Cancel',
+                message: 'tx-timeout',
+            },
+        });
     });
 
     it('signs a solana unstake, forwarding the composed amount', async () => {

--- a/suite-native/staking/src/stakeFormSolanaNativeThunks.ts
+++ b/suite-native/staking/src/stakeFormSolanaNativeThunks.ts
@@ -1,7 +1,7 @@
 import { selectSelectedDevice } from '@suite-common/device';
 import { createThunk } from '@suite-common/redux-utils';
 import { composeSolanaStakingTransaction, prepareSolanaStakeTxData } from '@suite-common/staking';
-import { getNetwork } from '@suite-common/wallet-config';
+import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import {
     selectAccountByKey,
     selectAddressDisplayType,
@@ -66,13 +66,26 @@ const buildSolanaStakeFormState = (
     stakeType,
 });
 
-const resolveSolanaStakingContext = (
+const resolveSolanaBlockchainUrl = async (
+    state: Parameters<typeof selectNetworkBlockchainInfo>[0],
+    symbol: NetworkSymbol,
+): Promise<string | undefined> => {
+    const connectedUrl = selectNetworkBlockchainInfo(state, symbol)?.url;
+    if (connectedUrl) return connectedUrl;
+
+    const info = await TrezorConnect.blockchainGetInfo({ coin: symbol });
+
+    return info.success ? info.payload.url : undefined;
+};
+
+const resolveSolanaStakingContext = async (
     state: Parameters<typeof selectAccountByKey>[0] &
         Parameters<typeof selectNetworkBlockchainInfo>[0],
     accountKey: AccountKey,
-):
+): Promise<
     | { success: true; account: SolanaAccount; blockchainUrl: string }
-    | { success: false; error: string; message?: string } => {
+    | { success: false; error: string; message?: string }
+> => {
     const account = selectAccountByKey(state, accountKey);
 
     if (account?.networkType !== 'solana') {
@@ -91,7 +104,7 @@ const resolveSolanaStakingContext = (
         };
     }
 
-    const blockchainUrl = selectNetworkBlockchainInfo(state, account.symbol)?.url;
+    const blockchainUrl = await resolveSolanaBlockchainUrl(state, account.symbol);
     if (!blockchainUrl) {
         return {
             success: false,
@@ -112,7 +125,7 @@ export const composeSolanaStakingTransactionFeeLevelsNativeThunk = createThunk<
     async ({ accountKey, stakeType, amount }, { getState, rejectWithValue }) => {
         if (!amount || amount === '0') return undefined;
 
-        const resolved = resolveSolanaStakingContext(getState(), accountKey);
+        const resolved = await resolveSolanaStakingContext(getState(), accountKey);
         if (!resolved.success) {
             return rejectWithValue({ error: resolved.error, message: resolved.message });
         }
@@ -150,7 +163,7 @@ export const signSolanaStakingTransactionNativeThunk = createThunk<
         { dispatch, getState, rejectWithValue },
     ) => {
         try {
-            const resolved = resolveSolanaStakingContext(getState(), accountKey);
+            const resolved = await resolveSolanaStakingContext(getState(), accountKey);
             if (!resolved.success) {
                 console.error(`${SIGN_LOG_PREFIX}: ${resolved.message}`);
 
@@ -219,7 +232,10 @@ export const signSolanaStakingTransactionNativeThunk = createThunk<
             dispatch(
                 sendFormActions.storePrecomposedTransaction({
                     formState,
-                    precomposedTransaction,
+                    precomposedTransaction: {
+                        ...precomposedTransaction,
+                        createdTimestamp: new Date().getTime(),
+                    },
                     accountKey,
                 }),
             );
@@ -254,6 +270,14 @@ export const signSolanaStakingTransactionNativeThunk = createThunk<
             const signResponse = deviceAccessResponse.payload;
 
             if (!signResponse.success) {
+                if (signResponse.error.message === 'tx-timeout') {
+                    return rejectWithValue({
+                        error: 'sign-transaction-timeout',
+                        errorCode: signResponse.error.code,
+                        message: signResponse.error.message,
+                    });
+                }
+
                 if (signResponse.error.message !== 'tx-cancelled') {
                     console.error(
                         `${SIGN_LOG_PREFIX}: Sign transaction failed: ${signResponse.error.message}`,

--- a/suite-native/test-utils/src/mocks/everstakeJestSetup.js
+++ b/suite-native/test-utils/src/mocks/everstakeJestSetup.js
@@ -9,3 +9,12 @@ if (!window.clearImmediate) {
         clearTimeout(id);
     };
 }
+
+// jsdom 20 lacks `crypto.randomUUID` (added in jsdom 22), but RN runtime code relies on it.
+const { randomUUID } = require('crypto');
+
+if (!globalThis.crypto) {
+    globalThis.crypto = { randomUUID };
+} else if (!globalThis.crypto.randomUUID) {
+    globalThis.crypto.randomUUID = randomUUID;
+}

--- a/suite-native/transaction-management/src/hooks/__tests__/useTxValidityTimer.test.tsx
+++ b/suite-native/transaction-management/src/hooks/__tests__/useTxValidityTimer.test.tsx
@@ -270,6 +270,16 @@ describe('useTxValidityTimer', () => {
             expect(mockTrezorConnectCancel).toHaveBeenCalledWith('tx-timeout');
         });
 
+        it('should not schedule cancellation when the deadline has already passed', () => {
+            renderTimer({ createdTimestamp: now - SOLANA_TIMEOUT_MS - 1_000 });
+
+            act(() => {
+                jest.advanceTimersByTime(SOLANA_TIMEOUT_MS * 2);
+            });
+
+            expect(mockTrezorConnectCancel).not.toHaveBeenCalled();
+        });
+
         const noCancelScenarios: { name: string; overrides: Partial<Params> }[] = [
             { name: 'while broadcasting', overrides: { isBroadcasting: true } },
             {

--- a/suite-native/transaction-management/src/hooks/useTxValidityTimer.tsx
+++ b/suite-native/transaction-management/src/hooks/useTxValidityTimer.tsx
@@ -46,10 +46,11 @@ export const useTxValidityTimer = ({
     useEffect(() => {
         if (!isValidityTimerRelevant || isBroadcasting || isTransactionAlreadySigned) return;
 
-        const timeoutId = setTimeout(
-            () => TrezorConnect.cancel('tx-timeout'),
-            Math.max(deadline - Date.now(), 0),
-        );
+        const msUntilDeadline = deadline - Date.now();
+
+        if (msUntilDeadline <= 0) return;
+
+        const timeoutId = setTimeout(() => TrezorConnect.cancel('tx-timeout'), msUntilDeadline);
 
         return () => clearTimeout(timeoutId);
     }, [isValidityTimerRelevant, isBroadcasting, isTransactionAlreadySigned, deadline]);


### PR DESCRIPTION
## Description

Solana signed transactions are bound to a blockhash that expires roughly one minute after signing, so users who linger on the stake, unstake, or claim review screen before broadcasting would submit an already-expired transaction. This adds a countdown timer to all three native staking review screens that auto-cancels the pending device call at expiry, prompts the user to re-sign, and disables the broadcast button until a fresh signature is in hand. Supporting fixes include gating the timer to timestamps produced by the current review (not stale leftovers from earlier flows), skipping the auto-cancel when the deadline has already passed, and cleaning up the shared send slice after a successful push.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/28611

## Screenshots:
<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 16 Plus - 2026-06-12 at 20 05 47" src="https://github.com/user-attachments/assets/37a3c98c-149b-40da-8640-55f3e4d68894" />
<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 16 Plus - 2026-06-12 at 20 06 16" src="https://github.com/user-attachments/assets/ebf7a70e-7870-4b9e-9d15-00248b8f7d75" />
