### PR TITLE
chore(intl): remove unused translation strings

### DIFF
--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -7614,10 +7614,6 @@ export const messages = defineMessages({
         id: 'TR_GUIDE_SUPPORT_AND_FEEDBACK',
         defaultMessage: 'Support & Feedback',
     },
-    TR_GUIDE_ARTICLES: {
-        id: 'TR_GUIDE_ARTICLES',
-        defaultMessage: 'Articles',
-    },
     TR_GUIDE_VIEW_HEADLINE_LEARN_AND_DISCOVER: {
         id: 'TR_GUIDE_VIEW_HEADLINE_LEARN_AND_DISCOVER',
         defaultMessage: 'Suite Guide',


### PR DESCRIPTION
## Summary
Removes unused translation strings from `messages.ts` that are no longer referenced in the codebase.

**Keys removed (1):**
- `TR_GUIDE_ARTICLES`

Identified by the `translations:list-unused` CI check.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change to suite/intl/src/messages.ts affects the central translation/intl message definitions used across the entire Trezor Suite UI. Since this is a broadly-used file with no static test mapping, all recommendations are inferred from LLM analysis of which tests assert on specific translation keys. The highest-risk tests are those that directly verify localized text content or language switching behavior (autodetect, general settings). Medium-priority tests are those asserting on specific translation keys in their domain areas. The recommended strategy is to run the high-priority tests unconditionally and medium-priority tests for broader confidence, while keeping the list focused on tests with concrete translation key assertions rather than every test that renders translated text.

<details><summary><b>Changed files (1)</b></summary>

- `suite/intl/src/messages.ts`

</details>

**Recommended tests (13)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/settings/autodetect.test.ts` — This test directly asserts on localized heading text from @suite/intl messages (TR_ONBOARDING_DATA_COLLECTION_HEADING) and verifies that the correct translated string is displayed for both English and Spanish locales. Changes to messages.ts could alter or break these translation keys.
- `suite/e2e/tests/settings/general.test.ts` — This test changes the application language from English to Spanish and verifies analytics events referencing language settings. It depends on the intl messages module for UI text rendering and locale handling, making it directly sensitive to changes in messages.ts.

</details>

<details><summary>🟡 <b>Medium priority (9)</b></summary>

- `suite/e2e/tests/settings/forget-device.test.ts` — This test asserts on multiple specific translation keys (TR_FORGET_DEVICE_MODAL_HEADING, TR_FORGET_DEVICE_MODAL_FINISH_HEADING, TR_FORGET_DEVICE_MODAL_BULLET_FORGET, etc.) from the intl messages system. Changes to message definitions could break these key-based assertions.
- `suite/e2e/tests/settings/coins.test.ts` — This test asserts on specific translation keys (TR_YOUR_WALLET_IS_READY_WHAT, TR_DASHBOARD_ACTIVATE_ASSETS_DESC, TR_DASHBOARD_GET_STARTED) rendered from the intl messages module. Changes to messages.ts could affect these translated strings.
- `suite/e2e/tests/staking/ada/stake.test.ts` — This test asserts on multiple translation keys (TR_EARN_STAKING_IN_A_NUTSHELL, TR_EARN_YOUR_FUNDS_STAY_ACCESSIBLE, TR_EARN_STAKE_TOKEN, TR_STAKE_FULL_BALANCE) from intl messages. Changes to message definitions in messages.ts could break these assertions.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — This test asserts on translation keys like TR_STAKE_UNSTAKE_TOKEN and TR_STAKE_FULL_BALANCE from the intl messages module. Changes to messages.ts could alter these message definitions.
- `suite/e2e/tests/staking/staking-form.test.ts` — This test asserts on multiple specific translation keys for validation errors (TR_BUY_VALIDATION_ERROR_MINIMUM_CRYPTO, AMOUNT_IS_NOT_IN_RANGE_DECIMALS, AMOUNT_IS_NOT_ENOUGH, AMOUNT_IS_NOT_SET, TR_STAKE_LEFT_AMOUNT_FOR_WITHDRAWAL). Changes to messages.ts could break these validation message assertions.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — This test asserts on translation keys for validation errors (AMOUNT_IS_NOT_IN_RANGE_DECIMALS, AMOUNT_IS_NOT_ENOUGH) and country display (TR_TRADING_COUNTRY_WORLD) sourced from intl messages. Changes to messages.ts could break these assertions.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — This test asserts on translation keys TR_PASSPHRASE_MISMATCH, TR_PASSPHRASE_MISMATCH_DESCRIPTION, and TR_PASSPHRASE_WALLET from intl messages. Changes to these message definitions in messages.ts would directly affect test assertions.
- `suite/e2e/tests/suite/db-locale-migration.test.ts` — This test verifies language persistence (Spanish) across database migration and checks the language select displays the correct label. Changes to the intl messages module could affect language-related UI text and settings display.
- `suite/e2e/tests/wallet/transactions.test.ts` — This test asserts on intl message translation keys for graph time range labels (TR_DATE_DAY_LONG, TR_DATE_WEEK_LONG, TR_DATE_MONTH_LONG, TR_DATE_YEAR_LONG, TR_ALL). Changes to these message definitions would directly break the assertions.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test asserts on translation keys TR_USE_HERE and TR_CONNECTED for device session status display. Changes to these specific messages in messages.ts could affect these assertions.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — This test asserts on translation keys like TR_STAKE_ON_EVERSTAKE, TR_TX_CONFIRMING, TR_TX_CONFIRMED, TR_EARN_AMOUNT_STAKED_INSTANTLY, and TR_EARN_INSTANTLY_STAKED. Changes to these messages could affect test outcomes.

</details>

_Updated: 2026-06-16T07:13:06.752Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/remove-unused-strings-20260616/web/](https://dev.suite.sldev.cz/suite-web/chore/remove-unused-strings-20260616/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/remove-unused-strings-20260616&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/remove-unused-strings-20260616&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox provider | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-16T07:17:35.889Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-16T07:16:29.930Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->