### PR TITLE
chore(suite-native): unexport intra-package device-onboarding navigator and constant

### DIFF
--- a/suite-native/module-device-onboarding/src/navigation/DeviceOnboardingStackNavigator.tsx
+++ b/suite-native/module-device-onboarding/src/navigation/DeviceOnboardingStackNavigator.tsx
@@ -33,7 +33,7 @@ import { WalletCreationScreen } from '../screens/WalletCreationScreen';
 import { WalletRecoveryRecapScreen } from '../screens/WalletRecoveryRecapScreen';
 import { WalletRecoveryScreen } from '../screens/WalletRecoveryScreen';
 
-export const DeviceOnboardingStack = createNativeStackNavigator<DeviceOnboardingStackParamList>();
+const DeviceOnboardingStack = createNativeStackNavigator<DeviceOnboardingStackParamList>();
 
 export const DeviceOnboardingStackNavigator = () => {
     const reportStepViewed = useReportOnboardingStepViewedAnalytics();

--- a/suite-native/module-device-onboarding/src/screens/BackupFailedModalScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/BackupFailedModalScreen.tsx
@@ -8,7 +8,7 @@ import { useOpenLink } from '@suite-native/link';
 import { Screen, ScreenHeader } from '@suite-native/navigation';
 import { HELP_CENTER_RECOVERY_ISSUES_URL } from '@trezor/urls';
 
-export const BACKUP_FAILED_SUPPORT_URL = `${HELP_CENTER_RECOVERY_ISSUES_URL}#open-chat`;
+const BACKUP_FAILED_SUPPORT_URL = `${HELP_CENTER_RECOVERY_ISSUES_URL}#open-chat`;
 
 export const BackupFailedModalScreen = () => {
     const openLink = useOpenLink();


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into a small isolated PR for easy, low-risk review.

The full staging branch is green; CI verifies this subset independently.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-native-device-onboarding&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->