### PR TITLE
chore(icons): remove dead legacy coin-image helpers

### DIFF
--- a/suite-common/icons/scripts/downloadCryptoIcons.ts
+++ b/suite-common/icons/scripts/downloadCryptoIcons.ts
@@ -11,12 +11,7 @@ import {
     UPDATED_ICONS_LIST_FILE,
 } from './constants';
 import { CoinListData } from './types';
-import {
-    COIN_IMAGE_SIZES,
-    LEGACY_COIN_IMAGE_SIZES,
-    createCoinImageName,
-    createCoinImageNameLegacy,
-} from '../src/coinImages';
+import { COIN_IMAGE_SIZES, createCoinImageName } from '../src/coinImages';
 import { getCoinData, getCoinList, getUpdatedIconsList } from './utils/fetchCoins';
 import { sleep } from './utils/sleep';
 
@@ -85,26 +80,6 @@ const updateIcon = async (coin: CoinListData) => {
             ([platform, contract]) => platform && contract,
         );
 
-        // Legacy naming – Make sure it's backwards compatible for older versions of the Trezor Suite
-        for (const size of LEGACY_COIN_IMAGE_SIZES) {
-            const finalImageBuffer = await resizeImage(originImageBuffer, size);
-
-            const fileNameLegacy = createCoinImageNameLegacy({ coingeckoId: coinData.id, size });
-            console.log(`[legacy] Writing image (${coin.id}):`, fileNameLegacy);
-            await writeImage(fileNameLegacy, finalImageBuffer);
-
-            for (const [coingeckoId, contractAddress] of platforms) {
-                const fileNameLegacyPlatform = createCoinImageNameLegacy({
-                    coingeckoId,
-                    contractAddress,
-                    size,
-                });
-                console.log(`[legacy] Writing image (${coin.id}):`, fileNameLegacyPlatform);
-                await writeImage(fileNameLegacyPlatform, finalImageBuffer);
-            }
-        }
-
-        // New naming
         for (const size of COIN_IMAGE_SIZES) {
             const finalImageBuffer = await resizeImage(originImageBuffer, size);
 

--- a/suite-common/icons/src/coinImages.ts
+++ b/suite-common/icons/src/coinImages.ts
@@ -1,14 +1,5 @@
 export const ICONS_URL_BASE = 'https://data.trezor.io/suite/icons/coins';
 
-/**
- * @deprecated Use `COIN_IMAGE_SIZES` instead
- */
-export const LEGACY_COIN_IMAGE_SIZES = [24, 48] as const satisfies number[];
-/**
- * @deprecated Use `CoinImageSize` instead
- */
-export type LegacyCoinImageSize = (typeof LEGACY_COIN_IMAGE_SIZES)[number];
-
 export const COIN_IMAGE_SIZES = [24, 40, 48, 80] as const satisfies number[];
 
 export type CoinImageSize = (typeof COIN_IMAGE_SIZES)[number];
@@ -24,7 +15,7 @@ function createCryptoId(coingeckoId: string, contractAddress?: string) {
     return encodeURIComponent(cryptoId);
 }
 
-export interface CreateCoinImageNameParams<Size extends CoinImageSize> {
+interface CreateCoinImageNameParams<Size extends CoinImageSize> {
     coingeckoId: string;
     contractAddress?: string;
     size: Size;
@@ -38,23 +29,4 @@ export function createCoinImageName<Size extends CoinImageSize>({
     const cryptoId = createCryptoId(coingeckoId, contractAddress);
 
     return `${cryptoId}${IMAGE_SIZE_SEPARATOR}${size}.webp` as const;
-}
-
-export interface CreateCoinImageNameLegacyParams {
-    coingeckoId: string;
-    contractAddress?: string;
-    size: LegacyCoinImageSize;
-}
-
-/**
- * @deprecated Use `createCoinImageName` instead
- */
-export function createCoinImageNameLegacy({
-    coingeckoId,
-    contractAddress,
-    size,
-}: CreateCoinImageNameLegacyParams) {
-    const cryptoId = createCryptoId(coingeckoId, contractAddress);
-
-    return `${cryptoId}${size === 24 ? '' : '@2x'}.webp` as const;
 }

--- a/suite-common/icons/src/iconUtils.ts
+++ b/suite-common/icons/src/iconUtils.ts
@@ -38,7 +38,7 @@ export const networkIconSymbolMap = {
     zec: 'zec',
 } as const satisfies Record<NetworkIconSymbol, NetworkIconName>;
 
-export const testnetNetworkIconSymbols = [
+const testnetNetworkIconSymbols = [
     'test',
     'regtest',
     'tada',
@@ -50,7 +50,7 @@ export const testnetNetworkIconSymbols = [
     'dsol',
 ] as const satisfies readonly NetworkIconSymbol[];
 
-export type TestnetNetworkIconSymbol = (typeof testnetNetworkIconSymbols)[number];
+type TestnetNetworkIconSymbol = (typeof testnetNetworkIconSymbols)[number];
 
 const testnetNetworkIconSymbolSet: ReadonlySet<NetworkIconSymbol> = new Set(
     testnetNetworkIconSymbols,


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into a small isolated PR for easy, low-risk review.

The full staging branch is green; CI verifies this subset independently.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect icon infrastructure: a build script for downloading crypto icons, a coin image mapping module, and an icon utility module. These are broadly imported across the app but are primarily rendering/display concerns. The risk is low — most likely these changes add/update icon assets or refine icon utility logic, which would only cause visual regressions (missing or incorrect icons) rather than functional failures. Since coinImages.ts maps to 121+ tests, it's a global dependency and most tests don't specifically assert on icon rendering. A small set of tests that verify asset/coin display UI are recommended at medium priority. The build script has no test coverage.

<details><summary><b>Changed files (3)</b></summary>

- `suite-common/icons/scripts/downloadCryptoIcons.ts`
- `suite-common/icons/src/coinImages.ts`
- `suite-common/icons/src/iconUtils.ts`

</details>

**Recommended tests (3)**

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — This test verifies asset display in grid and table views, including enabling new assets and verifying their visual contents. Changes to coinImages.ts (which provides cryptocurrency icon/image mappings) could affect how asset icons render in the dashboard assets section.
- `suite/e2e/tests/settings/coins.test.ts` — This test activates mainnet and testnet networks via the coins settings page and an Activate Assets modal with network buttons. Coin images are likely rendered alongside each network toggle/button, so changes to coinImages.ts could cause visual regressions or missing icons in the coin settings UI.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — This test navigates buy/sell/swap forms and verifies the correct cryptocurrency name is displayed, which involves asset pickers that render coin icons. Changes to coinImages.ts or iconUtils.ts could affect icon resolution in the asset picker component.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-common/icons/scripts/downloadCryptoIcons.ts`
- `suite-common/icons/src/iconUtils.ts`

_Updated: 2026-06-15T09:47:49.112Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-common-icons/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-common-icons/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-common-icons&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-common-icons&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-common-icons&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-15T09:52:47.958Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-15T09:51:26.600Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->