### PR TITLE
Pressing 'Escape' cancels the label editing

### DIFF
--- a/packages/product-components/src/components/EditableText/EditableText.tsx
+++ b/packages/product-components/src/components/EditableText/EditableText.tsx
@@ -340,16 +340,12 @@ export const EditableText = ({
         (e: React.KeyboardEvent<HTMLElement>) => {
             if (e.key !== 'Enter' && e.key !== 'Escape') return;
 
-            // Handle the shortcut on the focused element itself and stop propagation, so it is not
-            // shadowed by competing window-level handlers (e.g. a parent Modal closing on Escape).
             e.preventDefault();
             e.stopPropagation();
 
-            if (e.key === 'Enter') {
-                if (isDirty) {
-                    handleSave();
-                }
-            } else {
+            if (e.key === 'Enter' && isDirty) {
+                handleSave();
+            } else if (e.key === 'Escape') {
                 handleCancel();
             }
         },

--- a/packages/product-components/src/components/EditableText/EditableText.tsx
+++ b/packages/product-components/src/components/EditableText/EditableText.tsx
@@ -345,11 +345,11 @@ export const EditableText = ({
 
             if (e.key === 'Enter' && isDirty) {
                 handleSave();
-            } else if (e.key === 'Escape') {
+            } else if (e.key === 'Enter' || e.key === 'Escape') {
                 handleCancel();
             }
         },
-        [isDirty, handleSave, handleCancel],
+        [handleSave, handleCancel, isDirty],
     );
 
     const handleContainerClick = useCallback(

--- a/packages/product-components/src/components/EditableText/EditableText.tsx
+++ b/packages/product-components/src/components/EditableText/EditableText.tsx
@@ -20,7 +20,6 @@ import {
     SAVED_STATUS_TIMEOUT,
     escapeCssContent,
     extractTextFromNode,
-    useShortcuts,
     useTextTruncation,
 } from './utils';
 
@@ -337,6 +336,26 @@ export const EditableText = ({
         setSavingStatus('idle');
     }, []);
 
+    const handleKeyDown = useCallback(
+        (e: React.KeyboardEvent<HTMLElement>) => {
+            if (e.key !== 'Enter' && e.key !== 'Escape') return;
+
+            // Handle the shortcut on the focused element itself and stop propagation, so it is not
+            // shadowed by competing window-level handlers (e.g. a parent Modal closing on Escape).
+            e.preventDefault();
+            e.stopPropagation();
+
+            if (e.key === 'Enter') {
+                if (isDirty) {
+                    handleSave();
+                }
+            } else {
+                handleCancel();
+            }
+        },
+        [isDirty, handleSave, handleCancel],
+    );
+
     const handleContainerClick = useCallback(
         (e: React.MouseEvent<HTMLElement>) => {
             if (isEditable) {
@@ -393,8 +412,6 @@ export const EditableText = ({
         };
     }, [isEditable, handleCancel, handleSave, isDirty]);
 
-    useShortcuts({ isEditable, isDirty, handleSave, handleCancel });
-
     return (
         <Container
             ref={containerRef}
@@ -439,6 +456,7 @@ export const EditableText = ({
                         onInput={e => {
                             setCurrentValueTextContent(e.currentTarget.textContent || '');
                         }}
+                        onKeyDown={handleKeyDown}
                         onPaste={handlePaste}
                         $placeholder={placeholder}
                         $isEmpty={isEmpty}

--- a/packages/product-components/src/components/EditableText/utils.ts
+++ b/packages/product-components/src/components/EditableText/utils.ts
@@ -35,40 +35,6 @@ export const extractTextFromNode = (node: ReactNode): string => {
     return '';
 };
 
-type ShortcutsProps = {
-    isEditable: boolean;
-    isDirty: boolean;
-    handleSave: () => void;
-    handleCancel: () => void;
-};
-
-export const useShortcuts = ({ isEditable, isDirty, handleSave, handleCancel }: ShortcutsProps) => {
-    useEffect(() => {
-        if (!isEditable) return;
-
-        const downHandler = (e: KeyboardEvent) => {
-            if (isEditable) {
-                if (e.key === 'Enter' || e.key === 'Escape') {
-                    e.preventDefault();
-                    e.stopPropagation();
-
-                    if (e.key === 'Enter' && isDirty) {
-                        handleSave();
-                    } else if (e.key === 'Escape') {
-                        handleCancel();
-                    }
-                }
-            }
-        };
-
-        window.addEventListener('keydown', downHandler);
-
-        return () => {
-            window.removeEventListener('keydown', downHandler);
-        };
-    }, [handleCancel, handleSave, isEditable, isDirty]);
-};
-
 type UseTextTruncationProps = {
     elementRef: RefObject<HTMLElement | null>;
     isEditable: boolean;


### PR DESCRIPTION
Fixed the Escape to cancel the label edit.

## Notes for QA

**Happy paths**
- Labeling enabled (SuiteSync or Legacy) → edit **account label** → press `Esc` → editing cancelled, original value kept
- Edit **output/address label** in transaction detail modal → `Esc` → cancels edit **and** modal stays open
- Edit any label, change text → `Enter` → saves new value
- Edit label, no change → `Enter` → exits edit, value unchanged (no save)

**Edge cases**
- `Esc` inside transaction detail modal — verify modal does **not** close, only edit cancels
- Edit label → click outside / blur → verify expected save/cancel behavior unchanged
- Token transfer address label edit → `Esc`/`Enter` behave same as account labels
- Rapid `Enter` then `Esc` (or vice versa) mid-edit — no stuck/duplicate state
- Multiple editable labels on one screen — shortcuts only affect the focused one
- Empty label value → `Enter` — verify handled as before (no crash/save of empty)
- Regression check: account label edit `Esc` on **web** (original repro: T3W1, Chrome/Win)

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/28489


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect EditableText, a shared inline text editing component used primarily for metadata/labeling features (account labels, wallet labels, address labels, output labels). While it maps to 121 tests via transitive imports, its actual interactive usage is concentrated in the metadata/labeling test suite. The recommended strategy focuses on tests that directly exercise inline label editing (create, edit, cancel, remove) across different labeling providers (Dropbox, Google, Suite Sync) and entity types (accounts, wallets, addresses, outputs). Other tests that merely render the component without interactive editing are omitted.

<details><summary><b>Changed files (2)</b></summary>

- `packages/product-components/src/components/EditableText/EditableText.tsx`
- `packages/product-components/src/components/EditableText/utils.ts`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/metadata/legacy/account-metadata.test.ts` — EditableText is the core component for inline label editing. This test directly exercises editing account labels by typing, pressing Enter, clicking submit, pressing Escape to cancel, and clearing labels — all behaviors that depend on EditableText's input handling and utils.
- `suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — This test exercises editing transaction output labels via keyboard Enter, submit button click, and Escape cancel — directly exercising the EditableText component's input, submission, and cancellation behaviors.
- `suite/e2e/tests/metadata/legacy/wallet-metadata.test.ts` — This test adds and edits wallet labels in the device switcher, which uses EditableText for inline label editing. It verifies label persistence across reloads and editing labels on non-selected wallets.
- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — This test creates new account, wallet, address, and output labels via Suite Sync — all label editing flows use EditableText for the inline text input and confirmation behavior.
- `suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts` — This test removes previously synced labels (account, wallet, address, output) — the removal flow involves clearing the EditableText input and confirming, directly exercising the component's empty-value handling.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/metadata/legacy/address-metadata.test.ts` — This test adds and edits address labels using the metadata labeling UI, which relies on EditableText for inline label input. It covers adding a new label and editing an existing one.
- `suite/e2e/tests/metadata/legacy/dropbox-api-errors.test.ts` — This test edits account labels and verifies behavior when the save fails (label reverts to default). The revert-on-error behavior likely depends on EditableText's state management.
- `suite/e2e/tests/metadata/legacy/remembered-device.test.ts` — This test edits labels on remembered devices after provider disconnect/reconnect cycles. The label editing flow uses EditableText and tests its behavior across provider state changes.
- `suite/e2e/tests/metadata/legacy/switching-providers.test.ts` — This test adds custom labels via different metadata providers (Dropbox, Google), which involves inline label editing through EditableText. It verifies label values after provider switches.
- `suite/e2e/tests/metadata/legacy/metadata-lifecycle.test.ts` — This test exercises the full metadata labeling lifecycle including editing labels, disabling/re-enabling labeling, and verifying label state — all using EditableText for inline editing.
- `suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts` — This test edits account labels via the legacy Dropbox provider before migrating to Suite Sync. The label editing step directly uses EditableText for inline input.
- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — This test changes wallet and account labels across multiple passphrase wallets via Suite Sync, exercising EditableText for inline label editing in multi-wallet contexts.

</details>

_Updated: 2026-06-16T12:19:15.022Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/esc-button-press&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/esc-button-press&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-16T12:23:45.730Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-16T12:22:48.917Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/esc-button-press/web/](https://dev.suite.sldev.cz/suite-web/fix/esc-button-press/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->