### PR TITLE
chore(firmware-authenticity): remove dead hash-check-notification helper, unexport module prefix

### DIFF
--- a/suite-common/firmware-authenticity/src/reportSecurityCheckThunk.ts
+++ b/suite-common/firmware-authenticity/src/reportSecurityCheckThunk.ts
@@ -1,7 +1,7 @@
 import { createThunk } from '@suite-common/redux-utils';
 import { type ReportSecurityCheckParams } from '@suite-common/suite-types';
 
-export const FIRMWARE_AUTHENTICITY_MODULE_PREFIX = '@common/firmware-authenticity';
+const FIRMWARE_AUTHENTICITY_MODULE_PREFIX = '@common/firmware-authenticity';
 
 /**
  * Wrapper thunk around extra.services.reportSecurityCheck

--- a/suite-common/firmware-authenticity/src/utils.ts
+++ b/suite-common/firmware-authenticity/src/utils.ts
@@ -38,17 +38,6 @@ export const getIsRevisionCheckErrorWithNotification = (
 ): error is RevisionCheckErrorWithNotification =>
     revisionCheckErrorScenarios[error].shouldNotify === true;
 
-export type HashCheckErrorWithNotification = keyof FilterPropertiesByType<
-    typeof hashCheckErrorScenarios,
-    { shouldNotify: true }
->;
-
-export const getIsHashCheckErrorWithNotification = (
-    error: FirmwareHashCheckError,
-): error is HashCheckErrorWithNotification =>
-    // @ts-expect-error if this no longer gives error, then TODO hash check notifications must be implemented
-    hashCheckErrorScenarios[error].shouldNotify === true;
-
 type AuthenticityChecks = AcquiredDevice['authenticityChecks'];
 
 export const filterInconclusiveAuthenticityChecks = (


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into a small isolated PR for easy, low-risk review.

The full staging branch is green; CI verifies this subset independently.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are in the firmware-authenticity module (reportSecurityCheckThunk and utils), which is a broadly imported dependency (121 tests). However, its actual runtime impact is concentrated in firmware verification flows during onboarding, device connection, and firmware installation. The recommended strategy focuses on tests that directly exercise firmware checks, device authenticity verification, entropy check failure handling, and onboarding flows where firmware hash checks are explicitly validated or dismissed. Most of the 121 statically-mapped tests only transitively import this module and are unlikely to be affected.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/firmware-authenticity/src/reportSecurityCheckThunk.ts`
- `suite-common/firmware-authenticity/src/utils.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/firmware/custom-firmware.test.ts` — This test directly exercises firmware installation on a device, which is the closest E2E flow to firmware authenticity checking. Changes to reportSecurityCheckThunk and utils in the firmware-authenticity module could affect how the app handles firmware verification during or after installation.
- `suite/e2e/tests/onboarding/firmware-check.test.ts` — This test explicitly validates firmware readiness detection during onboarding, which directly involves firmware authenticity/security checks. The changed files (reportSecurityCheckThunk, utils) are core to the firmware authenticity verification that runs during this flow.
- `suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts` — This test validates device compromised modal behavior and entropy check failure handling during onboarding — directly related to security check infrastructure. The reportSecurityCheckThunk likely feeds into the device-compromised modal logic tested here.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/suite/initial-run.test.ts` — This test covers the full initial onboarding flow including optionally dismissing a firmware hash check error modal (@device-compromised/dismiss-button), which is directly triggered by firmware authenticity check results from the changed thunk.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts` — This test includes passing through the device authenticity check step during T3T1 onboarding. Changes to firmware authenticity utils and the security check thunk could affect whether this step completes correctly.
- `suite/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts` — This onboarding wallet creation test goes through firmware setup steps where firmware authenticity checks run. A regression in the security check thunk could block wallet creation.

</details>

_Updated: 2026-06-17T08:35:54.385Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-firmware-authenticity&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-firmware-authenticity&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-firmware-authenticity&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-17T08:40:25.891Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-17T08:39:24.552Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-firmware-authenticity/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-firmware-authenticity/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- BLAME-AUTHORS -->
**Author(s) of the removed code** (via `git blame`): @Lemonexe — please confirm this code is genuinely dead and safe to delete, and not intentional preparation. 🙏