### PR TITLE
chore(suite-native): unexport intra-package pending-coin-visibility state type

### DIFF
--- a/suite-native/discovery/src/pendingCoinVisibilitySlice.ts
+++ b/suite-native/discovery/src/pendingCoinVisibilitySlice.ts
@@ -2,7 +2,7 @@ import { type PayloadAction, createSlice } from '@reduxjs/toolkit';
 
 import type { NetworkSymbol } from '@suite-common/wallet-config';
 
-export type PendingCoinVisibilityState = {
+type PendingCoinVisibilityState = {
     symbols: NetworkSymbol[];
 };
 


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into a small isolated PR for easy, low-risk review.

The full staging branch is green; CI verifies this subset independently.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-native-discovery&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->