### PR TITLE
fix(sentry): apply ignoreErrors filter also on extras

### DIFF
--- a/suite-common/sentry/src/ignoreErrors.ts
+++ b/suite-common/sentry/src/ignoreErrors.ts
@@ -7,7 +7,7 @@ import type { Options } from '@sentry/core';
  * This is a good place to add commonly occurring lifecycle errors that may happen during normal use (not preventable).
  * Do not add here errors that are now definitively fixed (those belong in Sentry ingest inbound filters).
  */
-export const ignoreErrorsCommon = [
+export const ignoreErrorsCommon: RegExp[] = [
     /.*Sequence of config.*is older than the current one.*/,
 
     // Various kinds of network connectivity problems

--- a/suite-common/sentry/src/index.ts
+++ b/suite-common/sentry/src/index.ts
@@ -1,3 +1,4 @@
 export * from './constants';
 export { ignoreErrorsCommon } from './ignoreErrors';
 export { redactSentryEvent } from './redactSentryEvent';
+export type { ChainableBeforeSend } from './types';

--- a/suite-common/sentry/src/redactSentryEvent.ts
+++ b/suite-common/sentry/src/redactSentryEvent.ts
@@ -1,6 +1,5 @@
-import type { ErrorEvent } from '@sentry/core';
-
 import { ALLOW_REPORT_TAG, MAX_EVENTS_INTERVAL_LENGTH, MAX_EVENTS_PER_INTERVAL } from './constants';
+import { type ChainableBeforeSend } from './types';
 
 let eventCountThisSession = 0;
 let countingStartTimestamp = Date.now();
@@ -18,7 +17,9 @@ const incrementOrResetCounter = () => {
  * Note that in case of Desktop & Mobile, the SDKs share tags and userId between processes
  * (it consistently handles events e.g. from Electron Main vs. Renderer)
  */
-export const redactSentryEvent = (event: ErrorEvent): ErrorEvent | null => {
+export const redactSentryEvent: ChainableBeforeSend = event => {
+    if (event === null) return null;
+
     incrementOrResetCounter();
     // hard limit the number of events sent this session (app instance), to prevent a flurry of events sent in a loop
     if (eventCountThisSession > MAX_EVENTS_PER_INTERVAL) {

--- a/suite-common/sentry/src/types.ts
+++ b/suite-common/sentry/src/types.ts
@@ -1,0 +1,7 @@
+import type { ErrorEvent } from '@sentry/core';
+
+/**
+ * Allows to to compose a Sentry beforeSend from smaller atomic functions, because
+ * Sentry's beforeSend type can return null, but doesn't accept it.
+ */
+export type ChainableBeforeSend = (event: ErrorEvent | null) => ErrorEvent | null;

--- a/suite-native/sentry/src/ignoreErrors.ts
+++ b/suite-native/sentry/src/ignoreErrors.ts
@@ -2,7 +2,7 @@ import type { Options } from '@sentry/core';
 
 import { ignoreErrorsCommon } from '@suite-common/sentry';
 
-export const ignoreErrors = [
+export const ignoreErrors: RegExp[] = [
     ...ignoreErrorsCommon,
     /.*Websocket closed.*/,
     /.*Network request failed.*/,

--- a/suite/sentry/src/config.ts
+++ b/suite/sentry/src/config.ts
@@ -5,9 +5,14 @@ import {
     captureConsoleIntegration,
     elementTimingIntegration,
 } from '@sentry/browser';
-import type { ErrorEvent, Options } from '@sentry/core';
+import type { Options } from '@sentry/core';
 
-import { COINJOIN_NETWORK_TAG, COINJOIN_REPORT_TAG, redactSentryEvent } from '@suite-common/sentry';
+import {
+    COINJOIN_NETWORK_TAG,
+    COINJOIN_REPORT_TAG,
+    type ChainableBeforeSend,
+    redactSentryEvent,
+} from '@suite-common/sentry';
 import { isDevEnv } from '@suite-common/suite-utils';
 import { isCodesignBuild } from '@trezor/env-utils';
 import { redactUserPathFromString } from '@trezor/utils';
@@ -25,7 +30,8 @@ import { ignoreErrors } from './ignoreErrors';
  *
  * This is relevant only on Desktop.
  */
-const redactUserPath = (event: ErrorEvent): ErrorEvent => {
+const redactUserPath: ChainableBeforeSend = event => {
+    if (event === null) return null;
     try {
         const eventAsString = JSON.stringify(event);
         const redactedString = redactUserPathFromString(eventAsString);
@@ -43,7 +49,8 @@ const redactUserPath = (event: ErrorEvent): ErrorEvent => {
 };
 
 // Leaves only what is really necessary on a coinjoin error event
-const redactCoinjoinData = (event: ErrorEvent): ErrorEvent => {
+const redactCoinjoinData: ChainableBeforeSend = event => {
+    if (event === null) return null;
     if (event.tags?.[COINJOIN_REPORT_TAG]) {
         return {
             type: event.type,
@@ -60,7 +67,7 @@ const redactCoinjoinData = (event: ErrorEvent): ErrorEvent => {
     return event;
 };
 
-const beforeSend = (event: ErrorEvent) =>
+const beforeSend: ChainableBeforeSend = event =>
     redactSentryEvent(redactUserPath(redactCoinjoinData(event)));
 
 const beforeBreadcrumb: Options['beforeBreadcrumb'] = breadcrumb => {

--- a/suite/sentry/src/config.ts
+++ b/suite/sentry/src/config.ts
@@ -67,8 +67,28 @@ const redactCoinjoinData: ChainableBeforeSend = event => {
     return event;
 };
 
+const UNHANDLED_REJECTION_MESSAGE = '[global] unhandledrejection';
+/**
+ * Filter Sentry events for ignoreErrors in `extras` payload – but only do it for certain event.message types,
+ * which are known to hide (wrap) other errors in their extras payload.
+ */
+export const ignoreErrorsInGlobalUnhandledRejection: ChainableBeforeSend = event => {
+    if (event === null) return event;
+    const shouldProcessMessage = event.message?.includes(UNHANDLED_REJECTION_MESSAGE);
+    if (!shouldProcessMessage) return event;
+
+    const serializedMessage = JSON.stringify(event.extra);
+    if (typeof serializedMessage !== 'string') return event;
+
+    const isIgnoredError = ignoreErrors.some(ignoreError => ignoreError.test(serializedMessage));
+
+    return isIgnoredError ? null : event;
+};
+
 const beforeSend: ChainableBeforeSend = event =>
-    redactSentryEvent(redactUserPath(redactCoinjoinData(event)));
+    redactSentryEvent(
+        redactUserPath(redactCoinjoinData(ignoreErrorsInGlobalUnhandledRejection(event))),
+    );
 
 const beforeBreadcrumb: Options['beforeBreadcrumb'] = breadcrumb => {
     // filter out analytics requests and image fetches

--- a/suite/sentry/src/config.ts
+++ b/suite/sentry/src/config.ts
@@ -69,15 +69,18 @@ const redactCoinjoinData: ChainableBeforeSend = event => {
 
 const UNHANDLED_REJECTION_MESSAGE = '[global] unhandledrejection';
 /**
- * Filter Sentry events for ignoreErrors in `extras` payload – but only do it for certain event.message types,
- * which are known to hide (wrap) other errors in their extras payload.
+ * Filter Sentry events for ignoreErrors in `event.extra.arguments` payload,
+ * but only do it for global error handler events identified by specific event.message.
+ * Global handlers write the handler arguments (i.e. the error payload itself) to `extra.arguments`:
+ * https://github.com/getsentry/sentry-javascript/blob/4b6156b6629ff5442f266ba4fbbfa7fabceba9d5/packages/browser/src/helpers.ts#L133-L136
  */
 export const ignoreErrorsInGlobalUnhandledRejection: ChainableBeforeSend = event => {
     if (event === null) return event;
     const shouldProcessMessage = event.message?.includes(UNHANDLED_REJECTION_MESSAGE);
-    if (!shouldProcessMessage) return event;
+    const extraArguments = event.extra?.arguments;
+    if (!shouldProcessMessage || !extraArguments) return event;
 
-    const serializedMessage = JSON.stringify(event.extra);
+    const serializedMessage = JSON.stringify(extraArguments);
     if (typeof serializedMessage !== 'string') return event;
 
     const isIgnoredError = ignoreErrors.some(ignoreError => ignoreError.test(serializedMessage));

--- a/suite/sentry/src/ignoreErrors.ts
+++ b/suite/sentry/src/ignoreErrors.ts
@@ -2,7 +2,7 @@ import type { Options } from '@sentry/core';
 
 import { ignoreErrorsCommon } from '@suite-common/sentry';
 
-export const ignoreErrors = [
+export const ignoreErrors: RegExp[] = [
     ...ignoreErrorsCommon,
     /.*ResizeObserver loop limit exceeded.*/,
     /.*Timeout waiting for TOR control port.*/,


### PR DESCRIPTION
## Description

On Web and Desktop, there is a lot of noise in Sentry because `ignoreErrors` are not applied on unandled promise rejections: [see Sentry error](https://satoshilabs.sentry.io/issues/7374780363/?environment=production&project=5193825&query=is%3Aunresolved%20%5Bglobal%5D%20unhandledrejection&referrer=issue-stream)
Scroll down to Additional data, click Arguments, and there is the actual error payload. 
Those are quite staggering numbers unfortunately, it probably ate up a lot of Sentry quota :see_no_evil: 

:point_right: filter `ignoreErrors` also anywhere in `event.extra`, if the message contains `[global] unhandledrejection`. I wanted to be conservative, so as not to lose valuable events of other message types, just because it contains a filtered phrase somewhere ine extras.

:thought_balloon: At first I wanted to make something smarter, more generic in `suite-common/sentry`, but what good is abstraction & unit tests if it's just a very specific Sentry event payload? I think this dirty fix is appropriate, given how tightly it is tied to specific Sentry behavior = you have to test it manually anyway..

## Notes for QA

Sentry testing error works ([example from local](https://satoshilabs.sentry.io/issues/6878488207/?environment=develop&project=5193825&query=&referrer=issue-stream))

Pasting this in browser console (Desktop or Web) **should** send Sentry error with globalunhandled rejection, because it is not an ignored one ([example from local](https://satoshilabs.sentry.io/issues/7374780363/?environment=develop&project=5193825&query=&referrer=issue-stream)):
```
setTimeout(() => {
  Promise.reject({foo: "bar", reason: "something failed" });
}, 10);
```

Pasting this in browser console (Desktop or Web) **should not** send Sentry error (`Aborted by timeout` = ignored):
```
setTimeout(() => {
  Promise.reject({message: "Aborted by timeout.", reason: "something failed" });
}, 10);
```

## Related Issue

Resolve https://satoshilabs.sentry.io/issues/7374780363 and other similar stuff
Resolve https://github.com/trezor/trezor-suite/security/code-scanning/315

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/apply-ignoreErrors-filter-on-sentry-extras&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/apply-ignoreErrors-filter-on-sentry-extras&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/apply-ignoreErrors-filter-on-sentry-extras&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All 7 changed files are in the Sentry error-reporting infrastructure (ignore lists, redaction logic, config, and types). These are global utilities that are transitively imported by 121+ E2E tests but do not affect any user-facing behavior, UI rendering, or business logic tested by E2E tests. Sentry configuration changes (which errors to ignore, how to redact events, type definitions) only affect error reporting to the Sentry backend — no E2E test validates Sentry event submission or error filtering. Therefore, no E2E tests are recommended. Unit/integration tests for the Sentry modules themselves (if they exist) would be the appropriate validation layer.

<details><summary><b>Changed files (7)</b></summary>

- `suite-common/sentry/src/ignoreErrors.ts`
- `suite-common/sentry/src/index.ts`
- `suite-common/sentry/src/redactSentryEvent.ts`
- `suite-common/sentry/src/types.ts`
- `suite-native/sentry/src/ignoreErrors.ts`
- `suite/sentry/src/config.ts`
- `suite/sentry/src/ignoreErrors.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (7)**
- `suite-common/sentry/src/ignoreErrors.ts`
- `suite-common/sentry/src/index.ts`
- `suite-common/sentry/src/redactSentryEvent.ts`
- `suite-common/sentry/src/types.ts`
- `suite-native/sentry/src/ignoreErrors.ts`
- `suite/sentry/src/config.ts`
- `suite/sentry/src/ignoreErrors.ts`

_Updated: 2026-06-25T14:09:38.230Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |

</details>

_Updated: 2026-06-25T14:14:24.379Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |

</details>

_Updated: 2026-06-25T14:13:07.833Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/apply-ignoreErrors-filter-on-sentry-extras/web/](https://dev.suite.sldev.cz/suite-web/fix/apply-ignoreErrors-filter-on-sentry-extras/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->