### PR TITLE
fix(suite): prevent fiat value overflow in stake form UI

### DIFF
--- a/packages/components/src/components/form/BottomText.tsx
+++ b/packages/components/src/components/form/BottomText.tsx
@@ -60,6 +60,7 @@ export const BottomText = ({
                     typographyStyle="body-sm"
                     as="div"
                     flex="auto"
+                    overflowWrap="anywhere"
                 >
                     {children}
                 </Text>

--- a/packages/suite/src/components/earn/modals/StakeModal/StakeForm/StakeInputs.tsx
+++ b/packages/suite/src/components/earn/modals/StakeModal/StakeForm/StakeInputs.tsx
@@ -27,7 +27,7 @@ import { type FormPercentButtonValue } from 'src/views/wallet/trading/common/Tra
 
 export const StakeInputs = () => {
     const { translationString } = useTranslation();
-    const { CryptoAmountFormatter } = useFormatters();
+    const { CryptoAmountFormatter, BaseCurrencyAmountFormatter } = useFormatters();
     const locale = useSelector(selectLanguage);
     const { analytics } = useServices(selectDesktopAnalyticsDep);
 
@@ -70,6 +70,7 @@ export const StakeInputs = () => {
                 amountLimits,
                 localCurrency: baseCurrencyCode,
                 formatter: CryptoAmountFormatter,
+                fiatFormatter: BaseCurrencyAmountFormatter,
                 decimals: network.decimals,
                 rate: currentRate?.rate,
             }),

--- a/packages/suite/src/components/earn/modals/UnstakeModal/UnstakeForm/UnstakeInputs.tsx
+++ b/packages/suite/src/components/earn/modals/UnstakeModal/UnstakeForm/UnstakeInputs.tsx
@@ -22,7 +22,7 @@ import {
 
 export const UnstakeInputs = () => {
     const { translationString } = useTranslation();
-    const { CryptoAmountFormatter } = useFormatters();
+    const { CryptoAmountFormatter, BaseCurrencyAmountFormatter } = useFormatters();
 
     const locale = useSelector(selectLanguage);
 
@@ -67,6 +67,7 @@ export const UnstakeInputs = () => {
                 amountLimits,
                 localCurrency: baseCurrencyCode,
                 formatter: CryptoAmountFormatter,
+                fiatFormatter: BaseCurrencyAmountFormatter,
                 decimals: network.decimals,
                 rate: currentRate?.rate,
             }),

--- a/packages/suite/src/utils/suite/validation.ts
+++ b/packages/suite/src/utils/suite/validation.ts
@@ -1,7 +1,7 @@
 import { type TranslationFunction } from '@suite/intl';
-import { type Formatter } from '@suite-common/formatters';
+import { type Formatter, type Formatters } from '@suite-common/formatters';
 import { getDisplaySymbol, isNetworkSymbol } from '@suite-common/wallet-config';
-import { type Account } from '@suite-common/wallet-types';
+import { type Account, asBaseCurrencyAmount } from '@suite-common/wallet-types';
 import {
     fromBaseCurrencyToCryptoUnit,
     getAmountValidationResult,
@@ -135,12 +135,20 @@ interface ValidateFiatLimitsOptions {
     decimals: number;
     rate?: number;
     formatter: Formatter<string, string>;
+    fiatFormatter: Formatters['BaseCurrencyAmountFormatter'];
 }
 
 export const validateFiatLimits =
     (
         translationString: TranslationFunction,
-        { amountLimits, localCurrency, formatter, decimals, rate }: ValidateFiatLimitsOptions,
+        {
+            amountLimits,
+            localCurrency,
+            formatter,
+            fiatFormatter,
+            decimals,
+            rate,
+        }: ValidateFiatLimitsOptions,
     ) =>
     (value: string, formValues?: { setMaxOutputId?: number }) => {
         if (value && amountLimits) {
@@ -183,7 +191,10 @@ export const validateFiatLimits =
                     return translationString(
                         'TR_STAKING_VALIDATION_ERROR_NOT_ENOUGH_FOR_FEES_FIAT',
                         {
-                            missingAmount: missingAmount.toString(),
+                            missingAmount:
+                                fiatFormatter.format(asBaseCurrencyAmount(missingAmount), {
+                                    style: 'decimal',
+                                }) ?? missingAmount.toFixed(2),
                             currency: localCurrency.toUpperCase(),
                         },
                     );


### PR DESCRIPTION
Formats the missing-amount value shown in the staking fee validation error and lets input bottom text wrap so a very large entered value can no longer overflow its container in the stake and unstake forms. Applies to both the crypto and fiat input directions.

Resolves #28595

<img width="1018" height="872" alt="Screenshot 2026-06-18 at 16 43 53" src="https://github.com/user-attachments/assets/5c1adc8d-905e-4c2e-bd06-e9cc00015a9e" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes target staking form inputs (StakeInputs.tsx, UnstakeInputs.tsx), form validation utilities (validation.ts), and form error display (BottomText.tsx). The highest risk is in the staking flows where these components are directly used — ETH, SOL, and ADA stake/unstake tests should be prioritized. BottomText and validation.ts are broadly imported (121 tests each), but their functional impact is concentrated in forms with amount validation — primarily staking forms and trading sell/buy forms. The testing strategy focuses on staking E2E tests as the primary risk area, with medium-priority coverage for trading input validation tests that share the same validation and error display infrastructure.

<details><summary><b>Changed files (4)</b></summary>

- `packages/components/src/components/form/BottomText.tsx`
- `packages/suite/src/components/earn/modals/StakeModal/StakeForm/StakeInputs.tsx`
- `packages/suite/src/components/earn/modals/UnstakeModal/UnstakeForm/UnstakeInputs.tsx`
- `packages/suite/src/utils/suite/validation.ts`

</details>

**Recommended tests (13)**

<details><summary>🔴 <b>High priority (7)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Directly exercises the StakeInputs component (StakeModal/StakeForm/StakeInputs.tsx) and staking form validation. This test fills in staking amounts, validates input, and confirms transactions — exactly the code paths changed in StakeInputs.tsx and validation.ts.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Tests staking additional ETH through the stake form, directly using StakeInputs.tsx for amount entry and validation. Changes to the staking input component or validation logic could break the stake-more flow.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — Directly exercises the UnstakeInputs component (UnstakeModal/UnstakeForm/UnstakeInputs.tsx) — user fills in unstaking amounts with pre-filled balance, validates input, and confirms. Also covers the claim flow after unstaking.
- `suite/e2e/tests/staking/staking-form.test.ts` — Explicitly tests staking form validation: minimum amount errors, decimal digit limits, insufficient funds, empty input, percentage buttons, max button, and crypto/fiat switching. This is the most direct test of StakeInputs.tsx, validation.ts, and BottomText.tsx error display.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Tests SOL initial staking flow including form input, amount validation, and device confirmation. StakeInputs.tsx is used for the Solana staking form entry, and validation.ts handles input validation.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — Tests the SOL stake-more flow filling the staking form with additional amount. Directly uses StakeInputs and validation logic for amount entry and validation display.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — Tests SOL unstaking flow with pre-filled unstake amount and form validation. Directly exercises UnstakeInputs.tsx and validation.ts through the unstaking form interaction.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/staking/ada/stake.test.ts` — Tests Cardano staking flow which may use StakeInputs for the staking form. ADA staking involves deposit/fee display that could be affected by BottomText changes, though ADA staking has a different flow than ETH/SOL.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — Tests Cardano unstaking flow which may use UnstakeInputs component. The unstake modal and fee display could be affected by changes to UnstakeInputs.tsx and BottomText.tsx.
- `suite/e2e/tests/staking/ada/claim.test.ts` — Tests Cardano reward claiming which involves modals with fee/amount display. While not directly a stake/unstake input flow, it uses related earn modal components that may share BottomText for validation messages.
- `suite/e2e/tests/staking/sol/rewards.test.ts` — Tests SOL staking rewards display and tab interactions. While it doesn't directly fill staking forms, it verifies the staking dashboard which renders alongside the modified staking components.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Tests form input validation for sell amounts (decimal limits, insufficient funds, percentage buttons, max button). Uses validation.ts for amount validation and BottomText for error display — changes to these could affect sell form error messages.
- `suite/e2e/tests/trading/buy-negative.test.ts` — Tests buy form validation error messages (max/min limits, no offers). Validation.ts changes could affect how buy form validation errors are processed and BottomText changes could affect how they are displayed.

</details>

_Updated: 2026-06-13T06:22:01.615Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/stake-form-fiat-overflow/web/](https://dev.suite.sldev.cz/suite-web/fix/stake-form-fiat-overflow/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/stake-form-fiat-overflow&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/stake-form-fiat-overflow&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-13T06:26:12.931Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-13T06:24:55.461Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->