### PR TITLE
chore: bump typescript to 6.0.3

### DIFF
--- a/coins/coins-cardano/tsconfig.lib.json
+++ b/coins/coins-cardano/tsconfig.lib.json
@@ -1,6 +1,9 @@
 {
     "extends": "../../tsconfig.lib.json",
-    "compilerOptions": { "outDir": "./lib" },
+    "compilerOptions": {
+        "outDir": "./lib",
+        "rootDir": "./src"
+    },
     "include": ["./src"],
     "references": []
 }

--- a/coins/coins-solana/tsconfig.lib.json
+++ b/coins/coins-solana/tsconfig.lib.json
@@ -1,6 +1,9 @@
 {
     "extends": "../../tsconfig.lib.json",
-    "compilerOptions": { "outDir": "./lib" },
+    "compilerOptions": {
+        "outDir": "./lib",
+        "rootDir": "./src"
+    },
     "include": ["./src"],
     "references": [
         { "path": "../../packages/type-utils" },

--- a/coins/coins-stellar/tsconfig.lib.json
+++ b/coins/coins-stellar/tsconfig.lib.json
@@ -1,6 +1,9 @@
 {
     "extends": "../../tsconfig.lib.json",
-    "compilerOptions": { "outDir": "./lib" },
+    "compilerOptions": {
+        "outDir": "./lib",
+        "rootDir": "./src"
+    },
     "include": ["./src"],
     "references": [
         { "path": "../../packages/utils" }

--- a/coins/coins-xrpl/tsconfig.lib.json
+++ b/coins/coins-xrpl/tsconfig.lib.json
@@ -1,6 +1,9 @@
 {
     "extends": "../../tsconfig.lib.json",
-    "compilerOptions": { "outDir": "./lib" },
+    "compilerOptions": {
+        "outDir": "./lib",
+        "rootDir": "./src"
+    },
     "include": ["./src"],
     "references": []
 }

--- a/eslint-local-rules/index.js
+++ b/eslint-local-rules/index.js
@@ -1,8 +1,8 @@
+const path = require('path');
+
 require('ts-node').register({
     transpileOnly: true,
-    compilerOptions: {
-        module: 'commonjs',
-    },
+    project: path.join(__dirname, 'tsconfig.json'),
 });
 
 module.exports = require('./rules').rules;

--- a/eslint-local-rules/rules.ts
+++ b/eslint-local-rules/rules.ts
@@ -154,16 +154,22 @@ export const rules = {
 
             return {
                 ImportDeclaration(node) {
-                    if (packageNames.includes(node.source.value)) {
+                    const sourceValue = node.source.value;
+
+                    if (typeof sourceValue === 'string' && packageNames.includes(sourceValue)) {
                         node.specifiers.forEach(specifier => {
                             if (
                                 specifier.type === 'ImportSpecifier' ||
                                 specifier.type === 'ImportDefaultSpecifier'
                             ) {
-                                if (!importedComponents.has(node.source.value)) {
-                                    importedComponents.set(node.source.value, new Set<string>());
+                                let components = importedComponents.get(sourceValue);
+
+                                if (components === undefined) {
+                                    components = new Set<string>();
+                                    importedComponents.set(sourceValue, components);
                                 }
-                                importedComponents.get(node.source.value).add(specifier.local.name);
+
+                                components.add(specifier.local.name);
                             }
                         });
                     }
@@ -355,6 +361,10 @@ export const rules = {
                 const parts = value.split('/');
                 const domain = parts[0];
                 const eventSegments = parts.slice(1);
+                if (domain === undefined) {
+                    return { messageId: 'invalidFormat' };
+                }
+
                 if (!ALLOWED_DOMAINS.has(domain)) {
                     return { messageId: 'invalidDomain', data: { domain } };
                 }

--- a/eslint-local-rules/tsconfig.json
+++ b/eslint-local-rules/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "extends": "../tsconfig.base.json",
+    "compilerOptions": {
+        "module": "NodeNext",
+        "moduleResolution": "nodenext",
+        "rootDir": ".",
+        "noImplicitAny": false,
+        "noEmit": true,
+        "composite": false,
+        "declaration": false,
+        "declarationMap": false,
+        "emitDeclarationOnly": false
+    },
+    "include": ["./*.ts"]
+}

--- a/jest.config.native.js
+++ b/jest.config.native.js
@@ -25,7 +25,7 @@ module.exports = {
         '^@evolu/react-native$': '<rootDir>/../../suite-native/test-utils/src/mocks/evoluMock.ts',
         '^@evolu/react-native/expo-sqlite$':
             '<rootDir>/../../suite-native/test-utils/src/mocks/evoluMock.ts',
-        '^(@formatjs/[^/]+)/(polyfill|locale-data/.+)$': '<rootDir>/../../node_modules/$1/$2.js',
+        '^(@formatjs/[^/]+)/(polyfill|locale-data/.+)$': '<rootDir>/../../node_modules/$1/$2',
         '^@rozenite/redux-devtools-plugin$':
             '<rootDir>/../../suite-native/test-utils/src/mocks/rozeniteReduxDevtoolsPluginMock.ts',
     },

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
         "s": "yarn native:start"
     },
     "resolutions": {
-        "typescript": "5.9.3",
+        "typescript": "6.0.3",
         "prettier": "^3.8.3",
         "react-native": "0.83.2",
         "type-fest": "5.5.0",
@@ -160,7 +160,7 @@
         "ts-node": "^10.9.2",
         "tslib": "^2.6.2",
         "tsx": "^4.21.0",
-        "typescript": "5.9.3",
+        "typescript": "6.0.3",
         "typescript-eslint": "^8.60.0",
         "version-bump-prompt": "^6.1.0"
     },

--- a/packages/analytics-docs/tsconfig.json
+++ b/packages/analytics-docs/tsconfig.json
@@ -10,7 +10,6 @@
     "compilerOptions": {
         "outDir": "libDev",
         "types": ["vite/client", "jest"],
-        "baseUrl": ".",
         "paths": {
             "@trezor/analytics-log-server": [
                 "../analytics-log-server/src/index.ts"

--- a/packages/auth-server/tsconfig.lib.json
+++ b/packages/auth-server/tsconfig.lib.json
@@ -2,9 +2,10 @@
     "extends": "../../tsconfig.lib.json",
     "include": ["./src"],
     "compilerOptions": {
-        "outDir": "./lib",
-        "module": "commonjs",
-        "moduleResolution": "node"
+        "rootDir": "./src",
+        "module": "node16",
+        "moduleResolution": "node16",
+        "outDir": "./lib"
     },
     "references": []
 }

--- a/packages/blockchain-link-types/tsconfig.lib.json
+++ b/packages/blockchain-link-types/tsconfig.lib.json
@@ -1,7 +1,10 @@
 {
     "extends": "../../tsconfig.lib.json",
     "include": ["./src"],
-    "compilerOptions": { "outDir": "./lib" },
+    "compilerOptions": {
+        "outDir": "./lib",
+        "rootDir": "./src"
+    },
     "references": [
         { "path": "../utils" },
         { "path": "../utxo-lib" },

--- a/packages/blockchain-link-utils/tsconfig.lib.json
+++ b/packages/blockchain-link-utils/tsconfig.lib.json
@@ -1,7 +1,10 @@
 {
     "extends": "../../tsconfig.lib.json",
     "include": ["./src"],
-    "compilerOptions": { "outDir": "./lib" },
+    "compilerOptions": {
+        "outDir": "./lib",
+        "rootDir": "./src"
+    },
     "references": [
         { "path": "../../coins/coins-solana" },
         { "path": "../../coins/coins-stellar" },

--- a/packages/blockchain-link/tsconfig.lib.json
+++ b/packages/blockchain-link/tsconfig.lib.json
@@ -2,6 +2,7 @@
     "extends": "../../tsconfig.lib.json",
     "compilerOptions": {
         "outDir": "./lib",
+        "rootDir": "./src",
         "lib": ["webworker"],
         "types": ["jest", "node", "web"]
     },

--- a/packages/connect-common/tsconfig.lib.json
+++ b/packages/connect-common/tsconfig.lib.json
@@ -3,7 +3,7 @@
     "include": ["./src"],
     "compilerOptions": {
         "outDir": "./lib",
-        "esModuleInterop": false,
+        "rootDir": "./src",
         "types": ["node", "chrome", "jest"]
     },
     "references": [

--- a/packages/connect-data/tsconfig.lib.json
+++ b/packages/connect-data/tsconfig.lib.json
@@ -4,7 +4,6 @@
     "compilerOptions": {
         "outDir": "./lib",
         "rootDir": "./src",
-        "esModuleInterop": false,
         "types": ["node", "chrome", "jest"]
     },
     "references": []

--- a/packages/connect-examples/mobile-expo/package.json
+++ b/packages/connect-examples/mobile-expo/package.json
@@ -20,7 +20,7 @@
     "devDependencies": {
         "@babel/core": "7.29.7",
         "@types/react": "19.2.14",
-        "typescript": "5.9.3"
+        "typescript": "6.0.3"
     },
     "private": true
 }

--- a/packages/connect-explorer/css.d.ts
+++ b/packages/connect-explorer/css.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';

--- a/packages/connect-explorer/tsconfig.json
+++ b/packages/connect-explorer/tsconfig.json
@@ -5,10 +5,9 @@
         "lib": ["dom", "dom.iterable", "esnext"],
         "emitDeclarationOnly": false,
         "noEmit": true,
-        "baseUrl": ".",
         "paths": {
             "@suite-common/icons/src/icons": [
-                "src/icons/minimalIcons.ts"
+                "./src/icons/minimalIcons.ts"
             ]
         },
         "plugins": [

--- a/packages/connect-mobile/tsconfig.lib.json
+++ b/packages/connect-mobile/tsconfig.lib.json
@@ -1,7 +1,10 @@
 {
     "extends": "../../tsconfig.lib.json",
     "include": ["./src"],
-    "compilerOptions": { "outDir": "./lib" },
+    "compilerOptions": {
+        "outDir": "./lib",
+        "rootDir": "./src"
+    },
     "references": [
         { "path": "../connect-common" },
         { "path": "../utils" }

--- a/packages/connect-plugin-ethereum/tsconfig.lib.json
+++ b/packages/connect-plugin-ethereum/tsconfig.lib.json
@@ -1,6 +1,9 @@
 {
     "extends": "../../tsconfig.lib.json",
     "include": ["./src"],
-    "compilerOptions": { "outDir": "./lib" },
+    "compilerOptions": {
+        "outDir": "./lib",
+        "rootDir": "./src"
+    },
     "references": []
 }

--- a/packages/connect-plugin-stellar/tsconfig.lib.json
+++ b/packages/connect-plugin-stellar/tsconfig.lib.json
@@ -1,6 +1,9 @@
 {
     "extends": "../../tsconfig.lib.json",
     "include": ["./src"],
-    "compilerOptions": { "outDir": "./lib" },
+    "compilerOptions": {
+        "outDir": "./lib",
+        "rootDir": "./src"
+    },
     "references": []
 }

--- a/packages/connect-web/tsconfig.json
+++ b/packages/connect-web/tsconfig.json
@@ -1,8 +1,6 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "module": "commonjs",
-        "moduleResolution": "node",
         "outDir": "libDev",
         "types": [
             "chrome",

--- a/packages/connect-web/tsconfig.lib.json
+++ b/packages/connect-web/tsconfig.lib.json
@@ -3,6 +3,7 @@
     "include": ["./src"],
     "compilerOptions": {
         "outDir": "./lib",
+        "rootDir": "./src",
         "types": ["chrome", "w3c-web-usb"]
     },
     "references": [

--- a/packages/connect-webextension/tsconfig.lib.json
+++ b/packages/connect-webextension/tsconfig.lib.json
@@ -3,6 +3,7 @@
     "include": ["./src"],
     "compilerOptions": {
         "outDir": "./lib",
+        "rootDir": "./src",
         "types": ["chrome", "w3c-web-usb"]
     },
     "references": [

--- a/packages/connect/tsconfig.lib.json
+++ b/packages/connect/tsconfig.lib.json
@@ -3,6 +3,7 @@
     "include": ["./src"],
     "compilerOptions": {
         "outDir": "./lib",
+        "rootDir": "./src",
         "lib": ["webworker", "ES2022"],
         "types": ["w3c-web-usb"]
     },

--- a/packages/crypto-utils/tsconfig.lib.json
+++ b/packages/crypto-utils/tsconfig.lib.json
@@ -1,6 +1,9 @@
 {
     "extends": "../../tsconfig.lib.json",
     "include": ["./src"],
-    "compilerOptions": { "outDir": "./lib" },
+    "compilerOptions": {
+        "outDir": "./lib",
+        "rootDir": "./src"
+    },
     "references": [{ "path": "../type-utils" }]
 }

--- a/packages/device-authenticity/tsconfig.lib.json
+++ b/packages/device-authenticity/tsconfig.lib.json
@@ -1,7 +1,10 @@
 {
     "extends": "../../tsconfig.lib.json",
     "include": ["./src"],
-    "compilerOptions": { "outDir": "./lib" },
+    "compilerOptions": {
+        "outDir": "./lib",
+        "rootDir": "./src"
+    },
     "references": [
         { "path": "../protobuf" },
         { "path": "../utils" }

--- a/packages/device-utils/tsconfig.lib.json
+++ b/packages/device-utils/tsconfig.lib.json
@@ -1,7 +1,10 @@
 {
     "extends": "../../tsconfig.lib.json",
     "include": ["./src"],
-    "compilerOptions": { "outDir": "./lib" },
+    "compilerOptions": {
+        "outDir": "./lib",
+        "rootDir": "./src"
+    },
     "references": [
         { "path": "../protobuf" },
         { "path": "../type-utils" },

--- a/packages/env-utils/tsconfig.lib.json
+++ b/packages/env-utils/tsconfig.lib.json
@@ -1,6 +1,9 @@
 {
     "extends": "../../tsconfig.lib.json",
     "include": ["./src"],
-    "compilerOptions": { "outDir": "./lib" },
+    "compilerOptions": {
+        "outDir": "./lib",
+        "rootDir": "./src"
+    },
     "references": []
 }

--- a/packages/protobuf/tsconfig.lib.json
+++ b/packages/protobuf/tsconfig.lib.json
@@ -1,6 +1,9 @@
 {
     "extends": "../../tsconfig.lib.json",
     "include": ["./src"],
-    "compilerOptions": { "outDir": "./lib" },
+    "compilerOptions": {
+        "outDir": "./lib",
+        "rootDir": "./src"
+    },
     "references": [{ "path": "../eslint" }]
 }

--- a/packages/protocol/tsconfig.lib.json
+++ b/packages/protocol/tsconfig.lib.json
@@ -3,6 +3,7 @@
     "include": ["./src"],
     "compilerOptions": {
         "outDir": "./lib",
+        "rootDir": "./src",
         "target": "es2022",
         "lib": ["es2022", "esnext"]
     },

--- a/packages/schema-utils/tsconfig.lib.json
+++ b/packages/schema-utils/tsconfig.lib.json
@@ -1,7 +1,10 @@
 {
     "extends": "../../tsconfig.lib.json",
     "include": ["./src"],
-    "compilerOptions": { "outDir": "./lib" },
+    "compilerOptions": {
+        "outDir": "./lib",
+        "rootDir": "./src"
+    },
     "references": [
         { "path": "../type-utils" },
         { "path": "../eslint" }

--- a/packages/suite-data/package.json
+++ b/packages/suite-data/package.json
@@ -12,8 +12,8 @@
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "build:lib": "yarn browser-detection && yarn favicon && yarn guide-pull-content",
-        "browser-detection": "webpack --config ./browser-detection.webpack.ts",
-        "favicon": "webpack --config ./favicon.webpack.ts",
+        "browser-detection": "TS_NODE_PROJECT=\"./tsconfig.webpack.json\" webpack --config ./browser-detection.webpack.ts",
+        "favicon": "TS_NODE_PROJECT=\"./tsconfig.webpack.json\" webpack --config ./favicon.webpack.ts",
         "guide-pull-content": "yarn tsx ./src/guide/index.ts",
         "update-coinjoin-middleware": "./files/bin/coinjoin/update.sh",
         "type-check": "yarn g:tsc --build tsconfig.json",

--- a/packages/suite-data/tsconfig.webpack.json
+++ b/packages/suite-data/tsconfig.webpack.json
@@ -1,0 +1,14 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "module": "NodeNext",
+        "moduleResolution": "nodenext",
+        "rootDir": ".",
+        "noEmit": true,
+        "composite": false,
+        "declaration": false,
+        "declarationMap": false,
+        "emitDeclarationOnly": false
+    },
+    "include": ["*.webpack.ts"]
+}

--- a/packages/suite-desktop-api/tsconfig.json
+++ b/packages/suite-desktop-api/tsconfig.json
@@ -2,7 +2,6 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
         "noImplicitAny": false,
-        "esModuleInterop": false,
         "outDir": "./libDev"
     },
     "include": ["."],

--- a/packages/suite-desktop-ui/tsconfig.json
+++ b/packages/suite-desktop-ui/tsconfig.json
@@ -2,7 +2,9 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
         "outDir": "libDev",
-        "baseUrl": "../suite"
+        "paths": {
+            "src/*": ["../suite/src/*"]
+        }
     },
     "include": ["."],
     "references": [

--- a/packages/suite-web/tsconfig.json
+++ b/packages/suite-web/tsconfig.json
@@ -2,7 +2,9 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
         "outDir": "./libDev",
-        "baseUrl": "../suite"
+        "paths": {
+            "src/*": ["../suite/src/*"]
+        }
     },
     "include": ["."],
     "references": [

--- a/packages/suite/tsconfig.json
+++ b/packages/suite/tsconfig.json
@@ -8,7 +8,9 @@
             }
         ],
         "outDir": "./libDev",
-        "baseUrl": "."
+        "paths": {
+            "src/*": ["./src/*"]
+        }
     },
     "include": [".", "e2e", "**/*.json"],
     "references": [

--- a/packages/transport-bridge/package.json
+++ b/packages/transport-bridge/package.json
@@ -12,7 +12,7 @@
         "build:node:bin": "yarn esbuild ./src/bin.ts --bundle --outfile=dist/bin.js --platform=node --target=node18 --external:usb",
         "build:node:module": "yarn esbuild ./src/index.ts --bundle --outfile=dist/index.js --platform=node --target=node18 --external:usb",
         "build:node": "yarn build:node:bin && yarn build:node:module",
-        "build:ui": "TS_NODE_PROJECT=\"tsconfig.json\" webpack --config ./webpack/ui.webpack.config.ts",
+        "build:ui": "TS_NODE_PROJECT=\"webpack/tsconfig.json\" webpack --config ./webpack/ui.webpack.config.ts",
         "build:js": "yarn g:rimraf -rf dist && yarn build:node && yarn build:ui",
         "build": "yarn build:js",
         "build:lib": "yarn build:js",

--- a/packages/transport-bridge/webpack/tsconfig.json
+++ b/packages/transport-bridge/webpack/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "extends": "../../../tsconfig.base.json",
+    "compilerOptions": {
+        "module": "NodeNext",
+        "moduleResolution": "nodenext",
+        "rootDir": ".",
+        "noEmit": true,
+        "composite": false,
+        "declaration": false,
+        "declarationMap": false,
+        "emitDeclarationOnly": false
+    },
+    "include": ["./*.ts"]
+}

--- a/packages/transport-common/tsconfig.lib.json
+++ b/packages/transport-common/tsconfig.lib.json
@@ -4,6 +4,7 @@
     "compilerOptions": {
         "lib": ["ES2023"],
         "outDir": "./lib",
+        "rootDir": "./src",
         "types": ["node"]
     },
     "references": [

--- a/packages/transport-web/tsconfig.lib.json
+++ b/packages/transport-web/tsconfig.lib.json
@@ -3,6 +3,7 @@
     "include": ["./src"],
     "compilerOptions": {
         "outDir": "./lib",
+        "rootDir": "./src",
         "lib": ["DOM", "ES2023"],
         "types": []
     },

--- a/packages/transport/tsconfig.lib.json
+++ b/packages/transport/tsconfig.lib.json
@@ -3,6 +3,7 @@
     "include": ["./src"],
     "compilerOptions": {
         "outDir": "./lib",
+        "rootDir": "./src",
         "types": ["node"]
     },
     "references": [

--- a/packages/type-utils/tsconfig.lib.json
+++ b/packages/type-utils/tsconfig.lib.json
@@ -1,6 +1,9 @@
 {
     "extends": "../../tsconfig.lib.json",
     "include": ["./src"],
-    "compilerOptions": { "outDir": "./lib" },
+    "compilerOptions": {
+        "outDir": "./lib",
+        "rootDir": "./src"
+    },
     "references": []
 }

--- a/packages/utils/tsconfig.lib.json
+++ b/packages/utils/tsconfig.lib.json
@@ -1,7 +1,10 @@
 {
     "extends": "../../tsconfig.lib.json",
     "include": ["./src"],
-    "compilerOptions": { "outDir": "./lib" },
+    "compilerOptions": {
+        "outDir": "./lib",
+        "rootDir": "./src"
+    },
     "references": [
         { "path": "../eslint" },
         { "path": "../type-utils" }

--- a/packages/utxo-lib/tsconfig.lib.json
+++ b/packages/utxo-lib/tsconfig.lib.json
@@ -1,7 +1,10 @@
 {
     "extends": "../../tsconfig.lib.json",
     "include": ["./src"],
-    "compilerOptions": { "outDir": "./lib" },
+    "compilerOptions": {
+        "outDir": "./lib",
+        "rootDir": "./src"
+    },
     "references": [
         { "path": "../utils" },
         { "path": "../eslint" }

--- a/packages/websocket-client/tsconfig.lib.json
+++ b/packages/websocket-client/tsconfig.lib.json
@@ -2,6 +2,7 @@
     "extends": "../../tsconfig.lib.json",
     "compilerOptions": {
         "outDir": "./lib",
+        "rootDir": "./src",
         "lib": ["webworker"],
         "types": ["jest", "node", "web"]
     },

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -211,7 +211,7 @@
         "ts-jest": "29.4.1",
         "ts-node": "^10.9.2",
         "tsx": "^4.21.0",
-        "typescript": "5.9.3",
+        "typescript": "6.0.3",
         "uri-scheme": "^2.0.18"
     },
     "private": true

--- a/suite-native/intl/src/IntlProvider.tsx
+++ b/suite-native/intl/src/IntlProvider.tsx
@@ -7,11 +7,11 @@ import '@formatjs/intl-getcanonicallocales/polyfill.js';
 import '@formatjs/intl-locale/polyfill.js';
 // Intl.ListFormat polyfill and locale data
 import '@formatjs/intl-listformat/polyfill.js';
-import '@formatjs/intl-listformat/locale-data/en';
-import '@formatjs/intl-listformat/locale-data/cs';
-import '@formatjs/intl-listformat/locale-data/de';
-import '@formatjs/intl-listformat/locale-data/pt';
-import '@formatjs/intl-listformat/locale-data/ja';
+import '@formatjs/intl-listformat/locale-data/en.js';
+import '@formatjs/intl-listformat/locale-data/cs.js';
+import '@formatjs/intl-listformat/locale-data/de.js';
+import '@formatjs/intl-listformat/locale-data/pt.js';
+import '@formatjs/intl-listformat/locale-data/ja.js';
 
 import { IntlProvider as ReactIntlProvider } from 'react-intl';
 import { useSelector } from 'react-redux';

--- a/suite/metadata/src/__tests__/metadataActions.test.ts
+++ b/suite/metadata/src/__tests__/metadataActions.test.ts
@@ -100,10 +100,12 @@ const getInitialState = (state?: InitialState) => {
 type State = ReturnType<typeof getInitialState>;
 const initStore = (state: State) => {
     const store = configureMockStore<State, any>({
-        reducer: (s = state, action: any) => ({
-            ...s,
-            metadata: metadataReducer(s.metadata, action),
-        }),
+        reducer: (s = state, action: any): State => {
+            // the reducer may also receive the empty PreloadedState ({}), fall back to the initial state
+            const current = { ...state, ...s };
+
+            return { ...current, metadata: metadataReducer(current.metadata, action) };
+        },
         preloadedState: state,
         serializableCheck: {
             ignoredActions: ['@modal/open-user-context'],

--- a/suite/metadata/tsconfig.json
+++ b/suite/metadata/tsconfig.json
@@ -2,7 +2,6 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
         "outDir": "libDev",
-        "baseUrl": ".",
         "paths": {
             "src/*": [
                 "../../packages/suite/src/*"

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -47,8 +47,9 @@
     ],
     "ts-node": {
         "compilerOptions": {
-            "module": "CommonJS",
-            "moduleResolution": "node"
+            "module": "Node16",
+            "moduleResolution": "node16",
+            "rootDir": "."
         }
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11684,7 +11684,7 @@ __metadata:
     ts-jest: "npm:29.4.1"
     ts-node: "npm:^10.9.2"
     tsx: "npm:^4.21.0"
-    typescript: "npm:5.9.3"
+    typescript: "npm:6.0.3"
     uri-scheme: "npm:^2.0.18"
     vm-browserify: "npm:^1.1.2"
     xml2js: "npm:^0.6.2"
@@ -22753,7 +22753,7 @@ __metadata:
     expo-status-bar: "npm:~55.0.4"
     react: "npm:19.2.4"
     react-native: "npm:0.83.2"
-    typescript: "npm:5.9.3"
+    typescript: "npm:6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -44366,7 +44366,7 @@ __metadata:
     ts-node: "npm:^10.9.2"
     tslib: "npm:^2.6.2"
     tsx: "npm:^4.21.0"
-    typescript: "npm:5.9.3"
+    typescript: "npm:6.0.3"
     typescript-eslint: "npm:^8.60.0"
     version-bump-prompt: "npm:^6.1.0"
   dependenciesMeta:
@@ -44904,23 +44904,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.9.3":
-  version: 5.9.3
-  resolution: "typescript@npm:5.9.3"
+"typescript@npm:6.0.3":
+  version: 6.0.3
+  resolution: "typescript@npm:6.0.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/c089d9d3da2729fd4ac517f9b0e0485914c4b3c26f80dc0cffcb5de1719a17951e92425d55db59515c1a7ddab65808466debb864d0d56dcf43f27007d0709594
+  checksum: 10/0ef2357a4cffd916b52b683a021cdab0f81eea4e9aa35f2d254581c9a5106da02224e3392e1b0ed42b7a48f80c966e5f52b8e1a27941fa0523c1705a9c2e0330
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>":
-  version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
+"typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>":
+  version: 6.0.3
+  resolution: "typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>::version=6.0.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/696e1b017bc2635f4e0c94eb4435357701008e2f272f553d06e35b494b8ddc60aa221145e286c28ace0c89ee32827a28c2040e3a69bdc108b1a5dc8fb40b72e3
+  checksum: 10/22b67a18dafedf9b1468b64ca20d9aa02ea61d449b65413d8aa6552aeb63f52ef369e86beb25b6b4c91a803d9726ee5c196f391a9b64201263263410a4223ee6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
bumped typescript to 6.0.3

## Notes for QA
Anything can break. general testing of app

## Related Issue

Resolve #26865 



<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set consists almost entirely of tsconfig.json modifications, package.json updates, and build/lint configuration changes (eslint rules, jest config, webpack tsconfig). These are infrastructure/build-level changes that affect TypeScript compilation settings, dependency versions, and tooling — not runtime application logic. The only source code change is in suite-native/intl/src/IntlProvider.tsx (a React Native component not exercised by web/desktop E2E tests) and suite/metadata/src/__tests__/metadataActions.test.ts (a unit test file, not application code). Since no application runtime code is changed, there is no concrete reason to expect any E2E test regressions. If the build succeeds and unit tests pass, the application behavior should be identical. No E2E tests are recommended.

<details><summary><b>Changed files (53)</b></summary>

- `coins/coins-cardano/tsconfig.lib.json`
- `coins/coins-solana/tsconfig.lib.json`
- `coins/coins-stellar/tsconfig.lib.json`
- `coins/coins-xrpl/tsconfig.lib.json`
- `eslint-local-rules/index.js`
- `eslint-local-rules/rules.ts`
- `eslint-local-rules/tsconfig.json`
- `jest.config.native.js`
- `package.json`
- `packages/analytics-docs/tsconfig.json`
- `packages/auth-server/tsconfig.lib.json`
- `packages/blockchain-link-types/tsconfig.lib.json`
- `packages/blockchain-link-utils/tsconfig.lib.json`
- `packages/blockchain-link/tsconfig.lib.json`
- `packages/connect-common/tsconfig.lib.json`
- `packages/connect-data/tsconfig.lib.json`
- `packages/connect-examples/mobile-expo/package.json`
- `packages/connect-explorer/css.d.ts`
- `packages/connect-explorer/tsconfig.json`
- `packages/connect-mobile/tsconfig.lib.json`
- `packages/connect-plugin-ethereum/tsconfig.lib.json`
- `packages/connect-plugin-stellar/tsconfig.lib.json`
- `packages/connect-web/tsconfig.json`
- `packages/connect-web/tsconfig.lib.json`
- `packages/connect-webextension/tsconfig.lib.json`
- `packages/connect/tsconfig.lib.json`
- `packages/crypto-utils/tsconfig.lib.json`
- `packages/device-authenticity/tsconfig.lib.json`
- `packages/device-utils/tsconfig.lib.json`
- `packages/env-utils/tsconfig.lib.json`
- `packages/protobuf/tsconfig.lib.json`
- `packages/protocol/tsconfig.lib.json`
- `packages/schema-utils/tsconfig.lib.json`
- `packages/suite-data/package.json`
- `packages/suite-data/tsconfig.webpack.json`
- `packages/suite-desktop-api/tsconfig.json`
- `packages/suite-desktop-ui/tsconfig.json`
- `packages/suite-web/tsconfig.json`
- `packages/suite/tsconfig.json`
- `packages/transport-bridge/package.json`
- `packages/transport-bridge/webpack/tsconfig.json`
- `packages/transport-common/tsconfig.lib.json`
- `packages/transport-web/tsconfig.lib.json`
- `packages/transport/tsconfig.lib.json`
- `packages/type-utils/tsconfig.lib.json`
- `packages/utils/tsconfig.lib.json`
- `packages/utxo-lib/tsconfig.lib.json`
- `packages/websocket-client/tsconfig.lib.json`
- `suite-native/app/package.json`
- `suite-native/intl/src/IntlProvider.tsx`
- `suite/metadata/src/__tests__/metadataActions.test.ts`
- `suite/metadata/tsconfig.json`
- `tsconfig.base.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (53)**
- `coins/coins-cardano/tsconfig.lib.json`
- `coins/coins-solana/tsconfig.lib.json`
- `coins/coins-stellar/tsconfig.lib.json`
- `coins/coins-xrpl/tsconfig.lib.json`
- `eslint-local-rules/index.js`
- `eslint-local-rules/rules.ts`
- `eslint-local-rules/tsconfig.json`
- `jest.config.native.js`
- `package.json`
- `packages/analytics-docs/tsconfig.json`
- `packages/auth-server/tsconfig.lib.json`
- `packages/blockchain-link-types/tsconfig.lib.json`
- `packages/blockchain-link-utils/tsconfig.lib.json`
- `packages/blockchain-link/tsconfig.lib.json`
- `packages/connect-common/tsconfig.lib.json`
- `packages/connect-data/tsconfig.lib.json`
- `packages/connect-examples/mobile-expo/package.json`
- `packages/connect-explorer/css.d.ts`
- `packages/connect-explorer/tsconfig.json`
- `packages/connect-mobile/tsconfig.lib.json`
- `packages/connect-plugin-ethereum/tsconfig.lib.json`
- `packages/connect-plugin-stellar/tsconfig.lib.json`
- `packages/connect-web/tsconfig.json`
- `packages/connect-web/tsconfig.lib.json`
- `packages/connect-webextension/tsconfig.lib.json`
- `packages/connect/tsconfig.lib.json`
- `packages/crypto-utils/tsconfig.lib.json`
- `packages/device-authenticity/tsconfig.lib.json`
- `packages/device-utils/tsconfig.lib.json`
- `packages/env-utils/tsconfig.lib.json`
- `packages/protobuf/tsconfig.lib.json`
- `packages/protocol/tsconfig.lib.json`
- `packages/schema-utils/tsconfig.lib.json`
- `packages/suite-data/package.json`
- `packages/suite-data/tsconfig.webpack.json`
- `packages/suite-desktop-api/tsconfig.json`
- `packages/suite-desktop-ui/tsconfig.json`
- `packages/suite-web/tsconfig.json`
- `packages/suite/tsconfig.json`
- `packages/transport-bridge/package.json`
- `packages/transport-bridge/webpack/tsconfig.json`
- `packages/transport-common/tsconfig.lib.json`
- `packages/transport-web/tsconfig.lib.json`
- `packages/transport/tsconfig.lib.json`
- `packages/type-utils/tsconfig.lib.json`
- `packages/utils/tsconfig.lib.json`
- `packages/utxo-lib/tsconfig.lib.json`
- `packages/websocket-client/tsconfig.lib.json`
- `suite-native/app/package.json`
- `suite-native/intl/src/IntlProvider.tsx`
- `suite/metadata/src/__tests__/metadataActions.test.ts`
- `suite/metadata/tsconfig.json`
- `tsconfig.base.json`

_Updated: 2026-06-25T17:03:49.284Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/bump-typescript-to-6-0-3&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/bump-typescript-to-6-0-3&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/bump-typescript-to-6-0-3&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |

</details>

_Updated: 2026-06-25T17:08:37.338Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |

</details>

_Updated: 2026-06-25T17:07:20.500Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/bump-typescript-to-6-0-3/web/](https://dev.suite.sldev.cz/suite-web/chore/bump-typescript-to-6-0-3/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->