### PR TITLE
test(suite): stabilize passphrase test by timeout

### DIFF
--- a/suite/e2e/support/pageObjects/dashboardPage.ts
+++ b/suite/e2e/support/pageObjects/dashboardPage.ts
@@ -199,6 +199,9 @@ export class DashboardPage {
         await this.passphraseInput.fill(passphrase);
         await this.passphraseSubmitButton.click();
 
+        // Give Connect time to emit REQUEST_PASSPHRASE before we submit
+        // submitting in the ~100ms gap before it drops the response and the device prompt never shows.
+        await this.page.waitForTimeout(2_000);
         await this.devicePrompt.confirmOnDevicePromptIsShown();
         await this.device.pressYes();
 


### PR DESCRIPTION
This is the outcome of long analysis on what was wrong in suite flaky test. The race condition is problem only for automation. Unfortunately, I didn't find anything we could wait for -> explicit wait.

Claude analysis of connect communication between a passed and failed run:

The root cause is an ordering race between Suite's passphrase submit and Connect's passphrase request 

The race, in the data
Look at the two events that flip order:

PASS — Connect asks first, then Suite answers:


+4806ms  request_passphrase (callId 7bd2c664)   ← Connect asks
+5030ms  submitPassphrase                        ← Suite answers (224ms later)
+5114ms  ui-button  → prompt appears ✓
FAIL — Suite answers first, into the void:


+4850ms  submitPassphrase                        ← Suite answers
+4952ms  request_passphrase (callId 09cd5a07)    ← Connect asks 102ms LATER
         (nothing answers it → hang → timeout) ✗
In the failed run, Suite sent the second passphrase ~100ms before Connect emitted the REQUEST_PASSPHRASE for that call. The response lands with nothing waiting for it and is discarded; then Connect emits its request and waits for a passphrase that never comes again. The device is never driven, no ui-button ever fires, the "Confirm passphrase" modal stays up, and the test times out. The margin is ~100–200ms — a true race.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-passphrase-tests&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-passphrase-tests&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-15T15:53:34.094Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-15T15:52:06.067Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-passphrase-tests/web/](https://dev.suite.sldev.cz/suite-web/fix-passphrase-tests/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->