### PR TITLE
fix(suite): Separate skip heading translation key

### DIFF
--- a/packages/suite/src/components/onboarding/SkipStepConfirmation.tsx
+++ b/packages/suite/src/components/onboarding/SkipStepConfirmation.tsx
@@ -32,7 +32,7 @@ const getModalContent = (
             };
         case STEP.ID_SECURITY_STEP:
             return {
-                heading: <Translation id="TR_SKIP_BACKUP" />,
+                heading: <Translation id="TR_SKIP_BACKUP_HEADER" />,
                 secondaryButtonText: <Translation id="TR_SKIP_BACKUP" />,
                 body: <Translation id="TR_SKIP_BACKUP_DESCRIPTION" />,
                 nextStep: resolveNextAfterSkipped(STEP.ID_SET_PIN_STEP),

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -2479,6 +2479,10 @@ export const messages = defineMessages({
         defaultMessage: 'Skip',
         id: 'TR_SKIP_BACKUP',
     },
+    TR_SKIP_BACKUP_HEADER: {
+        defaultMessage: 'Skip',
+        id: 'TR_SKIP_BACKUP_HEADER',
+    },
     TR_SKIP_BACKUP_DESCRIPTION: {
         defaultMessage:
             'A wallet backup lets you recover your assets if your Trezor gets lost, stolen, or damaged. Without a wallet backup, you could lose access to your assets permanently.',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve  https://github.com/trezor/trezor-suite/issues/28751

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect two files: the SkipStepConfirmation onboarding component and the intl messages file. SkipStepConfirmation is used during onboarding when users skip steps like backup or PIN setup, making onboarding wallet creation and recovery flows the primary risk area. The messages.ts file is a global translation file mapping to virtually all tests, but only tests that assert on specific translation content related to the changed strings are meaningfully affected. The recommended strategy focuses on onboarding create-wallet and recovery-success tests across device models, plus initial-run and analytics-consent tests that exercise the complete onboarding flow.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/components/onboarding/SkipStepConfirmation.tsx`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (13)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts` — SkipStepConfirmation is an onboarding component likely used when skipping steps like backup or PIN setup. This test covers the full wallet creation onboarding flow on T2T1 including Shamir backup and PIN, which are steps that could involve skip confirmations.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts` — This test covers the full T3T1 onboarding wallet creation flow including firmware, authenticity check, tutorial skip, Shamir backup, and PIN setup — all steps where SkipStepConfirmation could be triggered.
- `suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts` — Covers T3W1 onboarding with firmware hash check dismissal, THP pairing, tutorial skip, Shamir backup, and PIN — the skip confirmation component is most relevant during these onboarding step transitions.
- `suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts` — T1B1 create wallet onboarding flow includes backup and PIN setup steps where the SkipStepConfirmation dialog may appear when users attempt to skip steps.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-success.test.ts` — Recovery onboarding flow includes a PIN skip step (onboardingPage.pin.skip) which likely triggers the SkipStepConfirmation component to confirm skipping PIN setup.
- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-success.test.ts` — T1B1 recovery success flow explicitly skips PIN setup (pin.skip) after recovery, which would invoke the SkipStepConfirmation dialog.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts` — This recovery persistence test includes skipping PIN (onboardingPage.pin.skip) after Shamir recovery, directly exercising the skip confirmation flow.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts` — Offline onboarding flow covers wallet creation with Shamir backup and PIN setup. The SkipStepConfirmation component could be affected by translation changes from messages.ts in offline mode.
- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — Tests the analytics consent dialog during onboarding and then completes the full onboarding flow. Changes to the SkipStepConfirmation component could affect step navigation during onboarding.
- `suite/e2e/tests/suite/initial-run.test.ts` — Tests the initial run/onboarding persistence flow including completing onboarding steps. SkipStepConfirmation is part of the onboarding flow that this test exercises.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/onboarding/firmware-check.test.ts` — Tests firmware readiness detection during onboarding with disabled firmware checks. The SkipStepConfirmation could be involved when disabling/skipping firmware checks, though the test focuses on detection rather than skipping.
- `suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts` — Tests entropy check failure during wallet creation onboarding. The flow passes through backup checkboxes and seed confirmation where SkipStepConfirmation may be rendered.
- `suite/e2e/tests/settings/autodetect.test.ts` — Tests locale autodetection including Spanish language. Changes to messages.ts translation strings could affect the expected heading text assertions in this test.

</details>

_Updated: 2026-06-15T18:25:02.641Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/separate-skip-heading-translation-key/web/](https://dev.suite.sldev.cz/suite-web/separate-skip-heading-translation-key/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=separate-skip-heading-translation-key&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=separate-skip-heading-translation-key&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-15T18:30:48.996Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-15T18:28:30.255Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->