### PR TITLE
chore(connect): get rid of node-fetch in favor of native fetch

### DIFF
--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -118,7 +118,6 @@
         "@vitest/browser-playwright": "^4.1.6",
         "crypto-browserify": "3.12.1",
         "jest": "29.7.0",
-        "node-fetch": "^3.3.2",
         "process": "^0.11.10",
         "stream-browserify": "^3.0.0",
         "tsx": "^4.21.0",

--- a/packages/connect/src/device/__tests__/checkFirmwareRevision.test.ts
+++ b/packages/connect/src/device/__tests__/checkFirmwareRevision.test.ts
@@ -1,5 +1,3 @@
-import { FetchError } from 'node-fetch';
-
 import type { FirmwareRevisionCheckResult } from '@trezor/connect-common/src/types/device';
 import type { FirmwareRelease } from '@trezor/device-utils';
 import { DeviceModelInternal, FirmwareType } from '@trezor/device-utils';
@@ -101,11 +99,22 @@ describe.each(DeviceNames)(`${checkFirmwareRevision.name} for device %s`, intern
         {
             it: 'errors with a specific error message when the check cannot be performed because the revision is not found locally and the user is offline',
             httpRequestMock: () => {
-                throw new FetchError('You are offline!', 'network', {
-                    code: 'ENOTFOUND',
-                    name: 'FetchError',
-                    message: 'You are offline!',
+                // Native `fetch` throws `TypeError: fetch failed` with the underlying
+                // system error exposed on `cause`.
+                throw new TypeError('fetch failed', {
+                    cause: Object.assign(new Error('You are offline!'), { code: 'ENOTFOUND' }),
                 });
+            },
+            params: createDeviceParams({
+                expectedRevision: undefined, // firmware not known by local releases.json file
+            }),
+            expected: { success: false, error: 'cannot-perform-check-offline' },
+        },
+        {
+            it: 'errors with a specific error message when the check cannot be performed because the revision is not found locally and the browser is offline',
+            httpRequestMock: () => {
+                // Browser/Chromium `fetch` throws `TypeError: Failed to fetch` for offline failures.
+                throw new TypeError('Failed to fetch');
             },
             params: createDeviceParams({
                 expectedRevision: undefined, // firmware not known by local releases.json file

--- a/packages/connect/src/device/checkFirmwareRevision.ts
+++ b/packages/connect/src/device/checkFirmwareRevision.ts
@@ -14,9 +14,50 @@ import { HttpRequestError } from '../utils/assetUtils';
 const isNotFoundError = (e: unknown): boolean =>
     e instanceof HttpRequestError && e.response.status === 404;
 
-const isNodeJSOfflineError = (e: Error) => ['FetchError', 'AbortError'].includes(e.name);
+// System error codes that signify a missing connection or unreachable host.
+const NODEJS_NETWORK_ERROR_CODES = [
+    'ENOTFOUND',
+    'ECONNREFUSED',
+    'ECONNRESET',
+    'EAI_AGAIN',
+    'ENETUNREACH',
+    'EHOSTUNREACH',
+    'ETIMEDOUT',
+];
+
+// Native `fetch` (undici) reports connectivity failures as `TypeError: fetch failed` and attaches
+// the underlying system error on the `cause` chain, so we walk it to find the error code.
+const getNodeJSErrorCode = (e: unknown): string | undefined => {
+    if (typeof e !== 'object' || e === null) {
+        return undefined;
+    }
+    if ('code' in e && typeof e.code === 'string') {
+        return e.code;
+    }
+    if ('cause' in e) {
+        return getNodeJSErrorCode(e.cause);
+    }
+
+    return undefined;
+};
+
+const isNodeJSOfflineError = (e: Error) => {
+    if (e instanceof TypeError && e.message.includes('fetch failed')) {
+        return true;
+    }
+
+    const code = getNodeJSErrorCode(e);
+
+    return code !== undefined && NODEJS_NETWORK_ERROR_CODES.includes(code);
+};
+
 const isReactNativeOfflineError = (e: Error) =>
     e.name === 'TypeError' && e.message.includes('Network request failed');
+
+// Browser/Chromium `fetch` throws `TypeError: Failed to fetch` when the request never completes.
+const isBrowserOfflineError = (e: Error) =>
+    e instanceof TypeError && e.message.includes('Failed to fetch');
+
 const isAbortControllerTimeout = (e: Error) =>
     e.message.includes('Aborted') ||
     e.name === 'AbortError' ||
@@ -24,15 +65,19 @@ const isAbortControllerTimeout = (e: Error) =>
 
 /**
  * Check if an error signifies a missing fetch response (meaning network connection loss or unavailable host).
- * This can only by correctly identified in nodeJS or React native runtimes (i.e. Suite Desktop main process, or Suite Mobile).
- * In browser runtime (Suite Web), all fetch errors are lumped together as CORS errors, therefore indistinguishable.
- * (even a request that had no response is CORS error, since a non-existent response does not have CORS headers).
+ * Each runtime surfaces this differently: nodeJS/undici as `fetch failed` (with a system error code on
+ * the `cause` chain), React native as `Network request failed`, and browser/Chromium as `Failed to fetch`.
  * Additionally, AbortController timeouts are also considered to be network issues.
  */
 const isOfflineError = (e: unknown): boolean => {
     if (!(e instanceof Error)) return false;
 
-    return isNodeJSOfflineError(e) || isReactNativeOfflineError(e) || isAbortControllerTimeout(e);
+    return (
+        isNodeJSOfflineError(e) ||
+        isReactNativeOfflineError(e) ||
+        isBrowserOfflineError(e) ||
+        isAbortControllerTimeout(e)
+    );
 };
 
 const failFirmwareRevisionCheck = (

--- a/packages/connect/src/utils/assetUtils.ts
+++ b/packages/connect/src/utils/assetUtils.ts
@@ -1,5 +1,3 @@
-import fetch from 'cross-fetch';
-
 import { firmwareAssets } from '@trezor/connect-data';
 import connectDataCoinsEth from '@trezor/connect-data/files/coins-eth.json';
 import connectDataCoins from '@trezor/connect-data/files/coins.json';

--- a/yarn.lock
+++ b/yarn.lock
@@ -16089,7 +16089,6 @@ __metadata:
     crypto-browserify: "npm:3.12.1"
     jest: "npm:29.7.0"
     jws: "npm:^4.0.1"
-    node-fetch: "npm:^3.3.2"
     process: "npm:^0.11.10"
     stream-browserify: "npm:^3.0.0"
     tsx: "npm:^4.21.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Getting rid of `node-fetch` in favor of native fetch. In order to properly support the functionality in `packages/connect/src/device/checkFirmwareRevision.ts` I have to do some changes so we can properly identify `offline` errors in all the environments where we run.

## Notes for QA
Test that Check firmware authenticity works as expected.


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are focused on firmware revision checking logic (checkFirmwareRevision.ts), its unit test, a utility file (assetUtils.ts), and a package.json update. Both checkFirmwareRevision.ts and assetUtils.ts map to 121 tests each, indicating they are deeply shared infrastructure — most tests should NOT be run since they only transitively depend on these files. The highest-risk tests are those that directly exercise firmware validation during onboarding and custom firmware installation. The assetUtils.ts change appears to be a utility used broadly but without specific E2E tests that focus on asset resolution behavior in isolation.

<details><summary><b>Changed files (4)</b></summary>

- `packages/connect/package.json`
- `packages/connect/src/device/__tests__/checkFirmwareRevision.test.ts`
- `packages/connect/src/device/checkFirmwareRevision.ts`
- `packages/connect/src/utils/assetUtils.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/onboarding/firmware-check.test.ts` — This test directly exercises firmware readiness detection during onboarding, which is the core user-facing behavior affected by changes to checkFirmwareRevision.ts. It validates that firmware is detected as ready across multiple device models (T1B1, T2T1, T3B1, T3T1), directly exercising the changed firmware revision check logic.
- `suite/e2e/tests/firmware/custom-firmware.test.ts` — Custom firmware installation directly involves firmware validation and revision checking. Changes to checkFirmwareRevision.ts could affect whether custom firmware is accepted or rejected, making this a critical test for the changed code path.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts` — This test explicitly interacts with firmware checks during onboarding (disableNecessaryFirmwareChecks, firmware hash check dismissal). Changes to checkFirmwareRevision.ts could alter error handling behavior for firmware validation during wallet creation.
- `suite/e2e/tests/suite/initial-run.test.ts` — This test covers the initial onboarding flow including dismissing firmware hash check error modals (@device-compromised/dismiss-button). Changes to checkFirmwareRevision.ts could affect whether/when the firmware hash check error modal appears during initial run.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts` — This test covers onboarding in offline mode and explicitly references TR_FIRMWARE_REVISION_CHECK_OTHER_ERROR translation key, indicating it exercises firmware revision check error paths. Changes to checkFirmwareRevision.ts could affect offline firmware validation behavior.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/settings/autodetect.test.ts` — This test dismisses firmware hash check errors during setup (onboardingPage firmware hash check dismissal), which exercises the firmware revision check error UI path that could be affected by changes to checkFirmwareRevision.ts.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/connect/package.json`
- `packages/connect/src/device/__tests__/checkFirmwareRevision.test.ts`
- `packages/connect/src/utils/assetUtils.ts`

_Updated: 2026-06-19T09:52:29.083Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=get-rid-of-fetch-deps&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=get-rid-of-fetch-deps&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=get-rid-of-fetch-deps&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy BTC > Buy Bitcoin from best offer | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-19T09:57:36.861Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-19T09:55:49.085Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/get-rid-of-fetch-deps/web/](https://dev.suite.sldev.cz/suite-web/get-rid-of-fetch-deps/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->