### PR TITLE
fix(device-mutex): use global crypto.randomUUID instead of importing from crypto module

### DIFF
--- a/jest.config.native.js
+++ b/jest.config.native.js
@@ -46,6 +46,7 @@ module.exports = {
         '<rootDir>/../../suite-native/test-utils/src/mocks/expoAndRNMock.jsx',
         '<rootDir>/../../suite-native/test-utils/src/mocks/everstakeJestSetup.js',
         '<rootDir>/../../suite-native/test-utils/src/mocks/TextEncoderMock.js',
+        '<rootDir>/../../suite-native/test-utils/src/mocks/randomUUIDMock.js',
         '<rootDir>/../../suite-common/tx-simulation/src/jestSetup.ts',
         '<rootDir>/../../node_modules/@shopify/react-native-skia/jestSetup.js',
         '<rootDir>/../../node_modules/@shopify/flash-list/jestSetup.js',

--- a/suite-native/device-mutex/src/requestDeviceAccess.ts
+++ b/suite-native/device-mutex/src/requestDeviceAccess.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'crypto';
 import { activateKeepAwakeAsync, deactivateKeepAwake } from 'expo-keep-awake';
 
 import { deviceAccessMutex } from './DeviceAccessMutex';
@@ -17,7 +16,7 @@ export const requestDeviceAccess = async <TReturnType>(
         : deviceAccessMutex.lock());
     if (!wasLockSuccessful) return DEVICE_ACCESS_ERROR;
 
-    const keepAwakeTag = randomUUID();
+    const keepAwakeTag = crypto.randomUUID();
 
     try {
         activateKeepAwakeAsync(keepAwakeTag); // Prevents screen from sleeping while app interacts with device.

--- a/suite-native/test-utils/src/mocks/randomUUIDMock.js
+++ b/suite-native/test-utils/src/mocks/randomUUIDMock.js
@@ -1,0 +1,6 @@
+const { randomUUID } = require('crypto');
+
+// jsdom's crypto does not expose randomUUID; patch it using Node's built-in.
+if (typeof global.crypto !== 'undefined' && !global.crypto.randomUUID) {
+    global.crypto.randomUUID = randomUUID;
+}


### PR DESCRIPTION
## Description

- `requestDeviceAccess.ts` imported `randomUUID` from the `'crypto'` Node module, which Metro resolves to `crypto-browserify` — a polyfill that does not expose `randomUUID`
- Switched to `crypto.randomUUID()` (bare global), which is correctly provided by `react-native-quick-crypto` patching `global.crypto` in `globalPolyfills.js`
- Regression introduced in #28502 (`a0f5a88509`)

## Notes for QA

- Navigate to a receive address screen with a hardware wallet connected
- Tap "Show address" and confirm on the device — should complete without throwing `TypeError: crypto.randomUUID is not a function`

## Related Issue

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/device-mutex-crypto-random-uuid&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/device-mutex-crypto-random-uuid&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All three changed files are in the suite-native ecosystem (jest.config.native.js, suite-native/device-mutex/src/requestDeviceAccess.ts, suite-native/test-utils/src/mocks/randomUUIDMock.js). These are native mobile-specific files: a Jest config for native tests, a device mutex utility for native device access, and a UUID mock for native test utilities. None of the 136 candidate E2E tests cover suite-native functionality — they all target the suite-web or suite-desktop (Electron) platforms. There is no static mapping and no inferred connection between these native-only changes and any of the Playwright E2E tests. The risk to the web/desktop E2E test suite is effectively zero; unit tests within the suite-native package would be the appropriate coverage mechanism.

<details><summary><b>Changed files (3)</b></summary>

- `jest.config.native.js`
- `suite-native/device-mutex/src/requestDeviceAccess.ts`
- `suite-native/test-utils/src/mocks/randomUUIDMock.js`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (3)**
- `jest.config.native.js`
- `suite-native/device-mutex/src/requestDeviceAccess.ts`
- `suite-native/test-utils/src/mocks/randomUUIDMock.js`

_Updated: 2026-06-16T07:34:52.435Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/device-mutex-crypto-random-uuid/web/](https://dev.suite.sldev.cz/suite-web/fix/device-mutex-crypto-random-uuid/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-16T07:38:25.199Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-16T07:38:21.645Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->