### PR TITLE
chore(connect-popup): reuse constant

### DIFF
--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -61,7 +61,7 @@ export const connectPopupCallThunkInner = createThunk<
                 methodInfoPayload.requiredPermissions.includes('management') ||
                 methodInfoPayload.requiredPermissions.includes('internal') ||
                 (methodInfoPayload.requiredPermissions.includes('push_tx') &&
-                    source.type === 'deeplink')
+                    source.type === CALL_SOURCE_DEEPLINK)
             ) {
                 throw TypedError('Method_NotAllowed');
             }
@@ -293,7 +293,7 @@ export const connectPopupDeeplinkThunk = createThunk<void, { url: string }>(
         dispatch(
             connectPopupCallThunk({
                 source: {
-                    type: 'deeplink',
+                    type: CALL_SOURCE_DEEPLINK,
                     origin: `${callbackUrl.protocol}//${callbackUrl.host}`,
                     manifest: {
                         appName: queryParams.appName ?? '',


### PR DESCRIPTION
Part of the dead-code elimination sweep, tracked in #28463. Split into a small isolated PR for easy, low-risk review.

**This batch deliberately removes only dead definitions/code — no export-surface-only changes.** Pure unexports and barrel-export narrowing are intentionally excluded here and deferred for a separate discussion.

The full staging branch is green; CI verifies this subset independently.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is in connectPopupThunks.ts, which maps to all 121 E2E tests — indicating it is a broadly shared infrastructure module that handles device connection popup/prompt logic. Since this is a global dependency, most tests are only transitively affected. The highest-risk tests are those that explicitly exercise device connection prompts, THP pairing, session management, and reconnection flows where the popup thunks are most directly invoked. The recommended strategy focuses on a small set of tests covering initial connection (onboarding/THP), reconnection after disconnect, session management, and passphrase re-entry — scenarios where changes to popup thunk logic would most visibly break functionality.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/connect-popup/src/connectPopupThunks.ts`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/suite/initial-run.test.ts` — connectPopupThunks likely handles the THP pairing/connect popup flow during onboarding. This test explicitly exercises THP connection prompts, pairing code entry, and the initial run flow where connect popup logic is most directly invoked.
- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — This test navigates directly to /accounts during onboarding, triggering the connect popup/device connection flow including THP pairing code handling. The connectPopupThunks module directly manages how the app handles device connection prompts during onboarding.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — This test exercises device disconnect/reconnect with passphrase re-confirmation, which involves the connect popup flow for re-establishing device sessions. Changes to connectPopupThunks could affect how reconnection prompts and passphrase dialogs are triggered.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test validates Bridge session stealing/reclaiming and 'Use Here' vs 'Connected' status flows. connectPopupThunks likely manages the popup/prompt logic when sessions are overtaken and need to be reclaimed, making it directly relevant.
- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts` — This test involves device power cycling and reconnection with passphrase re-entry for address verification. The connect popup thunks manage the device connection prompt flow that occurs on reconnect, which this test exercises extensively.
- `suite/e2e/tests/wallet/without-device.test.ts` — This test verifies behavior when the device is disconnected mid-flow, including the connection modal (@suite/connection-modal) that appears when trying to send without a device. connectPopupThunks likely controls this connection modal behavior.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts` — This test validates recovery persistence across page reloads and device reconnects, involving device confirmation prompts managed by the connect popup infrastructure. Changes could affect how device prompts are restored after reload.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/backup/t2t1-fail.test.ts` — This test simulates device disconnect during backup and verifies reconnection handling. The connect popup thunks may influence how the app detects and responds to device disconnection events during active operations.
- `suite/e2e/tests/recovery/dry-run.test.ts` — This test exercises device disconnection (bridge stop) during recovery dry run and subsequent reconnection. The connect popup flow may be involved in reinitializing the device session after bridge restart.

</details>

_Updated: 2026-06-15T16:25:29.619Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-connect-popup-thunks&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-connect-popup-thunks&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-connect-popup-thunks&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-15T16:30:24.077Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-15T16:28:49.350Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-connect-popup-thunks/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-connect-popup-thunks/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->