### PR TITLE
chore(suite-native): unexport intra-package intl slice and helpers

### DIFF
--- a/suite-native/intl/src/localeSlice.ts
+++ b/suite-native/intl/src/localeSlice.ts
@@ -25,7 +25,7 @@ export const localePersistWhitelist: Array<keyof LocaleState> = [
     'systemLocaleCode',
 ];
 
-export const localeSlice = createSlice({
+const localeSlice = createSlice({
     name: 'locale',
     initialState: localeInitialState,
     reducers: {
@@ -43,8 +43,7 @@ export const localeReducer = localeSlice.reducer;
 
 export const selectAppLocaleCode = (state: LocaleSliceRootState) => state.locale.appLocaleCode;
 
-export const selectSystemLocaleCode = (state: LocaleSliceRootState) =>
-    state.locale.systemLocaleCode;
+const selectSystemLocaleCode = (state: LocaleSliceRootState) => state.locale.systemLocaleCode;
 
 export const selectLocale = (state: LocaleSliceRootState) => {
     const userSelectedLocaleCode = selectAppLocaleCode(state);

--- a/suite-native/intl/src/types.ts
+++ b/suite-native/intl/src/types.ts
@@ -1,7 +1,7 @@
 import { LANGUAGES } from './languages';
 import { type messages } from './messages';
 
-export type Translations = typeof messages;
+type Translations = typeof messages;
 
 /**
  * Builds up valid keypaths for translations.
@@ -25,8 +25,7 @@ type RecursiveKeyOfHandleValue<TValue, Text extends string> = TValue extends any
 
 export type SupportedLocaleCode = keyof typeof LANGUAGES;
 
-export const isSupportedLanguage = (locale: string): locale is SupportedLocaleCode =>
-    locale in LANGUAGES;
+const isSupportedLanguage = (locale: string): locale is SupportedLocaleCode => locale in LANGUAGES;
 
 export const isOfficiallySupportedLanguage = (locale: string): locale is SupportedLocaleCode =>
     isSupportedLanguage(locale) && LANGUAGES[locale].type === 'official';


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into a small isolated PR for easy, low-risk review.

The full staging branch is green; CI verifies this subset independently.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-native-intl&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- BLAME-AUTHORS -->
**Author(s) of the removed code** (via `git blame`): @PeKne — please confirm this code is genuinely dead and safe to delete, and not intentional preparation. 🙏