### PR TITLE
fix(trading): clear stale quotes and derive payment methods from quotes

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/common/__tests__/useTradingClearStaleQuotes.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/common/__tests__/useTradingClearStaleQuotes.test.tsx
@@ -1,0 +1,85 @@
+import { renderHookWithStoreProvider } from '@suite-common/test-utils';
+import {
+    type TradingType,
+    tradingBuyActions,
+    tradingExchangeActions,
+    tradingSellActions,
+} from '@suite-common/trading';
+
+import { configureStore } from 'src/support/tests/configureStore';
+
+import { useTradingClearStaleQuotes } from '../useTradingClearStaleQuotes';
+
+const clearQuotesActionTypeByType = {
+    buy: tradingBuyActions.clearQuotes.type,
+    sell: tradingSellActions.clearQuotes.type,
+    exchange: tradingExchangeActions.clearQuotes.type,
+} satisfies Record<TradingType, string>;
+
+const getState = (type: TradingType, hasQuotes: boolean) => ({
+    wallet: {
+        trading: {
+            buy: { quotes: type === 'buy' && hasQuotes ? [{ id: '1' }] : [] },
+            sell: { quotes: type === 'sell' && hasQuotes ? [{ id: '1' }] : [] },
+            exchange: { quotes: type === 'exchange' && hasQuotes ? [{ id: '1' }] : [] },
+        },
+    },
+});
+
+const renderClearStaleQuotes = (
+    state: ReturnType<typeof getState>,
+    props: { type: TradingType; isEnabled: boolean; isAmountEmpty: boolean },
+) => {
+    const store = configureStore()(state);
+
+    renderHookWithStoreProvider(() => useTradingClearStaleQuotes(props), { store });
+
+    return store;
+};
+
+const tradingTypes: TradingType[] = ['buy', 'sell', 'exchange'];
+
+describe('useTradingClearStaleQuotes', () => {
+    it.each(tradingTypes)(
+        'dispatches %s clearQuotes when enabled, amount is empty and quotes exist',
+        type => {
+            const store = renderClearStaleQuotes(getState(type, true), {
+                type,
+                isEnabled: true,
+                isAmountEmpty: true,
+            });
+
+            expect(store.getActions()).toEqual([{ type: clearQuotesActionTypeByType[type] }]);
+        },
+    );
+
+    it('does not dispatch when amount is not empty', () => {
+        const store = renderClearStaleQuotes(getState('buy', true), {
+            type: 'buy',
+            isEnabled: true,
+            isAmountEmpty: false,
+        });
+
+        expect(store.getActions()).toEqual([]);
+    });
+
+    it('does not dispatch when there are no quotes to clear', () => {
+        const store = renderClearStaleQuotes(getState('buy', false), {
+            type: 'buy',
+            isEnabled: true,
+            isAmountEmpty: true,
+        });
+
+        expect(store.getActions()).toEqual([]);
+    });
+
+    it('does not dispatch when disabled', () => {
+        const store = renderClearStaleQuotes(getState('buy', true), {
+            type: 'buy',
+            isEnabled: false,
+            isAmountEmpty: true,
+        });
+
+        expect(store.getActions()).toEqual([]);
+    });
+});

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingClearStaleQuotes.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingClearStaleQuotes.ts
@@ -1,0 +1,38 @@
+import { useEffect } from 'react';
+
+import {
+    type TradingType,
+    selectTradingQuotesByType,
+    tradingBuyActions,
+    tradingExchangeActions,
+    tradingSellActions,
+} from '@suite-common/trading';
+
+import { useDispatch, useSelector } from 'src/hooks/suite';
+
+type UseTradingClearStaleQuotesProps = {
+    type: TradingType;
+    isEnabled: boolean;
+    isAmountEmpty: boolean;
+};
+
+const clearQuotesActionByType = {
+    buy: tradingBuyActions.clearQuotes,
+    sell: tradingSellActions.clearQuotes,
+    exchange: tradingExchangeActions.clearQuotes,
+} satisfies Record<TradingType, unknown>;
+
+export const useTradingClearStaleQuotes = ({
+    type,
+    isEnabled,
+    isAmountEmpty,
+}: UseTradingClearStaleQuotesProps) => {
+    const dispatch = useDispatch();
+    const hasQuotes = useSelector(state => selectTradingQuotesByType(state, type).length > 0);
+
+    useEffect(() => {
+        if (isEnabled && isAmountEmpty && hasQuotes) {
+            dispatch(clearQuotesActionByType[type]());
+        }
+    }, [type, isEnabled, isAmountEmpty, hasQuotes, dispatch]);
+};

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
@@ -15,21 +15,17 @@ import {
     TRADING_FORM_PROVIDER_SELECT,
     type TradingAmountLimitProps,
     type TradingBuyFormProps,
-    type TradingBuyType,
     buyThunks,
-    getTradingQuotesByPaymentMethod,
     isCountrySubdivisionEmpty,
     mapFiatCurrencyCodeToBaseCurrencyCode,
     selectTradingBuyAmountLimits,
     selectTradingBuyInfo,
     selectTradingBuyIsFromRedirect,
     selectTradingBuyIsLoading,
-    selectTradingBuyQuotes,
+    selectTradingBuyQuotesByPaymentMethod,
     selectTradingBuyQuotesRequest,
     selectTradingBuySelectedQuote,
-    selectTradingPaymentMethods,
     selectTradingVerifiedAddress,
-    tradingActions,
     tradingBuyActions,
     tradingThunks,
 } from '@suite-common/trading';
@@ -53,6 +49,7 @@ import {
 } from 'src/types/trading/tradingForm';
 import { createQuoteLink, createTxLink } from 'src/utils/wallet/trading/buyUtils';
 
+import { useTradingClearStaleQuotes } from './common/useTradingClearStaleQuotes';
 import { useTradingFiatValues } from './common/useTradingFiatValues';
 import { useTradingInitializer } from './common/useTradingInitializer';
 import { useTradingFormAccount } from './useTradingFormAccount';
@@ -68,14 +65,12 @@ export const useTradingBuyForm = ({
 
     const buyInfo = useSelector(selectTradingBuyInfo);
     const isFromRedirect = useSelector(selectTradingBuyIsFromRedirect);
-    const quotes = useSelector(selectTradingBuyQuotes);
     const quotesRequest = useSelector(selectTradingBuyQuotesRequest);
     const selectedQuote = useSelector(selectTradingBuySelectedQuote);
     const amountLimits = useSelector(selectTradingBuyAmountLimits);
     const isLoading = useSelector(selectTradingBuyIsLoading);
 
     const verifiedAddress = useSelector(selectTradingVerifiedAddress);
-    const paymentMethods = useSelector(selectTradingPaymentMethods);
 
     const { device } = useTradingInitializer({
         pageType,
@@ -101,13 +96,8 @@ export const useTradingBuyForm = ({
           };
     useTradingFiatValues(fiatTradingValuesParams);
 
-    const {
-        defaultValues,
-        defaultSubdivision,
-        defaultCountry,
-        defaultCurrency,
-        defaultPaymentMethod,
-    } = useTradingBuyFormDefaultValues(cryptoId, buyInfo);
+    const { defaultValues, defaultSubdivision, defaultCountry, defaultCurrency } =
+        useTradingBuyFormDefaultValues(cryptoId, buyInfo);
     const redirectValues = useTradingBuyFormRedirectValues(isFromRedirect, quotesRequest);
     const shouldSkipInitialReset = !isFormPage;
     const methods = useForm<TradingBuyFormProps>({
@@ -139,9 +129,8 @@ export const useTradingBuyForm = ({
     const isFormInvalid = !(formIsValid && hasValues) || !isReceiveAddressFormValid;
     const isLoadingOrInvalid = noProviders || isFormLoading || isFormInvalid;
 
-    const quotesByPaymentMethod = getTradingQuotesByPaymentMethod<TradingBuyType>(
-        quotes,
-        values?.paymentMethod?.value ?? '',
+    const quotesByPaymentMethod = useSelector(state =>
+        selectTradingBuyQuotesByPaymentMethod(state, values?.paymentMethod?.value),
     );
     // based on selected cryptoSymbol, because of using for validation cryptoInput
     const network = getNetwork(
@@ -277,20 +266,13 @@ export const useTradingBuyForm = ({
             }
 
             if (quotePaymentMethod && paymentMethod?.value !== quotePaymentMethod) {
-                const matchingOption = paymentMethods.find(
-                    method => method.value === quotePaymentMethod,
-                );
-
-                setValue(
-                    TRADING_FORM_PAYMENT_METHOD_SELECT,
-                    matchingOption ?? {
-                        value: quotePaymentMethod,
-                        label: quote.paymentMethodName ?? quotePaymentMethod,
-                    },
-                );
+                setValue(TRADING_FORM_PAYMENT_METHOD_SELECT, {
+                    value: quotePaymentMethod,
+                    label: quote.paymentMethodName ?? quotePaymentMethod,
+                });
             }
         },
-        [paymentMethod, paymentMethods, provider, setValue],
+        [paymentMethod, provider, setValue],
     );
 
     useEffect(() => {
@@ -325,6 +307,8 @@ export const useTradingBuyForm = ({
             handleSubmit,
         ],
     );
+
+    useTradingClearStaleQuotes({ type, isEnabled: isFormPage, isAmountEmpty });
 
     // call change handler on every change of select inputs
     useEffect(() => {
@@ -408,8 +392,6 @@ export const useTradingBuyForm = ({
         defaultCountry,
         defaultSubdivision,
         defaultCurrency,
-        defaultPaymentMethod,
-        paymentMethods,
         buyInfo,
         amountLimits,
         network,
@@ -430,7 +412,6 @@ export const useTradingBuyForm = ({
         },
         clearQuotesAndParams: () => {
             dispatch(tradingBuyActions.clearQuotesAndParams());
-            dispatch(tradingActions.savePaymentMethods([]));
         },
     };
 };

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingBuyFormDefaultValues.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingBuyFormDefaultValues.ts
@@ -7,7 +7,6 @@ import {
     TRADING_DEFAULT_PAYMENT_METHOD,
     type TradingBuyInfoSelector,
     type TradingCountryCode,
-    type TradingPaymentMethodListProps,
     buildTradingFiatOption,
     getDefaultCountry,
     getDefaultCountrySubdivision,
@@ -47,14 +46,6 @@ export const useTradingBuyFormDefaultValues = (
         return createAssetOptionFromCryptoId(cryptoId);
     }, [createAssetOptionFromCryptoId, cryptoId, coins]);
 
-    const defaultPaymentMethod: TradingPaymentMethodListProps = useMemo(
-        () => ({
-            value: TRADING_DEFAULT_PAYMENT_METHOD,
-            label: '',
-        }),
-        [],
-    );
-
     const baseCurrencyCode = useSelector(selectBaseCurrency);
     const suggestedFiatCurrency = getSupportedFiatCurrencyWithFallback(baseCurrencyCode);
     const defaultCurrency = useMemo(
@@ -69,12 +60,12 @@ export const useTradingBuyFormDefaultValues = (
             cryptoSelect: defaultCrypto,
             countrySelect: defaultCountry,
             countrySubdivisionSelect: defaultSubdivision,
-            paymentMethod: defaultPaymentMethod,
+            paymentMethod: { value: TRADING_DEFAULT_PAYMENT_METHOD, label: '' },
             provider: undefined,
             amountInCrypto: false,
             receiveAddress: undefined,
         }),
-        [defaultCountry, defaultCrypto, defaultCurrency, defaultPaymentMethod, defaultSubdivision],
+        [defaultCountry, defaultCrypto, defaultCurrency, defaultSubdivision],
     );
 
     return {
@@ -82,7 +73,6 @@ export const useTradingBuyFormDefaultValues = (
         defaultCountry,
         defaultSubdivision,
         defaultCurrency,
-        defaultPaymentMethod,
         suggestedFiatCurrency,
     };
 };

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -74,6 +74,7 @@ import {
 import { createQuoteLink } from 'src/utils/wallet/trading/exchangeUtils';
 
 import { useTradingAssetDecimals } from './common/useTradingAssetDecimals';
+import { useTradingClearStaleQuotes } from './common/useTradingClearStaleQuotes';
 import { useTradingInitializer } from './common/useTradingInitializer';
 import { useTradingFormAccount } from './useTradingFormAccount';
 import { useTradingReceiveAddress } from './useTradingReceiveAddress';
@@ -245,6 +246,8 @@ export const useTradingExchangeForm = ({
         },
         setIsScheduledQuotesRefresh,
     });
+
+    useTradingClearStaleQuotes({ type, isEnabled: isFormPage, isAmountEmpty });
 
     const helpers = useTradingFormActions({
         account,

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
@@ -17,26 +17,22 @@ import {
     TRADING_FORM_PROVIDER_SELECT,
     type TradingAmountLimitProps,
     type TradingSellFormProps,
-    type TradingSellType,
     type TradingSignAndPushSendFormTransactionProps,
     type TradingTransactionSell,
-    getTradingQuotesByPaymentMethod,
     isSendRejectedError,
     selectTradingComposedTransactionInfo,
     selectTradingIsSlip24Allowed,
-    selectTradingPaymentMethods,
     selectTradingSellAmountLimits,
     selectTradingSellInfo,
     selectTradingSellIsFromRedirect,
     selectTradingSellIsLoading,
-    selectTradingSellQuotes,
+    selectTradingSellQuotesByPaymentMethod,
     selectTradingSellQuotesRequest,
     selectTradingSellSelectedQuote,
     selectTradingSellTransactionId,
     selectTradingTrades,
     sellThunks,
     sellUtils,
-    tradingActions,
     tradingSellActions,
     tradingThunks,
 } from '@suite-common/trading';
@@ -60,6 +56,7 @@ import { type TradingSellFormContextProps } from 'src/types/trading/tradingForm'
 import { createQuoteLink } from 'src/utils/wallet/trading/sellUtils';
 
 import { useTradingAssetDecimals } from './common/useTradingAssetDecimals';
+import { useTradingClearStaleQuotes } from './common/useTradingClearStaleQuotes';
 import { useTradingInitializer } from './common/useTradingInitializer';
 import { useTradingFormAccount } from './useTradingFormAccount';
 
@@ -74,12 +71,10 @@ export const useTradingSellForm = ({
     const isLoading = useSelector(selectTradingSellIsLoading);
     const quotesRequest = useSelector(selectTradingSellQuotesRequest);
     const isFromRedirect = useSelector(selectTradingSellIsFromRedirect);
-    const quotes = useSelector(selectTradingSellQuotes);
     const transactionId = useSelector(selectTradingSellTransactionId);
     const selectedQuote = useSelector(selectTradingSellSelectedQuote);
     const sellInfo = useSelector(selectTradingSellInfo);
     const amountLimits = useSelector(selectTradingSellAmountLimits);
-    const paymentMethods = useSelector(selectTradingPaymentMethods);
 
     const [showReserveBanner, setShowReserveBanner] = useState<boolean>(false);
 
@@ -116,18 +111,13 @@ export const useTradingSellForm = ({
             trade.tradeType === 'sell' && trade.key === transactionId,
     );
 
-    const {
-        defaultValues,
-        defaultCountry,
-        defaultSubdivision,
-        defaultCurrency,
-        defaultPaymentMethod,
-    } = useTradingSellFormDefaultValues(
-        accountKey,
-        cryptoId,
-        sellInfo?.country,
-        sellInfo?.countrySubdivision,
-    );
+    const { defaultValues, defaultCountry, defaultSubdivision, defaultCurrency } =
+        useTradingSellFormDefaultValues(
+            accountKey,
+            cryptoId,
+            sellInfo?.country,
+            sellInfo?.countrySubdivision,
+        );
     const redirectValues = useTradingSellFormRedirectValues(isFromRedirect, quotesRequest);
     const shouldSkipInitialReset = !isFormPage;
     const shouldResetOnInitialSellInfoLoad = useRef(!sellInfo);
@@ -146,9 +136,8 @@ export const useTradingSellForm = ({
     const noProviders = Object.keys(sellInfo?.providerInfos ?? {}).length === 0;
     const isInitialDataLoading = !sellInfo?.providerInfos;
 
-    const quotesByPaymentMethod = getTradingQuotesByPaymentMethod<TradingSellType>(
-        quotes,
-        values?.paymentMethod?.value ?? '',
+    const quotesByPaymentMethod = useSelector(state =>
+        selectTradingSellQuotesByPaymentMethod(state, values?.paymentMethod?.value),
     );
     const { getAssetDecimals } = useTradingAssetDecimals();
     const decimals = useMemo(
@@ -203,6 +192,8 @@ export const useTradingSellForm = ({
         },
         setValue,
     });
+
+    useTradingClearStaleQuotes({ type, isEnabled: isFormPage, isAmountEmpty });
 
     const helpers = useTradingFormActions({
         account,
@@ -418,20 +409,13 @@ export const useTradingSellForm = ({
             }
 
             if (quotePaymentMethod && paymentMethod?.value !== quotePaymentMethod) {
-                const matchingOption = paymentMethods.find(
-                    method => method.value === quotePaymentMethod,
-                );
-
-                setValue(
-                    TRADING_FORM_PAYMENT_METHOD_SELECT,
-                    matchingOption ?? {
-                        value: quotePaymentMethod,
-                        label: quote.paymentMethodName ?? quotePaymentMethod,
-                    },
-                );
+                setValue(TRADING_FORM_PAYMENT_METHOD_SELECT, {
+                    value: quotePaymentMethod,
+                    label: quote.paymentMethodName ?? quotePaymentMethod,
+                });
             }
         },
-        [paymentMethod, paymentMethods, provider, setValue],
+        [paymentMethod, provider, setValue],
     );
 
     // react-hook-form auto register custom form fields (without HTMLElement)
@@ -490,8 +474,6 @@ export const useTradingSellForm = ({
         defaultCountry,
         defaultSubdivision,
         defaultCurrency,
-        defaultPaymentMethod,
-        paymentMethods,
         sellInfo,
         quotesRequest,
         quotes: quotesByPaymentMethod,
@@ -518,7 +500,6 @@ export const useTradingSellForm = ({
         showReserveBanner,
         setShowReserveBanner,
         clearQuotesAndParams: () => {
-            dispatch(tradingActions.savePaymentMethods([]));
             dispatch(tradingSellActions.clearQuotesAndParams());
         },
     };

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellFormDefaultValues.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellFormDefaultValues.ts
@@ -6,7 +6,6 @@ import { selectTorState } from '@suite/tor';
 import {
     TRADING_DEFAULT_PAYMENT_METHOD,
     type TradingCountryCode,
-    type TradingPaymentMethodListProps,
     buildTradingBaseCurrencyOptionFromFiat,
     buildTradingFiatOption,
     getDefaultCountry,
@@ -47,13 +46,6 @@ export const useTradingSellFormDefaultValues = (
 
     const { address, token } = resolveAddressAndToken(account, defaultAsset?.contractAddress);
 
-    const defaultPaymentMethod: TradingPaymentMethodListProps = useMemo(
-        () => ({
-            value: TRADING_DEFAULT_PAYMENT_METHOD,
-            label: '',
-        }),
-        [],
-    );
     const baseCurrencyCode = useSelector(selectBaseCurrency);
     const defaultCurrency = useMemo(
         () => buildTradingFiatOption(getSupportedFiatCurrencyWithFallback(baseCurrencyCode)),
@@ -83,10 +75,10 @@ export const useTradingSellFormDefaultValues = (
             sendCryptoSelect: defaultAsset,
             countrySelect: defaultCountry,
             countrySubdivisionSelect: defaultSubdivision,
-            paymentMethod: defaultPaymentMethod,
+            paymentMethod: { value: TRADING_DEFAULT_PAYMENT_METHOD, label: '' },
             amountInCrypto: true,
         }),
-        [defaultFormState, defaultAsset, defaultCountry, defaultPaymentMethod, defaultSubdivision],
+        [defaultFormState, defaultAsset, defaultCountry, defaultSubdivision],
     );
 
     return {
@@ -94,6 +86,5 @@ export const useTradingSellFormDefaultValues = (
         defaultCountry,
         defaultSubdivision,
         defaultCurrency,
-        defaultPaymentMethod,
     };
 };

--- a/packages/suite/src/types/trading/tradingForm.ts
+++ b/packages/suite/src/types/trading/tradingForm.ts
@@ -32,7 +32,6 @@ import type {
     TradingExchangeInfoSelector,
     TradingExchangeType,
     TradingFiatCurrencyOption,
-    TradingPaymentMethodListProps,
     TradingPaymentMethodType,
     TradingSellFormProps,
     TradingSellInfoSelector,
@@ -70,7 +69,6 @@ export interface TradingBuyFormDefaultValuesProps {
     defaultValues: TradingBuyFormProps;
     defaultCountry: TradingCountryOption;
     defaultCurrency: TradingFiatCurrencyOption;
-    defaultPaymentMethod: TradingPaymentMethodListProps;
     suggestedFiatCurrency: FiatCurrencyCode;
     defaultSubdivision: TradingCountrySubdivisionOption | undefined;
 }
@@ -86,7 +84,6 @@ export interface TradingSellFormDefaultValuesProps {
     defaultValues: TradingSellFormProps;
     defaultCountry: TradingCountryOption;
     defaultCurrency: TradingFiatCurrencyOption;
-    defaultPaymentMethod: TradingPaymentMethodListProps;
     defaultSubdivision: TradingCountrySubdivisionOption | undefined;
 }
 
@@ -113,8 +110,6 @@ interface TradingCommonFormBuySellProps {
     defaultCountry: TradingCountryOption;
     defaultSubdivision: TradingCountrySubdivisionOption | undefined;
     defaultCurrency: TradingFiatCurrencyOption;
-    defaultPaymentMethod: TradingPaymentMethodListProps;
-    paymentMethods: TradingPaymentMethodListProps[];
     amountLimits?: AmountLimitProps;
 }
 

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingBuyFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingBuyFormInputs.tsx
@@ -39,7 +39,7 @@ export const TradingBuyFormInputs = () => {
 
     const { isLoading } = useSelector(selectTradingLoadingAndTimestamp);
 
-    const { device, setAmountLimits, getValues, setValue, quotes, isAmountEmpty } = context;
+    const { device, setAmountLimits, getValues, setValue, quotes } = context;
     const {
         [TRADING_FORM_CRYPTO_CURRENCY_SELECT]: cryptoSelect,
         [TRADING_FORM_CRYPTO_INPUT]: cryptoInput,
@@ -110,7 +110,7 @@ export const TradingBuyFormInputs = () => {
             </TradingFormCard>
 
             <TradingFormCard>
-                {quotes?.length > 0 && !isAmountEmpty && (
+                {quotes?.length > 0 && (
                     <TradingFormInputPaymentMethod label="TR_TRADING_PAYMENT_METHOD" />
                 )}
                 <TradingFormInputCountry label="TR_TRADING_COUNTRY" />

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputPaymentMethod/PaymentMethodModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputPaymentMethod/PaymentMethodModal.tsx
@@ -5,12 +5,10 @@ import { Translation, type TranslationKey } from '@suite/intl';
 import {
     TRADING_FORM_PAYMENT_METHOD_SELECT,
     TRADING_FORM_PROVIDER_SELECT,
-    selectTradingBuyQuotesPerPaymentMethod,
-    selectTradingSellQuotesPerPaymentMethod,
+    selectTradingQuotesPerPaymentMethodByType,
 } from '@suite-common/trading';
 import { Modal } from '@trezor/components';
 import { CardList } from '@trezor/product-components';
-import { exhaustive } from '@trezor/type-utils';
 
 import { useSelector } from 'src/hooks/suite';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
@@ -30,16 +28,9 @@ interface PaymentMethodModalProps {
 export const PaymentMethodModal = ({ onClose, heading }: PaymentMethodModalProps) => {
     const { type, setValue } = useTradingFormContext<TradingTradeBuySellType>();
 
-    const quotes: TradingTradeDetailBuySellType[] = useSelector(state => {
-        switch (type) {
-            case 'buy':
-                return selectTradingBuyQuotesPerPaymentMethod(state);
-            case 'sell':
-                return selectTradingSellQuotesPerPaymentMethod(state);
-            default:
-                return exhaustive(type, 'Unexpected trade type');
-        }
-    });
+    const quotes: TradingTradeDetailBuySellType[] = useSelector(state =>
+        selectTradingQuotesPerPaymentMethodByType(state, type),
+    );
 
     const selectPaymentMethod = useCallback(
         (quote: TradingTradeDetailBuySellType) => {

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputPaymentMethod/TradingFormInputPaymentMethod.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputPaymentMethod/TradingFormInputPaymentMethod.tsx
@@ -6,11 +6,15 @@ import { Translation, useTranslation } from '@suite/intl';
 import { PaymentMethodIcon } from '@suite/trading';
 import {
     TRADING_FORM_PAYMENT_METHOD_SELECT,
+    type TradingPaymentMethodListProps,
     type TradingPaymentMethodProps,
+    selectTradingPaymentMethodsByType,
+    selectTradingSelectedPaymentMethodByType,
 } from '@suite-common/trading';
 import { GhostContainer, Icon, Row, SkeletonRectangle, Text } from '@trezor/components';
 
 import { FakeSelect } from 'src/components/suite';
+import { useSelector } from 'src/hooks/suite';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { type TradingTradeBuySellType } from 'src/types/trading/trading';
 import { type TradingFormInputDefaultProps } from 'src/types/trading/tradingForm';
@@ -57,29 +61,26 @@ export const TradingFormInputPaymentMethod = ({
 }: TradingFormInputPaymentMethodProps) => {
     const { translationString } = useTranslation();
     const [isModalOpen, setIsModalOpen] = useState(false);
-
     const {
-        paymentMethods,
-        defaultPaymentMethod,
+        type,
         form: {
             state: { isFormLoading },
         },
     } = useTradingFormContext<TradingTradeBuySellType>();
 
-    const paymentMethod = useWatch({ name: TRADING_FORM_PAYMENT_METHOD_SELECT });
-    const hasPaymentMethods = paymentMethods.length > 0;
+    const options = useSelector(state => selectTradingPaymentMethodsByType(state, type));
 
-    const selectedOption = hasPaymentMethods
-        ? paymentMethods.find(item => item.value === (paymentMethod?.value ?? defaultPaymentMethod))
-        : undefined;
+    const paymentMethod = useWatch({ name: TRADING_FORM_PAYMENT_METHOD_SELECT }) as
+        | TradingPaymentMethodListProps
+        | undefined;
+    const hasPaymentMethods = options.length > 0;
 
-    // @ts-expect-error: indexing with noUncheckedIndexedAccess
-    const firstPaymentMethod: (typeof paymentMethods)[number] = paymentMethods[0];
-    const paymentMethodValue: TradingPaymentMethodProps =
-        selectedOption?.value ?? paymentMethod?.value ?? firstPaymentMethod?.value;
+    const selectedOption = useSelector(state =>
+        selectTradingSelectedPaymentMethodByType(state, type, paymentMethod?.value),
+    );
 
     const displayLabel = hasPaymentMethods
-        ? (selectedOption?.label ?? paymentMethod?.label ?? paymentMethods[0]?.label ?? '')
+        ? (selectedOption?.label ?? '')
         : translationString('TR_TRADING_NO_METHODS_AVAILABLE');
 
     return (
@@ -113,7 +114,7 @@ export const TradingFormInputPaymentMethod = ({
                             isFormLoading={isFormLoading}
                             hasPaymentMethods={hasPaymentMethods}
                             displayLabel={displayLabel}
-                            paymentMethod={paymentMethodValue}
+                            paymentMethod={selectedOption?.value ?? ''}
                         />
                     </Row>
                 </GhostContainer>

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingSellFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingSellFormInputs.tsx
@@ -49,7 +49,6 @@ export const TradingSellFormInputs = () => {
         showReserveBanner,
         quotes,
         defaultCountry,
-        isAmountEmpty,
     } = context;
     const { getValues } = useFormContext<TradingSellFormProps>();
     const { outputs, sendCryptoSelect, amountInCrypto, countrySelect } = getValues();
@@ -138,7 +137,7 @@ export const TradingSellFormInputs = () => {
                     composedLevels={composedLevels}
                     changeFeeLevel={changeFeeLevel}
                 />
-                {!!quotes.length && !isAmountEmpty && (
+                {!!quotes.length && (
                     <TradingFormInputPaymentMethod label="TR_TRADING_RECEIVE_METHOD" />
                 )}
 

--- a/suite-common/trading/src/hooks/__tests__/resolveAssetTokenOption.test.ts
+++ b/suite-common/trading/src/hooks/__tests__/resolveAssetTokenOption.test.ts
@@ -13,7 +13,6 @@ const renderHook = (preloadedCoins: Coins | null = coins as Coins) =>
             info: {
                 coins: preloadedCoins ?? undefined,
                 platforms: undefined,
-                paymentMethods: [],
             },
         }),
     });

--- a/suite-common/trading/src/reducers/__fixtures__/buyTradingReducer.ts
+++ b/suite-common/trading/src/reducers/__fixtures__/buyTradingReducer.ts
@@ -134,6 +134,7 @@ export const buyTradingFixtures = [
         initialState: {
             ...buyInitialState,
             quotes: buyQuotes,
+            selectedQuote: mercuryoBuyQuote,
         },
         actions: [
             {

--- a/suite-common/trading/src/reducers/__fixtures__/exchangeTradingReducer.ts
+++ b/suite-common/trading/src/reducers/__fixtures__/exchangeTradingReducer.ts
@@ -134,6 +134,7 @@ export const exchangeTradingFixtures = [
         initialState: {
             ...exchangeInitialState,
             quotes: exchangeQuotes,
+            selectedQuote: changellyExchangeQuote,
         },
         actions: [
             {

--- a/suite-common/trading/src/reducers/__fixtures__/sellTradingReducer.ts
+++ b/suite-common/trading/src/reducers/__fixtures__/sellTradingReducer.ts
@@ -119,6 +119,22 @@ export const sellTradingFixtures = [
         },
     },
     {
+        description: 'should clear quotes',
+        initialState: {
+            ...sellInitialState,
+            quotes: sellQuotes,
+            selectedQuote: btcdirectBankTransferSellQuote,
+        },
+        actions: [
+            {
+                type: tradingSellActions.clearQuotes.type,
+            },
+        ],
+        result: {
+            ...sellInitialState,
+        },
+    },
+    {
         description: 'should save selected quote',
         initialState: sellInitialState,
         actions: [

--- a/suite-common/trading/src/reducers/__fixtures__/tradingReducer.ts
+++ b/suite-common/trading/src/reducers/__fixtures__/tradingReducer.ts
@@ -8,11 +8,7 @@ import { accounts } from './account';
 const firstAccount: (typeof accounts)[number] = accounts[0];
 import { buyThunks } from '../../thunks/buy';
 import { exchangeThunks } from '../../thunks/exchange';
-import {
-    type TradingPaymentMethodListProps,
-    type TradingTransactionBuy,
-    type TradingTransactionExchange,
-} from '../../types';
+import { type TradingTransactionBuy, type TradingTransactionExchange } from '../../types';
 import {
     type TradingComposedTransactionInfo,
     initialState,
@@ -79,17 +75,6 @@ const symbolsInfo: InfoResponse = {
         },
     },
 };
-
-const paymentMethods: TradingPaymentMethodListProps[] = [
-    {
-        value: '',
-        label: '',
-    },
-    {
-        value: 'creditCard',
-        label: 'Credit Card',
-    },
-];
 
 const composedTransactionInfo: TradingComposedTransactionInfo = {
     selectedFee: 'normal',
@@ -242,7 +227,6 @@ export const tradingFixtures = [
             info: {
                 platforms: symbolsInfo.platforms,
                 coins: symbolsInfo.coins,
-                paymentMethods: [],
             },
         },
     },
@@ -289,23 +273,6 @@ export const tradingFixtures = [
         result: {
             ...initialState,
             trades: [tradeBuy, tradeExchange],
-        },
-    },
-    {
-        description: 'should save payment methods',
-        initialState,
-        actions: [
-            {
-                type: tradingActions.savePaymentMethods.type,
-                payload: paymentMethods,
-            },
-        ],
-        result: {
-            ...initialState,
-            info: {
-                ...initialState.info,
-                paymentMethods,
-            },
         },
     },
     {

--- a/suite-common/trading/src/reducers/__tests__/tradingReducerExtended.test.ts
+++ b/suite-common/trading/src/reducers/__tests__/tradingReducerExtended.test.ts
@@ -51,7 +51,6 @@ describe('Testing trading reducer', () => {
                     trading: {
                         ...initialState,
                         isLoading: true,
-                        info: { paymentMethods: [{ value: 'creditCard', label: 'Credit Card' }] },
                         buy: {
                             quotes: [{ id: '1', name: 'Quote 1' }],
                             amountLimits: { min: 0, max: 100 },
@@ -72,9 +71,6 @@ describe('Testing trading reducer', () => {
                 isLoading: false,
             }),
         );
-        expect(store.getState().wallet.trading.info).toEqual(
-            expect.objectContaining({ paymentMethods: [] }),
-        );
     });
 
     it('sellThunks.handleRequestThunk.rejected should clear quotes, amountLimits and set isLoading to false', () => {
@@ -90,7 +86,6 @@ describe('Testing trading reducer', () => {
                     trading: {
                         ...initialState,
                         isLoading: true,
-                        info: { paymentMethods: [{ value: 'creditCard', label: 'Credit Card' }] },
                         sell: {
                             quotes: [{ id: '1', name: 'Quote 1' }],
                             amountLimits: { min: 0, max: 100 },
@@ -110,9 +105,6 @@ describe('Testing trading reducer', () => {
                 quotes: [],
                 amountLimits: undefined,
             }),
-        );
-        expect(store.getState().wallet.trading.info).toEqual(
-            expect.objectContaining({ paymentMethods: [] }),
         );
     });
 
@@ -156,7 +148,7 @@ describe('Testing trading reducer', () => {
         );
     });
 
-    it('sellThunks.handleRequestThunk.pending should clear payment methods and set isLoading to true', () => {
+    it('sellThunks.handleRequestThunk.pending should set isLoading to true', () => {
         const store = configureMockStore({
             extra: {},
             reducer: combineReducers({
@@ -168,7 +160,6 @@ describe('Testing trading reducer', () => {
                 wallet: {
                     trading: {
                         ...initialState,
-                        info: { paymentMethods: [{ value: 'creditCard', label: 'Credit Card' }] },
                         sell: {
                             ...sellInitialState,
                             isLoading: false,
@@ -184,9 +175,6 @@ describe('Testing trading reducer', () => {
             expect.objectContaining({
                 isLoading: true,
             }),
-        );
-        expect(store.getState().wallet.trading.info).toEqual(
-            expect.objectContaining({ paymentMethods: [] }),
         );
     });
 

--- a/suite-common/trading/src/reducers/buyReducer.ts
+++ b/suite-common/trading/src/reducers/buyReducer.ts
@@ -73,6 +73,7 @@ const tradingBuySlice = createSlice({
         },
         clearQuotes(state) {
             state.quotes = [];
+            state.selectedQuote = undefined;
         },
         setIsLoading(state, action: PayloadAction<boolean>) {
             state.isLoading = action.payload;

--- a/suite-common/trading/src/reducers/exchangeReducer.ts
+++ b/suite-common/trading/src/reducers/exchangeReducer.ts
@@ -71,6 +71,7 @@ const tradingExchangeSlice = createSlice({
         },
         clearQuotes(state) {
             state.quotes = [];
+            state.selectedQuote = undefined;
         },
         setTradingAccountKey(state, action: PayloadAction<AccountKey | undefined>) {
             state.tradingAccountKey = action.payload;

--- a/suite-common/trading/src/reducers/sellReducer.ts
+++ b/suite-common/trading/src/reducers/sellReducer.ts
@@ -67,6 +67,10 @@ const tradingSellSlice = createSlice({
         saveQuotes(state, action: PayloadAction<SellFiatTrade[]>) {
             state.quotes = action.payload;
         },
+        clearQuotes(state) {
+            state.quotes = [];
+            state.selectedQuote = undefined;
+        },
         saveSelectedQuote(state, action: PayloadAction<SellFiatTrade | undefined>) {
             state.selectedQuote = action.payload;
         },

--- a/suite-common/trading/src/reducers/tradingCommonReducer.ts
+++ b/suite-common/trading/src/reducers/tradingCommonReducer.ts
@@ -10,12 +10,7 @@ import {
 import { type AccountKey, type PrecomposedTransactionFinal } from '@suite-common/wallet-types';
 import { type CardanoOutput, type FeeLevel, type PROTO } from '@trezor/connect';
 
-import {
-    type TradingPaymentMethodListProps,
-    type TradingTransaction,
-    type TradingType,
-    type TradingVerifiedAddress,
-} from '../types';
+import { type TradingTransaction, type TradingType, type TradingVerifiedAddress } from '../types';
 import { type TradingBuyState, buyInitialState } from './buyReducer';
 import { TRADING_PREFIX } from '../constants';
 import { type TradingExchangeState, exchangeInitialState } from './exchangeReducer';
@@ -44,7 +39,6 @@ export interface TradingComposedTransactionInfo {
 export interface TradingInfo {
     platforms?: Platforms;
     coins?: Coins;
-    paymentMethods: TradingPaymentMethodListProps[];
 }
 
 export interface TradingPrefilledFromAccount {
@@ -91,7 +85,6 @@ export const initialState: TradingState = {
     info: {
         platforms: undefined,
         coins: undefined,
-        paymentMethods: [],
     },
     buy: buyInitialState,
     exchange: exchangeInitialState,
@@ -135,9 +128,6 @@ const tradingCommonSlice = createSlice({
         saveInfo(state, action: PayloadAction<InfoResponse>) {
             state.info.coins = action.payload.coins;
             state.info.platforms = action.payload.platforms;
-        },
-        savePaymentMethods(state, action: PayloadAction<TradingPaymentMethodListProps[]>) {
-            state.info.paymentMethods = action.payload;
         },
         saveComposedTransactionInfo(state, action: PayloadAction<TradingComposedTransactionInfo>) {
             state.composedTransactionInfo = action.payload;

--- a/suite-common/trading/src/reducers/tradingReducer.ts
+++ b/suite-common/trading/src/reducers/tradingReducer.ts
@@ -48,7 +48,6 @@ const tradingSlice = createSliceWithExtraDeps({
                 state.buy.amountLimits = undefined;
                 state.buy.quotes = [];
                 state.buy.quotesRequest = undefined;
-                state.info.paymentMethods = [];
             })
             .addCase(exchangeThunks.handleRequestThunk.pending, state => {
                 state.exchange.isLoading = true;
@@ -64,7 +63,6 @@ const tradingSlice = createSliceWithExtraDeps({
             })
             .addCase(sellThunks.handleRequestThunk.pending, state => {
                 state.sell.isLoading = true;
-                state.info.paymentMethods = [];
             })
             .addCase(sellThunks.handleRequestThunk.fulfilled, state => {
                 state.sell.isLoading = false;
@@ -74,7 +72,6 @@ const tradingSlice = createSliceWithExtraDeps({
                 state.sell.quotes = [];
                 state.sell.quotesRequest = undefined;
                 state.sell.isLoading = false;
-                state.info.paymentMethods = [];
             })
             .addCase(sellThunks.handleTradeThunk.pending, state => {
                 state.exchange.isLoading = true;

--- a/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
+++ b/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
@@ -21,7 +21,7 @@ import { type BuyInfo, type TradingBuyState } from '../../reducers/buyReducer';
 import { type ExchangeInfo, exchangeInitialState } from '../../reducers/exchangeReducer';
 import { type SellInfo, sellInitialState } from '../../reducers/sellReducer';
 import { type TradingRootState, initialState } from '../../reducers/tradingCommonReducer';
-import type { TradingPaymentMethodListProps, TradingType } from '../../types';
+import type { TradingType } from '../../types';
 import {
     type TradingRootStateWithDeviceAndAccounts,
     bestBuyQuotePerPaymentMethodProjection,
@@ -74,11 +74,14 @@ import {
     selectTradingLastErrorMessageByTradeType,
     selectTradingModalAccountKey,
     selectTradingNativeCoinSymbolByCryptoId,
-    selectTradingPaymentMethods,
+    selectTradingPaymentMethodsByType,
     selectTradingPlatformByCryptoId,
     selectTradingPrefilledFromAccount,
     selectTradingProviderByNameAndTradeType,
     selectTradingProviderMetadata,
+    selectTradingQuotesByType,
+    selectTradingQuotesPerPaymentMethodByType,
+    selectTradingSelectedPaymentMethodByType,
     selectTradingSellAccountKey,
     selectTradingSellAmountLimits,
     selectTradingSellFormStep,
@@ -259,12 +262,6 @@ describe('tradingSelectors', () => {
                     ...initialState,
                     buy: getBuyState(),
                     info: {
-                        paymentMethods: [
-                            {
-                                value: 'creditCard',
-                                label: 'Credit Card label',
-                            },
-                        ] as TradingPaymentMethodListProps[],
                         coins: coins as Coins,
                         platforms: platforms as Platforms,
                     },
@@ -667,10 +664,6 @@ describe('tradingSelectors', () => {
         expect(selectTradingSellSelectedQuote(state)).toBe(state.wallet.trading.sell.selectedQuote);
     });
 
-    it('selectTradingPaymentMethods should return correct data', () => {
-        expect(selectTradingPaymentMethods(state)).toBe(state.wallet.trading.info.paymentMethods);
-    });
-
     it('selectTradingTrades should return correct data', () => {
         expect(selectTradingTrades(state)).toBe(state.wallet.trading.trades);
     });
@@ -1015,9 +1008,9 @@ describe('tradingSelectors', () => {
                 },
             ];
 
-            expect(selectTradingBuyQuotesByPaymentMethod(state, 'eps')).toEqual({
-                fixed: [state.wallet.trading.buy.quotes[0]],
-            });
+            expect(selectTradingBuyQuotesByPaymentMethod(state, 'eps')).toEqual([
+                state.wallet.trading.buy.quotes[0],
+            ]);
         });
 
         it('should be stable', () => {
@@ -1549,9 +1542,9 @@ describe('tradingSelectors', () => {
                 },
             ];
 
-            expect(selectTradingSellQuotesByPaymentMethod(state, 'creditCard')).toEqual({
-                fixed: [state.wallet.trading.sell.quotes[0]],
-            });
+            expect(selectTradingSellQuotesByPaymentMethod(state, 'creditCard')).toEqual([
+                state.wallet.trading.sell.quotes[0],
+            ]);
         });
 
         it('should be stable', () => {
@@ -1590,9 +1583,7 @@ describe('tradingSelectors', () => {
 
         describe('isFullyLoaded', () => {
             it('should be false when trading info is empty', () => {
-                state.wallet.trading.info = {
-                    paymentMethods: [],
-                };
+                state.wallet.trading.info = {};
 
                 expect(selectTradingBuyLoadingTimestampAndStatus(state).isFullyLoaded).toBe(false);
             });
@@ -1690,9 +1681,7 @@ describe('tradingSelectors', () => {
 
         describe('isFullyLoaded', () => {
             it('should be false when trading info is empty', () => {
-                state.wallet.trading.info = {
-                    paymentMethods: [],
-                };
+                state.wallet.trading.info = {};
 
                 expect(selectTradingSellLoadingTimestampAndStatus(state).isFullyLoaded).toBe(false);
             });
@@ -1718,6 +1707,125 @@ describe('tradingSelectors', () => {
     describe(selectTradingSellQuotes.name, () => {
         it('should return quotes from trading sell state', () => {
             expect(selectTradingSellQuotes(state)).toBe(state.wallet.trading.sell.quotes);
+        });
+    });
+
+    describe(selectTradingQuotesByType.name, () => {
+        it('should return buy quotes for buy type', () => {
+            expect(selectTradingQuotesByType(state, 'buy')).toBe(state.wallet.trading.buy.quotes);
+        });
+
+        it('should return sell quotes for sell type', () => {
+            expect(selectTradingQuotesByType(state, 'sell')).toBe(state.wallet.trading.sell.quotes);
+        });
+
+        it('should return exchange quotes for exchange type', () => {
+            expect(selectTradingQuotesByType(state, 'exchange')).toBe(
+                state.wallet.trading.exchange.quotes,
+            );
+        });
+    });
+
+    describe(selectTradingPaymentMethodsByType.name, () => {
+        it('should return buy payment methods for buy type', () => {
+            state.wallet.trading.buy.quotes = [
+                {
+                    fiatStringAmount: '10',
+                    fiatCurrency: 'EUR',
+                    receiveCurrency: 'bitcoin' as CryptoId,
+                    receiveStringAmount: '5',
+                    rate: 2,
+                    paymentMethod: 'creditCard',
+                    paymentMethodName: 'Credit Card',
+                    quoteId: 'quoteId1',
+                },
+            ];
+
+            expect(selectTradingPaymentMethodsByType(state, 'buy')).toEqual([
+                { value: 'creditCard', label: 'Credit Card' },
+            ]);
+        });
+
+        it('should return sell payment methods for sell type', () => {
+            expect(selectTradingPaymentMethodsByType(state, 'sell')).toEqual(
+                selectTradingSellPaymentMethods(state),
+            );
+        });
+
+        it('should return an empty array for exchange type', () => {
+            expect(selectTradingPaymentMethodsByType(state, 'exchange')).toEqual([]);
+        });
+    });
+
+    describe(selectTradingSelectedPaymentMethodByType.name, () => {
+        beforeEach(() => {
+            state.wallet.trading.buy.quotes = [
+                {
+                    fiatStringAmount: '10',
+                    fiatCurrency: 'EUR',
+                    receiveCurrency: 'bitcoin' as CryptoId,
+                    receiveStringAmount: '5',
+                    rate: 2,
+                    paymentMethod: 'creditCard',
+                    paymentMethodName: 'Credit Card',
+                    quoteId: 'quoteId1',
+                },
+                {
+                    fiatStringAmount: '10',
+                    fiatCurrency: 'EUR',
+                    receiveCurrency: 'bitcoin' as CryptoId,
+                    receiveStringAmount: '5',
+                    rate: 2,
+                    paymentMethod: 'bankTransfer',
+                    paymentMethodName: 'Bank Transfer',
+                    quoteId: 'quoteId2',
+                },
+            ];
+        });
+
+        it('should return the option matching the selected payment method', () => {
+            expect(selectTradingSelectedPaymentMethodByType(state, 'buy', 'bankTransfer')).toEqual({
+                value: 'bankTransfer',
+                label: 'Bank Transfer',
+            });
+        });
+
+        it('should fall back to the first option when the selected method is not available', () => {
+            expect(selectTradingSelectedPaymentMethodByType(state, 'buy', 'applePay')).toEqual({
+                value: 'creditCard',
+                label: 'Credit Card',
+            });
+        });
+
+        it('should fall back to the first option when no method is selected', () => {
+            expect(selectTradingSelectedPaymentMethodByType(state, 'buy', undefined)).toEqual({
+                value: 'creditCard',
+                label: 'Credit Card',
+            });
+        });
+
+        it('should return undefined when there are no payment methods', () => {
+            expect(
+                selectTradingSelectedPaymentMethodByType(state, 'exchange', 'creditCard'),
+            ).toBeUndefined();
+        });
+    });
+
+    describe(selectTradingQuotesPerPaymentMethodByType.name, () => {
+        it('should return buy quotes per payment method for buy type', () => {
+            expect(selectTradingQuotesPerPaymentMethodByType(state, 'buy')).toEqual(
+                selectTradingBuyQuotesPerPaymentMethod(state),
+            );
+        });
+
+        it('should return sell quotes per payment method for sell type', () => {
+            expect(selectTradingQuotesPerPaymentMethodByType(state, 'sell')).toEqual(
+                selectTradingSellQuotesPerPaymentMethod(state),
+            );
+        });
+
+        it('should return an empty array for exchange type', () => {
+            expect(selectTradingQuotesPerPaymentMethodByType(state, 'exchange')).toEqual([]);
         });
     });
 

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -36,6 +36,8 @@ import type { TradingRootState, TradingState } from '../reducers/tradingCommonRe
 import {
     type TradingBuyPaymentMethodProps,
     type TradingFiatCurrenciesProps,
+    type TradingPaymentMethodListProps,
+    type TradingPaymentMethodProps,
     type TradingSellPaymentMethodProps,
     type TradingTransaction,
     type TradingType,
@@ -357,9 +359,6 @@ export const selectTradingExchangeSelectedQuote = (state: TradingRootState) =>
 export const selectTradingSellSelectedQuote = (state: TradingRootState) =>
     state.wallet.trading.sell.selectedQuote;
 
-export const selectTradingPaymentMethods = (state: TradingRootState) =>
-    state.wallet.trading.info.paymentMethods;
-
 export const selectTradingTrades = (state: TradingRootState) =>
     returnStableArrayIfEmpty(state.wallet.trading.trades);
 
@@ -558,12 +557,13 @@ export const selectTradingBuyQuotes = (state: TradingRootState) => state.wallet.
 export const selectTradingBuyQuotesByPaymentMethod = createMemoizedSelector(
     [
         selectTradingBuyQuotes,
-        (_: TradingRootState, paymentMethod: TradingBuyPaymentMethodProps | undefined) =>
+        (_: TradingRootState, paymentMethod: TradingPaymentMethodProps | undefined) =>
             paymentMethod,
     ],
-    (quotes, paymentMethod) => ({
-        fixed: paymentMethod ? getTradingQuotesByPaymentMethod<'buy'>(quotes, paymentMethod) : [],
-    }),
+    (quotes, paymentMethod) =>
+        returnStableArrayIfEmpty(
+            paymentMethod ? getTradingQuotesByPaymentMethod<'buy'>(quotes, paymentMethod) : [],
+        ),
 );
 
 export const selectTradingBuyQuoteByOrderId = (
@@ -613,15 +613,32 @@ export const selectTradingSellAmountLimits = (state: TradingRootState) =>
 export const selectTradingSellQuotes = (state: TradingRootState) =>
     state.wallet.trading.sell.quotes;
 
+export const selectTradingQuotesByType = (
+    state: TradingRootState,
+    type: TradingType,
+): BuyTrade[] | SellFiatTrade[] | ExchangeTrade[] => {
+    switch (type) {
+        case 'buy':
+            return selectTradingBuyQuotes(state);
+        case 'sell':
+            return selectTradingSellQuotes(state);
+        case 'exchange':
+            return selectTradingExchangeQuotes(state);
+        default:
+            return exhaustive(type);
+    }
+};
+
 export const selectTradingSellQuotesByPaymentMethod = createMemoizedSelector(
     [
         selectTradingSellQuotes,
-        (_: TradingRootState, paymentMethod: TradingSellPaymentMethodProps | undefined) =>
+        (_: TradingRootState, paymentMethod: TradingPaymentMethodProps | undefined) =>
             paymentMethod,
     ],
-    (quotes, paymentMethod) => ({
-        fixed: paymentMethod ? getTradingQuotesByPaymentMethod<'sell'>(quotes, paymentMethod) : [],
-    }),
+    (quotes, paymentMethod) =>
+        returnStableArrayIfEmpty(
+            paymentMethod ? getTradingQuotesByPaymentMethod<'sell'>(quotes, paymentMethod) : [],
+        ),
 );
 
 export const selectTradingExchangeFormStep = (state: TradingRootState) =>
@@ -711,6 +728,59 @@ export const selectTradingSellPaymentMethods = createMemoizedSelector(
             value: quote.paymentMethod as TradingSellPaymentMethodProps,
             label: quote.paymentMethodName ?? '',
         })),
+);
+
+export const selectTradingQuotesPerPaymentMethodByType = createMemoizedSelector(
+    [
+        selectTradingBuyQuotesPerPaymentMethod,
+        selectTradingSellQuotesPerPaymentMethod,
+        (_: TradingRootState, type: TradingType) => type,
+    ],
+    (buyQuotes, sellQuotes, type): BuyTrade[] | SellFiatTrade[] => {
+        switch (type) {
+            case 'buy':
+                return buyQuotes;
+            case 'sell':
+                return sellQuotes;
+            case 'exchange':
+                return [];
+            default:
+                return exhaustive(type);
+        }
+    },
+);
+
+export const selectTradingPaymentMethodsByType = createMemoizedSelector(
+    [
+        selectTradingBuyPaymentMethods,
+        selectTradingSellPaymentMethods,
+        (_: TradingRootState, type: TradingType) => type,
+    ],
+    (buyPaymentMethods, sellPaymentMethods, type): TradingPaymentMethodListProps[] => {
+        switch (type) {
+            case 'buy':
+                return buyPaymentMethods;
+            case 'sell':
+                return sellPaymentMethods;
+            case 'exchange':
+                return [];
+            default:
+                return exhaustive(type);
+        }
+    },
+);
+
+export const selectTradingSelectedPaymentMethodByType = createMemoizedSelector(
+    [
+        selectTradingPaymentMethodsByType,
+        (
+            _: TradingRootState,
+            __: TradingType,
+            paymentMethod: TradingPaymentMethodProps | undefined,
+        ) => paymentMethod,
+    ],
+    (paymentMethods, paymentMethod): TradingPaymentMethodListProps | undefined =>
+        paymentMethods.find(option => option.value === paymentMethod) ?? paymentMethods[0],
 );
 
 export const selectTradingBuyAccountKey = (state: TradingRootState) =>

--- a/suite-common/trading/src/thunks/buy/__tests__/handleBuyRequestThunk.test.ts
+++ b/suite-common/trading/src/thunks/buy/__tests__/handleBuyRequestThunk.test.ts
@@ -12,6 +12,7 @@ import {
     initialState,
 } from '../../../reducers/tradingCommonReducer';
 import { prepareTradingReducer } from '../../../reducers/tradingReducer';
+import { selectTradingBuyPaymentMethods } from '../../../selectors/tradingSelectors';
 import {
     type HandleBuyRequestThunkProps,
     type TradingAssetOption,
@@ -139,7 +140,7 @@ describe('handleBuyRequestThunk', () => {
             receiveAddress: 'RECEIVE_ADDRESS',
             wantCrypto: false,
         });
-        expect(state.info.paymentMethods.length).toEqual(1);
+        expect(selectTradingBuyPaymentMethods(store.getState()).length).toEqual(1);
         expect(state.isLoading).toBe(false);
         expect(state.quoteRefetchingState.status).toBe('running');
         expect(state.quoteRefetchingState.lastFetchTimestamp).toBeGreaterThan(0);

--- a/suite-common/trading/src/thunks/buy/handleBuyRequestThunk.ts
+++ b/suite-common/trading/src/thunks/buy/handleBuyRequestThunk.ts
@@ -9,7 +9,6 @@ import { invityAPI } from '../../invityAPI';
 import { tradingBuyActions } from '../../reducers/buyReducer';
 import { tradingActions } from '../../reducers/tradingCommonReducer';
 import {
-    selectTradingBuyPaymentMethods,
     selectTradingBuyQuotesRequest,
     selectTradingCoinSymbolByCryptoId,
 } from '../../selectors/tradingSelectors';
@@ -130,7 +129,6 @@ export const handleBuyRequestThunk = createThunk<
             dispatch(tradingBuyActions.setAmountLimits(undefined));
             dispatch(tradingBuyActions.saveQuotes(quotesSuccess));
             dispatch(tradingBuyActions.saveQuoteRequest(requestData));
-            dispatch(tradingActions.savePaymentMethods([]));
 
             return fulfillWithValue(quotesSuccess);
         }
@@ -154,7 +152,6 @@ export const handleBuyRequestThunk = createThunk<
         dispatch(tradingBuyActions.saveQuotes(quotesSuccess));
         dispatch(tradingBuyActions.setAmountLimits(limits));
         dispatch(tradingBuyActions.saveQuoteRequest(requestData));
-        dispatch(tradingActions.savePaymentMethods(selectTradingBuyPaymentMethods(getState())));
         dispatch(tradingActions.setRefetchQuotesTimestamp(Date.now()));
 
         return fulfillWithValue(quotesSuccess);

--- a/suite-common/trading/src/thunks/common/__tests__/loadInitialDataThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/loadInitialDataThunk.test.ts
@@ -95,9 +95,7 @@ const testUpdatedInfoData = async (type: 'outdated' | 'account-changed') => {
     jest.spyOn(Date, 'now').mockImplementation(() => mockedLastLoadedTimestamp);
 
     const store = initStore({
-        info: {
-            paymentMethods: [],
-        },
+        info: {},
         lastLoadedTimestamp: type === 'outdated' ? 0 : mockedLastLoadedTimestamp,
     });
 

--- a/suite-common/trading/src/thunks/sell/handleSellRequestThunk.ts
+++ b/suite-common/trading/src/thunks/sell/handleSellRequestThunk.ts
@@ -8,10 +8,7 @@ import { TRADING_DEFAULT_SELL_FLOWS, TRADING_SELL_THUNK_PREFIX } from '../../con
 import { invityAPI } from '../../invityAPI';
 import { tradingSellActions } from '../../reducers/sellReducer';
 import { tradingActions } from '../../reducers/tradingCommonReducer';
-import {
-    selectTradingCoinSymbolByCryptoId,
-    selectTradingSellPaymentMethods,
-} from '../../selectors/tradingSelectors';
+import { selectTradingCoinSymbolByCryptoId } from '../../selectors/tradingSelectors';
 import {
     type HandleSellRequestThunkProps,
     type MinimalSellFormProps,
@@ -138,7 +135,6 @@ export const handleSellRequestThunk = createThunk<
             dispatch(tradingSellActions.setAmountLimits(undefined));
             dispatch(tradingSellActions.saveQuotes(quotesSuccess));
             dispatch(tradingSellActions.saveQuoteRequest(requestData));
-            dispatch(tradingActions.savePaymentMethods([]));
 
             return fulfillWithValue(quotesSuccess);
         }
@@ -160,7 +156,6 @@ export const handleSellRequestThunk = createThunk<
 
         dispatch(tradingSellActions.saveQuotes(successQuotes));
         dispatch(tradingSellActions.saveQuoteRequest(requestData));
-        dispatch(tradingActions.savePaymentMethods(selectTradingSellPaymentMethods(getState())));
         dispatch(tradingSellActions.setAmountLimits(limits));
 
         const { setMaxOutputId } = formValues;

--- a/suite-native/trading-fixtures/src/__fixtures__/tradingState.ts
+++ b/suite-native/trading-fixtures/src/__fixtures__/tradingState.ts
@@ -3,7 +3,6 @@ import type { Coins, CryptoId, FiatCurrenciesProps, FiatCurrencyCode, Platforms 
 import {
     type TradingBuyState,
     type TradingExchangeState,
-    type TradingPaymentMethodListProps,
     type TradingSellState,
     type TradingType,
 } from '@suite-common/trading';
@@ -129,12 +128,6 @@ export const getInitializedTradingState = (tradeType: TradingType = 'buy') =>
         exchange: getInitializedExchangeState(),
         sell: getInitializedSellState(),
         info: {
-            paymentMethods: [
-                {
-                    value: 'creditCard',
-                    label: 'Credit Card label',
-                },
-            ] as TradingPaymentMethodListProps[],
             coins: coins as Coins,
             platforms: platforms as Platforms,
         },
@@ -152,17 +145,6 @@ export const getInitializedTradingStateWithQuotes = () => {
     state.buy.quotes = buyQuotes as TradingBuyState['quotes'];
     state.exchange.quotes = exchangeQuotes;
     state.sell.quotes = sellQuotes;
-
-    state.info.paymentMethods = [
-        {
-            value: 'creditCard',
-            label: 'Credit Card',
-        },
-        {
-            value: 'applePay',
-            label: 'Apple Pay',
-        },
-    ];
 
     return state;
 };


### PR DESCRIPTION
## Description

- derive buy and sell payment method options from memoized quote selectors instead of storing duplicated payment-method data in trading state/context
- update the payment method input and modal to read labels and available methods directly from selector-backed quotes
- remove redundant payment-method plumbing from trading form defaults, context props, reducers, and request thunks
- clear buy, sell, and exchange quotes immediately when the form amount becomes empty on form pages

## Notes for QA

- In Trading Buy or Sell form, enter an amount and open Payment method, verify only available methods are listed and the selected label matches the active quotes.
- In Trading Buy or Sell form, switch the payment method and reopen the selector, verify the selected method stays in sync with displayed offers.
- In Trading Buy, Sell, and Exchange form, clear the amount field, verify existing offers disappear immediately on the form page.

## Related Issue

Resolve #28758

## Screenshots:

N/A

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/28758-trading-payment-methods&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/28758-trading-payment-methods&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/28758-trading-payment-methods&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-17T10:15:49.320Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-17T10:14:31.634Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/28758-trading-payment-methods/web/](https://dev.suite.sldev.cz/suite-web/fix/28758-trading-payment-methods/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->