### PR TITLE
Feat/suite sync success toasts

### DIFF
--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
@@ -392,6 +392,13 @@ export const NotificationRenderer = ({
                 values: { error: notification.error },
             });
 
+        case 'suite-sync-enabled':
+            return renderNotificationView(render, notification, {
+                variant: 'success',
+                message: 'TR_SUITE_SYNC_ENABLED_SUCCESS',
+                icon: 'check',
+            });
+
         case 'tx-received':
             return (
                 <TransactionRenderer

--- a/suite-common/toast-notifications/src/types.ts
+++ b/suite-common/toast-notifications/src/types.ts
@@ -136,6 +136,7 @@ export type ToastPayload<TranslationKey extends UnknownTranslationKey = UnknownT
               | 'thp-credentials-reset'
               | 'sign-transaction-timeout'
               | 'suite-sync-keys-error'
+              | 'suite-sync-enabled'
               | 'bip-329-labels-imported';
       }
     | {

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -83,6 +83,7 @@ export const messages = {
     suiteSync: {
         label: 'Label',
         addLabel: 'Add label',
+        enabledToast: 'Suite Sync turned on successfully.',
         disableAlert: {
             title: 'Turn off Suite Sync?',
             description:

--- a/suite-native/module-settings/src/components/ToggleSuiteSyncCard.tsx
+++ b/suite-native/module-settings/src/components/ToggleSuiteSyncCard.tsx
@@ -15,11 +15,13 @@ import { TouchableSwitchRow } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { StorageContext } from '@suite-native/storage';
 import { useSuiteSyncErrorHandler } from '@suite-native/suite-sync';
+import { useToast } from '@suite-native/toasts';
 
 export const ToggleSuiteSyncCard = () => {
     const { analytics } = useServices(selectNativeAnalyticsDep);
     const storageContext = useContext(StorageContext);
     const { showAlert } = useAlert();
+    const { showToast } = useToast();
 
     const { turnOffSuiteSync, turnOnSuiteSync } = useServices(
         selectTurnOffSuiteSyncDep,
@@ -66,7 +68,13 @@ export const ToggleSuiteSyncCard = () => {
                 },
             });
 
-            if (!result.success) {
+            if (result.success) {
+                showToast({
+                    intent: 'neutral',
+                    icon: 'check',
+                    message: <Translation id="suiteSync.enabledToast" />,
+                });
+            } else {
                 handleSuiteSyncError(result.error);
             }
         }

--- a/suite-native/module-settings/src/components/ToggleSuiteSyncCard.tsx
+++ b/suite-native/module-settings/src/components/ToggleSuiteSyncCard.tsx
@@ -14,14 +14,13 @@ import { events as nativeEvents, selectNativeAnalyticsDep } from '@suite-native/
 import { TouchableSwitchRow } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { StorageContext } from '@suite-native/storage';
-import { useSuiteSyncErrorHandler } from '@suite-native/suite-sync';
-import { useToast } from '@suite-native/toasts';
+import { useShowSuiteSyncEnabledToast, useSuiteSyncErrorHandler } from '@suite-native/suite-sync';
 
 export const ToggleSuiteSyncCard = () => {
     const { analytics } = useServices(selectNativeAnalyticsDep);
     const storageContext = useContext(StorageContext);
     const { showAlert } = useAlert();
-    const { showToast } = useToast();
+    const { showSuiteSyncEnabledToast } = useShowSuiteSyncEnabledToast();
 
     const { turnOffSuiteSync, turnOnSuiteSync } = useServices(
         selectTurnOffSuiteSyncDep,
@@ -69,11 +68,7 @@ export const ToggleSuiteSyncCard = () => {
             });
 
             if (result.success) {
-                showToast({
-                    intent: 'neutral',
-                    icon: 'check',
-                    message: <Translation id="suiteSync.enabledToast" />,
-                });
+                showSuiteSyncEnabledToast();
             } else {
                 handleSuiteSyncError(result.error);
             }

--- a/suite-native/suite-sync/src/index.ts
+++ b/suite-native/suite-sync/src/index.ts
@@ -1,3 +1,4 @@
 export { createSuiteSyncNativeCompositionRoot } from './createSuiteSyncNativeCompositionRoot';
+export { useShowSuiteSyncEnabledToast } from './useShowSuiteSyncEnabledToast';
 export { useSuiteSyncErrorHandler } from './useSuiteSyncErrorHandler';
 export { useTurnOnSuiteSyncGuard } from './useTurnOnSuiteSyncGuard';

--- a/suite-native/suite-sync/src/useShowSuiteSyncEnabledToast.tsx
+++ b/suite-native/suite-sync/src/useShowSuiteSyncEnabledToast.tsx
@@ -1,0 +1,16 @@
+import { Translation } from '@suite-native/intl';
+import { useToast } from '@suite-native/toasts';
+
+export const useShowSuiteSyncEnabledToast = () => {
+    const { showToast } = useToast();
+
+    const showSuiteSyncEnabledToast = () => {
+        showToast({
+            intent: 'neutral',
+            icon: 'check',
+            message: <Translation id="suiteSync.enabledToast" />,
+        });
+    };
+
+    return { showSuiteSyncEnabledToast };
+};

--- a/suite-native/suite-sync/src/useTurnOnSuiteSyncGuard.tsx
+++ b/suite-native/suite-sync/src/useTurnOnSuiteSyncGuard.tsx
@@ -26,6 +26,7 @@ import { useToast } from '@suite-native/toasts';
 import { exhaustive } from '@trezor/type-utils';
 
 import { suiteSyncErrorMessageMap } from './suiteSyncErrorMessages';
+import { useShowSuiteSyncEnabledToast } from './useShowSuiteSyncEnabledToast';
 
 export const useTurnOnSuiteSyncGuard = () => {
     const { showAlert } = useAlert();
@@ -36,6 +37,7 @@ export const useTurnOnSuiteSyncGuard = () => {
     );
 
     const { showToast } = useToast();
+    const { showSuiteSyncEnabledToast } = useShowSuiteSyncEnabledToast();
     const { translate } = useTranslate();
     const navigation =
         useNavigation<
@@ -112,11 +114,7 @@ export const useTurnOnSuiteSyncGuard = () => {
             }
         }
 
-        showToast({
-            intent: 'neutral',
-            icon: 'check',
-            message: <Translation id="suiteSync.enabledToast" />,
-        });
+        showSuiteSyncEnabledToast();
 
         onSuccess();
     };

--- a/suite-native/suite-sync/src/useTurnOnSuiteSyncGuard.tsx
+++ b/suite-native/suite-sync/src/useTurnOnSuiteSyncGuard.tsx
@@ -112,6 +112,12 @@ export const useTurnOnSuiteSyncGuard = () => {
             }
         }
 
+        showToast({
+            intent: 'neutral',
+            icon: 'check',
+            message: <Translation id="suiteSync.enabledToast" />,
+        });
+
         onSuccess();
     };
 

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -11807,6 +11807,10 @@ export const messages = defineMessages({
         id: 'TR_TURN_ON_SECURE_SYNC_LABELS_MODAL_HEADING',
         defaultMessage: 'Turn on Suite Sync',
     },
+    TR_SUITE_SYNC_ENABLED_SUCCESS: {
+        id: 'TR_SUITE_SYNC_ENABLED_SUCCESS',
+        defaultMessage: 'Suite Sync turned on successfully.',
+    },
     TR_TURN_ON_SECURE_SYNC_DATA_STORED_LOCALLY: {
         id: 'TR_TURN_ON_SECURE_SYNC_DATA_STORED_LOCALLY',
         defaultMessage: 'Securely sync your labels and names between mobile & desktop.',

--- a/suite/suite-sync/src/SuiteSyncTurnOnModal.tsx
+++ b/suite/suite-sync/src/SuiteSyncTurnOnModal.tsx
@@ -78,6 +78,8 @@ export const SuiteSyncTurnOnModal = ({
             }
         }
 
+        dispatch(notificationsActions.addToast({ type: 'suite-sync-enabled' }));
+
         onSuccess?.();
     };
 


### PR DESCRIPTION
Added a succesfull toasts for turning on SS.

## Notes for QA

**Happy paths**
- Desktop/web — turn on Suite Sync via modal → success toast `Suite Sync turned on successfully.`
- Mobile — enable Suite Sync via settings toggle → same success toast
- Mobile — enable via turn-on guard flow → same success toast (check icon, no duplicate)

**Edge cases**
- Enable fails (keys error / cancelled) — verify NO success toast, only error handling
- Turn OFF Suite Sync — verify no success toast appears
- Toggle on→off→on — verify toast each enable, not stale/duplicated
- Mobile — confirm toast fires once when both toggle + guard paths could overlap (no double toast)
- Re-enable already-synced wallet — verify toast still shows

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/28243

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes primarily affect Suite Sync functionality (SuiteSyncTurnOnModal, suite-sync hooks, intl messages) and the toast notification system (NotificationRenderer, toast types). The highest risk is to Suite Sync E2E flows which directly exercise the changed modal and enablement logic. Secondary risk is to tests that assert on specific toast notifications, since NotificationRenderer and toast types are shared infrastructure. Most of the 121 tests mapped via static coverage are only transitively dependent and don't need to run. The suite-native/* files have no web E2E coverage as they are mobile-only.

<details><summary><b>Changed files (9)</b></summary>

- `packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx`
- `suite-common/toast-notifications/src/types.ts`
- `suite-native/intl/src/messages.ts`
- `suite-native/module-settings/src/components/ToggleSuiteSyncCard.tsx`
- `suite-native/suite-sync/src/index.ts`
- `suite-native/suite-sync/src/useShowSuiteSyncEnabledToast.tsx`
- `suite-native/suite-sync/src/useTurnOnSuiteSyncGuard.tsx`
- `suite/intl/src/messages.ts`
- `suite/suite-sync/src/SuiteSyncTurnOnModal.tsx`

</details>

**Recommended tests (16)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — This test directly exercises Suite Sync label creation and syncing to Evolu Relay. The changes to suite/suite-sync/src/SuiteSyncTurnOnModal.tsx and suite/intl/src/messages.ts (which contains Suite Sync related translations) directly affect the Suite Sync enablement flow that this test triggers via metadataPage.enableSuiteSync.
- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — This test covers Suite Sync enablement across multiple wallets including the Suite Sync banner and enabling Suite Sync via device confirmation (confirmSuiteSyncSetup). Changes to the SuiteSyncTurnOnModal and intl messages directly impact the modal and banner text used in this flow.
- `suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts` — This test enables Suite Sync and then removes labels, verifying the sync flow. The SuiteSyncTurnOnModal changes affect the initial enablement step, and any toast notification changes from NotificationRenderer or toast types could affect the UI during label operations.
- `suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — This test covers the full Suite Sync flow including device-specific confirmation prompts and label syncing from Evolu relay. The SuiteSyncTurnOnModal is directly exercised when initiating Suite Sync setup, and intl message changes could affect displayed text.
- `suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts` — This test migrates labels from legacy local file labeling to Suite Sync and verifies a toast notification '@toast/legacy-labeling-migration-success'. Changes to NotificationRenderer and toast-notifications/types.ts could affect how this migration success toast renders, and the SuiteSyncTurnOnModal change affects the enableSuiteSync step.
- `suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts` — This test migrates Dropbox labels to Suite Sync by seeding Evolu relay data and enabling Suite Sync. The SuiteSyncTurnOnModal is part of that enablement flow, and intl messages may contain related translation keys.

</details>

<details><summary>🟡 <b>Medium priority (8)</b></summary>

- `suite/e2e/tests/backup/t2t1-fail.test.ts` — This test explicitly asserts on toast notifications (@toast/backup-failed) and error banners. Changes to NotificationRenderer and toast notification types could affect how the backup-failed toast is rendered or whether it appears at all.
- `suite/e2e/tests/backup/t2t1-success.test.ts` — This test verifies analytics for backup creation and relies on the backup flow completing, but doesn't directly assert on toast notifications. However, the backup flow uses device confirmation prompts rendered through the notification system.
- `suite/e2e/tests/settings/passphrase.test.ts` — This test explicitly asserts that a '@toast/settings-applied' toast notification appears and then disappears. Changes to NotificationRenderer and toast types directly affect whether this toast renders correctly.
- `suite/e2e/tests/settings/t1b1-device-settings.test.ts` — This test asserts on '@toast/pin-changed' and '@pin-mismatch' toast notifications. Changes to the NotificationRenderer and toast types could affect rendering of these specific toast notifications.
- `suite/e2e/tests/wallet/sign-and-verify-eth.test.ts` — This test asserts on '@toast/sign-message-success' and '@toast/verify-message-success' toast notifications. Changes to NotificationRenderer and toast types could affect these toast renderings.
- `suite/e2e/tests/suite/bug-report-form.test.ts` — This test asserts on '@toast/user-feedback-send-success' toast notification visibility. NotificationRenderer changes could affect how this feedback success toast is rendered.
- `suite/e2e/tests/metadata/legacy/dropbox-api-errors.test.ts` — This test asserts on '@toast/error' toast notifications when Dropbox API returns errors. Changes to NotificationRenderer could affect how error toasts are rendered.
- `suite/e2e/tests/metadata/legacy/google-api-errors.test.ts` — This test asserts on '@toast/error' toast notification when Google API returns authentication errors. NotificationRenderer changes could affect error toast rendering.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/wallet/send-doge.test.ts` — This test asserts on '@toast/sign-tx-error' toast notification. While this is a specific toast assertion, the DOGE send flow is fairly isolated from Suite Sync changes.
- `suite/e2e/tests/settings/forget-device.test.ts` — This test verifies toast notification for device forgotten (verifyToastDeviceForgotten). Changes to NotificationRenderer and toast types could plausibly affect this toast.

</details>

⚠️ **Changes with no test coverage (5)**
- `suite-native/intl/src/messages.ts`
- `suite-native/module-settings/src/components/ToggleSuiteSyncCard.tsx`
- `suite-native/suite-sync/src/index.ts`
- `suite-native/suite-sync/src/useShowSuiteSyncEnabledToast.tsx`
- `suite-native/suite-sync/src/useTurnOnSuiteSyncGuard.tsx`

_Updated: 2026-06-22T14:17:10.383Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/suite-sync-success-toasts/web/](https://dev.suite.sldev.cz/suite-web/feat/suite-sync-success-toasts/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/suite-sync-success-toasts&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/suite-sync-success-toasts&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/suite-sync-success-toasts&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-22T14:22:11.136Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-22T14:20:42.452Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->