### PR TITLE
chore(react-query): remove empty mutation/query key maps

### DIFF
--- a/suite-common/react-query/src/constants/mutationKeys.ts
+++ b/suite-common/react-query/src/constants/mutationKeys.ts
@@ -1,9 +1,5 @@
 import { type AllowedMutationKey } from '../types';
 
-export const commonMutationKeys = {} as const satisfies Record<string, AllowedMutationKey>;
-
 export const desktopMutationKeys = {
     getYieldOpportunities: ['get-yield-opportunities'],
 } as const satisfies Record<string, AllowedMutationKey>;
-
-export const mobileMutationKeys = {} as const satisfies Record<string, AllowedMutationKey>;

--- a/suite-common/react-query/src/constants/queryKeys.ts
+++ b/suite-common/react-query/src/constants/queryKeys.ts
@@ -2,7 +2,6 @@ import type { AllowedQueryKey } from '../types';
 
 export const commonQueryKeys = {
     networkTxSimulation: (input?: any) => ['network-tx-simulation', input],
-    depositTxSimulation: (input?: any) => ['tx-simulation-deposit', input],
     dappScan: (url?: string) => ['dapp-scan', url],
     validatorsQueue: (accountKey: string | undefined, timestamp?: number) => [
         'everstake',
@@ -24,8 +23,6 @@ export const desktopQueryKeys = {
     inactiveTokens: (symbol: string, accountKey?: string) =>
         accountKey ? ['inactive-tokens', symbol, accountKey] : ['inactive-tokens', symbol],
 } as const satisfies Record<string, AllowedQueryKey>;
-
-export const mobileQueryKeys = {} as const satisfies Record<string, AllowedQueryKey>;
 
 export const tradingQueryKeys = {
     otcData: () => ['trading', 'otc-data'],


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into a small isolated PR for easy, low-risk review.

The full staging branch is green; CI verifies this subset independently.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are `mutationKeys.ts` and `queryKeys.ts` — constant definition files for React Query cache keys. These are extremely broad shared infrastructure files that map to all 121 E2E tests via transitive imports. Changes to these files (adding, renaming, or removing key constants) would only cause runtime failures if a key rename broke a specific React Query hook's cache invalidation or data fetching. Since these are constant definitions (not logic), and no test in the LLM analysis references React Query keys, mutation keys, or query caching as part of their tested behavior, there is no specific evidence that any individual E2E test would regress from this change. The risk is very low — if a key constant were mistyped or removed, it would be caught by TypeScript compilation rather than E2E tests. No targeted E2E tests are recommended; a build/type-check step provides better coverage for this change.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/react-query/src/constants/mutationKeys.ts`
- `suite-common/react-query/src/constants/queryKeys.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (2)**
- `suite-common/react-query/src/constants/mutationKeys.ts`
- `suite-common/react-query/src/constants/queryKeys.ts`

_Updated: 2026-06-17T08:34:59.645Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-react-query/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-react-query/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-react-query&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-react-query&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-react-query&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-17T08:40:31.307Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-17T08:39:09.962Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- BLAME-AUTHORS -->
**Author(s) of the removed code** (via `git blame`): @cermakjiri @izmy @sherpaPSX — please confirm this code is genuinely dead and safe to delete, and not intentional preparation. 🙏