### PR TITLE
fix(wallet-core): fetch token fiat rates for all remembered wallets

### DIFF
--- a/suite-common/wallet-core/src/fiat-rates/__tests__/fiatRatesSelectors.test.ts
+++ b/suite-common/wallet-core/src/fiat-rates/__tests__/fiatRatesSelectors.test.ts
@@ -1,0 +1,66 @@
+import { type DeviceRootState } from '@suite-common/device';
+import { type TrezorDevice } from '@suite-common/suite-types';
+import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
+import { type TokenDefinitionsRootState } from '@suite-common/token-definitions';
+import { type Account, type TokenAddress } from '@suite-common/wallet-types';
+
+import { type AccountsRootState } from '../../accounts/accountsReducer';
+import { selectTickerFromAccounts } from '../fiatRatesSelectors';
+import { type FiatRatesRootState } from '../fiatRatesTypes';
+
+const STANDARD_WALLET_SSID = 'standardWallet@device_id:0' as const;
+const STANDARD_WALLET = mockSuiteDevice({ state: { staticSessionId: STANDARD_WALLET_SSID } });
+
+const PASSPHRASE_WALLET_SSID = 'passphraseWallet@device_id:0' as const;
+const PASSPHRASE_WALLET = mockSuiteDevice({ state: { staticSessionId: PASSPHRASE_WALLET_SSID } });
+
+const USDT = '0xdac17f958d2ee523a2206206994597c13d831ec7' as TokenAddress;
+const USDC = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as TokenAddress;
+
+const ethAccount = (deviceState: string, tokenContract: TokenAddress): Account =>
+    ({
+        symbol: 'eth',
+        deviceState,
+        tokens: [{ contract: tokenContract, balance: '1000000', protocols: [] }],
+    }) as unknown as Account;
+
+type State = FiatRatesRootState & TokenDefinitionsRootState & AccountsRootState & DeviceRootState;
+
+const getState = (selectedDevice: TrezorDevice): State =>
+    ({
+        wallet: {
+            fiat: { current: {}, lastWeek: {}, historic: {} },
+            accounts: [
+                ethAccount(STANDARD_WALLET_SSID, USDT),
+                ethAccount(PASSPHRASE_WALLET_SSID, USDC),
+            ],
+        },
+        tokenDefinitions: {
+            eth: { coin: { data: [USDT, USDC], error: false, isLoading: false } },
+        },
+        device: {
+            devices: [STANDARD_WALLET, PASSPHRASE_WALLET],
+            selectedDevice,
+        },
+    }) as unknown as State;
+
+describe('selectTickerFromAccounts', () => {
+    it('returns token tickers from all remembered wallets, not only the selected one', () => {
+        const result = selectTickerFromAccounts(getState(STANDARD_WALLET));
+
+        const tokenAddresses = result.map(ticker => ticker.tokenAddress).filter(Boolean);
+
+        expect(tokenAddresses).toContain(USDT);
+        expect(tokenAddresses).toContain(USDC);
+    });
+
+    it('returns the same token tickers regardless of which wallet is currently selected', () => {
+        const fromStandard = selectTickerFromAccounts(getState(STANDARD_WALLET));
+        const fromPassphrase = selectTickerFromAccounts(getState(PASSPHRASE_WALLET));
+
+        const sortByKey = (tickers: typeof fromStandard) =>
+            [...tickers].map(ticker => `${ticker.symbol}-${ticker.tokenAddress ?? ''}`).sort();
+
+        expect(sortByKey(fromStandard)).toEqual(sortByKey(fromPassphrase));
+    });
+});

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesSelectors.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesSelectors.ts
@@ -23,7 +23,7 @@ import { BigNumber } from '@trezor/utils';
 
 import { MAX_AGE } from './fiatRatesConstants';
 import { type FiatRatesRootState } from './fiatRatesTypes';
-import { selectDeviceAccounts } from '../accounts/accountsSelectors';
+import { selectAccounts } from '../accounts/accountsSelectors';
 
 export const selectCurrentFiatRates = (state: FiatRatesRootState): RatesByKey | undefined =>
     state.wallet.fiat?.['current'];
@@ -88,7 +88,10 @@ export const selectShouldUpdateFiatRate = (
 export const selectTickerFromAccounts = (
     state: FiatRatesRootState & TokenDefinitionsRootState,
 ): TickerId[] => {
-    const accounts = selectDeviceAccounts(state as any);
+    // Use accounts of all remembered devices/wallets, not just the selected one, so that
+    // token fiat rates are fetched for every wallet. Otherwise tokens that exist only on a
+    // non-selected wallet (e.g. a passphrase wallet) never get a rate fetched on launch.
+    const accounts = selectAccounts(state as any);
 
     return pipe(
         accounts,


### PR DESCRIPTION
This changes selectTickerFromAccounts to enumerate tickers from all remembered accounts via selectAccounts, so every wallet's tokens get rates; existing per-ticker freshness checks, deduplication, and chunked throttling still prevent over-fetching. 

It should not be a big overhead, it should just fix ugly edgecases when people can get hearthattacks. Fiat rates fetch do no longer block loading the app so it should be fine. Lucy if you read this, do not report the 7d change please 😀 

Resolve #27856
Resolve #23429

Before:
<img width="1268" height="469" alt="Screenshot 2026-06-18 at 16 52 56" src="https://github.com/user-attachments/assets/6ccbea9b-72aa-4500-9884-beaf4bf39a62" />

Now:
<img width="1291" height="586" alt="Screenshot 2026-06-18 at 16 54 16" src="https://github.com/user-attachments/assets/9148ef06-00d5-491e-bef9-34a12d177c00" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are limited to fiat rate selectors and their unit tests. The selector file (fiatRatesSelectors.ts) is a broadly imported utility (121 tests), so most E2E tests transitively depend on it but few directly exercise fiat rate display logic. The unit test file has no E2E coverage, which is expected. The risk is low-to-moderate: a regression would manifest as incorrect or missing fiat values in the UI. The recommended strategy focuses on the handful of tests that explicitly assert on fiat currency display values.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/wallet-core/src/fiat-rates/__tests__/fiatRatesSelectors.test.ts`
- `suite-common/wallet-core/src/fiat-rates/fiatRatesSelectors.ts`

</details>

**Recommended tests (5)**

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — This test explicitly verifies fiat balance display ($0.00, $###) across dashboard components. Changes to fiatRatesSelectors could affect how fiat amounts are resolved and displayed, causing assertion failures on fiat amount values.
- `suite/e2e/tests/dashboard/assets.test.ts` — This test verifies asset contents display in grid and table views, which includes fiat amounts derived from fiat rate selectors. Changes to fiatRatesSelectors could affect how asset fiat values are computed and rendered.
- `suite/e2e/tests/settings/general.test.ts` — This test verifies fiat currency display changes (USD→EUR with $0.00→€0.00) on the dashboard. Fiat rate selectors are directly involved in resolving and formatting fiat currency values shown on the dashboard.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/wallet/coin-balance.test.ts` — This test checks account balance display including fiat amounts. While it primarily checks crypto balances, the fiat rate selectors feed into the balance display pipeline and could affect how balances are resolved.
- `suite/e2e/tests/settings/electrum.test.ts` — This test explicitly asserts that the fiat amount (assetFiatAmount) is visible for a regtest asset after discovery. A regression in fiatRatesSelectors could cause fiat amount elements to not render or display incorrectly.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/wallet-core/src/fiat-rates/__tests__/fiatRatesSelectors.test.ts`

_Updated: 2026-06-13T06:28:05.494Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/token-fiat-rates-multi-wallet&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/token-fiat-rates-multi-wallet&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/token-fiat-rates-multi-wallet&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/token-fiat-rates-multi-wallet/web/](https://dev.suite.sldev.cz/suite-web/fix/token-fiat-rates-multi-wallet/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-13T06:32:34.618Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-13T06:31:27.695Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->