### PR TITLE
fix(suite): fix search, duplicate option in global send/receive

### DIFF
--- a/packages/product-components/src/components/SelectAssetModal/hooks/useNetworkSelect.ts
+++ b/packages/product-components/src/components/SelectAssetModal/hooks/useNetworkSelect.ts
@@ -14,7 +14,7 @@ export interface SearchAssetSelectConfig {
 export const useNetworkSelect = (config?: SearchAssetSelectConfig) => {
     const { networks = [], includeAllOption, allLabel, selectedNetwork } = config ?? {};
 
-    const options = useMemo(() => {
+    const allOptions = useMemo(() => {
         const networkOptions = networks
             .map(symbol => {
                 const network = getNetwork(symbol);
@@ -29,8 +29,15 @@ export const useNetworkSelect = (config?: SearchAssetSelectConfig) => {
     }, [networks, includeAllOption, allLabel]);
 
     const selectedOption = useMemo(
-        () => options.find(option => option.value === selectedNetwork),
-        [options, selectedNetwork],
+        () => allOptions.find(option => option.value === selectedNetwork),
+        [allOptions, selectedNetwork],
+    );
+
+    // The currently selected option is already shown in the select value, so it is
+    // filtered out of the menu to avoid showing it twice.
+    const options = useMemo(
+        () => allOptions.filter(option => option.value !== selectedNetwork),
+        [allOptions, selectedNetwork],
     );
 
     return { options, selectedOption };

--- a/packages/suite/src/components/suite/asset-picker/constants/index.ts
+++ b/packages/suite/src/components/suite/asset-picker/constants/index.ts
@@ -7,4 +7,6 @@ export const ASSET_ROW_HEIGHTS_BY_SIZE = {
     lg: 32,
 } as const satisfies Record<AssetGroupSpaceSize, number>;
 
+// Includes 2px below the header so the flat card's bottom border (drawn with an
+// outline outside the box) is not overlapped by the following virtualized row.
 export const EXPANDABLE_ASSET_ROW_TOKENS_HEADER_HEIGHT = 46;

--- a/packages/suite/src/components/suite/asset-picker/hooks/useFilterAccountsWithTokens.ts
+++ b/packages/suite/src/components/suite/asset-picker/hooks/useFilterAccountsWithTokens.ts
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import { getDefaultAccountLabel } from '@suite/account';
 import { useTranslation } from '@suite/intl';
 import { selectAccountLabelsLegacy } from '@suite/metadata';
+import { type AccountKey } from '@suite-common/wallet-types';
 import { accountSearchFn, isTokenMatchesSearch } from '@suite-common/wallet-utils';
 
 import { useSelector } from 'src/hooks/suite';
@@ -17,58 +18,96 @@ export function useFilterAccountsWithTokens(
     const { translationString } = useTranslation();
     const accountLegacyLabels = useSelector(selectAccountLabelsLegacy);
 
-    return useMemo(
-        () =>
-            accountsWithTokens
-                .filter(item => {
-                    if (!search) {
-                        return true;
+    return useMemo(() => {
+        if (!search) {
+            return accountsWithTokens;
+        }
+
+        // An account row matches the search by its symbol, network name, account
+        // number or label. A token row matches by its own name/symbol/contract.
+        // To keep the grouped list consistent: an account that matches keeps all of
+        // its tokens, while a token that matches keeps its parent account row (so
+        // tokens are never orphaned and accounts never hide their matching tokens).
+        const matchedAccountKeys = new Set<AccountKey>();
+        const accountKeysWithMatchedToken = new Set<AccountKey>();
+
+        for (const item of accountsWithTokens) {
+            switch (item.type) {
+                case 'account': {
+                    const { key } = item.account;
+
+                    const accountLabel =
+                        item.account.label ??
+                        accountLegacyLabels[key] ??
+                        getDefaultAccountLabel(translationString, item.account) ??
+                        '';
+
+                    if (
+                        accountSearchFn(item.account, search, {
+                            tokensMatch: false,
+                            accountLabel,
+                        })
+                    ) {
+                        matchedAccountKeys.add(key);
                     }
+                    break;
+                }
 
-                    switch (item.type) {
-                        case 'account': {
-                            const { key } = item.account;
-
-                            const accountLabel =
-                                item.account.label ??
-                                (Object.prototype.hasOwnProperty.call(accountLegacyLabels, key)
-                                    ? accountLegacyLabels[key]
-                                    : getDefaultAccountLabel(translationString, item.account)) ??
-                                '';
-
-                            return accountSearchFn(item.account, search, {
-                                tokensMatch: false,
-                                accountLabel,
-                            });
-                        }
-
-                        case 'token':
-                            return isTokenMatchesSearch(item.token, search);
-
-                        case 'hidden-tokens':
-                        case 'non-tradable-tokens':
-                            return item.tokens.some(token => isTokenMatchesSearch(token, search));
+                case 'token':
+                    if (isTokenMatchesSearch(item.token, search)) {
+                        accountKeysWithMatchedToken.add(item.account.key);
                     }
-                })
-                .map(item => {
-                    if (item.type === 'hidden-tokens' || item.type === 'non-tradable-tokens') {
-                        const matchedTokens = item.tokens.filter(token =>
-                            isTokenMatchesSearch(token, search),
+                    break;
+
+                case 'hidden-tokens':
+                case 'non-tradable-tokens':
+                    if (item.tokens.some(token => isTokenMatchesSearch(token, search))) {
+                        accountKeysWithMatchedToken.add(item.account.key);
+                    }
+                    break;
+            }
+        }
+
+        return accountsWithTokens
+            .filter(item => {
+                const accountMatched = matchedAccountKeys.has(item.account.key);
+
+                switch (item.type) {
+                    case 'account':
+                        return accountMatched || accountKeysWithMatchedToken.has(item.account.key);
+
+                    case 'token':
+                        return accountMatched || isTokenMatchesSearch(item.token, search);
+
+                    case 'hidden-tokens':
+                    case 'non-tradable-tokens':
+                        return (
+                            accountMatched ||
+                            item.tokens.some(token => isTokenMatchesSearch(token, search))
                         );
+                }
+            })
+            .map(item => {
+                if (
+                    (item.type === 'hidden-tokens' || item.type === 'non-tradable-tokens') &&
+                    !matchedAccountKeys.has(item.account.key)
+                ) {
+                    const matchedTokens = item.tokens.filter(token =>
+                        isTokenMatchesSearch(token, search),
+                    );
 
-                        return {
-                            ...item,
-                            tokens: matchedTokens,
-                            // Update height based on matched tokens count
-                            height: calculateExpandableTokensHeight(
-                                item.expanded,
-                                matchedTokens.length,
-                            ),
-                        };
-                    }
+                    return {
+                        ...item,
+                        tokens: matchedTokens,
+                        // Update height based on matched tokens count
+                        height: calculateExpandableTokensHeight(
+                            item.expanded,
+                            matchedTokens.length,
+                        ),
+                    };
+                }
 
-                    return item;
-                }),
-        [accountLegacyLabels, accountsWithTokens, search, translationString],
-    );
+                return item;
+            });
+    }, [accountLegacyLabels, accountsWithTokens, search, translationString]);
 }


### PR DESCRIPTION
Makes the global send/receive asset search consistent so that an account that matches the query keeps all of its tokens and a matching token keeps its parent account row, instead of dropping account headers or hiding tokens of a matched account (added unit tests for useFilterAccountsWithTokens). Removes the currently selected option from the network filter dropdown so it is no longer listed twice (once as the select value and once in the menu).

The bullet 4) is not resolved as it is there because of `mapFillTypeToCSS`. I will crease issue for growth team.

Resolves #23331

<img width="295" height="420" alt="Screenshot 2026-06-19 at 11 17 18" src="https://github.com/user-attachments/assets/d72c6024-a0a1-4d58-b01e-cbaa8d6413cd" />
<img width="539" height="706" alt="Screenshot 2026-06-19 at 11 16 17" src="https://github.com/user-attachments/assets/df985c77-006f-4553-8827-5cc019b4dfd3" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect three files in the asset picker component: a network selection hook (useNetworkSelect), asset picker constants, and a token filtering hook (useFilterAccountsWithTokens). These are used primarily in trading/swap flows and the global receive/send asset picker. The two broadly-mapped files (121 tests each) are shared dependencies but only meaningfully affect tests that directly interact with the asset picker UI for selecting assets, tokens, or networks. The 10 tests mapped to useFilterAccountsWithTokens are the most directly impacted. Testing strategy should focus on swap flows (which heavily exercise asset/token selection), the global receive/send flow, and buy flows that use the asset picker with network filtering.

<details><summary><b>Changed files (3)</b></summary>

- `packages/product-components/src/components/SelectAssetModal/hooks/useNetworkSelect.ts`
- `packages/suite/src/components/suite/asset-picker/constants/index.ts`
- `packages/suite/src/components/suite/asset-picker/hooks/useFilterAccountsWithTokens.ts`

</details>

**Recommended tests (14)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test directly exercises the asset picker component (tradingPage.assetPicker with filtering, search, network selection) for both global receive and send flows. Changes to useFilterAccountsWithTokens and asset-picker constants/hooks directly affect how accounts are filtered and displayed in the asset picker modal used in this test.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — This swap test fills a swap form selecting sell/buy assets and a receive account via the asset picker, directly exercising useFilterAccountsWithTokens for token filtering and useNetworkSelect for network selection within the swap flow.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — This test swaps a Solana USDT token to Bitcoin, requiring asset picker token filtering (useFilterAccountsWithTokens) to select the SPL token as the sell asset and network selection to pick the buy asset.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Swapping between two SPL tokens (USDT to USDC) on Solana directly exercises token filtering in the asset picker via useFilterAccountsWithTokens to select both sell and buy token assets.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — This test specifically verifies selecting a buy asset from a disabled network (XLM/Stellar) in the swap form, directly testing useNetworkSelect behavior and asset picker filtering logic when networks are not enabled.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/trading/buy-ethereum.test.ts` — This test searches and selects Ethereum via the asset picker with network filtering (selectBuyAsset), exercising useNetworkSelect for filtering assets by network in the buy flow.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — This test selects a Solana SPL token (Jupiter/JUP) via the asset picker by filtering by network and searching by name, directly exercising useNetworkSelect and the asset picker's filtering capabilities.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Swapping SOL to BTC requires filling the swap form with asset selection via the asset picker. While coin-to-coin is less token-specific than token swaps, it still exercises useNetworkSelect and asset picker infrastructure.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — This test fills a swap form selecting BTC and ETH assets via the asset picker before testing fee behavior. Asset selection relies on useFilterAccountsWithTokens and useNetworkSelect.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — This test fills a swap form selecting ETH and BTC assets via the asset picker before testing Ethereum custom fees. Asset selection relies on useFilterAccountsWithTokens and useNetworkSelect.
- `suite/e2e/tests/trading/navigation.test.ts` — This test verifies navigating to buy/sell/swap forms from various entry points and checks that the correct crypto is preselected. The asset picker and network selection logic from the changed files are used when verifying form state.
- `suite/e2e/tests/dashboard/assets.test.ts` — This test enables new assets via the 'Activate Assets' modal which uses the asset picker infrastructure, and the enableNetworkViaActivateAssetsModal method likely exercises useNetworkSelect for network filtering.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trading-live/live-swap-coin-to-token.test.ts` — Live swap test exercises asset picker for cross-chain token swap (SOL to USDC on Base). While it uses the changed hooks, it requires live trading infrastructure making it expensive to run for a low-risk change.
- `suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts` — Live swap test for SPL token to coin exercises asset picker token filtering. However, it requires live trading infrastructure and is expensive; the mocked swap tests above provide sufficient coverage.

</details>

_Updated: 2026-06-19T09:48:02.708Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/global-send-receive-visual-issues/web/](https://dev.suite.sldev.cz/suite-web/fix/global-send-receive-visual-issues/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/global-send-receive-visual-issues&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/global-send-receive-visual-issues&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy BTC > Buy Bitcoin from best offer | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-19T09:52:24.522Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-19T09:51:15.470Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->