### PR TITLE
Asset list rerenders

### DIFF
--- a/suite-native/assets/package.json
+++ b/suite-native/assets/package.json
@@ -11,7 +11,6 @@
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
     },
     "dependencies": {
-        "@mobily/ts-belt": "^3.13.1",
         "@react-navigation/native": "7.1.28",
         "@suite-common/assets": "workspace:*",
         "@suite-common/device": "workspace:*",

--- a/suite-native/assets/src/assetsSelectors.ts
+++ b/suite-native/assets/src/assetsSelectors.ts
@@ -1,5 +1,3 @@
-import { G } from '@mobily/ts-belt';
-
 import { calculateAssetsPercentage } from '@suite-common/assets';
 import type { DeviceRootState } from '@suite-common/device';
 import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
@@ -11,7 +9,6 @@ import {
     type WalletSettingsRootState,
     selectBaseCurrency,
     selectCurrentFiatRates,
-    selectDeviceAccounts,
     selectVisibleDeviceAccounts,
 } from '@suite-common/wallet-core';
 import { type BaseCurrencyAmount, asBaseCurrencyAmount } from '@suite-common/wallet-types';
@@ -38,8 +35,10 @@ export type AssetsRootState = AccountsRootState &
 const createMemoizedSelector = createWeakMapSelector.withTypes<AssetsRootState>();
 
 /*
-We do not memoize most of following selectors because they are using only with `useSelectorDeepComparison` hook which is faster than memoization.
-TODO: revalidate if this is still true for reselect
+Selectors here are memoized via `createWeakMapSelector`. Where the inputs churn (e.g. during
+discovery) but the output is value-stable, attach a `resultEqualityCheck` so the selector keeps
+returning the same reference. Consumers can then use a plain `useSelector` (`===`) instead of the
+per-dispatch deep walk of `useSelectorDeepComparison`.
 */
 
 const areNetworkSymbolsEqual = (
@@ -50,19 +49,6 @@ const areNetworkSymbolsEqual = (
     previousNetworkSymbols.every(
         (networkSymbol, index) => networkSymbol === nextNetworkSymbols[index],
     );
-
-export const selectVisibleDeviceAccountsKeysByNetworkSymbol = (
-    state: AssetsRootState,
-    symbol: NetworkSymbol | null,
-) => {
-    if (G.isNull(symbol)) return [];
-
-    const accounts = selectDeviceAccounts(state).filter(
-        account => account.symbol === symbol && account.visible,
-    );
-
-    return accounts.map(account => account.key);
-};
 
 export const selectDeviceNetworkSymbolsWithAssets = createMemoizedSelector(
     [selectVisibleDeviceAccounts],
@@ -167,9 +153,18 @@ const selectAssetsFiatValuePercentage = createMemoizedSelector(
     },
 );
 
+type AssetFiatPercentage = {
+    fiatPercentage: number;
+    fiatPercentageOffset: number;
+};
+
+const areAssetPercentagesEqual = (previous: AssetFiatPercentage, next: AssetFiatPercentage) =>
+    previous.fiatPercentage === next.fiatPercentage &&
+    previous.fiatPercentageOffset === next.fiatPercentageOffset;
+
 export const selectAssetFiatValuePercentage = createMemoizedSelector(
     [selectAssetsFiatValuePercentage, (_state, symbol: NetworkSymbol) => symbol],
-    (assetsPercentages, symbol) => {
+    (assetsPercentages, symbol): AssetFiatPercentage => {
         const asset = assetsPercentages.find(a => a.symbol === symbol);
 
         const assetPercentage = {
@@ -178,5 +173,10 @@ export const selectAssetFiatValuePercentage = createMemoizedSelector(
         };
 
         return assetPercentage;
+    },
+    {
+        memoizeOptions: {
+            resultEqualityCheck: areAssetPercentagesEqual,
+        },
     },
 );

--- a/suite-native/assets/src/assetsSelectors.ts
+++ b/suite-native/assets/src/assetsSelectors.ts
@@ -91,9 +91,7 @@ const selectDeviceAssetsWithBalances = createMemoizedSelector(
             };
         });
 
-        let totalFiatBalance = asBaseCurrencyAmount(new BigNumber(0));
-
-        const assets = deviceNetworkSymbolsWithAssets.map((symbol: NetworkSymbol) => {
+        return deviceNetworkSymbolsWithAssets.map((symbol: NetworkSymbol): AssetType => {
             const networkAccounts = accountsWithFiatBalance.filter(
                 account => account.symbol === symbol,
             );
@@ -110,27 +108,19 @@ const selectDeviceAssetsWithBalances = createMemoizedSelector(
                 return sum.plus(fiatValue);
             }, new BigNumber(0));
 
-            if (fiatBalance) {
-                totalFiatBalance = asBaseCurrencyAmount(totalFiatBalance.plus(fiatBalance));
-            }
-
-            const asset: AssetType = {
+            return {
                 symbol,
                 // For assets we should always only 8 decimals to save space
                 assetBalance: assetBalance.toFixed(8),
                 fiatBalance: fiatBalance ? asBaseCurrencyAmount(fiatBalance) : null,
             };
-
-            return asset;
         });
-
-        return { assets, totalFiatBalance: asBaseCurrencyAmount(totalFiatBalance) };
     },
 );
 
 export const selectAssetCryptoValue = (state: AssetsRootState, symbol: NetworkSymbol) => {
     const assets = selectDeviceAssetsWithBalances(state);
-    const asset = assets.assets.find(a => a.symbol === symbol);
+    const asset = assets.find(a => a.symbol === symbol);
 
     return asset?.assetBalance ?? '0';
 };
@@ -138,7 +128,7 @@ export const selectAssetCryptoValue = (state: AssetsRootState, symbol: NetworkSy
 export const selectAssetFiatValue = createMemoizedSelector(
     [selectDeviceAssetsWithBalances, (_state, symbol: NetworkSymbol) => symbol],
     (assets, symbol) => {
-        const asset = assets.assets.find(a => a.symbol === symbol);
+        const asset = assets.find(a => a.symbol === symbol);
 
         return asset?.fiatBalance?.toString() ?? null;
     },
@@ -147,7 +137,7 @@ export const selectAssetFiatValue = createMemoizedSelector(
 const selectAssetsFiatValuePercentage = createMemoizedSelector(
     [selectDeviceAssetsWithBalances],
     assets => {
-        const percentages = calculateAssetsPercentage(assets.assets);
+        const percentages = calculateAssetsPercentage(assets);
 
         return percentages;
     },

--- a/suite-native/assets/src/assetsSelectors.ts
+++ b/suite-native/assets/src/assetsSelectors.ts
@@ -1,65 +1,26 @@
+import { shallowEqual } from 'react-redux';
+
 import {
     type AssetFiatBalanceWithPercentage,
     calculateAssetsPercentage,
 } from '@suite-common/assets';
-import type { DeviceRootState } from '@suite-common/device';
 import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
-import { type TokenDefinitionsRootState } from '@suite-common/token-definitions';
 import { type NetworkSymbol, networkSymbolCollection } from '@suite-common/wallet-config';
 import {
-    type AccountsRootState,
-    type DiscoveryRootState,
-    type FiatRatesRootState,
-    type WalletSettingsRootState,
     selectBaseCurrency,
     selectCurrentFiatRates,
     selectHasRunningDiscovery,
     selectVisibleDeviceAccounts,
     selectVisibleDeviceAccountsByNetworkSymbol,
 } from '@suite-common/wallet-core';
-import {
-    type AccountKey,
-    type BaseCurrencyAmount,
-    asBaseCurrencyAmount,
-} from '@suite-common/wallet-types';
+import { type AccountKey, asBaseCurrencyAmount } from '@suite-common/wallet-types';
 import { getAccountFiatBalance, isStakingSymbol } from '@suite-common/wallet-utils';
-import {
-    type NativeStakingRootState,
-    getAccountCryptoBalanceWithStaking,
-} from '@suite-native/staking';
+import { getAccountCryptoBalanceWithStaking } from '@suite-native/staking';
 import { BigNumber } from '@trezor/utils';
 
-export interface AssetType {
-    symbol: NetworkSymbol;
-    assetBalance: string;
-    fiatBalance: BaseCurrencyAmount | null;
-}
-
-export type AssetsRootState = AccountsRootState &
-    FiatRatesRootState &
-    WalletSettingsRootState &
-    TokenDefinitionsRootState &
-    NativeStakingRootState &
-    DeviceRootState &
-    DiscoveryRootState;
+import { type AssetFiatPercentage, type AssetType, type AssetsRootState } from './types';
 
 const createMemoizedSelector = createWeakMapSelector.withTypes<AssetsRootState>();
-
-/*
-Selectors here are memoized via `createWeakMapSelector`. Where the inputs churn (e.g. during
-discovery) but the output is value-stable, attach a `resultEqualityCheck` so the selector keeps
-returning the same reference. Consumers can then use a plain `useSelector` (`===`) instead of the
-per-dispatch deep walk of `useSelectorDeepComparison`.
-*/
-
-const areNetworkSymbolsEqual = (
-    previousNetworkSymbols: NetworkSymbol[],
-    nextNetworkSymbols: NetworkSymbol[],
-) =>
-    previousNetworkSymbols.length === nextNetworkSymbols.length &&
-    previousNetworkSymbols.every(
-        (networkSymbol, index) => networkSymbol === nextNetworkSymbols[index],
-    );
 
 export const selectDeviceNetworkSymbolsWithAssets = createMemoizedSelector(
     [selectVisibleDeviceAccounts],
@@ -72,7 +33,10 @@ export const selectDeviceNetworkSymbolsWithAssets = createMemoizedSelector(
     },
     {
         memoizeOptions: {
-            resultEqualityCheck: areNetworkSymbolsEqual,
+            // accounts churn every discovery tick but the symbol set rarely changes; shallowEqual
+            // keeps the previous array reference when symbols match, so `Assets` re-renders only
+            // when a network is added or removed, not on every balance update.
+            resultEqualityCheck: shallowEqual,
         },
     },
 );
@@ -163,18 +127,9 @@ export const selectAssetFiatValue = createMemoizedSelector(
     },
 );
 
-type AssetFiatPercentage = {
-    fiatPercentage: number;
-    fiatPercentageOffset: number;
-};
-
 const selectAssetsFiatValuePercentage = createMemoizedSelector(
     [selectDeviceAssetsWithBalances, selectHasRunningDiscovery],
     (assets, hasDiscovery): AssetFiatBalanceWithPercentage[] =>
-        // While discovery runs the totals change every tick, so skip the full percentage pass and
-        // compute it once discovery finishes. The empty result must stay a STABLE reference
-        // (returnStableArrayIfEmpty) - that stability is what keeps selectAssetFiatValuePercentage
-        // stable during discovery, so its consumer needs no resultEqualityCheck.
         hasDiscovery ? returnStableArrayIfEmpty([]) : calculateAssetsPercentage(assets),
 );
 

--- a/suite-native/assets/src/assetsSelectors.ts
+++ b/suite-native/assets/src/assetsSelectors.ts
@@ -1,14 +1,19 @@
-import { calculateAssetsPercentage } from '@suite-common/assets';
+import {
+    type AssetFiatBalanceWithPercentage,
+    calculateAssetsPercentage,
+} from '@suite-common/assets';
 import type { DeviceRootState } from '@suite-common/device';
 import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import { type TokenDefinitionsRootState } from '@suite-common/token-definitions';
 import { type NetworkSymbol, networkSymbolCollection } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
+    type DiscoveryRootState,
     type FiatRatesRootState,
     type WalletSettingsRootState,
     selectBaseCurrency,
     selectCurrentFiatRates,
+    selectHasRunningDiscovery,
     selectVisibleDeviceAccounts,
 } from '@suite-common/wallet-core';
 import { type BaseCurrencyAmount, asBaseCurrencyAmount } from '@suite-common/wallet-types';
@@ -30,7 +35,8 @@ export type AssetsRootState = AccountsRootState &
     WalletSettingsRootState &
     TokenDefinitionsRootState &
     NativeStakingRootState &
-    DeviceRootState;
+    DeviceRootState &
+    DiscoveryRootState;
 
 const createMemoizedSelector = createWeakMapSelector.withTypes<AssetsRootState>();
 
@@ -134,39 +140,29 @@ export const selectAssetFiatValue = createMemoizedSelector(
     },
 );
 
-const selectAssetsFiatValuePercentage = createMemoizedSelector(
-    [selectDeviceAssetsWithBalances],
-    assets => {
-        const percentages = calculateAssetsPercentage(assets);
-
-        return percentages;
-    },
-);
-
 type AssetFiatPercentage = {
     fiatPercentage: number;
     fiatPercentageOffset: number;
 };
 
-const areAssetPercentagesEqual = (previous: AssetFiatPercentage, next: AssetFiatPercentage) =>
-    previous.fiatPercentage === next.fiatPercentage &&
-    previous.fiatPercentageOffset === next.fiatPercentageOffset;
+const selectAssetsFiatValuePercentage = createMemoizedSelector(
+    [selectDeviceAssetsWithBalances, selectHasRunningDiscovery],
+    (assets, hasDiscovery): AssetFiatBalanceWithPercentage[] =>
+        // While discovery runs the totals change every tick, so skip the full percentage pass and
+        // compute it once discovery finishes. The empty result must stay a STABLE reference
+        // (returnStableArrayIfEmpty) - that stability is what keeps selectAssetFiatValuePercentage
+        // stable during discovery, so its consumer needs no resultEqualityCheck.
+        hasDiscovery ? returnStableArrayIfEmpty([]) : calculateAssetsPercentage(assets),
+);
 
 export const selectAssetFiatValuePercentage = createMemoizedSelector(
     [selectAssetsFiatValuePercentage, (_state, symbol: NetworkSymbol) => symbol],
     (assetsPercentages, symbol): AssetFiatPercentage => {
         const asset = assetsPercentages.find(a => a.symbol === symbol);
 
-        const assetPercentage = {
+        return {
             fiatPercentage: Math.ceil(asset?.fiatPercentage ?? 0),
             fiatPercentageOffset: Math.floor(asset?.fiatPercentageOffset ?? 0),
         };
-
-        return assetPercentage;
-    },
-    {
-        memoizeOptions: {
-            resultEqualityCheck: areAssetPercentagesEqual,
-        },
     },
 );

--- a/suite-native/assets/src/assetsSelectors.ts
+++ b/suite-native/assets/src/assetsSelectors.ts
@@ -1,8 +1,8 @@
-import { A, G, pipe } from '@mobily/ts-belt';
+import { G } from '@mobily/ts-belt';
 
 import { calculateAssetsPercentage } from '@suite-common/assets';
 import type { DeviceRootState } from '@suite-common/device';
-import { createWeakMapSelector } from '@suite-common/redux-utils';
+import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import { type TokenDefinitionsRootState } from '@suite-common/token-definitions';
 import { type NetworkSymbol, networkSymbolCollection } from '@suite-common/wallet-config';
 import {
@@ -42,6 +42,15 @@ We do not memoize most of following selectors because they are using only with `
 TODO: revalidate if this is still true for reselect
 */
 
+const areNetworkSymbolsEqual = (
+    previousNetworkSymbols: NetworkSymbol[],
+    nextNetworkSymbols: NetworkSymbol[],
+) =>
+    previousNetworkSymbols.length === nextNetworkSymbols.length &&
+    previousNetworkSymbols.every(
+        (networkSymbol, index) => networkSymbol === nextNetworkSymbols[index],
+    );
+
 export const selectVisibleDeviceAccountsKeysByNetworkSymbol = (
     state: AssetsRootState,
     symbol: NetworkSymbol | null,
@@ -55,30 +64,30 @@ export const selectVisibleDeviceAccountsKeysByNetworkSymbol = (
     return accounts.map(account => account.key);
 };
 
-export const selectDeviceNetworksWithAssets = createMemoizedSelector(
+export const selectDeviceNetworkSymbolsWithAssets = createMemoizedSelector(
     [selectVisibleDeviceAccounts],
-    accounts =>
-        pipe(
-            accounts,
-            A.map(account => account.symbol),
-            A.uniq,
-            A.sort((a, b) => {
-                const aOrder = networkSymbolCollection.indexOf(a) ?? Number.MAX_SAFE_INTEGER;
-                const bOrder = networkSymbolCollection.indexOf(b) ?? Number.MAX_SAFE_INTEGER;
+    accounts => {
+        const networkSymbols = new Set(accounts.map(account => account.symbol));
 
-                return aOrder - bOrder;
-            }),
-        ),
+        return returnStableArrayIfEmpty(
+            networkSymbolCollection.filter(networkSymbol => networkSymbols.has(networkSymbol)),
+        );
+    },
+    {
+        memoizeOptions: {
+            resultEqualityCheck: areNetworkSymbolsEqual,
+        },
+    },
 );
 
 const selectDeviceAssetsWithBalances = createMemoizedSelector(
     [
         selectVisibleDeviceAccounts,
-        selectDeviceNetworksWithAssets,
+        selectDeviceNetworkSymbolsWithAssets,
         selectBaseCurrency,
         selectCurrentFiatRates,
     ],
-    (accounts, deviceNetworksWithAssets, baseCurrencyCode, rates) => {
+    (accounts, deviceNetworkSymbolsWithAssets, baseCurrencyCode, rates) => {
         const accountsWithFiatBalance = accounts.map(account => {
             const shouldIncludeStaking = isStakingSymbol(account.symbol);
 
@@ -98,7 +107,7 @@ const selectDeviceAssetsWithBalances = createMemoizedSelector(
 
         let totalFiatBalance = asBaseCurrencyAmount(new BigNumber(0));
 
-        const assets = deviceNetworksWithAssets.map((symbol: NetworkSymbol) => {
+        const assets = deviceNetworkSymbolsWithAssets.map((symbol: NetworkSymbol) => {
             const networkAccounts = accountsWithFiatBalance.filter(
                 account => account.symbol === symbol,
             );

--- a/suite-native/assets/src/assetsSelectors.ts
+++ b/suite-native/assets/src/assetsSelectors.ts
@@ -15,8 +15,13 @@ import {
     selectCurrentFiatRates,
     selectHasRunningDiscovery,
     selectVisibleDeviceAccounts,
+    selectVisibleDeviceAccountsByNetworkSymbol,
 } from '@suite-common/wallet-core';
-import { type BaseCurrencyAmount, asBaseCurrencyAmount } from '@suite-common/wallet-types';
+import {
+    type AccountKey,
+    type BaseCurrencyAmount,
+    asBaseCurrencyAmount,
+} from '@suite-common/wallet-types';
 import { getAccountFiatBalance, isStakingSymbol } from '@suite-common/wallet-utils';
 import {
     type NativeStakingRootState,
@@ -129,6 +134,24 @@ export const selectAssetCryptoValue = (state: AssetsRootState, symbol: NetworkSy
     const asset = assets.find(a => a.symbol === symbol);
 
     return asset?.assetBalance ?? '0';
+};
+
+export const selectHasMultipleDeviceAccountsForNetworkSymbol = (
+    state: AssetsRootState,
+    symbol: NetworkSymbol,
+) => selectVisibleDeviceAccountsByNetworkSymbol(state, symbol).length > 1;
+
+// Returns a primitive (key or null) so a plain `useSelector` (`===`) only re-renders when it
+// actually flips - which happens once, when the account count crosses 1<->2.
+export const selectSingleDeviceAccountKeyForNetworkSymbol = (
+    state: AssetsRootState,
+    symbol: NetworkSymbol,
+): AccountKey | null => {
+    if (selectHasMultipleDeviceAccountsForNetworkSymbol(state, symbol)) {
+        return null;
+    }
+
+    return selectVisibleDeviceAccountsByNetworkSymbol(state, symbol)[0]?.key ?? null;
 };
 
 export const selectAssetFiatValue = createMemoizedSelector(

--- a/suite-native/assets/src/components/AccountsCount.tsx
+++ b/suite-native/assets/src/components/AccountsCount.tsx
@@ -1,0 +1,22 @@
+import { useSelector } from 'react-redux';
+
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { selectVisibleDeviceAccountsByNetworkSymbol } from '@suite-common/wallet-core';
+import { Text } from '@suite-native/atoms';
+
+import { type AssetsRootState } from '../assetsSelectors';
+
+type AccountsCountProps = { symbol: NetworkSymbol };
+
+export const AccountsCount = ({ symbol }: AccountsCountProps) => {
+    const accountsCount = useSelector(
+        (state: AssetsRootState) =>
+            selectVisibleDeviceAccountsByNetworkSymbol(state, symbol).length,
+    );
+
+    return (
+        <Text variant="body-sm" color="contentSecondary">
+            {accountsCount}
+        </Text>
+    );
+};

--- a/suite-native/assets/src/components/AccountsCount.tsx
+++ b/suite-native/assets/src/components/AccountsCount.tsx
@@ -4,7 +4,7 @@ import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { selectVisibleDeviceAccountsByNetworkSymbol } from '@suite-common/wallet-core';
 import { Text } from '@suite-native/atoms';
 
-import { type AssetsRootState } from '../assetsSelectors';
+import { type AssetsRootState } from '../types';
 
 type AccountsCountProps = { symbol: NetworkSymbol };
 

--- a/suite-native/assets/src/components/AssetItem.tsx
+++ b/suite-native/assets/src/components/AssetItem.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { useSelector } from 'react-redux';
+import { useSelector, useStore } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
 import { BASE_CRYPTO_MAX_DISPLAYED_DECIMALS, useFormatters } from '@suite-common/formatters';
-import { useSelectorDeepComparison } from '@suite-common/redux-utils';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { selectVisibleDeviceAccountsByNetworkSymbol } from '@suite-common/wallet-core';
 import { asBaseCurrencyAmount } from '@suite-common/wallet-types';
 import { AccountsListItemBase, StakingBadge } from '@suite-native/accounts';
 import { Badge, Box, Text } from '@suite-native/atoms';
@@ -32,7 +32,6 @@ import {
     selectAssetCryptoValue,
     selectAssetFiatValue,
     selectAssetFiatValuePercentage,
-    selectVisibleDeviceAccountsKeysByNetworkSymbol,
 } from '../assetsSelectors';
 
 type AssetItemProps = {
@@ -90,12 +89,14 @@ const PercentageIcon = React.memo(({ symbol }: AssetItemSubComponentProps) => {
 
 export const AssetItem = React.memo(({ cryptoCurrencySymbol }: AssetItemProps) => {
     const navigation = useNavigation<NavigationType>();
+    const store = useStore<AssetsRootState>();
     const { NetworkNameFormatter } = useFormatters();
-    const accountsKeysForNetworkSymbol = useSelectorDeepComparison((state: AssetsRootState) =>
-        selectVisibleDeviceAccountsKeysByNetworkSymbol(state, cryptoCurrencySymbol),
+    // Subscribe only to the count (a number, compared with `===`) so the row chrome re-renders
+    // when an account is added/removed, not on every balance tick during discovery.
+    const accountsPerAsset = useSelector(
+        (state: AssetsRootState) =>
+            selectVisibleDeviceAccountsByNetworkSymbol(state, cryptoCurrencySymbol).length,
     );
-
-    const accountCount = accountsKeysForNetworkSymbol.length;
     const hasAnyTokens = useSelector((state: TokensRootState) =>
         selectHasDeviceAnyTokensForNetwork(state, cryptoCurrencySymbol),
     );
@@ -104,15 +105,21 @@ export const AssetItem = React.memo(({ cryptoCurrencySymbol }: AssetItemProps) =
     );
 
     const handleAssetPress = () => {
-        if (accountCount > 1 || hasAnyTokens || hasAnyAccountsWithStaking) {
+        // Read the accounts lazily at press time to avoid subscribing the whole array to the store.
+        const networkAccounts = selectVisibleDeviceAccountsByNetworkSymbol(
+            store.getState(),
+            cryptoCurrencySymbol,
+        );
+
+        if (networkAccounts.length === 1 && !hasAnyTokens && !hasAnyAccountsWithStaking) {
+            navigation.navigate(RootStackRoutes.AccountDetail, {
+                accountKey: networkAccounts[0]?.key,
+                closeActionType: 'back',
+            });
+        } else {
             navigation.navigate(AppTabsRoutes.AccountsStack, {
                 screen: AccountsStackRoutes.Accounts,
                 params: { networksFilter: [cryptoCurrencySymbol] },
-            });
-        } else {
-            navigation.navigate(RootStackRoutes.AccountDetail, {
-                accountKey: accountsKeysForNetworkSymbol[0],
-                closeActionType: 'back',
             });
         }
     };
@@ -128,7 +135,7 @@ export const AssetItem = React.memo(({ cryptoCurrencySymbol }: AssetItemProps) =
                         <Icon size="medium" color="contentSecondary" name="wallet" />
                     </Box>
                     <Text variant="body-sm" color="contentSecondary">
-                        {accountCount}
+                        {accountsPerAsset}
                     </Text>
                     {hasAnyAccountsWithStaking && (
                         <StakingBadge networkSymbol={cryptoCurrencySymbol} />

--- a/suite-native/assets/src/components/AssetItem.tsx
+++ b/suite-native/assets/src/components/AssetItem.tsx
@@ -1,11 +1,10 @@
 import { memo } from 'react';
-import { useSelector, useStore } from 'react-redux';
+import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
 import { useFormatters } from '@suite-common/formatters';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { selectVisibleDeviceAccountsByNetworkSymbol } from '@suite-common/wallet-core';
 import { AccountsListItemBase, StakingBadge } from '@suite-native/accounts';
 import { Badge, Box } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';
@@ -24,7 +23,10 @@ import {
 } from '@suite-native/staking';
 import { type TokensRootState, selectHasDeviceAnyTokensForNetwork } from '@suite-native/tokens';
 
-import { type AssetsRootState } from '../assetsSelectors';
+import {
+    type AssetsRootState,
+    selectSingleDeviceAccountKeyForNetworkSymbol,
+} from '../assetsSelectors';
 import { AccountsCount } from './AccountsCount';
 import { CryptoAmount } from './CryptoAmount';
 import { FiatAmount } from './FiatAmount';
@@ -48,8 +50,10 @@ type NavigationType = TabToStackCompositeNavigationProp<
 // no benefit (and a leaf memo can't hide an unstable selector anyway - that fires regardless).
 export const AssetItem = memo(({ cryptoCurrencySymbol }: AssetItemProps) => {
     const navigation = useNavigation<NavigationType>();
-    const store = useStore<AssetsRootState>();
     const { NetworkNameFormatter } = useFormatters();
+    const singleAccountKey = useSelector((state: AssetsRootState) =>
+        selectSingleDeviceAccountKeyForNetworkSymbol(state, cryptoCurrencySymbol),
+    );
     const hasAnyTokens = useSelector((state: TokensRootState) =>
         selectHasDeviceAnyTokensForNetwork(state, cryptoCurrencySymbol),
     );
@@ -58,15 +62,10 @@ export const AssetItem = memo(({ cryptoCurrencySymbol }: AssetItemProps) => {
     );
 
     const handleAssetPress = () => {
-        // Read the accounts lazily at press time to avoid subscribing the whole array to the store.
-        const networkAccounts = selectVisibleDeviceAccountsByNetworkSymbol(
-            store.getState(),
-            cryptoCurrencySymbol,
-        );
-
-        if (networkAccounts.length === 1 && !hasAnyTokens && !hasAnyAccountsWithStaking) {
+        // A single tokenless account opens its detail directly; anything else opens the list.
+        if (singleAccountKey && !hasAnyTokens && !hasAnyAccountsWithStaking) {
             navigation.navigate(RootStackRoutes.AccountDetail, {
-                accountKey: networkAccounts[0]?.key,
+                accountKey: singleAccountKey,
                 closeActionType: 'back',
             });
         } else {

--- a/suite-native/assets/src/components/AssetItem.tsx
+++ b/suite-native/assets/src/components/AssetItem.tsx
@@ -23,14 +23,12 @@ import {
 } from '@suite-native/staking';
 import { type TokensRootState, selectHasDeviceAnyTokensForNetwork } from '@suite-native/tokens';
 
-import {
-    type AssetsRootState,
-    selectSingleDeviceAccountKeyForNetworkSymbol,
-} from '../assetsSelectors';
+import { selectSingleDeviceAccountKeyForNetworkSymbol } from '../assetsSelectors';
 import { AccountsCount } from './AccountsCount';
 import { CryptoAmount } from './CryptoAmount';
 import { FiatAmount } from './FiatAmount';
 import { PercentageIcon } from './PercentageIcon';
+import { type AssetsRootState } from '../types';
 
 type AssetItemProps = {
     cryptoCurrencySymbol: NetworkSymbol;
@@ -42,12 +40,8 @@ type NavigationType = TabToStackCompositeNavigationProp<
     RootStackParamList
 >;
 
-// Memoized because `Assets` re-renders every time a newly discovered network grows the list.
-// Without this, each new network would re-render every existing row; with it, unchanged rows bail.
-// `cryptoCurrencySymbol` is a stable primitive, so the memo is never silently defeated.
-// The sub-components are intentionally NOT memoized - they each subscribe to their own value and
-// re-render only when it changes, and this component rarely re-renders, so memoizing them adds
-// no benefit (and a leaf memo can't hide an unstable selector anyway - that fires regardless).
+// Memoized so existing rows bail when `Assets` re-renders to add a newly discovered network.
+// Sub-components aren't memoized: each subscribes to its own value, and this rarely re-renders.
 export const AssetItem = memo(({ cryptoCurrencySymbol }: AssetItemProps) => {
     const navigation = useNavigation<NavigationType>();
     const { NetworkNameFormatter } = useFormatters();

--- a/suite-native/assets/src/components/AssetItem.tsx
+++ b/suite-native/assets/src/components/AssetItem.tsx
@@ -1,16 +1,14 @@
-import React from 'react';
+import { memo } from 'react';
 import { useSelector, useStore } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
-import { BASE_CRYPTO_MAX_DISPLAYED_DECIMALS, useFormatters } from '@suite-common/formatters';
+import { useFormatters } from '@suite-common/formatters';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { selectVisibleDeviceAccountsByNetworkSymbol } from '@suite-common/wallet-core';
-import { asBaseCurrencyAmount } from '@suite-common/wallet-types';
 import { AccountsListItemBase, StakingBadge } from '@suite-native/accounts';
-import { Badge, Box, Text } from '@suite-native/atoms';
-import { BaseCurrencyAmountFormatter, CryptoAmountFormatter } from '@suite-native/formatters';
-import { CryptoIconWithPercentage, Icon } from '@suite-native/icons';
+import { Badge, Box } from '@suite-native/atoms';
+import { Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 import {
     AccountsStackRoutes,
@@ -25,14 +23,12 @@ import {
     selectHasAnyDeviceAccountsWithStaking,
 } from '@suite-native/staking';
 import { type TokensRootState, selectHasDeviceAnyTokensForNetwork } from '@suite-native/tokens';
-import { BigNumber } from '@trezor/utils';
 
-import {
-    type AssetsRootState,
-    selectAssetCryptoValue,
-    selectAssetFiatValue,
-    selectAssetFiatValuePercentage,
-} from '../assetsSelectors';
+import { type AssetsRootState } from '../assetsSelectors';
+import { AccountsCount } from './AccountsCount';
+import { CryptoAmount } from './CryptoAmount';
+import { FiatAmount } from './FiatAmount';
+import { PercentageIcon } from './PercentageIcon';
 
 type AssetItemProps = {
     cryptoCurrencySymbol: NetworkSymbol;
@@ -44,59 +40,16 @@ type NavigationType = TabToStackCompositeNavigationProp<
     RootStackParamList
 >;
 
-type AssetItemSubComponentProps = { symbol: NetworkSymbol };
-
-const CryptoAmount = React.memo(({ symbol }: AssetItemSubComponentProps) => {
-    const cryptoValue = useSelector((state: AssetsRootState) =>
-        selectAssetCryptoValue(state, symbol),
-    );
-
-    return (
-        <CryptoAmountFormatter
-            value={cryptoValue}
-            symbol={symbol}
-            // Every asset crypto amount is rounded to 8 decimals to prevent UI overflow.
-            decimals={BASE_CRYPTO_MAX_DISPLAYED_DECIMALS}
-            testID={`@assets/cryptoAmount/${symbol}`}
-        />
-    );
-});
-
-const FiatAmount = React.memo(({ symbol }: AssetItemSubComponentProps) => {
-    const fiatValue = useSelector((state: AssetsRootState) => selectAssetFiatValue(state, symbol));
-
-    return (
-        <BaseCurrencyAmountFormatter
-            symbol={symbol}
-            value={fiatValue !== null ? asBaseCurrencyAmount(new BigNumber(fiatValue)) : null}
-        />
-    );
-});
-
-const PercentageIcon = React.memo(({ symbol }: AssetItemSubComponentProps) => {
-    const assetPercentages = useSelector((state: AssetsRootState) =>
-        selectAssetFiatValuePercentage(state, symbol),
-    );
-
-    return (
-        <CryptoIconWithPercentage
-            iconName={symbol}
-            percentage={assetPercentages.fiatPercentage}
-            percentageOffset={assetPercentages.fiatPercentageOffset}
-        />
-    );
-});
-
-export const AssetItem = React.memo(({ cryptoCurrencySymbol }: AssetItemProps) => {
+// Memoized because `Assets` re-renders every time a newly discovered network grows the list.
+// Without this, each new network would re-render every existing row; with it, unchanged rows bail.
+// `cryptoCurrencySymbol` is a stable primitive, so the memo is never silently defeated.
+// The sub-components are intentionally NOT memoized - they each subscribe to their own value and
+// re-render only when it changes, and this component rarely re-renders, so memoizing them adds
+// no benefit (and a leaf memo can't hide an unstable selector anyway - that fires regardless).
+export const AssetItem = memo(({ cryptoCurrencySymbol }: AssetItemProps) => {
     const navigation = useNavigation<NavigationType>();
     const store = useStore<AssetsRootState>();
     const { NetworkNameFormatter } = useFormatters();
-    // Subscribe only to the count (a number, compared with `===`) so the row chrome re-renders
-    // when an account is added/removed, not on every balance tick during discovery.
-    const accountsPerAsset = useSelector(
-        (state: AssetsRootState) =>
-            selectVisibleDeviceAccountsByNetworkSymbol(state, cryptoCurrencySymbol).length,
-    );
     const hasAnyTokens = useSelector((state: TokensRootState) =>
         selectHasDeviceAnyTokensForNetwork(state, cryptoCurrencySymbol),
     );
@@ -134,9 +87,7 @@ export const AssetItem = React.memo(({ cryptoCurrencySymbol }: AssetItemProps) =
                     <Box>
                         <Icon size="medium" color="contentSecondary" name="wallet" />
                     </Box>
-                    <Text variant="body-sm" color="contentSecondary">
-                        {accountsPerAsset}
-                    </Text>
+                    <AccountsCount symbol={cryptoCurrencySymbol} />
                     {hasAnyAccountsWithStaking && (
                         <StakingBadge networkSymbol={cryptoCurrencySymbol} />
                     )}

--- a/suite-native/assets/src/components/AssetItem.tsx
+++ b/suite-native/assets/src/components/AssetItem.tsx
@@ -81,8 +81,8 @@ const PercentageIcon = React.memo(({ symbol }: AssetItemSubComponentProps) => {
     return (
         <CryptoIconWithPercentage
             iconName={symbol}
-            percentage={assetPercentages?.fiatPercentage}
-            percentageOffset={assetPercentages?.fiatPercentageOffset}
+            percentage={assetPercentages.fiatPercentage}
+            percentageOffset={assetPercentages.fiatPercentageOffset}
         />
     );
 });

--- a/suite-native/assets/src/components/Assets.tsx
+++ b/suite-native/assets/src/components/Assets.tsx
@@ -2,18 +2,17 @@ import Animated, { FadeInDown, LinearTransition } from 'react-native-reanimated'
 import { useSelector } from 'react-redux';
 
 import { selectIsDeviceAuthorized } from '@suite-common/device';
-import { useSelectorDeepComparison } from '@suite-common/redux-utils';
 import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { AnimatedContainerCard } from '@suite-native/atoms';
 import { AccountsRediscoveryNeededWarning } from '@suite-native/discovery';
 import { FiveBinariesHomeBanner } from '@suite-native/module-earn';
 
-import { selectDeviceNetworksWithAssets } from '../assetsSelectors';
+import { selectDeviceNetworkSymbolsWithAssets } from '../assetsSelectors';
 import { AssetItem } from './AssetItem';
 import { DiscoveryAssetsLoader } from './DiscoveryAssetsLoader';
 
 export const Assets = () => {
-    const deviceNetworks = useSelectorDeepComparison(selectDeviceNetworksWithAssets);
+    const deviceNetworkSymbols = useSelector(selectDeviceNetworkSymbolsWithAssets);
 
     const hasDiscovery = useSelector(selectHasRunningDiscovery);
     const isDeviceAuthorized = useSelector(selectIsDeviceAuthorized);
@@ -24,7 +23,7 @@ export const Assets = () => {
             <FiveBinariesHomeBanner />
             <AnimatedContainerCard noPadding layout={LinearTransition}>
                 <AccountsRediscoveryNeededWarning hasPadding />
-                {deviceNetworks.map(symbol => (
+                {deviceNetworkSymbols.map(symbol => (
                     <Animated.View
                         entering={isLoading ? FadeInDown : undefined}
                         layout={LinearTransition}
@@ -33,7 +32,9 @@ export const Assets = () => {
                         <AssetItem cryptoCurrencySymbol={symbol} />
                     </Animated.View>
                 ))}
-                {isLoading && <DiscoveryAssetsLoader isListEmpty={deviceNetworks.length < 1} />}
+                {isLoading && (
+                    <DiscoveryAssetsLoader isListEmpty={deviceNetworkSymbols.length < 1} />
+                )}
             </AnimatedContainerCard>
         </>
     );

--- a/suite-native/assets/src/components/CryptoAmount.tsx
+++ b/suite-native/assets/src/components/CryptoAmount.tsx
@@ -4,7 +4,8 @@ import { BASE_CRYPTO_MAX_DISPLAYED_DECIMALS } from '@suite-common/formatters';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { CryptoAmountFormatter } from '@suite-native/formatters';
 
-import { type AssetsRootState, selectAssetCryptoValue } from '../assetsSelectors';
+import { selectAssetCryptoValue } from '../assetsSelectors';
+import { type AssetsRootState } from '../types';
 
 type CryptoAmountProps = { symbol: NetworkSymbol };
 

--- a/suite-native/assets/src/components/CryptoAmount.tsx
+++ b/suite-native/assets/src/components/CryptoAmount.tsx
@@ -1,0 +1,25 @@
+import { useSelector } from 'react-redux';
+
+import { BASE_CRYPTO_MAX_DISPLAYED_DECIMALS } from '@suite-common/formatters';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { CryptoAmountFormatter } from '@suite-native/formatters';
+
+import { type AssetsRootState, selectAssetCryptoValue } from '../assetsSelectors';
+
+type CryptoAmountProps = { symbol: NetworkSymbol };
+
+export const CryptoAmount = ({ symbol }: CryptoAmountProps) => {
+    const cryptoValue = useSelector((state: AssetsRootState) =>
+        selectAssetCryptoValue(state, symbol),
+    );
+
+    return (
+        <CryptoAmountFormatter
+            value={cryptoValue}
+            symbol={symbol}
+            // Every asset crypto amount is rounded to 8 decimals to prevent UI overflow.
+            decimals={BASE_CRYPTO_MAX_DISPLAYED_DECIMALS}
+            testID={`@assets/cryptoAmount/${symbol}`}
+        />
+    );
+};

--- a/suite-native/assets/src/components/FiatAmount.tsx
+++ b/suite-native/assets/src/components/FiatAmount.tsx
@@ -1,0 +1,21 @@
+import { useSelector } from 'react-redux';
+
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { asBaseCurrencyAmount } from '@suite-common/wallet-types';
+import { BaseCurrencyAmountFormatter } from '@suite-native/formatters';
+import { BigNumber } from '@trezor/utils';
+
+import { type AssetsRootState, selectAssetFiatValue } from '../assetsSelectors';
+
+type FiatAmountProps = { symbol: NetworkSymbol };
+
+export const FiatAmount = ({ symbol }: FiatAmountProps) => {
+    const fiatValue = useSelector((state: AssetsRootState) => selectAssetFiatValue(state, symbol));
+
+    return (
+        <BaseCurrencyAmountFormatter
+            symbol={symbol}
+            value={fiatValue !== null ? asBaseCurrencyAmount(new BigNumber(fiatValue)) : null}
+        />
+    );
+};

--- a/suite-native/assets/src/components/FiatAmount.tsx
+++ b/suite-native/assets/src/components/FiatAmount.tsx
@@ -5,7 +5,8 @@ import { asBaseCurrencyAmount } from '@suite-common/wallet-types';
 import { BaseCurrencyAmountFormatter } from '@suite-native/formatters';
 import { BigNumber } from '@trezor/utils';
 
-import { type AssetsRootState, selectAssetFiatValue } from '../assetsSelectors';
+import { selectAssetFiatValue } from '../assetsSelectors';
+import { type AssetsRootState } from '../types';
 
 type FiatAmountProps = { symbol: NetworkSymbol };
 

--- a/suite-native/assets/src/components/PercentageIcon.tsx
+++ b/suite-native/assets/src/components/PercentageIcon.tsx
@@ -1,0 +1,22 @@
+import { useSelector } from 'react-redux';
+
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { CryptoIconWithPercentage } from '@suite-native/icons';
+
+import { type AssetsRootState, selectAssetFiatValuePercentage } from '../assetsSelectors';
+
+type PercentageIconProps = { symbol: NetworkSymbol };
+
+export const PercentageIcon = ({ symbol }: PercentageIconProps) => {
+    const assetPercentages = useSelector((state: AssetsRootState) =>
+        selectAssetFiatValuePercentage(state, symbol),
+    );
+
+    return (
+        <CryptoIconWithPercentage
+            iconName={symbol}
+            percentage={assetPercentages.fiatPercentage}
+            percentageOffset={assetPercentages.fiatPercentageOffset}
+        />
+    );
+};

--- a/suite-native/assets/src/components/PercentageIcon.tsx
+++ b/suite-native/assets/src/components/PercentageIcon.tsx
@@ -3,7 +3,8 @@ import { useSelector } from 'react-redux';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { CryptoIconWithPercentage } from '@suite-native/icons';
 
-import { type AssetsRootState, selectAssetFiatValuePercentage } from '../assetsSelectors';
+import { selectAssetFiatValuePercentage } from '../assetsSelectors';
+import { type AssetsRootState } from '../types';
 
 type PercentageIconProps = { symbol: NetworkSymbol };
 

--- a/suite-native/assets/src/types.ts
+++ b/suite-native/assets/src/types.ts
@@ -1,0 +1,30 @@
+import { type DeviceRootState } from '@suite-common/device';
+import { type TokenDefinitionsRootState } from '@suite-common/token-definitions';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import {
+    type AccountsRootState,
+    type DiscoveryRootState,
+    type FiatRatesRootState,
+    type WalletSettingsRootState,
+} from '@suite-common/wallet-core';
+import { type BaseCurrencyAmount } from '@suite-common/wallet-types';
+import { type NativeStakingRootState } from '@suite-native/staking';
+
+export interface AssetType {
+    symbol: NetworkSymbol;
+    assetBalance: string;
+    fiatBalance: BaseCurrencyAmount | null;
+}
+
+export type AssetFiatPercentage = {
+    fiatPercentage: number;
+    fiatPercentageOffset: number;
+};
+
+export type AssetsRootState = AccountsRootState &
+    FiatRatesRootState &
+    WalletSettingsRootState &
+    TokenDefinitionsRootState &
+    NativeStakingRootState &
+    DeviceRootState &
+    DiscoveryRootState;

--- a/yarn.lock
+++ b/yarn.lock
@@ -11929,7 +11929,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-native/assets@workspace:suite-native/assets"
   dependencies:
-    "@mobily/ts-belt": "npm:^3.13.1"
     "@react-navigation/native": "npm:7.1.28"
     "@suite-common/assets": "workspace:*"
     "@suite-common/device": "workspace:*"


### PR DESCRIPTION
## Description

The home Asset list re-rendered on nearly every account / balance / rate update during discovery. This isolates subscriptions so only the data that actually changed re-renders.

- **Stable network-symbol list** — `selectDeviceNetworkSymbolsWithAssets` rebuilt with `Set` + `networkSymbolCollection.filter`, plus a `shallowEqual` `resultEqualityCheck` so its reference changes only when a network is added/removed — not on every balance tick. `Assets` drops `useSelectorDeepComparison` for a plain `useSelector`.
- **Skip percentage calc during discovery** — `selectAssetsFiatValuePercentage` short-circuits to a stable empty array while `selectHasRunningDiscovery` is `true`, so `calculateAssetsPercentage` runs once at the end instead of every tick.
- **Isolated leaf components** — account count, fiat, crypto and percentage each subscribe to a single value in their own leaf, so the row chrome (`AccountsListItemBase`) renders once instead of once per discovered account.
- **Navigation without `store.getState()`** — the press handler derives its target from primitive selectors (`selectSingleDeviceAccountKeyForNetworkSymbol`) instead of an imperative store read.
- **Cleanup** — dropped unused `totalFiatBalance`, removed the `@mobily/ts-belt` dependency, extracted shared types into `types.ts`.

## Notes for QA
- `AssetItem` stays `memo`-wrapped so existing rows bail when a new network grows the list; the leaves intentionally don't need `memo`.
- ⚠️ Percentage rings show **0% during discovery**, then snap to real values once it finishes (`selectHasRunningDiscovery` is global) — worth a quick on-device check.

Resolve https://github.com/trezor/trezor-suite/issues/28396

## Screenshots

https://github.com/user-attachments/assets/ba4a838c-18a0-450b-b252-271995c71bf4







<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All changed files are under `suite-native/assets/`, which is the React Native mobile app's assets module (selectors, components like AssetItem, CryptoAmount, FiatAmount, PercentageIcon, etc.). The E2E test suite exclusively covers the desktop/web Trezor Suite application — none of the 106 candidate tests exercise suite-native code paths. The `suite-native` components and selectors have no static or inferred coverage from any of the available Playwright E2E tests. This change set carries zero regression risk for the desktop/web E2E test suite, and no tests need to be run.

<details><summary><b>Changed files (9)</b></summary>

- `suite-native/assets/package.json`
- `suite-native/assets/src/assetsSelectors.ts`
- `suite-native/assets/src/components/AccountsCount.tsx`
- `suite-native/assets/src/components/AssetItem.tsx`
- `suite-native/assets/src/components/Assets.tsx`
- `suite-native/assets/src/components/CryptoAmount.tsx`
- `suite-native/assets/src/components/FiatAmount.tsx`
- `suite-native/assets/src/components/PercentageIcon.tsx`
- `suite-native/assets/src/types.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (9)**
- `suite-native/assets/package.json`
- `suite-native/assets/src/assetsSelectors.ts`
- `suite-native/assets/src/components/AccountsCount.tsx`
- `suite-native/assets/src/components/AssetItem.tsx`
- `suite-native/assets/src/components/Assets.tsx`
- `suite-native/assets/src/components/CryptoAmount.tsx`
- `suite-native/assets/src/components/FiatAmount.tsx`
- `suite-native/assets/src/components/PercentageIcon.tsx`
- `suite-native/assets/src/types.ts`

_Updated: 2026-06-29T12:34:41.848Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/juriczech/suite-native-asset-perf/web/](https://dev.suite.sldev.cz/suite-web/juriczech/suite-native-asset-perf/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=juriczech/suite-native-asset-perf&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=juriczech/suite-native-asset-perf&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=juriczech/suite-native-asset-perf&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "sol staking,unstake and claim on SOL account" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-29T12:39:49.610Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-06-29T12:38:14.392Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->
