### PR TITLE
fix(suite-native): resolve crc v4 subpath imports in Metro

### DIFF
--- a/suite-native/app/metro.config.js
+++ b/suite-native/app/metro.config.js
@@ -72,6 +72,8 @@ const config = {
                 '@evolu/common/local-first': `${rootNodeModulesPath}/@evolu/common/dist/src/local-first/index.js`,
                 '@evolu/common/polyfills': `${rootNodeModulesPath}/@evolu/common/dist/src/Polyfills.js`,
                 '@evolu/react-native/polyfills': `${rootNodeModulesPath}/@evolu/react-native/dist/src/Polyfills.js`,
+                'crc/calculators/crc32': `${rootNodeModulesPath}/crc/cjs-default-unwrap/calculators/crc32.js`,
+                'crc/calculators/crc16xmodem': `${rootNodeModulesPath}/crc/cjs-default-unwrap/calculators/crc16xmodem.js`,
                 uuid: `${rootNodeModulesPath}/uuid/dist/index.js`,
 
                 // web3-validator package is by default trying to use non-existing minified index file. This fixes that.


### PR DESCRIPTION
The `crc` v3 → v4 bump (#28230) switched `@trezor/address-validator` to per-calculator imports (`crc/calculators/crc32` in `ada_validator.ts`, `crc/calculators/crc16xmodem` in `stellar_validator.ts`). These subpaths only exist in crc v4's `exports` map — there are no physical files at the package root.

`suite-native/app/metro.config.js` runs with `resolver.unstable_enablePackageExports: false`, so Metro ignores the `exports` map and fails to resolve them:

```
error Unable to resolve module crc/calculators/crc32 from packages/address-validator/src/ada_validator.ts: crc/calculators/crc32 could not be found within the project
```

This broke the `suite-native Android E2E` "replace JS bundle" step on `develop`. The job did not run on #28230 (it is conditionally triggered and did not fire for an `address-validator` change), so the regression landed green.

## Fix

Map both subpaths to their physical `cjs-default-unwrap` files in the metro resolver `overrides`, matching the existing pattern for other packages that expose entry points via `exports` (tracked by #20733). Webpack/Node builds were unaffected since they honor the `exports` map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/metro-crc-subpath-exports&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->