### PR TITLE
Stellar: XDR parse web fix

### DIFF
--- a/coins/coins-stellar/src/runtime/transactions/transform.ts
+++ b/coins/coins-stellar/src/runtime/transactions/transform.ts
@@ -26,13 +26,13 @@ const transformSigner = (signer: Signer) => {
 
         return { type: 0, key, weight };
     }
-    if ('preAuthTx' in signer && signer.preAuthTx instanceof Buffer) {
-        const key = signer.preAuthTx.toString('hex');
+    if ('preAuthTx' in signer) {
+        const key = Buffer.from(signer.preAuthTx).toString('hex');
 
         return { type: 1, key, weight };
     }
-    if ('sha256Hash' in signer && signer.sha256Hash instanceof Buffer) {
-        const key = signer.sha256Hash.toString('hex');
+    if ('sha256Hash' in signer) {
+        const key = Buffer.from(signer.sha256Hash).toString('hex');
 
         return { type: 2, key, weight };
     }


### PR DESCRIPTION
## Description

Since #27801 we support passing Stellar txs in XDR format. In transform util, we checked that some of the fields are `instanceof Buffer`, which isn't true on web (`stellar-sdk` apparently behaves a little bit differently) and because of that, some of the e2e tests were broken. This should fix it.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to the Stellar (XLM) transaction transform module. None of the 36 candidate E2E tests have static coverage mapping to this file, and very few tests interact with Stellar at all. The only test with a tangential connection is the swap-token-to-disabled-network test, which specifically swaps to XLM/Stellar. The risk is low overall since Stellar-specific transaction transformation is not directly exercised by any available E2E test. Unit or integration tests closer to the coins-stellar package would provide better coverage.

<details><summary><b>Changed files (1)</b></summary>

- `coins/coins-stellar/src/runtime/transactions/transform.ts`

</details>

**Recommended tests (1)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — This test swaps a token (USDT on Solana) to Stellar (XLM), which is the network whose transaction transform logic was changed. If the Stellar transaction transform affects how swap quotes or swap flows handle Stellar assets, this test could surface a regression. This is inferred, not statically mapped.

</details>

⚠️ **Changes with no test coverage (1)**
- `coins/coins-stellar/src/runtime/transactions/transform.ts`

_Updated: 2026-06-15T09:10:29.355Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/stellar-xdr-web/web/](https://dev.suite.sldev.cz/suite-web/fix/stellar-xdr-web/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/stellar-xdr-web&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/stellar-xdr-web&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-15T09:15:57.638Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-15T09:14:27.497Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->