### PR TITLE
chore(suite-native): unexport intra-package passphrase navigator

### DIFF
--- a/suite-native/module-passphrase/src/PassphraseStackNavigator.tsx
+++ b/suite-native/module-passphrase/src/PassphraseStackNavigator.tsx
@@ -23,7 +23,7 @@ import { PassphraseFormScreen } from './screens/PassphraseFormScreen';
 import { PassphraseLoadingScreen } from './screens/PassphraseLoadingScreen';
 import { PassphraseVerifyEmptyWalletScreen } from './screens/PassphraseVerifyEmptyWalletScreen';
 
-export const PassphraseStack = createNativeStackNavigator<PassphraseStackParamList>();
+const PassphraseStack = createNativeStackNavigator<PassphraseStackParamList>();
 
 export const PassphraseStackNavigator = () => {
     const selectedDevice = useSelector(selectSelectedDevice);


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into a small isolated PR for easy, low-risk review.

The full staging branch is green; CI verifies this subset independently.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-native-passphrase&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->