### PR TITLE
test(agent): add stage cost breakdown

### DIFF
--- a/.github/workflows/test-suite-nightly-fix-agent.yml
+++ b/.github/workflows/test-suite-nightly-fix-agent.yml
@@ -360,6 +360,7 @@ jobs:
         with:
           name: fix-agent-report
           path: report-download/
+        continue-on-error: true
 
       - name: Download analyze cost artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/packages/e2e-utils/src/fixBot/ANALYSIS_AGENT.md
+++ b/packages/e2e-utils/src/fixBot/ANALYSIS_AGENT.md
@@ -20,6 +20,8 @@ Do not write code.
 
 ## Step 1 — Find the latest nightly runs
 
+_Cost marker: run `echo fixagent-stage-discovery` before starting this step._
+
 For **each** platform (Web `Og0NOQ`, Desktop `4ytF0E`):
 
 Use `currents-get-runs` with `projectId`, `branches=["develop"]`, `tags=["nightly"]`, `limit=2`.
@@ -59,6 +61,8 @@ file path.
 or the skipped list — omit them entirely from the report.
 
 ## Step 3 — Get full debugging data per instance
+
+_Cost marker: run `echo fixagent-stage-investigate` before starting this step._
 
 For each failed or pending `instanceId`, use `currents-get-spec-instance` and extract:
 
@@ -110,6 +114,8 @@ instance. Read the full file and any page objects, fixtures, or helpers it uses.
 
 ## Step 6 — Produce the diagnosis report
 
+_Cost marker: run `echo fixagent-stage-report` before starting this step._
+
 Write the report to `packages/e2e-utils/src/fixBot/reports/report.md`.
 
 Open with:
@@ -151,6 +157,8 @@ After all test entries, append a **Prompt gaps** section:
 If nothing was unclear, write `## Prompt gaps\n\n_None._`
 
 ## Step 7 — Cluster and route each failure
+
+_Cost marker: run `echo fixagent-stage-cluster` before starting this step._
 
 Group the diagnosed failures into clusters by shared root cause — failures needing the same code
 change belong together, regardless of platform, device group, or spec file.  

--- a/packages/e2e-utils/src/fixBot/FIX_AGENT.md
+++ b/packages/e2e-utils/src/fixBot/FIX_AGENT.md
@@ -78,11 +78,11 @@ or change what the test checks, the failure is not yours to fix — bail as in S
 
 ## Step 2 — Pre-flight
 
+_Cost marker: run `echo fixagent-stage-preflight` before starting this step._
+
 Confirm each validation actually fails before attempting any fix.
 
 ```bash
-touch /tmp/preflight-marker
-
 # For each validation — select config by platform:
 (cd suite/e2e && yarn xvfb-maybe -- playwright test \
   --config=./playwright-config/playwright-<web|desktop>.config.ts \
@@ -98,7 +98,7 @@ Non-zero = failing — read the trace before deciding anything further (see belo
 ### Reading traces after pre-flight and any test run
 
 ```bash
-find suite/e2e/test-results -name 'trace.zip' -newer /tmp/preflight-marker
+find suite/e2e/test-results -name 'trace.zip'
 ```
 
 Unzip and read the screenshot closest to the failure:
@@ -134,6 +134,8 @@ Track your current iteration number starting at 1. Stop when budget is exhausted
 
 ### Per iteration
 
+_Cost marker: at the start of each iteration, run `echo fixagent-stage-iteration-<N>` with the current iteration number (e.g. `fixagent-stage-iteration-1`)._
+
 **1. Make changes** within the allowed surface (see Fix Constraints).
 
 **Missing / mismatched locator.** When a locator the test uses is not found, do not reflexively
@@ -143,12 +145,11 @@ current one. Add a new `data-testid` only if the element genuinely has none.
 
 **2. Run all validations that are still failing:**
 
-Run each failing validation separately so you get one trace per spec.
+Run each failing validation separately, reading its trace right after the run (see
+"Reading traces" above) — `test-results` is overwritten by the next run.
 Select config by platform:
 
 ```bash
-touch /tmp/iter-<N>-marker
-
 (cd suite/e2e && yarn xvfb-maybe -- playwright test \
   --config=./playwright-config/playwright-<web|desktop>.config.ts \
   --project=<group> \
@@ -158,7 +159,7 @@ touch /tmp/iter-<N>-marker
 **3. Read traces for any that still fail:**
 
 ```bash
-find suite/e2e/test-results -name 'trace.zip' -newer /tmp/iter-<N>-marker
+find suite/e2e/test-results -name 'trace.zip'
 unzip -q <trace.zip> -d /tmp/trace-iter-<N>/
 ls /tmp/trace-iter-<N>/resources/page@*.jpeg | sort | tail -10
 ```
@@ -184,6 +185,8 @@ Then use `git commit --fixup $FIRST_SHA` for all subsequent iterations.
 ---
 
 ## Step 4 — Write the PR description and return the result
+
+_Cost marker: run `echo fixagent-stage-finalize` before starting this step._
 
 **`pr-description.md`** — write this file to the repo root (current directory) using the
 Write tool (see the section below for its contents).

--- a/packages/e2e-utils/src/fixBot/common.ts
+++ b/packages/e2e-utils/src/fixBot/common.ts
@@ -13,6 +13,7 @@ import {
     type SlackFixSummary,
     SlackFixSummarySchema,
 } from './schemas';
+import { type AgentName, formatStageBreakdown } from './stageCost';
 
 export const EMPTY_LEDGER: Ledger = { version: 1, updatedAt: '1970-01-01', entries: [] };
 
@@ -94,40 +95,53 @@ export function runClaude(opts: {
     return { output, status: result.status, signal: result.signal, spawnError: result.error };
 }
 
-function parseClaudeOutput(raw: string): ClaudeResult {
-    const unsafeParsed: unknown = JSON.parse(raw.trim());
-    const entries = Array.isArray(unsafeParsed) ? unsafeParsed : [unsafeParsed];
+function parseEnvelopeEntries(rawOutput: string): unknown[] | null {
+    try {
+        const parsed: unknown = JSON.parse(rawOutput.trim());
+
+        return Array.isArray(parsed) ? parsed : [parsed];
+    } catch {
+        return null;
+    }
+}
+
+function findResultEntry(entries: unknown[]): ClaudeResult | null {
     const resultEntry = entries
         .map(entry => ClaudeResultSchema.safeParse(entry))
         .find(parsed => parsed.success && parsed.data.type === 'result');
 
-    if (!resultEntry?.success) {
-        throw new Error('No result entry found in Claude output');
-    }
+    return resultEntry?.success ? resultEntry.data : null;
+}
 
-    return resultEntry.data;
+function logResultToTerminal(agentName: AgentName, claudeResult: ClaudeResult): void {
+    const RESULT_PREVIEW_LIMIT = 800;
+    log(`[${agentName}] subtype=${claudeResult.subtype ?? 'N/A'}`);
+
+    if (claudeResult.result) {
+        log(`${claudeResult.result.slice(0, RESULT_PREVIEW_LIMIT)}`);
+    }
 }
 
 export function processAgentOutput(
     rawOutput: string,
-    agent: 'nightlyAnalyzer' | 'nightlyFixer',
+    agent: AgentName,
     model: string,
 ): ClaudeResult | null {
-    let result: ClaudeResult;
-    try {
-        result = parseClaudeOutput(rawOutput);
-    } catch {
+    const entries = parseEnvelopeEntries(rawOutput);
+    if (!entries) {
         warn(`[${agent}] agent output unparsable (${rawOutput.length} bytes)`);
 
         return null;
     }
 
-    const subtype = result.subtype ?? '?';
-    const text = result.result ?? '';
-    const preview = text.length > 800 ? `${text.slice(0, 800)}…` : text;
+    const result = findResultEntry(entries);
+    if (!result) {
+        warn(`[${agent}] no result entry found in agent output`);
 
-    log(`[${agent}] subtype=${subtype}`);
-    if (preview) log(preview);
+        return null;
+    }
+
+    logResultToTerminal(agent, result);
 
     reportTokenUsage({
         timestamp: new Date().toISOString(),
@@ -141,6 +155,9 @@ export function processAgentOutput(
         output_tokens: result.usage?.output_tokens ?? null,
         total_cost_usd: result.total_cost_usd,
     });
+
+    const breakdown = formatStageBreakdown(agent, entries, result);
+    log(breakdown ?? `[${agent}] no stage breakdown available`);
 
     return result;
 }

--- a/packages/e2e-utils/src/fixBot/notify.ts
+++ b/packages/e2e-utils/src/fixBot/notify.ts
@@ -36,21 +36,38 @@ function formatTestRef(validations: AnalysisReport['fixTasks'][number]['validati
     return `    ${first.spec} [${first.group}]${extrasPart}`;
 }
 
+function runUrl(): string {
+    const runId = process.env.GITHUB_RUN_ID ?? '';
+    const repo = process.env.GITHUB_REPOSITORY ?? 'trezor/trezor-suite';
+
+    return `https://github.com/${repo}/actions/runs/${runId}`;
+}
+
+function readReport(reportPath: string): AnalysisReport | null {
+    try {
+        const parsed = AnalysisReportSchema.safeParse(
+            JSON.parse(readFileSync(reportPath, 'utf-8')),
+        );
+
+        return parsed.success ? parsed.data : null;
+    } catch (err) {
+        error(`[notify] Could not read report at ${reportPath}: ${String(err)}`);
+
+        return null;
+    }
+}
+
 function buildMessage(
     report: AnalysisReport,
     summaries: SlackFixSummary[],
     analyzeCost: number | null,
 ): string {
-    const runId = process.env.GITHUB_RUN_ID ?? '';
-    const repo = process.env.GITHUB_REPOSITORY ?? 'trezor/trezor-suite';
-    const runUrl = `https://github.com/${repo}/actions/runs/${runId}`;
-
     const summaryById = new Map(summaries.map(s => [s.taskId, s]));
 
     const lines: string[] = [];
 
     // Header
-    lines.push(`🤖 *Nightly Fix Agent — ${report.runDate}*  <${runUrl}|GHA Run>`);
+    lines.push(`🤖 *Nightly Fix Agent — ${report.runDate}*  <${runUrl()}|GHA Run>`);
     lines.push('');
 
     // Analyzer summary line
@@ -163,7 +180,16 @@ async function main(): Promise<void> {
         process.exit(1);
     }
 
-    const report = AnalysisReportSchema.parse(JSON.parse(readFileSync(reportPath, 'utf-8')));
+    const report = readReport(reportPath);
+
+    if (!report) {
+        await sendSlackNotification(
+            `🤖 *Nightly Fix Agent*  <${runUrl()}|GHA Run>\n\n❓ Analysis agent did not complete correctly.`,
+        );
+
+        return;
+    }
+
     const summaries = readSummaries(summariesDir);
     const analyzeCost = readAnalysisCost(analyzeCostFile);
 

--- a/packages/e2e-utils/src/fixBot/schemas.ts
+++ b/packages/e2e-utils/src/fixBot/schemas.ts
@@ -69,6 +69,21 @@ export const ClaudeResultSchema = z.object({
     duration_ms: z.number().optional(),
 });
 
+export const AgentMessageEntrySchema = z.object({
+    type: z.literal('assistant'),
+    parent_tool_use_id: z.string().nullish(),
+    message: z.object({
+        id: z.string(),
+        content: z.array(
+            z.object({
+                type: z.string(),
+                input: z.record(z.string(), z.unknown()).optional(),
+            }),
+        ),
+        usage: ClaudeUsageSchema.optional(),
+    }),
+});
+
 export const SlackFixSummarySchema = FixResultSchema.extend({
     prUrl: z.string().nullable().default(null),
     costUsd: z.number().nullable().default(null),

--- a/packages/e2e-utils/src/fixBot/stageCost.ts
+++ b/packages/e2e-utils/src/fixBot/stageCost.ts
@@ -1,0 +1,146 @@
+import { AgentMessageEntrySchema, type ClaudeResult } from './schemas';
+
+export type AgentName = 'nightlyAnalyzer' | 'nightlyFixer';
+
+const STAGE_MARKER = /fixagent-stage-([a-z0-9-]+)/g;
+
+// Token prices relative to the base input price: cache reads bill at ~0.1×, cache
+// writes at ~2× (Claude Code's 1-hour cache TTL). Output is excluded — the CLI does
+// not report usable per-message output tokens, so it cannot be attributed to a
+// stage. The base price cancels out when shares are normalised, so these relative
+// weights are model-independent.
+const CACHE_READ_WEIGHT = 0.1;
+const CACHE_WRITE_WEIGHT = 2;
+
+const INITIAL_STAGE = 'setup';
+
+interface StageUsage {
+    messages: number;
+    inputTokens: number;
+    cacheWriteTokens: number;
+    cacheReadTokens: number;
+}
+
+const emptyStage = (): StageUsage => ({
+    messages: 0,
+    inputTokens: 0,
+    cacheWriteTokens: 0,
+    cacheReadTokens: 0,
+});
+
+const stageWeight = (stage: StageUsage): number =>
+    stage.inputTokens +
+    stage.cacheWriteTokens * CACHE_WRITE_WEIGHT +
+    stage.cacheReadTokens * CACHE_READ_WEIGHT;
+
+// The stage a tool-use call opens, or null if it carries no marker. When a single
+// command chains several markers, the last one wins.
+const stageOpenedBy = (input: Record<string, unknown> | undefined): string | null => {
+    const command = typeof input?.command === 'string' ? input.command : '';
+
+    return [...command.matchAll(STAGE_MARKER)].at(-1)?.[1] ?? null;
+};
+
+function attributeStageCosts(entries: unknown[]): {
+    stages: Map<string, StageUsage>;
+    warnings: Set<string>;
+} {
+    const stages = new Map<string, StageUsage>();
+    const countedMessageIds = new Set<string>();
+    const warnings = new Set<string>();
+    let currentStage = INITIAL_STAGE;
+
+    for (const rawEntry of entries) {
+        const parsed = AgentMessageEntrySchema.safeParse(rawEntry);
+        if (!parsed.success) continue; // skip system / user / result / rate-limit entries
+
+        const { message, parent_tool_use_id: parentToolUseId } = parsed.data;
+
+        // Flip the stage as soon as a marker appears, so the marker message itself
+        // is attributed to the stage it opens.
+        for (const block of message.content) {
+            if (block.type === 'tool_use')
+                currentStage = stageOpenedBy(block.input) ?? currentStage;
+        }
+
+        // --verbose repeats one message once per content block; count usage once.
+        if (countedMessageIds.has(message.id)) continue;
+        countedMessageIds.add(message.id);
+
+        if (parentToolUseId) warnings.add(`sub-agent activity attributed to "${currentStage}"`);
+
+        const usage = message.usage ?? {};
+        const stage = stages.get(currentStage) ?? emptyStage();
+        stage.messages += 1;
+        stage.inputTokens += usage.input_tokens ?? 0;
+        stage.cacheWriteTokens += usage.cache_creation_input_tokens ?? 0;
+        stage.cacheReadTokens += usage.cache_read_input_tokens ?? 0;
+        stages.set(currentStage, stage);
+    }
+
+    return { stages, warnings };
+}
+
+function formatTable(headers: string[], rows: string[][]): string {
+    const widths = headers.map((header, column) =>
+        Math.max(header.length, ...rows.map(row => (row[column] ?? '').length)),
+    );
+    const renderRow = (cells: string[]) =>
+        cells
+            .map((cell, column) => {
+                const width = widths[column] ?? 0;
+
+                return column === 0 ? cell.padEnd(width) : cell.padStart(width);
+            })
+            .join('  ');
+
+    return [renderRow(headers), ...rows.map(renderRow)].join('\n');
+}
+
+// Per-stage cost breakdown for terminal logging. Input and cache tokens are
+// attributed exactly per stage; the `~cost` column distributes the authoritative
+// total_cost_usd by each stage's input+cache weight. Output tokens cannot be placed
+// per stage, so they are folded into that split proportionally and also reported as
+// a run-level figure.
+export function formatStageBreakdown(
+    agent: AgentName,
+    entries: unknown[],
+    result: ClaudeResult,
+): string | null {
+    const { stages, warnings } = attributeStageCosts(entries);
+    if (stages.size === 0) return null;
+
+    const totalWeight = [...stages.values()].reduce((sum, stage) => sum + stageWeight(stage), 0);
+    const totalCost = result.total_cost_usd;
+
+    const rows = [...stages.entries()].map(([name, stage]) => {
+        const share = totalWeight > 0 ? stageWeight(stage) / totalWeight : 0;
+
+        return [
+            name,
+            String(stage.messages),
+            String(stage.inputTokens),
+            String(stage.cacheWriteTokens),
+            String(stage.cacheReadTokens),
+            `${(share * 100).toFixed(1)}%`,
+            totalCost !== undefined ? `$${(share * totalCost).toFixed(4)}` : '—',
+        ];
+    });
+
+    const table = formatTable(
+        ['stage', 'msgs', 'input', 'cache write', 'cache read', 'share', '~cost'],
+        rows,
+    );
+
+    const outputTokens = result.usage?.output_tokens ?? 0;
+    const footer =
+        `output: ${outputTokens} tok (run-level, folded into the split) ` +
+        (totalCost !== undefined ? `· run total: $${totalCost.toFixed(4)}` : '');
+
+    return [
+        `Stage cost breakdown — ${agent}`,
+        table,
+        footer,
+        ...[...warnings].map(w => `⚠ ${w}`),
+    ].join('\n');
+}


### PR DESCRIPTION
To be able to adjust and finetune fix agent we need a cost breakdown. This Pr introduces simple mechanism to breakdown price of agent run and post it to GHA terminal. Example:

```
━━━ Task fix-001 ━━━
Branch:  fix/nightly-2026-06-12-passphrase-confirm-modal-step
Web:     2  Desktop: 0

⚠ Sandbox disabled: sandbox.enabled is set but dependencies are missing: socat not installed · install missing tools (e.g. apt install bubblewrap socat) or run /sandbox for details
  Commands will run WITHOUT sandboxing. Network and filesystem restrictions will NOT be enforced.

[nightlyFixer] subtype=success
[TOKEN_USAGE] {"timestamp":"2026-06-14T20:02:36.725Z","run_id":"local","script":"nightlyFixer","model":"claude-sonnet-4-6","source":"cli","workflow":null,"pr_number":null,"input_tokens":23,"output_tokens":17981,"total_cost_usd":0.7807422}
Stage cost breakdown — nightlyFixer
stage      msgs  input  cache write  cache read  share    ~cost
setup         1      2        21108           0  20.0%  $0.1564
preflight    17     17        40886      665617  70.4%  $0.5494
finalize      3      3          794      186489   9.6%  $0.0750
output: 17981 tok (run-level, folded into the split) · run total: $0.7807
Agent done.
```

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All four changed files are within the `packages/e2e-utils/src/fixBot/` directory, which appears to be internal tooling for a "fix bot" (common utilities, notification, schemas, and stage cost logic). None of the 69 candidate E2E tests reference or exercise fixBot functionality based on the LLM analysis — the tests reference `@trezor/e2e-utils` only for `TestCategory`, `TestPriority`, `TestStream`, and `createTestAnnotation`, none of which reside in the fixBot module. There is no static coverage mapping for these files either. This change carries very low regression risk for user-facing functionality and no E2E tests need to be run.

<details><summary><b>Changed files (4)</b></summary>

- `packages/e2e-utils/src/fixBot/common.ts`
- `packages/e2e-utils/src/fixBot/notify.ts`
- `packages/e2e-utils/src/fixBot/schemas.ts`
- `packages/e2e-utils/src/fixBot/stageCost.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (4)**
- `packages/e2e-utils/src/fixBot/common.ts`
- `packages/e2e-utils/src/fixBot/notify.ts`
- `packages/e2e-utils/src/fixBot/schemas.ts`
- `packages/e2e-utils/src/fixBot/stageCost.ts`

_Updated: 2026-06-14T20:32:40.754Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/nightly-fix-agent-cost-detail/web/](https://dev.suite.sldev.cz/suite-web/nightly-fix-agent-cost-detail/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=nightly-fix-agent-cost-detail&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=nightly-fix-agent-cost-detail&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-14T20:37:44.706Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-14T20:36:16.103Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->