### PR TITLE
chore(suite-native): unexport intra-package app slice and persisted-state type

### DIFF
--- a/suite-native/state/src/appSlice.ts
+++ b/suite-native/state/src/appSlice.ts
@@ -12,7 +12,7 @@ export const appSliceInitialState: AppSliceState = {
     isAppReady: false,
 };
 
-export const appSlice = createSlice({
+const appSlice = createSlice({
     name: 'app',
     initialState: appSliceInitialState,
     reducers: {

--- a/suite-native/state/src/store.ts
+++ b/suite-native/state/src/store.ts
@@ -35,7 +35,7 @@ import { prepareRootReducers } from './reducers';
 
 type RootReducerShape = ReturnType<typeof prepareRootReducers>;
 
-export type FullPersistedAppState = ReducerState<RootReducerShape>;
+type FullPersistedAppState = ReducerState<RootReducerShape>;
 
 type ExcludePersist<T> = Omit<T, '_persist'>;
 type ExcludeChildPersists<T> = {


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into a small isolated PR for easy, low-risk review.

The full staging branch is green; CI verifies this subset independently.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-native-state&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->