### PR TITLE
chore(bip329): unexport intra-package bip329 dependency types

### DIFF
--- a/suite-common/bip329/src/createBip329.ts
+++ b/suite-common/bip329/src/createBip329.ts
@@ -5,13 +5,13 @@ import { type LegacyToBip329Dep } from './legacy/createLegacyToBip329';
 import { type ImportBip329ToSuiteSyncDep } from './suiteSync/createBip329ToSuiteSync';
 import { type ExportSuiteSyncToBip329Dep } from './suiteSync/createSuiteSyncToBip329';
 
-export type GetIsSuiteSyncEnabled = () => boolean;
+type GetIsSuiteSyncEnabled = () => boolean;
 
 export type GetIsSuiteSyncEnabledDep = {
     getIsSuiteSyncEnabled: GetIsSuiteSyncEnabled;
 };
 
-export type CreateBip329Deps = GetIsSuiteSyncEnabledDep &
+type CreateBip329Deps = GetIsSuiteSyncEnabledDep &
     LegacyToBip329Dep &
     ExportSuiteSyncToBip329Dep &
     ImportBip329ToSuiteSyncDep;

--- a/suite-common/bip329/src/suiteSync/createSuiteSyncToBip329.ts
+++ b/suite-common/bip329/src/suiteSync/createSuiteSyncToBip329.ts
@@ -12,13 +12,13 @@ export type AllLabelsForAccount = {
     outputLabels: SuiteSyncOutput[];
 };
 
-export type GetAllLabelsForAccountParams = {
+type GetAllLabelsForAccountParams = {
     walletDescriptor: WalletDescriptor;
     accountDescriptor: AccountDescriptor;
     networkSymbol: NetworkSymbol;
 };
 
-export type GetAllLabelsForAccount = (params: GetAllLabelsForAccountParams) => AllLabelsForAccount;
+type GetAllLabelsForAccount = (params: GetAllLabelsForAccountParams) => AllLabelsForAccount;
 
 export type GetAllLabelsForAccountDeps = {
     getAllLabelsForAccount: GetAllLabelsForAccount;


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into a small isolated PR for easy, low-risk review.

The full staging branch is green; CI verifies this subset independently.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are in the BIP329 label creation/conversion modules used by Suite Sync. Both files map to 121 tests via transitive imports, indicating they are bundled as broad dependencies. However, the actual functional impact is concentrated on metadata/labeling features, specifically Suite Sync label synchronization and potentially label export. The recommended strategy focuses on the 4 Suite Sync tests (which directly exercise the label sync pipeline) at high priority, plus a few metadata/export tests at medium priority where BIP329 conversion is plausibly in the code path.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/bip329/src/createBip329.ts`
- `suite-common/bip329/src/suiteSync/createSuiteSyncToBip329.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — createSuiteSyncToBip329.ts is part of the Suite Sync labeling pipeline. This test creates account, wallet, address, and output labels via Suite Sync and verifies they are synchronized to the Evolu Relay backend. Changes to the BIP329 conversion layer used by Suite Sync could break label creation and synchronization.
- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — This test exercises Suite Sync label syncing across multiple passphrase-protected wallets, verifying wallet and account labels are persisted with correct owner IDs and descriptors to the Evolu relay. The createSuiteSyncToBip329 module directly participates in this data transformation pipeline.
- `suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts` — Tests removing previously synced labels (account, wallet, address, output) via Suite Sync and verifying null values are synced back to the Evolu relay. The BIP329/Suite Sync conversion layer is directly in the data path for label removal synchronization.
- `suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — Tests syncing labels from the Evolu relay server to the Suite UI for accounts, wallets, addresses, and transaction outputs. The createSuiteSyncToBip329 module handles the conversion between Suite Sync format and BIP329, which is critical for this read path.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts` — Tests migrating account labels from legacy Dropbox labeling to Suite Sync. The migration path likely involves BIP329 format conversion, so changes to createBip329 or createSuiteSyncToBip329 could affect label migration correctness.
- `suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — Tests output/transaction labeling and CSV export containing labels. The createBip329 module may be involved in formatting label data for export. The test explicitly verifies CSV export contains output labels, which could use BIP329 format.
- `suite/e2e/tests/wallet/export-transactions.test.ts` — Tests exporting transaction history in PDF, CSV, and JSON formats. BIP329 is a label export standard, and createBip329.ts changes could affect how labels are serialized in exported transaction files.

</details>

_Updated: 2026-06-15T09:48:15.011Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-bip329/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-bip329/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-bip329&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-bip329&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-bip329&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-15T09:53:14.869Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-15T09:52:06.915Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->