### PR TITLE
fix(suite-native): hide token detail chart and price card when price data is unavailable

### DIFF
--- a/suite-native/module-accounts-management/src/components/AccountDetailGraph.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountDetailGraph.tsx
@@ -53,6 +53,9 @@ export const AccountDetailGraph = ({ accountKey, tokenContract }: AccountDetailG
             totalFiatBalance,
         });
 
+    const isTokenPriceUnavailable = !isLoading && (!!error || graphPoints.length <= 1);
+    const isGraphHidden = !!tokenContract && isTokenPriceUnavailable;
+
     return (
         <VStack spacing="sp24">
             <AccountDetailHeader
@@ -61,7 +64,7 @@ export const AccountDetailGraph = ({ accountKey, tokenContract }: AccountDetailG
                 totalFiatBalance={totalFiatBalance}
             />
 
-            {isHistoryEnabledAccount && (
+            {isHistoryEnabledAccount && !isGraphHidden && (
                 <>
                     <Graph<FiatGraphPointWithCryptoBalance>
                         onPointSelected={setSelectedPoint}

--- a/suite-native/module-accounts-management/src/components/CoinPriceCard.tsx
+++ b/suite-native/module-accounts-management/src/components/CoinPriceCard.tsx
@@ -66,9 +66,13 @@ export const CoinPriceCard = ({ accountKey, tokenContract }: CoinPriceCardProps)
     const token = useSelector((state: TokensRootState) =>
         selectAccountTokenInfo(state, accountKey, tokenContract),
     );
-    const { currentValue, valuePercentageChange } = useDayCoinPriceChange(symbol, tokenContract);
+    const { currentValue, valuePercentageChange, isLoading } = useDayCoinPriceChange(
+        symbol,
+        tokenContract,
+    );
 
     if (!symbol) return null;
+    if (!isLoading && currentValue === null) return null;
 
     const tokenName = token?.name ?? token?.symbol;
     const mainnetName = getNetworkDisplaySymbolName(symbol);

--- a/suite-native/module-accounts-management/src/hooks/__tests__/useDayCoinPriceChange.test.ts
+++ b/suite-native/module-accounts-management/src/hooks/__tests__/useDayCoinPriceChange.test.ts
@@ -1,0 +1,71 @@
+import { getFiatRatesForTimestamps } from '@suite-common/fiat-services';
+import { type TokenAddress } from '@suite-common/wallet-types';
+import { renderHookWithStoreProvider, waitFor } from '@suite-native/test-utils-store';
+
+import { useDayCoinPriceChange } from '../useDayCoinPriceChange';
+
+jest.mock('@suite-common/fiat-services', () => ({
+    getFiatRatesForTimestamps: jest.fn(),
+}));
+
+jest.mock('@suite-common/wallet-core', () => ({
+    ...jest.requireActual('@suite-common/wallet-core'),
+    selectBaseCurrency: () => 'usd',
+    selectIsElectrumBackendSelected: () => false,
+}));
+
+const mockGetFiatRatesForTimestamps = getFiatRatesForTimestamps as jest.Mock;
+
+const tokenContract = '0x0000000000000000000000000000000000000001' as TokenAddress;
+
+describe('useDayCoinPriceChange', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('starts in loading state', () => {
+        mockGetFiatRatesForTimestamps.mockReturnValue(new Promise(() => {}));
+
+        const { result } = renderHookWithStoreProvider(() =>
+            useDayCoinPriceChange('eth', tokenContract),
+        );
+
+        expect(result.current.isLoading).toBe(true);
+        expect(result.current.currentValue).toBeNull();
+    });
+
+    it('exposes the current price once the fetch resolves with rates', async () => {
+        mockGetFiatRatesForTimestamps.mockResolvedValue({
+            tickers: [{ rates: { usd: 100 } }, { rates: { usd: 110 } }],
+        });
+
+        const { result } = renderHookWithStoreProvider(() =>
+            useDayCoinPriceChange('eth', tokenContract),
+        );
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+        expect(result.current.currentValue?.toNumber()).toBe(110);
+    });
+
+    it('reports no price when the fetch returns no rates (token not on CoinGecko)', async () => {
+        mockGetFiatRatesForTimestamps.mockResolvedValue(undefined);
+
+        const { result } = renderHookWithStoreProvider(() =>
+            useDayCoinPriceChange('eth', tokenContract),
+        );
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+        expect(result.current.currentValue).toBeNull();
+    });
+
+    it('reports no price when the fetch fails', async () => {
+        mockGetFiatRatesForTimestamps.mockRejectedValue(new Error('fetch failed'));
+
+        const { result } = renderHookWithStoreProvider(() =>
+            useDayCoinPriceChange('eth', tokenContract),
+        );
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+        expect(result.current.currentValue).toBeNull();
+    });
+});

--- a/suite-native/module-accounts-management/src/hooks/useDayCoinPriceChange.ts
+++ b/suite-native/module-accounts-management/src/hooks/useDayCoinPriceChange.ts
@@ -28,6 +28,7 @@ export const useDayCoinPriceChange = (
     const [currentValue, setCurrentValue] = useState<BaseCurrencyAmount | null>(null);
     const [weekAgoValue, setWeekAgoValue] = useState<number | null>(null);
     const [valuePercentageChange, setValuePercentageChange] = useState<number | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
 
     const fiatCurrencyCode = useSelector(selectBaseCurrency);
     const isElectrumBackend = useSelector((state: BlockchainRootState) =>
@@ -38,32 +39,41 @@ export const useDayCoinPriceChange = (
     const isCoingeckoForce = tokenContract && symbol !== 'eth';
 
     useEffect(() => {
+        setIsLoading(true);
+
         const getPrices = async () => {
             if (!symbol) return;
             const currentTimestamp = getUnixTime(Date.now());
             const weekAgoTimestamp = currentTimestamp - 7 * UNIX_DAY;
 
-            const timestampedFiatRates = await getFiatRatesForTimestamps(
-                { symbol, tokenAddress: tokenContract },
-                [weekAgoTimestamp, currentTimestamp],
-                fiatCurrencyCode,
-                isElectrumBackend,
-                isCoingeckoForce,
-            );
+            try {
+                const timestampedFiatRates = await getFiatRatesForTimestamps(
+                    { symbol, tokenAddress: tokenContract },
+                    [weekAgoTimestamp, currentTimestamp],
+                    fiatCurrencyCode,
+                    isElectrumBackend,
+                    isCoingeckoForce,
+                );
 
-            if (!timestampedFiatRates) return;
+                const { tickers } = timestampedFiatRates ?? { tickers: [] };
+                // @ts-expect-error: noUncheckedIndexedAccess
+                const weekAgo: TimestampedFiatRate = tickers[0];
+                // @ts-expect-error: noUncheckedIndexedAccess
+                const today: TimestampedFiatRate = tickers[1];
 
-            const { tickers } = timestampedFiatRates;
-            // @ts-expect-error: noUncheckedIndexedAccess
-            const weekAgo: TimestampedFiatRate = tickers[0];
-            // @ts-expect-error: noUncheckedIndexedAccess
-            const today: TimestampedFiatRate = tickers[1];
-
-            setWeekAgoValue(weekAgo?.rates[fiatCurrencyCode] ?? null);
-            const currentRate = today?.rates[fiatCurrencyCode];
-            setCurrentValue(
-                currentRate !== undefined ? asBaseCurrencyAmount(new BigNumber(currentRate)) : null,
-            );
+                setWeekAgoValue(weekAgo?.rates[fiatCurrencyCode] ?? null);
+                const currentRate = today?.rates[fiatCurrencyCode];
+                setCurrentValue(
+                    currentRate !== undefined
+                        ? asBaseCurrencyAmount(new BigNumber(currentRate))
+                        : null,
+                );
+            } catch {
+                setWeekAgoValue(null);
+                setCurrentValue(null);
+            } finally {
+                setIsLoading(false);
+            }
         };
 
         getPrices();
@@ -75,8 +85,10 @@ export const useDayCoinPriceChange = (
     useEffect(() => {
         if (isNotNullOrUndefined(currentValue) && isNotNullOrUndefined(weekAgoValue)) {
             setValuePercentageChange(percentageDiff(weekAgoValue, currentValue.toNumber()));
+        } else {
+            setValuePercentageChange(null);
         }
     }, [currentValue, weekAgoValue]);
 
-    return { currentValue, valuePercentageChange };
+    return { currentValue, valuePercentageChange, isLoading };
 };


### PR DESCRIPTION
On a token detail screen, tokens without a CoinGecko price (such as ERC-4626 vault tokens not listed there) made the price chart and coin price card fail to load and render a permanently broken state. The chart and price card are now hidden when the price/history fetch errors or returns no data, while still showing the loading skeleton during a pending fetch and the full UI for tokens that do have a price.

Resolves #27939

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/hide-token-chart-no-price&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->